### PR TITLE
fix(integrations): remove `can_add = True` since it is inherited

### DIFF
--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -305,7 +305,6 @@ class BitbucketServerIntegrationProvider(IntegrationProvider):
     metadata = metadata
     integration_cls = BitbucketServerIntegration
     needs_default_identity = True
-    can_add = True
     features = frozenset([IntegrationFeatures.COMMITS])
     setup_dialog_config = {"width": 1030, "height": 1000}
 

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -1123,8 +1123,6 @@ class JiraServerIntegrationProvider(IntegrationProvider):
 
     needs_default_identity = True
 
-    can_add = True
-
     features = frozenset([IntegrationFeatures.ISSUE_BASIC, IntegrationFeatures.ISSUE_SYNC])
 
     setup_dialog_config = {"width": 1030, "height": 1000}


### PR DESCRIPTION
`BitbucketServerIntegrationProvider` and `JiraServerIntegrationProvider` are inherited from `IntegrationProvider` which has `can_add = True` by default, so no need to repeat it.

https://github.com/getsentry/sentry/blob/2f5451f1a0a67d453966639ecfa43168f23e6ce1/src/sentry/integrations/base.py#L176