### PR TITLE
fix: createuser should not block if a user exists

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -188,7 +188,7 @@ create-superuser() {
     if [[ -n "${GITHUB_ACTIONS+x}" ]]; then
         sentry createuser --superuser --email foo@tbd.com --no-password --no-input
     else
-        sentry createuser --superuser --email admin@sentry.io --password admin
+        sentry createuser --superuser --email admin@sentry.io --password admin --no-input
         echo "Password is admin."
     fi
 }

--- a/src/sentry/runner/commands/createuser.py
+++ b/src/sentry/runner/commands/createuser.py
@@ -137,7 +137,9 @@ def createuser(emails, org_id, password, superuser, staff, no_password, no_input
                 user.update(**fields)
                 verb = "updated"
             else:
-                raise click.ClickException(f"User: {email} exists, use --force-update to force.")
+                click.echo(f"User: {email} exists, use --force-update to force.")
+                continue
+
         # Create a new user if they don't already exist.
         else:
             user = User.objects.create(**fields)


### PR DESCRIPTION
`make bootstrap` (and `devenv sync`) currently fails like this if the superuser exists, it should be more repeatable and idempotent:

```
--> Creating a superuser account
Error: User: admin@sentry.io exists, use --force-update to force.
make: *** [bootstrap] Error 1
```