### PR TITLE
fix(metrics) Check custom rules are created only for transaction (back-end)

### DIFF
--- a/src/sentry/api/endpoints/custom_rules.py
+++ b/src/sentry/api/endpoints/custom_rules.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 from typing import List, Optional
 
 import sentry_sdk
@@ -32,6 +33,19 @@ MAX_RULE_PERIOD = parse_stats_period(MAX_RULE_PERIOD_STRING)
 DEFAULT_PERIOD_STRING = "1h"
 # the number of samples to collect per custom rule
 NUM_SAMPLES_PER_CUSTOM_RULE = 100
+
+
+class UnsupportedSearchQueryReason(Enum):
+    # we only support transaction queries
+    NOT_TRANSACTION_QUERY = "not_transaction_query"
+
+
+class UnsupportedSearchQuery(Exception):
+    def __init__(self, error_code: UnsupportedSearchQueryReason, *args, **kwargs):
+        super().__init__(error_code.value, *args, **kwargs)
+        self.error_code = error_code.value
+
+    pass
 
 
 class CustomRulesInputSerializer(serializers.Serializer):
@@ -150,6 +164,8 @@ class CustomRulesEndpoint(OrganizationEndpoint):
             _schedule_invalidate_project_configs(organization, projects)
 
             return _rule_to_response(rule)
+        except UnsupportedSearchQuery as e:
+            return Response({"query": [e.error_code]}, status=400)
         except InvalidSearchQuery as e:
             return Response({"query": [str(e)]}, status=400)
 
@@ -198,6 +214,8 @@ class CustomRulesEndpoint(OrganizationEndpoint):
 
         try:
             condition = get_condition(query)
+        except UnsupportedSearchQuery as e:
+            return Response({"query": [e.error_code]}, status=400)
         except InvalidSearchQuery as e:
             return Response({"query": [str(e)]}, status=400)
         except ValueError as e:
@@ -245,19 +263,41 @@ def _rule_to_response(rule: CustomDynamicSamplingRule) -> Response:
     return Response(response_data, status=200)
 
 
+def _is_not_supported(searchFilters: List[SearchFilter]) -> Optional[UnsupportedSearchQueryReason]:
+    """
+    Check if the search query is not supported by the custom rules
+
+    Curently we only support transaction queries
+    """
+    transaction_filter = False
+
+    for searchFilter in searchFilters:
+        if searchFilter.key.name == "event.type" and searchFilter.value.value == "transaction":
+            transaction_filter = True
+            break
+    if not transaction_filter:
+        return UnsupportedSearchQueryReason.NOT_TRANSACTION_QUERY
+    return None
+
+
 def get_condition(query: Optional[str]) -> RuleCondition:
     try:
         if not query:
-            # True condition when query not specified
-            condition: RuleCondition = {"op": "and", "inner": []}
+            raise UnsupportedSearchQuery(UnsupportedSearchQueryReason.NOT_TRANSACTION_QUERY)
         else:
             tokens = parse_search_query(query)
+
+            reason = _is_not_supported(tokens)
+            if reason is not None:
+                raise UnsupportedSearchQuery(reason)
             # transform a simple message query into a transaction condition:
             # "foo environment:development" -> "transaction:foo environment:development"
             tokens = message_to_transaction_condition(tokens)
             converter = SearchQueryConverter(tokens)
             condition = converter.convert()
         return condition
+    except UnsupportedSearchQuery:
+        raise  # do not log unsupported queries (they are expected)
     except Exception as ex:
         with sentry_sdk.push_scope() as scope:
             scope.set_extra("query", query)

--- a/tests/sentry/api/endpoints/test_custom_rules.py
+++ b/tests/sentry/api/endpoints/test_custom_rules.py
@@ -8,6 +8,8 @@ from sentry.api.endpoints.custom_rules import (
     DEFAULT_PERIOD_STRING,
     MAX_RULE_PERIOD_STRING,
     CustomRulesInputSerializer,
+    UnsupportedSearchQuery,
+    UnsupportedSearchQueryReason,
     get_condition,
 )
 from sentry.models.dynamicsampling import CUSTOM_RULE_DATE_FORMAT, CustomDynamicSamplingRule
@@ -35,7 +37,13 @@ class CustomRulesGetEndpoint(APITestCase):
 
         # create a project rule for second and third project
         now = timezone.now()
-        self.proj_condition = {"op": "eq", "name": "event.environment", "value": "prod"}
+        self.proj_condition = {
+            "op": "and",
+            "inner": [
+                {"op": "eq", "name": "event.environment", "value": "prod"},
+                {"op": "eq", "name": "event.tags.event.type", "value": "transaction"},
+            ],
+        }
         start = now - timedelta(hours=2)
         end = now + timedelta(hours=2)
         projects = self.known_projects[1:3]
