### PR TITLE
ref(participants): Check for group list

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -164,7 +164,7 @@ def get_current_release_version_of_group(
 
 def update_groups(
     request: Request,
-    group_ids: Sequence[int],
+    group_ids: Sequence[int] | None,
     projects: Sequence[Project],
     organization_id: int,
     search_fn: SearchFunction | None,
@@ -711,7 +711,7 @@ def handle_is_subscribed(
 
 def handle_is_bookmarked(
     is_bookmarked: bool,
-    group_list: Sequence[Group],
+    group_list: Sequence[Group] | None,
     group_ids: Sequence[Group],
     project_lookup: Dict[int, Project],
     acting_user: User | None,

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -734,11 +734,12 @@ def handle_is_bookmarked(
             group__in=group_ids,
             user_id=acting_user.id if acting_user else None,
         ).delete()
-        if features.has("organizations:participants-purge", group_list[0].organization):
-            GroupSubscription.objects.filter(
-                user_id=acting_user.id,
-                group__in=group_ids,
-            ).delete()
+        if group_list:
+            if features.has("organizations:participants-purge", group_list[0].organization):
+                GroupSubscription.objects.filter(
+                    user_id=acting_user.id,
+                    group__in=group_ids,
+                ).delete()
 
 
 def handle_has_seen(


### PR DESCRIPTION
Group list is an optional param so we need to check if it exists before trying to check a feature flag's status. 

Fixes SENTRY-16V3