### PR TITLE
feat(api): Create query param to show disabled ticket integrations

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -19,10 +19,11 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         """
         Retrieve the list of configuration options for a given project.
         """
-
         action_list = []
         condition_list = []
         filter_list = []
+
+        available_ticket_actions = set()
 
         project_has_filters = features.has("projects:alert-filters", project)
         can_create_tickets = features.has(
@@ -57,6 +58,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
                 context["actionType"] = "ticket"
                 context["ticketType"] = node.ticket_type
                 context["link"] = node.link
+                available_ticket_actions.add(node.id)
 
             # It is possible for a project to have no services. In that scenario we do
             # not want the front end to render the action as the action does not have
@@ -80,5 +82,10 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
                 action_list.append(context)
 
         context = {"actions": action_list, "conditions": condition_list, "filters": filter_list}
+
+        if request.GET.get("includeAllTickets") is not None:
+            # Add disabled ticket integrations to response
+            disabled_actions = TICKET_ACTIONS - available_ticket_actions
+            context["disabledTicketActions"] = sorted(list(disabled_actions))
 
         return Response(context)

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -83,7 +83,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
 
         context = {"actions": action_list, "conditions": condition_list, "filters": filter_list}
 
-        if request.GET.get("includeAllTickets") is not None:
+        if can_create_tickets and request.GET.get("includeAllTickets") is not None:
             # Add disabled ticket integrations to response
             disabled_actions = TICKET_ACTIONS - available_ticket_actions
             context["disabledTicketActions"] = sorted(list(disabled_actions))

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -19,6 +19,7 @@ class ProjectRuleConfigurationTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
+        self.ticket_actions = [JIRA_ACTION, AZURE_DEV_OPS_ACTION]
 
     def test_simple(self):
         team = self.create_team()
@@ -98,20 +99,26 @@ class ProjectRuleConfigurationTest(APITestCase):
 
     def test_ticket_rules_not_in_available_actions(self):
         with self.feature({"organizations:integrations-ticket-rules": False}):
-            response = self.get_success_response(self.organization.slug, self.project.slug)
-            action_ids = [action["id"] for action in response.data["actions"]]
-            assert EMAIL_ACTION in action_ids
-            assert JIRA_ACTION not in action_ids
-
-    def test_show_disabled_ticket_actions(self):
-        with self.feature({"organizations:integrations-ticket-rules": False}):
             response = self.get_success_response(
                 self.organization.slug, self.project.slug, includeAllTickets=True
             )
-            disabled_ticket_actions = response.data["disabledTicketActions"]
-            assert len(disabled_ticket_actions) == 2
-            assert JIRA_ACTION in disabled_ticket_actions
-            assert AZURE_DEV_OPS_ACTION in disabled_ticket_actions
+
+            action_ids = [action["id"] for action in response.data["actions"]]
+            assert EMAIL_ACTION in action_ids
+            for action in self.ticket_actions:
+                assert action not in action_ids
+            assert "disabledTicketActions" not in response.data
+
+    # @patch.object(RuleSerializer, "serialize", return_value=[])
+    @patch("sentry.api.endpoints.project_rules_configuration.rules", new=[])
+    def test_show_disabled_ticket_actions(self):
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, includeAllTickets=True
+        )
+        disabled_ticket_actions = response.data["disabledTicketActions"]
+        assert len(disabled_ticket_actions) == 2
+        for ticket in self.ticket_actions:
+            assert ticket in disabled_ticket_actions
 
     def test_sentry_app_alertable_webhook(self):
         team = self.create_team()

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -109,7 +109,6 @@ class ProjectRuleConfigurationTest(APITestCase):
                 assert action not in action_ids
             assert "disabledTicketActions" not in response.data
 
-    # @patch.object(RuleSerializer, "serialize", return_value=[])
     @patch("sentry.api.endpoints.project_rules_configuration.rules", new=[])
     def test_show_disabled_ticket_actions(self):
         response = self.get_success_response(


### PR DESCRIPTION
We want to show disabled integrations on the alert rule action dropdown. Each disabled integration would have a button on the right linking to respective integration setup page.

This change allows us to pass a query parameter that will then include all disabled ticket actions in the response.

### Mockup
<img width="1156" alt="Untitled" src="https://github.com/getsentry/sentry/assets/67301797/78890684-409c-4305-91a5-a34603360717">
