### PR TITLE
DO NOT MERGE: feat(metrics): Add dlq to release heath and generic metrics pipelines

### DIFF
--- a/bin/send_metrics.py
+++ b/bin/send_metrics.py
@@ -149,7 +149,13 @@ def produce_msgs(messages, is_generic, host, dryrun):
     show_default=True,
     help="Specify which org id(s) to send",
 )
-def main(use_cases, rand_str, host, dryrun, org_id):
+@click.option(
+    "--num-bad-msg",
+    default=0,
+    show_default=True,
+    help="Number of additional badly formatted metric messages to send",
+)
+def main(use_cases, rand_str, host, dryrun, org_id, num_bad_msg):
     if UseCaseID.SESSIONS.value in use_cases and len(use_cases) > 1:
         click.secho(
             "ERROR: UseCaseID.SESSIONS is in use_cases and there are more than 1 use cases",
@@ -158,9 +164,10 @@ def main(use_cases, rand_str, host, dryrun, org_id):
         )
         exit(1)
 
+    rand_str = rand_str or "".join(random.choices(string.ascii_uppercase + string.digits, k=8))
+
     is_generic = UseCaseID.SESSIONS.value not in use_cases
 
-    rand_str = rand_str or "".join(random.choices(string.ascii_uppercase + string.digits, k=8))
     messages = list(
         itertools.chain.from_iterable(
             (
@@ -172,6 +179,9 @@ def main(use_cases, rand_str, host, dryrun, org_id):
             for org in org_id
         )
     )
+
+    messages.extend([{"BAD_VALUE": rand_str, "idx": i} for i in range(num_bad_msg)])
+
     random.shuffle(messages)
 
     produce_msgs(messages, is_generic, host, dryrun)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3246,9 +3246,11 @@ KAFKA_INGEST_EVENTS = "ingest-events"
 KAFKA_INGEST_ATTACHMENTS = "ingest-attachments"
 KAFKA_INGEST_TRANSACTIONS = "ingest-transactions"
 KAFKA_INGEST_METRICS = "ingest-metrics"
+KAFKA_INGEST_METRICS_DLQ = "ingest-metrics-dlq"
 KAFKA_SNUBA_METRICS = "snuba-metrics"
 KAFKA_PROFILES = "profiles"
 KAFKA_INGEST_PERFORMANCE_METRICS = "ingest-performance-metrics"
+KAFKA_INGEST_PERFORMANCE_METRICS_DLQ = "ingest-performance-metrics-dlq"
 KAFKA_SNUBA_GENERIC_METRICS = "snuba-generic-metrics"
 KAFKA_INGEST_REPLAY_EVENTS = "ingest-replay-events"
 KAFKA_INGEST_REPLAYS_RECORDINGS = "ingest-replay-recordings"
@@ -3257,7 +3259,6 @@ KAFKA_INGEST_MONITORS = "ingest-monitors"
 KAFKA_EVENTSTREAM_GENERIC = "generic-events"
 KAFKA_GENERIC_EVENTS_COMMIT_LOG = "snuba-generic-events-commit-log"
 KAFKA_GROUP_ATTRIBUTES = "group-attributes"
-
 # spans
 KAFKA_INGEST_SPANS = "ingest-spans"
 KAFKA_SNUBA_SPANS = "snuba-spans"
@@ -3294,11 +3295,14 @@ KAFKA_TOPICS: Mapping[str, Optional[TopicDefinition]] = {
     KAFKA_INGEST_TRANSACTIONS: {"cluster": "default"},
     # Topic for receiving metrics from Relay
     KAFKA_INGEST_METRICS: {"cluster": "default"},
+    # Topic for routing invalid messages from KAFKA_INGEST_METRICS
+    KAFKA_INGEST_METRICS_DLQ: {"cluster": "default"},
     # Topic for indexer translated metrics
     KAFKA_SNUBA_METRICS: {"cluster": "default"},
     # Topic for receiving profiles from Relay
     KAFKA_PROFILES: {"cluster": "default"},
     KAFKA_INGEST_PERFORMANCE_METRICS: {"cluster": "default"},
+    KAFKA_INGEST_PERFORMANCE_METRICS_DLQ: {"cluster": "default"},
     KAFKA_SNUBA_GENERIC_METRICS: {"cluster": "default"},
     KAFKA_INGEST_REPLAY_EVENTS: {"cluster": "default"},
     KAFKA_INGEST_REPLAYS_RECORDINGS: {"cluster": "default"},

--- a/src/sentry/conf/types/consumer_definition.py
+++ b/src/sentry/conf/types/consumer_definition.py
@@ -23,3 +23,7 @@ class ConsumerDefinition(TypedDict, total=False):
     require_synchronization: bool
     synchronize_commit_group_default: str
     synchronize_commit_log_topic_default: str
+
+    dlq_topic: str
+    dlq_max_invalid_ratio: float
+    dlq_max_consecutive_count: int

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import shutil
 import threading
 import types
-from typing import MutableSequence, NoReturn, Sequence
+from typing import List, MutableSequence, NoReturn, Sequence
 from urllib.parse import urlparse
 
 import click
@@ -129,6 +129,7 @@ def _get_daemon(name: str) -> tuple[str, list[str]]:
     envvar="SENTRY_DEVSERVER_BIND",
     required=False,
 )
+@click.option("--enable-dlq", "dlq_consumers", multiple=True, help="The consumer to enable DLQ for")
 @log_options()  # needs this decorator to be typed
 @configuration  # needs this decorator to be typed
 def devserver(
@@ -146,6 +147,7 @@ def devserver(
     dev_consumer: bool,
     bind: str | None,
     client_hostname: str,
+    dlq_consumers: List[str] | None,
 ) -> NoReturn:
     "Starts a lightweight web server for development."
     if bind is None:
@@ -403,6 +405,7 @@ Alternatively, run without --workers.
                             "--consumer-group=sentry-consumer",
                             "--auto-offset-reset=latest",
                             "--no-strict-offset-reset",
+                            *(("--enable-dlq",) if dlq_consumers and name in dlq_consumers else ()),
                         ],
                     )
                 )

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -706,6 +706,12 @@ def profiles_consumer(**options):
     help="A file to touch roughly every second to indicate that the consumer is still alive. See https://getsentry.github.io/arroyo/strategies/healthcheck.html for more information.",
 )
 @click.option(
+    "--enable-dlq",
+    help="Enable dql to route invalid messages to. See https://getsentry.github.io/arroyo/dlqs.html#arroyo.dlq.DlqPolicy for more information.",
+    is_flag=True,
+    default=False,
+)
+@click.option(
     "--log-level",
     type=click.Choice(["debug", "info", "warning", "error", "critical"], case_sensitive=False),
     help="log level to pass to the arroyo consumer",
@@ -776,6 +782,7 @@ def dev_consumer(consumer_names):
             max_poll_interval_ms=None,
             synchronize_commit_group=None,
             synchronize_commit_log_topic=None,
+            enable_dlq=False,
             healthcheck_file_path=None,
             validate_schema=True,
         )

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -1,6 +1,6 @@
 import logging
 import random
