### PR TITLE
fix(stat-detectors): Factor in TPM to geo analysis score

### DIFF
--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -144,13 +144,13 @@ def fetch_geo_analysis_results(transaction_name, regression_breakpoint, params, 
             adjusted_params["start"] = regression_breakpoint + BUFFER
 
         geo_code_durations = metrics_query(
-            ["p95(transaction.duration)", "geo.country_code", "count()"],
+            ["p95(transaction.duration)", "geo.country_code", "tpm()"],
             f"event.type:transaction transaction:{transaction_name}",
             adjusted_params,
             referrer=f"{BASE_REFERRER}-{GEO_ANALYSIS}",
             limit=METRICS_MAX_LIMIT,
-            # Order by descending count to ensure more active countries are prioritized
-            orderby=["-count()"],
+            # Order by descending TPM to ensure more active countries are prioritized
+            orderby=["-tpm()"],
         )
 
         return geo_code_durations
@@ -175,16 +175,20 @@ def fetch_geo_analysis_results(transaction_name, regression_breakpoint, params, 
         )
         duration_after = after_results[key]["p95_transaction_duration"]
         if duration_after > duration_before:
+            duration_delta = duration_after - duration_before
             analysis_results.append(
                 {
                     "geo.country_code": key,
                     "duration_before": duration_before,
                     "duration_after": duration_after,
-                    "duration_delta": duration_after - duration_before,
+                    "duration_delta": duration_delta,
+                    # Multiply duration delta by current TPM to prioritize largest changes
+                    # by most active countries
+                    "score": duration_delta * after_results[key]["tpm"],
                 }
             )
 
-    analysis_results.sort(key=lambda x: x["duration_delta"], reverse=True)
+    analysis_results.sort(key=lambda x: x["score"], reverse=True)
     return analysis_results
 
 

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -488,11 +488,13 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                 "duration_before": 10.0,
                 "duration_after": 100.0,
                 "duration_delta": 90.0,
+                "score": 0.08333333333333334,
             },
             {
                 "geo.country_code": "MS",
                 "duration_before": 0.0,
                 "duration_after": 50.0,
                 "duration_delta": 50.0,
+                "score": 0.0462962962962963,
             },
         ]


### PR DESCRIPTION
I noticed that I was getting a lot of "new" countries surfacing, I think factoring TPM will be beneficial here because it effectively shows the users the biggest changes, but also relative to how active the country is.