@@ -51,7 +59,13 @@ class CustomRulesGetEndpoint(APITestCase):
 
         # create an org rule
         now = timezone.now()
-        self.org_condition = {"op": "eq", "name": "event.environment", "value": "dev"}
+        self.org_condition = {
+            "op": "and",
+            "inner": [
+                {"op": "eq", "name": "event.tags.event.type", "value": "transaction"},
+                {"op": "eq", "name": "event.environment", "value": "dev"},
+            ],
+        }
         start = now - timedelta(hours=2)
         end = now + timedelta(hours=2)
         CustomDynamicSamplingRule.update_or_create(
@@ -64,21 +78,21 @@ class CustomRulesGetEndpoint(APITestCase):
             sample_rate=1.0,
         )
 
-        # create a condition with empty query
-        now = timezone.now()
-        self.empty_condition = {"op": "and", "inner": []}
-        start = now - timedelta(hours=2)
-        end = now + timedelta(hours=2)
-
-        CustomDynamicSamplingRule.update_or_create(
-            condition=self.empty_condition,
-            start=start,
-            end=end,
-            project_ids=[self.known_projects[0].id],
-            organization_id=self.organization.id,
-            num_samples=100,
-            sample_rate=1.0,
-        )
+        # # create a condition with empty query
+        # now = timezone.now()
+        # self.empty_condition = {"op": "and", "inner": []}
+        # start = now - timedelta(hours=2)
+        # end = now + timedelta(hours=2)
+        #
+        # CustomDynamicSamplingRule.update_or_create(
+        #     condition=self.empty_condition,
+        #     start=start,
+        #     end=end,
+        #     project_ids=[self.known_projects[0].id],
+        #     organization_id=self.organization.id,
+        #     num_samples=100,
+        #     sample_rate=1.0,
+        # )
 
     def test_finds_project_rule(self):
         """
@@ -93,7 +107,7 @@ class CustomRulesGetEndpoint(APITestCase):
             resp = self.get_response(
                 self.organization.slug,
                 qs_params={
-                    "query": "environment:prod",
+                    "query": "environment:prod event.type:transaction",
                     "project": [proj.id for proj in self.known_projects[1:3]],
                 },
             )
@@ -105,28 +119,6 @@ class CustomRulesGetEndpoint(APITestCase):
         assert self.known_projects[1].id in data["projects"]
         assert self.known_projects[2].id in data["projects"]
 
-    def test_finds_rule_with_empty_query(self):
-        """
-        Tests that the endpoint finds the rule when the query
-        is empty
-        """
-
-        # call the endpoint
-        with Feature({"organizations:investigation-bias": True}):
-            resp = self.get_response(
-                self.organization.slug,
-                qs_params={
-                    "query": "",
-                    "project": [self.known_projects[0].id],
-                },
-            )
-
-        assert resp.status_code == 200
-        data = resp.data
-        assert data["condition"] == self.empty_condition
-        assert len(data["projects"]) == 1
-        assert self.known_projects[0].id in data["projects"]
-
     def test_finds_org_condition(self):
         """
         A request for org will find an org rule ( if condition matches)
@@ -137,7 +129,7 @@ class CustomRulesGetEndpoint(APITestCase):
             resp = self.get_response(
                 self.organization.slug,
                 qs_params={
-                    "query": "environment:dev",
+                    "query": "environment:dev event.type:transaction",
                     "project": [],
                 },
             )
@@ -148,7 +140,7 @@ class CustomRulesGetEndpoint(APITestCase):
             resp = self.get_response(
                 self.organization.slug,
                 qs_params={
-                    "query": "environment:dev",
+                    "query": "environment:dev event.type:transaction",
                     "project": [],
                 },
             )
@@ -162,7 +154,7 @@ class CustomRulesGetEndpoint(APITestCase):
             resp = self.get_response(
                 self.organization.slug,
                 qs_params={
-                    "query": "environment:integration",
+                    "query": "environment:integration event.type:transaction",
                     "project": [self.known_projects[1].id],
                 },
             )
@@ -178,7 +170,7 @@ class CustomRulesGetEndpoint(APITestCase):
             resp = self.get_response(
                 self.organization.slug,
                 qs_params={
-                    "query": "environment:prod",
+                    "query": "environment:prod event.type:transaction",
                     "project": [project.id for project in self.known_projects[1:3]],
                 },
             )