-from collections import defaultdict
+from collections import defaultdict, deque
 from typing import (
     Any,
     Callable,
@@ -8,7 +8,6 @@ from typing import (
     Mapping,
     MutableMapping,
     MutableSequence,
-    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -23,14 +22,17 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message
 from django.conf import settings
 from sentry_kafka_schemas.codecs import Codec, ValidationError
-from sentry_kafka_schemas.schema_types.ingest_metrics_v1 import IngestMetric
 from sentry_kafka_schemas.schema_types.snuba_generic_metrics_v1 import GenericMetric
 from sentry_kafka_schemas.schema_types.snuba_metrics_v1 import Metric
 
 from sentry import options
 from sentry.sentry_metrics.aggregation_option_registry import get_aggregation_option
 from sentry.sentry_metrics.configuration import MAX_INDEXED_COLUMN_LENGTH
-from sentry.sentry_metrics.consumers.indexer.common import IndexerOutputMessageBatch, MessageBatch
+from sentry.sentry_metrics.consumers.indexer.common import (
+    BrokerMeta,
+    IndexerOutputMessageBatch,
+    MessageBatch,
+)
 from sentry.sentry_metrics.consumers.indexer.parsed_message import ParsedMessage
 from sentry.sentry_metrics.consumers.indexer.routing_producer import RoutingPayload
 from sentry.sentry_metrics.indexer.base import Metadata
@@ -47,11 +49,6 @@ ACCEPTED_METRIC_TYPES = {"s", "c", "d"}  # set, counter, distribution
 
 OrgId = int
 Headers = MutableSequence[Tuple[str, bytes]]
-
-
-class PartitionIdxOffset(NamedTuple):
-    partition_idx: int
-    offset: int
 
 
 def valid_metric_name(name: Optional[str]) -> bool:
@@ -87,6 +84,10 @@ class IndexerBatch:
         self.__message_size_sum: MutableMapping[UseCaseID, int] = defaultdict(int)
         self.__message_size_max: MutableMapping[UseCaseID, int] = defaultdict(int)
 
+        self.invalid_msg_meta: Set[BrokerMeta] = set()
+        self.filtered_msg_meta: Set[BrokerMeta] = set()
+        self.parsed_payloads_by_meta: MutableMapping[BrokerMeta, ParsedMessage] = {}
+
         self._extract_messages()
 
     def _extract_namespace(self, headers: Headers) -> Optional[str]:
@@ -98,94 +99,136 @@ class IndexerBatch:
 
     @metrics.wraps("process_messages.extract_messages")
     def _extract_messages(self) -> None:
-        self.skipped_offsets: Set[PartitionIdxOffset] = set()
-        self.parsed_payloads_by_offset: MutableMapping[PartitionIdxOffset, ParsedMessage] = {}
-
-        disabled_msgs_cnt: MutableMapping[str, int] = defaultdict(int)
+        skipped_msgs_cnt: MutableMapping[str, int] = defaultdict(int)
 
         for msg in self.outer_message.payload:
+
             assert isinstance(msg.value, BrokerValue)
-            partition_offset = PartitionIdxOffset(msg.value.partition.index, msg.value.offset)
+            broker_meta = BrokerMeta(msg.value.partition, msg.value.offset)
 
             if (namespace := self._extract_namespace(msg.payload.headers)) in options.get(
                 "sentry-metrics.indexer.disabled-namespaces"
             ):
                 assert namespace
-                self.skipped_offsets.add(partition_offset)
-                disabled_msgs_cnt[namespace] += 1
-                continue
-            try:
-                parsed_payload: ParsedMessage = json.loads(
-                    msg.payload.value.decode("utf-8"), use_rapid_json=True
-                )
-            except rapidjson.JSONDecodeError:
-                self.skipped_offsets.add(partition_offset)
-                logger.error(
-                    "process_messages.invalid_json",
-                    extra={"payload_value": str(msg.payload.value)},
-                    exc_info=True,
-                )
-                continue
-            try:
-                if self.__input_codec:
-                    self.__input_codec.validate(parsed_payload)
-            except ValidationError:
-                if settings.SENTRY_METRICS_INDEXER_RAISE_VALIDATION_ERRORS:
-                    raise
-
-                # For now while this is still experimental, those errors are
-                # not supposed to be fatal.
-                logger.warning(
-                    "process_messages.invalid_schema",
-                    extra={"payload_value": str(msg.payload.value)},
-                    exc_info=True,
-                )
-
-            try:
-                parsed_payload["use_case_id"] = use_case_id = extract_use_case_id(
-                    parsed_payload["name"]
-                )
-            except ValidationError:
-                self.skipped_offsets.add(partition_offset)
-                logger.error(
-                    "process_messages.invalid_metric_resource_identifier",
-                    extra={"payload_value": str(msg.payload.value)},
-                    exc_info=True,
-                )
+                skipped_msgs_cnt[namespace] += 1
+                self.filtered_msg_meta.add(broker_meta)
                 continue
 
-            self.__message_count[use_case_id] += 1
-            self.__message_size_max[use_case_id] = max(
-                len(msg.payload.value), self.__message_size_max[use_case_id]
-            )
-            self.__message_size_sum[use_case_id] += len(msg.payload.value)
+            try:
+                parsed_payload = self._extract_message(msg)
+                self._validate_message(parsed_payload)
+                self.parsed_payloads_by_meta[broker_meta] = parsed_payload
+            except Exception:
+                self.invalid_msg_meta.add(broker_meta)
 
-            # Ensure that the parsed_payload can be cast back to to
-            # IngestMetric. If there are any schema changes, this check would
-            # fail and ParsedMessage needs to be adjusted to be a superset of
-            # IngestMetric again.
-            _: IngestMetric = parsed_payload
-
-            self.parsed_payloads_by_offset[partition_offset] = parsed_payload
-
-        for namespace, cnt in disabled_msgs_cnt.items():
+        for namespace, cnt in skipped_msgs_cnt.items():
             metrics.incr(
                 "process_messages.namespace_disabled",
                 amount=cnt,
                 tags={"namespace": namespace},
             )
 
+    def _extract_message(
+        self,
+        msg: Message[KafkaPayload],
+    ) -> ParsedMessage:
+        assert isinstance(msg.value, BrokerValue)
+        try:
+            parsed_payload: ParsedMessage = json.loads(
+                msg.payload.value.decode("utf-8"), use_rapid_json=True
+            )
+        except rapidjson.JSONDecodeError:
+            logger.error(
+                "process_messages.invalid_json",
+                extra={"payload_value": str(msg.payload.value)},
+                exc_info=True,
+            )
+            raise
+        try:
+            if self.__input_codec:
+                self.__input_codec.validate(parsed_payload)
+        except ValidationError:
+            if settings.SENTRY_METRICS_INDEXER_RAISE_VALIDATION_ERRORS:
+                raise
+            logger.warning(
+                "process_messages.invalid_schema",
+                extra={"payload_value": str(msg.payload.value)},
+                exc_info=True,
+            )
+        try:
+            parsed_payload["use_case_id"] = use_case_id = extract_use_case_id(
+                parsed_payload["name"]
+            )
+        except ValidationError:
+            logger.error(
+                "process_messages.invalid_metric_resource_identifier",
+                extra={"payload_value": str(msg.payload.value)},
+                exc_info=True,
+            )
+            raise
+
+        self.__message_count[use_case_id] += 1
+        self.__message_size_max[use_case_id] = max(
+            len(msg.payload.value), self.__message_size_max[use_case_id]
+        )
+        self.__message_size_sum[use_case_id] += len(msg.payload.value)
+
+        return parsed_payload
+
+    def _validate_message(self, parsed_payload: ParsedMessage) -> None:
+        metric_name = parsed_payload["name"]
+        metric_type = parsed_payload["type"]
+        use_case_id = parsed_payload["use_case_id"]
+        org_id = parsed_payload["org_id"]
+        tags = parsed_payload.get("tags", {})
+
+        if not valid_metric_name(metric_name):
+            logger.error(
+                "process_messages.invalid_metric_name",
+                extra={
+                    "use_case_id": use_case_id,
+                    "org_id": org_id,
+                    "metric_name": metric_name,
+                },
+            )
+            raise ValueError(f"Invalid metric name: {metric_name}")
+
+        if metric_type not in ACCEPTED_METRIC_TYPES:
+            logger.error(
+                "process_messages.invalid_metric_type",
+                extra={
+                    "use_case_id": use_case_id,
+                    "org_id": org_id,
+                    "metric_type": metric_type,
+                },
+            )
+            raise ValueError(f"Invalid metric type: {metric_type}")
+
+        if self.tags_validator(tags) is False:
+            # sentry doesn't seem to actually capture nested logger.error extra args
+            sentry_sdk.set_extra("all_metric_tags", tags)
+            logger.error(
+                "process_messages.invalid_tags",
+                extra={
+                    "use_case_id": use_case_id,
+                    "org_id": org_id,
+                    "metric_name": metric_name,
+                    "tags": tags,
+                },
+            )
+            raise ValueError(f"Invalid metric tags: {tags}")
+
     @metrics.wraps("process_messages.filter_messages")
-    def filter_messages(self, keys_to_remove: Sequence[PartitionIdxOffset]) -> None:
+    def filter_messages(self, keys_to_remove: Sequence[BrokerMeta]) -> None:
         # XXX: it is useful to be able to get a sample of organization ids that are affected by rate limits, but this is really slow.
-        for offset in keys_to_remove:
+        for broker_meta in keys_to_remove:
             if _should_sample_debug_log():
                 sentry_sdk.set_tag(
                     "sentry_metrics.organization_id",
-                    self.parsed_payloads_by_offset[offset]["org_id"],
+                    self.parsed_payloads_by_meta[broker_meta]["org_id"],
                 )
                 sentry_sdk.set_tag(
-                    "sentry_metrics.metric_name", self.parsed_payloads_by_offset[offset]["name"]
+                    "sentry_metrics.metric_name", self.parsed_payloads_by_meta[broker_meta]["name"]
                 )
                 logger.error(
                     "process_messages.dropped_message",
@@ -194,7 +237,7 @@ class IndexerBatch:
                     },
                 )
 
-        self.skipped_offsets.update(keys_to_remove)
+        self.filtered_msg_meta.update(keys_to_remove)
 
     @metrics.wraps("process_messages.extract_strings")
     def extract_strings(self) -> Mapping[UseCaseID, Mapping[OrgId, Set[str]]]:
@@ -202,61 +245,14 @@ class IndexerBatch:
             lambda: defaultdict(set)
         )
 
