### PR TITLE
feat(statistical-detectors): Bump min delta for function regressions

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -216,7 +216,7 @@ def _detect_transaction_change_points(
         request = {
             "data": data,
             "sort": "-trend_percentage()",
-            "trendFunction": trend_function,
+            "min_change()": 100_000_000,  # require a minimum 100ms increase (in ns)
             # Disable the fall back to use the midpoint as the breakpoint
             # which was originally intended to detect a gradual regression
             # for the trends use case. That does not apply here.


### PR DESCRIPTION
We've been seeing a lot of small regressions that dont seem to be significant regressions. Set a minimum threshold so that we don't create issues on these.