### PR TITLE
feat(replay): Allow filtering of accessibility reports

### DIFF
--- a/static/app/utils/replays/hooks/mockA11yData.ts
+++ b/static/app/utils/replays/hooks/mockA11yData.ts
@@ -28,7 +28,7 @@ export function A11yData(startTimestampMs: number) {
                 'Element\'s default semantics were not overridden with role="none" or role="presentation"',
             },
           ],
-          element: '<button class="svelte-19ke1iv">',
+          element: '<button class="primary svelte-19ke1iv">',
           target: ['button:nth-child(1)'],
         },
       ],

--- a/static/app/views/replays/detail/accessibility/accessibilityFilters.tsx
+++ b/static/app/views/replays/detail/accessibility/accessibilityFilters.tsx
@@ -1,0 +1,55 @@
+import {CompactSelect, SelectOption} from 'sentry/components/compactSelect';
+import SearchBar from 'sentry/components/searchBar';
+import {t} from 'sentry/locale';
+import useAccessibilityFilters from 'sentry/views/replays/detail/accessibility/useAccessibilityFilters';
+import FiltersGrid from 'sentry/views/replays/detail/filtersGrid';
+
+type Props = {
+  accessibilityData: undefined | unknown[];
+} & ReturnType<typeof useAccessibilityFilters>;
+
+function AccessibilityFilters({
+  getImpactLevels,
+  getIssueTypes,
+  accessibilityData,
+  searchTerm,
+  selectValue,
+  setFilters,
+  setSearchTerm,
+}: Props) {
+  const impactLevels = getImpactLevels();
+  const issueTypes = getIssueTypes();
+
+  return (
+    <FiltersGrid>
+      <CompactSelect
+        disabled={!impactLevels.length && !issueTypes.length}
+        multiple
+        onChange={setFilters as (selection: SelectOption<string>[]) => void}
+        options={[
+          {
+            label: t('Impact Level'),
+            options: impactLevels,
+          },
+          {
+            label: t('Type'),
+            options: issueTypes,
+          },
+        ]}
+        size="sm"
+        triggerLabel={selectValue?.length === 0 ? t('Any') : null}
+        triggerProps={{prefix: t('Filter')}}
+        value={selectValue}
+      />
+      <SearchBar
+        size="sm"
+        onChange={setSearchTerm}
+        placeholder={t('Search Accessibility Issues')}
+        query={searchTerm}
+        disabled={!accessibilityData || !accessibilityData.length}
+      />
+    </FiltersGrid>
+  );
+}
+
+export default AccessibilityFilters;

--- a/static/app/views/replays/detail/accessibility/index.tsx
+++ b/static/app/views/replays/detail/accessibility/index.tsx
@@ -10,13 +10,13 @@ import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import useMockA11yData from 'sentry/utils/replays/hooks/useMockA11yData';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 import useUrlParams from 'sentry/utils/useUrlParams';
-// import AccessibilityFilters from 'sentry/views/replays/detail/accessibility/accessibilityFilters';
+import AccessibilityFilters from 'sentry/views/replays/detail/accessibility/accessibilityFilters';
 import AccessibilityHeaderCell, {
   COLUMN_COUNT,
 } from 'sentry/views/replays/detail/accessibility/accessibilityHeaderCell';
 import AccessibilityTableCell from 'sentry/views/replays/detail/accessibility/accessibilityTableCell';
 // import AccessibilityDetails from 'sentry/views/replays/detail/accessibility/details';
-// import useAccessibilityFilters from 'sentry/views/replays/detail/accessibility/useAccessibilityFilters';
+import useAccessibilityFilters from 'sentry/views/replays/detail/accessibility/useAccessibilityFilters';
 import useSortAccessibility from 'sentry/views/replays/detail/accessibility/useSortAccessibility';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import NoRowRenderer from 'sentry/views/replays/detail/noRowRenderer';
