### PR TITLE
fix(stat-detectors): Skip empty geo code in analysis

### DIFF
--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -170,6 +170,9 @@ def fetch_geo_analysis_results(transaction_name, regression_breakpoint, params, 
 
     analysis_results = []
     for key in changed_keys | new_keys:
+        if key == "":
+            continue
+
         duration_before = (
             before_results[key]["p95_transaction_duration"] if before_results.get(key) else 0.0
         )


### PR DESCRIPTION
It looks like geo code can be an empty string. Skip these in the results because it's not actionable for a user.
