### PR TITLE
fix(fly): add terms sentence

### DIFF
--- a/src/sentry/templates/sentry/organization-login.html
+++ b/src/sentry/templates/sentry/organization-login.html
@@ -69,10 +69,15 @@
           Sign in with your {{ provider_name }} account to continue.
           {% endif %}
         </p>
-
         <p><button type="submit" class="btn btn-default btn-login-{{ provider_key }}">
           <span class="provider-logo {{ provider_key }}"></span> Login with {{ provider_name }}
         </button></p>
+        <div class="auth-terms">
+        {% if terms_url and privacy_policy_url and is_provider_partner %}
+          By clicking the login button you are accepting Sentry’s <a href="{{ terms_url }}" target="_blank">terms of service</a> and <a href="{{ privacy_policy_url }}" target="_blank">privacy policy</a>.
+        {% endif %}
+        </div>
+      </p>
       </div>
     </form>
   {% else %}

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -12,6 +12,9 @@ from sentry.services.hybrid_cloud.organization import RpcOrganization, organizat
 from sentry.utils.auth import initiate_login
 from sentry.web.frontend.auth_login import AuthLoginView
 
+TERMS_URL = "https://sentry.io/terms/"
+PRIVACY_POLICY_URL = "https://sentry.io/privacy/"
+
 
 class AuthOrganizationLoginView(AuthLoginView):
     def respond_login(self, request: Request, context, *args, **kwargs) -> HttpResponse:
@@ -37,7 +40,6 @@ class AuthOrganizationLoginView(AuthLoginView):
             return helper.current_step()
 
         provider = auth_provider.get_provider()
-
         context = {
             "CAN_REGISTER": False,
             "organization": organization,
@@ -45,6 +47,9 @@ class AuthOrganizationLoginView(AuthLoginView):
             "provider_name": provider.name,
             "authenticated": request.user.is_authenticated,
             "referrer": referrer,
+            "terms_url": TERMS_URL,
+            "privacy_policy_url": PRIVACY_POLICY_URL,
+            "is_provider_partner": provider.is_partner,
         }
 
         return self.respond("sentry/organization-login.html", context)

--- a/static/less/layout.less
+++ b/static/less/layout.less
@@ -225,6 +225,16 @@ body.auth {
     }
   }
 
+  .auth-terms {
+    color: @gray-light;
+    a {
+      color: @gray-light;
+      &:hover {
+        color: @gray-dark;
+      }
+    }
+  }
+
   .auth-toggle {
     display: flex;
   }


### PR DESCRIPTION
request by legal: https://www.notion.so/sentry/Fly-partnership-changes-to-meet-legal-standards-471fca1333804ccbac3d7f5e398ef77d?pvs=4#b097800bcb8b4c8d9c3dcf22f54d0170


before (and after if provider.is_partner is False. It is True only for Fly):
![Screenshot 2023-10-12 at 1 13 59 PM](https://github.com/getsentry/sentry/assets/132939361/287f6eab-bee6-4729-93c9-d9255fd214a3)

after:
![Screenshot 2023-10-12 at 12 58 13 PM](https://github.com/getsentry/sentry/assets/132939361/e6271d6b-7745-4e62-b8e7-d5c99ebb9cd4)

Hovering on links shows that they're clickable:
![Screenshot 2023-10-12 at 1 07 00 PM](https://github.com/getsentry/sentry/assets/132939361/e023f0fb-63c0-415f-bfee-c4970a64c9e0)

Clicking on links will open a new tab.
