### PR TITLE
fix(metrics) Check custom rules are created only for transaction (front-end)

### DIFF
--- a/static/app/components/dynamicSampling/investigationRule.spec.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.spec.tsx
@@ -1,8 +1,11 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {fireEvent, render, screen} from 'sentry-test/reactTestingLibrary';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {InvestigationRuleCreation} from 'sentry/components/dynamicSampling/investigationRule';
 import EventView from 'sentry/utils/discover/eventView';
+
+jest.mock('sentry/actionCreators/indicator');
 
 describe('InvestigationRule', function () {
   let context;
@@ -113,7 +116,7 @@ describe('InvestigationRule', function () {
     expect(getRuleMock).toHaveBeenCalledTimes(0);
   });
 
-  it('renders shows a button when not enough samples are present and there is no rule', async function () {
+  it('shows a button when not enough samples are present and there is no rule', async function () {
     initComponentEnvironment({hasFeature: true, hasRule: false});
     render(
       <InvestigationRuleCreation buttonProps={{}} eventView={eventView} numSamples={1} />,
@@ -130,7 +133,7 @@ describe('InvestigationRule', function () {
     expect(getRuleMock).toHaveBeenCalledTimes(1);
   });
 
-  it('shows label when not enough samples are present and there is a rule', async function () {
+  it('shows a label when not enough samples are present and there is a rule', async function () {
     initComponentEnvironment({hasFeature: true, hasRule: true});
     render(
       <InvestigationRuleCreation buttonProps={{}} eventView={eventView} numSamples={1} />,
@@ -147,13 +150,51 @@ describe('InvestigationRule', function () {
     expect(getRuleMock).toHaveBeenCalledTimes(1);
   });
 
+  it('does not render when the rule is not a transaction rule', async function () {
+    initComponentEnvironment({hasFeature: true, hasRule: false});
+    const getRule = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dynamic-sampling/custom-rules/',
+      method: 'GET',
+      statusCode: 400,
+      body: {query: ['not_transaction_query']},
+    });
+    render(
+      <InvestigationRuleCreation buttonProps={{}} eventView={eventView} numSamples={1} />,
+      {organization}
+    );
+    await expectNotToRender();
+
+    expect(addErrorMessage).not.toHaveBeenCalled();
+    // check we did call the endpoint to check if a rule exists
+    expect(getRule).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render when there is an unknown error but shows an error', async function () {
+    initComponentEnvironment({hasFeature: true, hasRule: false});
+    const getRule = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dynamic-sampling/custom-rules/',
+      method: 'GET',
+      statusCode: 400,
+      body: {query: ['some-unknown-error']},
+    });
+    render(
+      <InvestigationRuleCreation buttonProps={{}} eventView={eventView} numSamples={1} />,
+      {organization}
+    );
+    await expectNotToRender();
+
+    expect(addErrorMessage).toHaveBeenCalledTimes(1);
+    // check we did call the endpoint to check if a rule exists
+    expect(getRule).toHaveBeenCalledTimes(1);
+  });
+
   it('should create a new rule when clicking on the button and update the UI', async function () {
     initComponentEnvironment({hasFeature: true, hasRule: false});
     const createRule = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dynamic-sampling/custom-rules/',
       method: 'POST',
       statusCode: 200,
-      body: JSON.stringify(getCustomRule()),
+      body: getCustomRule(),
     });
 
     render(
@@ -174,7 +215,7 @@ describe('InvestigationRule', function () {
       url: '/organizations/org-slug/dynamic-sampling/custom-rules/',
       method: 'GET',
       statusCode: 200,
-      body: JSON.stringify(getCustomRule()),
+      body: getCustomRule(),
     });
     await tick();
     expect(createRule).toHaveBeenCalledTimes(1);
@@ -187,5 +228,34 @@ describe('InvestigationRule', function () {
     expect(buttons).toHaveLength(0);
     // check we did call the endpoint to check if the newly created rule exists
     expect(sencondResponse).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show an error when creating a new rule fails', async function () {
+    initComponentEnvironment({hasFeature: true, hasRule: false});
+    const createRule = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dynamic-sampling/custom-rules/',
+      method: 'POST',
+      statusCode: 400,
+      body: {query: ['some-error']},
+    });
+
+    render(
+      <InvestigationRuleCreation buttonProps={{}} eventView={eventView} numSamples={1} />,
+      {organization}
+    );
+
+    // wait for the button to appear
+    const button = await screen.findByText(buttonText);
+    expect(button).toBeInTheDocument();
+    // we should  not be showing the label
+    const labels = screen.queryAllByText(labelText);
+    expect(labels).toHaveLength(0);
+    // now the user creates a rule
+    fireEvent.click(button);
+
+    await tick();
+    expect(createRule).toHaveBeenCalledTimes(1);
+    // we should show some error that the rule could not be created
+    expect(addErrorMessage).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This PR adds front-end functionality for creating investigation rules only
when the user explicitly asks for transactions.

Check 400 returns from investigation rule query.
If the 400 is due to a rule without an event.type: transaction
do not show an error ( it is not an error), just don't offer to
create an investigation rule for it.

Show errors in other cases.

Resolves https://github.com/getsentry/sentry/issues/57900
