### PR TITLE
feat(backup): Settable --findings_file for all commands

### DIFF
--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+from typing import Callable, Sequence, TextIO
+
 import click
 
 from sentry.backup.comparators import get_default_comparators
-from sentry.backup.findings import FindingJSONEncoder
+from sentry.backup.findings import Finding, FindingJSONEncoder
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.validate import validate
 from sentry.runner.decorators import configuration
 from sentry.utils import json
+
+DEFAULT_INDENT = 2
 
 DECRYPT_WITH_HELP = """A path to a file containing a private key with which to decrypt a tarball
                     previously encrypted using an `export ... --encrypt_with=<PUBLIC_KEY>` command.
@@ -28,6 +32,8 @@ ENCRYPT_WITH_HELP = """A path to the a public key with which to encrypt this exp
 FINDINGS_FILE_HELP = """Optional file that records comparator findings, saved in the JSON format.
                      If left unset, no such file is written."""
 
+INDENT_HELP = "Number of spaces to indent for the JSON output. (default: 2)"
+
 MERGE_USERS_HELP = """If this flag is set and users in the import JSON have matching usernames to
                    those already in the database, the existing users are used instead and their
                    associated user scope models are not updated. If this flag is not set, new users
@@ -41,6 +47,13 @@ OVERWRITE_CONFIGS_HELP = """Imports are generally non-destructive of old data. H
                          retained in the event of a collision."""
 
 
+def get_printer(silent: bool) -> Callable:
+    if silent:
+        return lambda *args, **kwargs: None
+    else:
+        return click.echo
+
+
 def parse_filter_arg(filter_arg: str) -> set[str] | None:
     filter_by = None
     if filter_arg:
@@ -49,14 +62,25 @@ def parse_filter_arg(filter_arg: str) -> set[str] | None:
     return filter_by
 
 
-findings_encoder = FindingJSONEncoder(
-    sort_keys=True,
-    ensure_ascii=True,
-    check_circular=True,
-    allow_nan=True,
-    indent=2,
-    encoding="utf-8",
-)
+def write_findings(
+    findings_file: TextIO | None, findings: Sequence[Finding], indent: int, printer: Callable
+):
+    for f in findings:
+        printer(f.pretty(), err=True)
+
+    if findings_file:
+        findings_encoder = FindingJSONEncoder(
+            sort_keys=True,
+            ensure_ascii=True,
+            check_circular=True,
+            allow_nan=True,
+            indent=indent,
+            encoding="utf-8",
+        )
+
+        with findings_file as file:
+            encoded = findings_encoder.encode(findings)
+            file.write(encoded)
 
 
 @click.command(name="compare")
@@ -88,11 +112,7 @@ def compare(left, right, findings_file):
 
     res = validate(left_data, right_data, get_default_comparators())
     if res:
-        if findings_file:
-            with findings_file as f:
-                encoded = findings_encoder.encode(res.findings)
-                f.write(encoded)
-
+        write_findings(findings_file, res.findings, DEFAULT_INDENT, click.echo)
         click.echo(f"Done, found {len(res.findings)} differences:\n\n{res.pretty()}")
     else:
         click.echo("Done, found 0 differences!")
@@ -118,6 +138,12 @@ def import_():
     "If this option is not set, all encountered users are imported.",
 )
 @click.option(
+    "--findings_file",
+    type=click.File("w"),
+    required=False,
+    help=FINDINGS_FILE_HELP,
+)
+@click.option(
     "--merge_users",
     default=False,
     is_flag=True,
@@ -125,20 +151,26 @@ def import_():
 )
 @click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
-def import_users(src, decrypt_with, filter_usernames, merge_users, silent):
+def import_users(src, decrypt_with, filter_usernames, findings_file, merge_users, silent):
     """
     Import the Sentry users from an exported JSON file.
     """
 
-    from sentry.backup.imports import import_in_user_scope
+    from sentry.backup.imports import ImportingError, import_in_user_scope
 
-    import_in_user_scope(
-        src,
-        decrypt_with=decrypt_with,
-        flags=ImportFlags(merge_users=merge_users),
-        user_filter=parse_filter_arg(filter_usernames),
-        printer=(lambda *args, **kwargs: None) if silent else click.echo,
-    )
+    printer = get_printer(silent)
+    try:
+        import_in_user_scope(
+            src,
+            decrypt_with=decrypt_with,
+            flags=ImportFlags(merge_users=merge_users),
+            user_filter=parse_filter_arg(filter_usernames),
+            printer=printer,
+        )
+    except ImportingError as e:
+        if e.context:
+            write_findings(findings_file, [e.context], DEFAULT_INDENT, printer)
+        raise e
 
 
 @import_.command(name="organizations")
@@ -157,6 +189,12 @@ def import_users(src, decrypt_with, filter_usernames, merge_users, silent):
     "Users not members of at least one organization in this set will not be imported.",
 )
 @click.option(
+    "--findings_file",
+    type=click.File("w"),
+    required=False,
+    help=FINDINGS_FILE_HELP,
+)
+@click.option(
     "--merge_users",
     default=False,
     is_flag=True,
@@ -164,20 +202,26 @@ def import_users(src, decrypt_with, filter_usernames, merge_users, silent):
 )
 @click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
-def import_organizations(src, decrypt_with, filter_org_slugs, merge_users, silent):
+def import_organizations(src, decrypt_with, filter_org_slugs, findings_file, merge_users, silent):
     """
     Import the Sentry organizations, and all constituent Sentry users, from an exported JSON file.
     """
 
-    from sentry.backup.imports import import_in_organization_scope
+    from sentry.backup.imports import ImportingError, import_in_organization_scope
 
-    import_in_organization_scope(
-        src,
-        decrypt_with=decrypt_with,
-        flags=ImportFlags(merge_users=merge_users),
-        org_filter=parse_filter_arg(filter_org_slugs),
-        printer=(lambda *args, **kwargs: None) if silent else click.echo,
-    )
+    printer = get_printer(silent)
+    try:
+        import_in_organization_scope(
+            src,
+            decrypt_with=decrypt_with,
+            flags=ImportFlags(merge_users=merge_users),
+            org_filter=parse_filter_arg(filter_org_slugs),
+            printer=printer,
+        )
+    except ImportingError as e:
+        if e.context:
+            write_findings(findings_file, [e.context], DEFAULT_INDENT, printer)
+        raise e
 
 
 @import_.command(name="config")
@@ -187,7 +231,12 @@ def import_organizations(src, decrypt_with, filter_org_slugs, merge_users, silen
     type=click.File("rb"),
     help=DECRYPT_WITH_HELP,
 )
-@click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
+@click.option(
+    "--findings_file",
+    type=click.File("w"),
+    required=False,
+    help=FINDINGS_FILE_HELP,
+)
 @click.option(
     "--merge_users",
     default=False,
@@ -200,20 +249,27 @@ def import_organizations(src, decrypt_with, filter_org_slugs, merge_users, silen
     is_flag=True,
     help=OVERWRITE_CONFIGS_HELP,
 )
+@click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
-def import_config(src, decrypt_with, merge_users, overwrite_configs, silent):
+def import_config(src, decrypt_with, findings_file, merge_users, overwrite_configs, silent):
     """
     Import all configuration and administrator accounts needed to set up this Sentry instance.
     """
 
-    from sentry.backup.imports import import_in_config_scope
+    from sentry.backup.imports import ImportingError, import_in_config_scope
 
-    import_in_config_scope(
-        src,
-        decrypt_with=decrypt_with,
-        flags=ImportFlags(merge_users=merge_users, overwrite_configs=overwrite_configs),
-        printer=(lambda *args, **kwargs: None) if silent else click.echo,
-    )
+    printer = get_printer(silent)
+    try:
+        import_in_config_scope(
+            src,
+            decrypt_with=decrypt_with,
+            flags=ImportFlags(merge_users=merge_users, overwrite_configs=overwrite_configs),
+            printer=printer,
+        )
+    except ImportingError as e:
+        if e.context:
+            write_findings(findings_file, [e.context], DEFAULT_INDENT, printer)
+        raise e
 
 
 @import_.command(name="global")
@@ -224,6 +280,12 @@ def import_config(src, decrypt_with, merge_users, overwrite_configs, silent):
     help=DECRYPT_WITH_HELP,
 )
 @click.option(
+    "--findings_file",
+    type=click.File("w"),
+    required=False,
+    help=FINDINGS_FILE_HELP,
+)
+@click.option(
     "--overwrite_configs",
     default=False,
     is_flag=True,
@@ -231,19 +293,25 @@ def import_config(src, decrypt_with, merge_users, overwrite_configs, silent):
 )
 @click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
-def import_global(src, decrypt_with, silent, overwrite_configs):
+def import_global(src, decrypt_with, findings_file, overwrite_configs, silent):
     """
     Import all Sentry data from an exported JSON file.
     """
 
-    from sentry.backup.imports import import_in_global_scope
+    from sentry.backup.imports import ImportingError, import_in_global_scope
 
-    import_in_global_scope(
-        src,
-        decrypt_with=decrypt_with,
-        flags=ImportFlags(overwrite_configs=overwrite_configs),
-        printer=(lambda *args, **kwargs: None) if silent else click.echo,
-    )
+    printer = get_printer(silent)
+    try:
+        import_in_global_scope(
+            src,
+            decrypt_with=decrypt_with,
+            flags=ImportFlags(overwrite_configs=overwrite_configs),
+            printer=printer,
+        )
+    except ImportingError as e:
+        if e.context:
+            write_findings(findings_file, [e.context], DEFAULT_INDENT, printer)
+        raise e
 
 
 @click.group(name="export")
@@ -266,27 +334,39 @@ def export():
     "If this option is not set, all encountered users are imported.",
 )
 @click.option(
+    "--findings_file",
+    type=click.File("w"),
+    required=False,
+    help=FINDINGS_FILE_HELP,
+)
+@click.option(
     "--indent",
     default=2,
     type=int,
-    help="Number of spaces to indent for the JSON output. (default: 2)",
+    help=INDENT_HELP,
 )
 @click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
-def export_users(dest, encrypt_with, filter_usernames, indent, silent):
+def export_users(dest, encrypt_with, filter_usernames, findings_file, indent, silent):
     """
     Export all Sentry users in the JSON format.
     """
 
-    from sentry.backup.exports import export_in_user_scope
+    from sentry.backup.exports import ExportingError, export_in_user_scope
 
-    export_in_user_scope(
-        dest,
-        encrypt_with=encrypt_with,
-        indent=indent,
-        user_filter=parse_filter_arg(filter_usernames),
-        printer=(lambda *args, **kwargs: None) if silent else click.echo,
-    )
+    printer = get_printer(silent)
+    try:
+        export_in_user_scope(
+            dest,
+            encrypt_with=encrypt_with,
+            indent=indent,
+            user_filter=parse_filter_arg(filter_usernames),
+            printer=printer,
+        )
+    except ExportingError as e:
+        if e.context:
+            write_findings(findings_file, [e.context], DEFAULT_INDENT, printer)
+        raise e
 
 
 @export.command(name="organizations")
@@ -305,27 +385,39 @@ def export_users(dest, encrypt_with, filter_usernames, indent, silent):
     "Users not members of at least one organization in this set will not be exported.",
 )
 @click.option(
+    "--findings_file",
+    type=click.File("w"),
+    required=False,
+    help=FINDINGS_FILE_HELP,
+)
+@click.option(
     "--indent",
     default=2,
     type=int,
-    help="Number of spaces to indent for the JSON output. (default: 2)",
+    help=INDENT_HELP,
 )
 @click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
-def export_organizations(dest, encrypt_with, filter_org_slugs, indent, silent):
+def export_organizations(dest, encrypt_with, filter_org_slugs, findings_file, indent, silent):
     """
     Export all Sentry organizations, and their constituent users, in the JSON format.
     """
 
-    from sentry.backup.exports import export_in_organization_scope
+    from sentry.backup.exports import ExportingError, export_in_organization_scope
 
-    export_in_organization_scope(
-        dest,
-        encrypt_with=encrypt_with,
-        indent=indent,
-        org_filter=parse_filter_arg(filter_org_slugs),
-        printer=(lambda *args, **kwargs: None) if silent else click.echo,
-    )
+    printer = get_printer(silent)
+    try:
+        export_in_organization_scope(
+            dest,
+            encrypt_with=encrypt_with,
+            indent=indent,
+            org_filter=parse_filter_arg(filter_org_slugs),
+            printer=printer,
+        )
+    except ExportingError as e:
+        if e.context:
+            write_findings(findings_file, [e.context], DEFAULT_INDENT, printer)
+        raise e
 
 
 @export.command(name="config")
@@ -336,26 +428,38 @@ def export_organizations(dest, encrypt_with, filter_org_slugs, indent, silent):
     help=ENCRYPT_WITH_HELP,
 )
 @click.option(
+    "--findings_file",
+    type=click.File("w"),
+    required=False,
+    help=FINDINGS_FILE_HELP,
+)
+@click.option(
     "--indent",
     default=2,
     type=int,
-    help="Number of spaces to indent for the JSON output. (default: 2)",
+    help=INDENT_HELP,
 )
 @click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
-def export_config(dest, encrypt_with, indent, silent):
+def export_config(dest, encrypt_with, findings_file, indent, silent):
     """
     Export all configuration and administrator accounts needed to set up this Sentry instance.
     """
 
-    from sentry.backup.exports import export_in_config_scope
+    from sentry.backup.exports import ExportingError, export_in_config_scope
 
-    export_in_config_scope(
-        dest,
-        encrypt_with=encrypt_with,
-        indent=indent,
-        printer=(lambda *args, **kwargs: None) if silent else click.echo,
-    )
+    printer = get_printer(silent)
+    try:
+        export_in_config_scope(
+            dest,
+            encrypt_with=encrypt_with,
+            indent=indent,
+            printer=printer,
+        )
+    except ExportingError as e:
+        if e.context:
+            write_findings(findings_file, [e.context], DEFAULT_INDENT, printer)
+        raise e
 
 
 @export.command(name="global")
@@ -366,23 +470,35 @@ def export_config(dest, encrypt_with, indent, silent):
     help=ENCRYPT_WITH_HELP,
 )
 @click.option(
+    "--findings_file",
+    type=click.File("w"),
+    required=False,
+    help=FINDINGS_FILE_HELP,
+)
+@click.option(
     "--indent",
     default=2,
     type=int,
-    help="Number of spaces to indent for the JSON output. (default: 2)",
+    help=INDENT_HELP,
 )
 @click.option("--silent", "-q", default=False, is_flag=True, help="Silence all debug output.")
 @configuration
-def export_global(dest, encrypt_with, indent, silent):
+def export_global(dest, encrypt_with, findings_file, indent, silent):
     """
     Export all Sentry data in the JSON format.
     """
 
-    from sentry.backup.exports import export_in_global_scope
+    from sentry.backup.exports import ExportingError, export_in_global_scope
 
-    export_in_global_scope(
-        dest,
-        encrypt_with=encrypt_with,
-        indent=indent,
-        printer=(lambda *args, **kwargs: None) if silent else click.echo,
-    )
+    printer = get_printer(silent)
+    try:
+        export_in_global_scope(
+            dest,
+            encrypt_with=encrypt_with,
+            indent=indent,
+            printer=printer,
+        )
+    except ExportingError as e:
+        if e.context:
+            write_findings(findings_file, [e.context], DEFAULT_INDENT, printer)
+        raise e

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -87,7 +87,7 @@ def write_findings(
 @click.argument("left", type=click.File("rb"))
 @click.argument("right", type=click.File("rb"))
 @click.option(
-    "--findings_file",
+    "--findings-file",
     type=click.File("w"),
     required=False,
     help=FINDINGS_FILE_HELP,
@@ -126,25 +126,28 @@ def import_():
 @import_.command(name="users")
 @click.argument("src", type=click.File("rb"))
 @click.option(
-    "--decrypt_with",
+    "--decrypt-with",
+    "--decrypt_with",  # For backwards compatibility with self-hosted@23.10.0
     type=click.File("rb"),
     help=DECRYPT_WITH_HELP,
 )
 @click.option(
-    "--filter_usernames",
+    "--filter-usernames",
+    "--filter_usernames",  # For backwards compatibility with self-hosted@23.10.0
     default="",
     type=str,
     help="An optional comma-separated list of users to include. "
     "If this option is not set, all encountered users are imported.",
 )
 @click.option(
-    "--findings_file",
+    "--findings-file",
     type=click.File("w"),
     required=False,
     help=FINDINGS_FILE_HELP,
 )
 @click.option(
-    "--merge_users",
+    "--merge-users",
+    "--merge_users",  # For backwards compatibility with self-hosted@23.10.0
     default=False,
     is_flag=True,
     help=MERGE_USERS_HELP,
@@ -176,12 +179,14 @@ def import_users(src, decrypt_with, filter_usernames, findings_file, merge_users
 @import_.command(name="organizations")
 @click.argument("src", type=click.File("rb"))
 @click.option(
-    "--decrypt_with",
+    "--decrypt-with",
+    "--decrypt_with",  # For backwards compatibility with self-hosted@23.10.0
     type=click.File("rb"),
     help=DECRYPT_WITH_HELP,
 )
 @click.option(
-    "--filter_org_slugs",
+    "--filter-org-slugs",
+    "--filter_org_slugs",  # For backwards compatibility with self-hosted@23.10.0
     default="",
     type=str,
     help="An optional comma-separated list of organization slugs to include. "
@@ -189,13 +194,14 @@ def import_users(src, decrypt_with, filter_usernames, findings_file, merge_users
     "Users not members of at least one organization in this set will not be imported.",
 )
 @click.option(
-    "--findings_file",
+    "--findings-file",
     type=click.File("w"),
     required=False,
     help=FINDINGS_FILE_HELP,
 )
 @click.option(
-    "--merge_users",
+    "--merge-users",
+    "--merge_users",  # For backwards compatibility with self-hosted@23.10.0
     default=False,
     is_flag=True,
     help=MERGE_USERS_HELP,
@@ -227,24 +233,27 @@ def import_organizations(src, decrypt_with, filter_org_slugs, findings_file, mer
 @import_.command(name="config")
 @click.argument("src", type=click.File("rb"))
 @click.option(
-    "--decrypt_with",
+    "--decrypt-with",
+    "--decrypt_with",  # For backwards compatibility with self-hosted@23.10.0
     type=click.File("rb"),
     help=DECRYPT_WITH_HELP,
 )
 @click.option(
-    "--findings_file",
+    "--findings-file",
     type=click.File("w"),
     required=False,
     help=FINDINGS_FILE_HELP,
 )
 @click.option(
-    "--merge_users",
+    "--merge-users",
+    "--merge_users",  # For backwards compatibility with self-hosted@23.10.0
     default=False,
     is_flag=True,
     help=MERGE_USERS_HELP,
 )
 @click.option(
-    "--overwrite_configs",
+    "--overwrite-configs",
+    "--overwrite_configs",  # For backwards compatibility with self-hosted@23.10.0
     default=False,
     is_flag=True,
     help=OVERWRITE_CONFIGS_HELP,
@@ -275,18 +284,20 @@ def import_config(src, decrypt_with, findings_file, merge_users, overwrite_confi
 @import_.command(name="global")
 @click.argument("src", type=click.File("rb"))
 @click.option(
-    "--decrypt_with",
+    "--decrypt-with",
+    "--decrypt_with",  # For backwards compatibility with self-hosted@23.10.0
     type=click.File("rb"),
     help=DECRYPT_WITH_HELP,
 )
 @click.option(
-    "--findings_file",
+    "--findings-file",
     type=click.File("w"),
     required=False,
     help=FINDINGS_FILE_HELP,
 )
 @click.option(
-    "--overwrite_configs",
+    "--overwrite-configs",
+    "--overwrite_configs",  # For backwards compatibility with self-hosted@23.10.0
     default=False,
     is_flag=True,
     help=OVERWRITE_CONFIGS_HELP,
@@ -322,19 +333,21 @@ def export():
 @export.command(name="users")
 @click.argument("dest", default="-", type=click.File("wb"))
 @click.option(
-    "--encrypt_with",
+    "--encrypt-with",
+    "--encrypt_with",  # For backwards compatibility with self-hosted@23.10.0
     type=click.File("rb"),
     help=ENCRYPT_WITH_HELP,
 )
 @click.option(
-    "--filter_usernames",
+    "--filter-usernames",
+    "--filter_usernames",  # For backwards compatibility with self-hosted@23.10.0
     default="",
     type=str,
     help="An optional comma-separated list of users to include. "
     "If this option is not set, all encountered users are imported.",
 )
 @click.option(
-    "--findings_file",
+    "--findings-file",
     type=click.File("w"),
     required=False,
     help=FINDINGS_FILE_HELP,
@@ -372,12 +385,14 @@ def export_users(dest, encrypt_with, filter_usernames, findings_file, indent, si
 @export.command(name="organizations")
 @click.argument("dest", default="-", type=click.File("wb"))
 @click.option(
-    "--encrypt_with",
+    "--encrypt-with",
+    "--encrypt_with",  # For backwards compatibility with self-hosted@23.10.0
     type=click.File("rb"),
     help=ENCRYPT_WITH_HELP,
 )
 @click.option(
-    "--filter_org_slugs",
+    "--filter-org-slugs",
+    "--filter_org_slugs",  # For backwards compatibility with self-hosted@23.10.0
     default="",
     type=str,
     help="An optional comma-separated list of organization slugs to include. "
@@ -385,7 +400,7 @@ def export_users(dest, encrypt_with, filter_usernames, findings_file, indent, si
     "Users not members of at least one organization in this set will not be exported.",
 )
 @click.option(
-    "--findings_file",
+    "--findings-file",
     type=click.File("w"),
     required=False,
     help=FINDINGS_FILE_HELP,
@@ -423,12 +438,13 @@ def export_organizations(dest, encrypt_with, filter_org_slugs, findings_file, in
 @export.command(name="config")
 @click.argument("dest", default="-", type=click.File("wb"))
 @click.option(
-    "--encrypt_with",
+    "--encrypt-with",
+    "--encrypt_with",  # For backwards compatibility with self-hosted@23.10.0
     type=click.File("rb"),
     help=ENCRYPT_WITH_HELP,
 )
 @click.option(
-    "--findings_file",
+    "--findings-file",
     type=click.File("w"),
     required=False,
     help=FINDINGS_FILE_HELP,
@@ -465,12 +481,13 @@ def export_config(dest, encrypt_with, findings_file, indent, silent):
 @export.command(name="global")
 @click.argument("dest", default="-", type=click.File("wb"))
 @click.option(
-    "--encrypt_with",
+    "--encrypt-with",
+    "--encrypt_with",  # For backwards compatibility with self-hosted@23.10.0
     type=click.File("rb"),
     help=ENCRYPT_WITH_HELP,
 )
 @click.option(
-    "--findings_file",
+    "--findings-file",
     type=click.File("w"),
     required=False,
     help=FINDINGS_FILE_HELP,

--- a/src/sentry/services/hybrid_cloud/import_export/model.py
+++ b/src/sentry/services/hybrid_cloud/import_export/model.py
@@ -146,7 +146,9 @@ class RpcImportError(RpcModel, Finding):
         return f"RpcImportError(\n    kind: {self.get_kind()},{self._pretty_inner()}\n)"
 
     def to_dict(self) -> Dict[str, Any]:
-        return dict(self)
+        d = dict(self)
+        del d["is_err"]
+        return d
 
 
 class RpcImportOk(RpcModel):
@@ -227,7 +229,9 @@ class RpcExportError(RpcModel, Finding):
         return f"RpcExportError(\n    kind: {self.get_kind()},{self._pretty_inner()}\n)"
 
     def to_dict(self) -> Dict[str, Any]:
-        return dict(self)
+        d = dict(self)
+        del d["is_err"]
+        return d
 
 
 RpcExportResult = Annotated[Union[RpcExportOk, RpcExportError], Field(discriminator="is_err")]

--- a/src/sentry/services/hybrid_cloud/import_export/model.py
+++ b/src/sentry/services/hybrid_cloud/import_export/model.py
@@ -5,7 +5,7 @@
 
 from collections import defaultdict
 from enum import Enum, unique
-from typing import Dict, Literal, Optional, Set, Tuple, Union
+from typing import Any, Dict, Literal, Optional, Set, Tuple, Union
 
 from pydantic import Field, StrictInt, StrictStr
 from typing_extensions import Annotated
@@ -145,6 +145,9 @@ class RpcImportError(RpcModel, Finding):
     def pretty(self) -> str:
         return f"RpcImportError(\n    kind: {self.get_kind()},{self._pretty_inner()}\n)"
 
+    def to_dict(self) -> Dict[str, Any]:
+        return dict(self)
+
 
 class RpcImportOk(RpcModel):
     """
