### PR TITLE
feat(anr): Remove anr-rate feature flag from frontend UI

### DIFF
--- a/static/app/views/projectDetail/projectCharts.spec.tsx
+++ b/static/app/views/projectDetail/projectCharts.spec.tsx
@@ -4,15 +4,12 @@ import {SessionsField} from 'sentry-fixture/sessions';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {PlatformKey} from 'sentry/types';
 import ProjectCharts from 'sentry/views/projectDetail/projectCharts';
 
-function renderProjectCharts(
-  features?: string[],
-  platform?: string,
-  chartDisplay?: string
-) {
+function renderProjectCharts(platform?: PlatformKey, chartDisplay?: string) {
   const {organization, router, project} = initializeOrg({
-    organization: Organization({features}),
+    organization: Organization(),
     projects: [{platform}],
     router: {
       params: {orgId: 'org-slug', projectId: 'project-slug'},
@@ -57,8 +54,8 @@ describe('ProjectDetail > ProjectCharts', () => {
     jest.resetAllMocks();
   });
 
-  it('renders ANR options', async () => {
-    renderProjectCharts(['anr-rate'], 'android');
+  it('renders ANR options for android projects', async () => {
+    renderProjectCharts('android');
 
     await userEvent.click(
       screen.getByRole('button', {name: 'Display Crash Free Sessions'})
@@ -68,8 +65,19 @@ describe('ProjectDetail > ProjectCharts', () => {
     expect(screen.getByText('ANR Rate')).toBeInTheDocument();
   });
 
-  it('does not render ANR options for non-android platforms', async () => {
-    renderProjectCharts(['anr-rate'], 'python');
+  it('renders ANR options for electron projects', async () => {
+    renderProjectCharts('javascript-electron');
+
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Display Crash Free Sessions'})
+    );
+
+    expect(screen.getByText('Foreground ANR Rate')).toBeInTheDocument();
+    expect(screen.getByText('ANR Rate')).toBeInTheDocument();
+  });
+
+  it('does not render ANR options for non-compatible platforms', async () => {
+    renderProjectCharts('python');
 
     await userEvent.click(
       screen.getByRole('button', {name: 'Display Crash Free Sessions'})
@@ -117,7 +125,7 @@ describe('ProjectDetail > ProjectCharts', () => {
       url: '/organizations/org-slug/sessions/',
       body: responseBody,
     });
-    renderProjectCharts(['anr-rate'], 'android', 'anr_rate');
+    renderProjectCharts('android', 'anr_rate');
     expect(screen.getByText('ANR Rate')).toBeInTheDocument();
 
     await waitFor(() =>

--- a/static/app/views/projectDetail/projectCharts.tsx
+++ b/static/app/views/projectDetail/projectCharts.tsx
@@ -32,6 +32,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withApi from 'sentry/utils/withApi';
+import {isPlatformANRCompatible} from 'sentry/views/projectDetail/utils';
 import {
   getSessionTermDescription,
   SessionTerm,
@@ -82,14 +83,14 @@ class ProjectCharts extends Component<Props, State> {
   };
 
   get defaultDisplayModes() {
-    const {hasSessions, hasTransactions, organization, project} = this.props;
+    const {hasSessions, hasTransactions, project} = this.props;
 
     if (!hasSessions && !hasTransactions) {
       return [DisplayModes.ERRORS];
     }
 
     if (hasSessions && !hasTransactions) {
-      if (organization.features.includes('anr-rate') && project?.platform === 'android') {
+      if (isPlatformANRCompatible(project?.platform)) {
         return [DisplayModes.STABILITY, DisplayModes.ANR_RATE];
       }
       return [DisplayModes.STABILITY, DisplayModes.ERRORS];
@@ -99,7 +100,7 @@ class ProjectCharts extends Component<Props, State> {
       return [DisplayModes.FAILURE_RATE, DisplayModes.APDEX];
     }
 
-    if (organization.features.includes('anr-rate') && project?.platform === 'android') {
+    if (isPlatformANRCompatible(project?.platform)) {
       return [DisplayModes.STABILITY, DisplayModes.ANR_RATE];
     }
 
@@ -212,7 +213,7 @@ class ProjectCharts extends Component<Props, State> {
       },
     ];
 
-    if (organization.features.includes('anr-rate') && project?.platform === 'android') {
+    if (isPlatformANRCompatible(project?.platform)) {
       return [
         {
           value: DisplayModes.ANR_RATE,
@@ -322,8 +323,7 @@ class ProjectCharts extends Component<Props, State> {
     const {totalValues} = this.state;
     const hasDiscover = organization.features.includes('discover-basic');
     const displayMode = this.displayMode;
-    const hasAnrRateFeature =
-      organization.features.includes('anr-rate') && project?.platform === 'android';
+    const hasAnrRateFeature = isPlatformANRCompatible(project?.platform);
 
     return (
       <Panel>

--- a/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.spec.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectAnrScoreCard.spec.tsx
@@ -113,7 +113,7 @@ describe('ProjectDetail > ProjectAnr', function () {
   });
 
   it('renders open in issues CTA', async function () {
-    organization.features = ['discover-basic', 'anr-rate'];
+    organization.features = ['discover-basic'];
     render(
       <ProjectAnrScoreCard
         organization={{...organization}}

--- a/static/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
@@ -8,6 +8,7 @@ import {
   Project,
   SessionFieldWithOperation,
 } from 'sentry/types';
+import {isPlatformANRCompatible} from 'sentry/views/projectDetail/utils';
 
 import {ProjectAnrScoreCard} from './projectAnrScoreCard';
 import ProjectApdexScoreCard from './projectApdexScoreCard';
@@ -62,7 +63,7 @@ function ProjectScoreCards({
         query={query}
       />
 
-      {organization.features.includes('anr-rate') && project?.platform === 'android' ? (
+      {isPlatformANRCompatible(project?.platform) ? (
         <ProjectAnrScoreCard
           organization={organization}
           selection={selection}

--- a/static/app/views/projectDetail/utils.tsx
+++ b/static/app/views/projectDetail/utils.tsx
@@ -1,8 +1,14 @@
 import {Location} from 'history';
 
+import {PlatformKey} from 'sentry/types';
+
 export function didProjectOrEnvironmentChange(location1: Location, location2: Location) {
   return (
     location1.query.environment !== location2.query.environment ||
     location1.query.project !== location2.query.project
   );
+}
+
+export function isPlatformANRCompatible(platform?: PlatformKey) {
+  return platform === 'javascript-electron' || platform === 'android';
 }


### PR DESCRIPTION
Continuing the work in https://github.com/getsentry/sentry/pull/58238 we now clean up the `organizations:anr-rate` feature flag in the frontend, introduced with https://github.com/getsentry/sentry/pull/42547.

For now we make the ANR logic dependent on project platform. 

After this we can update `getsentry` to stop setting the feature flag, and then delete it entirely.