### PR TITLE
fix(source-map-debugger): Show min version for debug IDs

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebuggerData.tsx
@@ -44,6 +44,7 @@ interface SourceMapDebugBlueThunderResponse {
   sdk_debug_id_support: 'not-supported' | 'unofficial-sdk' | 'needs-upgrade' | 'full';
   sdk_version: string | null;
   has_scraping_data?: boolean;
+  min_debug_id_sdk_version?: string | null;
 }
 
 export function useSourceMapDebuggerData(event: Event, projectSlug: string) {
@@ -181,5 +182,6 @@ export function prepareSourceMapDebuggerFrameInformation(
     scrapingProgress,
     frameIsResolved,
     hasScrapingData: sourceMapDebuggerData.has_scraping_data ?? false,
+    minDebugIdSdkVersion: sourceMapDebuggerData.min_debug_id_sdk_version ?? null,
   } satisfies FrameSourceMapDebuggerData;
 }

--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -106,6 +106,7 @@ export interface FrameSourceMapDebuggerData {
   hasScrapingData: boolean;
   matchingSourceFileNames: string[];
   matchingSourceMapName: string | null;
+  minDebugIdSdkVersion: string | null;
   release: string | null;
   releaseHasSomeArtifact: boolean;
   releaseProgress: number;
@@ -444,22 +445,25 @@ function InstalledSdkChecklistItem({
         <CheckListInstruction type="muted">
           <h6>{t('Outdated SDK')}</h6>
           <p>
-            {sourceResolutionResults.sdkVersion
+            {sourceResolutionResults.sdkVersion !== null
               ? tct(
-                  'You are using version [currentVersion] of the Sentry SDK which does not support debug IDs. You should upgrade to at lease version [targetVersion].',
+                  'You are using version [currentVersion] of the Sentry SDK which does not support debug IDs.',
                   {
                     currentVersion: (
                       <MonoBlock>{sourceResolutionResults.sdkVersion}</MonoBlock>
                     ),
-                    targetVersion: <MonoBlock>7.56.0</MonoBlock>,
                   }
                 )
-              : tct(
-                  'You are using an outdated version of the Sentry SDK which does not support debug IDs. You should upgrade to at least version [targetVersion]',
-                  {
-                    targetVersion: <MonoBlock>7.56.0</MonoBlock>,
-                  }
-                )}
+              : t(
+                  'You are using an outdated version of the Sentry SDK which does not support debug IDs.'
+                )}{' '}
+            {sourceResolutionResults.minDebugIdSdkVersion !== null
+              ? tct('You should upgrade to version [targetVersion] or higher.', {
+                  targetVersion: (
+                    <MonoBlock>{sourceResolutionResults.minDebugIdSdkVersion}</MonoBlock>
+                  ),
+                })
+              : t('You should upgrade to the latest version.')}
           </p>
           <p>
             {tct(


### PR DESCRIPTION
Shows different minimum versions for different SDKs.