### PR TITLE
fix(alerts): Do not modify duplicate issue alert

### DIFF
--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -466,7 +466,7 @@ describe('IssueRuleEditor', function () {
         router: {
           location: {
             query: {
-              createFromDuplicate: true,
+              createFromDuplicate: 'true',
               duplicateRuleId: `${rule.id}`,
             },
           },
@@ -474,7 +474,32 @@ describe('IssueRuleEditor', function () {
       });
 
       expect(await screen.findByTestId('alert-name')).toHaveValue(`${rule.name} copy`);
+      expect(screen.queryByText('A new issue is created')).toBeInTheDocument();
       expect(mock).toHaveBeenCalled();
+    });
+
+    it('does not add FirstSeenEventCondition to a duplicate rule', async function () {
+      MockApiClient.addMockResponse({
+        url: endpoint,
+        method: 'GET',
+        body: {...rule, conditions: []},
+      });
+      createWrapper({
+        organization: {
+          access: ['alerts:write'],
+        },
+        router: {
+          location: {
+            query: {
+              createFromDuplicate: 'true',
+              duplicateRuleId: `${rule.id}`,
+            },
+          },
+        },
+      });
+
+      expect(await screen.findByTestId('alert-name')).toHaveValue(`${rule.name} copy`);
+      expect(screen.queryByText('A new issue is created')).not.toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -325,16 +325,11 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
         addErrorMessage(detail, {append: true})
       );
     }
-    if (!ruleId) {
+
+    if (!ruleId && !this.isDuplicateRule) {
       // now that we've loaded all the possible conditions, we can populate the
       // value of conditions for a new alert
-      const id = 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition';
-      this.handleChange('conditions', [
-        {
-          id,
-          label: `${CHANGE_ALERT_PLACEHOLDERS_LABELS[id]}...`,
-        },
-      ]);
+      this.handleChange('conditions', [{id: IssueAlertConditionType.FIRST_SEEN_EVENT}]);
     }
   }
 


### PR DESCRIPTION
Skip adding the "A new issue is created" default condition when duplicating alerts. Fixes #56409

