### PR TITLE
feat(replay): Refactor conditions for showing "Jump up|down" buttons inside a replay table, and add them into Errors

### DIFF
--- a/static/app/components/replays/useJumpButtons.tsx
+++ b/static/app/components/replays/useJumpButtons.tsx
@@ -1,0 +1,65 @@
+import {useCallback, useMemo, useState} from 'react';
+import {ScrollParams} from 'react-virtualized';
+
+import {getNextReplayFrame} from 'sentry/utils/replays/getReplayEvent';
+import {ReplayFrame} from 'sentry/utils/replays/types';
+
+/**
+ * The range (`[startIndex, endIndex]`) of table rows that are visible,
+ * not including the table header.
+ */
+type VisibleRange = [number, number];
+
+interface Props {
+  currentTime: number;
+  frames: ReplayFrame[];
+  rowHeight: number;
+  setScrollToRow: (row: number) => void;
+}
+
+export default function useJumpButtons({
+  currentTime,
+  frames,
+  rowHeight,
+  setScrollToRow,
+}: Props) {
+  const [visibleRange, setVisibleRange] = useState<VisibleRange>([0, 0]);
+
+  const indexOfCurrentRow = useMemo(() => {
+    const frame = getNextReplayFrame({
+      frames,
+      targetOffsetMs: currentTime,
+      allowExact: true,
+    });
+    const frameIndex = frames.findIndex(spanFrame => frame === spanFrame);
+    // frameIndex is -1 at end of replay, so use last index
+    const index = frameIndex === -1 ? frames.length - 1 : frameIndex;
+    return index;
+  }, [currentTime, frames]);
+
+  const handleClick = useCallback(() => {
+    // When Jump Down, ensures purple line is visible and index needs to be 1 to jump to top of network list
+    if (indexOfCurrentRow > visibleRange[1] || indexOfCurrentRow === 0) {
+      setScrollToRow(indexOfCurrentRow + 1);
+    } else {
+      setScrollToRow(indexOfCurrentRow);
+    }
+  }, [indexOfCurrentRow, setScrollToRow, visibleRange]);
+
+  const handleScroll = useCallback(
+    ({clientHeight, scrollTop}: ScrollParams) => {
+      setVisibleRange([
+        Math.floor(scrollTop / rowHeight),
+        Math.floor(scrollTop + clientHeight / rowHeight),
+      ]);
+    },
+    [rowHeight]
+  );
+
+  return {
+    showJumpUpButton: indexOfCurrentRow < visibleRange[0],
+    showJumpDownButton: indexOfCurrentRow > visibleRange[1],
+    handleClick,
+    handleScroll,
+  };
+}

--- a/static/app/views/replays/detail/errorList/index.tsx
+++ b/static/app/views/replays/detail/errorList/index.tsx
@@ -1,10 +1,11 @@
-import {useMemo, useRef} from 'react';
+import {useMemo, useRef, useState} from 'react';
 import {AutoSizer, CellMeasurer, GridCellProps, MultiGrid} from 'react-virtualized';
 import styled from '@emotion/styled';
 
 import Placeholder from 'sentry/components/placeholder';
 import JumpButtons from 'sentry/components/replays/jumpButtons';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import useJumpButtons from 'sentry/components/replays/useJumpButtons';
 import {t} from 'sentry/locale';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import ErrorFilters from 'sentry/views/replays/detail/errorList/errorFilters';
@@ -34,6 +35,8 @@ function ErrorList() {
   const errorFrames = replay?.getErrorFrames();
   const startTimestampMs = replay?.getReplay().started_at.getTime() ?? 0;
 
+  const [scrollToRow, setScrollToRow] = useState<undefined | number>(undefined);
+
   const filterProps = useErrorFilters({errorFrames: errorFrames || []});
   const {items: filteredItems, searchTerm, setSearchTerm} = filterProps;
   const clearSearchTerm = () => setSearchTerm('');
@@ -49,6 +52,18 @@ function ErrorList() {
       dynamicColumnIndex: 1,
       deps,
     });
+
+  const {
+    showJumpUpButton,
+    showJumpDownButton,
+    handleClick: onClickToJump,
+    handleScroll,
+  } = useJumpButtons({
+    currentTime,
+    frames: filteredItems,
+    setScrollToRow,
+    rowHeight: BODY_HEIGHT,
+  });
 
   const cellRenderer = ({columnIndex, rowIndex, key, style, parent}: GridCellProps) => {
     const error = items[rowIndex - 1];
@@ -97,9 +112,6 @@ function ErrorList() {
     );
   };
 
-  const showJumpUpButton = false;
-  const showJumpDownButton = false;
-
   return (
     <FluidHeight>
       <ErrorFilters errorFrames={errorFrames} {...filterProps} />
@@ -127,6 +139,13 @@ function ErrorList() {
                     </NoRowRenderer>
                   )}
                   onScrollbarPresenceChange={onScrollbarPresenceChange}
+                  onScroll={scrollParams => {
+                    if (scrollToRow !== undefined) {
+                      setScrollToRow(undefined);
+                    }
+                    handleScroll(scrollParams);
+                  }}
+                  scrollToRow={scrollToRow}
                   overscanColumnCount={COLUMN_COUNT}
                   overscanRowCount={5}
                   rowCount={items.length + 1}
