### PR TITLE
feat(anr): Remove anr-rate feature flag from sessions endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features, release_health
+from sentry import release_health
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -28,17 +28,6 @@ class OrganizationSessionsEndpoint(OrganizationEventsEndpointBase):
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
     def get(self, request: Request, organization) -> Response:
-        query_params = MultiValueDict(request.GET)
-
-        fields = set(query_params.getlist("field", []))
-        anr_fields = {"anr_rate()", "foreground_anr_rate()"}
-        if fields.intersection(anr_fields) and not features.has(
-            "organizations:anr-rate", organization, actor=request.user
-        ):
-            return Response(
-                {"detail": "This organization does not have the ANR rate feature"}, status=400
-            )
-
         def data_fn(offset: int, limit: int):
             with self.handle_query_errors():
                 with sentry_sdk.start_span(

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -387,8 +387,7 @@ class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
         }
 
         def req(**kwargs):
-            with self.feature("organizations:anr-rate"):
-                return self.do_request(dict(default_request, **kwargs))
+            return self.do_request(dict(default_request, **kwargs))
 
         response = req()
         assert response.status_code == 200
@@ -1677,8 +1676,7 @@ class OrganizationSessionsEndpointMetricsTest(
         }
 
         def req(**kwargs):
-            with self.feature("organizations:anr-rate"):
-                return self.do_request(dict(default_request, **kwargs))
+            return self.do_request(dict(default_request, **kwargs))
 
         # basic test case
         response = req()


### PR DESCRIPTION
As part of getting https://github.com/getsentry/sentry-electron/issues/774 working, we need to clean up the ANR feature flag usage, as the feature has now been GA for a while (and is not dependent on any plan).

the flag was initially introduced with https://github.com/getsentry/sentry/pull/42547 and was used here https://github.com/getsentry/sentry/pull/43741. It's also being used in getsentry codebase here: https://github.com/getsentry/getsentry/blob/eac81d6e3695368b5fed563257aec7a308f1d70a/getsentry/conf/settings/singletenant.py#L630.

On the UI side I'll be updating the views to not rely on the `anr-rate` flag, but instead on a combination of looking at platform/sdk name/checking if metrics extraction is enabled.

After that I'll be updating `getsentry` code, then removing the feature flag entirely here.