### PR TITLE
feat(stat-detectors): Add geo analysis to adv analysis endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -144,11 +144,13 @@ def fetch_geo_analysis_results(transaction_name, regression_breakpoint, params, 
             adjusted_params["start"] = regression_breakpoint + BUFFER
 
         geo_code_durations = metrics_query(
-            ["p95(transaction.duration)", "geo.country_code"],
+            ["p95(transaction.duration)", "geo.country_code", "count()"],
             f"event.type:transaction transaction:{transaction_name} project_id:{project_id}",
             adjusted_params,
             referrer=f"{BASE_REFERRER}-{GEO_ANALYSIS}",
             limit=METRICS_MAX_LIMIT,
+            # Order by descending count to ensure more impactful countries are prioritized
+            orderby=["-count()"],
         )
 
         return geo_code_durations

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -145,7 +145,7 @@ def fetch_geo_analysis_results(transaction_name, regression_breakpoint, params, 
 
         geo_code_durations = metrics_query(
             ["p95(transaction.duration)", "geo.country_code", "count()"],
-            f"event.type:transaction transaction:{transaction_name} project_id:{project_id}",
+            f"event.type:transaction transaction:{transaction_name}",
             adjusted_params,
             referrer=f"{BASE_REFERRER}-{GEO_ANALYSIS}",
             limit=METRICS_MAX_LIMIT,
@@ -219,7 +219,7 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
         with self.handle_query_errors():
             transaction_count_query = metrics_query(
                 ["count()"],
-                f"event.type:transaction transaction:{transaction_name} project_id:{project_id}",
+                f"event.type:transaction transaction:{transaction_name}",
                 params,
                 referrer=f"{BASE_REFERRER}-{analysis_type}",
             )

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
 
+import sentry_sdk
 from rest_framework.response import Response
 from snuba_sdk import Column, Condition, Function, LimitBy, Op
 
@@ -11,6 +12,7 @@ from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
 from sentry.api.endpoints.organization_events_spans_performance import EventID, get_span_description
 from sentry.api.helpers.span_analysis import span_analysis
 from sentry.search.events.builder import QueryBuilder
+from sentry.search.events.constants import METRICS_MAX_LIMIT
 from sentry.search.events.types import QueryBuilderConfig
 from sentry.search.utils import parse_datetime_string
 from sentry.snuba.dataset import Dataset
@@ -20,7 +22,9 @@ from sentry.utils.snuba import raw_snql_query
 DEFAULT_LIMIT = 50
 QUERY_LIMIT = 10000 // 2
 BUFFER = timedelta(hours=6)
-REFERRER = "api.organization-events-root-cause-analysis"
+BASE_REFERRER = "api.organization-events-root-cause-analysis"
+SPAN_ANALYSIS = "span"
+GEO_ANALYSIS = "geo"
 
 _query_thread_pool = ThreadPoolExecutor()
 
@@ -95,10 +99,11 @@ def get_parallelized_snql_queries(transaction, regression_breakpoint, params):
 
 
 def query_spans(transaction, regression_breakpoint, params):
+    referrer = f"{BASE_REFERRER}-{SPAN_ANALYSIS}"
     snql_queries = get_parallelized_snql_queries(transaction, regression_breakpoint, params)
 
     # Parallelize the request for span data
-    snuba_results = list(_query_thread_pool.map(raw_snql_query, snql_queries, [REFERRER, REFERRER]))
+    snuba_results = list(_query_thread_pool.map(raw_snql_query, snql_queries, [referrer, referrer]))
     span_results = []
 
     # append all the results
@@ -107,6 +112,78 @@ def query_spans(transaction, regression_breakpoint, params):
         span_results += output_dict
 
     return span_results
+
+
+def fetch_span_analysis_results(transaction_name, regression_breakpoint, params, project_id):
+    span_data = query_spans(
+        transaction=transaction_name,
+        regression_breakpoint=regression_breakpoint,
+        params=params,
+    )
+
+    span_analysis_results = span_analysis(span_data)
+
+    for result in span_analysis_results:
+        result["span_description"] = get_span_description(
+            EventID(project_id, result["sample_event_id"]),
+            result["span_op"],
+            result["span_group"],
+        )
+
+    return span_analysis_results
+
+
+def fetch_geo_analysis_results(transaction_name, regression_breakpoint, params, project_id):
+    def get_geo_data(period):
+        # Copy the params so we aren't modifying the base params each time
+        adjusted_params = {**params}
+
+        if period == "before":
+            adjusted_params["end"] = regression_breakpoint - BUFFER
+        else:
+            adjusted_params["start"] = regression_breakpoint + BUFFER
+
+        geo_code_durations = metrics_query(
+            ["p95(transaction.duration)", "geo.country_code"],
+            f"event.type:transaction transaction:{transaction_name} project_id:{project_id}",
+            adjusted_params,
+            referrer=f"{BASE_REFERRER}-{GEO_ANALYSIS}",
+            limit=METRICS_MAX_LIMIT,
+        )
+
+        return geo_code_durations
+
+    # For each country code in the second half, compare it to the first half
+    geo_results = [get_geo_data("before"), get_geo_data("after")]
+
+    # Format the data for more efficient comparison
+    for index, result in enumerate(geo_results):
+        geo_results[index] = {
+            f"{data.get('geo.country_code')}": data for data in result.get("data")
+        }
+
+    before_results, after_results = geo_results
+    changed_keys = set(before_results.keys()) & set(after_results.keys())
+    new_keys = set(after_results.keys()) - set(before_results.keys())
+
+    analysis_results = []
+    for key in changed_keys | new_keys:
+        duration_before = (
+            before_results[key]["p95_transaction_duration"] if before_results.get(key) else 0.0
+        )
+        duration_after = after_results[key]["p95_transaction_duration"]
+        if duration_after > duration_before:
+            analysis_results.append(
+                {
+                    "geo.country_code": key,
+                    "duration_before": duration_before,
+                    "duration_after": duration_after,
+                    "duration_delta": duration_after - duration_before,
+                }
+            )
+
+    analysis_results.sort(key=lambda x: x["duration_delta"], reverse=True)
+    return analysis_results
 
 
 @region_silo_endpoint
@@ -127,6 +204,7 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
         transaction_name = request.GET.get("transaction")
         project_id = request.GET.get("project")
         regression_breakpoint = request.GET.get("breakpoint")
+        analysis_type = request.GET.get("type", SPAN_ANALYSIS)
         if not transaction_name or not project_id or not regression_breakpoint:
             # Project ID is required to ensure the events we query for are
             # the same transaction
@@ -141,26 +219,22 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
                 ["count()"],
                 f"event.type:transaction transaction:{transaction_name} project_id:{project_id}",
                 params,
-                referrer="api.organization-events-root-cause-analysis",
+                referrer=f"{BASE_REFERRER}-{analysis_type}",
             )
 
         if transaction_count_query["data"][0]["count"] == 0:
             return Response(status=400, data="Transaction not found")
 
-        span_data = query_spans(
-            transaction=transaction_name,
-            regression_breakpoint=regression_breakpoint,
-            params=params,
-        )
-
-        span_analysis_results = span_analysis(span_data)
-
-        for result in span_analysis_results:
-            result["span_description"] = get_span_description(
-                EventID(project_id, result["sample_event_id"]),
-                result["span_op"],
-                result["span_group"],
+        sentry_sdk.set_tag("analysis_type", analysis_type)
+        results = []
+        if analysis_type == SPAN_ANALYSIS:
+            results = fetch_span_analysis_results(
+                transaction_name, regression_breakpoint, params, project_id
+            )
+        elif analysis_type == GEO_ANALYSIS:
+            results = fetch_geo_analysis_results(
+                transaction_name, regression_breakpoint, params, project_id
             )
 
         limit = int(request.GET.get("per_page", DEFAULT_LIMIT))
-        return Response(span_analysis_results[:limit], status=200)
+        return Response(results[:limit], status=200)

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -149,7 +149,7 @@ def fetch_geo_analysis_results(transaction_name, regression_breakpoint, params, 
             adjusted_params,
             referrer=f"{BASE_REFERRER}-{GEO_ANALYSIS}",
             limit=METRICS_MAX_LIMIT,
-            # Order by descending count to ensure more impactful countries are prioritized
+            # Order by descending count to ensure more active countries are prioritized
             orderby=["-count()"],
         )
 

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -27,7 +27,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
         )
         self.store_performance_metric(
             name=TransactionMRI.DURATION.value,
-            tags={"transaction": "foo"},
+            tags={"transaction": "foo", "geo.country_code": "US"},
             org_id=self.org.id,
             project_id=self.project.id,
             value=1,
@@ -423,3 +423,76 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
         # Before spans occur 1 hour before breakpoint
         # After spans occur 1 hour after breakpoint
         assert response.data == []
+
+    def test_geo_code(self):
+        breakpoint_timestamp = self.now - timedelta(days=1)
+
+        # Before
+        self.store_performance_metric(
+            name=TransactionMRI.DURATION.value,
+            tags={"transaction": "foo", "geo.country_code": "US"},
+            org_id=self.org.id,
+            project_id=self.project.id,
+            value=10,
+            days_before_now=2,
+        )
+
+        # Not in after
+        self.store_performance_metric(
+            name=TransactionMRI.DURATION.value,
+            tags={"transaction": "foo", "geo.country_code": "DE"},
+            org_id=self.org.id,
+            project_id=self.project.id,
+            value=10,
+            days_before_now=2,
+        )
+
+        # After
+        self.store_performance_metric(
+            name=TransactionMRI.DURATION.value,
+            tags={"transaction": "foo", "geo.country_code": "US"},
+            org_id=self.org.id,
+            project_id=self.project.id,
+            value=100,
+            hours_before_now=6,
+        )
+
+        # Not in before
+        self.store_performance_metric(
+            name=TransactionMRI.DURATION.value,
+            tags={"transaction": "foo", "geo.country_code": "MS"},
+            org_id=self.org.id,
+            project_id=self.project.id,
+            value=50,
+            hours_before_now=6,
+        )
+
+        with self.feature(FEATURES):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "transaction": "foo",
+                    "project": self.project.id,
+                    "breakpoint": breakpoint_timestamp,
+                    "start": self.now - timedelta(days=3),
+                    "end": self.now,
+                    "type": "geo",
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert response.data == [
+            {
+                "geo.country_code": "US",
+                "duration_before": 10.0,
+                "duration_after": 95.05,
+                "duration_delta": 85.05,
+            },
+            {
+                "geo.country_code": "MS",
+                "duration_before": 0.0,
+                "duration_after": 50.0,
+                "duration_delta": 50.0,
+            },
+        ]

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -27,7 +27,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
         )
         self.store_performance_metric(
             name=TransactionMRI.DURATION.value,
-            tags={"transaction": "foo", "geo.country_code": "US"},
+            tags={"transaction": "foo"},
             org_id=self.org.id,
             project_id=self.project.id,
             value=1,
@@ -430,7 +430,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
         # Before
         self.store_performance_metric(
             name=TransactionMRI.DURATION.value,
-            tags={"transaction": "foo", "geo.country_code": "US"},
+            tags={"transaction": "bar", "geo.country_code": "US"},
             org_id=self.org.id,
             project_id=self.project.id,
             value=10,
@@ -440,7 +440,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
         # Not in after
         self.store_performance_metric(
             name=TransactionMRI.DURATION.value,
-            tags={"transaction": "foo", "geo.country_code": "DE"},
+            tags={"transaction": "bar", "geo.country_code": "DE"},
             org_id=self.org.id,
             project_id=self.project.id,
             value=10,
@@ -450,7 +450,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
         # After
         self.store_performance_metric(
             name=TransactionMRI.DURATION.value,
-            tags={"transaction": "foo", "geo.country_code": "US"},
+            tags={"transaction": "bar", "geo.country_code": "US"},
             org_id=self.org.id,
             project_id=self.project.id,
             value=100,
@@ -460,7 +460,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
         # Not in before
         self.store_performance_metric(
             name=TransactionMRI.DURATION.value,
-            tags={"transaction": "foo", "geo.country_code": "MS"},
+            tags={"transaction": "bar", "geo.country_code": "MS"},
             org_id=self.org.id,
             project_id=self.project.id,
             value=50,
@@ -472,7 +472,7 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                 self.url,
                 format="json",
                 data={
-                    "transaction": "foo",
+                    "transaction": "bar",
                     "project": self.project.id,
                     "breakpoint": breakpoint_timestamp,
                     "start": self.now - timedelta(days=3),
@@ -486,8 +486,8 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             {
                 "geo.country_code": "US",
                 "duration_before": 10.0,
-                "duration_after": 95.05,
-                "duration_delta": 85.05,
+                "duration_after": 100.0,
+                "duration_delta": 90.0,
             },
             {
                 "geo.country_code": "MS",

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -456,19 +456,11 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             value=100,
             hours_before_now=6,
         )
-        self.store_performance_metric(
-            name=TransactionMRI.DURATION.value,
-            tags={"transaction": "bar", "geo.country_code": "US"},
-            org_id=self.org.id,
-            project_id=self.project.id,
-            value=100,
-            hours_before_now=6,
-        )
 
         # Not in before
         self.store_performance_metric(
             name=TransactionMRI.DURATION.value,
-            tags={"transaction": "bar", "geo.country_code": "DE"},
+            tags={"transaction": "bar", "geo.country_code": "MS"},
             org_id=self.org.id,
             project_id=self.project.id,
             value=50,

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -456,11 +456,19 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             value=100,
             hours_before_now=6,
         )
+        self.store_performance_metric(
+            name=TransactionMRI.DURATION.value,
+            tags={"transaction": "bar", "geo.country_code": "US"},
+            org_id=self.org.id,
+            project_id=self.project.id,
+            value=100,
+            hours_before_now=6,
+        )
 
         # Not in before
         self.store_performance_metric(
             name=TransactionMRI.DURATION.value,
-            tags={"transaction": "bar", "geo.country_code": "MS"},
+            tags={"transaction": "bar", "geo.country_code": "DE"},
             org_id=self.org.id,
             project_id=self.project.id,
             value=50,


### PR DESCRIPTION
The endpoint can now receive a "type" parameter which can be set to "geo" and it conducts two metrics queries for before/after the breakpoint and does a comparison to surface the biggest changes in time first

Also added a tag so I can filter and look at data specific to which type of analysis is being conducted.