-        for partition_offset, message in self.parsed_payloads_by_offset.items():
-            if partition_offset in self.skipped_offsets:
+        for broker_meta, message in self.parsed_payloads_by_meta.items():
+            if broker_meta in self.invalid_msg_meta or broker_meta in self.filtered_msg_meta:
                 continue
 
-            partition_idx, offset = partition_offset
-
             metric_name = message["name"]
-            metric_type = message["type"]
             use_case_id = message["use_case_id"]
             org_id = message["org_id"]
             tags = message.get("tags", {})
-
-            if not valid_metric_name(metric_name):
-                logger.error(
-                    "process_messages.invalid_metric_name",
-                    extra={
-                        "use_case_id": use_case_id,
-                        "org_id": org_id,
-                        "metric_name": metric_name,
-                        "partition": partition_idx,
-                        "offset": offset,
-                    },
-                )
-                self.skipped_offsets.add(partition_offset)
-                continue
-
-            if metric_type not in ACCEPTED_METRIC_TYPES:
-                logger.error(
-                    "process_messages.invalid_metric_type",
-                    extra={
-                        "use_case_id": use_case_id,
-                        "org_id": org_id,
-                        "metric_type": metric_type,
-                        "offset": offset,
-                    },
-                )
-                self.skipped_offsets.add(partition_offset)
-                continue
-
-            if self.tags_validator(tags) is False:
-                # sentry doesn't seem to actually capture nested logger.error extra args
-                sentry_sdk.set_extra("all_metric_tags", tags)
-                logger.error(
-                    "process_messages.invalid_tags",
-                    extra={
-                        "use_case_id": use_case_id,
-                        "org_id": org_id,
-                        "metric_name": metric_name,
-                        "tags": tags,
-                        "partition": partition_idx,
-                        "offset": offset,
-                    },
-                )
-                self.skipped_offsets.add(partition_offset)
-                continue
 
             strings_in_message = {
                 metric_name,
@@ -290,12 +286,10 @@ class IndexerBatch:
             used_tags: Set[str] = set()
             output_message_meta: Dict[str, Dict[str, str]] = defaultdict(dict)
             assert isinstance(message.value, BrokerValue)
-            partition_offset = PartitionIdxOffset(
-                message.value.partition.index, message.value.offset
-            )
-            if partition_offset in self.skipped_offsets:
+            broker_meta = BrokerMeta(message.value.partition, message.value.offset)
+            if broker_meta in self.invalid_msg_meta or broker_meta in self.filtered_msg_meta:
                 continue
-            old_payload_value = self.parsed_payloads_by_offset.pop(partition_offset)
+            old_payload_value = self.parsed_payloads_by_meta.pop(broker_meta)
 
             metric_name = old_payload_value["name"]
             org_id = old_payload_value["org_id"]
@@ -490,4 +484,8 @@ class IndexerBatch:
                 self.__message_size_max[use_case_id],
                 tags={"use_case_id": use_case_id.value},
             )
