### PR TITLE
fix(meps): Only overwrite status code if int

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -365,7 +365,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         # once those APIs are used across the application.
         if "transaction.status" in first_row:
             for row in results:
-                if "transaction.status" in row:
+                if "transaction.status" in row and type(row["transaction.status"]) is int:
                     row["transaction.status"] = SPAN_STATUS_CODE_TO_NAME.get(
                         row["transaction.status"]
                     )


### PR DESCRIPTION
When we fetch transaction.status results from metrics, the status code that's returned back is not an int but rather a string with the value we'd typically get if we resolve through the map. This causes issues because for metrics responses, `transaction.status` gets set to `None` for all rows.

This checks if the value is an int and if it is, fetch from the map, otherwise don't overwrite it.