### PR TITLE
feat(hybridcloud) Include org_id in reply-to addresses

### DIFF
--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -35,7 +35,7 @@ def get_headers(notification: BaseNotification) -> Mapping[str, Any]:
             {
                 "X-Sentry-Logger": group.logger,
                 "X-Sentry-Logger-Level": group.get_level_display(),
-                "X-Sentry-Reply-To": group_id_to_email(group.id),
+                "X-Sentry-Reply-To": group_id_to_email(group.id, group.project.organization_id),
             }
         )
 

--- a/src/sentry/services/smtp.py
+++ b/src/sentry/services/smtp.py
@@ -35,7 +35,7 @@ class SentrySMTPServer(Service, SMTPServer):
             return STATUS[552]
 
         try:
-            group_id = email_to_group_id(rcpttos[0])
+            group_id, org_id = email_to_group_id(rcpttos[0])
         except Exception:
             logger.info("%r is not a valid email address", rcpttos)
             return STATUS[550]
@@ -58,6 +58,7 @@ class SentrySMTPServer(Service, SMTPServer):
             # If there's no body, we don't need to go any further
             return STATUS[200]
 
+        # TODO(hybridcloud) this needs to emit an outbox to the correct region.
         process_inbound_email.delay(mailfrom, group_id, payload)
         return STATUS[200]
 

--- a/src/sentry/utils/email/address.py
+++ b/src/sentry/utils/email/address.py
@@ -4,7 +4,6 @@ import re
 from email.utils import parseaddr
 
 from django.conf import settings
-from django.utils.encoding import force_bytes
 
 from sentry import options
 
@@ -28,18 +27,30 @@ def get_from_email_domain() -> str:
     return _from_email_domain_cache[1]
 
 
-def email_to_group_id(address: str) -> int:
+def email_to_group_id(address: str) -> tuple[int | None, int | None]:
     """
     Email address should be in the form of:
         {group_id}+{signature}@example.com
+    Or
+        {group_id}.{org_id}+{signature}@example.com
+
+    The form with org_id and group_id is newer
+    and required for multi-region sentry
     """
     address = address.split("@", 1)[0]
     signed_data = address.replace("+", ":")
