### PR TITLE
feat(stat-detectors): Add widget for surfacing geo location regressions

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/spanOpBreakdown.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/spanOpBreakdown.tsx
@@ -145,32 +145,24 @@ function EventSpanOpBreakdown({event}: {event: Event}) {
   ];
 
   if (postBreakpointIsLoading || preBreakpointIsLoading) {
-    return (
-      <Wrapper>
-        <LoadingIndicator />
-      </Wrapper>
-    );
+    return <LoadingIndicator />;
   }
 
   if (postBreakpointIsError || preBreakpointIsError) {
     return (
-      <Wrapper>
-        <EmptyStateWrapper>
-          <EmptyStateWarning withIcon>
-            <div>{t('Unable to fetch span breakdowns')}</div>
-          </EmptyStateWarning>
-        </EmptyStateWrapper>
-      </Wrapper>
+      <EmptyStateWrapper>
+        <EmptyStateWarning withIcon>
+          <div>{t('Unable to fetch span breakdowns')}</div>
+        </EmptyStateWarning>
+      </EmptyStateWrapper>
     );
   }
 
   return (
-    <Wrapper>
-      <DataSection>
-        <strong>{t('Operation Breakdown:')}</strong>
-        <PieChart data={spanOpDiffs} series={series} />
-      </DataSection>
-    </Wrapper>
+    <DataSection>
+      <strong>{t('Operation Breakdown:')}</strong>
+      <PieChart data={spanOpDiffs} series={series} />
+    </DataSection>
   );
 }
 
