### PR TITLE
feat(perf): Use flag to optionally skip compatibility checks

### DIFF
--- a/static/app/utils/performance/contexts/metricsCardinality.tsx
+++ b/static/app/utils/performance/contexts/metricsCardinality.tsx
@@ -73,6 +73,27 @@ export function MetricsCardinalityProvider(props: {
   eventView.fields = [{field: 'tpm()'}];
   const _eventView = adjustEventViewTime(eventView);
 
+  if (
+    props.organization.features.includes(
+      'performance-remove-metrics-compatibility-fallback'
+    )
+  ) {
+    return (
+      <Provider
+        sendOutcomeAnalytics={props.sendOutcomeAnalytics}
+        organization={props.organization}
+        value={{
+          isLoading: false,
+          outcome: {
+            forceTransactionsOnly: false,
+          },
+        }}
+      >
+        {props.children}
+      </Provider>
+    );
+  }
+
   return (
     <Fragment>
       <MetricsCompatibilityQuery eventView={_eventView} {...baseDiscoverProps}>


### PR DESCRIPTION
### Summary
We've now hit near perfect accuracy between metrics<->transactions when it comes to cardinality sources that previously caused missing metrics (eg. `transaction.source:unknown` etc.)

This will opt a user out of the compatibility check, forcing all queries onto the metrics dataset where appropriate.


