### PR TITLE
fix(discord): Handle channel id none error

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -32,8 +32,7 @@ class AlertRuleTriggerActionSerializer(Serializer):
                     "discord.action.description.no.channel",
                     extra={"target_identifier": action.target_identifier},
                 )
-                action.target_display = ""
-            return "Send a Discord notification to " + action.target_display
+            return f"Send a Discord notification to {action.target_display or ''}"
 
     def get_identifier_from_action(self, action):
         if action.type in [

--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -1,5 +1,9 @@
+import logging
+
 from sentry.api.serializers import Serializer, register
 from sentry.incidents.models import AlertRuleTriggerAction
+
+logger = logging.getLogger(__name__)
 
 
 @register(AlertRuleTriggerAction)
@@ -23,6 +27,12 @@ class AlertRuleTriggerActionSerializer(Serializer):
         elif action.type == action.Type.OPSGENIE.value:
             return "Send an Opsgenie notification to " + action.target_display
         elif action.type == action.Type.DISCORD.value:
+            if not action.target_display:
+                logger.info(
+                    "discord.action.description.no.channel",
+                    extra={"target_identifier": action.target_identifier},
+                )
+                action.target_display = ""
             return "Send a Discord notification to " + action.target_display
 
     def get_identifier_from_action(self, action):


### PR DESCRIPTION
Found in [logs](https://console.cloud.google.com/logs/query;cursorTimestamp=2023-10-12T18:49:53.320159585Z;duration=PT6H;query=SEARCH%2528%22%60discord%60%22%2529%0A--Hide%20similar%20entries%0A-%2528jsonPayload.response_code%3D%22200%22%2529%0A--End%20of%20hide%20similar%20entries%0Aseverity%3DERROR%0A--Hide%20similar%20entries%0A-%2528textPayload%3D~%22%2528%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%2529%20-%20-%20%5C%5B12%2FOct%2F20%2528%2528%5Cd%7B2%7D%2529:%2528%5Cd%7B2%7D%2529%2528%3F::%2528%5Cd%7B2%7D%2528%3F:%5C.%5Cd*%2529%3F%2529%2529%3F%2528%3F:%2528%5B%2B-%5D%2528%3F:%5Cd%7B2%7D%2529:%3F%2528%3F:%5Cd%7B2%7D%2529%3F%7CZ%2529%3F%2529%2529%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D%2B%20%2B0000%5C%5D%20%5C%22POST%20%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D%2B%20HTTP%2F1.1%5C%22%20%2528%2528%3F:%5Cd%5B,.%5D%3F%2529*%5Cd%2529%20%2528%2528%3F:%5Cd%5B,.%5D%3F%2529*%5Cd%2529%20%5C%22https:%2F%2Fdiscord.sentry.io%2F%5C%22%20%5C%22Mozilla%2F5.0%20%5C%2528Macintosh%3B%20Intel%20Mac%20OS%20X%2010_15_7%5C%2529%20AppleWebKit%2F537.36%20%5C%2528KHTML,%20like%20Gecko%5C%2529%20Chrome%2F%2528%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%2529%20Safari%2F537.36%22%2529%0A--End%20of%20hide%20similar%20entries%0A--Hide%20similar%20entries%0A-%2528textPayload%3D~%22%2528%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%2529%20-%20-%20%5C%5B12%2FOct%2F20%2528%2528%5Cd%7B2%7D%2529:%2528%5Cd%7B2%7D%2529%2528%3F::%2528%5Cd%7B2%7D%2528%3F:%5C.%5Cd*%2529%3F%2529%2529%3F%2528%3F:%2528%5B%2B-%5D%2528%3F:%5Cd%7B2%7D%2529:%3F%2528%3F:%5Cd%7B2%7D%2529%3F%7CZ%2529%3F%2529%2529%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D%2B%20%2B0000%5C%5D%20%5C%22POST%20%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D%2B%20HTTP%2F1.1%5C%22%20%2528%2528%3F:%5Cd%5B,.%5D%3F%2529*%5Cd%2529%20%2528%2528%3F:%5Cd%5B,.%5D%3F%2529*%5Cd%2529%20%5C%22https:%2F%2Fdiscord.sentry.io%2F%5C%22%20%5C%22Mozilla%2F5.0%20%5C%2528Macintosh%3B%20Intel%20Mac%20OS%20X%2010_15_7%5C%2529%20AppleWebKit%2F537.36%20%5C%2528KHTML,%20like%20Gecko%5C%2529%20Chrome%2F%2528%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%2529%20Safari%2F537.36%22%2529%0A--End%20of%20hide%20similar%20entries%0A--Hide%20similar%20entries%0A-%2528textPayload%3D~%22%2528%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%2529%20-%20-%20%5C%5B12%2FOct%2F20%2528%2528%5Cd%7B2%7D%2529:%2528%5Cd%7B2%7D%2529%2528%3F::%2528%5Cd%7B2%7D%2528%3F:%5C.%5Cd*%2529%3F%2529%2529%3F%2528%3F:%2528%5B%2B-%5D%2528%3F:%5Cd%7B2%7D%2529:%3F%2528%3F:%5Cd%7B2%7D%2529%3F%7CZ%2529%3F%2529%2529%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D%2B%20%2B0000%5C%5D%20%5C%22POST%20%5B%5E%20%3D%5Ct%5Cn%5Cr%5Cf%5C%22%5C%2528%5C%2529%5C%5B%5C%5D%5C%7C'%5D%2B%20HTTP%2F1.1%5C%22%20%2528%2528%3F:%5Cd%5B,.%5D%3F%2529*%5Cd%2529%20%2528%2528%3F:%5Cd%5B,.%5D%3F%2529*%5Cd%2529%20%5C%22https:%2F%2Fdiscord.sentry.io%2F%5C%22%20%5C%22Mozilla%2F5.0%20%5C%2528Macintosh%3B%20Intel%20Mac%20OS%20X%2010_15_7%5C%2529%20AppleWebKit%2F537.36%20%5C%2528KHTML,%20like%20Gecko%5C%2529%20Chrome%2F%2528%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%5C.%5Cd%7B1,3%7D%2529%20Safari%2F537.36%22%2529%0A--End%20of%20hide%20similar%20entries%0Atimestamp%3D%222023-10-12T18:49:53.320159585Z%22%0AinsertId%3D%22q8fpexeas8wgoblh%22%0Atimestamp%3D%222023-10-12T18:49:53.320159585Z%22%0AinsertId%3D%22q8fpexeas8wgoblh%22;summaryFields=:false:32:beginning?project=internal-sentry)

return "Send a Discord notification to " + action.target_display
TypeError: can only concatenate str (not "NoneType") to str