@@ -188,7 +180,7 @@ class CustomRulesGetEndpoint(APITestCase):
             resp = self.get_response(
                 self.organization.slug,
                 qs_params={
-                    "query": "environment:prod",
+                    "query": "environment:prod event.type:transaction",
                     "project": [self.known_projects[0].id],
                 },
             )
@@ -225,34 +217,6 @@ class CustomRulesEndpoint(APITestCase):
         start_date = datetime.strptime(data["startDate"], CUSTOM_RULE_DATE_FORMAT)
         end_date = datetime.strptime(data["endDate"], CUSTOM_RULE_DATE_FORMAT)
         assert end_date - start_date == timedelta(days=2)
-        projects = data["projects"]
-        assert projects == [self.project.id]
-        org_id = data["orgId"]
-        assert org_id == self.organization.id
-
-        # check the database
-        rule_id = data["ruleId"]
-        rules = list(self.organization.customdynamicsamplingrule_set.all())
-        assert len(rules) == 1
-        rule = rules[0]
-        assert rule.external_rule_id == rule_id
-
-    def test_empty_query(self):
-        request_data = {
-            "query": "",
-            "projects": [self.project.id],
-            "period": "1h",
-        }
-        with Feature({"organizations:investigation-bias": True}):
-            resp = self.get_response(self.organization.slug, raw_data=request_data)
-
-        assert resp.status_code == 200
-
-        data = resp.data
-
-        start_date = datetime.strptime(data["startDate"], CUSTOM_RULE_DATE_FORMAT)
-        end_date = datetime.strptime(data["endDate"], CUSTOM_RULE_DATE_FORMAT)
-        assert end_date - start_date == timedelta(days=2)  # hard coded at 2 days
         projects = data["projects"]
         assert projects == [self.project.id]
         org_id = data["orgId"]
@@ -477,20 +441,38 @@ class TestCustomRuleSerializerWithProjects(TestCase):
 @pytest.mark.parametrize(
     "query,condition",
     [
-        ("", {"op": "and", "inner": []}),
         (
             "event.type:transaction",
             {"name": "event.tags.event.type", "op": "eq", "value": "transaction"},
         ),
-        ("environment:prod", {"op": "eq", "name": "event.environment", "value": "prod"}),
-        ("hello world", {"op": "eq", "name": "event.transaction", "value": "hello world"}),
         (
-            "environment:prod hello world",
+            "environment:prod event.type:transaction",
+            {
+                "op": "and",
+                "inner": [
+                    {"op": "eq", "name": "event.environment", "value": "prod"},
+                    {"op": "eq", "name": "event.tags.event.type", "value": "transaction"},
+                ],
+            },
+        ),
+        (
+            "hello world event.type:transaction",
+            {
+                "op": "and",
+                "inner": [
+                    {"op": "eq", "name": "event.transaction", "value": "hello world"},
+                    {"op": "eq", "name": "event.tags.event.type", "value": "transaction"},
+                ],
+            },
+        ),
+        (
+            "environment:prod hello world event.type:transaction",
             {
                 "op": "and",
                 "inner": [
                     {"op": "eq", "name": "event.environment", "value": "prod"},
                     {"op": "eq", "name": "event.transaction", "value": "hello world"},
+                    {"op": "eq", "name": "event.tags.event.type", "value": "transaction"},
                 ],
             },
         ),
@@ -502,3 +484,32 @@ def test_get_condition(query, condition):
     """
     actual_condition = get_condition(query)
     assert actual_condition == condition
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "event.type:error",
+        "environment:production",
+        "event.type:error environment:production",
+        "",
+        "hello world",
+    ],
+)
+def test_get_condition_not_supported(query):
+    with pytest.raises(UnsupportedSearchQuery) as excinfo:
+        get_condition(query)
+    assert excinfo.value.error_code == UnsupportedSearchQueryReason.NOT_TRANSACTION_QUERY.value
+
+
+@pytest.mark.parametrize(
+    "query",
+    ["", "event.type:error", "environment:production"],
+)
+def test_get_condition_non_transaction_rule(query):
+    """
+    Test that the get_condition function raises UnsupportedSearchQuery when event.type is not transaction
+    """
+    with pytest.raises(UnsupportedSearchQuery) as excinfo:
+        get_condition(query)
+    assert excinfo.value.error_code == UnsupportedSearchQueryReason.NOT_TRANSACTION_QUERY.value


### PR DESCRIPTION
This PR changes the  `CustomRulesEndpoint` endpoint to only accept rules for transactions.
Previously any rule was accepted although the condition was generated for transactions only.

Resolves https://github.com/getsentry/sentry/issues/57900