### PR TITLE
ref(replays): change empty state messaging for selectors

### DIFF
--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -120,7 +120,7 @@ function AccordionWidget({
             <div>{t('No results found')}</div>
             <EmptySubtitle>
               {tct(
-                "Once your users start clicking around, you'll see the top selectors that were [type] clicked here.",
+                'There were no [type] clicks within this timeframe. Expand your timeframe, or increase your sample rate to see more data.',
                 {type: deadOrRage}
               )}
             </EmptySubtitle>
@@ -310,7 +310,7 @@ export const RightAlignedCell = styled('div')`
 
 const EmptySubtitle = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
-  line-height: 1.8em;
+  line-height: 1.6em;
   padding-left: ${space(1)};
   padding-right: ${space(1)};
 `;

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -120,7 +120,7 @@ function AccordionWidget({
             <div>{t('No results found')}</div>
             <EmptySubtitle>
               {tct(
-                'There were no [type] clicks within this timeframe. Expand your timeframe, or increase your sample rate to see more data.',
+                'There were no [type] clicks within this timeframe. Expand your timeframe, or increase your replay sample rate to see more data.',
                 {type: deadOrRage}
               )}
             </EmptySubtitle>

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -196,7 +196,7 @@ export default function SelectorTable({
       <Title>{t('No dead or rage clicks found')}</Title>
       <Subtitle>
         {t(
-          'There were no dead or rage clicks within this timeframe. Expand your timeframe, or increase your sample rate to see more data.'
+          'There were no dead or rage clicks within this timeframe. Expand your timeframe, or increase your replay sample rate to see more data.'
         )}
       </Subtitle>
     </MessageContainer>

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -196,7 +196,7 @@ export default function SelectorTable({
       <Title>{t('No dead or rage clicks found')}</Title>
       <Subtitle>
         {t(
-          "Once your users start clicking around, you'll see the top selectors that were dead or rage clicked here."
+          'There were no dead or rage clicks within this timeframe. Expand your timeframe, or increase your sample rate to see more data.'
         )}
       </Subtitle>
     </MessageContainer>


### PR DESCRIPTION

<img width="1164" alt="SCR-20231013-jztq" src="https://github.com/getsentry/sentry/assets/56095982/ab3c9c2f-3a5d-490a-b598-c9852ebd2520">
<img width="1149" alt="SCR-20231013-jzmi" src="https://github.com/getsentry/sentry/assets/56095982/bd7aafd5-9dd3-40f0-8b69-b127e13c3e3a">

