### PR TITLE
ref: default freeze_time to today to prevent events from being too old

### DIFF
--- a/src/sentry/testutils/helpers/datetime.py
+++ b/src/sentry/testutils/helpers/datetime.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import time_machine
-from django.utils import timezone
 
 __all__ = ["iso_format", "before_now", "timestamp_format"]
 
@@ -26,12 +25,14 @@ class MockClock:
     """Returns a distinct, increasing timestamp each time it is called."""
 
     def __init__(self, initial=None):
-        self.time = initial or timezone.now()
+        self.time = initial or datetime.now(timezone.utc)
 
     def __call__(self):
         self.time += timedelta(seconds=1)
         return self.time
 
 
-def freeze_time(t: str | datetime = "2023-09-13 01:02:00") -> time_machine.travel:
+def freeze_time(t: str | datetime | None = None) -> time_machine.travel:
+    if t is None:
+        t = datetime.now(timezone.utc)
     return time_machine.travel(t, tick=False)

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -3375,7 +3375,7 @@ class DSLatestReleaseBoostTest(TestCase):
             for o in mocked_invalidate.mock_calls
         )
 
-    @freeze_time()
+    @freeze_time("2022-11-03 10:00:00")
     @mock.patch("sentry.dynamic_sampling.rules.helpers.latest_releases.BOOSTED_RELEASES_LIMIT", 2)
     def test_least_recently_boosted_release_is_removed_if_limit_is_exceeded(self):
         ts = time()


### PR DESCRIPTION
this likely will introduce new flakes as freezing on a date boundary is still an edge case -- but for now fixes the systemic too-old-event failures




<!-- Describe your PR here. -->