### PR TITLE
feat(starfish): Make release selector searchable

### DIFF
--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -1,18 +1,23 @@
+import {useState} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
+import debounce from 'lodash/debounce';
 
-import {CompactSelect} from 'sentry/components/compactSelect';
+import {CompactSelect, SelectOption} from 'sentry/components/compactSelect';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
-import {t} from 'sentry/locale';
+import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
+import {t, tn} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {useLocation} from 'sentry/utils/useLocation';
 import {
   useReleases,
   useReleaseSelection,
+  useReleaseStats,
 } from 'sentry/views/starfish/queries/useReleases';
 
 const ALL_RELEASES = {
-  value: '',
+  value: 'allReleases',
   label: t('All Releases'),
 };
 
@@ -23,25 +28,42 @@ type Props = {
 };
 
 export function ReleaseSelector({selectorName, selectorKey, selectorValue}: Props) {
-  const {data, isLoading} = useReleases();
+  const [activeRelease, setActiveRelease] = useState<string | undefined>(undefined);
+  const [searchTerm, setSearchTerm] = useState<string | undefined>(undefined);
+  const {data, isLoading} = useReleases(searchTerm);
+  const {data: releaseStats} = useReleaseStats();
   const location = useLocation();
   let value = selectorValue;
 
   if (!isLoading && !defined(value)) {
     value = ALL_RELEASES.value;
   }
+
+  const options: SelectOption<number>[] = [];
+  (data ?? [ALL_RELEASES]).forEach(release => {
+    const option = {
+      value: release.version,
+      label: release.shortVersion ?? release.version,
+      details: (
+        <LabelDetails sessionCount={releaseStats[release.version]?.['sum(session)']} />
+      ),
+    };
+
+    options.push(option);
+  });
+
   return (
     <StyledCompactSelect
       triggerProps={{
         prefix: selectorName,
       }}
-      value={selectorValue}
-      options={[
-        ...(data ?? [ALL_RELEASES]).map(release => ({
-          value: release.version,
-          label: release.shortVersion ?? release.version,
-        })),
-      ]}
+      searchable
+      value={activeRelease ?? selectorValue}
+      options={[{options}]}
+      onSearch={debounce(val => {
+        setActiveRelease(activeRelease ?? selectorValue);
+        setSearchTerm(val);
+      }, DEFAULT_DEBOUNCE_DURATION)}
       onChange={newValue => {
         browserHistory.push({
           ...location,
@@ -52,6 +74,22 @@ export function ReleaseSelector({selectorName, selectorKey, selectorValue}: Prop
         });
       }}
     />
+  );
+}
+
+type LabelDetailsProps = {
+  sessionCount?: number;
+};
+
+function LabelDetails(props: LabelDetailsProps) {
+  return (
+    <DetailsContainer>
+      <div>
+        {defined(props.sessionCount)
+          ? tn('%s session', '%s sessions', props.sessionCount)
+          : '-'}
+      </div>
+    </DetailsContainer>
   );
 }
 
@@ -73,4 +111,11 @@ const StyledCompactSelect = styled(CompactSelect)`
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     max-width: 275px;
   }
+`;
+
+const DetailsContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  gap: ${space(1)};
 `;

--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -72,7 +72,7 @@ export function useReleaseStats() {
     }).filter(([, value]) => defined(value) && value !== '')
   );
 
-  const {data, isLoading} = useApiQuery<any>(
+  const result = useApiQuery<any>(
     [
       `/organizations/${organization.slug}/sessions/`,
       {
@@ -84,8 +84,8 @@ export function useReleaseStats() {
 
   const releaseStatsMap: {[release: string]: {project: number; 'sum(session)': number}} =
     {};
-  if (data && data.groups) {
-    data.groups.forEach(group => {
+  if (result.data && result.data.groups) {
+    result.data.groups.forEach(group => {
       const release = group.by.release;
       const project = group.by.project;
       const sessionCount = group.totals['sum(session)'];
@@ -95,7 +95,7 @@ export function useReleaseStats() {
   }
 
   return {
+    ...result,
     data: releaseStatsMap,
-    isLoading,
   };
 }

--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -53,6 +53,10 @@ export function useReleaseStats() {
     allowEmptyPeriod: true,
   });
 
+  // The sessions endpoint does not support wildcard search.
+  // So we're just getting top 250 values ordered by count.
+  // Hopefully this is enough to populate session count for
+  // any releases searched in the release selector.
   const urlQuery = Object.fromEntries(
     Object.entries({
       project: projects,
@@ -63,7 +67,7 @@ export function useReleaseStats() {
       start,
       end,
       statsPeriod,
-      per_page: 100,
+      per_page: 250,
       interval: getInterval({start, end, period: statsPeriod}, 'low'),
     }).filter(([, value]) => defined(value) && value !== '')
   );

--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -17,7 +17,7 @@ export function useReleases() {
         query: {
           sort: 'date',
           project: projects,
-          per_page: 50,
+          per_page: 20,
           environment: environments,
         },
       },
@@ -38,4 +38,28 @@ export function useReleaseSelection() {
     (releases && releases.length > 1 ? releases?.[1]?.version : undefined);
 
   return {primaryRelease, secondaryRelease, isLoading};
+}
+
+export function useReleaseStats() {
+  const {data: releases, isLoading} = useReleases();
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const {environments, projects} = selection;
+
+  const {data} = useApiQuery<any>(
+    [
+      `/organizations/${organization.slug}/sessions`,
+      {
+        query: {
+          project: projects,
+          environment: environments,
+        },
+      },
+    ],
+    {staleTime: Infinity}
+  );
+  return {
+    releases,
+    isLoading,
+  };
 }


### PR DESCRIPTION
Also adds session counts to the selector.
![Screenshot 2023-10-16 at 4 00 31 PM](https://github.com/getsentry/sentry/assets/63818634/00c2d807-b066-4ac3-99b1-525073502960)
