### PR TITLE
Recognize all http codes <300 as success codes

### DIFF
--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -255,7 +255,7 @@ class Client implements ApiNamespace.Client {
       const body =
         typeof response.body === 'function' ? response.body(url, options) : response.body;
 
-      if (![200, 202].includes(response.statusCode)) {
+      if (response.statusCode >= 300) {
         response.callCount++;
 
         const errorResponse = Object.assign(


### PR DESCRIPTION
This PR changes the mock http client used in tests to recognise all http status codes < 300 as success codes.
Previously we only recognised 200 and 202.
IMO anything < 400 should not be considered an error but I left the redirects to be still considered an error in order to minimise changes from current behaviour ( although all the tests ran successfully with status_code < 400 ). 
