### PR TITLE
feat(projects-overview): Use metrics for charts

### DIFF
--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -26,6 +26,7 @@ import {space} from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {callIfFunction} from 'sentry/utils/callIfFunction';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -55,6 +56,7 @@ class ProjectCard extends Component<Props> {
       projectId: project.id,
       query: {
         transactionStats: this.hasPerformance ? '1' : undefined,
+        dataset: DiscoverDatasets.METRICS_ENHANCED,
         sessionStats: '1',
       },
     });


### PR DESCRIPTION
Use the metric dataset for the charts on the project overview.

- closes https://github.com/getsentry/sentry/issues/57896
- closes https://github.com/getsentry/sentry/issues/56819