### PR TITLE
chore(performance-detector-thresholds): Flipping default flag val to True

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1696,7 +1696,7 @@ SENTRY_FEATURES = {
     # Enable performance issues dev options, includes changing parts of issues that we're using for development.
     "organizations:performance-issues-dev": False,
     # Enable performance issues detector threshold configuration
-    "organizations:project-performance-settings-admin": False,
+    "organizations:project-performance-settings-admin": True,
     # Enable feature to load more than 100 rows in performance trace view.
     "organizations:trace-view-load-more": False,
     # Enable dashboard widget indicators.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1340,12 +1340,12 @@ register(
 )
 register(
     "performance.issues.n_plus_one_db.duration_threshold",
-    default=90.0,
+    default=50.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "performance.issues.slow_db_query.duration_threshold",
-    default=900.0,  # ms
+    default=500.0,  # ms
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
@@ -1380,7 +1380,7 @@ register(
 )
 register(
     "performance.issues.consecutive_http.span_duration_threshold",
-    default=900,  # ms
+    default=500,  # ms
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -102,6 +102,7 @@ class OrganizationSerializerTest(TestCase):
             "performance-issues-search",
             "transaction-name-normalize",
             "transaction-name-mark-scrubbed-as-sanitized",
+            "project-performance-settings-admin",
         }
 
     @mock.patch("sentry.features.batch_has")

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -183,7 +183,7 @@ class PerformanceDetectionTest(TestCase):
 
         default_settings = get_detection_settings(self.project)
 
-        assert default_settings[DetectorType.N_PLUS_ONE_DB_QUERIES]["duration_threshold"] == 90
+        assert default_settings[DetectorType.N_PLUS_ONE_DB_QUERIES]["duration_threshold"] == 50
         assert (
             default_settings[DetectorType.RENDER_BLOCKING_ASSET_SPAN]["fcp_ratio_threshold"] == 0.33
         )
@@ -197,7 +197,7 @@ class PerformanceDetectionTest(TestCase):
         assert default_settings[DetectorType.N_PLUS_ONE_API_CALLS]["total_duration"] == 300
         assert default_settings[DetectorType.LARGE_HTTP_PAYLOAD]["payload_size_threshold"] == 300000
         assert default_settings[DetectorType.CONSECUTIVE_HTTP_OP]["min_time_saved"] == 2000
-        assert default_settings[DetectorType.SLOW_DB_QUERY][0]["duration_threshold"] == 900
+        assert default_settings[DetectorType.SLOW_DB_QUERY][0]["duration_threshold"] == 500
 
         self.project_option_mock.return_value = {
             "n_plus_one_db_duration_threshold": 100000,

--- a/tests/sentry/utils/performance_issues/test_slow_db_span_detector.py
+++ b/tests/sentry/utils/performance_issues/test_slow_db_span_detector.py
@@ -34,7 +34,7 @@ class SlowDBQueryDetectorTest(TestCase):
         return list(detector.stored_problems.values())
 
     def test_calls_detect_slow_span(self):
-        no_slow_span_event = create_event([create_span("db", 899.0)] * 1)
+        no_slow_span_event = create_event([create_span("db", 499.0)] * 1)
         slow_not_allowed_op_span_event = create_event([create_span("random", 1001.0, "example")])
         slow_span_event = create_event([create_span("db", 1001.0)] * 1)
 


### PR DESCRIPTION
- Enables detector thresholds settings to ST/SH.
- Addresses issue: https://github.com/getsentry/sentry/issues/57921
- Made default thresholds in the server the same as what we have in prod.