### PR TITLE
chore(replay): Update height of replay table rows to match ui library

### DIFF
--- a/static/app/views/replays/detail/errorList/index.tsx
+++ b/static/app/views/replays/detail/errorList/index.tsx
@@ -19,7 +19,7 @@ import NoRowRenderer from 'sentry/views/replays/detail/noRowRenderer';
 import useVirtualizedGrid from 'sentry/views/replays/detail/useVirtualizedGrid';
 
 const HEADER_HEIGHT = 25;
-const BODY_HEIGHT = 28;
+const BODY_HEIGHT = 25;
 
 const cellMeasurer = {
   defaultHeight: BODY_HEIGHT,

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -27,7 +27,7 @@ import NoRowRenderer from 'sentry/views/replays/detail/noRowRenderer';
 import useVirtualizedGrid from 'sentry/views/replays/detail/useVirtualizedGrid';
 
 const HEADER_HEIGHT = 25;
-const BODY_HEIGHT = 28;
+const BODY_HEIGHT = 25;
 
 const RESIZEABLE_HANDLE_HEIGHT = 90;
 


### PR DESCRIPTION
The rows in the UI Library are 25px tall: https://www.figma.com/file/tlGOyIijfu309du7zXTDTM/Library%3A-Replay?node-id=0%3A1&mode=dev

| Before | After |
| --- | --- |
| ![SCR-20231012-offw](https://github.com/getsentry/sentry/assets/187460/e340bdcb-6f4d-4195-a2f6-c512205337d9) | ![SCR-20231012-ofei](https://github.com/getsentry/sentry/assets/187460/72464107-1742-4d75-8acc-d8c0aef4b7e4) |
