### PR TITLE
feat(replays): Move timeline to bottom of screen

### DIFF
--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -39,7 +39,7 @@ function ReplayLayout({layout = LayoutKey.TOPBAR}: Props) {
   const organization = useOrganization();
   const hasNewTimeline = organization.features.includes('session-replay-new-timeline');
 
-  const timeline = (
+  const timeline = hasNewTimeline ? null : (
     <ErrorBoundary mini>
       <ReplayTimeline />
     </ErrorBoundary>
@@ -55,6 +55,7 @@ function ReplayLayout({layout = LayoutKey.TOPBAR}: Props) {
 
   const controller = hasNewTimeline ? (
     <ErrorBoundary>
+      <ReplayTimeline />
       <ReplayController toggleFullscreen={toggleFullscreen} />
     </ErrorBoundary>
   ) : null;
@@ -81,7 +82,7 @@ function ReplayLayout({layout = LayoutKey.TOPBAR}: Props) {
 
   if (layout === LayoutKey.NO_VIDEO) {
     return (
-      <BodyContent>
+      <BodyContent style={{gridTemplateRows: hasNewTimeline ? '1fr auto' : 'auto 1fr'}}>
         {timeline}
         <FluidHeight ref={measureRef}>
           {hasSize ? <PanelContainer key={layout}>{focusArea}</PanelContainer> : null}
@@ -92,7 +93,7 @@ function ReplayLayout({layout = LayoutKey.TOPBAR}: Props) {
 
   if (layout === LayoutKey.SIDEBAR_LEFT) {
     return (
-      <BodyContent>
+      <BodyContent style={{gridTemplateRows: hasNewTimeline ? '1fr auto' : 'auto 1fr'}}>
         {timeline}
         <FluidHeight ref={measureRef}>
           {hasSize ? (
@@ -116,7 +117,7 @@ function ReplayLayout({layout = LayoutKey.TOPBAR}: Props) {
 
   // layout === 'topbar'
   return (
-    <BodyContent>
+    <BodyContent style={{gridTemplateRows: hasNewTimeline ? '1fr auto' : 'auto 1fr'}}>
       {timeline}
       <FluidHeight ref={measureRef}>
         {hasSize ? (


### PR DESCRIPTION
Move the timeline to bottom of screen, on top of the replay controller, changes are behind feature flag.

Before: 
<img width="1497" alt="image" src="https://github.com/getsentry/sentry/assets/55311782/cdc5eebc-eb28-4378-8530-8496cd0d325e">

After:
<img width="1497" alt="image" src="https://github.com/getsentry/sentry/assets/55311782/0b2ed435-f91e-4004-8665-0b35a4a6e99d">


Relates to https://github.com/getsentry/team-replay/issues/198
