### PR TITLE
feat(crons): Limit clock ticks to the slowest partition

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -570,15 +570,20 @@ def _process_checkin(
         logger.exception("Failed to process check-in", exc_info=True)
 
 
-def _process_message(ts: datetime, wrapper: CheckinMessage | ClockPulseMessage) -> None:
-    # XXX: Relay does not attach a message type, to properly discriminate
-    # we add it by default here. This can be removed once the message_type
-    # is guaranteed
+def _process_message(
+    ts: datetime,
+    partition: int,
+    wrapper: CheckinMessage | ClockPulseMessage,
+) -> None:
+
+    # XXX: Relay does not attach a message type, to properly discriminate the
+    # message_type we add it by default here. This can be removed once the
+    # message_type is guaranteed
     if "message_type" not in wrapper:
         wrapper["message_type"] = "check_in"
 
     try:
-        try_monitor_tasks_trigger(ts)
+        try_monitor_tasks_trigger(ts, partition)
     except Exception:
         logger.exception("Failed to trigger monitor tasks", exc_info=True)
 
@@ -608,7 +613,11 @@ class StoreMonitorCheckInStrategyFactory(ProcessingStrategyFactory[KafkaPayload]
             assert isinstance(message.value, BrokerValue)
             try:
                 wrapper = msgpack.unpackb(message.payload.value)
-                _process_message(message.value.timestamp, wrapper)
+                _process_message(
+                    message.value.timestamp,
+                    message.value.partition.index,
+                    wrapper,
+                )
             except Exception:
                 logger.exception("Failed to process message payload")
 


### PR DESCRIPTION
Part of https://github.com/getsentry/sentry/issues/55821

This function keeps a global clock driven by the monitor ingest topic to trigger the monitor tasks once per minute.

This change updates this function to track the slowest partition within the topic. This will help to avoid the clock being moved forward when a single partition has a large number of check-ins read out of it (in a backlog situation), causing check-ins to be marked missed since they were not read before the clock ticked.

This change does NOT yet use the slowest partition timestamp as the driver of the global clock, but simply logs the timestamp so we can validate in production that it is still accurately moving forward.

In a future PR I will switch this function to use the slowest partition timestamp as the `reference_ts` and add tests to validate this works