### PR TITLE
test(ui): Remove waitForNextUpdate for react 18

### DIFF
--- a/static/app/components/onboardingWizard/useOnboardingDocs.spec.tsx
+++ b/static/app/components/onboardingWizard/useOnboardingDocs.spec.tsx
@@ -1,3 +1,5 @@
+import {act} from 'react-test-renderer';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
@@ -39,7 +41,7 @@ describe('useOnboardingDocs', function () {
       });
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useOnboardingDocs, {
+    const {result} = reactHooks.renderHook(useOnboardingDocs, {
       initialProps: {
         project,
         docKeys,
@@ -49,7 +51,8 @@ describe('useOnboardingDocs', function () {
       },
       wrapper,
     });
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
     const {docContents, isLoading, hasOnboardingContents} = result.current;
 
     expect(isLoading).toEqual(false);

--- a/static/app/components/replays/useReplaysCount.spec.tsx
+++ b/static/app/components/replays/useReplaysCount.spec.tsx
@@ -1,3 +1,4 @@
+import {act} from 'react-test-renderer';
 import {Organization} from 'sentry-fixture/organization';
 
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
@@ -73,7 +74,7 @@ describe('useReplaysCount', () => {
       body: {},
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+    const {result} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
         groupIds: mockGroupIds,
@@ -93,7 +94,8 @@ describe('useReplaysCount', () => {
       })
     );
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
   });
 
   it('should query for groupIds on performance issues', async () => {
@@ -103,7 +105,7 @@ describe('useReplaysCount', () => {
       body: {},
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+    const {result} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
         issueCategory: IssueCategory.PERFORMANCE,
@@ -124,7 +126,8 @@ describe('useReplaysCount', () => {
       })
     );
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
   });
 
   it('should return the count of each groupId, or zero if not included in the response', async () => {
@@ -136,7 +139,7 @@ describe('useReplaysCount', () => {
       },
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+    const {result} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
         groupIds: mockGroupIds,
@@ -146,7 +149,8 @@ describe('useReplaysCount', () => {
     expect(result.current).toEqual({});
     expect(replayCountRequest).toHaveBeenCalled();
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     expect(result.current).toEqual({
       '123': 42,
@@ -161,14 +165,15 @@ describe('useReplaysCount', () => {
       body: {},
     });
 
-    const {result, rerender, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+    const {result, rerender} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
         groupIds: mockGroupIds,
       },
     });
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     expect(replayCountRequest).toHaveBeenCalledTimes(1);
     expect(replayCountRequest).toHaveBeenCalledWith(
@@ -192,7 +197,8 @@ describe('useReplaysCount', () => {
       groupIds: [...mockGroupIds, '789'],
     });
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     expect(replayCountRequest).toHaveBeenCalledTimes(2);
     expect(replayCountRequest).toHaveBeenCalledWith(
@@ -220,14 +226,15 @@ describe('useReplaysCount', () => {
       body: {},
     });
 
-    const {result, rerender, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+    const {result, rerender} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
         groupIds: mockGroupIds,
       },
     });
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     expect(replayCountRequest).toHaveBeenCalledTimes(1);
     expect(replayCountRequest).toHaveBeenCalledWith(
@@ -265,7 +272,7 @@ describe('useReplaysCount', () => {
       body: {},
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+    const {result} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
         replayIds: mockReplayIds,
@@ -285,7 +292,8 @@ describe('useReplaysCount', () => {
       })
     );
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
   });
 
   it('should return the count of each replayId, or zero if not included in the response', async () => {
@@ -297,7 +305,7 @@ describe('useReplaysCount', () => {
       },
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+    const {result} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
         replayIds: mockReplayIds,
@@ -307,7 +315,8 @@ describe('useReplaysCount', () => {
     expect(result.current).toEqual({});
     expect(countRequest).toHaveBeenCalled();
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     expect(result.current).toEqual({
       abc: 42,
@@ -322,7 +331,7 @@ describe('useReplaysCount', () => {
       body: {},
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+    const {result} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
         transactionNames: mockTransactionNames,
@@ -342,7 +351,8 @@ describe('useReplaysCount', () => {
       })
     );
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
   });
 
   it('should return the count of each transactionName, or zero if not included in the response', async () => {
@@ -354,7 +364,7 @@ describe('useReplaysCount', () => {
       },
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+    const {result} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
         transactionNames: mockTransactionNames,
@@ -364,7 +374,8 @@ describe('useReplaysCount', () => {
     expect(result.current).toEqual({});
     expect(countRequest).toHaveBeenCalled();
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     expect(result.current).toEqual({
       '/home': 42,

--- a/static/app/utils/profiling/hooks/useProfileFunctionTrends.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctionTrends.spec.tsx
@@ -1,4 +1,5 @@
 import {ReactElement, useMemo} from 'react';
+import {act} from 'react-test-renderer';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
@@ -62,7 +63,10 @@ describe('useProfileFunctionTrendss', function () {
     );
     expect(hook.result.current.isLoading).toEqual(true);
     expect(hook.result.current.isFetched).toEqual(false);
-    await hook.waitForNextUpdate();
+
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
+
     expect(hook.result.current).toMatchObject(
       expect.objectContaining({
         isLoading: false,

--- a/static/app/utils/profiling/hooks/useProfileFunctions.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctions.spec.tsx
@@ -1,4 +1,5 @@
 import {ReactElement, useMemo} from 'react';
+import {act} from 'react-test-renderer';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {makeTestQueryClient} from 'sentry-test/queryClient';
@@ -70,7 +71,10 @@ describe('useProfileFunctions', function () {
     );
     expect(hook.result.current.isLoading).toEqual(true);
     expect(hook.result.current.isFetched).toEqual(false);
-    await hook.waitForNextUpdate();
+
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
+
     expect(hook.result.current).toMatchObject(
       expect.objectContaining({
         isLoading: false,

--- a/static/app/utils/replays/hooks/useInitialTimeOffsetMs.spec.tsx
+++ b/static/app/utils/replays/hooks/useInitialTimeOffsetMs.spec.tsx
@@ -1,3 +1,5 @@
+import {act} from 'react-test-renderer';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
@@ -41,7 +43,7 @@ describe('useInitialTimeOffsetMs', () => {
       const offsetInSeconds = 23;
       mockQuery({t: String(offsetInSeconds)});
 
-      const {result, waitForNextUpdate} = reactHooks.renderHook(useInitialTimeOffsetMs, {
+      const {result} = reactHooks.renderHook(useInitialTimeOffsetMs, {
         initialProps: {
           orgSlug: organization.slug,
           projectSlug: project.slug,
@@ -49,7 +51,8 @@ describe('useInitialTimeOffsetMs', () => {
           replayStartTimestampMs: undefined,
         },
       });
-      await waitForNextUpdate();
+      // TODO(scttcper): React 18 switch to waitFor
+      await act(tick);
 
       expect(result.current).toStrictEqual({offsetMs: 23 * 1000});
     });
@@ -62,7 +65,7 @@ describe('useInitialTimeOffsetMs', () => {
         query: 'click.tag:button',
       });
 
-      const {result, waitForNextUpdate} = reactHooks.renderHook(useInitialTimeOffsetMs, {
+      const {result} = reactHooks.renderHook(useInitialTimeOffsetMs, {
         initialProps: {
           orgSlug: organization.slug,
           projectSlug: project.slug,
@@ -70,7 +73,8 @@ describe('useInitialTimeOffsetMs', () => {
           replayStartTimestampMs: undefined,
         },
       });
-      await waitForNextUpdate();
+      // TODO(scttcper): React 18 switch to waitFor
+      await act(tick);
 
       expect(result.current).toStrictEqual({offsetMs: 23 * 1000});
       expect(MockFetchReplayClicks).toHaveBeenCalledTimes(0);
@@ -87,18 +91,16 @@ describe('useInitialTimeOffsetMs', () => {
       async ({input}) => {
         mockQuery({event_t: input});
 
-        const {result, waitForNextUpdate} = reactHooks.renderHook(
-          useInitialTimeOffsetMs,
-          {
-            initialProps: {
-              orgSlug: organization.slug,
-              projectSlug: project.slug,
-              replayId: replay.id,
-              replayStartTimestampMs: new Date(NOON).getTime(),
-            },
-          }
-        );
-        await waitForNextUpdate();
+        const {result} = reactHooks.renderHook(useInitialTimeOffsetMs, {
+          initialProps: {
+            orgSlug: organization.slug,
+            projectSlug: project.slug,
+            replayId: replay.id,
+            replayStartTimestampMs: new Date(NOON).getTime(),
+          },
+        });
+        // TODO(scttcper): React 18 switch to waitFor
+        await act(tick);
 
         // Expecting 5 minutes difference, in ms
         expect(result.current).toStrictEqual({offsetMs: 5 * 60 * 1000});
@@ -108,19 +110,17 @@ describe('useInitialTimeOffsetMs', () => {
     it('should return 0 offset if there is no replayStartTimetsamp, then recalculate when the startTimestamp appears', async () => {
       mockQuery({event_t: FIVE_PAST_FORMATTED});
 
-      const {result, rerender, waitForNextUpdate} = reactHooks.renderHook(
-        useInitialTimeOffsetMs,
-        {
-          initialProps: {
-            orgSlug: organization.slug,
-            projectSlug: project.slug,
-            replayId: replay.id,
-            replayStartTimestampMs: undefined,
-          },
-        }
-      );
+      const {result, rerender} = reactHooks.renderHook(useInitialTimeOffsetMs, {
+        initialProps: {
+          orgSlug: organization.slug,
+          projectSlug: project.slug,
+          replayId: replay.id,
+          replayStartTimestampMs: undefined,
+        },
+      });
 
-      await waitForNextUpdate();
+      // TODO(scttcper): React 18 switch to waitFor
+      await act(tick);
       expect(result.current).toStrictEqual({offsetMs: 0});
 
       rerender({
@@ -129,7 +129,8 @@ describe('useInitialTimeOffsetMs', () => {
         replayId: replay.id,
         replayStartTimestampMs: new Date(NOON).getTime(),
       });
-      await waitForNextUpdate();
+      // TODO(scttcper): React 18 switch to waitFor
+      await act(tick);
 
       // Expecting 5 minutes difference, in ms
       expect(result.current).toStrictEqual({offsetMs: 5 * 60 * 1000});
@@ -146,7 +147,7 @@ describe('useInitialTimeOffsetMs', () => {
         clicks: [],
       });
 
-      const {result, waitForNextUpdate} = reactHooks.renderHook(useInitialTimeOffsetMs, {
+      const {result} = reactHooks.renderHook(useInitialTimeOffsetMs, {
         initialProps: {
           orgSlug: organization.slug,
           projectSlug: project.slug,
@@ -154,7 +155,8 @@ describe('useInitialTimeOffsetMs', () => {
           replayStartTimestampMs: new Date(NOON).getTime(),
         },
       });
-      await waitForNextUpdate();
+      // TODO(scttcper): React 18 switch to waitFor
+      await act(tick);
 
       expect(result.current).toStrictEqual({offsetMs: 5 * 60 * 1000});
       expect(MockFetchReplayClicks).toHaveBeenCalledTimes(0);
@@ -165,7 +167,7 @@ describe('useInitialTimeOffsetMs', () => {
     it('should skip this strategy if there is no `click.*` term in the query', async () => {
       mockQuery({query: 'user.email:*@sentry.io'});
 
-      const {result, waitForNextUpdate} = reactHooks.renderHook(useInitialTimeOffsetMs, {
+      const {result} = reactHooks.renderHook(useInitialTimeOffsetMs, {
         initialProps: {
           orgSlug: organization.slug,
           projectSlug: project.slug,
@@ -173,7 +175,8 @@ describe('useInitialTimeOffsetMs', () => {
           replayStartTimestampMs: new Date(NOON).getTime(),
         },
       });
-      await waitForNextUpdate();
+      // TODO(scttcper): React 18 switch to waitFor
+      await act(tick);
 
       expect(MockFetchReplayClicks).toHaveBeenCalledTimes(0);
       expect(result.current).toStrictEqual({offsetMs: 0});
@@ -187,7 +190,7 @@ describe('useInitialTimeOffsetMs', () => {
         clicks: [{node_id: 7, timestamp: FIVE_PAST_FORMATTED}],
       });
 
-      const {result, waitForNextUpdate} = reactHooks.renderHook(useInitialTimeOffsetMs, {
+      const {result} = reactHooks.renderHook(useInitialTimeOffsetMs, {
         initialProps: {
           orgSlug: organization.slug,
           projectSlug: project.slug,
@@ -195,7 +198,8 @@ describe('useInitialTimeOffsetMs', () => {
           replayStartTimestampMs: new Date(NOON).getTime(),
         },
       });
-      await waitForNextUpdate();
+      // TODO(scttcper): React 18 switch to waitFor
+      await act(tick);
 
       expect(MockFetchReplayClicks).toHaveBeenCalledTimes(1);
       // Expecting 5 minutes difference, in ms
@@ -217,18 +221,16 @@ describe('useInitialTimeOffsetMs', () => {
         clicks: [{node_id: 7, timestamp: FIVE_PAST_FORMATTED}],
       });
 
-      const {result, rerender, waitForNextUpdate} = reactHooks.renderHook(
-        useInitialTimeOffsetMs,
-        {
-          initialProps: {
-            orgSlug: organization.slug,
-            projectSlug: project.slug,
-            replayId: replay.id,
-            replayStartTimestampMs: undefined,
-          },
-        }
-      );
-      await waitForNextUpdate();
+      const {result, rerender} = reactHooks.renderHook(useInitialTimeOffsetMs, {
+        initialProps: {
+          orgSlug: organization.slug,
+          projectSlug: project.slug,
+          replayId: replay.id,
+          replayStartTimestampMs: undefined,
+        },
+      });
+      // TODO(scttcper): React 18 switch to waitFor
+      await act(tick);
 
       expect(MockFetchReplayClicks).toHaveBeenCalledTimes(0);
       expect(result.current).toStrictEqual({
@@ -241,7 +243,8 @@ describe('useInitialTimeOffsetMs', () => {
         replayId: replay.id,
         replayStartTimestampMs: new Date(NOON).getTime(),
       });
-      await waitForNextUpdate();
+      // TODO(scttcper): React 18 switch to waitFor
+      await act(tick);
 
       expect(MockFetchReplayClicks).toHaveBeenCalledTimes(1);
       expect(result.current).toStrictEqual({

--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -1,3 +1,4 @@
+import {act} from 'react-test-renderer';
 import {duration} from 'moment';
 import {ReplayError} from 'sentry-fixture/replayError';
 
@@ -70,14 +71,15 @@ describe('useReplayData', () => {
       body: {data: mockReplayResponse},
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplayData, {
+    const {result} = reactHooks.renderHook(useReplayData, {
       initialProps: {
         replayId: mockReplayResponse.id,
         orgSlug: organization.slug,
       },
     });
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     expect(result.current).toEqual({
       attachments: expect.any(Array),
@@ -142,7 +144,7 @@ describe('useReplayData', () => {
       match: [(_url, options) => options.query?.cursor === '0:1:0'],
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplayData, {
+    const {result} = reactHooks.renderHook(useReplayData, {
       initialProps: {
         replayId: mockReplayResponse.id,
         orgSlug: organization.slug,
@@ -151,7 +153,8 @@ describe('useReplayData', () => {
     });
 
     jest.runAllTimers();
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     expect(mockedSegmentsCall1).toHaveBeenCalledTimes(1);
     expect(mockedSegmentsCall2).toHaveBeenCalledTimes(1);
@@ -230,7 +233,7 @@ describe('useReplayData', () => {
       ],
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplayData, {
+    const {result} = reactHooks.renderHook(useReplayData, {
       initialProps: {
         replayId: mockReplayResponse.id,
         orgSlug: organization.slug,
@@ -239,7 +242,8 @@ describe('useReplayData', () => {
     });
 
     jest.runAllTimers();
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     expect(mockedErrorsCall1).toHaveBeenCalledTimes(1);
     expect(mockedErrorsCall2).toHaveBeenCalledTimes(1);
@@ -295,7 +299,7 @@ describe('useReplayData', () => {
       body: {data: mockErrorResponse},
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplayData, {
+    const {result} = reactHooks.renderHook(useReplayData, {
       initialProps: {
         replayId: mockReplayResponse.id,
         orgSlug: organization.slug,
@@ -319,7 +323,8 @@ describe('useReplayData', () => {
     expect(result.current).toEqual(expectedReplayData);
 
     jest.advanceTimersByTime(10);
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     // Afterwards we see the attachments & errors requests are made
     expect(mockedReplayCall).toHaveBeenCalledTimes(1);
@@ -335,7 +340,8 @@ describe('useReplayData', () => {
     );
 
     jest.advanceTimersByTime(100);
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     // Next we see that some rrweb data has arrived
     expect(result.current).toStrictEqual(
@@ -347,7 +353,8 @@ describe('useReplayData', () => {
     );
 
     jest.advanceTimersByTime(250);
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     // Finally we see fetching is complete, errors are here too
     expect(result.current).toStrictEqual(

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
@@ -1,3 +1,4 @@
+import {act} from 'react-test-renderer';
 import {Location} from 'history';
 import {Organization} from 'sentry-fixture/organization';
 
@@ -36,7 +37,7 @@ describe('useReplaysFromIssue', () => {
       },
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysFromIssue, {
+    const {result} = reactHooks.renderHook(useReplaysFromIssue, {
       initialProps: {
         group: MOCK_GROUP,
         location,
@@ -50,7 +51,8 @@ describe('useReplaysFromIssue', () => {
       pageLinks: null,
     });
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     expect(result.current).toEqual({
       eventView: expect.objectContaining({
@@ -72,7 +74,7 @@ describe('useReplaysFromIssue', () => {
       },
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysFromIssue, {
+    const {result} = reactHooks.renderHook(useReplaysFromIssue, {
       initialProps: {
         group: MOCK_GROUP,
         location,
@@ -86,7 +88,8 @@ describe('useReplaysFromIssue', () => {
       pageLinks: null,
     });
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     expect(result.current).toEqual({
       eventView: expect.objectContaining({
@@ -106,7 +109,7 @@ describe('useReplaysFromIssue', () => {
       body: {},
     });
 
-    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysFromIssue, {
+    const {result} = reactHooks.renderHook(useReplaysFromIssue, {
       initialProps: {
         group: MOCK_GROUP,
         location,
@@ -120,7 +123,8 @@ describe('useReplaysFromIssue', () => {
       pageLinks: null,
     });
 
-    await waitForNextUpdate();
+    // TODO(scttcper): React 18 switch to waitFor
+    await act(tick);
 
     expect(result.current).toEqual({
       eventView: expect.objectContaining({


### PR DESCRIPTION
This is gone in the next version of RTL, prep for react 18. In the next version we can just use waitFor which triggers act for you