-        return IndexerOutputMessageBatch(new_messages, cogs_usage)
+        return IndexerOutputMessageBatch(
+            new_messages,
+            deque(sorted(self.invalid_msg_meta)),
+            cogs_usage,
+        )

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import functools
 import logging
-from typing import Any, Mapping, Optional, Union, cast
+from collections import deque
+from typing import Any, Deque, Mapping, NamedTuple, Optional, Union, cast
 
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
 from arroyo.commit import ONCE_PER_SECOND
+from arroyo.dlq import InvalidMessage
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies import ProcessingStrategy as ProcessingStep
@@ -39,19 +41,32 @@ logger = logging.getLogger(__name__)
 class Unbatcher(ProcessingStep[Union[FilteredPayload, IndexerOutputMessageBatch]]):
     def __init__(
         self,
-        next_step: ProcessingStep[Union[KafkaPayload, RoutingPayload]],
+        next_step: ProcessingStep[Union[FilteredPayload, KafkaPayload, RoutingPayload]],
     ) -> None:
         self.__next_step = next_step
         self.__closed = False
+        self._invalid_msg_meta: Deque[NamedTuple] = deque()
 
     def poll(self) -> None:
+        if self._invalid_msg_meta:
+            partition, offset = self._invalid_msg_meta.popleft()
+            raise InvalidMessage(partition, offset)
+
         self.__next_step.poll()
 
     def submit(self, message: Message[Union[FilteredPayload, IndexerOutputMessageBatch]]) -> None:
         assert not self.__closed
 
