### PR TITLE
fix(metrics):Disable investigation rule getRule retry requests for 4xx errors.

### DIFF
--- a/static/app/components/dynamicSampling/investigationRule.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.tsx
@@ -92,6 +92,18 @@ function useGetExistingRule(
     {
       staleTime: 0,
       enabled,
+      // No retries for 4XX errors.
+      // This makes the error feedback a lot faster, and there is no unnecessary network traffic.
+      retry: (failureCount, error) => {
+        if (failureCount >= 2) {
+          return false;
+        }
+        if (error.status && error.status >= 400 && error.status < 500) {
+          // don't retry 4xx errors (in theory 429 should be retried but not immediately)
+          return false;
+        }
+        return true;
+      },
     }
   );
 
@@ -141,6 +153,7 @@ function useCreateInvestigationRuleMutation(vars: CreateCustomRuleVariables) {
         success: false,
       });
     },
+    retry: false,
   });
   return mutate;
 }


### PR DESCRIPTION
This PR disables react-query retry functionality in the InvestigationRule component for the cases 
where we get a 4xx response.

Resolves: https://github.com/getsentry/sentry/issues/57764