### PR TITLE
feat(suspect-commits): Add GitHub implementation for getting commit context from all frames

### DIFF
--- a/src/sentry/integrations/github/blame.py
+++ b/src/sentry/integrations/github/blame.py
@@ -1,0 +1,201 @@
+import logging
+from dataclasses import asdict
+from datetime import timezone
+from typing import Dict, Optional, Sequence, TypedDict
+
+from django.utils.datastructures import OrderedSet
+from isodate import parse_datetime
+
+from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo, SourceLineInfo
+from sentry.shared_integrations.response.mapping import MappingApiResponse
+
+logger = logging.getLogger("sentry.integrations.github")
+
+
+class GitHubAuthor(TypedDict):
+    name: Optional[str]
+    email: Optional[str]
+
+
+class GitHubFileBlameCommit(TypedDict):
+    oid: str
+    author: Optional[GitHubAuthor]
+    message: str
+    committedDate: str
+
+
+class GitHubFileBlameRange(TypedDict):
+    commit: GitHubFileBlameCommit
+    startingLine: int
+    endingLine: int
+    age: int
+
+
+FilePathMapping = Dict[str, Dict[str, OrderedSet]]
+
+
+def generate_file_path_mapping(files: Sequence[SourceLineInfo]) -> FilePathMapping:
+    """
+    Generates a nested mapping of repo -> ref -> file paths.
+    This map is used to dedupe matching repos, refs, and file paths and only query
+    for them once. This mapping is passed to `create_blame_query` and
+    `extract_commits_from_blame_response`.
+    """
+    file_path_mapping: FilePathMapping = {}
+    for file in files:
+        repo = file_path_mapping.setdefault(file.repo.name, {})
+        paths = repo.setdefault(file.ref, OrderedSet())
+        paths.add(file.path)
+
+    return file_path_mapping
+
+
+def create_blame_query(file_path_mapping: FilePathMapping) -> str:
+    """
+    Create a GraphQL query to get blame information for a list of files
+    """
+    repo_queries = ""
+    for repo_index, (full_repo_name, ref) in enumerate(file_path_mapping.items()):
+        ref_queries = ""
+        for ref_index, (ref_name, file_paths) in enumerate(ref.items()):
+            blame_queries = "".join(
+                [
+                    _make_blame_query(file_path, file_path_index)
+                    for file_path_index, file_path in enumerate(file_paths)
+                ]
+            )
+            ref_queries += _make_ref_query(ref_name, blame_queries, ref_index)
+
+        try:
+            [repo_owner, repo_name] = full_repo_name.split("/", maxsplit=1)
+        except ValueError:
+            continue
+
+        repo_queries += _make_repo_query(repo_name, repo_owner, ref_queries, repo_index)
+
+    return f"""query {{{repo_queries}\n}}"""
+
+
+def extract_commits_from_blame_response(
+    response: MappingApiResponse,
+    files: Sequence[SourceLineInfo],
+    file_path_mapping: FilePathMapping,
+) -> Sequence[FileBlameInfo]:
+    """
+    Using the file path mapping that generated the initial GraphQL query,
+    this function extracts all commits from the response and maps each one
+    back to the correct file.
+    """
+    logger_info = {}
+    file_blames: Sequence[FileBlameInfo] = []
+    for repo_index, (full_repo_name, ref) in enumerate(file_path_mapping.items()):
+        repo = response.get("data", {}).get(f"repository{repo_index}")
+        if not repo:
+            logger.info(f"Repository {full_repo_name} does not exist in GitHub.", extra=logger_info)
+            continue
+        for ref_index, (ref_name, file_paths) in enumerate(ref.items()):
+            ref = repo.get(f"ref{ref_index}")
+            if not ref:
+                logger.info(
+                    f"Branch {ref_name} for repository {full_repo_name} does not exist in GitHub.",
+                    extra=logger_info,
+                )
+                continue
+            for file_path_index, file_path in enumerate(file_paths):
+                blame = ref.get("target", {}).get(f"blame{file_path_index}")
+                if not blame:
+                    logger.info(
+                        f"File {file_path} for branch {ref_name} for repository {full_repo_name} does not exist in GitHub.",
+                        extra=logger_info,
+                    )
+                    continue
+                matching_file, blame_info = _get_matching_file_and_blame(
+                    files=files,
+                    blame_ranges=blame.get("ranges", []),
+                    path=file_path,
+                    repo_name=full_repo_name,
+                    ref=ref_name,
+                )
+                if not blame_info:
+                    logger.info(
+                        f"No matching commit found for line {matching_file.lineno} in file {matching_file.path} in branch {matching_file.ref} in repository {full_repo_name} in GitHub.",
+                        extra=logger_info,
+                    )
+                    continue
+                file_blames.append(blame_info)
+    return file_blames
+
+
+def _get_matching_file_and_blame(
+    files: Sequence[SourceLineInfo],
+    blame_ranges: Sequence[GitHubFileBlameRange],
+    path: str,
+    repo_name: str,
+    ref: str,
+):
+    matching_file = [
+        f for f in files if f.path == path and f.repo.name == repo_name and f.ref == ref
+    ][0]
+    matching_blame_range: GitHubFileBlameRange | None = next(
+        iter(
+            [
+                r
+                for r in blame_ranges
+                if r["startingLine"] <= matching_file.lineno <= r["endingLine"]
+            ]
+        ),
+        None,
+    )
+    if not matching_blame_range:
+        return matching_file, None
+
+    commit = matching_blame_range.get("commit") or {}
+    author = commit.get("author") or {}
+    blame = FileBlameInfo(
+        **asdict(matching_file),
+        commit=CommitInfo(
+            commitId=commit.get("oid"),
+            commitAuthorName=author.get("name"),
+            commitAuthorEmail=author.get("email"),
+            commitMessage=commit.get("message"),
+            committedDate=parse_datetime(commit.get("committedDate")).astimezone(timezone.utc),
+        ),
+    )
+
+    return matching_file, blame
+
+
+def _make_ref_query(ref: str, blame_queries: str, index: int):
+    return f"""
+        ref{index}: ref(qualifiedName: "{ref}") {{
+            target {{
+                ... on Commit {{{blame_queries}
+                }}
+            }}
+        }}"""
+
+
+def _make_blame_query(path: str, index: int):
+    return f"""
+                    blame{index}: blame(path: "{path}") {{
+                        ranges {{
+                            commit {{
+                                oid
+                                author {{
+                                    name
+                                    email
+                                }}
+                                message
+                                committedDate
+                            }}
+                            startingLine
+                            endingLine
+                            age
+                        }}
+                    }}"""
+
+
+def _make_repo_query(repo_name: str, repo_owner: str, ref_queries: str, index: int):
+    return f"""
+    repository{index}: repository(name: "{repo_name}", owner: "{repo_owner}") {{{ref_queries}
+    }}"""

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -676,7 +676,13 @@ class GitHubClientMixin(GithubProxyClient):
                 allow_text=False,
             )
         except ValueError as e:
