### PR TITLE
fix(replays): don't overfetch url

### DIFF
--- a/fixtures/js-stubs/replayList.ts
+++ b/fixtures/js-stubs/replayList.ts
@@ -28,7 +28,6 @@ export function ReplayList(
       },
       project_id: '2',
       started_at: new Date('2022-09-15T06:50:03+00:00'),
-      urls: [],
       user: {
         display_name: 'testDisplayName',
         email: '',

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -137,7 +137,6 @@ describe('GroupReplays', () => {
                 'os',
                 'project_id',
                 'started_at',
-                'urls',
                 'user',
               ],
               per_page: 50,

--- a/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
+++ b/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
@@ -53,7 +53,6 @@ export default function ExampleReplaysList({
             'finished_at',
             'is_archived',
             'started_at',
-            'urls',
           ],
           projects: [projectId],
           query: selectorQuery,

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -124,7 +124,6 @@ export const REPLAY_LIST_FIELDS = [
   'os.version',
   'project_id',
   'started_at',
-  'urls',
   'user',
 ];
 
@@ -143,7 +142,6 @@ export type ReplayListRecord = Pick<
   | 'os'
   | 'project_id'
   | 'started_at'
-  | 'urls'
   | 'user'
 >;
 


### PR DESCRIPTION
since we deleted our `StringWalker` / displaying URLs in the `ReplayCell`, we no longer need to fetch URLs 