### PR TITLE
fix(fly): Turn links blue

### DIFF
--- a/static/less/layout.less
+++ b/static/less/layout.less
@@ -227,12 +227,6 @@ body.auth {
 
   .auth-terms {
     color: @gray-light;
-    a {
-      color: @gray-light;
-      &:hover {
-        color: @gray-dark;
-      }
-    }
   }
 
   .auth-toggle {


### PR DESCRIPTION
Legal didn't like the links being grey so I'm removing the styling to turn them back to blue.

<img width="745" alt="Screenshot 2023-10-16 at 10 07 39 AM" src="https://github.com/getsentry/sentry/assets/132939361/da4aba89-dc59-477d-b441-a33e1a01212b">