-            sentry_sdk.capture_exception(e)
+            logger.exception(
+                e,
+                {
+                    "provider": "github",
+                    "organization_integration_id": self.org_integration_id,
+                },
+            )
             return []
 
         if not isinstance(response, MappingApiResponse):

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -689,7 +689,10 @@ class GitHubClientMixin(GithubProxyClient):
             logger.info("GitHub blame response had some errors", extra={"error": err_message})
 
         return extract_commits_from_blame_response(
-            response=response, file_path_mapping=file_path_mapping, files=files
+            response=response,
+            file_path_mapping=file_path_mapping,
+            files=files,
+            extra={"provider": "github", "organization_integration_id": self.org_integration_id},
         )
 
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -686,7 +686,14 @@ class GitHubClientMixin(GithubProxyClient):
             err_message = ", ".join(
                 [error.get("message", "") for error in response.get("errors", [])]
             )
-            logger.info("GitHub blame response had some errors", extra={"error": err_message})
+            logger.error(
+                "get_blame_for_files.graphql_error",
+                extra={
+                    "provider": "github",
+                    "error": err_message,
+                    "organization_integration_id": self.org_integration_id,
+                },
+            )
 
         return extract_commits_from_blame_response(
             response=response,

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -8,7 +8,13 @@ import sentry_sdk
 from requests import PreparedRequest
 
 from sentry.constants import ObjectStatus
+from sentry.integrations.github.blame import (
+    create_blame_query,
+    extract_commits_from_blame_response,
+    generate_file_path_mapping,
+)
 from sentry.integrations.github.utils import get_jwt, get_next_link
+from sentry.integrations.mixins.commit_context import FileBlameInfo, SourceLineInfo
 from sentry.integrations.utils.code_mapping import (
     MAX_CONNECTION_ERRORS,
     Repo,
@@ -22,6 +28,7 @@ from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.shared_integrations.client.base import BaseApiResponseX
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions.base import ApiError
+from sentry.shared_integrations.response.mapping import MappingApiResponse
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils.cache import cache
 from sentry.utils.json import JSONData
@@ -658,6 +665,32 @@ class GitHubClientMixin(GithubProxyClient):
             raise ApiError("Branch does not exist in GitHub.")
 
         return ref.get("target", {}).get("blame", {}).get("ranges", [])
+
+    def get_blame_for_files(self, files: Sequence[SourceLineInfo]) -> Sequence[FileBlameInfo]:
+        file_path_mapping = generate_file_path_mapping(files)
+
+        try:
+            response = self.post(
+                path="/graphql",
+                data={"query": create_blame_query(file_path_mapping)},
+                allow_text=False,
+            )
+        except ValueError as e:
+            sentry_sdk.capture_exception(e)
+            return []
+
+        if not isinstance(response, MappingApiResponse):
+            raise ApiError("Response is not JSON")
+
+        if response.get("errors"):
+            err_message = ", ".join(
+                [error.get("message", "") for error in response.get("errors", [])]
+            )
+            logger.info("GitHub blame response had some errors", extra={"error": err_message})
+
+        return extract_commits_from_blame_response(
+            response=response, file_path_mapping=file_path_mapping, files=files
+        )
 
 
 class GitHubAppsClient(GitHubClientMixin):

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -22,7 +22,11 @@ from sentry.integrations import (
     IntegrationProvider,
 )
 from sentry.integrations.mixins import RepositoryMixin
-from sentry.integrations.mixins.commit_context import CommitContextMixin
+from sentry.integrations.mixins.commit_context import (
+    CommitContextMixin,
+    FileBlameInfo,
+    SourceLineInfo,
+)
 from sentry.integrations.utils.code_mapping import RepoTree
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
@@ -241,6 +245,11 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
         except ApiError:
             return False
         return True
+
+    def get_commit_context_all_frames(
+        self, files: Sequence[SourceLineInfo]
+    ) -> Sequence[FileBlameInfo]:
+        return self.get_blame_for_files(files)
 
     def get_commit_context(
         self, repo: Repository, filepath: str, ref: str, event_frame: Mapping[str, Any]

--- a/src/sentry/integrations/mixins/commit_context.py
+++ b/src/sentry/integrations/mixins/commit_context.py
@@ -1,17 +1,46 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Mapping, Protocol, Sequence
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.models.identity import Identity
+from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
+
+
+@dataclass
+class SourceLineInfo:
+    lineno: int
+    path: str
+    ref: str
+    repo: Repository
+    code_mapping: RepositoryProjectPathConfig
+
+
+@dataclass
+class CommitInfo:
+    commitId: str | None
+    committedDate: datetime
+    commitMessage: str | None
+    commitAuthorName: str | None
+    commitAuthorEmail: str | None
+
+
+@dataclass
+class FileBlameInfo(SourceLineInfo):
+    commit: CommitInfo
 
 
 class GetBlameForFile(Protocol):
     def get_blame_for_file(
         self, repo: Repository, filepath: str, ref: str, lineno: int
-    ) -> Sequence[Mapping[str, Any]]:
+    ) -> Sequence[Mapping[str, Any]] | None:
+        ...
+
+    def get_blame_for_files(self, files: Sequence[SourceLineInfo]) -> Sequence[FileBlameInfo]:
         ...
 
 
@@ -48,6 +77,33 @@ class CommitContextMixin(GetClient):
             raise e
 
         return response
+
+    def get_blame_for_files(self, files: Sequence[SourceLineInfo]) -> Sequence[FileBlameInfo]:
+        """
+        Calls the client's `get_blame_for_files` method to fetch blame for a list of files.
+
+        files: list of FileBlameInfo objects
+        """
+        try:
+            client = self.get_client()
+        except Identity.DoesNotExist:
+            return []
+        try:
+            response = client.get_blame_for_files(files)
+        except IdentityNotValid:
+            return []
+        except ApiError as e:
+            raise e
+
+        return response
+
+    def get_commit_context_all_frames(
+        self, files: Sequence[SourceLineInfo]
+    ) -> Sequence[FileBlameInfo]:
+        """
+        Given a list of source files and line numbers,returns the commit info for the most recent commit.
+        """
+        raise NotImplementedError
 
     def get_commit_context(
         self, repo: Repository, filepath: str, branch: str, event_frame: Mapping[str, Any]

--- a/src/sentry/integrations/mixins/commit_context.py
+++ b/src/sentry/integrations/mixins/commit_context.py
@@ -37,10 +37,10 @@ class FileBlameInfo(SourceLineInfo):
 class GetBlameForFile(Protocol):
     def get_blame_for_file(
         self, repo: Repository, filepath: str, ref: str, lineno: int
-    ) -> Sequence[Mapping[str, Any]] | None:
+    ) -> list[dict[str, Any]] | None:
         ...
 
-    def get_blame_for_files(self, files: Sequence[SourceLineInfo]) -> Sequence[FileBlameInfo]:
+    def get_blame_for_files(self, files: Sequence[SourceLineInfo]) -> list[FileBlameInfo]:
         ...
 
 
@@ -78,7 +78,7 @@ class CommitContextMixin(GetClient):
 
         return response
 
-    def get_blame_for_files(self, files: Sequence[SourceLineInfo]) -> Sequence[FileBlameInfo]:
+    def get_blame_for_files(self, files: Sequence[SourceLineInfo]) -> list[FileBlameInfo]:
         """
         Calls the client's `get_blame_for_files` method to fetch blame for a list of files.
 
@@ -97,9 +97,7 @@ class CommitContextMixin(GetClient):
 
         return response
 
-    def get_commit_context_all_frames(
-        self, files: Sequence[SourceLineInfo]
-    ) -> Sequence[FileBlameInfo]:
+    def get_commit_context_all_frames(self, files: Sequence[SourceLineInfo]) -> list[FileBlameInfo]:
         """
         Given a list of source files and line numbers,returns the commit info for the most recent commit.
         """

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -798,7 +798,7 @@ class GitHubClientFileBlameQueryBuilderTest(TestCase):
     def test_get_blame_for_files_same_repo(self, get_jwt):
         """
         When all files are in the same repo, only one repository object should be
-        queried, but files blames within the repo should be deduped
+        queried and files blames within the repo should be deduped
         """
         file1 = SourceLineInfo(
             path="src/sentry/integrations/github/client_1.py",

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1,6 +1,7 @@
 import base64
 import re
-from datetime import datetime, timedelta
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 import pytest
@@ -13,6 +14,7 @@ from responses import matchers
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.client import GitHubAppsClient
 from sentry.integrations.github.integration import GitHubIntegration
+from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo, SourceLineInfo
 from sentry.integrations.notify_disable import notify_disable
 from sentry.integrations.request_buffer import IntegrationRequestBuffer
 from sentry.models.integrations.integration import Integration
@@ -23,6 +25,7 @@ from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.utils import json
 from sentry.utils.cache import cache
 
 GITHUB_CODEOWNERS = {
@@ -233,15 +236,15 @@ class GitHubAppsClientTest(TestCase):
                         ... on Commit {{
                             blame(path: "{path}") {{
                                 ranges {{
-                                        commit {{
-                                            oid
-                                            author {{
-                                                name
-                                                email
-                                            }}
-                                            message
-                                            committedDate
+                                    commit {{
+                                        oid
+                                        author {{
+                                            name
+                                            email
                                         }}
+                                        message
+                                        committedDate
+                                    }}
                                     startingLine
                                     endingLine
                                     age
@@ -746,3 +749,579 @@ class GithubProxyClientTest(TestCase):
         with pytest.raises(Exception):
             self.gh_client.get_blame_for_file(self.repo, "foo.py", "main", 1)
         assert Integration.objects.get(id=self.integration.id).status == ObjectStatus.DISABLED
+
+
+class GitHubClientFileBlameQueryBuilderTest(TestCase):
+    """
+    Tests that get_blame_for_files builds the correct GraphQL query
+    """
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    def setUp(self, get_jwt):
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="Github Test Org",
+            external_id="1",
+            metadata={"access_token": None, "expires_at": None},
+        )
+        self.repo_1 = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="integrations:github",
+            external_id=123,
+            integration_id=integration.id,
+        )
+        self.repo_2 = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/bar",
+            url="https://github.com/Test-Organization/bar",
+            provider="integrations:github",
+            external_id=456,
+            integration_id=integration.id,
+        )
+        install = integration.get_installation(organization_id=self.organization.id)
+        assert isinstance(install, GitHubIntegration)
+        self.install = install
+        self.github_client = self.install.get_client()
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/app/installations/1/access_tokens",
+            body='{"token": "12345token", "expires_at": "2030-01-01T00:00:00Z"}',
+            status=200,
+            content_type="application/json",
+        )
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @responses.activate
+    def test_get_blame_for_files_same_repo(self, get_jwt):
+        """
+        When all files are in the same repo, only one repository object should be
+        queried, but files blames within the repo should be deduped
+        """
+        file1 = SourceLineInfo(
+            path="src/sentry/integrations/github/client_1.py",
+            lineno=10,
+            ref="master",
+            repo=self.repo_1,
+            code_mapping=None,  # type: ignore
+        )
+        file2 = SourceLineInfo(
+            path="src/sentry/integrations/github/client_1.py",
+            lineno=15,
+            ref="master",
+            repo=self.repo_1,
+            code_mapping=None,  # type: ignore
+        )
+        file3 = SourceLineInfo(
+            path="src/sentry/integrations/github/client_2.py",
+            lineno=20,
+            ref="master",
+            repo=self.repo_1,
+            code_mapping=None,  # type: ignore
+        )
+        query = """query {
+    repository0: repository(name: "foo", owner: "Test-Organization") {
+        ref0: ref(qualifiedName: "master") {
+            target {
+                ... on Commit {
+                    blame0: blame(path: "src/sentry/integrations/github/client_1.py") {
+                        ranges {
+                            commit {
+                                oid
+                                author {
+                                    name
+                                    email
+                                }
+                                message
+                                committedDate
+                            }
+                            startingLine
+                            endingLine
+                            age
+                        }
+                    }
+                    blame1: blame(path: "src/sentry/integrations/github/client_2.py") {
+                        ranges {
+                            commit {
+                                oid
+                                author {
+                                    name
+                                    email
+                                }
+                                message
+                                committedDate
+                            }
+                            startingLine
+                            endingLine
+                            age
+                        }
+                    }
+                }
+            }
+        }
+    }
+}"""
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/graphql",
+            json={
+                "query": query,
+                "data": {},
+            },
+            content_type="application/json",
+        )
+
+        self.github_client.get_blame_for_files([file1, file2, file3])
+        assert json.loads(responses.calls[1].request.body)["query"] == query
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @responses.activate
+    def test_get_blame_for_files_different_repos(self, get_jwt):
+        """
+        When files are in different repos, multiple repository objects should be
+        queried. Files within the same repo and branch should be deduped.
+        """
+        file1 = SourceLineInfo(
+            path="src/sentry/integrations/github/client_1.py",
+            lineno=10,
+            ref="master",
+            repo=self.repo_1,
+            code_mapping=None,  # type:ignore
+        )
+        file2 = SourceLineInfo(
+            path="src/sentry/integrations/github/client_2.py",
+            lineno=15,
+            ref="master",
+            repo=self.repo_1,
+            code_mapping=None,  # type:ignore
+        )
+        file3 = SourceLineInfo(
+            path="src/getsentry/file.py",
+            lineno=20,
+            ref="master",
+            repo=self.repo_2,
+            code_mapping=None,  # type:ignore
+        )
+        query = """query {
+    repository0: repository(name: "foo", owner: "Test-Organization") {
+        ref0: ref(qualifiedName: "master") {
+            target {
+                ... on Commit {
+                    blame0: blame(path: "src/sentry/integrations/github/client_1.py") {
+                        ranges {
+                            commit {
+                                oid
+                                author {
+                                    name
+                                    email
+                                }
+                                message
+                                committedDate
+                            }
+                            startingLine
+                            endingLine
+                            age
+                        }
+                    }
+                    blame1: blame(path: "src/sentry/integrations/github/client_2.py") {
+                        ranges {
+                            commit {
+                                oid
+                                author {
+                                    name
+                                    email
+                                }
+                                message
+                                committedDate
+                            }
+                            startingLine
+                            endingLine
+                            age
+                        }
+                    }
+                }
+            }
+        }
+    }
+    repository1: repository(name: "bar", owner: "Test-Organization") {
+        ref0: ref(qualifiedName: "master") {
+            target {
+                ... on Commit {
+                    blame0: blame(path: "src/getsentry/file.py") {
+                        ranges {
+                            commit {
+                                oid
+                                author {
+                                    name
+                                    email
+                                }
+                                message
+                                committedDate
+                            }
+                            startingLine
+                            endingLine
+                            age
+                        }
+                    }
+                }
+            }
+        }
+    }
+}"""
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/graphql",
+            json={
+                "query": query,
+                "data": {},
+            },
+            content_type="application/json",
+        )
+
+        self.github_client.get_blame_for_files([file1, file2, file3])
+        assert json.loads(responses.calls[1].request.body)["query"] == query
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @responses.activate
+    def test_get_blame_for_files_different_refs(self, get_jwt):
+        """
+        When files are in the same repo but different branches, query multiple
+        ref objects. Files should still be deduped.
+        """
+        file1 = SourceLineInfo(
+            path="src/sentry/integrations/github/client.py",
+            lineno=10,
+            ref="master",
+            repo=self.repo_1,
+            code_mapping=None,  # type:ignore
+        )
+        file2 = SourceLineInfo(
+            path="src/sentry/integrations/github/client.py",
+            lineno=15,
+            ref="master",
+            repo=self.repo_1,
+            code_mapping=None,  # type:ignore
+        )
+        file3 = SourceLineInfo(
+            path="src/sentry/integrations/github/client.py",
+            lineno=20,
+            ref="staging",
+            repo=self.repo_1,
+            code_mapping=None,  # type:ignore
+        )
+        query = """query {
+    repository0: repository(name: "foo", owner: "Test-Organization") {
+        ref0: ref(qualifiedName: "master") {
+            target {
+                ... on Commit {
+                    blame0: blame(path: "src/sentry/integrations/github/client.py") {
+                        ranges {
+                            commit {
+                                oid
+                                author {
+                                    name
+                                    email
+                                }
+                                message
+                                committedDate
+                            }
+                            startingLine
+                            endingLine
+                            age
+                        }
+                    }
+                }
+            }
+        }
+        ref1: ref(qualifiedName: "staging") {
+            target {
+                ... on Commit {
+                    blame0: blame(path: "src/sentry/integrations/github/client.py") {
+                        ranges {
+                            commit {
+                                oid
+                                author {
+                                    name
+                                    email
+                                }
+                                message
+                                committedDate
+                            }
+                            startingLine
+                            endingLine
+                            age
+                        }
+                    }
+                }
+            }
+        }
+    }
+}"""
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/graphql",
+            json={
+                "query": query,
+                "data": {},
+            },
+            content_type="application/json",
+        )
+
+        self.github_client.get_blame_for_files([file1, file2, file3])
+        assert json.loads(responses.calls[1].request.body)["query"] == query
+
+
+class GitHubClientFileBlameResponseTest(TestCase):
+    """
+    Tests that get_blame_for_files handles the GraphQL response correctly
+    """
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    def setUp(self, get_jwt):
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="Github Test Org",
+            external_id="1",
+            metadata={"access_token": None, "expires_at": None},
+        )
+        self.repo_1 = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="integrations:github",
+            external_id=123,
+            integration_id=integration.id,
+        )
+        self.repo_2 = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/bar",
+            url="https://github.com/Test-Organization/bar",
+            provider="integrations:github",
+            external_id=456,
+            integration_id=integration.id,
+        )
+        self.repo_3 = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/other",
+            url="https://github.com/Test-Organization/other",
+            provider="integrations:github",
+            external_id=789,
+            integration_id=integration.id,
+        )
+        install = integration.get_installation(organization_id=self.organization.id)
+        assert isinstance(install, GitHubIntegration)
+        self.install = install
+        self.github_client = self.install.get_client()
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/app/installations/1/access_tokens",
+            body='{"token": "12345token", "expires_at": "2030-01-01T00:00:00Z"}',
+            status=200,
+            content_type="application/json",
+        )
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @responses.activate
+    def test_get_blame_for_files_full_response(self, get_jwt):
+        """
+        Tests that the correct commits are returned when a full response is returned
+        """
+        file1 = SourceLineInfo(
+            path="src/sentry/integrations/github/client_1.py",
+            lineno=10,
+            ref="master",
+            repo=self.repo_1,
+            code_mapping=None,  # type:ignore
+        )
+        file2 = SourceLineInfo(
+            path="src/sentry/integrations/github/client_1.py",
+            lineno=15,
+            ref="master",
+            repo=self.repo_1,
+            code_mapping=None,  # type:ignore
+        )
+        file3 = SourceLineInfo(
+            path="src/sentry/integrations/github/client_2.py",
+            lineno=20,
+            ref="master",
+            repo=self.repo_1,
+            code_mapping=None,  # type:ignore
+        )
+        data = {
+            "repository0": {
+                "ref0": {
+                    "target": {
+                        "blame0": {
+                            "ranges": [
+                                {
+                                    "commit": {
+                                        "oid": "987",
+                                        "author": {
+                                            "name": "not this one",
+                                            "email": "blah@example.com",
+                                        },
+                                        "message": "bye",
+                                        "committedDate": "2022-01-01T00:00:00Z",
+                                    },
+                                    "startingLine": 1,
+                                    "endingLine": 9,
+                                    "age": 0,
+                                },
+                                {
+                                    "commit": {
+                                        "oid": "123",
+                                        "author": {"name": "foo1", "email": "foo1@example.com"},
+                                        "message": "hello",
+                                        "committedDate": "2022-01-01T00:00:00Z",
+                                    },
+                                    "startingLine": 10,
+                                    "endingLine": 15,
+                                    "age": 0,
+                                },
+                            ]
+                        },
+                        "blame1": {
+                            "ranges": [
+                                {
+                                    "commit": {
+                                        "oid": "456",
+                                        "author": {"name": "foo2", "email": "foo2@example.com"},
+                                        "message": "hello",
+                                        "committedDate": "2020-01-01T00:00:00Z",
+                                    },
+                                    "startingLine": 20,
+                                    "endingLine": 20,
+                                    "age": 0,
+                                }
+                            ]
+                        },
+                    }
+                }
+            }
+        }
+
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/graphql",
+            json={
+                "data": data,
+            },
+            content_type="application/json",
+        )
+
+        response = self.github_client.get_blame_for_files([file1, file2, file3])
+        self.assertEqual(
+            response,
+            [
+                FileBlameInfo(
+                    **asdict(file1),
+                    commit=CommitInfo(
+                        commitId="123",
+                        commitAuthorName="foo1",
+                        commitAuthorEmail="foo1@example.com",
+                        commitMessage="hello",
+                        committedDate=datetime(2022, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                    ),
+                ),
+                FileBlameInfo(
+                    **asdict(file3),
+                    commit=CommitInfo(
+                        commitId="456",
+                        commitAuthorName="foo2",
+                        commitAuthorEmail="foo2@example.com",
+                        commitMessage="hello",
+                        committedDate=datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                    ),
+                ),
+            ],
+        )
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @responses.activate
+    def test_get_blame_for_files_response_partial_data(self, get_jwt):
+        """
+        Tests that commits are still returned when some data is missing from the response
+        """
+        file1 = SourceLineInfo(
+            path="src/sentry/integrations/github/client_1.py",
+            lineno=10,
+            ref="master",
+            repo=self.repo_1,
+            code_mapping=None,  # type: ignore
+        )
+        file2 = SourceLineInfo(
+            path="src/sentry/integrations/github/client_2.py",
+            lineno=15,
+            ref="master",
+            repo=self.repo_1,
+            code_mapping=None,  # type:ignore
+        )
+        file3 = SourceLineInfo(
+            path="src/sentry/integrations/github/client.py",
+            lineno=20,
+            ref="master",
+            repo=self.repo_2,
+            code_mapping=None,  # type:ignore
+        )
+        file4 = SourceLineInfo(
+            path="src/sentry/integrations/github/client.py",
+            lineno=25,
+            ref="master",
+            repo=self.repo_3,
+            code_mapping=None,  # type:ignore
+        )
+        data = {
+            "repository0": {
+                "ref0": {
+                    "target": {
+                        "blame0": {
+                            "ranges": [
+                                {
+                                    "commit": {
+                                        "oid": "123",
+                                        "author": None,
+                                        "message": None,
+                                        "committedDate": "2022-01-01T00:00:00Z",
+                                    },
+                                    "startingLine": 10,
+                                    "endingLine": 15,
+                                    "age": 0,
+                                }
+                            ]
+                        },
+                        "blame1": {"ranges": []},
+                    }
+                }
+            },
+            "repository1": {"ref0": None},
+            "repository2": None,
+        }
+
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/graphql",
+            json={
+                "data": data,
+            },
+            content_type="application/json",
+        )
+
+        response = self.github_client.get_blame_for_files([file1, file2, file3, file4])
+        self.assertEqual(
+            response,
+            [
+                FileBlameInfo(
+                    **asdict(file1),
+                    commit=CommitInfo(
+                        commitId="123",
+                        commitAuthorName=None,
+                        commitAuthorEmail=None,
+                        commitMessage=None,
+                        committedDate=datetime(2022, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                    ),
+                ),
+            ],
+        )


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/57433

Note that while this adds funcionality to the GitHub integration, this code path is only used in tests so far. Followup PRs will hook this up to the commit_context task under the feature flag `organizations:suspect-commits-all-frames`. Other followup work will add rate limit checking as well.

- Adds `get_commit_context_all_frames` and `get_blame_for_files` to `CommitContextMixin`, which are similar to the existing `get_commit_context` and `get_blame_for_file`, except that they will make a request for multiple frames at once
- Implements these functions for GitHub (GitLab will come later)
- Using the GraphQL API, queries are dynamically generated to fetch all files at once. There is quite a bit of logic in `github/blame.py` which deals with deduping the list of file info, generating the proper query, and then extracting/formatting the query data. 