@@ -135,11 +154,13 @@ function ErrorList() {
                 />
               )}
             </AutoSizer>
-            <JumpButtons
-              jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
-              onClick={() => {}}
-              tableHeaderHeight={HEADER_HEIGHT}
-            />
+            {sortConfig.by === 'timestamp' && errorFrames?.length ? (
+              <JumpButtons
+                jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
+                onClick={onClickToJump}
+                tableHeaderHeight={HEADER_HEIGHT}
+              />
+            ) : null}
           </OverflowHidden>
         ) : (
           <Placeholder height="100%" />

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -5,9 +5,9 @@ import styled from '@emotion/styled';
 import Placeholder from 'sentry/components/placeholder';
 import JumpButtons from 'sentry/components/replays/jumpButtons';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import useJumpButtons from 'sentry/components/replays/useJumpButtons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {getNextReplayFrame} from 'sentry/utils/replays/getReplayEvent';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import {getFrameMethod, getFrameStatus} from 'sentry/utils/replays/resourceFrame';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -48,7 +48,6 @@ function NetworkList() {
   const startTimestampMs = replay?.getReplay()?.started_at?.getTime() || 0;
 
   const [scrollToRow, setScrollToRow] = useState<undefined | number>(undefined);
-  const [visibleRange, setVisibleRange] = useState([0, 0]);
 
   const filterProps = useNetworkFilters({networkFrames: networkFrames || []});
   const {items: filteredItems, searchTerm, setSearchTerm} = filterProps;
@@ -89,6 +88,18 @@ function NetworkList() {
     networkFrames && detailDataIndex
       ? Math.min(maxContainerHeight, containerSize)
       : undefined;
+
+  const {
+    showJumpUpButton,
+    showJumpDownButton,
+    handleClick: onClickToJump,
+    handleScroll,
+  } = useJumpButtons({
+    currentTime,
+    frames: filteredItems,
+    setScrollToRow,
+    rowHeight: BODY_HEIGHT,
+  });
 
   const onClickCell = useCallback(
     ({dataIndex, rowIndex}: {dataIndex: number; rowIndex: number}) => {
@@ -164,42 +175,6 @@ function NetworkList() {
     );
   };
 
-  const handleClick = () => {
-    const index = indexAtCurrentTime();
-    // When Jump Down, ensures purple line is visible and index needs to be 1 to jump to top of network list
-    if (index > visibleRange[1] || index === 0) {
-      setScrollToRow(index + 1);
-    } else {
-      setScrollToRow(index);
-    }
-  };
-
-  function indexAtCurrentTime() {
-    const frame = getNextReplayFrame({
-      frames: items,
-      targetOffsetMs: currentTime,
-      allowExact: true,
-    });
-    const frameIndex = items.findIndex(spanFrame => frame === spanFrame);
-    // frameIndex is -1 at end of replay, so use last index
-    const index = frameIndex === -1 ? items.length - 1 : frameIndex;
-    return index;
-  }
-
-  function pixelsToRow(pixels) {
-    return Math.floor(pixels / BODY_HEIGHT);
-  }
-
-  const currentIndex = indexAtCurrentTime();
-  const showJumpDownButton =
-    sortConfig.by === 'startTimestamp' &&
-    currentIndex > visibleRange[1] &&
-    networkFrames?.length;
-  const showJumpUpButton =
-    sortConfig.by === 'startTimestamp' &&
-    currentIndex < visibleRange[0] &&
-    networkFrames?.length;
-
   return (
     <FluidHeight>
       <NetworkFilters networkFrames={networkFrames} {...filterProps} />
@@ -233,14 +208,11 @@ function NetworkList() {
                       </NoRowRenderer>
                     )}
                     onScrollbarPresenceChange={onScrollbarPresenceChange}
-                    onScroll={({clientHeight, scrollTop}) => {
+                    onScroll={scrollParams => {
                       if (scrollToRow !== undefined) {
                         setScrollToRow(undefined);
                       }
-                      setVisibleRange([
-                        pixelsToRow(scrollTop),
-                        pixelsToRow(scrollTop + clientHeight),
-                      ]);
+                      handleScroll(scrollParams);
                     }}
                     scrollToRow={scrollToRow}
                     overscanColumnCount={COLUMN_COUNT}
@@ -251,11 +223,13 @@ function NetworkList() {
                   />
                 )}
               </AutoSizer>
-              <JumpButtons
-                jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
-                onClick={handleClick}
-                tableHeaderHeight={HEADER_HEIGHT}
-              />
+              {sortConfig.by === 'startTimestamp' && networkFrames?.length ? (
+                <JumpButtons
+                  jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
+                  onClick={onClickToJump}
+                  tableHeaderHeight={HEADER_HEIGHT}
+                />
+              ) : null}
             </OverflowHidden>
           ) : (
             <Placeholder height="100%" />


### PR DESCRIPTION
Now we have jump up/down in the Error Table, when it's sorted by timestamp:

![SCR-20231012-nfmk](https://github.com/getsentry/sentry/assets/187460/642670e4-ba26-4663-9224-9abab7970c05)
![SCR-20231012-nfll](https://github.com/getsentry/sentry/assets/187460/9f605377-6807-45fd-8062-c2e2f0aec34c)


I didn't try to put it onto the Console or Breadcrumbs lists yet, because they do not have fixed row heights it's going to be a little different.