### PR TITLE
fix(dashboard): Update metric for session count

### DIFF
--- a/fixtures/js-stubs/metrics.ts
+++ b/fixtures/js-stubs/metrics.ts
@@ -234,11 +234,11 @@ export function MetricsSessionUserCountByStatusByRelease(): MetricsApiResponse {
       {
         by: {'session.status': 'crashed', release: '1'},
         totals: {
-          'sum(sentry.sessions.session)': 34,
+          'session.all': 34,
           'count_unique(sentry.sessions.user)': 1,
         },
         series: {
-          'sum(sentry.sessions.session)': [0, 0, 0, 0, 0, 0, 0, 0, 0, 23, 11, 0, 0, 0],
+          'session.all': [0, 0, 0, 0, 0, 0, 0, 0, 0, 23, 11, 0, 0, 0],
           'count_unique(sentry.sessions.user)': [
             0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0,
           ],
@@ -247,11 +247,11 @@ export function MetricsSessionUserCountByStatusByRelease(): MetricsApiResponse {
       {
         by: {'session.status': 'abnormal', release: '1'},
         totals: {
-          'sum(sentry.sessions.session)': 1,
+          'session.all': 1,
           'count_unique(sentry.sessions.user)': 1,
         },
         series: {
-          'sum(sentry.sessions.session)': [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          'session.all': [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           'count_unique(sentry.sessions.user)': [
             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
           ],
@@ -260,11 +260,11 @@ export function MetricsSessionUserCountByStatusByRelease(): MetricsApiResponse {
       {
         by: {'session.status': 'errored', release: '1'},
         totals: {
-          'sum(sentry.sessions.session)': 451,
+          'session.all': 451,
           'count_unique(sentry.sessions.user)': 2,
         },
         series: {
-          'sum(sentry.sessions.session)': [0, 0, 0, 0, 0, 37, 0, 0, 0, 335, 79, 0, 0, 0],
+          'session.all': [0, 0, 0, 0, 0, 37, 0, 0, 0, 335, 79, 0, 0, 0],
           'count_unique(sentry.sessions.user)': [
             0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 2, 0, 0, 0,
           ],
@@ -273,13 +273,11 @@ export function MetricsSessionUserCountByStatusByRelease(): MetricsApiResponse {
       {
         by: {'session.status': 'healthy', release: '1'},
         totals: {
-          'sum(sentry.sessions.session)': 5058,
+          'session.all': 5058,
           'count_unique(sentry.sessions.user)': 3,
         },
         series: {
-          'sum(sentry.sessions.session)': [
-            0, 0, 0, 0, 0, 2503, 661, 0, 0, 1464, 430, 0, 0, 0,
-          ],
+          'session.all': [0, 0, 0, 0, 0, 2503, 661, 0, 0, 1464, 430, 0, 0, 0],
           'count_unique(sentry.sessions.user)': [
             0, 0, 0, 0, 0, 3, 3, 0, 0, 1, 1, 0, 0, 0,
           ],
@@ -288,11 +286,11 @@ export function MetricsSessionUserCountByStatusByRelease(): MetricsApiResponse {
       {
         by: {'session.status': 'crashed', release: '2'},
         totals: {
-          'sum(sentry.sessions.session)': 35,
+          'session.all': 35,
           'count_unique(sentry.sessions.user)': 2,
         },
         series: {
-          'sum(sentry.sessions.session)': [1, 0, 0, 0, 0, 0, 0, 0, 0, 23, 11, 0, 0, 0],
+          'session.all': [1, 0, 0, 0, 0, 0, 0, 0, 0, 23, 11, 0, 0, 0],
           'count_unique(sentry.sessions.user)': [
             1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 0,
           ],
@@ -301,11 +299,11 @@ export function MetricsSessionUserCountByStatusByRelease(): MetricsApiResponse {
       {
         by: {'session.status': 'abnormal', release: '2'},
         totals: {
-          'sum(sentry.sessions.session)': 1,
+          'session.all': 1,
           'count_unique(sentry.sessions.user)': 1,
         },
         series: {
-          'sum(sentry.sessions.session)': [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          'session.all': [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           'count_unique(sentry.sessions.user)': [
             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
           ],
@@ -314,11 +312,11 @@ export function MetricsSessionUserCountByStatusByRelease(): MetricsApiResponse {
       {
         by: {'session.status': 'errored', release: '2'},
         totals: {
-          'sum(sentry.sessions.session)': 452,
+          'session.all': 452,
           'count_unique(sentry.sessions.user)': 1,
         },
         series: {
-          'sum(sentry.sessions.session)': [1, 0, 0, 0, 0, 37, 0, 0, 0, 335, 79, 0, 0, 0],
+          'session.all': [1, 0, 0, 0, 0, 37, 0, 0, 0, 335, 79, 0, 0, 0],
           'count_unique(sentry.sessions.user)': [
             1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0,
           ],
@@ -327,13 +325,11 @@ export function MetricsSessionUserCountByStatusByRelease(): MetricsApiResponse {
       {
         by: {'session.status': 'healthy', release: '2'},
         totals: {
-          'sum(sentry.sessions.session)': 5059,
+          'session.all': 5059,
           'count_unique(sentry.sessions.user)': 10,
         },
         series: {
-          'sum(sentry.sessions.session)': [
-            1, 0, 0, 0, 0, 2503, 661, 0, 0, 1464, 430, 0, 0, 0,
-          ],
+          'session.all': [1, 0, 0, 0, 0, 2503, 661, 0, 0, 1464, 430, 0, 0, 0],
           'count_unique(sentry.sessions.user)': [
             1, 0, 0, 0, 0, 10, 3, 0, 0, 4, 3, 0, 0, 0,
           ],

--- a/static/app/views/dashboards/widgetBuilder/releaseWidget/fields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/releaseWidget/fields.tsx
@@ -14,7 +14,7 @@ import {FieldValue, FieldValueKind} from 'sentry/views/discover/table/types';
 enum SessionMetric {
   ANR_RATE = 'session.anr_rate',
   FOREGROUND_ANR_RATE = 'session.foreground_anr_rate',
-  SESSION = 'sentry.sessions.session',
+  SESSION_COUNT = 'session.all',
   SESSION_DURATION = 'sentry.sessions.session.duration',
   SESSION_ERROR = 'sentry.sessions.session.error',
   SESSION_CRASH_FREE_RATE = 'session.crash_free_rate',
@@ -58,7 +58,7 @@ export const FIELD_TO_METRICS_EXPRESSION = {
   'count_errored(session)': SessionMetric.SESSION_ERRORED,
   'count_errored(user)': SessionMetric.USER_ERRORED,
   'count_unique(user)': `count_unique(${SessionMetric.USER})`,
-  'sum(session)': `sum(${SessionMetric.SESSION})`,
+  'sum(session)': SessionMetric.SESSION_COUNT,
   'crash_free_rate(session)': SessionMetric.SESSION_CRASH_FREE_RATE,
   'crash_free_rate(user)': SessionMetric.USER_CRASH_FREE_RATE,
   'crash_rate(session)': SessionMetric.SESSION_CRASH_RATE,

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -215,7 +215,7 @@ describe('WidgetBuilder', function () {
     MockApiClient.addMockResponse({
       method: 'GET',
       url: '/organizations/org-slug/metrics/data/',
-      body: MetricsField('sum(sentry.sessions.session)'),
+      body: MetricsField('session.all'),
     });
 
     tagsMock = MockApiClient.addMockResponse({

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -214,7 +214,7 @@ describe('WidgetBuilder', function () {
     metricsDataMock = MockApiClient.addMockResponse({
       method: 'GET',
       url: '/organizations/org-slug/metrics/data/',
-      body: MetricsField('sum(sentry.sessions.session)'),
+      body: MetricsField('session.all'),
     });
 
     MockApiClient.addMockResponse({

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilderSortBy.spec.tsx
@@ -194,7 +194,7 @@ describe('WidgetBuilder', function () {
     MockApiClient.addMockResponse({
       method: 'GET',
       url: '/organizations/org-slug/metrics/data/',
-      body: MetricsField('sum(sentry.sessions.session)'),
+      body: MetricsField('session.all'),
     });
 
     MockApiClient.addMockResponse({

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
@@ -80,7 +80,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
     jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
-      body: MetricsField(`sum(sentry.sessions.session)`),
+      body: MetricsField(`session.all`),
     });
     const children = jest.fn(() => <div />);
 
@@ -608,10 +608,10 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
     jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
     const metricsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
-      body: SessionsField(`sum(sentry.sessions.session)`),
+      body: SessionsField(`session.all`),
       match: [
         MockApiClient.matchQuery({
-          field: [`sum(sentry.sessions.session)`],
+          field: [`session.all`],
         }),
       ],
     });
@@ -634,7 +634,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
       expect.objectContaining({
         query: {
           environment: ['prod'],
-          field: ['sum(sentry.sessions.session)'],
+          field: ['session.all'],
           groupBy: [],
           interval: '30m',
           project: [1],
@@ -651,7 +651,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
       expect.objectContaining({
         query: {
           environment: ['prod'],
-          field: ['sum(sentry.sessions.session)'],
+          field: ['session.all'],
           groupBy: [],
           interval: '30m',
           project: [1],
@@ -672,7 +672,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
       body: {detail: badMessage},
       match: [
         MockApiClient.matchQuery({
-          field: [`sum(sentry.sessions.session)`],
+          field: [`session.all`],
         }),
       ],
     });
@@ -703,7 +703,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
     jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
-      body: SessionsField(`sum(sentry.sessions.session)`),
+      body: SessionsField(`session.all`),
     });
 
     render(
@@ -735,7 +735,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
   it('does not re-fetch when renaming legend alias / adding falsy fields', () => {
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
-      body: SessionsField(`sum(sentry.sessions.session)`),
+      body: SessionsField(`session.all`),
     });
     const children = jest.fn(() => <div />);
 
@@ -779,7 +779,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
   it('does not re-fetch when dashboard filter remains the same', () => {
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
-      body: SessionsField(`sum(sentry.sessions.session)`),
+      body: SessionsField(`session.all`),
     });
     const children = jest.fn(() => <div />);
 


### PR DESCRIPTION
'sum(sentry.sessions.session)' is being mapped to an internal metric that double counts crashed sessions (see [comment](https://github.com/getsentry/sentry/issues/54703#issuecomment-1733465340)).
We need to query `session.all` instead.

- closes https://github.com/getsentry/sentry/issues/57121#top