### PR TITLE
update release threshold api routes

### DIFF
--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -169,7 +169,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
         )  # maybe prefetch "deploy_set" as well?
 
         # ========================================================================
-        # Step 3: flatten thresholds and compile projects/releases/thresholds by type
+        # Step 3: flatten thresholds and compile projects/release-thresholds by type
         # ========================================================================
         thresholds_by_type: DefaultDict[int, dict[str, list]] = defaultdict()
         for release in queryset:

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1548,11 +1548,6 @@ ORGANIZATION_URLS = [
         name="sentry-api-0-organization-sessions",
     ),
     re_path(
-        r"^(?P<organization_slug>[^\/]+)/releases/thresholds/$",
-        ReleaseThresholdIndexEndpoint.as_view(),
-        name="sentry-api-0-organization-release-thresholds",
-    ),
-    re_path(
         r"^(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/resolved/$",
         OrganizationIssuesResolvedInReleaseEndpoint.as_view(),
         name="sentry-api-0-organization-release-resolved",
@@ -1631,6 +1626,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_slug>[^\/]+)/releases/$",
         OrganizationReleasesEndpoint.as_view(),
         name="sentry-api-0-organization-releases",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/release-thresholds/$",
+        ReleaseThresholdIndexEndpoint.as_view(),
+        name="sentry-api-0-organization-release-thresholds",
     ),
     # TODO: also integrate release threshold status into the releases response?
     re_path(
@@ -2186,12 +2186,12 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         name="sentry-api-0-project-releases",
     ),
     re_path(
-        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/thresholds/$",
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/release-thresholds/$",
         ReleaseThresholdEndpoint.as_view(),
         name="sentry-api-0-project-release-thresholds",
     ),
     re_path(
-        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/releases/thresholds/(?P<release_threshold>[^/]+)/$",
+        r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/release-thresholds/(?P<release_threshold>[^/]+)/$",
         ReleaseThresholdDetailsEndpoint.as_view(),
         name="sentry-api-0-project-release-thresholds-details",
     ),

--- a/static/app/views/releases/utils/useFetchThresholdsListData.tsx
+++ b/static/app/views/releases/utils/useFetchThresholdsListData.tsx
@@ -26,7 +26,7 @@ export default function useFetchThresholdsListData({
 
   return useApiQuery<Threshold[]>(
     [
-      `/organizations/${organization.id}/releases/thresholds/`,
+      `/organizations/${organization.id}/release-thresholds/`,
       {
         query,
       },


### PR DESCRIPTION
rather than conflicting with the existing `/releases/` routes
opt to simply have a separate url to manage release thresholds

NOTE: none of these routes are being utilized atm