### PR TITLE
feat(platforms): Add Astro as a platform (frontend)

### DIFF
--- a/fixtures/integration-docs/_platforms.json
+++ b/fixtures/integration-docs/_platforms.json
@@ -135,6 +135,12 @@
           "name": "AngularJS"
         },
         {
+          "link": "https://docs.sentry.io/platforms/javascript/guides/astro/",
+          "type": "framework",
+          "id": "javascript-astro",
+          "name": "Astro"
+        },
+        {
           "link": "https://docs.getsentry.com/clients/javascript/integrations/backbone/",
           "type": "framework",
           "id": "javascript-backbone",

--- a/fixtures/integration-docs/javascript-astro.json
+++ b/fixtures/integration-docs/javascript-astro.json
@@ -1,0 +1,6 @@
+{
+  "html": "<div class=\"section\" id=\"installation\"></div>\n",
+  "link": "https://docs.sentry.io/platforms/javascript/guides/astro/",
+  "id": "javascript-astro",
+  "name": "Astro"
+}

--- a/static/app/components/events/interfaces/crashContent/exception/utils.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/utils.tsx
@@ -35,4 +35,5 @@ export const sourceMapSdkDocsMap: Record<string, string> = {
   'sentry.javascript.svelte': 'svelte',
   'sentry.javascript.sveltekit': 'sveltekit',
   'sentry.javascript.react-native': 'react-native',
+  'sentry.javascript.atro': 'astro',
 };

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -668,6 +668,7 @@ export function isEventFromBrowserJavaScriptSDK(
     'sentry.javascript.remix',
     'sentry.javascript.svelte',
     'sentry.javascript.sveltekit',
+    'sentry.javascript.astro',
   ].includes(sdkName.toLowerCase());
 }
 

--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -55,6 +55,7 @@ export const topJavascriptFrameworks = [
   'javascript-svelte',
   'javascript-sveltekit',
   'javascript-remix',
+  'javascript-astro',
 ];
 
 const topPythonFrameworks = [

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -16,6 +16,7 @@ export const frontend: PlatformKey[] = [
   'javascript',
   'javascript-angular',
   'javascript-angularjs',
+  'javascript-astro',
   'javascript-backbone',
   'javascript-ember',
   'javascript-gatsby',
@@ -245,6 +246,7 @@ export const releaseHealth: PlatformKey[] = [
   'javascript-react',
   'javascript-angular',
   'javascript-angularjs',
+  'javascript-astro',
   'javascript-backbone',
   'javascript-ember',
   'javascript-gatsby',
@@ -296,6 +298,7 @@ export const replayPlatforms: readonly PlatformKey[] = [
   'electron',
   'javascript-angular',
   // 'javascript-angularjs', // Unsupported, angularjs requires the v6.x core SDK
+  'javascript-astro',
   'javascript-backbone',
   'javascript-capacitor',
   'javascript-electron',
@@ -320,6 +323,7 @@ export const replayOnboardingPlatforms: readonly PlatformKey[] = [
   'capacitor',
   'electron',
   'javascript-angular',
+  'javascript-astro',
   // 'javascript-angularjs', // Unsupported, angularjs requires the v6.x core SDK
   // 'javascript-backbone', // No docs yet
   'javascript-capacitor',

--- a/static/app/data/platformPickerCategories.tsx
+++ b/static/app/data/platformPickerCategories.tsx
@@ -33,7 +33,6 @@ const browser: Set<PlatformKey> = new Set([
   'dart',
   'javascript',
   'javascript-angular',
-  'javascript-astro',
   'javascript-ember',
   'javascript-gatsby',
   'javascript-nextjs',

--- a/static/app/data/platformPickerCategories.tsx
+++ b/static/app/data/platformPickerCategories.tsx
@@ -33,6 +33,7 @@ const browser: Set<PlatformKey> = new Set([
   'dart',
   'javascript',
   'javascript-angular',
+  'javascript-astro',
   'javascript-ember',
   'javascript-gatsby',
   'javascript-nextjs',

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -264,6 +264,13 @@ const platforms: PlatformIntegration[] = [
     link: 'https://docs.sentry.io/platforms/javascript/guides/angular/',
   },
   {
+    id: 'javascript-astro',
+    name: 'Astro',
+    type: 'framework',
+    language: 'javascript',
+    link: 'https://docs.sentry.io/platforms/javascript/guides/astro/',
+  },
+  {
     id: 'javascript-ember',
     name: 'Ember',
     type: 'framework',

--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -263,13 +263,14 @@ const platforms: PlatformIntegration[] = [
     language: 'javascript',
     link: 'https://docs.sentry.io/platforms/javascript/guides/angular/',
   },
-  {
-    id: 'javascript-astro',
-    name: 'Astro',
-    type: 'framework',
-    language: 'javascript',
-    link: 'https://docs.sentry.io/platforms/javascript/guides/astro/',
-  },
+  // TODO: comment back in when we have a getting-started page for Astro
+  // {
+  //   id: 'javascript-astro',
+  //   name: 'Astro',
+  //   type: 'framework',
+  //   language: 'javascript',
+  //   link: 'https://docs.sentry.io/platforms/javascript/guides/astro/',
+  // },
   {
     id: 'javascript-ember',
     name: 'Ember',

--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -72,6 +72,7 @@ const platformToIcon = {
   javascript: 'javascript',
   'javascript-angular': 'angularjs',
   'javascript-angularjs': 'angularjs',
+  'javascript-astro': 'astro',
   'javascript-backbone': 'backbone',
   'javascript-browser': 'javascript',
   'javascript-capacitor': 'capacitor',

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -176,6 +176,7 @@ export type PlatformKey =
   | 'javascript'
   | 'javascript-angular'
   | 'javascript-angularjs'
+  | 'javascript-astro'
   | 'javascript-backbone'
   | 'javascript-browser'
   | 'javascript-capacitor'


### PR DESCRIPTION
Adds the `javascript-astro` platform in the frontend. Exception: Project selection will come in a follow-up PR along with the Astro getting started page

ref https://github.com/getsentry/sentry-javascript/issues/9182