-        # FilteredPayloads are not handled in the indexer
-        for transformed_message in cast(IndexerOutputMessageBatch, message.payload).data:
+        if isinstance(message.payload, FilteredPayload):
+            self.__next_step.submit(cast(Message[KafkaPayload], message))
+            return
+
+        transformed_messages = cast(IndexerOutputMessageBatch, message.payload).data
+        invalid_msg_meta = cast(IndexerOutputMessageBatch, message.payload).invalid_msg_meta
+        _ = cast(IndexerOutputMessageBatch, message.payload).cogs_data
+        self._invalid_msg_meta.extend(invalid_msg_meta)
+
+        for transformed_message in transformed_messages:
             self.__next_step.submit(transformed_message)
 
     def close(self) -> None:

--- a/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
+++ b/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
@@ -14,7 +14,7 @@ from sentry.ratelimits.cardinality import (
     Timestamp,
 )
 from sentry.sentry_metrics.configuration import MetricsIngestConfiguration, UseCaseKey
-from sentry.sentry_metrics.consumers.indexer.batch import PartitionIdxOffset
+from sentry.sentry_metrics.consumers.indexer.common import BrokerMeta
 from sentry.sentry_metrics.use_case_id_registry import (
     USE_CASE_ID_CARDINALITY_LIMIT_QUOTA_OPTIONS,
     UseCaseID,
@@ -32,7 +32,7 @@ class CardinalityLimiterState:
     _metric_path_key: UseCaseKey
     _grants: Optional[Sequence[GrantedQuota]]
     _timestamp: Optional[Timestamp]
-    keys_to_remove: Sequence[PartitionIdxOffset]
+    keys_to_remove: Sequence[BrokerMeta]
 
 
 def _build_quota_key(use_case_id: UseCaseID, org_id: OrgId) -> str:
@@ -80,10 +80,10 @@ class TimeseriesCardinalityLimiter:
         self.backend: CardinalityLimiter = rate_limiter
 
     def check_cardinality_limits(
-        self, metric_path_key: UseCaseKey, messages: Mapping[PartitionIdxOffset, InboundMessage]
+        self, metric_path_key: UseCaseKey, messages: Mapping[BrokerMeta, InboundMessage]
     ) -> CardinalityLimiterState:
         request_hashes = defaultdict(set)
-        hash_to_offset: Mapping[str, Dict[int, PartitionIdxOffset]] = defaultdict(dict)
+        hash_to_meta: Mapping[str, Dict[int, BrokerMeta]] = defaultdict(dict)
         prefix_to_quota = {}
 
         # this works by applying one cardinality limiter rollout option
@@ -109,7 +109,7 @@ class TimeseriesCardinalityLimiter:
                 16,
             )
             prefix = _build_quota_key(message["use_case_id"], org_id)
-            hash_to_offset[prefix][message_hash] = key
+            hash_to_meta[prefix][message_hash] = key
             request_hashes[prefix].add(message_hash)
             configured_quota = _construct_quotas(message["use_case_id"])
 
@@ -144,10 +144,10 @@ class TimeseriesCardinalityLimiter:
 
         timestamp, grants = self.backend.check_within_quotas(requested_quotas)
 
-        keys_to_remove = hash_to_offset
-        # make sure that hash_to_offset is no longer used, as the underlying
+        keys_to_remove = hash_to_meta
+        # make sure that hash_to_broker_meta is no longer used, as the underlying
         # dict will be mutated
-        del hash_to_offset
+        del hash_to_meta
 
         for grant in grants:
             for hash in grant.granted_unit_hashes:

--- a/tests/sentry/sentry_metrics/limiters/test_cardinality_limiter.py
+++ b/tests/sentry/sentry_metrics/limiters/test_cardinality_limiter.py
@@ -2,6 +2,7 @@ import time
 from typing import Optional, Sequence, Tuple
 
 import pytest
