### PR TITLE
feat(platforms): Add Astro as a platform (backend)

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
+++ b/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
@@ -645,6 +645,7 @@ def get_sdk_debug_id_support(event_data):
         official_sdks = [
             "sentry.javascript.angular",
             "sentry.javascript.angular-ivy",
+            "sentry.javascript.astro",
             "sentry.javascript.browser",
             "sentry.javascript.capacitor",
             "sentry.javascript.cordova",

--- a/src/sentry/api/helpers/actionable_items_helper.py
+++ b/src/sentry/api/helpers/actionable_items_helper.py
@@ -10,6 +10,7 @@ class ActionPriority:
 
 
 sourcemap_sdks = [
+    "sentry.javascript.astro",
     "sentry.javascript.browser",
     "sentry.javascript.node",
     "sentry.javascript.react",

--- a/src/sentry/dynamic_sampling/rules/helpers/time_to_adoptions.py
+++ b/src/sentry/dynamic_sampling/rules/helpers/time_to_adoptions.py
@@ -60,6 +60,7 @@ LATEST_RELEASE_TTAS = {
     "javascript": 11035,
     "javascript-angular": 5156,
     "javascript-angularjs": 11592,
+    "javascript-astro": 5943,
     "javascript-backbone": 3463,
     "javascript-browser": 3552,
     "javascript-ember": 10246,

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -92,6 +92,7 @@ GETTING_STARTED_DOCS_PLATFORMS = [
     "java-spring-boot",
     "javascript",
     "javascript-angular",
+    "javascript-astro",
     "javascript-ember",
     "javascript-gatsby",
     "javascript-nextjs",

--- a/src/sentry/tasks/check_am2_compatibility.py
+++ b/src/sentry/tasks/check_am2_compatibility.py
@@ -43,6 +43,7 @@ SUPPORTED_SDK_VERSIONS = {
     # JavaScript
     "sentry-browser": "7.6.0",
     "sentry.javascript.angular": "7.6.0",
+    "sentry.javascript.astro": "7.6.0",
     "sentry.javascript.browser": "7.6.0",
     "sentry.javascript.ember": "7.6.0",
     "sentry.javascript.gatsby": "7.6.0",

--- a/src/sentry/utils/event.py
+++ b/src/sentry/utils/event.py
@@ -71,6 +71,7 @@ def is_event_from_browser_javascript_sdk(event):
         return False
 
     return sdk_name.lower() in [
+        "sentry.javascript.astro",
         "sentry.javascript.browser",
         "sentry.javascript.react",
         "sentry.javascript.gatsby",

--- a/src/sentry/utils/platform_categories.py
+++ b/src/sentry/utils/platform_categories.py
@@ -16,6 +16,7 @@ FRONTEND = [
     "javascript-remix",
     "javascript-svelte",
     "javascript-sveltekit",
+    "javascript-astro",
     "unity",
 ]
 


### PR DESCRIPTION
Adds Astro as a platform to the relevant places in the backend. Frontend PR will follow soon.

ref: https://github.com/getsentry/sentry-javascript/issues/9182