### PR TITLE
feat(eventuser): Query Snuba for EventUser data

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -11,6 +11,7 @@ from .codeowners_updated import *  # noqa: F401,F403
 from .comment_webhooks import *  # noqa: F401,F403
 from .cron_monitor_created import *  # noqa: F401,F403
 from .eventuser_endpoint_request import *  # noqa: F401,F403
+from .eventuser_equality_check import *  # noqa: F401,F403
 from .first_cron_checkin_sent import *  # noqa: F401,F403
 from .first_event_sent import *  # noqa: F401,F403
 from .first_profile_sent import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/eventuser_equality_check.py
+++ b/src/sentry/analytics/events/eventuser_equality_check.py
@@ -1,0 +1,17 @@
+from sentry import analytics
+
+
+class EventUserEqualityCheck(analytics.Event):
+    type = "eventuser_equality.check"
+
+    attributes = (
+        analytics.Attribute("event_id"),
+        analytics.Attribute("project_id"),
+        analytics.Attribute("group_id"),
+        analytics.Attribute("snuba_eventuser_equality", type=bool),
+        analytics.Attribute("event_eventuser_equality", type=bool),
+        analytics.Attribute("snuba_event_equality", type=bool),
+    )
+
+
+analytics.register(EventUserEqualityCheck)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1423,6 +1423,8 @@ SENTRY_FEATURES = {
     "organizations:escalating-issues-v2": False,
     # Enable emiting escalating data to the metrics backend
     "organizations:escalating-metrics-backend": False,
+    # Enable querying Snuba to get the EventUser
+    "organizations:eventuser-from-snuba": False,
     # Enable the frontend to request from region & control silo domains.
     "organizations:frontend-domainsplit": False,
     # Allows an org to have a larger set of project ownership rules per project

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -231,6 +231,7 @@ default_manager.add("organizations:escalating-issues", OrganizationFeature, Feat
 default_manager.add("organizations:escalating-issues-msteams", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:escalating-issues-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:escalating-metrics-backend", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:eventuser-from-snuba", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:integrations-gh-invite", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:getting-started-doc-with-product-selection", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:integrations-deployment", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -133,7 +133,7 @@ def find_and_compare_eventuser_data(event: Event, eventuser: EventUser):
     try:
         snuba_eventuser = find_eventuser_with_snuba(event)
     except Exception:
-        logger.exception("Error when attempting to fetch EventUser data from Snuba")
+        return logger.exception("Error when attempting to fetch EventUser data from Snuba")
 
     # Compare Snuba result with EventUser record
     snuba_eventuser_equality = _is_snuba_result_equal_to_eventuser(snuba_eventuser, eventuser)

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -6,7 +6,7 @@ from django.db import IntegrityError, router
 from django.utils import timezone
 from snuba_sdk import Column, Condition, Entity, Op, Query, Request
 
-from sentry import eventstore, features
+from sentry import analytics, eventstore, features
 from sentry.api.serializers import serialize
 from sentry.eventstore.models import Event
 from sentry.models.eventuser import EventUser
@@ -155,6 +155,16 @@ def find_and_compare_eventuser_data(event: Event, eventuser: EventUser):
             "event_eventuser_equality": event_eventuser_equality,
             "snuba_event_equality": snuba_event_equality,
         },
+    )
+
+    analytics.record(
+        "eventuser_equality.check",
+        event_id=event.event_id,
+        project_id=event.project_id,
+        group_id=event.group_id,
+        snuba_eventuser_equality=snuba_eventuser_equality,
+        event_eventuser_equality=event_eventuser_equality,
+        snuba_event_equality=snuba_event_equality,
     )
 
 

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -1,13 +1,24 @@
-from datetime import timedelta
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Mapping, Tuple
 
 from django.db import IntegrityError, router
 from django.utils import timezone
+from snuba_sdk import Column, Condition, Entity, Op, Query, Request
 
-from sentry import eventstore
+from sentry import eventstore, features
+from sentry.api.serializers import serialize
+from sentry.eventstore.models import Event
 from sentry.models.eventuser import EventUser
 from sentry.models.userreport import UserReport
 from sentry.signals import user_feedback_received
+from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.utils.db import atomic_transaction
+from sentry.utils.snuba import raw_snql_query
+
+logger = logging.getLogger(__name__)
+
+REFERRER = "sentry.ingest.userreport"
 
 
 class Conflict(Exception):
@@ -27,6 +38,9 @@ def save_userreport(project, report, start_time=None):
     # TODO(dcramer): we should probably create the user if they dont
     # exist, and ideally we'd also associate that with the event
     euser = find_event_user(report, event)
+
+    if features.has("organizations:eventuser-from-snuba", project.organization):
+        find_event_user_with_snuba(event, euser)
 
     if euser and not euser.name and report.get("name"):
         euser.update(name=report["name"])
@@ -93,6 +107,7 @@ def find_event_user(report_data, event):
             return None
 
     tag = event.get_tag("sentry:user")
+
     if not tag:
         return None
 
@@ -100,3 +115,111 @@ def find_event_user(report_data, event):
         return EventUser.for_tags(project_id=report_data["project_id"], values=[tag])[tag]
     except KeyError:
         pass
+
+
+def find_event_user_with_snuba(event: Event, eventuser: EventUser):
+    """
+    Query Snuba to get the EventUser information for an Event.
+    Then compare with the EventUser record and confirm that the
+    query result is equivalent.
+    """
+    start_date, end_date = _start_and_end_dates(event.datetime)
+
+    query = _generate_entity_dataset_query(
+        event.project_id, event.group_id, event.event_id, start_date, end_date
+    )
+    request = Request(
+        dataset=Dataset.Events.value,
+        app_id=REFERRER,
+        query=query,
+        tenant_ids={"referrer": REFERRER, "organization_id": event.project.organization.id},
+    )
+    data_results = raw_snql_query(request, referrer=REFERRER)["data"]
+
+    if len(data_results) == 0:
+        return logger.info(
+            "Errors dataset query to find EventUser did not return any results.",
+            extra={
+                "eventuser": serialize(eventuser),
+                "event_id": event.event_id,
+                "project_id": event.project_id,
+                "group_id": event.group_id,
+            },
+        )
+
+    if not _is_equal_to_eventuser(eventuser, data_results[0]):
+        return logger.info(
+            "EventUser not the same as Errors dataset query.",
+            extra={
+                "eventuser": serialize(eventuser),
+                "dataset_results": data_results[0],
+                "event_id": event.event_id,
+                "project_id": event.project_id,
+                "group_id": event.group_id,
+            },
+        )
+
+    else:
+        return logger.info(
+            "EventUser equal to results from Errors dataset query.",
+            extra={
+                "event_id": event.event_id,
+                "project_id": event.project_id,
+                "group_id": event.group_id,
+            },
+        )
+
+
+def _is_equal_to_eventuser(eventuser: EventUser, snuba_result: Mapping[str, Any]):
+    EVENTUSER_TO_SNUBA_KEY_MAP = {
+        "project_id": ["project_id"],
+        "ident": ["user_id"],
+        "email": ["user_email"],
+        "username": ["user_name"],
+        "ip_address": ["ip_address_v6", "ip_address_v4"],
+    }
+    for eventuser_key, snuba_result_keys in EVENTUSER_TO_SNUBA_KEY_MAP.items():
+        if getattr(eventuser, eventuser_key) not in [
+            snuba_result[key] for key in snuba_result_keys
+        ]:
+            return False
+
+    return True
+
+
+def _generate_entity_dataset_query(
+    project_id: int,
+    group_id: int,
+    event_id: str,
+    start_date: datetime,
+    end_date: datetime,
+) -> Query:
+
+    """This simply generates a query based on the passed parameters"""
+
+    return Query(
+        match=Entity(EntityKey.Events.value),
+        select=[
+            Column("project_id"),
+            Column("group_id"),
+            Column("ip_address_v6"),
+            Column("ip_address_v4"),
+            Column("event_id"),
+            Column("user_id"),
+            Column("user"),
+            Column("user_name"),
+            Column("user_email"),
+        ],
+        where=[
+            Condition(Column("project_id"), Op.EQ, project_id),
+            Condition(Column("group_id"), Op.EQ, group_id),
+            Condition(Column("event_id"), Op.EQ, event_id),
+            Condition(Column("timestamp"), Op.GTE, start_date),
+            Condition(Column("timestamp"), Op.LT, end_date),
+        ],
+    )
+
+
+def _start_and_end_dates(time: datetime) -> Tuple[datetime, datetime]:
+    """Return the 10 min range start and end time range ."""
+    return time - timedelta(minutes=5), time + timedelta(minutes=5)

--- a/tests/sentry/api/endpoints/test_organization_user_reports.py
+++ b/tests/sentry/api/endpoints/test_organization_user_reports.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timedelta
 from unittest import mock
 
-from sentry.ingest.userreport import save_userreport
+from sentry.api.serializers import serialize
+from sentry.ingest.userreport import find_event_user, save_userreport
 from sentry.models.group import GroupStatus
 from sentry.models.userreport import UserReport
 from sentry.testutils.cases import APITestCase, SnubaTestCase
@@ -117,8 +118,9 @@ class OrganizationUserReportListTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400
 
     @with_feature("organizations:eventuser-from-snuba")
+    @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.ingest.userreport.logger")
-    def test_with_event_user(self, mock_logger):
+    def test_with_event_user(self, mock_logger, mock_record):
         event = self.store_event(
             data={
                 "event_id": "d" * 32,
@@ -143,27 +145,44 @@ class OrganizationUserReportListTest(APITestCase, SnubaTestCase):
             "comments": "It broke",
         }
         save_userreport(self.project_1, report_data)
-
+        eventuser = find_event_user(report_data, event)
         response = self.get_response(self.project_1.organization.slug, project=[self.project_1.id])
         assert response.status_code == 200
         assert response.data[0]["comments"] == "It broke"
         assert response.data[0]["user"]["name"] == "Alice"
         assert response.data[0]["user"]["email"] == "alice@example.com"
-        assert mock_logger.info.call_count == 2
-        mock_logger.info.assert_any_call(
-            "EventUser equal to results from Errors dataset query.",
+        assert mock_logger.info.call_count == 1
+        mock_logger.info.assert_called_once_with(
+            "EventUser equality checks with Snuba and Event.",
             extra={
                 "event_id": event.event_id,
                 "project_id": event.project_id,
                 "group_id": event.group_id,
+                "eventuser": serialize(eventuser),
+                "dataset_results": {
+                    "project_id": event.project_id,
+                    "group_id": event.group_id,
+                    "ip_address_v6": None,
+                    "ip_address_v4": "8.8.8.8",
+                    "event_id": event.event_id,
+                    "user_id": "123",
+                    "user": "id:123",
+                    "user_name": "haveibeenpwned",
+                    "user_email": "alice@example.com",
+                },
+                "event.data.user": event.data.get("user", {}),
+                "snuba_eventuser_equality": True,
+                "event_eventuser_equality": True,
+                "snuba_event_equality": True,
             },
         )
 
-        mock_logger.info.assert_any_call(
-            "EventUser equal to Event user data.",
-            extra={
-                "event_id": event.event_id,
-                "project_id": event.project_id,
-                "group_id": event.group_id,
-            },
+        mock_record.assert_called_with(
+            "eventuser_equality.check",
+            event_id=event.event_id,
+            project_id=event.project_id,
+            group_id=event.group_id,
+            snuba_eventuser_equality=True,
+            event_eventuser_equality=True,
+            snuba_event_equality=True,
         )


### PR DESCRIPTION
## Objective:

We want to confirm that the data in EventUser can be replicated by either Snuba or the Event. This PR creates a new feature flag. Under this flag, we query Snuba and then do a 3 way comparison with the results, the EventUser record and the Event. 
We will create a new analytic event so that we can query the results. And we will also add a log to debug specific events.