### PR TITLE
feat(starfish): Add samples to endpoint graphs

### DIFF
--- a/static/app/views/performance/charts/chart.tsx
+++ b/static/app/views/performance/charts/chart.tsx
@@ -33,7 +33,7 @@ type Props = {
 };
 
 // adapted from https://stackoverflow.com/questions/11397239/rounding-up-for-a-graph-maximum
-function computeAxisMax(data: Series[]) {
+export function computeAxisMax(data: Series[]) {
   // assumes min is 0
   const valuesDict = data.map(value => value.data.map(point => point.value));
   const maxValue = max(valuesDict.map(max)) as number;

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -1,4 +1,4 @@
-import {useTheme} from '@emotion/react';
+import {Theme, useTheme} from '@emotion/react';
 
 import {t} from 'sentry/locale';
 import {EChartClickHandler, EChartHighlightHandler, Series} from 'sentry/types/echarts';
@@ -31,6 +31,29 @@ type Props = {
   transactionMethod?: string;
 };
 
+export function getSampleSymbol(
+  duration: number,
+  compareToDuration: number,
+  theme: Theme
+): {color: string; symbol: string} {
+  if (isNearAverage(duration, compareToDuration)) {
+    return {
+      symbol: crossIconPath,
+      color: theme.gray500,
+    };
+  }
+
+  return duration > compareToDuration
+    ? {
+        symbol: upwardPlayIconPath,
+        color: theme.red300,
+      }
+    : {
+        symbol: downwardPlayIconPath,
+        color: theme.green300,
+      };
+}
+
 function DurationChart({
   groupId,
   transactionName,
@@ -43,28 +66,6 @@ function DurationChart({
   const theme = useTheme();
   const {setPageError} = usePageError();
   const pageFilter = usePageFilters();
-
-  const getSampleSymbol = (
-    duration: number,
-    compareToDuration: number
-  ): {color: string; symbol: string} => {
-    if (isNearAverage(duration, compareToDuration)) {
-      return {
-        symbol: crossIconPath,
-        color: theme.gray500,
-      };
-    }
-
-    return duration > compareToDuration
-      ? {
-          symbol: upwardPlayIconPath,
-          color: theme.red300,
-        }
-      : {
-          symbol: downwardPlayIconPath,
-          color: theme.green300,
-        };
-  };
 
   const filters = {
     transactionName,
@@ -131,7 +132,7 @@ function DurationChart({
       'transaction.id': transaction_id,
       span_id,
     }) => {
-      const {symbol, color} = getSampleSymbol(duration, avg);
+      const {symbol, color} = getSampleSymbol(duration, avg, theme);
       return {
         data: [
           {

--- a/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
+++ b/static/app/views/starfish/views/webServiceView/endpointOverview/index.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useState} from 'react';
 import {browserHistory} from 'react-router';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
@@ -16,6 +17,7 @@ import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {IssueCategory, NewQuery} from 'sentry/types';
+import type {SeriesDataUnit} from 'sentry/types/echarts';
 import {Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
 import {tooltipFormatterUsingAggregateOutputType} from 'sentry/utils/discover/charts';
@@ -28,26 +30,29 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import withApi from 'sentry/utils/withApi';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {SidebarSpacer} from 'sentry/views/performance/transactionSummary/utils';
 import {AVG_COLOR, ERRORS_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
-import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
+import Chart, {
+  computeAxisMax,
+  useSynchronizeCharts,
+} from 'sentry/views/starfish/components/chart';
 import StarfishDatePicker from 'sentry/views/starfish/components/datePicker';
 import {TransactionSamplesTable} from 'sentry/views/starfish/components/samplesTable/transactionSamplesTable';
+import useSlowMedianFastSamplesQuery from 'sentry/views/starfish/components/samplesTable/useSlowMedianFastSamplesQuery';
 import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/starfishPageFiltersContainer';
 import {ModuleName} from 'sentry/views/starfish/types';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {getDateConditions} from 'sentry/views/starfish/utils/getDateConditions';
 import {useRoutingContext} from 'sentry/views/starfish/utils/routingContext';
+import {useEventsStatsQuery} from 'sentry/views/starfish/utils/useEventsStatsQuery';
 import SpansTable from 'sentry/views/starfish/views/spans/spansTable';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
+import {getSampleSymbol} from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart';
 import IssuesTable from 'sentry/views/starfish/views/webServiceView/endpointOverview/issuesTable';
 import {SpanGroupBreakdownContainer} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
 const SPANS_TABLE_LIMIT = 5;
-
-const EventsRequest = withApi(_EventsRequest);
 
 export type SampleFilter = 'ALL' | '500s';
 
@@ -56,10 +61,30 @@ type State = {
   spansFilter: ModuleName;
 };
 
+function transformData(data) {
+  const transformedSeries: {[yAxisName: string]: Series} = {};
+  if (defined(data)) {
+    Object.keys(data).forEach(yAxis => {
+      transformedSeries[yAxis] = {
+        seriesName: yAxis,
+        data:
+          data[yAxis]?.data.map(datum => {
+            return {
+              name: datum[0] * 1000,
+              value: datum[1][0].count,
+            } as SeriesDataUnit;
+          }) ?? [],
+      };
+    });
+  }
+  return transformedSeries;
+}
+
 export default function EndpointOverview() {
   const location = useLocation();
   const routingContext = useRoutingContext();
   const organization = useOrganization();
+  const [highlightedId, setHighlightedId] = useState<string | undefined>(undefined);
 
   const {endpoint, 'http.method': httpMethod} = location.query;
   const transaction = endpoint
@@ -109,160 +134,171 @@ export default function EndpointOverview() {
     location,
   });
 
-  function renderSidebarCharts() {
+  function generateLine(average, name): Series {
+    return {
+      seriesName: name,
+      data: [],
+      markLine: {
+        data: [{valueDim: 'x', yAxis: average}],
+        symbol: ['none', 'none'],
+        lineStyle: {
+          color: theme.gray400,
+        },
+        emphasis: {disabled: true},
+        label: {
+          position: 'insideEndBottom',
+          formatter: () => name,
+          fontSize: 14,
+          color: theme.chartLabel,
+          backgroundColor: theme.chartOther,
+        },
+      },
+    };
+  }
+
+  function renderSidebarCharts(sampleData, loading, results) {
+    if (loading || !results) {
+      return null;
+    }
+    // Force label to be Requests
+    const throughputResults = {seriesName: 'Requests', data: results['tps()'].data};
+    const percentileData: Series = {
+      seriesName: t('Average'),
+      data: results['avg(transaction.duration)'].data,
+    };
+    const avgLine = generateLine(
+      defined(totals) && totals.data
+        ? totals.data[0]['avg(transaction.duration)']
+        : undefined,
+      'duration'
+    );
+    const tpsLine = generateLine(
+      defined(totals) && totals.data ? totals.data[0]['tps()'] : undefined,
+      'throughput'
+    );
+
     return (
-      <EventsRequest
-        query={query.formatString()}
-        includePrevious={false}
-        partial
-        limit={5}
-        interval={getInterval(
-          pageFilter.selection.datetime,
-          STARFISH_CHART_INTERVAL_FIDELITY
-        )}
-        includeTransformedData
-        environment={eventView.environment}
-        project={eventView.project}
-        period={eventView.statsPeriod}
-        referrer="api.starfish-web-service.starfish-endpoint-overview"
-        start={eventView.start}
-        end={eventView.end}
-        organization={organization}
-        yAxis={['tps()', 'http_error_count()', 'avg(transaction.duration)']}
-        dataset={DiscoverDatasets.METRICS}
-      >
-        {({loading, results}) => {
-          if (!results) {
-            return null;
-          }
-          // Force label to be Requests
-          const throughputResults = {seriesName: 'Requests', data: results[0].data};
-          const percentileData: Series = {
-            seriesName: t('Requests'),
-            data: results[2].data,
-          };
-          return (
-            <Fragment>
-              <Header>
-                <ChartLabel>{DataTitles.avg}</ChartLabel>
-                <QuestionTooltip
-                  size="sm"
-                  position="right"
-                  title={t('The average duration of requests in the selected period')}
-                />
-              </Header>
-              <ChartSummaryValue
-                isLoading={isTotalsLoading}
-                value={
-                  defined(totals)
-                    ? t(
-                        '%sms',
-                        (totals.data[0]['avg(transaction.duration)'] as number).toFixed(2)
-                      )
-                    : undefined
-                }
-              />
-              <Chart
-                height={80}
-                data={[percentileData]}
-                loading={loading}
-                utc={false}
-                grid={{
-                  left: '8px',
-                  right: '0',
-                  top: '8px',
-                  bottom: '0',
-                }}
-                disableXAxis
-                definedAxisTicks={2}
-                isLineChart
-                chartColors={[AVG_COLOR]}
-                tooltipFormatterOptions={{
-                  valueFormatter: value =>
-                    tooltipFormatterUsingAggregateOutputType(value, 'duration'),
-                }}
-              />
-              <Header>
-                <ChartLabel>{DataTitles.throughput}</ChartLabel>
-                <QuestionTooltip
-                  size="sm"
-                  position="right"
-                  title={t(
-                    'the number of requests made to this endpoint per second in the selected period'
-                  )}
-                />
-              </Header>
-              <ChartSummaryValue
-                isLoading={isTotalsLoading}
-                value={
-                  defined(totals)
-                    ? t('%s/s', (totals.data[0]['tps()'] as number).toFixed(2))
-                    : undefined
-                }
-              />
-              <Chart
-                height={80}
-                data={[throughputResults]}
-                loading={loading}
-                utc={false}
-                isLineChart
-                definedAxisTicks={2}
-                disableXAxis
-                chartColors={[THROUGHPUT_COLOR]}
-                aggregateOutputFormat="rate"
-                rateUnit={RateUnits.PER_SECOND}
-                grid={{
-                  left: '8px',
-                  right: '0',
-                  top: '8px',
-                  bottom: '0',
-                }}
-                tooltipFormatterOptions={{
-                  valueFormatter: value => formatRate(value, RateUnits.PER_SECOND),
-                }}
-              />
-              <SidebarSpacer />
-              <Header>
-                <ChartLabel>{DataTitles.errorCount}</ChartLabel>
-                <QuestionTooltip
-                  size="sm"
-                  position="right"
-                  title={t(
-                    'the total number of requests that resulted in 5XX response codes over a given time range'
-                  )}
-                />
-              </Header>
-              <ChartSummaryValue
-                isLoading={isTotalsLoading}
-                value={
-                  defined(totals)
-                    ? tooltipFormatterUsingAggregateOutputType(
-                        totals.data[0]['http_error_count()'] as number,
-                        'integer'
-                      )
-                    : undefined
-                }
-              />
-              <Chart
-                height={80}
-                data={[results[1]]}
-                loading={loading}
-                utc={false}
-                grid={{
-                  left: '8px',
-                  right: '0',
-                  top: '8px',
-                  bottom: '0',
-                }}
-                definedAxisTicks={2}
-                isLineChart
-                chartColors={[ERRORS_COLOR]}
-              />
-              <SidebarSpacer />
-            </Fragment>
-          );
-        }}
-      </EventsRequest>
+      <StickySidebar>
+        <Fragment>
+          <Header>
+            <ChartLabel>{DataTitles.avg}</ChartLabel>
+            <QuestionTooltip
+              size="sm"
+              position="right"
+              title={t('The average duration of requests in the selected period')}
+            />
+          </Header>
+          <ChartSummaryValue
+            isLoading={isTotalsLoading}
+            value={
+              defined(totals)
+                ? t(
+                    '%sms',
+                    (totals.data[0]['avg(transaction.duration)'] as number).toFixed(2)
+                  )
+                : undefined
+            }
+          />
+          <Chart
+            height={80}
+            data={[percentileData, avgLine]}
+            loading={loading}
+            utc={false}
+            grid={{
+              left: '8px',
+              right: '0',
+              top: '8px',
+              bottom: '0',
+            }}
+            disableXAxis
+            definedAxisTicks={2}
+            isLineChart
+            chartColors={[AVG_COLOR]}
+            scatterPlot={sampleData}
+            tooltipFormatterOptions={{
+              valueFormatter: value =>
+                tooltipFormatterUsingAggregateOutputType(value, 'duration'),
+            }}
+          />
+          <Header>
+            <ChartLabel>{DataTitles.throughput}</ChartLabel>
+            <QuestionTooltip
+              size="sm"
+              position="right"
+              title={t(
+                'the number of requests made to this endpoint per second in the selected period'
+              )}
+            />
+          </Header>
+          <ChartSummaryValue
+            isLoading={isTotalsLoading}
+            value={
+              defined(totals)
+                ? t('%s/s', (totals.data[0]['tps()'] as number).toFixed(2))
+                : undefined
+            }
+          />
+          <Chart
+            height={80}
+            data={[throughputResults, tpsLine]}
+            loading={loading}
+            utc={false}
+            isLineChart
+            definedAxisTicks={2}
+            disableXAxis
+            chartColors={[THROUGHPUT_COLOR]}
+            aggregateOutputFormat="rate"
+            rateUnit={RateUnits.PER_SECOND}
+            grid={{
+              left: '8px',
+              right: '0',
+              top: '8px',
+              bottom: '0',
+            }}
+            tooltipFormatterOptions={{
+              valueFormatter: value => formatRate(value, RateUnits.PER_SECOND),
+            }}
+          />
+          <SidebarSpacer />
+          <Header>
+            <ChartLabel>{DataTitles.errorCount}</ChartLabel>
+            <QuestionTooltip
+              size="sm"
+              position="right"
+              title={t(
+                'the total number of requests that resulted in 5XX response codes over a given time range'
+              )}
+            />
+          </Header>
+          <ChartSummaryValue
+            isLoading={isTotalsLoading}
+            value={
+              defined(totals)
+                ? tooltipFormatterUsingAggregateOutputType(
+                    totals.data[0]['http_error_count()'] as number,
+                    'integer'
+                  )
+                : undefined
+            }
+          />
+          <Chart
+            height={80}
+            data={[results['http_error_count()']]}
+            loading={loading}
+            utc={false}
+            grid={{
+              left: '8px',
+              right: '0',
+              top: '8px',
+              bottom: '0',
+            }}
+            definedAxisTicks={2}
+            isLineChart
+            chartColors={[ERRORS_COLOR]}
+          />
+          <SidebarSpacer />
+        </Fragment>
+      </StickySidebar>
     );
   }
 
@@ -280,6 +316,69 @@ export default function EndpointOverview() {
     });
   };
 
+  const yAxis = ['tps()', 'http_error_count()', 'avg(transaction.duration)'];
+  const {isLoading: loading, data: results} = useEventsStatsQuery({
+    eventView: EventView.fromNewQueryWithPageFilters(
+      {
+        name: '',
+        fields: ['transaction', yAxis[0]],
+        yAxis,
+        query: query.formatString(),
+        dataset: DiscoverDatasets.METRICS,
+        version: 2,
+        interval: getInterval(
+          pageFilter.selection.datetime,
+          STARFISH_CHART_INTERVAL_FIDELITY
+        ),
+      },
+      pageFilter.selection
+    ),
+    excludeOther: true,
+    referrer: 'api.starfish-web-service.starfish-endpoint-overview',
+    initialData: {},
+  });
+  const transformedResults = transformData(results);
+
+  const axisMax =
+    !loading && results
+      ? computeAxisMax([transformedResults['avg(transaction.duration)']])
+      : undefined;
+  const theme = useTheme();
+  const {isLoading, data, aggregatesData} = useSlowMedianFastSamplesQuery(
+    EventView.fromNewQueryWithLocation(
+      {
+        id: undefined,
+        name: 'Endpoint Overview Samples',
+        query: query.formatString(),
+        fields: [],
+        dataset: DiscoverDatasets.DISCOVER,
+        version: 2,
+      },
+      location
+    ),
+    axisMax
+  );
+  const sampleData: Series[] = data.map(
+    ({timestamp, 'transaction.duration': duration, id}) => {
+      const {symbol, color} = getSampleSymbol(
+        duration,
+        aggregatesData?.['avg(transaction.duration)'],
+        theme
+      );
+      return {
+        data: [
+          {
+            name: timestamp,
+            value: duration,
+          },
+        ],
+        symbol,
+        color,
+        symbolSize: id === highlightedId ? 17 : 12,
+        seriesName: id.substring(0, 8),
+      };
+    }
+  );
   useSynchronizeCharts();
 
   return (
@@ -328,6 +427,8 @@ export default function EndpointOverview() {
                 <SegmentedControl.Item key="">{t('All Spans')}</SegmentedControl.Item>
                 <SegmentedControl.Item key="http">{t('http')}</SegmentedControl.Item>
                 <SegmentedControl.Item key="db">{t('db')}</SegmentedControl.Item>
+                <SegmentedControl.Item key="cache">{t('cache')}</SegmentedControl.Item>
+                <SegmentedControl.Item key="other">{t('other')}</SegmentedControl.Item>
               </SegmentedControl>
             </SegmentedControlContainer>
             <SpanMetricsTable
@@ -352,6 +453,11 @@ export default function EndpointOverview() {
               <TransactionSamplesTable
                 queryConditions={queryConditions}
                 sampleFilter={state.samplesFilter}
+                data={data}
+                setHighlightedId={setHighlightedId}
+                highlightedId={highlightedId}
+                isLoading={isLoading}
+                averageDuration={aggregatesData?.['avg(transaction.duration)']}
               />
             </RowContainer>
             <SegmentedControlContainer>
@@ -380,7 +486,7 @@ export default function EndpointOverview() {
             />
           </Layout.Main>
           <Layout.Side>
-            {renderSidebarCharts()}
+            {renderSidebarCharts(sampleData, loading, transformedResults)}
             <SidebarSpacer />
           </Layout.Side>
         </Layout.Body>
@@ -447,6 +553,11 @@ const RowContainer = styled('div')`
 
 const StyledRow = styled(PerformanceLayoutBodyRow)`
   margin-bottom: ${space(4)};
+`;
+
+const StickySidebar = styled('div')`
+  position: sticky;
+  top: 200px;
 `;
 
 const SegmentedControlContainer = styled('div')`

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdown.tsx
@@ -150,7 +150,8 @@ export function SpanGroupBreakdown({
               bottom: '0',
             }}
             definedAxisTicks={6}
-            stacked
+            isLineChart={dataDisplayType !== DataDisplayType.PERCENTAGE}
+            stacked={dataDisplayType === DataDisplayType.PERCENTAGE}
             aggregateOutputFormat={
               dataDisplayType === DataDisplayType.PERCENTAGE ? 'percentage' : 'duration'
             }

--- a/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
+++ b/static/app/views/starfish/views/webServiceView/spanGroupBreakdownContainer.tsx
@@ -33,7 +33,7 @@ type Props = {
 };
 
 type Group = {
-  'span.category': string;
+  'span.module': string;
 };
 
 export type DataRow = {
@@ -56,13 +56,13 @@ export function SpanGroupBreakdownContainer({transaction, transactionMethod}: Pr
   const theme = useTheme();
 
   const options: SelectOption<DataDisplayType>[] = [
-    {label: t('Percentages'), value: DataDisplayType.PERCENTAGE},
     {label: t('Average Duration'), value: DataDisplayType.DURATION_AVG},
+    {label: t('Percentages'), value: DataDisplayType.PERCENTAGE},
     {label: t('Total Duration'), value: DataDisplayType.CUMULATIVE_DURATION},
   ];
 
   const [dataDisplayType, setDataDisplayType] = useState<DataDisplayType>(
-    DataDisplayType.PERCENTAGE
+    DataDisplayType.DURATION_AVG
   );
 
   const {data: segments, isLoading: isSegmentsLoading} = useDiscoverQuery({
@@ -71,7 +71,7 @@ export function SpanGroupBreakdownContainer({transaction, transactionMethod}: Pr
       `transaction.op:http.server ${transaction ? `transaction:${transaction}` : ''} ${
         transactionMethod ? `http.method:${transactionMethod}` : ''
       }`,
-      ['span.category']
+      ['span.module']
     ),
     orgSlug: organization.slug,
     referrer: 'api.starfish-web-service.span-category-breakdown',
@@ -102,7 +102,7 @@ export function SpanGroupBreakdownContainer({transaction, transactionMethod}: Pr
       `transaction.op:http.server ${transaction ? `transaction:${transaction}` : ''} ${
         transactionMethod ? `http.method:${transactionMethod}` : ''
       }`,
-      ['span.category'],
+      ['span.module'],
       dataDisplayType,
       true
     ),
@@ -127,11 +127,11 @@ export function SpanGroupBreakdownContainer({transaction, transactionMethod}: Pr
   if (defined(segments)) {
     for (let index = 0; index < segments.data.length; index++) {
       const element = segments.data[index];
-      const category = element['span.category'] as string;
+      const spanModule = element['span.module'] as string;
       transformedData.push({
         cumulativeTime: parseInt(element[`sum(${SPAN_SELF_TIME})`] as string, 10),
         group: {
-          'span.category': category === '' ? NULL_SPAN_CATEGORY : category,
+          'span.module': spanModule === '' ? NULL_SPAN_CATEGORY : spanModule,
         },
       });
     }
@@ -140,20 +140,20 @@ export function SpanGroupBreakdownContainer({transaction, transactionMethod}: Pr
       transformedData.push({
         cumulativeTime: otherValue,
         group: {
-          'span.category': OTHER_SPAN_GROUP_MODULE,
+          'span.module': OTHER_SPAN_GROUP_MODULE,
         },
       });
     }
   }
 
-  const seriesByDomain: {[category: string]: Series} = {};
+  const seriesByDomain: {[spanModule: string]: Series} = {};
   const colorPalette = theme.charts.getColorPalette(transformedData.length - 2);
 
   if (defined(topData)) {
     if (!isTopDataLoading && transformedData.length > 0) {
       transformedData.forEach((segment, index) => {
-        const category = segment.group['span.category'] as string;
-        const label = category === '' ? NULL_SPAN_CATEGORY : category;
+        const spanModule = segment.group['span.module'] as string;
+        const label = spanModule === '' ? NULL_SPAN_CATEGORY : spanModule;
         seriesByDomain[label] = {
           seriesName: label,
           data: [],


### PR DESCRIPTION
- This updates the endpoint overview to match the styling in the endpoint graphs better so there's the corresponding icons in the graphs
- This also updates the main graph to default to the average to match the webserviceview