### PR TITLE
fix(heat-maps): visualMap is passed through options

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -350,7 +350,6 @@ function BaseChartUnwrapped({
   transformSinglePointToLine = false,
   onChartReady = () => {},
   'data-test-id': dataTestId,
-  visualMap,
 }: BaseChartProps) {
   const theme = useTheme();
 
@@ -513,7 +512,6 @@ function BaseChartUnwrapped({
     dataZoom,
     graphic,
     aria,
-    visualMap,
   };
 
   const chartStyles = {

--- a/static/app/components/events/eventStatisticalDetector/lineChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/lineChart.tsx
@@ -83,23 +83,25 @@ function LineChart({statsData, evidenceData, start, end, chartLabel}: ChartProps
               top: '40px',
               bottom: '0px',
             }}
-            visualMap={VisualMap({
-              show: false,
-              type: 'piecewise',
-              selectedMode: false,
-              dimension: 0,
-              pieces: [
-                {
-                  gte: 0,
-                  lt: evidenceData?.breakpoint ? evidenceData.breakpoint * 1000 : 0,
-                  color: theme.gray500,
-                },
-                {
-                  gte: evidenceData?.breakpoint ? evidenceData.breakpoint * 1000 : 0,
-                  color: theme.red300,
-                },
-              ],
-            })}
+            options={{
+              visualMap: VisualMap({
+                show: false,
+                type: 'piecewise',
+                selectedMode: false,
+                dimension: 0,
+                pieces: [
+                  {
+                    gte: 0,
+                    lt: evidenceData?.breakpoint ? evidenceData.breakpoint * 1000 : 0,
+                    color: theme.gray500,
+                  },
+                  {
+                    gte: evidenceData?.breakpoint ? evidenceData.breakpoint * 1000 : 0,
+                    color: theme.red300,
+                  },
+                ],
+              }),
+            }}
             xAxis={{
               type: 'time',
             }}


### PR DESCRIPTION
A change to the breakpoint chart broke heatmaps in performance. It should not be passed directly but rather through options
