### PR TITLE
feat(backup): Support export encryption

### DIFF
--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -15,6 +15,19 @@ from sentry.backup.validate import validate
 from sentry.runner.decorators import configuration
 from sentry.utils import json
 
+ENCRYPT_WITH_HELP = """A path to the a public key with which to encrypt this export. If this flag is
+                       enabled and points to a valid key, the output file will be a tarball
+                       containing 3 constituent files: 1. An encrypted JSON file called
+                       `export.json`, which is encrypted using 2. An asymmetrically encrypted data
+                       encryption key (DEK) called `data.key`, which is itself encrypted by 3. The
+                       public key contained in the file supplied to this flag, called `key.pub`. To
+                       decrypt the exported JSON data, decryptors should use the private key paired
+                       with `key.pub` to decrypt the DEK, which can then be used to decrypt the
+                       export data in `export.json`."""
+
+FINDINGS_FILE_HELP = """Optional file that records comparator findings, saved in the JSON format.
+                     If left unset, no such file is written."""
+
 MERGE_USERS_HELP = """If this flag is set and users in the import JSON have matching usernames to
                    those already in the database, the existing users are used instead and their
                    associated user scope models are not updated. If this flag is not set, new users
@@ -26,9 +39,6 @@ OVERWRITE_CONFIGS_HELP = """Imports are generally non-destructive of old data. H
                          with an existing value, the new value will overwrite the existing one. If
                          the flag is left in its (default) unset state, the old value will be
                          retained in the event of a collision."""
-
-FINDINGS_FILE_HELP = """Optional file that records comparator findings, saved in the JSON format.
-                     If left unset, no such file is written."""
 
 
 def parse_filter_arg(filter_arg: str) -> set[str] | None:
@@ -210,13 +220,11 @@ def export():
 
 
 @export.command(name="users")
-@click.argument("dest", default="-", type=click.File("w"))
-@click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
+@click.argument("dest", default="-", type=click.File("wb"))
 @click.option(
-    "--indent",
-    default=2,
-    type=int,
-    help="Number of spaces to indent for the JSON output. (default: 2)",
+    "--encrypt_with",
+    type=click.File("rb"),
+    help=ENCRYPT_WITH_HELP,
 )
 @click.option(
     "--filter_usernames",
@@ -225,8 +233,15 @@ def export():
     help="An optional comma-separated list of users to include. "
     "If this option is not set, all encountered users are imported.",
 )
+@click.option(
+    "--indent",
+    default=2,
+    type=int,
+    help="Number of spaces to indent for the JSON output. (default: 2)",
+)
+@click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
-def export_users(dest, silent, indent, filter_usernames):
+def export_users(dest, encrypt_with, filter_usernames, indent, silent):
     """
     Export all Sentry users in the JSON format.
     """
@@ -235,6 +250,7 @@ def export_users(dest, silent, indent, filter_usernames):
 
     export_in_user_scope(
         dest,
+        encrypt_with=encrypt_with,
         indent=indent,
         user_filter=parse_filter_arg(filter_usernames),
         printer=(lambda *args, **kwargs: None) if silent else click.echo,
@@ -242,13 +258,11 @@ def export_users(dest, silent, indent, filter_usernames):
 
 
 @export.command(name="organizations")
-@click.argument("dest", default="-", type=click.File("w"))
-@click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
+@click.argument("dest", default="-", type=click.File("wb"))
 @click.option(
-    "--indent",
-    default=2,
-    type=int,
-    help="Number of spaces to indent for the JSON output. (default: 2)",
+    "--encrypt_with",
+    type=click.File("rb"),
+    help=ENCRYPT_WITH_HELP,
 )
 @click.option(
     "--filter_org_slugs",
@@ -258,8 +272,15 @@ def export_users(dest, silent, indent, filter_usernames):
     "If this option is not set, all encountered organizations are exported. "
     "Users not members of at least one organization in this set will not be exported.",
 )
+@click.option(
+    "--indent",
+    default=2,
+    type=int,
+    help="Number of spaces to indent for the JSON output. (default: 2)",
+)
+@click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
-def export_organizations(dest, silent, indent, filter_org_slugs):
+def export_organizations(dest, encrypt_with, filter_org_slugs, indent, silent):
     """
     Export all Sentry organizations, and their constituent users, in the JSON format.
     """
@@ -268,6 +289,7 @@ def export_organizations(dest, silent, indent, filter_org_slugs):
 
     export_in_organization_scope(
         dest,
+        encrypt_with=encrypt_with,
         indent=indent,
         org_filter=parse_filter_arg(filter_org_slugs),
         printer=(lambda *args, **kwargs: None) if silent else click.echo,
@@ -275,16 +297,21 @@ def export_organizations(dest, silent, indent, filter_org_slugs):
 
 
 @export.command(name="config")
-@click.argument("dest", default="-", type=click.File("w"))
-@click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
+@click.argument("dest", default="-", type=click.File("wb"))
+@click.option(
+    "--encrypt_with",
+    type=click.File("rb"),
+    help=ENCRYPT_WITH_HELP,
+)
 @click.option(
     "--indent",
     default=2,
     type=int,
     help="Number of spaces to indent for the JSON output. (default: 2)",
 )
+@click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
-def export_config(dest, silent, indent):
+def export_config(dest, encrypt_with, indent, silent):
     """
     Export all configuration and administrator accounts needed to set up this Sentry instance.
     """
@@ -293,22 +320,28 @@ def export_config(dest, silent, indent):
 
     export_in_config_scope(
         dest,
+        encrypt_with=encrypt_with,
         indent=indent,
         printer=(lambda *args, **kwargs: None) if silent else click.echo,
     )
 
 
 @export.command(name="global")
-@click.argument("dest", default="-", type=click.File("w"))
-@click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
+@click.argument("dest", default="-", type=click.File("wb"))
+@click.option(
+    "--encrypt_with",
+    type=click.File("rb"),
+    help=ENCRYPT_WITH_HELP,
+)
 @click.option(
     "--indent",
     default=2,
     type=int,
     help="Number of spaces to indent for the JSON output. (default: 2)",
 )
+@click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
-def export_global(dest, silent, indent):
+def export_global(dest, encrypt_with, indent, silent):
     """
     Export all Sentry data in the JSON format.
     """
@@ -317,6 +350,7 @@ def export_global(dest, silent, indent):
 
     export_in_global_scope(
         dest,
+        encrypt_with=encrypt_with,
         indent=indent,
         printer=(lambda *args, **kwargs: None) if silent else click.echo,
     )

--- a/tests/sentry/backup/test_exports.py
+++ b/tests/sentry/backup/test_exports.py
@@ -5,8 +5,10 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, Type
 
+from sentry.backup.comparators import get_default_comparators
 from sentry.backup.dependencies import NormalizedModelName, get_model, get_model_name
 from sentry.backup.scopes import ExportScope
+from sentry.backup.validate import validate
 from sentry.db import models
 from sentry.models.email import Email
 from sentry.models.organization import Organization
@@ -16,16 +18,38 @@ from sentry.models.useremail import UserEmail
 from sentry.models.userip import UserIP
 from sentry.models.userpermission import UserPermission
 from sentry.models.userrole import UserRole, UserRoleUser
-from sentry.testutils.helpers.backups import BackupTestCase, export_to_file
+from sentry.testutils.helpers.backups import (
+    BackupTestCase,
+    ValidationError,
+    export_to_encrypted_tarball,
+    export_to_file,
+)
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.json import JSONData
 from tests.sentry.backup import get_matching_exportable_models
 
 
 class ExportTestCase(BackupTestCase):
-    def export(self, tmp_dir, **kwargs) -> JSONData:
+    def export(
+        self,
+        tmp_dir,
+        *,
+        scope: ExportScope,
+        filter_by: set[str] | None = None,
+    ) -> JSONData:
         tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
-        return export_to_file(tmp_path, **kwargs)
+        return export_to_file(tmp_path, scope=scope, filter_by=filter_by)
+
+    def export_and_encrypt(
+        self,
+        tmp_dir,
+        *,
+        scope: ExportScope,
+        filter_by: set[str] | None = None,
+    ) -> JSONData:
+        tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.enc.tar")
+        return export_to_encrypted_tarball(tmp_path, scope=scope, filter_by=filter_by)
 
 
 @region_silo_test(stable=True)
@@ -35,7 +59,7 @@ class ScopingTests(ExportTestCase):
     """
 
     @staticmethod
