### PR TITLE
fix(hc): Silo fixes for alert rule actions

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -52,11 +52,15 @@ def build_action_response(
         action_response["integrationId"] = integration.id
 
         if registered_type.type == AlertRuleTriggerAction.Type.PAGERDUTY:
+            if organization is None:
+                raise Exception("Organization is required for PAGERDUTY actions")
             action_response["options"] = [
                 {"value": id, "label": service_name}
                 for id, service_name in get_pagerduty_services(organization.id, integration.id)
             ]
         elif registered_type.type == AlertRuleTriggerAction.Type.OPSGENIE:
+            if organization is None:
+                raise Exception("Organization is required for OPSGENIE actions")
             action_response["options"] = [
                 {"value": id, "label": team}
                 for id, team in get_opsgenie_teams(organization.id, integration.id)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from collections import defaultdict
+from typing import Any, DefaultDict, List, Mapping
 
 from rest_framework import status
 from rest_framework.request import Request
@@ -9,7 +12,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.constants import SentryAppStatus
 from sentry.incidents.logic import (
     get_available_action_integrations_for_org,
     get_opsgenie_teams,
@@ -17,12 +19,17 @@ from sentry.incidents.logic import (
 )
 from sentry.incidents.models import AlertRuleTriggerAction
 from sentry.incidents.serializers import ACTION_TARGET_TYPE_TO_STRING
-from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
+from sentry.models.organization import Organization
+from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation, app_service
+from sentry.services.hybrid_cloud.integration import RpcIntegration
 
 
 def build_action_response(
-    registered_type, integration=None, organization=None, sentry_app_installation=None
-):
+    registered_type,
+    integration: RpcIntegration | None = None,
+    organization: Organization | None = None,
+    sentry_app_installation: RpcSentryAppInstallation | None = None,
+) -> Mapping[str, Any]:
     """
     Build the "available action" objects for the API. Each one can have different fields.
 
@@ -57,14 +64,14 @@ def build_action_response(
 
     elif sentry_app_installation:
         action_response["sentryAppName"] = sentry_app_installation.sentry_app.name
-        action_response["sentryAppId"] = sentry_app_installation.sentry_app_id
+        action_response["sentryAppId"] = sentry_app_installation.sentry_app.id
         action_response["sentryAppInstallationUuid"] = sentry_app_installation.uuid
-        action_response["status"] = SentryAppStatus.as_str(
-            sentry_app_installation.sentry_app.status
-        )
+        action_response["status"] = sentry_app_installation.sentry_app.status
 
         # Sentry Apps can be alertable but not have an Alert Rule UI Component
-        component = sentry_app_installation.prepare_sentry_app_components("alert-rule-action")
+        component = app_service.prepare_sentry_app_components(
+            installation_id=sentry_app_installation.id, component_type="alert-rule-action"
+        )
         if component:
             action_response["settings"] = component.schema.get("settings", {})
 
@@ -87,7 +94,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
         actions = []
 
         # Cache Integration objects in this data structure to save DB calls.
-        provider_integrations = defaultdict(list)
+        provider_integrations: DefaultDict[str, List[RpcIntegration]] = defaultdict(list)
         for integration in get_available_action_integrations_for_org(organization):
             provider_integrations[integration.provider].append(integration)
 
@@ -103,13 +110,13 @@ class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
 
             # Add all alertable SentryApps to the list.
             elif registered_type.type == AlertRuleTriggerAction.Type.SENTRY_APP:
+                installs = app_service.get_installed_for_organization(
+                    organization_id=organization.id
+                )
                 actions += [
                     build_action_response(registered_type, sentry_app_installation=install)
-                    for install in SentryAppInstallation.objects.get_installed_for_organization(
-                        organization.id
-                    ).filter(
-                        sentry_app__is_alertable=True,
-                    )
+                    for install in installs
+                    if install.sentry_app.is_alertable
                 ]
 
             else:

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -73,7 +73,7 @@ def build_action_response(
             installation_id=sentry_app_installation.id, component_type="alert-rule-action"
         )
         if component:
-            action_response["settings"] = component.schema.get("settings", {})
+            action_response["settings"] = component.app_schema.get("settings", {})
 
     return action_response
 

--- a/src/sentry/services/hybrid_cloud/app/impl.py
+++ b/src/sentry/services/hybrid_cloud/app/impl.py
@@ -28,6 +28,7 @@ from sentry.services.hybrid_cloud.app import (
 )
 from sentry.services.hybrid_cloud.app.serial import (
     serialize_sentry_app,
+    serialize_sentry_app_component,
     serialize_sentry_app_installation,
 )
 from sentry.services.hybrid_cloud.auth import AuthenticationContext
@@ -55,12 +56,7 @@ class DatabaseBackedAppService(AppService):
 
     def find_app_components(self, *, app_id: int) -> List[RpcSentryAppComponent]:
         return [
-            RpcSentryAppComponent(
-                uuid=str(c.uuid),
-                sentry_app_id=c.sentry_app_id,
-                type=c.type,
-                app_schema=c.schema,
-            )
+            serialize_sentry_app_component(c)
             for c in SentryAppComponent.objects.filter(sentry_app_id=app_id)
         ]
 
@@ -263,3 +259,12 @@ class DatabaseBackedAppService(AppService):
             installation = SentryAppInstallation.objects.get(sentry_app=sentry_app)
 
         return serialize_sentry_app_installation(installation=installation, app=sentry_app)
+
+    def prepare_sentry_app_components(
+        self, *, installation_id: int, component_type: str, project_slug: Optional[str] = None
+    ) -> Optional[RpcSentryAppComponent]:
+        from sentry.models.integrations.sentry_app_installation import prepare_sentry_app_components
+
+        installation = SentryAppInstallation.objects.get(id=installation_id)
+        component = prepare_sentry_app_components(installation, component_type, project_slug)
+        return serialize_sentry_app_component(component) if component else None

--- a/src/sentry/services/hybrid_cloud/app/model.py
+++ b/src/sentry/services/hybrid_cloud/app/model.py
@@ -44,6 +44,7 @@ class RpcSentryApp(RpcModel):
     uuid: str = ""
     events: List[str] = Field(default_factory=list)
     webhook_url: Optional[str] = None
+    is_alertable: bool = False
     is_published: bool = False
     is_unpublished: bool = False
     is_internal: bool = True

--- a/src/sentry/services/hybrid_cloud/app/serial.py
+++ b/src/sentry/services/hybrid_cloud/app/serial.py
@@ -2,11 +2,13 @@ from typing import Optional
 
 from sentry.constants import SentryAppStatus
 from sentry.models.apiapplication import ApiApplication
+from sentry.models.integrations import SentryAppComponent
 from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.services.hybrid_cloud.app import (
     RpcApiApplication,
     RpcSentryApp,
+    RpcSentryAppComponent,
     RpcSentryAppInstallation,
 )
 
@@ -34,11 +36,12 @@ def serialize_sentry_app(app: SentryApp) -> RpcSentryApp:
         uuid=app.uuid,
         events=app.events,
         webhook_url=app.webhook_url,
+        is_alertable=app.is_alertable,
         is_published=app.status == SentryAppStatus.PUBLISHED,
         is_unpublished=app.status == SentryAppStatus.UNPUBLISHED,
         is_internal=app.status == SentryAppStatus.INTERNAL,
         is_publish_request_inprogress=app.status == SentryAppStatus.PUBLISH_REQUEST_INPROGRESS,
-        status=app.status,
+        status=SentryAppStatus.as_str(app.status),
     )
 
 
@@ -57,4 +60,13 @@ def serialize_sentry_app_installation(
         date_deleted=installation.date_deleted,
         uuid=installation.uuid,
         api_token=installation.api_token.token if installation.api_token else None,
+    )
+
+
+def serialize_sentry_app_component(component: SentryAppComponent) -> RpcSentryAppComponent:
+    return RpcSentryAppComponent(
+        uuid=str(component.uuid),
+        sentry_app_id=component.sentry_app_id,
+        type=component.type,
+        app_schema=component.schema,
     )

--- a/src/sentry/services/hybrid_cloud/app/service.py
+++ b/src/sentry/services/hybrid_cloud/app/service.py
@@ -145,5 +145,12 @@ class AppService(RpcService):
     ) -> RpcSentryAppInstallation:
         pass
 
+    @rpc_method
+    @abc.abstractmethod
+    def prepare_sentry_app_components(
+        self, *, installation_id: int, component_type: str, project_slug: Optional[str] = None
+    ) -> Optional[RpcSentryAppComponent]:
+        pass
+
 
 app_service = cast(AppService, AppService.create_delegation())

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -5,6 +5,7 @@ from sentry.incidents.endpoints.organization_alert_rule_available_action_index i
 from sentry.incidents.models import AlertRuleTriggerAction
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
+from sentry.services.hybrid_cloud.app.serial import serialize_sentry_app_installation
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
@@ -25,7 +26,7 @@ METADATA = {
 }
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-alert-rule-available-actions"
     email = AlertRuleTriggerAction.get_registered_type(AlertRuleTriggerAction.Type.EMAIL)
@@ -109,7 +110,9 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
     def test_build_action_response_sentry_app(self):
         installation = self.install_new_sentry_app("foo")
 
-        data = build_action_response(self.sentry_app, sentry_app_installation=installation)
+        data = build_action_response(
+            self.sentry_app, sentry_app_installation=serialize_sentry_app_installation(installation)
+        )
 
         assert data["type"] == "sentry_app"
         assert data["allowedTargetTypes"] == ["sentry_app"]
@@ -180,7 +183,10 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         assert len(response.data) == 2
         assert build_action_response(self.email) in response.data
         assert (
-            build_action_response(self.sentry_app, sentry_app_installation=installation)
+            build_action_response(
+                self.sentry_app,
+                sentry_app_installation=serialize_sentry_app_installation(installation),
+            )
             in response.data
         )
 
@@ -193,7 +199,10 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
 
         assert len(response.data) == 2
         assert (
-            build_action_response(self.sentry_app, sentry_app_installation=installation)
+            build_action_response(
+                self.sentry_app,
+                sentry_app_installation=serialize_sentry_app_installation(installation),
+            )
             in response.data
         )
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -3,6 +3,7 @@ from sentry.incidents.endpoints.organization_alert_rule_available_action_index i
     build_action_response,
 )
 from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.models.integrations import SentryAppComponent, SentryAppInstallation
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.services.hybrid_cloud.app.serial import serialize_sentry_app_installation
@@ -39,7 +40,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         super().setUp()
         self.login_as(self.user)
 
-    def install_new_sentry_app(self, name, **kwargs):
+    def install_new_sentry_app(self, name, **kwargs) -> SentryAppInstallation:
         kwargs.update(
             name=name, organization=self.organization, is_alertable=True, verify_install=False
         )
@@ -117,6 +118,22 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         assert data["type"] == "sentry_app"
         assert data["allowedTargetTypes"] == ["sentry_app"]
         assert data["status"] == SentryAppStatus.UNPUBLISHED_STR
+
+    def test_build_action_response_sentry_app_with_component(self):
+        installation = self.install_new_sentry_app("foo")
+        test_settings = {"test-settings": []}
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            SentryAppComponent.objects.create(
+                sentry_app=installation.sentry_app,
+                type="alert-rule-action",
+                schema={"settings": test_settings},
+            )
+
+        data = build_action_response(
+            self.sentry_app, sentry_app_installation=serialize_sentry_app_installation(installation)
+        )
+
+        assert data["settings"] == test_settings
 
     def test_no_integrations(self):
         with self.feature("organizations:incidents"):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -1,3 +1,5 @@
+from typing import Any, Mapping
+
 from sentry.constants import ObjectStatus, SentryAppStatus
 from sentry.incidents.endpoints.organization_alert_rule_available_action_index import (
     build_action_response,
@@ -121,7 +123,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
 
     def test_build_action_response_sentry_app_with_component(self):
         installation = self.install_new_sentry_app("foo")
-        test_settings = {"test-settings": []}
+        test_settings: Mapping[str, Any] = {"test-settings": []}
         with assume_test_silo_mode(SiloMode.CONTROL):
             SentryAppComponent.objects.create(
                 sentry_app=installation.sentry_app,

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -69,6 +69,7 @@ from sentry.incidents.models import (
 from sentry.models.actor import ActorTuple, get_actor_id_for_user
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
+from sentry.services.hybrid_cloud.integration.serial import serialize_integration
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError, ApiTimeoutError
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
@@ -1997,14 +1998,18 @@ class GetAvailableActionIntegrationsForOrgTest(TestCase):
     def test_registered(self):
         integration = Integration.objects.create(external_id="1", provider="slack")
         integration.add_organization(self.organization)
-        assert list(get_available_action_integrations_for_org(self.organization)) == [integration]
+        assert list(get_available_action_integrations_for_org(self.organization)) == [
+            serialize_integration(integration)
+        ]
 
     def test_mixed(self):
         integration = Integration.objects.create(external_id="1", provider="slack")
         integration.add_organization(self.organization)
         other_integration = Integration.objects.create(external_id="12345", provider="random")
         other_integration.add_organization(self.organization)
-        assert list(get_available_action_integrations_for_org(self.organization)) == [integration]
+        assert list(get_available_action_integrations_for_org(self.organization)) == [
+            serialize_integration(integration)
+        ]
 
     def test_disabled_integration(self):
         integration = Integration.objects.create(


### PR DESCRIPTION
Restore #57949, which was reverted by #58091. Fix [SENTRY-16NH](https://sentry.sentry.io/issues/4544284664/).

Adapt OrganizationAlertRuleAvailableActionIndexEndpoint and get_available_action_integrations_for_org to run in the region silo.

Introduce a prepare_sentry_app_components method to AppService. Remove the method of the same name from the SentryAppInstallation model. (It previously dispatched to the same module-level function that AppService now calls. The model method was called nowhere else.)

Mark OrganizationAlertRuleAvailableActionIndexEndpointTest as stable. Change setup to pass RPC models as needed.