+from arroyo import Partition, Topic
 
 from sentry.ratelimits.cardinality import (
     CardinalityLimiter,
@@ -10,7 +11,7 @@ from sentry.ratelimits.cardinality import (
     Timestamp,
 )
 from sentry.sentry_metrics.configuration import UseCaseKey
-from sentry.sentry_metrics.consumers.indexer.batch import PartitionIdxOffset
+from sentry.sentry_metrics.consumers.indexer.common import BrokerMeta
 from sentry.sentry_metrics.indexer.limiters.cardinality import (
     TimeseriesCardinalityLimiter,
     _build_quota_key,
@@ -98,13 +99,13 @@ def test_reject_all():
         result = limiter.check_cardinality_limits(
             UseCaseKey.PERFORMANCE,
             {
-                PartitionIdxOffset(0, 0): {
+                BrokerMeta(Partition(Topic("topic"), 0), 0): {
                     "org_id": 1,
                     "name": "foo",
                     "tags": {},
                     "use_case_id": UseCaseID.TRANSACTIONS,
                 },
-                PartitionIdxOffset(0, 1): {
+                BrokerMeta(Partition(Topic("topic"), 0), 1): {
                     "org_id": 1,
                     "name": "bar",
                     "tags": {},
@@ -113,7 +114,10 @@ def test_reject_all():
             },
         )
 
-        assert result.keys_to_remove == [PartitionIdxOffset(0, 0), PartitionIdxOffset(0, 1)]
+        assert result.keys_to_remove == [
+            BrokerMeta(Partition(Topic("topic"), 0), 0),
+            BrokerMeta(Partition(Topic("topic"), 0), 1),
+        ]
 
 
 def test_reject_all_with_default():
@@ -147,19 +151,19 @@ def test_reject_all_with_default():
         result = limiter.check_cardinality_limits(
             UseCaseKey.PERFORMANCE,
             {
-                PartitionIdxOffset(0, 0): {
+                BrokerMeta(Partition(Topic("topic"), 0), 0): {
                     "org_id": 1,
                     "name": "foo",
                     "tags": {},
                     "use_case_id": UseCaseID.TRANSACTIONS,
                 },
-                PartitionIdxOffset(0, 1): {
+                BrokerMeta(Partition(Topic("topic"), 0), 1): {
                     "org_id": 1,
                     "name": "bar",
                     "tags": {},
                     "use_case_id": UseCaseID.SPANS,
                 },
-                PartitionIdxOffset(0, 2): {
+                BrokerMeta(Partition(Topic("topic"), 0), 2): {
                     "org_id": 1,
                     "name": "boo",
                     "tags": {},
@@ -169,9 +173,9 @@ def test_reject_all_with_default():
         )
 
         assert result.keys_to_remove == [
-            PartitionIdxOffset(0, 0),
-            PartitionIdxOffset(0, 1),
-            PartitionIdxOffset(0, 2),
+            BrokerMeta(Partition(Topic("topic"), 0), 0),
+            BrokerMeta(Partition(Topic("topic"), 0), 1),
+            BrokerMeta(Partition(Topic("topic"), 0), 2),
         ]
 
 
@@ -200,19 +204,19 @@ def test_reject_partial():
         result = limiter.check_cardinality_limits(
             UseCaseKey.PERFORMANCE,
             {
-                PartitionIdxOffset(0, 0): {
+                BrokerMeta(Partition(Topic("topic"), 0), 0): {
                     "org_id": 1,
                     "name": "foo",
                     "tags": {},
                     "use_case_id": UseCaseID.TRANSACTIONS,
                 },
-                PartitionIdxOffset(0, 1): {
+                BrokerMeta(Partition(Topic("topic"), 0), 1): {
                     "org_id": 1,
                     "name": "bar",
                     "tags": {},
                     "use_case_id": UseCaseID.TRANSACTIONS,
                 },
-                PartitionIdxOffset(0, 2): {
+                BrokerMeta(Partition(Topic("topic"), 0), 2): {
                     "org_id": 1,
                     "name": "baz",
                     "tags": {},
@@ -221,7 +225,7 @@ def test_reject_partial():
             },
         )
 
-        assert result.keys_to_remove == [PartitionIdxOffset(0, 2)]
+        assert result.keys_to_remove == [BrokerMeta(Partition(Topic("topic"), 0), 2)]
 
 
 def test_reject_partial_again():
@@ -249,31 +253,31 @@ def test_reject_partial_again():
         result = limiter.check_cardinality_limits(
             UseCaseKey.PERFORMANCE,
             {
-                PartitionIdxOffset(0, 0): {
+                BrokerMeta(Partition(Topic("topic"), 0), 0): {
                     "org_id": 1,
                     "name": "foo",
                     "tags": {},
                     "use_case_id": UseCaseID.TRANSACTIONS,
                 },
-                PartitionIdxOffset(0, 1): {
+                BrokerMeta(Partition(Topic("topic"), 0), 1): {
                     "org_id": 1,
                     "name": "bar",
                     "tags": {},
                     "use_case_id": UseCaseID.TRANSACTIONS,
                 },
-                PartitionIdxOffset(0, 2): {
+                BrokerMeta(Partition(Topic("topic"), 0), 2): {
                     "org_id": 1,
                     "name": "baz",
                     "tags": {},
                     "use_case_id": UseCaseID.SPANS,
                 },
-                PartitionIdxOffset(0, 3): {
+                BrokerMeta(Partition(Topic("topic"), 0), 3): {
                     "org_id": 1,
                     "name": "boo",
                     "tags": {},
                     "use_case_id": UseCaseID.CUSTOM,
                 },
-                PartitionIdxOffset(0, 4): {
+                BrokerMeta(Partition(Topic("topic"), 0), 4): {
                     "org_id": 1,
                     "name": "bye",
                     "tags": {},
@@ -282,7 +286,7 @@ def test_reject_partial_again():
             },
         )
 
-        assert result.keys_to_remove == [PartitionIdxOffset(0, 3)]
+        assert result.keys_to_remove == [BrokerMeta(Partition(Topic("topic"), 0), 3)]
 
 
 def test_accept_all():
@@ -314,31 +318,31 @@ def test_accept_all():
         result = limiter.check_cardinality_limits(
             UseCaseKey.PERFORMANCE,
             {
-                PartitionIdxOffset(0, 0): {
+                BrokerMeta(Partition(Topic("topic"), 0), 0): {
                     "org_id": 1,
                     "name": "foo",
                     "tags": {},
                     "use_case_id": UseCaseID.TRANSACTIONS,
                 },
-                PartitionIdxOffset(0, 1): {
+                BrokerMeta(Partition(Topic("topic"), 0), 1): {
                     "org_id": 1,
                     "name": "bar",
                     "tags": {},
                     "use_case_id": UseCaseID.TRANSACTIONS,
                 },
-                PartitionIdxOffset(0, 2): {
+                BrokerMeta(Partition(Topic("topic"), 0), 2): {
                     "org_id": 1,
                     "name": "baz",
                     "tags": {},
                     "use_case_id": UseCaseID.SPANS,
                 },
-                PartitionIdxOffset(0, 3): {
+                BrokerMeta(Partition(Topic("topic"), 0), 3): {
                     "org_id": 1,
                     "name": "bazz",
                     "tags": {},
                     "use_case_id": UseCaseID.ESCALATING_ISSUES,
                 },
-                PartitionIdxOffset(0, 4): {
+                BrokerMeta(Partition(Topic("topic"), 0), 4): {
                     "org_id": 1,
                     "name": "bye",
                     "tags": {},
@@ -378,19 +382,19 @@ def test_sample_rate_zero(set_sentry_option):
         result = limiter.check_cardinality_limits(
             UseCaseKey.PERFORMANCE,
             {
-                PartitionIdxOffset(0, 0): {
+                BrokerMeta(Partition(Topic("topic"), 0), 0): {
                     "org_id": 1,
                     "name": "foo",
                     "tags": {},
                     "use_case_id": UseCaseID.TRANSACTIONS,
                 },
-                PartitionIdxOffset(0, 1): {
+                BrokerMeta(Partition(Topic("topic"), 0), 1): {
                     "org_id": 1,
                     "name": "bar",
                     "tags": {},
                     "use_case_id": UseCaseID.SPANS,
                 },
-                PartitionIdxOffset(0, 2): {
+                BrokerMeta(Partition(Topic("topic"), 0), 2): {
                     "org_id": 1,
                     "name": "baz",
                     "tags": {},
@@ -433,13 +437,13 @@ def test_sample_rate_half(set_sentry_option):
         result = limiter.check_cardinality_limits(
             UseCaseKey.PERFORMANCE,
             {
-                PartitionIdxOffset(0, 0): {
+                BrokerMeta(Partition(Topic("topic"), 0), 0): {
                     "org_id": 1,
                     "name": "foo",
                     "tags": {},
                     "use_case_id": UseCaseID.TRANSACTIONS,
                 },
-                PartitionIdxOffset(0, 1): {
+                BrokerMeta(Partition(Topic("topic"), 0), 1): {
                     "org_id": 99,
                     "name": "bar",
                     "tags": {},
@@ -450,4 +454,4 @@ def test_sample_rate_half(set_sentry_option):
 
         # We are sampling org_id=1 into cardinality limiting. Because our quota is
         # zero, only that org's metrics are dropped.
-        assert result.keys_to_remove == [PartitionIdxOffset(0, 0)]
+        assert result.keys_to_remove == [BrokerMeta(Partition(Topic("topic"), 0), 0)]

--- a/tests/sentry/sentry_metrics/test_batch.py
+++ b/tests/sentry/sentry_metrics/test_batch.py
@@ -10,7 +10,8 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic, Value
 
 from sentry.sentry_metrics.aggregation_option_registry import AggregationOption
-from sentry.sentry_metrics.consumers.indexer.batch import IndexerBatch, PartitionIdxOffset
+from sentry.sentry_metrics.consumers.indexer.batch import IndexerBatch
+from sentry.sentry_metrics.consumers.indexer.common import BrokerMeta
 from sentry.sentry_metrics.consumers.indexer.tags_validator import ReleaseHealthTagsValidator
 from sentry.sentry_metrics.indexer.base import FetchType, FetchTypeExt, Metadata
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
@@ -1932,12 +1933,12 @@ def test_cardinality_limiter(caplog, settings):
         input_codec=_INGEST_CODEC,
         tags_validator=ReleaseHealthTagsValidator().is_allowed,
     )
-    keys_to_remove = list(batch.parsed_payloads_by_offset)[:2]
+    keys_to_remove = list(batch.parsed_payloads_by_meta)[:2]
     # the messages come in a certain order, and Python dictionaries preserve
     # their insertion order. So we can hardcode offsets here.
     assert keys_to_remove == [
-        PartitionIdxOffset(partition_idx=0, offset=0),
-        PartitionIdxOffset(partition_idx=0, offset=1),
+        BrokerMeta(partition=Partition(Topic("topic"), 0), offset=0),
+        BrokerMeta(partition=Partition(Topic("topic"), 0), offset=1),
     ]
     batch.filter_messages(keys_to_remove)
     assert batch.extract_strings() == {


### PR DESCRIPTION
# Add DLQ to release-health and generic metrics pipeline

This is a proof-of-concept, this pr will be revised to a working state and used for performance testing, but it will then be closed and broken up into incremental changes to be merged into prod.

### Overview

- Adds a `--enable-dlq` command line flag to sentry's consumer runner to toggle dlq
- Adds configuration about dlq topic for `ingest-metrics`, and `ingest-performance-metrics`
- Refactor batching mechanism for the metrics pipeline to store broker metadata for messages that are invalid, and messages that are skipped (rate limited)
- Updates the multiprocessing step to produce the broker metadata of the invalid messages, and the unbatcher to emit a `InvalidMessage` exception when encountering it
- Adds a new command line option for `send_metrics.py` to send malformed metric messages along with the other ones specified
- Update tests

### Local testing

<details>
<summary>Scenario 1: Processing failure at a location where the offset is recoverable</summary>

Run `python bin/send_metrics.py --num-bad-msg=28` to produce 12 valid metrics messages, and 28 malformed message mixed in, in random order.

```console
python bin/send_metrics.py --num-bad-msg=2
```

Start kcat on generic metrics' DLQ

```console
kcat -b localhost:9092 -t ingest-performance-metrics-dlq -C \
  -f '\nKey (%K bytes): %k
  Value (%S bytes): %s
  Timestamp: %T
  Partition: %p
  Offset: %o
  Headers: %h\n'
```

Confirm that 28 bad messages are in dlq

```console
Key (-1 bytes):
  Value (36 bytes): {"BAD_VALUE": "BCT32K3D", "idx": 17}
  Timestamp: 1697402976169
  Partition: 0
  Offset: 55
  Headers: original_partition=0,original_offset=116
% Reached end of topic ingest-performance-metrics-dlq [0] at offset 56

...

```

Confirm that the other message in the same batch is not lost

```sql
SELECT
    ...
WHERE arrayExists(v -> match(v, 'metric_e2e_.*BCT32K3D'), tags.raw_value)

Query id: dc46917f-4293-4f69-854e-76cf07e54107

┌─use_case_id───────┬─org_id─┬─project_id─┬─metric_id─┬───────────timestamp─┬─tags.key────────────────────────────────────────┬─tags.raw_value─────────────────────────────────────────────────────────┐
│ custom            │      1 │          3 │     65556 │ 2023-10-15 20:49:14 │ [67345,9223372036854776010,9223372036854776017] │ ['metric_e2e_custom_set_v_BCT32K3D','production','errored']            │
│ escalating_issues │      1 │          3 │     65545 │ 2023-10-15 20:49:14 │ [67348,9223372036854776010,9223372036854776017] │ ['metric_e2e_escalating_issues_set_v_BCT32K3D','production','errored'] │
│ spans             │      1 │          3 │     65536 │ 2023-10-15 20:49:14 │ [67354,9223372036854776010,9223372036854776017] │ ['metric_e2e_spans_set_v_BCT32K3D','production','errored']             │
│ transactions      │      1 │          3 │     65551 │ 2023-10-15 20:49:14 │ [67351,9223372036854776010,9223372036854776017] │ ['metric_e2e_transactions_set_v_BCT32K3D','production','errored']      │
└───────────────────┴────────┴────────────┴───────────┴─────────────────────┴─────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────┘
┌─use_case_id───────┬─org_id─┬─project_id─┬─metric_id─┬───────────timestamp─┬─tags.key────────────────────────────────────────┬─tags.raw_value──────────────────────────────────────────────────────────┐
│ custom            │      1 │          3 │     65555 │ 2023-10-15 20:49:14 │ [67347,9223372036854776010,9223372036854776017] │ ['metric_e2e_custom_counter_v_BCT32K3D','production','init']            │
│ escalating_issues │      1 │          3 │     65547 │ 2023-10-15 20:49:14 │ [67350,9223372036854776010,9223372036854776017] │ ['metric_e2e_escalating_issues_counter_v_BCT32K3D','production','init'] │
│ spans             │      1 │          3 │     65537 │ 2023-10-15 20:49:14 │ [67355,9223372036854776010,9223372036854776017] │ ['metric_e2e_spans_counter_v_BCT32K3D','production','init']             │
│ transactions      │      1 │          3 │     65553 │ 2023-10-15 20:49:14 │ [67353,9223372036854776010,9223372036854776017] │ ['metric_e2e_transactions_counter_v_BCT32K3D','production','init']      │
└───────────────────┴────────┴────────────┴───────────┴─────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────┘
┌─use_case_id───────┬─org_id─┬─project_id─┬─metric_id─┬───────────timestamp─┬─tags.key────────────────────────────────────────┬─tags.raw_value──────────────────────────────────────────────────────────┐
│ custom            │      1 │          3 │     65558 │ 2023-10-15 20:49:14 │ [67346,9223372036854776010,9223372036854776017] │ ['metric_e2e_custom_dist_v_BCT32K3D','production','healthy']            │
│ escalating_issues │      1 │          3 │     65546 │ 2023-10-15 20:49:14 │ [67349,9223372036854776010,9223372036854776017] │ ['metric_e2e_escalating_issues_dist_v_BCT32K3D','production','healthy'] │
│ spans             │      1 │          3 │     65538 │ 2023-10-15 20:49:14 │ [67356,9223372036854776010,9223372036854776017] │ ['metric_e2e_spans_dist_v_BCT32K3D','production','healthy']             │
│ transactions      │      1 │          3 │     65550 │ 2023-10-15 20:49:14 │ [67352,9223372036854776010,9223372036854776017] │ ['metric_e2e_transactions_dist_v_BCT32K3D','production','healthy']      │
└───────────────────┴────────┴────────────┴───────────┴─────────────────────┴─────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────┘

12 rows in set. Elapsed: 0.022 sec.
```

</details>



<details>
<summary>
Scenario 2: Processing failure at a location where the offset is unrecoverable
</summary>

Set custom use case cardinality limit to an invalid value

```python
register(
    "sentry-metrics.cardinality-limiter.limits.custom.per-org",
    default=[],
    flags=FLAG_AUTOMATOR_MODIFIABLE,
)
```

Start kcat on generic metrics' DLQ

```console
kcat -b localhost:9092 -t ingest-performance-metrics-dlq -C \
  -f '\nKey (%K bytes): %k
  Value (%S bytes): %s
  Timestamp: %T
  Partition: %p
  Offset: %o
  Headers: %h\n'
```


Run `python bin/send_metrics.py` to produce 12 valid metrics messages.

```console
python bin/send_metrics.py --num-bad-msg=28
```

Confirm that all messages are in dlq

```
Key (-1 bytes):
  Value (321 bytes): {"name": "d:escalating_issues/duration@second", "tags": {"environment": "production", "session.status": "healthy", "metric_e2e_escalating_issues_dist_k_09WYZ36M": "metric_e2e_escalating_issues_dist_v_09WYZ36M"}, "timestamp": 1697402773, "type": "d", "value": [4, 5, 6], "org_id": 1, "retention_days": 90, "project_id": 3}
  Timestamp: 1697402796135
  Partition: 0
  Offset: 32
  Headers: original_partition=0,original_offset=93
% Reached end of topic ingest-performance-metrics-dlq [0] at offset 33
```


</details>