### PR TITLE
ref(participants): Update tooltip text

### DIFF
--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -150,7 +150,9 @@ export default function GroupSidebar({
           <QuestionTooltip
             size="xs"
             position="top"
-            title={t('People who have resolved, ignored, or added a comment')}
+            title={t(
+              'People who have been assigned, resolved, unresolved, archived, bookmarked, subscribed, or added a comment'
+            )}
           />
         </SidebarSection.Title>
         <SidebarSection.Content>


### PR DESCRIPTION
Update the tooltip text on the participants section to include more ways to become a participant. I left out being mentioned in a comment because we're removing that (but it's behind a feature flag), but since the current list isn't exhaustive I think it's fine to leave out. 

**Before**
<img width="270" alt="Screenshot 2023-10-13 at 11 08 34 AM" src="https://github.com/getsentry/sentry/assets/29959063/d8576af7-03cb-443e-a933-d920803f2ecc">

**After**
<img width="329" alt="Screenshot 2023-10-13 at 11 08 10 AM" src="https://github.com/getsentry/sentry/assets/29959063/dc95e3e4-d962-495c-8052-6e8bd829f759">

Closes #57723 