### PR TITLE
fix(fly): require user consent for newsletter

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, List, MutableMapping, Optional
 from uuid import uuid4
 
 from django.db import router, transaction
-from django.db.models import Q, QuerySet
+from django.db.models import F, Q, QuerySet
 from django.utils.text import slugify
 
 from sentry.api.serializers import (
@@ -187,6 +187,7 @@ class DatabaseBackedUserService(UserService):
                 user_signup.send_robust(
                     sender=self, user=user, source="api", referrer=referrer or "unknown"
                 )
+                user.update(flags=F("flags").bitor(User.flags.newsletter_consent_prompt))
             else:
                 # Users are not supposed to have the same email but right now our auth pipeline let this happen
                 # So let's not break the user experience. Instead return the user with auth identity of ident or

--- a/tests/sentry/services/hybrid_cloud/user/test_impl.py
+++ b/tests/sentry/services/hybrid_cloud/user/test_impl.py
@@ -1,6 +1,7 @@
 from sentry.auth.providers.fly.provider import FlyOAuth2Provider
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
+from sentry.models.user import User
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
@@ -10,6 +11,14 @@ from sentry.testutils.silo import control_silo_test
 class DatabaseBackedUserService(TestCase):
     def setUp(self) -> None:
         super().setUp()
+
+    def test_create_new_user(self):
+        old_user_count = User.objects.all().count()
+        rpc_user = user_service.get_or_create_user_by_email(email="test@email.com")
+        user = User.objects.get(id=rpc_user.id)
+        new_user_count = User.objects.all().count()
+        assert new_user_count == old_user_count + 1
+        assert user.flags.newsletter_consent_prompt
 
     def test_get_or_create_user(self):
         user1 = self.create_user(email="test@email.com", username="1")


### PR DESCRIPTION
We automatically opted in people to marketing newsletter which is not ok, just like any other user fly user should explicitly consent to receiving marketing emails.

legal ask: https://www.notion.so/sentry/Fly-partnership-changes-to-meet-legal-standards-471fca1333804ccbac3d7f5e398ef77d?pvs=4#89e46dbb7c984287b3a3f77c316304df

before:
![Screenshot 2023-10-12 at 1 29 48 PM](https://github.com/getsentry/sentry/assets/132939361/8087094e-1f0e-4d17-a6f5-a7e127629ec1)

after:
![Screenshot 2023-10-12 at 1 29 48 PM](https://github.com/getsentry/sentry/assets/132939361/5bf5699f-8048-4719-8963-4ec0d95f1dd4)
![Screenshot 2023-10-12 at 1 30 01 PM](https://github.com/getsentry/sentry/assets/132939361/ce3bcc93-7128-4339-b8b7-d2509f54e71b)

This page shows only once per user.