@@ -181,11 +173,6 @@ const EmptyStateWrapper = styled('div')`
   justify-content: center;
   align-items: center;
   margin: ${space(1.5)} ${space(4)};
-`;
-
-const Wrapper = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
 `;
 
 export default EventSpanOpBreakdown;

--- a/static/app/components/events/eventStatisticalDetector/geoLocationDiff.spec.tsx
+++ b/static/app/components/events/eventStatisticalDetector/geoLocationDiff.spec.tsx
@@ -61,6 +61,7 @@ describe('GeoLocationDiff', () => {
         },
       ],
     });
+
     render(<GeoLocationDiff projectId={PROJECT_ID} event={mockEvent} />);
 
     expect(
@@ -92,6 +93,7 @@ describe('GeoLocationDiff', () => {
         },
       ],
     });
+
     render(<GeoLocationDiff projectId={PROJECT_ID} event={mockEvent} />);
 
     await userEvent.hover(await screen.findByText('+100.00%'));
@@ -124,6 +126,34 @@ describe('GeoLocationDiff', () => {
           end: new Date(BREAKPOINT_TIMESTAMP * 1000 + 7 * DAY).toISOString(),
         }),
       })
+    );
+  });
+
+  it('links to the transaction summary page with the geo code as a filter', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-root-cause-analysis/',
+      method: 'GET',
+      body: [
+        {
+          duration_after: 10,
+          duration_before: 5,
+          duration_delta: 5,
+          ['geo.country_code']: 'US',
+        },
+      ],
+    });
+
+    render(<GeoLocationDiff projectId={PROJECT_ID} event={mockEvent} />);
+
+    const url = new URL(
+      (await screen.findByText('+100.00%')).getAttribute('href') as string,
+      'http://mockHost.com'
+    );
+    expect(url.pathname).toBe('/organizations/org-slug/performance/summary/');
+    expect(url.searchParams.get('query')).toBe('geo.country_code:US');
+    expect(url.searchParams.get('display')).toBe('duration');
+    expect(new Set(url.searchParams.getAll('unselectedSeries'))).toEqual(
+      new Set(['avg()', 'p99()', 'p100()', 'p50()', 'p75()'])
     );
   });
 });

--- a/static/app/components/events/eventStatisticalDetector/geoLocationDiff.spec.tsx
+++ b/static/app/components/events/eventStatisticalDetector/geoLocationDiff.spec.tsx
@@ -63,12 +63,18 @@ describe('GeoLocationDiff', () => {
     });
     render(<GeoLocationDiff projectId={PROJECT_ID} event={mockEvent} />);
 
-    const firstRow = (await screen.findByText('US')).parentElement as HTMLElement;
+    expect(
+      await screen.findByText(
+        'An increase in the transaction duration has been detected for the following countries. The results are sorted by their overall effect on the duration, based off of the change in duration and the current TPM.'
+      )
+    ).toBeInTheDocument();
+
+    const firstRow = screen.getByText('US').parentElement as HTMLElement;
     expect(firstRow).toBeInTheDocument();
     within(firstRow).getByText('United States');
     within(firstRow).getByText('+100.00%');
 
-    const secondRow = (await screen.findByText('CA')).parentElement as HTMLElement;
+    const secondRow = screen.getByText('CA').parentElement as HTMLElement;
     expect(secondRow).toBeInTheDocument();
     within(secondRow).getByText('Canada');
     within(secondRow).getByText('+40.00%');

--- a/static/app/components/events/eventStatisticalDetector/geoLocationDiff.spec.tsx
+++ b/static/app/components/events/eventStatisticalDetector/geoLocationDiff.spec.tsx
@@ -1,0 +1,124 @@
+import {Event as EventMock} from 'sentry-fixture/event';
+
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+
+import {Event} from 'sentry/types';
+import {DAY} from 'sentry/utils/formatters';
+
+import GeoLocationDiff from './geoLocationDiff';
+
+describe('GeoLocationDiff', () => {
+  const DURATION_REGRESSION_TYPE = 1017;
+  const PROJECT_ID = '1';
+
+  // Breakpoint is stored as seconds
+  const BREAKPOINT_TIMESTAMP = (Date.now() - 7 * DAY) / 1000;
+  let mockEvent: Event;
+
+  beforeEach(() => {
+    mockEvent = {
+      ...EventMock(),
+      occurrence: {
+        evidenceData: {
+          breakpoint: BREAKPOINT_TIMESTAMP,
+          transaction: '/api/0/transaction-test-endpoint/',
+        },
+        evidenceDisplay: [
+          {
+            name: 'Transaction',
+            value: '/api/0/transaction-test-endpoint/',
+            important: false,
+          },
+        ],
+        fingerprint: [],
+        id: '',
+        issueTitle: '',
+        resourceId: '',
+        subtitle: '',
+        detectionTime: '',
+        eventId: '',
+        type: DURATION_REGRESSION_TYPE,
+      },
+    };
+  });
+
+  it('renders a row for each result with country code, name, and percent increase in duration', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-root-cause-analysis/',
+      method: 'GET',
+      body: [
+        {
+          duration_after: 10,
+          duration_before: 5,
+          duration_delta: 5,
+          ['geo.country_code']: 'US',
+        },
+        {
+          duration_after: 7,
+          duration_before: 5,
+          duration_delta: 2,
+          ['geo.country_code']: 'CA',
+        },
+      ],
+    });
+    render(<GeoLocationDiff projectId={PROJECT_ID} event={mockEvent} />);
+
+    const firstRow = (await screen.findByText('US')).parentElement as HTMLElement;
+    expect(firstRow).toBeInTheDocument();
+    within(firstRow).getByText('United States');
+    within(firstRow).getByText('+100.00%');
+
+    const secondRow = (await screen.findByText('CA')).parentElement as HTMLElement;
+    expect(secondRow).toBeInTheDocument();
+    within(secondRow).getByText('Canada');
+    within(secondRow).getByText('+40.00%');
+  });
+
+  it('shows the absolute durations in a tooltip when the percent increases are hovered', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-root-cause-analysis/',
+      method: 'GET',
+      body: [
+        {
+          duration_after: 10,
+          duration_before: 5,
+          duration_delta: 5,
+          ['geo.country_code']: 'US',
+        },
+      ],
+    });
+    render(<GeoLocationDiff projectId={PROJECT_ID} event={mockEvent} />);
+
+    await userEvent.hover(await screen.findByText('+100.00%'));
+
+    const tooltip = await screen.findByTestId('geo-duration-change-tooltip-content');
+    expect(tooltip).toHaveTextContent('From 5.00ms to 10.00ms');
+  });
+
+  it('requests 7 days of data around the event breakpoint', () => {
+    const request = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-root-cause-analysis/',
+      method: 'GET',
+      body: [
+        {
+          duration_after: 10,
+          duration_before: 5,
+          duration_delta: 5,
+          ['geo.country_code']: 'US',
+        },
+      ],
+    });
+
+    render(<GeoLocationDiff projectId={PROJECT_ID} event={mockEvent} />);
+
+    expect(request).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-root-cause-analysis/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          start: new Date(BREAKPOINT_TIMESTAMP * 1000 - 7 * DAY).toISOString(),
+          end: new Date(BREAKPOINT_TIMESTAMP * 1000 + 7 * DAY).toISOString(),
+        }),
+      })
+    );
+  });
+});

--- a/static/app/components/events/eventStatisticalDetector/geoLocationDiff.spec.tsx
+++ b/static/app/components/events/eventStatisticalDetector/geoLocationDiff.spec.tsx
@@ -69,15 +69,14 @@ describe('GeoLocationDiff', () => {
       )
     ).toBeInTheDocument();
 
-    const firstRow = screen.getByText('US').parentElement as HTMLElement;
-    expect(firstRow).toBeInTheDocument();
-    within(firstRow).getByText('United States');
-    within(firstRow).getByText('+100.00%');
+    const rows = screen.getAllByRole('listitem');
+    within(rows[0]).getByText('US');
+    within(rows[0]).getByText('United States');
+    within(rows[0]).getByText('+100.00%');
 
-    const secondRow = screen.getByText('CA').parentElement as HTMLElement;
-    expect(secondRow).toBeInTheDocument();
-    within(secondRow).getByText('Canada');
-    within(secondRow).getByText('+40.00%');
+    within(rows[1]).getByText('CA');
+    within(rows[1]).getByText('Canada');
+    within(rows[1]).getByText('+40.00%');
   });
 
   it('shows the absolute durations in a tooltip when the percent increases are hovered', async () => {

--- a/static/app/components/events/eventStatisticalDetector/geoLocationDiff.tsx
+++ b/static/app/components/events/eventStatisticalDetector/geoLocationDiff.tsx
@@ -144,20 +144,24 @@ function GeoLocationDiff({event, projectId}: {event: Event; projectId: string}) 
                   </span>
                   <div style={{justifySelf: 'end'}}>
                     <Tooltip
-                      title={tct('From [previousDuration] to [currentDuration]', {
-                        previousDuration: (
-                          <PerformanceDuration
-                            milliseconds={row.duration_before}
-                            abbreviation
-                          />
-                        ),
-                        currentDuration: (
-                          <PerformanceDuration
-                            milliseconds={row.duration_after}
-                            abbreviation
-                          />
-                        ),
-                      })}
+                      title={
+                        <div data-test-id="geo-duration-change-tooltip-content">
+                          {tct('From [previousDuration] to [currentDuration]', {
+                            previousDuration: (
+                              <PerformanceDuration
+                                milliseconds={row.duration_before}
+                                abbreviation
+                              />
+                            ),
+                            currentDuration: (
+                              <PerformanceDuration
+                                milliseconds={row.duration_after}
+                                abbreviation
+                              />
+                            ),
+                          })}
+                        </div>
+                      }
                       showUnderline
                     >
                       <Link to={transactionSummaryLink}>

--- a/static/app/components/events/eventStatisticalDetector/geoLocationDiff.tsx
+++ b/static/app/components/events/eventStatisticalDetector/geoLocationDiff.tsx
@@ -133,6 +133,8 @@ function GeoLocationDiff({event, projectId}: {event: Event; projectId: string}) 
               },
               projectID: projectId,
               display: DisplayModes.DURATION,
+              // Only show p95 series to align with issue context
+              unselectedSeries: ['avg()', 'p100()', 'p99()', 'p75()', 'p50()'],
             });
 
             return (

--- a/static/app/components/events/eventStatisticalDetector/geoLocationDiff.tsx
+++ b/static/app/components/events/eventStatisticalDetector/geoLocationDiff.tsx
@@ -182,6 +182,6 @@ export default GeoLocationDiff;
 
 const GeoAnalysisEntry = styled('div')`
   display: grid;
