### PR TITLE
ref(profiling): optimize render of call tree

### DIFF
--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -71,6 +71,33 @@ export const SECOND = 1000;
  *
  * Use `getExactDuration` for exact durations
  */
+
+const DURATION_LABELS = {
+  mo: t('mo'),
+  w: t('w'),
+  wk: t('wk'),
+  week: t('week'),
+  weeks: t('weeks'),
+  d: t('d'),
+  day: t('day'),
+  days: t('days'),
+  h: t('h'),
+  hr: t('hr'),
+  hour: t('hour'),
+  hours: t('hours'),
+  m: t('m'),
+  min: t('min'),
+  minute: t('minute'),
+  minutes: t('minutes'),
+  s: t('s'),
+  sec: t('sec'),
+  secs: t('secs'),
+  second: t('second'),
+  seconds: t('seconds'),
+  ms: t('ms'),
+  millisecond: t('millisecond'),
+  milliseconds: t('milliseconds'),
+};
 export function getDuration(
   seconds: number,
   fixedDigits: number = 0,
@@ -85,16 +112,18 @@ export function getDuration(
 
   if (absValue >= MONTH && !extraShort) {
     const {label, result} = roundWithFixed(msValue / MONTH, fixedDigits);
-    return `${label}${abbreviation ? t('mo') : ` ${tn('month', 'months', result)}`}`;
+    return `${label}${
+      abbreviation ? DURATION_LABELS.mo : ` ${tn('month', 'months', result)}`
+    }`;
   }
 
   if (absValue >= WEEK) {
     const {label, result} = roundWithFixed(msValue / WEEK, fixedDigits);
     if (extraShort) {
-      return `${label}${t('w')}`;
+      return `${label}${DURATION_LABELS.w}`;
     }
     if (abbreviation) {
-      return `${label}${t('wk')}`;
+      return `${label}${DURATION_LABELS.wk}`;
     }
     return `${label} ${tn('week', 'weeks', result)}`;
   }
@@ -103,7 +132,7 @@ export function getDuration(
     const {label, result} = roundWithFixed(msValue / DAY, fixedDigits);
 
     if (extraShort || abbreviation) {
-      return `${label}${t('d')}`;
+      return `${label}${DURATION_LABELS.d}`;
     }
     return `${label} ${tn('day', 'days', result)}`;
   }
@@ -111,10 +140,10 @@ export function getDuration(
   if (absValue >= HOUR) {
     const {label, result} = roundWithFixed(msValue / HOUR, fixedDigits);
     if (extraShort) {
-      return `${label}${t('h')}`;
+      return `${label}${DURATION_LABELS.h}`;
     }
     if (abbreviation) {
-      return `${label}${t('hr')}`;
+      return `${label}${DURATION_LABELS.hr}`;
     }
     return `${label} ${tn('hour', 'hours', result)}`;
   }
@@ -122,10 +151,10 @@ export function getDuration(
   if (absValue >= MINUTE) {
     const {label, result} = roundWithFixed(msValue / MINUTE, fixedDigits);
     if (extraShort) {
-      return `${label}${t('m')}`;
+      return `${label}${DURATION_LABELS.m}`;
     }
     if (abbreviation) {
-      return `${label}${t('min')}`;
+      return `${label}${DURATION_LABELS.min}`;
     }
     return `${label} ${tn('minute', 'minutes', result)}`;
   }
@@ -133,7 +162,7 @@ export function getDuration(
   if (absValue >= SECOND) {
     const {label, result} = roundWithFixed(msValue / SECOND, fixedDigits);
     if (extraShort || abbreviation) {
-      return `${label}${t('s')}`;
+      return `${label}${DURATION_LABELS.s}`;
     }
     return `${label} ${tn('second', 'seconds', result)}`;
   }
@@ -141,7 +170,7 @@ export function getDuration(
   const {label, result} = roundWithFixed(msValue, fixedDigits);
 
   if (extraShort || abbreviation) {
-    return `${label}${t('ms')}`;
+    return `${label}${DURATION_LABELS.ms}`;
   }
 
   return `${label} ${tn('millisecond', 'milliseconds', result)}`;


### PR DESCRIPTION
Optimize virtualized list rendering to reduce observable scroll sync lag caused by occasional frame drops.

Before:
<img width="1105" alt="CleanShot 2023-10-14 at 11 14 04@2x" src="https://github.com/getsentry/sentry/assets/9317857/2e95353c-6a20-4b71-b975-8d785e7ea9c3">

After:
<img width="1061" alt="CleanShot 2023-10-14 at 11 15 18@2x" src="https://github.com/getsentry/sentry/assets/9317857/caad675c-8d8d-45d1-9969-27e08bd06cdf">

Notable of optimizations:
- ensure that we do not set scrollTop to a container that was currently scrolling. Since the listener is non blocking, we only need to update other scroll containers.
- eagerly eval labels in getDuration as devtools profile showed that calls to parseText and jed dominated rendering
- wrap state dispatch inside scroll handler inside a raf so we do not end up saturating the main task queue with tasks which will eventually be dropped