### PR TITLE
fix(ci): fix rate limit test

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -5271,20 +5271,6 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         }
 
     @override_settings(SENTRY_SELF_HOSTED=False)
-    def test_ratelimit(self):
-        query = {
-            "field": ["transaction"],
-            "project": [self.project.id],
-        }
-        with freeze_time("2000-01-01"):
-            for _ in range(15):
-                self.do_request(query, features={"organizations:discover-events-rate-limit": True})
-            response = self.do_request(
-                query, features={"organizations:discover-events-rate-limit": True}
-            )
-            assert response.status_code == 429, response.content
-
-    @override_settings(SENTRY_SELF_HOSTED=False)
     def test_no_ratelimit(self):
         query = {
             "field": ["transaction"],


### PR DESCRIPTION
I don't know how this test passed but the rate limit was bumped up in https://github.com/getsentry/sentry/pull/57876 while the test was not modified.

* Move the test outside of the snuba acceptance suite since it does not actually test snuba
* fix the test to use the rate limit constant so it doesn't fail like this anymore