### PR TITLE
fix(hybridcloud) Assign control silo tasks to correct queues

### DIFF
--- a/src/sentry/tasks/integrations/link_all_repos.py
+++ b/src/sentry/tasks/integrations/link_all_repos.py
@@ -24,7 +24,7 @@ def get_repo_config(repo, integration_id):
 
 @instrumented_task(
     name="sentry.integrations.github.link_all_repos",
-    queue="integrations",
+    queue="integrations.control",
     max_retries=3,
     silo_mode=SiloMode.CONTROL,
 )

--- a/src/sentry/tasks/integrations/migrate_repo.py
+++ b/src/sentry/tasks/integrations/migrate_repo.py
@@ -12,7 +12,7 @@ from sentry.tasks.integrations import logger
 
 @instrumented_task(
     name="sentry.tasks.integrations.migrate_repo",
-    queue="integrations",
+    queue="integrations.control",
     default_retry_delay=60 * 5,
     max_retries=5,
     silo_mode=SiloMode.CONTROL,

--- a/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
+++ b/src/sentry/tasks/integrations/slack/link_slack_user_identities.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("sentry.integrations.slack.tasks")
 
 @instrumented_task(
     name="sentry.integrations.slack.link_users_identities",
-    queue="integrations",
+    queue="integrations.control",
     silo_mode=SiloMode.CONTROL,
 )
 def link_slack_user_identities(

--- a/src/sentry/tasks/integrations/sync_metadata.py
+++ b/src/sentry/tasks/integrations/sync_metadata.py
@@ -6,7 +6,7 @@ from sentry.tasks.base import instrumented_task, retry
 
 @instrumented_task(
     name="sentry.tasks.integrations.jira.sync_metadata",
-    queue="integrations",
+    queue="integrations.control",
     default_retry_delay=20,
     max_retries=5,
     silo_mode=SiloMode.CONTROL,

--- a/src/sentry/tasks/integrations/vsts/kickoff_subscription_check.py
+++ b/src/sentry/tasks/integrations/vsts/kickoff_subscription_check.py
@@ -9,7 +9,7 @@ from sentry.tasks.base import instrumented_task, retry
 
 @instrumented_task(
     name="sentry.tasks.integrations.kickoff_vsts_subscription_check",
-    queue="integrations",
+    queue="integrations.control",
     default_retry_delay=60 * 5,
     max_retries=5,
     silo_mode=SiloMode.CONTROL,

--- a/src/sentry/tasks/integrations/vsts/subscription_check.py
+++ b/src/sentry/tasks/integrations/vsts/subscription_check.py
@@ -12,7 +12,7 @@ from sentry.tasks.integrations import logger
 
 @instrumented_task(
     name="sentry.tasks.integrations.vsts_subscription_check",
-    queue="integrations",
+    queue="integrations.control",
     default_retry_delay=60 * 5,
     max_retries=5,
     silo_mode=SiloMode.CONTROL,


### PR DESCRIPTION
The integration tasks that will eventually run in control silo need to be moved to the control silo queues. This fixes problems in test-silo environment and keeps queue workloads separate for when we start separating the application into silo modes.

Fixes HC-TEST-CONTROL-BQ
Fixes HC-TEST-CONTROL-BE