@@ -222,6 +225,9 @@ class RpcExportError(RpcModel, Finding):
 
     def pretty(self) -> str:
         return f"RpcExportError(\n    kind: {self.get_kind()},{self._pretty_inner()}\n)"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dict(self)
 
 
 RpcExportResult = Annotated[Union[RpcExportOk, RpcExportError], Field(discriminator="is_err")]

--- a/src/sentry/services/hybrid_cloud/import_export/model.py
+++ b/src/sentry/services/hybrid_cloud/import_export/model.py
@@ -119,7 +119,6 @@ class RpcImportErrorKind(str, Enum):
     DeserializationFailed = "DeserializationFailed"
     IncorrectSiloModeForModel = "IncorrectSiloModeForModel"
     IntegrityError = "IntegrityError"
-    InvalidJSON = "InvalidJSON"
     UnknownModel = "UnknownModel"
     UnexpectedModel = "UnexpectedModel"
     UnspecifiedScope = "UnspecifiedScope"
@@ -144,7 +143,7 @@ class RpcImportError(RpcModel, Finding):
         return RpcImportErrorKind(self.kind)
 
     def pretty(self) -> str:
-        return f"RpcImportError(\n\tkind: {self.get_kind()},{self._pretty_inner()}\n)"
+        return f"RpcImportError(\n    kind: {self.get_kind()},{self._pretty_inner()}\n)"
 
 
 class RpcImportOk(RpcModel):