-  grid-template-columns: 20px auto auto;
+  grid-template-columns: min-content auto min-content;
   gap: 8px;
 `;

--- a/static/app/components/events/eventStatisticalDetector/geoLocationDiff.tsx
+++ b/static/app/components/events/eventStatisticalDetector/geoLocationDiff.tsx
@@ -1,0 +1,187 @@
+import {Fragment, useMemo} from 'react';
+import styled from '@emotion/styled';
+import invert from 'lodash/invert';
+
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import {DataSection} from 'sentry/components/events/styles';
+import Link from 'sentry/components/links/link';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import PerformanceDuration from 'sentry/components/performanceDuration';
+import {Tooltip} from 'sentry/components/tooltip';
+import countryCodesMap from 'sentry/data/countryCodesMap';
+import {t, tct} from 'sentry/locale';
+import {Event} from 'sentry/types';
+import {defined} from 'sentry/utils';
+import {useRelativeDateTime} from 'sentry/utils/profiling/hooks/useRelativeDateTime';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+import {
+  DisplayModes,
+  transactionSummaryRouteWithQuery,
+} from 'sentry/views/performance/transactionSummary/utils';
+
+interface GeoDiff {
+  duration_after: number;
+  duration_before: number;
+  duration_delta: number;
+  ['geo.country_code']: string;
+}
+
+interface UseFetchAdvancedAnalysisProps {
+  breakpoint: string;
+  end: string;
+  projectId: string;
+  start: string;
+  transaction: string;
+}
+
+function useFetchGeoAnalysis({
+  transaction,
+  start,
+  end,
+  breakpoint,
+  projectId,
+}: UseFetchAdvancedAnalysisProps) {
+  const organization = useOrganization();
+  return useApiQuery<GeoDiff[]>(
+    [
+      `/organizations/${organization.slug}/events-root-cause-analysis/`,
+      {
+        query: {
+          transaction,
+          project: projectId,
+          start,
+          end,
+          breakpoint,
+          per_page: 5,
+          type: 'geo',
+        },
+      },
+    ],
+    {
+      staleTime: 60000,
+      retry: false,
+    }
+  );
+}
+
+function calculatePercentChange(before: number, delta: number) {
+  return (delta / before) * 100;
+}
+
+function GeoLocationDiff({event, projectId}: {event: Event; projectId: string}) {
+  const organization = useOrganization();
+  const countryCodesToCountry = useMemo(() => invert(countryCodesMap), []);
+
+  const {transaction, breakpoint} = event?.occurrence?.evidenceData ?? {};
+  const breakpointTimestamp = new Date(breakpoint * 1000).toISOString();
+
+  const {start, end} = useRelativeDateTime({
+    anchor: breakpoint,
+    relativeDays: 7,
+  });
+  const {data, isLoading, isError} = useFetchGeoAnalysis({
+    transaction,
+    start: (start as Date).toISOString(),
+    end: (end as Date).toISOString(),
+    breakpoint: breakpointTimestamp,
+    projectId,
+  });
+
+  if (isLoading) {
+    return <LoadingIndicator />;
+  }
+
+  let content;
+  if (isError) {
+    content = (
+      <EmptyStateWarning>
+        <p>{t('Oops! Something went wrong when analyzing regressions by countries')}</p>
+      </EmptyStateWarning>
+    );
+  } else if (!defined(data) || data.length === 0) {
+    content = (
+      <EmptyStateWarning>
+        <p>
+          {t('Unable to find significant differences in country transaction durations')}
+        </p>
+      </EmptyStateWarning>
+    );
+  } else {
+    content = (
+      <Fragment>
+        <strong>{t('Countries Impacted:')}</strong>
+        <div style={{marginBottom: '8px'}}>
+          {t(
+            'An increase in the transaction duration has been detected for the following countries. The results are sorted by their overall effect on the duration, based off of the change in duration and the current TPM.'
+          )}
+        </div>
+        <ul>
+          {data.map(row => {
+            const countryCode = row['geo.country_code'];
+            const percentChange = calculatePercentChange(
+              row.duration_before,
+              row.duration_delta
+            );
+            const transactionSummaryLink = transactionSummaryRouteWithQuery({
+              orgSlug: organization.slug,
+              transaction,
+              query: {
+                start: (start as Date).toISOString(),
+                end: (end as Date).toISOString(),
+                query: `geo.country_code:${countryCode}`,
+              },
+              projectID: projectId,
+              display: DisplayModes.DURATION,
+            });
+
+            return (
+              <li key={countryCode}>
+                <GeoAnalysisEntry>
+                  <strong style={{justifySelf: 'start'}}>{countryCode}</strong>{' '}
+                  <span style={{justifySelf: 'start'}}>
+                    {countryCodesToCountry[countryCode]}
+                  </span>
+                  <div style={{justifySelf: 'end'}}>
+                    <Tooltip
+                      title={tct('From [previousDuration] to [currentDuration]', {
+                        previousDuration: (
+                          <PerformanceDuration
+                            milliseconds={row.duration_before}
+                            abbreviation
+                          />
+                        ),
+                        currentDuration: (
+                          <PerformanceDuration
+                            milliseconds={row.duration_after}
+                            abbreviation
+                          />
+                        ),
+                      })}
+                      showUnderline
+                    >
+                      <Link to={transactionSummaryLink}>
+                        {percentChange > 0 && '+'}
+                        {percentChange.toFixed(2)}%
+                      </Link>
+                    </Tooltip>
+                  </div>
+                </GeoAnalysisEntry>
+              </li>
+            );
+          })}
+        </ul>
+      </Fragment>
+    );
+  }
+
+  return <DataSection>{content}</DataSection>;
+}
+
+export default GeoLocationDiff;
+
+const GeoAnalysisEntry = styled('div')`
+  display: grid;
+  grid-template-columns: 20px auto auto;
+  gap: 8px;
+`;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -21,6 +21,7 @@ import {EventAffectedTransactions} from 'sentry/components/events/eventStatistic
 import EventComparison from 'sentry/components/events/eventStatisticalDetector/eventComparison';
 import {EventFunctionComparisonList} from 'sentry/components/events/eventStatisticalDetector/eventFunctionComparisonList';
 import {EventFunctionBreakpointChart} from 'sentry/components/events/eventStatisticalDetector/functionBreakpointChart';
+import GeoLocationDiff from 'sentry/components/events/eventStatisticalDetector/geoLocationDiff';
 import RegressionMessage from 'sentry/components/events/eventStatisticalDetector/regressionMessage';
 import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScreenshot';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
@@ -199,9 +200,14 @@ function PerformanceDurationRegressionIssueDetailsContent({
         <ErrorBoundary mini>
           <EventBreakpointChart event={event} />
         </ErrorBoundary>
-        <ErrorBoundary mini>
-          <EventSpanOpBreakdown event={event} />
-        </ErrorBoundary>
+        <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr'}}>
+          <ErrorBoundary mini>
+            <EventSpanOpBreakdown event={event} />
+          </ErrorBoundary>
+          <ErrorBoundary mini>
+            <GeoLocationDiff event={event} projectId={project.id} />
+          </ErrorBoundary>
+        </div>
         <ErrorBoundary mini>
           <AggregateSpanDiff event={event} projectId={project.id} />
         </ErrorBoundary>


### PR DESCRIPTION
The widget makes a request to the advanced analysis endpoint and shows the top 5 results in list format. The right-most side calculates the percent change and links users to the transaction summary page with that country code prefiltered.

I chose to use the duration breakdown chart because it doesn't seem like the trends chart propagates the filter. I suspect this is because the trends endpoint is strictly metrics based so we eliminated the ability to filter in that chart.

![Screenshot 2023-10-16 at 3 59 06 PM](https://github.com/getsentry/sentry/assets/22846452/f3788716-b8e7-4d07-a24d-9ea002e9d5ba)

Until we get flag icons, we'll just use the list format with the country code and country name for now.