### PR TITLE
Replays Time ago filter tooltip hover

### DIFF
--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -33,7 +33,7 @@ interface Props extends React.TimeHTMLAttributes<HTMLTimeElement> {
   /**
    * Tooltip text to be hoverable when isTooltipHoverable is true
    */
-  isTooltipHoverable?:boolean;
+  isTooltipHoverable?: boolean;
   /**
    * How often should the component live update the timestamp.
    *
@@ -108,7 +108,7 @@ function TimeSince({
   tooltipBody,
   tooltipSuffix,
   tooltipUnderlineColor,
-  isTooltipHoverable=false,
+  isTooltipHoverable = false,
   unitStyle,
   prefix = t('in'),
   suffix = t('ago'),

--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -31,6 +31,10 @@ interface Props extends React.TimeHTMLAttributes<HTMLTimeElement> {
    */
   disabledAbsoluteTooltip?: boolean;
   /**
+   * Tooltip text to be hoverable when isTooltipHoverable is true
+   */
+  isTooltipHoverable?:boolean;
+  /**
    * How often should the component live update the timestamp.
    *
    * You may specify a custom interval in milliseconds if necissary.
@@ -104,6 +108,7 @@ function TimeSince({
   tooltipBody,
   tooltipSuffix,
   tooltipUnderlineColor,
+  isTooltipHoverable=false,
   unitStyle,
   prefix = t('in'),
   suffix = t('ago'),
@@ -162,6 +167,7 @@ function TimeSince({
       disabled={disabledAbsoluteTooltip}
       underlineColor={tooltipUnderlineColor}
       showUnderline
+      isHoverable={isTooltipHoverable}
       title={
         <Fragment>
           {tooltipTitle && <div>{tooltipTitle}</div>}

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -67,7 +67,11 @@ function Page({children, orgSlug, replayRecord, projectSlug, replayErrors}: Prop
               {replayRecord ? (
                 <TimeContainer>
                   <IconCalendar color="gray300" size="xs" />
-                  <StyledTimeSince date={replayRecord.started_at} isTooltipHoverable unitStyle="regular" />
+                  <StyledTimeSince
+                    date={replayRecord.started_at}
+                    isTooltipHoverable
+                    unitStyle="regular"
+                  />
                 </TimeContainer>
               ) : (
                 <HeaderPlaceholder width="80px" height="16px" />

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -67,7 +67,7 @@ function Page({children, orgSlug, replayRecord, projectSlug, replayErrors}: Prop
               {replayRecord ? (
                 <TimeContainer>
                   <IconCalendar color="gray300" size="xs" />
-                  <StyledTimeSince date={replayRecord.started_at} unitStyle="regular" />
+                  <StyledTimeSince date={replayRecord.started_at} isTooltipHoverable unitStyle="regular" />
                 </TimeContainer>
               ) : (
                 <HeaderPlaceholder width="80px" height="16px" />


### PR DESCRIPTION
<!-- Describe your PR here. -->

<img width="504" alt="Screenshot 2023-10-17 at 11 06 45 AM" src="https://github.com/getsentry/sentry/assets/136301926/90a927df-c5e6-49f9-a311-f10a9a3afb44">

Makes ☝️ tooltip hoverable so I can copy the actual time.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
