### PR TITLE
ref(merging): Improve explanations on `Merged Issues` tab

### DIFF
--- a/static/app/views/issueDetails/groupMerged/index.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.tsx
@@ -106,9 +106,9 @@ class GroupMergedView extends Component<Props, State> {
     GroupingStore.onUnmerge({
       groupId: params.groupId,
       orgSlug: organization.slug,
-      loadingMessage: t('Unmerging events\u2026'),
-      successMessage: t('Events successfully queued for unmerging.'),
-      errorMessage: t('Unable to queue events for unmerging.'),
+      loadingMessage: t('Unmerging fingerprints\u2026'),
+      successMessage: t('Fingerprints successfully queued for unmerging.'),
+      errorMessage: t('Unable to queue fingerprints for unmerging.'),
     });
     const unmergeKeys = [...GroupingStore.getState().unmergeList.values()];
     trackAnalytics('issue_details.merged_tab.unmerge_clicked', {
@@ -172,7 +172,7 @@ class GroupMergedView extends Component<Props, State> {
           {isLoading && <LoadingIndicator />}
           {isError && (
             <LoadingError
-              message={t('Unable to load merged events, please try again later')}
+              message={t('Unable to load issue fingerprints. Please try again later.')}
               onRetry={this.fetchData}
             />
           )}

--- a/static/app/views/issueDetails/groupMerged/index.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.tsx
@@ -139,6 +139,25 @@ class GroupMergedView extends Component<Props, State> {
                 count: <QueryCount count={fingerprintsWithLatestEvent.length} />,
               })}
             </Title>
+            <br />
+            <br />
+            <small>
+              {t(
+                'Select one or more fingerprints to unmerge from the rest. This will move the corresponding events to a new issue.'
+              )}
+            </small>
+            {
+              // TODO: I'm sure all these `<br>`s aren't the best way to space things out.
+            }
+            <br />
+            <br />
+            <small>
+              {t(
+                'Note: If multiple fingerprints are selected, all events will move together into a single new issue.'
+              )}
+            </small>
+            <br />
+            <br />
             <small>
               {
                 // TODO: Once clickhouse is upgraded and the lag is no longer an issue, revisit this wording.

--- a/static/app/views/issueDetails/groupMerged/mergedToolbar.tsx
+++ b/static/app/views/issueDetails/groupMerged/mergedToolbar.tsx
@@ -60,11 +60,13 @@ export function MergedToolbar({
 
   const unmergeDisabledReason =
     mergedItems.length <= 1
-      ? t('To unmerge, the list must contain 2 or more items')
+      ? t('This is not a merged issue, as it contains only one fingerprint')
       : unmergeList.size === 0
-      ? t('To unmerge, 1 or more items must be selected')
+      ? t('Please select one or more fingerprints to unmerge from the rest')
       : GroupingStore.isAllUnmergedSelected()
-      ? t('We are unable to unmerge all items at once')
+      ? t(
+          'Moving all fingerprints into a new group together will have no effect. Please deselect at least one fingerprint.'
+        )
       : undefined;
 
   return (
@@ -92,7 +94,7 @@ export function MergedToolbar({
           onClick={handleShowDiff}
           title={
             !enableFingerprintCompare
-              ? t('To compare, exactly 2 items must be selected')
+              ? t('To compare issues, exactly 2 fingerprints must be selected')
               : undefined
           }
         >

--- a/static/app/views/issueDetails/groupMerged/mergedToolbar.tsx
+++ b/static/app/views/issueDetails/groupMerged/mergedToolbar.tsx
@@ -74,13 +74,13 @@ export function MergedToolbar({
           disabled={unmergeDisabled}
           onConfirm={onUnmerge}
           message={t(
-            'These events will be unmerged and grouped into a new issue. Are you sure you want to unmerge these events?'
+            'These fingerprints will be unmerged and their events will be grouped into a new issue. Are you sure you want to unmerge these fingerprints?'
           )}
         >
           <Button size="xs" title={unmergeDisabledReason}>
             {mergedItems.length <= 1
-              ? t('Unmerge')
-              : tct('Unmerge ([itemsSelectedQuantity])', {
+              ? t('Unmerge fingerprints') // button will always be disabled in this case
+              : tct('Unmerge [itemsSelectedQuantity] fingerprints', {
                   itemsSelectedQuantity: unmergeCount,
                 })}
           </Button>


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/57903, the heading on the Merged Issues tab was changed to be less confusing.  This is a continuation of the work clarifying text on that tab. 

Key changes:

- Add explanatory text to the subtitle.
- In messaging, talk about fingerprints being merged rather than events being merged.
- Improve tooltips when buttons are disabled to include reasons.