### PR TITLE
chore(deps): Bump platformicons

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "papaparse": "^5.3.2",
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.6",
-    "platformicons": "^5.6.5",
+    "platformicons": "^5.7.0",
     "po-catalog-loader": "2.0.0",
     "prettier": "3.0.3",
     "prismjs": "^1.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9175,10 +9175,10 @@ platform@^1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-platformicons@^5.6.5:
-  version "5.6.5"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.6.5.tgz#5cc0a2a39d78c5e71a23cc2f2a69f495947974bc"
-  integrity sha512-S96AArz7t6xMxfVW7BSyLKD+EJrAZ49JhcRVdPfVrmH5meLZxfD+Sc9hXY2kb2cTmQmYnRm/bi04kUt3WR0J3Q==
+platformicons@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.7.0.tgz#0499b7f1908774dfdca601c43e4ad91c3bbfcddd"
+  integrity sha512-sI9TbWkx3LCQY/UUGBm9loibbZHjdkmxD1rLyhm+3F0vdjm31qS44td8X1DNCdhXDp7gC30sl8mzcQ1J9s0/nw==
   dependencies:
     "@types/node" "*"
     "@types/react" "*"


### PR DESCRIPTION
This PR bumps our platformicons package which includes the icon for Astro with today's 5.7.0 release.

ref: https://github.com/getsentry/sentry-javascript/issues/9182