### PR TITLE
feat(metrics): Add method namespacing to indexer cache

### DIFF
--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -33,6 +33,10 @@ _INDEXER_CACHE_RESOLVE_CACHE_REPLENISHMENT_METRIC = (
 _INDEXER_CACHE_FETCH_METRIC = "sentry_metrics.indexer.memcache.fetch"
 
 
+BULK_RECORD_CACHE_NAME_SPACE = "br"
+RESOLVE_CACHE_NAMESPACE = "res"
+
+
 class StringIndexerCache:
     def __init__(self, cache_name: str, partition_key: str):
         self.version = 1
@@ -47,12 +51,21 @@ class StringIndexerCache:
         jitter = random.uniform(0, 0.25) * cache_ttl
         return int(cache_ttl + jitter)
 
-    def make_cache_key(self, key: str) -> str:
+    def _make_cache_key(self, key: str) -> str:
         use_case_id, org_id, string = key.split(":", 2)
         org_string = org_id + ":" + string
         hashed = md5_text(org_string).hexdigest()
 
         return f"indexer:{self.partition_key}:org:str:{use_case_id}:{hashed}"
+
+    # The new namespaced version of the above function, eventually this will replace
+    # _make_cache_key
+    def _make_namespaced_cache_key(self, namespace: str, key: str) -> str:
+        use_case_id, org_id, string = key.split(":", 2)
+        org_string = f"{org_id}:{string}"
+        hashed = md5_text(org_string).hexdigest()
+
+        return f"indexer:{self.partition_key}:{namespace}:org:str:{use_case_id}:{hashed}"
 
     def _format_results(
         self, keys: Iterable[str], results: Mapping[str, Optional[int]]
@@ -67,40 +80,83 @@ class StringIndexerCache:
         """
         formatted: MutableMapping[str, Optional[int]] = {}
         for key in keys:
-            cache_key = self.make_cache_key(key)
+            cache_key = self._make_cache_key(key)
             formatted[key] = results.get(cache_key)
 
         return formatted
 
-    def get(self, key: str) -> int:
-        result: int = self.cache.get(self.make_cache_key(key), version=self.version)
-        return result
+    # The new namespaced version of the above function, eventually this will replace
+    # _format_results
+    def _format_namespaced_results(
+        self, namespace: str, keys: Iterable[str], results: Mapping[str, Optional[int]]
+    ) -> MutableMapping[str, Optional[int]]:
+        """
+        Takes in keys formatted like "use_case_id:org_id:string", and results that have the
+        internally used hashed key such as:
+            {"indexer:org:str:transactions:b0a0e436f6fa42b9e33e73befbdbb9ba": 2}
+        and returns results that replace the hashed internal key with the externally
+        used key:
+            {"transactions:3:a": 2}
+        """
+        formatted: MutableMapping[str, Optional[int]] = {}
+        for key in keys:
+            cache_key = self._make_namespaced_cache_key(namespace, key)
+            formatted[key] = results.get(cache_key)
 
-    def set(self, key: str, value: int) -> None:
+        return formatted
+
+    def _validate_result(self, result: Optional[str]) -> Optional[int]:
+        if result is None:
+            return None
+        result, _ = result.split(":")
+
+        return int(result)
+
+    def get(self, namespace: str, key: str) -> Optional[int]:
+        if options.get("sentry-metrics.indexer.read-new-cache-namespace"):
+            result = self.cache.get(
+                self._make_namespaced_cache_key(namespace, key), version=self.version
+            )
+            return self._validate_result(result)
+        return self.cache.get(self._make_cache_key(key), version=self.version)
+
+    def set(self, namespace: str, key: str, value: int) -> None:
         self.cache.set(
-            key=self.make_cache_key(key),
+            key=self._make_cache_key(key),
             value=value,
             timeout=self.randomized_ttl,
             version=self.version,
         )
 
-    def get_many(self, keys: Iterable[str]) -> MutableMapping[str, Optional[int]]:
-        cache_keys = {self.make_cache_key(key): key for key in keys}
-        results: Mapping[str, Optional[int]] = self.cache.get_many(
-            cache_keys.keys(), version=self.version
-        )
-        return self._format_results(keys, results)
+    def get_many(self, namespace: str, keys: Iterable[str]) -> MutableMapping[str, Optional[int]]:
+        if options.get("sentry-metrics.indexer.read-new-cache-namespace"):
+            cache_keys = {self._make_namespaced_cache_key(namespace, key): key for key in keys}
+            namespaced_results: MutableMapping[str, Optional[int]] = {
+                k: self._validate_result(v)
+                for k, v in self.cache.get_many(cache_keys.keys(), version=self.version).items()
+            }
+            return self._format_namespaced_results(
+                namespace,
+                keys,
+                namespaced_results,
+            )
+        else:
+            cache_keys = {self._make_cache_key(key): key for key in keys}
+            results: Mapping[str, Optional[int]] = self.cache.get_many(
+                cache_keys.keys(), version=self.version
+            )
+            return self._format_results(keys, results)
 
-    def set_many(self, key_values: Mapping[str, int]) -> None:
-        cache_key_values = {self.make_cache_key(k): v for k, v in key_values.items()}
+    def set_many(self, namespace: str, key_values: Mapping[str, int]) -> None:
+        cache_key_values = {self._make_cache_key(k): v for k, v in key_values.items()}
         self.cache.set_many(cache_key_values, timeout=self.randomized_ttl, version=self.version)
 
-    def delete(self, key: str) -> None:
-        cache_key = self.make_cache_key(key)
+    def delete(self, namespace: str, key: str) -> None:
+        cache_key = self._make_cache_key(key)
         self.cache.delete(cache_key, version=self.version)
 
-    def delete_many(self, keys: Sequence[str]) -> None:
-        cache_keys = [self.make_cache_key(key) for key in keys]
+    def delete_many(self, namespace: str, keys: Sequence[str]) -> None:
+        cache_keys = [self._make_cache_key(key) for key in keys]
         self.cache.delete_many(cache_keys, version=self.version)
 
 
@@ -112,10 +168,11 @@ class CachingIndexer(StringIndexer):
     def bulk_record(
         self, strings: Mapping[UseCaseID, Mapping[OrgId, Set[str]]]
     ) -> UseCaseKeyResults:
+
         cache_keys = UseCaseKeyCollection(strings)
         metrics.gauge("sentry_metrics.indexer.lookups_per_batch", value=cache_keys.size)
         cache_key_strs = cache_keys.as_strings()
-        cache_results = self.cache.get_many(cache_key_strs)
+        cache_results = self.cache.get_many(BULK_RECORD_CACHE_NAME_SPACE, cache_key_strs)
 
         hits = [k for k, v in cache_results.items() if v is not None]
 
@@ -155,7 +212,9 @@ class CachingIndexer(StringIndexer):
             }
         )
 
-        self.cache.set_many(db_record_key_results.get_mapped_strings_to_ints())
+        self.cache.set_many(
+            BULK_RECORD_CACHE_NAME_SPACE, db_record_key_results.get_mapped_strings_to_ints()
+        )
 
         return cache_key_results.merge(db_record_key_results)
 
@@ -166,7 +225,7 @@ class CachingIndexer(StringIndexer):
     @metric_path_key_compatible_resolve
     def resolve(self, use_case_id: UseCaseID, org_id: int, string: str) -> Optional[int]:
         key = f"{use_case_id.value}:{org_id}:{string}"
-        result = self.cache.get(key)
+        result = self.cache.get(RESOLVE_CACHE_NAMESPACE, key)
 
         if result and isinstance(result, int):
             metrics.incr(
@@ -188,7 +247,7 @@ class CachingIndexer(StringIndexer):
                     _INDEXER_CACHE_RESOLVE_CACHE_REPLENISHMENT_METRIC,
                     tags={"use_case": use_case_id.value},
                 )
-                self.cache.set(key, id)
+                self.cache.set(RESOLVE_CACHE_NAMESPACE, key, id)
 
         return id
 

--- a/tests/sentry/sentry_metrics/test_all_indexers.py
+++ b/tests/sentry/sentry_metrics/test_all_indexers.py
@@ -202,80 +202,82 @@ def test_static_and_non_static_strings_generic_metrics(indexer):
 
 
 def test_indexer(indexer, indexer_cache, use_case_id):
-    org1_id = 1
-    org2_id = 2
-    strings = {"hello", "hey", "hi"}
+    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+        org1_id = 1
+        org2_id = 2
+        strings = {"hello", "hey", "hi"}
 
-    raw_indexer = indexer
-    indexer = CachingIndexer(indexer_cache, indexer)
+        raw_indexer = indexer
+        indexer = CachingIndexer(indexer_cache, indexer)
 
-    use_case_strings = {use_case_id: {org1_id: strings, org2_id: {"sup"}}}
+        use_case_strings = {use_case_id: {org1_id: strings, org2_id: {"sup"}}}
 
-    # create a record with diff org_id but same string that we test against
-    indexer.record(use_case_id, 999, "hey")
+        # create a record with diff org_id but same string that we test against
+        indexer.record(use_case_id, 999, "hey")
 
-    assert list(
-        indexer_cache.get_many(
-            [f"{use_case_id}:{org1_id}:{string}" for string in strings],
-        ).values()
-    ) == [None, None, None]
+        assert list(
+            indexer_cache.get_many(
+                "br",
+                [f"{use_case_id}:{org1_id}:{string}" for string in strings],
+            ).values()
+        ) == [None, None, None]
 
-    results = indexer.bulk_record(use_case_strings).results
+        results = indexer.bulk_record(use_case_strings).results
 
-    org1_string_ids = {
-        raw_indexer.resolve(use_case_id, org1_id, "hello"),
-        raw_indexer.resolve(use_case_id, org1_id, "hey"),
-        raw_indexer.resolve(use_case_id, org1_id, "hi"),
-    }
+        org1_string_ids = {
+            raw_indexer.resolve(use_case_id, org1_id, "hello"),
+            raw_indexer.resolve(use_case_id, org1_id, "hey"),
+            raw_indexer.resolve(use_case_id, org1_id, "hi"),
+        }
 
-    assert None not in org1_string_ids
-    assert len(org1_string_ids) == 3  # no overlapping ids
+        assert None not in org1_string_ids
+        assert len(org1_string_ids) == 3  # no overlapping ids
 
-    org2_string_id = raw_indexer.resolve(use_case_id, org2_id, "sup")
-    assert org2_string_id not in org1_string_ids
+        org2_string_id = raw_indexer.resolve(use_case_id, org2_id, "sup")
+        assert org2_string_id not in org1_string_ids
 
-    # verify org1 results and cache values
-    for id_value in results[use_case_id].results[org1_id].values():
-        assert id_value in org1_string_ids
+        # verify org1 results and cache values
+        for id_value in results[use_case_id].results[org1_id].values():
+            assert id_value in org1_string_ids
 
-    for cache_value in indexer_cache.get_many(
-        [f"{use_case_id.value}:{org1_id}:{string}" for string in strings]
-    ).values():
-        assert cache_value in org1_string_ids
+        for cache_value in indexer_cache.get_many(
+            "br", [f"{use_case_id.value}:{org1_id}:{string}" for string in strings]
+        ).values():
+            assert cache_value in org1_string_ids
 
-    # verify org2 results and cache values
-    assert results[use_case_id][org2_id]["sup"] == org2_string_id
-    assert indexer_cache.get(f"{use_case_id.value}:{org2_id}:sup") == org2_string_id
+        # verify org2 results and cache values
+        assert results[use_case_id][org2_id]["sup"] == org2_string_id
+        assert indexer_cache.get("br", f"{use_case_id.value}:{org2_id}:sup") == org2_string_id
 
-    # we should have no results for org_id 999
-    assert not results[use_case_id].results.get(999)
+        # we should have no results for org_id 999
+        assert not results[use_case_id].results.get(999)
 
 
 def test_resolve_and_reverse_resolve(indexer, indexer_cache, use_case_id):
     """
     Test `resolve` and `reverse_resolve` methods
     """
+    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+        org1_id = 1
+        strings = {"hello", "hey", "hi"}
 
-    org1_id = 1
-    strings = {"hello", "hey", "hi"}
+        indexer = CachingIndexer(indexer_cache, indexer)
 
-    indexer = CachingIndexer(indexer_cache, indexer)
+        org_strings = {org1_id: strings}
+        indexer.bulk_record({use_case_id: org_strings})
 
-    org_strings = {org1_id: strings}
-    indexer.bulk_record({use_case_id: org_strings})
+        # test resolve and reverse_resolve
+        id = indexer.resolve(use_case_id=use_case_id, org_id=org1_id, string="hello")
+        assert id is not None
+        assert indexer.reverse_resolve(use_case_id=use_case_id, org_id=org1_id, id=id) == "hello"
 
-    # test resolve and reverse_resolve
-    id = indexer.resolve(use_case_id=use_case_id, org_id=org1_id, string="hello")
-    assert id is not None
-    assert indexer.reverse_resolve(use_case_id=use_case_id, org_id=org1_id, id=id) == "hello"
+        # test record on a string that already exists
+        indexer.record(use_case_id=use_case_id, org_id=org1_id, string="hello")
+        assert indexer.resolve(use_case_id=use_case_id, org_id=org1_id, string="hello") == id
 
-    # test record on a string that already exists
-    indexer.record(use_case_id=use_case_id, org_id=org1_id, string="hello")
-    assert indexer.resolve(use_case_id=use_case_id, org_id=org1_id, string="hello") == id
-
-    # test invalid values
-    assert indexer.resolve(use_case_id=use_case_id, org_id=org1_id, string="beep") is None
-    assert indexer.reverse_resolve(use_case_id=use_case_id, org_id=org1_id, id=1234) is None
+        # test invalid values
+        assert indexer.resolve(use_case_id=use_case_id, org_id=org1_id, string="beep") is None
+        assert indexer.reverse_resolve(use_case_id=use_case_id, org_id=org1_id, id=1234) is None
 
 
 def test_already_created_plus_written_results(indexer, indexer_cache, use_case_id) -> None:
@@ -283,45 +285,46 @@ def test_already_created_plus_written_results(indexer, indexer_cache, use_case_i
     Test that we correctly combine db read results with db write results
     for the same organization.
     """
-    org_id = 1234
+    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+        org_id = 1234
 
-    raw_indexer = indexer
-    indexer = CachingIndexer(indexer_cache, indexer)
+        raw_indexer = indexer
+        indexer = CachingIndexer(indexer_cache, indexer)
 
-    v0 = raw_indexer.record(use_case_id, org_id, "v1.2.0:xyz")
-    v1 = raw_indexer.record(use_case_id, org_id, "v1.2.1:xyz")
-    v2 = raw_indexer.record(use_case_id, org_id, "v1.2.2:xyz")
+        v0 = raw_indexer.record(use_case_id, org_id, "v1.2.0:xyz")
+        v1 = raw_indexer.record(use_case_id, org_id, "v1.2.1:xyz")
+        v2 = raw_indexer.record(use_case_id, org_id, "v1.2.2:xyz")
 
-    expected_mapping = {"v1.2.0:xyz": v0, "v1.2.1:xyz": v1, "v1.2.2:xyz": v2}
+        expected_mapping = {"v1.2.0:xyz": v0, "v1.2.1:xyz": v1, "v1.2.2:xyz": v2}
 
-    results = indexer.bulk_record(
-        {use_case_id: {org_id: {"v1.2.0:xyz", "v1.2.1:xyz", "v1.2.2:xyz"}}}
-    )
-    assert len(results[use_case_id][org_id]) == len(expected_mapping) == 3
+        results = indexer.bulk_record(
+            {use_case_id: {org_id: {"v1.2.0:xyz", "v1.2.1:xyz", "v1.2.2:xyz"}}}
+        )
+        assert len(results[use_case_id][org_id]) == len(expected_mapping) == 3
 
-    for string, id in results[use_case_id][org_id].items():
-        assert expected_mapping[string] == id
+        for string, id in results[use_case_id][org_id].items():
+            assert expected_mapping[string] == id
 
-    results = indexer.bulk_record(
-        {use_case_id: {org_id: {"v1.2.0:xyz", "v1.2.1:xyz", "v1.2.2:xyz", "v1.2.3:xyz"}}},
-    )
-    v3 = raw_indexer.resolve(use_case_id, org_id, "v1.2.3:xyz")
-    expected_mapping["v1.2.3:xyz"] = v3
+        results = indexer.bulk_record(
+            {use_case_id: {org_id: {"v1.2.0:xyz", "v1.2.1:xyz", "v1.2.2:xyz", "v1.2.3:xyz"}}},
+        )
+        v3 = raw_indexer.resolve(use_case_id, org_id, "v1.2.3:xyz")
+        expected_mapping["v1.2.3:xyz"] = v3
 
-    assert len(results[use_case_id][org_id]) == len(expected_mapping) == 4
+        assert len(results[use_case_id][org_id]) == len(expected_mapping) == 4
 
-    for string, id in results[use_case_id][org_id].items():
-        assert expected_mapping[string] == id
+        for string, id in results[use_case_id][org_id].items():
+            assert expected_mapping[string] == id
 
-    fetch_meta = results.get_fetch_metadata()
-    assert_fetch_type_for_tag_string_set(
-        fetch_meta[use_case_id][org_id],
-        FetchType.CACHE_HIT,
-        {"v1.2.0:xyz", "v1.2.1:xyz", "v1.2.2:xyz"},
-    )
-    assert_fetch_type_for_tag_string_set(
-        fetch_meta[use_case_id][org_id], FetchType.FIRST_SEEN, {"v1.2.3:xyz"}
-    )
+        fetch_meta = results.get_fetch_metadata()
+        assert_fetch_type_for_tag_string_set(
+            fetch_meta[use_case_id][org_id],
+            FetchType.CACHE_HIT,
+            {"v1.2.0:xyz", "v1.2.1:xyz", "v1.2.2:xyz"},
+        )
+        assert_fetch_type_for_tag_string_set(
+            fetch_meta[use_case_id][org_id], FetchType.FIRST_SEEN, {"v1.2.3:xyz"}
+        )
 
 
 def test_already_cached_plus_read_results(indexer, indexer_cache, use_case_id) -> None:
@@ -329,58 +332,63 @@ def test_already_cached_plus_read_results(indexer, indexer_cache, use_case_id) -
     Test that we correctly combine cached results with read results
     for the same organization.
     """
-    org_id = 8
-    cached = {f"{use_case_id.value}:{org_id}:beep": 10, f"{use_case_id.value}:{org_id}:boop": 11}
-    indexer_cache.set_many(cached)
+    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+        org_id = 8
+        cached = {
+            f"{use_case_id.value}:{org_id}:beep": 10,
+            f"{use_case_id.value}:{org_id}:boop": 11,
+        }
+        indexer_cache.set_many("br", cached)
 
-    raw_indexer = indexer
-    indexer = CachingIndexer(indexer_cache, indexer)
+        raw_indexer = indexer
+        indexer = CachingIndexer(indexer_cache, indexer)
 
-    results = indexer.bulk_record({use_case_id: {org_id: {"beep", "boop"}}})
-    assert len(results[use_case_id][org_id]) == 2
-    assert results[use_case_id][org_id]["beep"] == 10
-    assert results[use_case_id][org_id]["boop"] == 11
+        results = indexer.bulk_record({use_case_id: {org_id: {"beep", "boop"}}})
+        assert len(results[use_case_id][org_id]) == 2
+        assert results[use_case_id][org_id]["beep"] == 10
+        assert results[use_case_id][org_id]["boop"] == 11
 
-    # confirm we did not write to the db if results were already cached
-    assert not raw_indexer.resolve(use_case_id, org_id, "beep")
-    assert not raw_indexer.resolve(use_case_id, org_id, "boop")
+        # confirm we did not write to the db if results were already cached
+        assert not raw_indexer.resolve(use_case_id, org_id, "beep")
+        assert not raw_indexer.resolve(use_case_id, org_id, "boop")
 
-    bam = raw_indexer.record(use_case_id, org_id, "bam")
-    assert bam is not None
+        bam = raw_indexer.record(use_case_id, org_id, "bam")
+        assert bam is not None
 
-    results = indexer.bulk_record({use_case_id: {org_id: {"beep", "boop", "bam"}}})
-    assert len(results[use_case_id][org_id]) == 3
-    assert results[use_case_id][org_id]["beep"] == 10
-    assert results[use_case_id][org_id]["boop"] == 11
-    assert results[use_case_id][org_id]["bam"] == bam
+        results = indexer.bulk_record({use_case_id: {org_id: {"beep", "boop", "bam"}}})
+        assert len(results[use_case_id][org_id]) == 3
+        assert results[use_case_id][org_id]["beep"] == 10
+        assert results[use_case_id][org_id]["boop"] == 11
+        assert results[use_case_id][org_id]["bam"] == bam
 
-    fetch_meta = results.get_fetch_metadata()
-    assert_fetch_type_for_tag_string_set(
-        fetch_meta[use_case_id][org_id], FetchType.CACHE_HIT, {"beep", "boop"}
-    )
-    assert_fetch_type_for_tag_string_set(
-        fetch_meta[use_case_id][org_id], FetchType.DB_READ, {"bam"}
-    )
+        fetch_meta = results.get_fetch_metadata()
+        assert_fetch_type_for_tag_string_set(
+            fetch_meta[use_case_id][org_id], FetchType.CACHE_HIT, {"beep", "boop"}
+        )
+        assert_fetch_type_for_tag_string_set(
+            fetch_meta[use_case_id][org_id], FetchType.DB_READ, {"bam"}
+        )
 
 
 def test_read_when_bulk_record(indexer, use_case_id):
-    strings = {
-        use_case_id: {
-            1: {"a"},
-            2: {"b", "c"},
-            3: {"d", "e", "f"},
-            4: {"g", "h", "i", "j"},
-            5: {"k", "l", "m", "n", "o"},
+    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+        strings = {
+            use_case_id: {
+                1: {"a"},
+                2: {"b", "c"},
+                3: {"d", "e", "f"},
+                4: {"g", "h", "i", "j"},
+                5: {"k", "l", "m", "n", "o"},
+            }
         }
-    }
-    indexer.bulk_record(strings)
-    results = indexer.bulk_record(strings)
-    assert all(
-        str_meta_data.fetch_type is FetchType.DB_READ
-        for key_result in results.results.values()
-        for metadata in key_result.meta.values()
-        for str_meta_data in metadata.values()
-    )
+        indexer.bulk_record(strings)
+        results = indexer.bulk_record(strings)
+        assert all(
+            str_meta_data.fetch_type is FetchType.DB_READ
+            for key_result in results.results.values()
+            for metadata in key_result.meta.values()
+            for str_meta_data in metadata.values()
+        )
 
 
 def test_rate_limited(indexer, use_case_id, writes_limiter_option_name):
@@ -435,6 +443,7 @@ def test_rate_limited(indexer, use_case_id, writes_limiter_option_name):
             f"{writes_limiter_option_name}.per-org": [
                 {"window_seconds": 10, "granularity_seconds": 10, "limit": 1}
             ],
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
         }
     ):
         results = indexer.bulk_record({use_case_id: org_strings})
@@ -455,6 +464,7 @@ def test_rate_limited(indexer, use_case_id, writes_limiter_option_name):
             f"{writes_limiter_option_name}.global": [
                 {"window_seconds": 10, "granularity_seconds": 10, "limit": 2}
             ],
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
         }
     ):
         results = indexer.bulk_record({use_case_id: org_strings2})
@@ -473,29 +483,30 @@ def test_bulk_reverse_resolve(indexer):
     Tests reverse resolve properly returns the corresponding strings
     in the proper order when given a combination of shared and non-shared ids.
     """
-    org_id = 7
-    use_case_id = UseCaseID.SESSIONS  # any use case would do
-    static_indexer = StaticStringIndexer(indexer)
+    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+        org_id = 7
+        use_case_id = UseCaseID.SESSIONS  # any use case would do
+        static_indexer = StaticStringIndexer(indexer)
 
-    a = indexer.record(use_case_id, org_id, "aaa")
-    b = indexer.record(use_case_id, org_id, "bbb")
-    c = indexer.record(use_case_id, org_id, "ccc")
-    production = SHARED_STRINGS["production"]
-    release = SHARED_STRINGS["release"]
-    environment = SHARED_STRINGS["environment"]
-    unknown1 = 6666
-    unknown2 = 6667
+        a = indexer.record(use_case_id, org_id, "aaa")
+        b = indexer.record(use_case_id, org_id, "bbb")
+        c = indexer.record(use_case_id, org_id, "ccc")
+        production = SHARED_STRINGS["production"]
+        release = SHARED_STRINGS["release"]
+        environment = SHARED_STRINGS["environment"]
+        unknown1 = 6666
+        unknown2 = 6667
 
-    indexes = [a, production, b, unknown1, release, environment, c, unknown2]
-    # we expect the indexer to resolve the indexes to the original strings and return None for unknown indexes
-    expected_result = {
-        a: "aaa",
-        b: "bbb",
-        c: "ccc",
-        production: "production",
-        release: "release",
-        environment: "environment",
-    }
-    actual_result = static_indexer.bulk_reverse_resolve(use_case_id, org_id, indexes)
+        indexes = [a, production, b, unknown1, release, environment, c, unknown2]
+        # we expect the indexer to resolve the indexes to the original strings and return None for unknown indexes
+        expected_result = {
+            a: "aaa",
+            b: "bbb",
+            c: "ccc",
+            production: "production",
+            release: "release",
+            environment: "environment",
+        }
+        actual_result = static_indexer.bulk_reverse_resolve(use_case_id, org_id, indexes)
 
-    assert actual_result == expected_result
+        assert actual_result == expected_result

--- a/tests/sentry/sentry_metrics/test_indexer_cache.py
+++ b/tests/sentry/sentry_metrics/test_indexer_cache.py
@@ -3,6 +3,7 @@ from django.conf import settings
 
 from sentry.sentry_metrics.indexer.cache import StringIndexerCache
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
+from sentry.testutils.helpers.options import override_options
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
 
@@ -21,45 +22,82 @@ def use_case_id() -> str:
 
 
 def test_cache(use_case_id: str) -> None:
-    cache.clear()
-    assert indexer_cache.get(f"{use_case_id}:1:blah:123") is None
-    indexer_cache.set(f"{use_case_id}:1:blah:123", 1)
-    assert indexer_cache.get(f"{use_case_id}:1:blah:123") == 1
+    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+        cache.clear()
+        namespace = "test"
+        assert indexer_cache.get(namespace, f"{use_case_id}:1:blah:123") is None
+        indexer_cache.set(namespace, f"{use_case_id}:1:blah:123", 1)
+        assert indexer_cache.get(namespace, f"{use_case_id}:1:blah:123") == 1
 
-    indexer_cache.delete(f"{use_case_id}:1:blah:123")
-    assert indexer_cache.get(f"{use_case_id}:1:blah:123") is None
+        indexer_cache.delete(namespace, f"{use_case_id}:1:blah:123")
+        assert indexer_cache.get(namespace, f"{use_case_id}:1:blah:123") is None
 
 
 def test_cache_many(use_case_id: str) -> None:
-    cache.clear()
-    values = {f"{use_case_id}:100:hello": 2, f"{use_case_id}:100:bye": 3}
-    assert indexer_cache.get_many(values.keys()) == {
-        f"{use_case_id}:100:hello": None,
-        f"{use_case_id}:100:bye": None,
-    }
-    indexer_cache.set_many(values)
-    assert indexer_cache.get_many(list(values.keys())) == values
+    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+        cache.clear()
+        namespace = "test"
+        values = {f"{use_case_id}:100:hello": 2, f"{use_case_id}:100:bye": 3}
+        assert indexer_cache.get_many(namespace, values.keys()) == {
+            f"{use_case_id}:100:hello": None,
+            f"{use_case_id}:100:bye": None,
+        }
+        indexer_cache.set_many(namespace, values)
+        assert indexer_cache.get_many(namespace, list(values.keys())) == values
 
-    indexer_cache.delete_many(list(values.keys()))
-    assert indexer_cache.get_many(values.keys()) == {
-        f"{use_case_id}:100:hello": None,
-        f"{use_case_id}:100:bye": None,
-    }
+        indexer_cache.delete_many(namespace, list(values.keys()))
+        assert indexer_cache.get_many(namespace, values.keys()) == {
+            f"{use_case_id}:100:hello": None,
+            f"{use_case_id}:100:bye": None,
+        }
 
 
 def test_make_cache_key(use_case_id: str) -> None:
-    orgId = 1
-    string = ":blah:blah"
-    nameSpace = md5_text(f"{orgId}:{string}").hexdigest()
-    key = indexer_cache.make_cache_key(f"{use_case_id}:{orgId}:{string}")
+    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+        cache.clear()
+        namespace = "test"
+        orgId = 1
+        string = ":blah:blah"
+        key = indexer_cache._make_cache_key(f"{use_case_id}:{orgId}:{string}")
 
-    assert key == f"indexer:test:org:str:{use_case_id}:{nameSpace}"
+        hashed = md5_text(f"{orgId}:{string}").hexdigest()
+
+        assert key == f"indexer:test:org:str:{use_case_id}:{hashed}"
+
+    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": True}):
+        cache.clear()
+        namespace = "test"
+        orgId = 1
+        string = ":blah:blah"
+        key = indexer_cache._make_namespaced_cache_key(namespace, f"{use_case_id}:{orgId}:{string}")
+
+        hashed = md5_text(f"{orgId}:{string}").hexdigest()
+
+        assert key == f"indexer:test:{namespace}:org:str:{use_case_id}:{hashed}"
 
 
 def test_formatted_results(use_case_id: str) -> None:
-    values = {f"{use_case_id}:1:::hello": 2, f"{use_case_id}:1:::bye": 3}
-    results = {indexer_cache.make_cache_key(k): v for k, v in values.items()}
-    assert indexer_cache._format_results(list(values.keys()), results) == values
+    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+        cache.clear()
+        namespace = "test"
+        values = {f"{use_case_id}:1:::hello": 2, f"{use_case_id}:1:::bye": 3}
+        results = {indexer_cache._make_cache_key(k): v for k, v in values.items()}
+        assert indexer_cache._format_results(list(values.keys()), results) == values
+
+    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": True}):
+        cache.clear()
+        namespace = "test"
+        values = {
+            f"{namespace}:{use_case_id}:1:::hello": 2,
+            f"{namespace}:{use_case_id}:1:::bye": 3,
+        }
+        results = {
+            indexer_cache._make_namespaced_cache_key(namespace, k): v for k, v in values.items()
+        }
+        assert (
+            indexer_cache._format_namespaced_results(namespace, list(values.keys()), results)
+            == values
+        )
 
 
 def test_ttl_jitter() -> None:
@@ -76,8 +114,10 @@ def test_ttl_jitter() -> None:
 
 
 def test_separate_namespacing() -> None:
-    indexer_cache.set("sessions:3:what", 1)
-    assert indexer_cache.get("sessions:3:what") == 1
-    indexer_cache.set("transactions:3:what", 2)
-    assert indexer_cache.get("sessions:3:what") == 1
-    assert indexer_cache.get("transactions:3:what") == 2
+    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+        namespace = "test"
+        indexer_cache.set(namespace, "sessions:3:what", 1)
+        assert indexer_cache.get(namespace, "sessions:3:what") == 1
+        indexer_cache.set(namespace, "transactions:3:what", 2)
+        assert indexer_cache.get(namespace, "sessions:3:what") == 1
+        assert indexer_cache.get(namespace, "transactions:3:what") == 2

--- a/tests/sentry/sentry_metrics/test_postgres_indexer.py
+++ b/tests/sentry/sentry_metrics/test_postgres_indexer.py
@@ -33,11 +33,11 @@ class PostgresIndexerV2Test(TestCase):
         """
         key = f"{self.use_case_id.value}:123:oop"
 
-        assert indexer_cache.get(key) is None
+        assert indexer_cache.get("br", key) is None
 
         assert isinstance(self.indexer.indexer, PGStringIndexerV2)
         self.indexer.indexer._get_db_records(
             UseCaseKeyCollection({self.use_case_id: {123: {"oop"}}})
         )
 
-        assert indexer_cache.get(key) is None
+        assert indexer_cache.get("br", key) is None


### PR DESCRIPTION
# This PR

- Add a `namespace` parameters to the `make_cache_key` function, and depending on the feature flag (set to false right now) will create cache keys from the new namespaces that are separate for the read path and write path.
- Functionally does not change anything unless the flag is set to True

**Next change in this stack PR**
https://github.com/getsentry/sentry/pull/58414

# Motivation

<details>
  <summary>Click to expand</summary>

The indexer is making the following assumptions with Memcached:

1. We are only adding key/value pairs to Memcached during `bulk_record` (the indexer’s “write path”)
2. Key/value pairs are gone from Memcached after 2 hours

It’s very easy to break 1 or 2 inadvertently. For example, we are inserting key/value pairs back into the cache during a `resolve` cache miss. Doing so is justified as some strings could be more read heavy than write heavy, such as users with automated scripts that are scanning for a specific key to show up.

</details>

# Background

<details>
  <summary>Click to expand</summary>

**How accessing the cache works today in the Indexer**

| Method | Key exists? | Behaviour |
| --- | --- | --- |
| bulk_record | ✅ | - Use the value from cache <br>- Emit `CACHE_READ` in header |
| bulk_record | ❌ | - Fetch value from Postgres<br>- Emit DB_READ in header<br>- Write {string} → {id} to cache |
| resolve | ✅ | - Use value from cache |
| resolve | ❌ | - Fetch value from Postgres<br>- Write {string} → {id} to cache |

where `bulk_record` = the code path for writing indexed strings

and     `resolve`         = the code path for querying strings
</details>

# Goal

<details>
  <summary>Click to expand</summary>
We store a timestamp of when the cache is stored in the value, and also partition the key between the write and read path.

`(writer + string) → (integer + timestamp)`

### ******************************How this works******************************

- Creates a distinction between, and handles appropriately, both the read and write path of replenishing the cache
- Log a metric in this scenario
- Simultaneously makes us aware of, and mitigates, unexpected cache behaviors
- Actually fixes the issue where we were replenishing the cache on the read path

| Method | Key exists? | Timestamp valid? | Behaviour |
| --- | --- | --- | --- |
| bulk_record | ✅ | ✅ | - Use value from cache<br>- Emit CACHE_READ in header |
| bulk_record | ✅ | ❌ | - Fetch value from Postgres<br>- Emit DB_READ in header<br>- Write br:{string} → {id}:{timestamp} to cache<br>- Increment metric |
| bulk_record | ❌ | - | - Fetch value from Postgres<br>- Emit DB_READ in header<br>- Write br:{string} → {id}:{timestamp} to cache |
| resolve | ✅ | ✅ | - Use value from cache |
| resolve | ✅ | ❌ | - Use value from cache<br>- Write res:{string} → {id}:{timestamp} to cache<br>- Increment metric |
| resolve | ❌ | - | - Fetch value from Postgres<br>- Write res:{string} → {id}:{timestamp} to cache |

</details>

# Deployment Plan

<details>
  <summary>Click to expand</summary>

1. [THIS PR] Deploy read paths that can toggle between reading from `(string) → (integer)` and `(writer + string) → (integer + timestamp)` via a sentry option
2. Deploy `bulk_record` changes to write to both types of key/value pairs (`(string) → (integer)` and `(writer + string) → (integer + timestamp)`) on each `bulk_record` lookup
3. Toggle the option deployed in step 1 to read from `(writer + string) → (integer + timestamp)`
4. (observability) Deploy logic to emit metric when timestamp that is greater than 2-3 hours
5. (mitigation) Deploy logic to reject key/value pairs when timestamp is greater than 2-3 hours
6. Add back the `resolve` path cache replenishment

</details>

# Local Testing

<details>
  <summary>Click to expand</summary>

Started sentry with memcache and kcat on `snuba-generic-metrics`

```
kcat -b localhost:9092 -t snuba-generic-metrics -C \
  -f '\nKey (%K bytes): %k
  Value (%S bytes): %s
  Timestamp: %T
  Partition: %p
  Offset: %o
  Headers: %h\n'
```

Send first batch of 3 messages with the send_metrics script

```
python bin/send_metrics.py --use-cases custom
```

Confirm that all 3 values have fetch type of FIRST_SEEN ("f")

```
Key (-1 bytes):
  Value (495 bytes): {"tags":{"9223372036854776010":"production","9223372036854776017":"init","67563":"metric_e2e_custom_counter_v_AIXH44IB"},"version":2,"retention_days":90,"mapping_meta":{"h":{"9223372036854776010":"environment","9223372036854776017":"session.status"},"f":{"67563":"metric_e2e_custom_counter_k_AIXH44IB"},"c":{"65555":"c:custom/custom@none"}},"use_case_id":"custom","metric_id":65555,"org_id":1,"timestamp":1697664813,"project_id":3,"type":"c","value":1,"sentry_received_timestamp":1697664813.218}
  Timestamp: 1697664834437
  Partition: 0
  Offset: 408
  Headers: mapping_sources=cfh,metric_type=c

Key (-1 bytes):
  Value (491 bytes): {"tags":{"9223372036854776010":"production","9223372036854776017":"errored","67562":"metric_e2e_custom_set_v_AIXH44IB"},"version":2,"retention_days":90,"mapping_meta":{"h":{"9223372036854776010":"environment","9223372036854776017":"session.status"},"f":{"67562":"metric_e2e_custom_set_k_AIXH44IB"},"c":{"65556":"s:custom/error@none"}},"use_case_id":"custom","metric_id":65556,"org_id":1,"timestamp":1697664813,"project_id":3,"type":"s","value":[3],"sentry_received_timestamp":1697664813.218}
  Timestamp: 1697664834437
  Partition: 0
  Offset: 409
  Headers: mapping_sources=cfh,metric_type=s

Key (-1 bytes):
  Value (502 bytes): {"tags":{"9223372036854776010":"production","9223372036854776017":"healthy","67561":"metric_e2e_custom_dist_v_AIXH44IB"},"version":2,"retention_days":90,"mapping_meta":{"h":{"9223372036854776010":"environment","9223372036854776017":"session.status"},"c":{"65558":"d:custom/duration@second"},"f":{"67561":"metric_e2e_custom_dist_k_AIXH44IB"}},"use_case_id":"custom","metric_id":65558,"org_id":1,"timestamp":1697664813,"project_id":3,"type":"d","value":[4,5,6],"sentry_received_timestamp":1697664813.218}
  Timestamp: 1697664834437
  Partition: 0
  Offset: 410
  Headers: mapping_sources=cfh,metric_type=d
% Reached end of topic snuba-generic-metrics [0] at offset 411
```

Send the same batch of 3 messages with the send_metrics script

```
python bin/send_metrics.py --use-cases custom --rand-str AIXH44IB
```

Confirm that the new messages all have fetch type of CACHE_HIT ("c")

```
Key (-1 bytes):
  Value (485 bytes): {"tags":{"9223372036854776010":"production","9223372036854776017":"errored","67562":"metric_e2e_custom_set_v_AIXH44IB"},"version":2,"retention_days":90,"mapping_meta":{"h":{"9223372036854776010":"environment","9223372036854776017":"session.status"},"c":{"67562":"metric_e2e_custom_set_k_AIXH44IB","65556":"s:custom/error@none"}},"use_case_id":"custom","metric_id":65556,"org_id":1,"timestamp":1697664926,"project_id":3,"type":"s","value":[3],"sentry_received_timestamp":1697664926.943}
  Timestamp: 1697664948036
  Partition: 0
  Offset: 411
  Headers: mapping_sources=ch,metric_type=s

Key (-1 bytes):
  Value (496 bytes): {"tags":{"9223372036854776010":"production","9223372036854776017":"healthy","67561":"metric_e2e_custom_dist_v_AIXH44IB"},"version":2,"retention_days":90,"mapping_meta":{"h":{"9223372036854776010":"environment","9223372036854776017":"session.status"},"c":{"65558":"d:custom/duration@second","67561":"metric_e2e_custom_dist_k_AIXH44IB"}},"use_case_id":"custom","metric_id":65558,"org_id":1,"timestamp":1697664926,"project_id":3,"type":"d","value":[4,5,6],"sentry_received_timestamp":1697664926.943}
  Timestamp: 1697664948036
  Partition: 0
  Offset: 412
  Headers: mapping_sources=ch,metric_type=d

Key (-1 bytes):
  Value (489 bytes): {"tags":{"9223372036854776010":"production","9223372036854776017":"init","67563":"metric_e2e_custom_counter_v_AIXH44IB"},"version":2,"retention_days":90,"mapping_meta":{"h":{"9223372036854776010":"environment","9223372036854776017":"session.status"},"c":{"67563":"metric_e2e_custom_counter_k_AIXH44IB","65555":"c:custom/custom@none"}},"use_case_id":"custom","metric_id":65555,"org_id":1,"timestamp":1697664926,"project_id":3,"type":"c","value":1,"sentry_received_timestamp":1697664926.943}
  Timestamp: 1697664948036
  Partition: 0
  Offset: 413
  Headers: mapping_sources=ch,metric_type=c
% Reached end of topic snuba-generic-metrics [0] at offset 414
```

</details>