### PR TITLE
feat(browser-starfish): add graph for asset size overtime

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
@@ -64,23 +64,23 @@ function ResourceSummaryCharts(props: {groupId: string}) {
  * @returns a reference to the initial series filled
  */
 export const fillSeries = (series: Series): Series => {
-  const data = series.data;
-
-  if (!data.length) {
+  if (!series.data.length) {
     return series;
   }
 
-  let lastSeenValue = data[0].value;
-  for (const dataPoint of data) {
-    const value = dataPoint.value;
-    if (value !== lastSeenValue && value !== 0) {
-      lastSeenValue = value;
-    } else {
-      dataPoint.value = lastSeenValue;
-    }
-  }
-  series.data = series.data.filter(dataPoint => dataPoint.value > 0);
-  return series;
+  let lastSeenValue = series.data[0].value;
+
+  return {
+    ...series,
+    data: series.data.map(dataPoint => {
+      const value = dataPoint.value;
+      if (value !== lastSeenValue && value !== 0) {
+        lastSeenValue = value;
+        return {...dataPoint};
+      }
+      return {...dataPoint, value: lastSeenValue};
+    }),
+  };
 };
 
 export default ResourceSummaryCharts;

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
@@ -1,30 +1,86 @@
+import {t} from 'sentry/locale';
+import {Series} from 'sentry/types/echarts';
+import {formatBytesBase2} from 'sentry/utils';
+import getDynamicText from 'sentry/utils/getDynamicText';
 import {AVG_COLOR} from 'sentry/views/starfish/colours';
 import Chart from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {getDurationChartTitle} from 'sentry/views/starfish/views/spans/types';
-import {Block} from 'sentry/views/starfish/views/spanSummaryPage/block';
+import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
+
+const {SPAN_SELF_TIME, HTTP_RESPONSE_CONTENT_LENGTH} = SpanMetricsField;
 
 function ResourceSummaryCharts(props: {groupId: string}) {
   const {data: spanMetricsSeriesData, isLoading: areSpanMetricsSeriesLoading} =
-    useSpanMetricsSeries(props.groupId, {}, [`avg(${SpanMetricsField.SPAN_SELF_TIME})`]);
+    useSpanMetricsSeries(props.groupId, {}, [
+      `avg(${SPAN_SELF_TIME})`,
+      `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
+    ]);
 
   return (
-    <Block>
-      <ChartPanel title={getDurationChartTitle('http')}>
-        <Chart
-          height={160}
-          data={[spanMetricsSeriesData?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]]}
-          loading={areSpanMetricsSeriesLoading}
-          utc={false}
-          chartColors={[AVG_COLOR]}
-          isLineChart
-          definedAxisTicks={4}
-        />
-      </ChartPanel>
-    </Block>
+    <BlockContainer>
+      <Block>
+        <ChartPanel title={getDurationChartTitle('http')}>
+          <Chart
+            height={160}
+            data={[spanMetricsSeriesData?.[`avg(${SPAN_SELF_TIME})`]]}
+            loading={areSpanMetricsSeriesLoading}
+            utc={false}
+            chartColors={[AVG_COLOR]}
+            isLineChart
+            definedAxisTicks={4}
+          />
+        </ChartPanel>
+      </Block>
+      <Block>
+        <ChartPanel title={t('Resource Size')}>
+          <Chart
+            height={160}
+            data={[spanMetricsSeriesData?.[`avg(${HTTP_RESPONSE_CONTENT_LENGTH})`]]}
+            loading={areSpanMetricsSeriesLoading}
+            utc={false}
+            chartColors={[AVG_COLOR]}
+            isLineChart
+            definedAxisTicks={4}
+            tooltipFormatterOptions={{
+              valueFormatter: bytes =>
+                getDynamicText({
+                  value: formatBytesBase2(bytes),
+                  fixed: 'xx KB',
+                }),
+            }}
+          />
+        </ChartPanel>
+      </Block>
+    </BlockContainer>
   );
 }
+
+/**
+ * Ensures a series has no zeros between two non-zero datapoints. This is useful in
+ * @param series the series to fill
+ * @returns a reference to the initial series filled
+ */
+export const fillSeries = (series: Series): Series => {
+  const data = series.data;
+
+  if (!data.length) {
+    return series;
+  }
+
+  let lastSeenValue = data[0].value;
+  for (const dataPoint of data) {
+    const value = dataPoint.value;
+    if (value !== lastSeenValue && value !== 0) {
+      lastSeenValue = value;
+    } else {
+      dataPoint.value = lastSeenValue;
+    }
+  }
+  series.data = series.data.filter(dataPoint => dataPoint.value > 0);
+  return series;
+};
 
 export default ResourceSummaryCharts;

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -27,6 +27,7 @@ export enum SpanMetricsField {
   SPAN_SELF_TIME = 'span.self_time',
   PROJECT_ID = 'project.id',
   RESOURCE_RENDER_BLOCKING_STATUS = 'resource.render_blocking_status',
+  HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length',
 }
 
 export type SpanNumberFields = 'span.self_time' | 'span.duration';


### PR DESCRIPTION
Adds an avg(asset size) overtime graph.
<img width="1013" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/c492590e-e1e1-49be-a678-8b5c336ba14c">