-    return int(force_bytes(signer.unsign(signed_data)))
+    unsigned = signer.unsign(signed_data)
+    if "." in unsigned:
+        parts = unsigned.split(".")
+        return (int(parts[0]), int(parts[1]))
+    return (int(unsigned), None)
 
 
-def group_id_to_email(group_id: int) -> str:
-    signed_data = signer.sign(str(group_id))
+def group_id_to_email(group_id: int, org_id: int | None = None) -> str:
+    sign_value = str(group_id)
+    if org_id:
+        sign_value = f"{group_id}.{org_id}"
+    signed_data = signer.sign(sign_value)
     return "@".join(
         (
             signed_data.replace(":", "+"),

--- a/src/sentry/web/frontend/mailgun_inbound_webhook.py
+++ b/src/sentry/web/frontend/mailgun_inbound_webhook.py
@@ -52,7 +52,8 @@ class MailgunInboundWebhookView(View):
         from_email = request.POST["sender"]
 
         try:
-            group_id = email_to_group_id(to_email)
+            # This needs to return a tuple of orgid, groupid
+            group_id, org_id = email_to_group_id(to_email)
         except Exception:
             logger.info("mailgun.invalid-email", extra={"email": to_email})
             return HttpResponse(status=200)
@@ -62,6 +63,8 @@ class MailgunInboundWebhookView(View):
             # If there's no body, we don't need to go any further
             return HttpResponse(status=200)
 
+        # TODO(hybridcloud) This needs to become an outbox message for the payload
+        # that is delivered to the correct region/org
         process_inbound_email.delay(from_email, group_id, payload)
 
         return HttpResponse(status=201)

--- a/tests/sentry/services/test_smtp.py
+++ b/tests/sentry/services/test_smtp.py
@@ -22,7 +22,7 @@ class SentrySMTPTest(TestCase):
         self.event  # side effect of generating an event
 
     def test_decode_email_address(self):
-        self.assertEqual(email_to_group_id(self.mailto), self.group.id)
+        assert email_to_group_id(self.mailto) == (self.group.id, self.organization.id)
 
     def test_process_message(self):
         with self.tasks():

--- a/tests/sentry/services/test_smtp.py
+++ b/tests/sentry/services/test_smtp.py
@@ -18,11 +18,11 @@ class SentrySMTPTest(TestCase):
     def setUp(self):
         self.address = ("0.0.0.0", 0)
         self.server = SentrySMTPServer(*self.address)
-        self.mailto = group_id_to_email(self.group.pk)
+        self.mailto = group_id_to_email(self.group.id, self.organization.id)
         self.event  # side effect of generating an event
 
     def test_decode_email_address(self):
-        self.assertEqual(email_to_group_id(self.mailto), self.group.pk)
+        self.assertEqual(email_to_group_id(self.mailto), self.group.id)
 
     def test_process_message(self):
         with self.tasks():

--- a/tests/sentry/utils/email/test_address.py
+++ b/tests/sentry/utils/email/test_address.py
@@ -1,60 +1,105 @@
-from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import control_silo_test
+import pytest
+from django.core.signing import BadSignature
+
+from sentry import options
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils.email.address import (
+    email_to_group_id,
     get_from_email_domain,
+    group_id_to_email,
     is_valid_email_address,
     parse_email,
     parse_user_name,
 )
 
 
-class GetFromEmailDomainTest(TestCase):
-    def test_get_from_email_domain(self):
-        with self.options({"mail.from": "matt@example.com"}):
-            assert get_from_email_domain() == "example.com"
+@django_db_all
+def test_get_from_email_domain():
+    with override_options({"mail.from": "matt@example.com"}):
+        assert get_from_email_domain() == "example.com"
 
-        with self.options({"mail.from": "root@localhost"}):
-            assert get_from_email_domain() == "localhost"
+    with override_options({"mail.from": "root@localhost"}):
+        assert get_from_email_domain() == "localhost"
 
-        with self.options({"mail.from": "garbage"}):
-            assert get_from_email_domain() == "garbage"
-
-
-class ValidEmailTest(TestCase):
-    def test_is_valid_email_address_number_at_qqcom(self):
-        assert is_valid_email_address("12345@qq.com") is False
-
-    def test_is_valid_email_address_normal_human_email_address(self):
-        assert is_valid_email_address("dcramer@gmail.com") is True
+    with override_options({"mail.from": "garbage"}):
+        assert get_from_email_domain() == "garbage"
 
 
-class ParseEmailTest(TestCase):
-    def test_empty(self):
-        assert parse_email("") == ""
-
-    def test_no_email(self):
-        assert parse_email("marcos@sentry.io") == ""
-
-    def test_empty_email(self):
-        assert parse_email("<>") == ""
-
-    def test_two_emails(self):
-        assert parse_email("<a><b>") == "a"
-
-    def test_simple(self):
-        assert parse_email("lauryn <lauryn@sentry.io>") == "lauryn@sentry.io"
+def test_is_valid_email_address_number_at_qqcom():
+    assert is_valid_email_address("12345@qq.com") is False
 
 
-@control_silo_test(stable=True)
-class ParseUserNameTest(TestCase):
-    def test_empty(self):
-        assert parse_user_name("") == ""
+def test_is_valid_email_address_normal_human_email_address():
+    assert is_valid_email_address("dcramer@gmail.com") is True
 
-    def test_no_email(self):
-        assert parse_user_name("marcos@sentry.io") == "marcos@sentry.io"
 
-    def test_empty_email(self):
-        assert parse_user_name("<>") == ""
+def test_parse_email_empty():
+    assert parse_email("") == ""
 
-    def test_simple(self):
-        assert parse_user_name("Max Bittker <max@getsentry.com>") == "Max Bittker"
+
+def test_parse_email_no_email():
+    assert parse_email("marcos@sentry.io") == ""
+
+
+def test_parse_email_empty_email():
+    assert parse_email("<>") == ""
+
+
+def test_parse_email_two_emails():
+    assert parse_email("<a><b>") == "a"
+
+
+def test_parse_email_simple():
+    assert parse_email("lauryn <lauryn@sentry.io>") == "lauryn@sentry.io"
+
+
+def test_parse_user_name_empty():
+    assert parse_user_name("") == ""
+
+
+def test_parse_user_name_no_email():
+    assert parse_user_name("marcos@sentry.io") == "marcos@sentry.io"
+
+
+def test_parse_user_name_empty_email():
+    assert parse_user_name("<>") == ""
+
+
+def test_parse_user_name_simple():
+    assert parse_user_name("Max Bittker <max@getsentry.com>") == "Max Bittker"
+
+
+@django_db_all
+def test_group_id_to_email_backwards_compat():
+    mailhost = options.get("mail.reply-hostname")
+    group_id = 1234567
+
+    signed = group_id_to_email(group_id)
+    assert f"@{mailhost}" in signed
+    assert f"{group_id}+" in signed
+
+    result_group_id, org_id = email_to_group_id(signed)
+    assert result_group_id == group_id
+    assert org_id is None
+
+
+@django_db_all
+def test_group_id_to_email_with_org_id():
+    mailhost = options.get("mail.reply-hostname")
+    group_id = 1234567
+    org_id = 9876543
+
+    signed = group_id_to_email(group_id, org_id)
+    assert f"@{mailhost}" in signed
+    assert f"{group_id}.{org_id}+" in signed
+
+    result_group_id, result_org_id = email_to_group_id(signed)
+    assert result_group_id == group_id
+    assert result_org_id == org_id
+
+    with pytest.raises(BadSignature):
+        assert email_to_group_id(f"trash@{mailhost}") == (None, None)
+
+    with pytest.raises(BadSignature):
+        assert email_to_group_id(f"trash:rubbish@{mailhost}") == (None, None)

--- a/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
+++ b/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
@@ -44,6 +44,7 @@ class TestMailgunInboundWebhookView(TestCase):
             },
         )
         assert resp.status_code == 500
+        assert process_inbound_email.call_count == 0
 
     @mock.patch("sentry.web.frontend.mailgun_inbound_webhook.process_inbound_email")
     def test_simple(self, process_inbound_email):


### PR DESCRIPTION
In order to route messages to the regions, we need to encode the org_id into the address. This is the first of a few changes that need to be made to mailgun messaging.

Next, I'm planning to convert reply processing from a celery task into an outbox that can be delivered to the target region that contains the organization and group.

If in the future we handle a reply that does not include an organization id, we can assume that it is from a MONOLITH_REGION organization and act accordingly.

Refs HC-552