@@ -222,7 +221,7 @@ class RpcExportError(RpcModel, Finding):
         return RpcExportErrorKind(self.kind)
 
     def pretty(self) -> str:
-        return f"RpcExportError(\n\tkind: {self.get_kind()},{self._pretty_inner()}\n)"
+        return f"RpcExportError(\n    kind: {self.get_kind()},{self._pretty_inner()}\n)"
 
 
 RpcExportResult = Annotated[Union[RpcExportOk, RpcExportError], Field(discriminator="is_err")]

--- a/tests/sentry/backup/test_findings.py
+++ b/tests/sentry/backup/test_findings.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import auto, unique
+from typing import Any, Dict
 
 from sentry.backup.dependencies import get_model_name
 from sentry.backup.findings import (
@@ -55,6 +56,9 @@ class TestFinding(Finding):
         if self.reason:
             out += f",\n    reason: {self.reason}"
         return out + "\n)"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
 
 
 class FindingsTests(TestCase):

--- a/tests/sentry/backup/test_findings.py
+++ b/tests/sentry/backup/test_findings.py
@@ -4,8 +4,21 @@ from dataclasses import dataclass
 from enum import auto, unique
 
 from sentry.backup.dependencies import get_model_name
-from sentry.backup.findings import Finding, FindingJSONEncoder, FindingKind, InstanceID
+from sentry.backup.findings import (
+    ComparatorFinding,
+    ComparatorFindingKind,
+    Finding,
+    FindingJSONEncoder,
+    FindingKind,
+    InstanceID,
+)
 from sentry.models.email import Email
+from sentry.services.hybrid_cloud.import_export.model import (
+    RpcExportError,
+    RpcExportErrorKind,
+    RpcImportError,
+    RpcImportErrorKind,
+)
 from sentry.testutils.cases import TestCase
 
 encoder = FindingJSONEncoder(
@@ -54,6 +67,7 @@ class FindingsTests(TestCase):
         assert (
             encoder.encode(finding)
             == """{
+    "finding": "TestFinding",
     "kind": "Unknown",
     "left_pk": null,
     "on": {
@@ -84,6 +98,7 @@ class FindingsTests(TestCase):
         assert (
             encoder.encode(finding)
             == """{
+    "finding": "TestFinding",
     "kind": "Foo",
     "left_pk": 2,
     "on": {
@@ -93,4 +108,113 @@ class FindingsTests(TestCase):
     "reason": "test reason",
     "right_pk": 3
 }"""
+        )
+        assert (
+            finding.pretty()
+            == """TestFinding(
+    kind: Foo,
+    on: InstanceID(model: 'sentry.email', ordinal: 1),
+    left_pk: 2,
+    right_pk: 3,
+    reason: test reason
+)"""
+        )
+
+    def test_comparator_finding(self):
+        finding = ComparatorFinding(
+            kind=ComparatorFindingKind.Unknown,
+            on=InstanceID(model=str(get_model_name(Email)), ordinal=1),
+            left_pk=2,
+            right_pk=3,
+            reason="test reason",
+        )
+        assert (
+            encoder.encode(finding)
+            == """{
+    "finding": "ComparatorFinding",
+    "kind": "Unknown",
+    "left_pk": 2,
+    "on": {
+        "model": "sentry.email",
+        "ordinal": 1
+    },
+    "reason": "test reason",
+    "right_pk": 3
+}"""
+        )
+        assert (
+            finding.pretty()
+            == """ComparatorFinding(
+    kind: Unknown,
+    on: InstanceID(model: 'sentry.email', ordinal: 1),
+    left_pk: 2,
+    right_pk: 3,
+    reason: test reason
+)"""
+        )
+
+    def test_rpc_export_error(self):
+        finding = RpcExportError(
+            kind=RpcExportErrorKind.Unknown,
+            on=InstanceID(model=str(get_model_name(Email)), ordinal=1),
+            left_pk=2,
+            right_pk=3,
+            reason="test reason",
+        )
+        assert (
+            encoder.encode(finding)
+            == """{
+    "finding": "RpcExportError",
+    "kind": "Unknown",
+    "left_pk": 2,
+    "on": {
+        "model": "sentry.email",
+        "ordinal": 1
+    },
+    "reason": "test reason",
+    "right_pk": 3
+}"""
+        )
+        assert (
+            finding.pretty()
+            == """RpcExportError(
+    kind: Unknown,
+    on: InstanceID(model: 'sentry.email', ordinal: 1),
+    left_pk: 2,
+    right_pk: 3,
+    reason: test reason
+)"""
+        )
+
+    def test_rpc_import_error(self):
+        finding = RpcImportError(
+            kind=RpcImportErrorKind.Unknown,
+            on=InstanceID(model=str(get_model_name(Email)), ordinal=1),
+            left_pk=2,
+            right_pk=3,
+            reason="test reason",
+        )
+        assert (
+            encoder.encode(finding)
+            == """{
+    "finding": "RpcImportError",
+    "kind": "Unknown",
+    "left_pk": 2,
+    "on": {
+        "model": "sentry.email",
+        "ordinal": 1
+    },
+    "reason": "test reason",
+    "right_pk": 3
+}"""
+        )
+        assert (
+            finding.pretty()
+            == """RpcImportError(
+    kind: Unknown,
+    on: InstanceID(model: 'sentry.email', ordinal: 1),
+    left_pk: 2,
+    right_pk: 3,
+    reason: test reason
+)"""
         )

--- a/tests/sentry/runner/commands/test_backup.py
+++ b/tests/sentry/runner/commands/test_backup.py
@@ -36,7 +36,7 @@ class GoodCompareCommandTests(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_findings = Path(tmp_dir).joinpath(f"{self._testMethodName}.findings.json")
             rv = CliRunner().invoke(
-                compare, [GOOD_FILE_PATH, GOOD_FILE_PATH, "--findings_file", str(tmp_findings)]
+                compare, [GOOD_FILE_PATH, GOOD_FILE_PATH, "--findings-file", str(tmp_findings)]
             )
             assert rv.exit_code == 0, rv.output
 
@@ -53,7 +53,7 @@ class GoodCompareCommandTests(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_findings = Path(tmp_dir).joinpath(f"{self._testMethodName}.findings.json")
             rv = CliRunner().invoke(
-                compare, [MAX_USER_PATH, MIN_USER_PATH, "--findings_file", str(tmp_findings)]
+                compare, [MAX_USER_PATH, MIN_USER_PATH, "--findings-file", str(tmp_findings)]
             )
             assert rv.exit_code == 0, rv.output
 
@@ -88,34 +88,34 @@ class GoodImportExportCommandTests(TransactionTestCase):
         cli_import_then_export("global")
 
     def test_global_scope_import_overwrite_configs(self):
-        cli_import_then_export("global", import_args=["--overwrite_configs"])
+        cli_import_then_export("global", import_args=["--overwrite-configs"])
 
     def test_config_scope(self):
         cli_import_then_export("config")
 
     def test_config_scope_import_overwrite_configs(self):
-        cli_import_then_export("config", import_args=["--overwrite_configs"])
+        cli_import_then_export("config", import_args=["--overwrite-configs"])
 
     def test_config_scope_export_merge_users(self):
-        cli_import_then_export("config", import_args=["--merge_users"])
+        cli_import_then_export("config", import_args=["--merge-users"])
 
     def test_organization_scope_import_filter_org_slugs(self):
-        cli_import_then_export("organizations", import_args=["--filter_org_slugs", "testing"])
+        cli_import_then_export("organizations", import_args=["--filter-org-slugs", "testing"])
 
     def test_organization_scope_export_filter_org_slugs(self):
-        cli_import_then_export("organizations", export_args=["--filter_org_slugs", "testing"])
+        cli_import_then_export("organizations", export_args=["--filter-org-slugs", "testing"])
 
     def test_user_scope(self):
         cli_import_then_export("users")
 
     def test_user_scope_export_merge_users(self):
-        cli_import_then_export("users", import_args=["--merge_users"])
+        cli_import_then_export("users", import_args=["--merge-users"])
 
     def test_user_scope_import_filter_usernames(self):
-        cli_import_then_export("users", import_args=["--filter_usernames", "testing@example.com"])
+        cli_import_then_export("users", import_args=["--filter-usernames", "testing@example.com"])
 
     def test_user_scope_export_filter_usernames(self):
-        cli_import_then_export("users", export_args=["--filter_usernames", "testing@example.com"])
+        cli_import_then_export("users", export_args=["--filter-usernames", "testing@example.com"])
 
 
 def cli_encrypted_import_then_export(scope: str):
@@ -138,20 +138,20 @@ def cli_encrypted_import_then_export(scope: str):
             i.write(create_encrypted_export_tarball(data, p).getvalue())
 
         rv = CliRunner().invoke(
-            import_, [scope, str(tmp_input_path), "--decrypt_with", str(tmp_priv_key_path)]
+            import_, [scope, str(tmp_input_path), "--decrypt-with", str(tmp_priv_key_path)]
         )
         assert rv.exit_code == 0, rv.output
 
         tmp_output_path = Path(tmp_dir).joinpath("output.tar")
         rv = CliRunner().invoke(
-            export, [scope, str(tmp_output_path), "--encrypt_with", str(tmp_pub_key_path)]
+            export, [scope, str(tmp_output_path), "--encrypt-with", str(tmp_pub_key_path)]
         )
         assert rv.exit_code == 0, rv.output
 
 
 class GoodImportExportCommandEncryptionTests(TransactionTestCase):
     """
-    Ensure that encryption using an `--encrypt_with` file works as expected.
+    Ensure that encryption using an `--encrypt-with` file works as expected.
     """
 
     def test_global_scope_encryption(self):
@@ -199,7 +199,7 @@ class BadImportExportCommandTests(TestCase):
                     f"{self._testMethodName}.{scope}.findings.json"
                 )
                 rv = CliRunner().invoke(
-                    import_, [scope, str(tmp_invalid_json), "--findings_file", str(tmp_findings)]
+                    import_, [scope, str(tmp_invalid_json), "--findings-file", str(tmp_findings)]
                 )
                 assert rv.exit_code == 1, rv.output
 
@@ -228,7 +228,7 @@ class BadImportExportCommandTests(TestCase):
 
             tmp_out_path = Path(tmp_dir).joinpath("bad.json")
             rv = CliRunner().invoke(
-                export, ["global", str(tmp_out_path), "--encrypt_with", str(tmp_pub_key_path)]
+                export, ["global", str(tmp_out_path), "--encrypt-with", str(tmp_pub_key_path)]
             )
             assert isinstance(rv.exception, ValueError)
             assert rv.exit_code == 1


### PR DESCRIPTION
Now that imports and exports take place over an RPC interface and have easily JSON-ifiable error kinds, we should take the final step and save those errors to JSON as needed.

Issue: getsentry/team-ospo#201
Issue: getsentry/team-ospo#203