### PR TITLE
ref(replays): link rage/dead clicks to breadcrumbs tab instead of DOM events

### DIFF
--- a/static/app/components/replays/header/replayMetaData.tsx
+++ b/static/app/components/replays/header/replayMetaData.tsx
@@ -24,13 +24,13 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
   const referrer = getRouteStringFromRoutes(routes);
   const eventView = EventView.fromLocation(location);
 
-  const domEventsTab = {
+  const breadcrumbTab = {
     ...location,
     query: {
       referrer,
       ...eventView.generateQueryStringObject(),
-      t_main: 'dom',
-      f_d_type: 'ui.slowClickDetected',
+      t_main: 'breadcrumbs',
+      f_b_type: 'rageOrDead',
     },
   };
 
@@ -39,7 +39,7 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
       <KeyMetricLabel>{t('Dead Clicks')}</KeyMetricLabel>
       <KeyMetricData>
         {replayRecord?.count_dead_clicks ? (
-          <Link to={domEventsTab}>
+          <Link to={breadcrumbTab}>
             <ClickCount color="yellow300">
               <IconCursorArrow size="sm" />
               {replayRecord.count_dead_clicks}
@@ -53,7 +53,7 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
       <KeyMetricLabel>{t('Rage Clicks')}</KeyMetricLabel>
       <KeyMetricData>
         {replayRecord?.count_rage_clicks ? (
-          <Link to={domEventsTab} color="red300">
+          <Link to={breadcrumbTab} color="red300">
             <ClickCount color="red300">
               <IconCursorArrow size="sm" />
               {replayRecord.count_rage_clicks}

--- a/static/app/components/replays/header/replayMetaData.tsx
+++ b/static/app/components/replays/header/replayMetaData.tsx
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import EventView from 'sentry/utils/discover/eventView';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
+import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import {ColorOrAlias} from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useRoutes} from 'sentry/utils/useRoutes';
@@ -29,7 +30,7 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
     query: {
       referrer,
       ...eventView.generateQueryStringObject(),
-      t_main: 'breadcrumbs',
+      t_main: TabKey.BREADCRUMBS,
       f_b_type: 'rageOrDead',
     },
   };

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -318,13 +318,12 @@ export function ReplayCell({
     },
   };
 
-  const replayDetailsDOMEventsTab = {
+  const replayDetailsDeadRage = {
     pathname: normalizeUrl(`/organizations/${organization.slug}/replays/${replay.id}/`),
     query: {
       referrer,
       ...eventView.generateQueryStringObject(),
-      t_main: 'dom',
-      f_d_type: 'ui.slowClickDetected',
+      f_b_type: 'rageOrDead',
     },
   };
 
@@ -335,7 +334,7 @@ export function ReplayCell({
       case 'dead-table':
       case 'rage-table':
       case 'selector-widget':
-        return replayDetailsDOMEventsTab;
+        return replayDetailsDeadRage;
       default:
         return replayDetails;
     }


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/57271

Replay metadata:

https://github.com/getsentry/sentry/assets/56095982/3e73df09-4f7a-4300-aea9-fbe15bdc762e

From widgets:

https://github.com/getsentry/sentry/assets/56095982/ff70f02f-0bde-47a4-9e3b-25d2f5e886de


