### PR TITLE
devenv: Added dev env doctor check for github access

### DIFF
--- a/devenv/checks/check_github_access.py
+++ b/devenv/checks/check_github_access.py
@@ -1,9 +1,6 @@
-import sys
-from os import path
 from typing import Set, Tuple
 
-sys.path.append(path.abspath(".local/share/sentry-devenv/devenv"))
-from devenv.lib import github  # type: ignore
+from devenv.lib import github
 
 tags: Set[str] = {"github"}
 name = "Check Github Access"

--- a/devenv/checks/check_github_access.py
+++ b/devenv/checks/check_github_access.py
@@ -1,0 +1,36 @@
+import sys
+from os import path
+from typing import Set, Tuple
+
+sys.path.append(path.abspath(".local/share/sentry-devenv/devenv"))
+from devenv.lib import github  # type: ignore
+
+tags: Set[str] = {"github"}
+name = "Check Github Access"
+
+
+def check() -> Tuple[bool, str]:
+    result = github.check_ssh_access()
+    if result:
+        return True, "You have access to Github"
+    return False, "You do not have access to Github"
+
+
+def fix() -> Tuple[bool, str]:
+    github.add_to_known_hosts()
+    if not github.check_ssh_access():
+        pubkey = github.generate_and_configure_ssh_keypair()
+        return (
+            False,
+            f"""
+        Failed to authenticate with an ssh key to GitHub.
+We've generated and configured one for you at ~/.ssh/sentry-github.
+Visit https://github.com/settings/ssh/new and add the following Authentication key:
+
+{pubkey}
+
+Then, you need to go to https://github.com/settings/keys, find your key,
+and click Configure SSO, for the getsentry organization.
+""",
+        )
+    return True, "You have access to Github"

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -170,6 +170,7 @@ s3transfer==0.6.1
 selenium==4.3.0
 sentry-arroyo==2.14.12
 sentry-cli==2.16.0
+sentry-devenv==1.1.1
 sentry-kafka-schemas==0.1.32
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.32

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,6 +36,7 @@ djangorestframework-stubs
 lxml-stubs
 msgpack-types>=0.2.0
 mypy>=1.4.1
+sentry-devenv>=1.1.1
 types-beautifulsoup4
 types-cachetools
 types-croniter


### PR DESCRIPTION
The first check for the [dev env doctor](https://github.com/getsentry/devenv/blob/main/doctor.py). It aims to check if a user has access to GitHub. It is worth noting that this is only relevant to Sentry employees (I believe), so we should make sure there is logic that can differentiate Sentry employees from others and only run certain checks accordingly. Additionally, I am currently using sys path to import from the devenv repo. I am aware that this is not ideal and am open to suggestions on better ways to approach this.