-    def verify_model_inclusion(data: JSONData, scope: ExportScope):
+    def verify_model_inclusion(data: JSONData, scope: ExportScope) -> None:
         """
         Ensure all in-scope models are included, and that no out-of-scope models are included.
         """
@@ -59,32 +83,51 @@ class ScopingTests(ExportTestCase):
                 f"The following models were not included in the export: ${unseen_models}; this is despite it being included in at least one of the following relocation scopes: {scope.value}"
             )
 
+    def verify_encryption_equality(
+        self, tmp_dir: str, unencrypted: JSONData, scope: ExportScope
+    ) -> None:
+        res = validate(
+            unencrypted,
+            self.export_and_encrypt(tmp_dir, scope=scope),
+            get_default_comparators(),
+        )
+        if res.findings:
+            raise ValidationError(res)
+
+    @freeze_time("2023-10-11 18:00:00")
     def test_user_export_scoping(self):
         self.create_exhaustive_instance(is_superadmin=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
-            data = self.export(tmp_dir, scope=ExportScope.User)
-            self.verify_model_inclusion(data, ExportScope.User)
+            unencrypted = self.export(tmp_dir, scope=ExportScope.User)
+            self.verify_model_inclusion(unencrypted, ExportScope.User)
+            assert unencrypted == self.export_and_encrypt(tmp_dir, scope=ExportScope.User)
 
+    @freeze_time("2023-10-11 18:00:00")
     def test_organization_export_scoping(self):
         self.create_exhaustive_instance(is_superadmin=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
-            data = self.export(tmp_dir, scope=ExportScope.Organization)
-            self.verify_model_inclusion(data, ExportScope.Organization)
+            unencrypted = self.export(tmp_dir, scope=ExportScope.Organization)
+            self.verify_model_inclusion(unencrypted, ExportScope.Organization)
+            assert unencrypted == self.export_and_encrypt(tmp_dir, scope=ExportScope.Organization)
 
+    @freeze_time("2023-10-11 18:00:00")
     def test_config_export_scoping(self):
         self.create_exhaustive_instance(is_superadmin=True)
         self.create_exhaustive_user("admin", is_admin=True)
         self.create_exhaustive_user("staff", is_staff=True)
         self.create_exhaustive_user("superuser", is_superuser=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
-            data = self.export(tmp_dir, scope=ExportScope.Config)
-            self.verify_model_inclusion(data, ExportScope.Config)
+            unencrypted = self.export(tmp_dir, scope=ExportScope.Config)
+            self.verify_model_inclusion(unencrypted, ExportScope.Config)
+            assert unencrypted == self.export_and_encrypt(tmp_dir, scope=ExportScope.Config)
 
+    @freeze_time("2023-10-11 18:00:00")
     def test_global_export_scoping(self):
         self.create_exhaustive_instance(is_superadmin=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
-            data = self.export(tmp_dir, scope=ExportScope.Global)
-            self.verify_model_inclusion(data, ExportScope.Global)
+            unencrypted = self.export(tmp_dir, scope=ExportScope.Global)
+            self.verify_model_inclusion(unencrypted, ExportScope.Global)
+            assert unencrypted == self.export_and_encrypt(tmp_dir, scope=ExportScope.Global)
 
 
 @region_silo_test(stable=True)


### PR DESCRIPTION
This change adds a new `--encrypt_with` flag to all export commands. This flag may be set to point at a file containing a public RSA key. This means that the resulting output, instead of being a single JSON file, will be a tarball containing a DEK minted using the public key, the public key itself, and the JSON export encrypted with the DEK.

Future changes will add corresponding decryption support to the import commands, and an endpoint on sentry.io that can be used to retrieve our public key for relocating users.

Issue: getsentry/team-ospo#207