### PR TITLE
fix(profiling): default sort profiles table by count desc

### DIFF
--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -66,7 +66,7 @@ function ProfilingContent({location}: ProfilingContentProps) {
   const fields = profilingUsingTransactions ? ALL_FIELDS : BASE_FIELDS;
 
   const sort = formatSort<FieldType>(decodeScalar(location.query.sort), fields, {
-    key: 'p95()',
+    key: 'count()',
     order: 'desc',
   });
 


### PR DESCRIPTION
Discussion on [slack](https://sentry.slack.com/archives/C02N5PB50JH/p1697470274313519)