@@ -42,13 +42,16 @@ function AccessibilityList() {
 
   const [scrollToRow, setScrollToRow] = useState<undefined | number>(undefined);
 
-  const filteredItems = accessibilityData || [];
-  const clearSearchTerm = () => {};
+  const filterProps = useAccessibilityFilters({
+    accessibilityData: accessibilityData || [],
+  });
+  const {items: filteredItems, searchTerm, setSearchTerm} = filterProps;
+  const clearSearchTerm = () => setSearchTerm('');
   const {handleSort, items, sortConfig} = useSortAccessibility({items: filteredItems});
 
   const containerRef = useRef<HTMLDivElement>(null);
   const gridRef = useRef<MultiGrid>(null);
-  const deps = useMemo(() => [items], [items]);
+  const deps = useMemo(() => [items, searchTerm], [items, searchTerm]);
   const {cache, getColumnWidth, onScrollbarPresenceChange, onWrapperResize} =
     useVirtualizedGrid({
       cellMeasurer,
@@ -69,7 +72,7 @@ function AccessibilityList() {
     onResize: () => {},
   });
   const {getParamValue: getDetailRow, setParamValue: setDetailRow} = useUrlParams(
-    'n_detail_row',
+    'a_detail_row',
     ''
   );
   const detailDataIndex = getDetailRow();
@@ -145,7 +148,7 @@ function AccessibilityList() {
 
   return (
     <FluidHeight>
-      {/* <AccessibilityFilters accessibilityData={accessibilityData} {...filterProps} /> */}
+      <AccessibilityFilters accessibilityData={accessibilityData} {...filterProps} />
       <AccessibilityTable
         ref={containerRef}
         data-test-id="replay-details-accessibility-tab"

--- a/static/app/views/replays/detail/accessibility/useAccessibilityFilters.tsx
+++ b/static/app/views/replays/detail/accessibility/useAccessibilityFilters.tsx
@@ -1,0 +1,144 @@
+import {useCallback, useMemo} from 'react';
+
+import type {SelectOption} from 'sentry/components/compactSelect';
+import {decodeList, decodeScalar} from 'sentry/utils/queryString';
+import useFiltersInLocationQuery from 'sentry/utils/replays/hooks/useFiltersInLocationQuery';
+import {HydratedA11yIssue} from 'sentry/utils/replays/hydrateA11yRecord';
+import {filterItems} from 'sentry/views/replays/detail/utils';
+
+export interface AccessibilitySelectOption extends SelectOption<string> {
+  qs: 'f_a_impact' | 'f_a_type';
+}
+
+const DEFAULT_FILTERS = {
+  f_a_impact: [],
+  f_a_type: [],
+} as Record<AccessibilitySelectOption['qs'], string[]>;
+
+export type FilterFields = {
+  f_a_impact: string[];
+  f_a_search: string;
+  f_a_type: string[];
+  a_detail_row?: string;
+};
+
+type Options = {
+  accessibilityData: HydratedA11yIssue[];
+};
+
+type Return = {
+  getImpactLevels: () => AccessibilitySelectOption[];
+  getIssueTypes: () => AccessibilitySelectOption[];
+  items: HydratedA11yIssue[];
+  searchTerm: string;
+  selectValue: string[];
+  setFilters: (val: AccessibilitySelectOption[]) => void;
+  setSearchTerm: (searchTerm: string) => void;
+};
+
+const FILTERS = {
+  impact: (item: HydratedA11yIssue, impacts: string[]) =>
+    impacts.length === 0 || impacts.includes(item.impact ?? ''),
+  type: (item: HydratedA11yIssue, types: string[]) =>
+    types.length === 0 || types.includes(item.id),
+  searchTerm: (item: HydratedA11yIssue, searchTerm: string) => {
+    return JSON.stringify(item).toLowerCase().includes(searchTerm);
+  },
+};
+
+const IMPACT_SORT_ORDER = {
+  minor: 3,
+  moderate: 3,
+  serious: 2,
+  critical: 1,
+};
+
+function useAccessibilityFilters({accessibilityData}: Options): Return {
+  const {setFilter, query} = useFiltersInLocationQuery<FilterFields>();
+
+  const impact = useMemo(() => decodeList(query.f_a_impact), [query.f_a_impact]);
+  const type = useMemo(() => decodeList(query.f_a_type), [query.f_a_type]);
+  const searchTerm = decodeScalar(query.f_a_search, '')?.toLowerCase();
+
+  const setFilterAndClearDetails = useCallback(
+    arg => {
+      setFilter({
+        ...arg,
+        a_detail_row: undefined,
+      });
+    },
+    [setFilter]
+  );
+
+  const items = useMemo(
+    () =>
+      filterItems({
+        items: accessibilityData,
+        filterFns: FILTERS,
+        filterVals: {impact, type, searchTerm},
+      }),
+    [accessibilityData, impact, type, searchTerm]
+  );
+
+  const getImpactLevels = useCallback(
+    () =>
+      Array.from(
+        new Set(accessibilityData.map(data => String(data.impact)).concat(impact))
+      )
+        .filter(Boolean)
+        .sort((a, b) => (IMPACT_SORT_ORDER[a] < IMPACT_SORT_ORDER[b] ? -1 : 1))
+        .map(
+          (value): AccessibilitySelectOption => ({
+            value,
+            label: value,
+            qs: 'f_a_impact',
+          })
+        ),
+    [accessibilityData, impact]
+  );
+
+  const getIssueTypes = useCallback(
+    () =>
+      Array.from(new Set(accessibilityData.map(data => data.id).concat(type)))
+        .sort()
+        .map(
+          (value): AccessibilitySelectOption => ({
+            value,
+            label: value,
+            qs: 'f_a_type',
+          })
+        ),
+    [accessibilityData, type]
+  );
+
+  const setSearchTerm = useCallback(
+    (f_a_search: string) =>
+      setFilterAndClearDetails({f_a_search: f_a_search || undefined}),
+    [setFilterAndClearDetails]
+  );
+
+  const setFilters = useCallback(
+    (value: AccessibilitySelectOption[]) => {
+      const groupedValues = value.reduce((state, selection) => {
+        return {
+          ...state,
+          [selection.qs]: [...state[selection.qs], selection.value],
+        };
+      }, DEFAULT_FILTERS);
+      setFilterAndClearDetails(groupedValues);
+    },
+    [setFilterAndClearDetails]
+  );
+
+  return {
+    getImpactLevels,
+    getIssueTypes,
+    items,
+    searchTerm,
+    selectValue: [...impact, ...type],
+    setFilters,
+    setSearchTerm,
+  };
+}
+
+export default useAccessibilityFilters;


### PR DESCRIPTION
Usual filter stuff. Filtering on impact/type so far, and the search box also works (filters against all text, which is a lot!)

![SCR-20231012-ocgd](https://github.com/getsentry/sentry/assets/187460/0ebe1b52-23fd-4d4a-ac53-b0aa3a1df551)
