### PR TITLE
feat(browser-starfish): add ability to filter by render blocking status, resource module

### DIFF
--- a/static/app/views/performance/browser/resources/utils/useResourceFilters.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceFilters.ts
@@ -8,12 +8,17 @@ export enum BrowserStarfishFields {
   DOMAIN = 'domain',
   GROUP_ID = 'groupId',
   DESCRIPTION = 'description',
+  RESOURCE_RENDER_BLOCKING_STATUS = 'resource.render_blocking_status',
 }
 
 export type ModuleFilters = {
-  [BrowserStarfishFields.DOMAIN]?: string;
+  [BrowserStarfishFields.RESOURCE_RENDER_BLOCKING_STATUS]:
+    | ''
+    | 'non-blocking'
+    | 'blocking';
   [BrowserStarfishFields.RESOURCE_TYPE]?: 'resource.script' | 'resource.img';
   [BrowserStarfishFields.TRANSACTION]?: string;
+  [BrowserStarfishFields.DOMAIN]?: string;
 };
 
 export const useResourceModuleFilters = () => {
@@ -25,5 +30,6 @@ export const useResourceModuleFilters = () => {
     BrowserStarfishFields.TRANSACTION,
     BrowserStarfishFields.GROUP_ID,
     BrowserStarfishFields.DESCRIPTION,
+    BrowserStarfishFields.RESOURCE_RENDER_BLOCKING_STATUS,
   ]);
 };

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -17,6 +17,11 @@ export const useResourcesQuery = ({sort}: {sort: ValidSort}) => {
     ...(resourceFilters.transaction
       ? [`transaction:"${resourceFilters.transaction}"`]
       : []),
+    ...(resourceFilters['resource.render_blocking_status']
+      ? [
+          `resource.render_blocking_status:${resourceFilters['resource.render_blocking_status']}`,
+        ]
+      : []),
   ];
 
   // TODO - we should be using metrics data here


### PR DESCRIPTION
If you add the query param `&resource.render_blocking_status=blocking` or &resource.render_blocking_status=non_blocking` in the url, the resource module will filter accordingly.

This Pr does not add the ui element to actual do the filtering (this is a todo), but this does enable an entry point from the page loads module.