### PR TITLE
chore(performance-detector-thresholds): Removing feature flag from front-end.

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidence.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.spec.tsx
@@ -100,7 +100,6 @@ describe('spanEvidence', () => {
         },
       ],
     });
-    organization.features = ['project-performance-settings-admin'];
 
     render(
       <SpanEvidenceSection

--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -45,8 +45,6 @@ export function SpanEvidenceSection({event, organization, projectSlug}: Props) {
   const issueType = getIssueTypeFromOccurenceType(event.occurrence?.type);
   const issueTitle = event.occurrence?.issueTitle;
   const sanitizedIssueTitle = issueTitle && sanitizeQuerySelector(issueTitle);
-  const hasConfigurableThresholds =
-    organization.features.includes('project-performance-settings-admin') && issueType;
 
   return (
     <EventDataSection
@@ -56,7 +54,7 @@ export function SpanEvidenceSection({event, organization, projectSlug}: Props) {
         'Span Evidence identifies the root cause of this issue, found in other similar events within the same issue.'
       )}
       actions={
-        hasConfigurableThresholds && (
+        issueType && (
           <LinkButton
             data-test-id="span-evidence-settings-btn"
             to={`/settings/projects/${projectSlug}/performance/?issueType=${issueType}#${sanitizedIssueTitle}`}

--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
@@ -66,6 +66,12 @@ describe('projectPerformance', function () {
       body: {},
       statusCode: 200,
     });
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/performance-issues/configure/',
+      method: 'GET',
+      body: {},
+      statusCode: 200,
+    });
   });
 
   it('renders the fields', function () {

--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
@@ -18,15 +18,11 @@ import ProjectPerformance, {
 
 describe('projectPerformance', function () {
   const org = Organization({
-    features: [
-      'performance-view',
-      'performance-issues-dev',
-      'project-performance-settings-admin',
-    ],
+    features: ['performance-view', 'performance-issues-dev'],
   });
   const project = TestStubs.Project();
   const configUrl = '/projects/org-slug/project-slug/transaction-threshold/configure/';
-  let getMock, postMock, deleteMock, performanceIssuesMock;
+  let getMock, postMock, deleteMock;
 
   const router = TestStubs.router();
   const routerProps = {
@@ -66,12 +62,6 @@ describe('projectPerformance', function () {
     });
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/',
-      method: 'GET',
-      body: {},
-      statusCode: 200,
-    });
-    performanceIssuesMock = MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/performance-issues/configure/',
       method: 'GET',
       body: {},
       statusCode: 200,
@@ -133,23 +123,6 @@ describe('projectPerformance', function () {
 
     await userEvent.click(screen.getByRole('button', {name: 'Reset All'}));
     expect(deleteMock).toHaveBeenCalled();
-  });
-
-  it('does not get performance issues settings without the feature flag', function () {
-    const orgWithoutPerfIssues = Organization({
-      features: ['performance-view', 'performance-issues-dev'],
-    });
-
-    render(
-      <ProjectPerformance
-        params={{projectId: project.slug}}
-        organization={orgWithoutPerfIssues}
-        project={project}
-        {...routerProps}
-      />
-    );
-
-    expect(performanceIssuesMock).not.toHaveBeenCalled();
   });
 
   it('renders detector threshold configuration - admin ui', async function () {

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -134,14 +134,12 @@ class ProjectPerformance extends DeprecatedAsyncView<Props, State> {
       ['project', `/projects/${organization.slug}/${projectId}/`],
     ];
 
-    if (organization.features.includes('project-performance-settings-admin')) {
-      const performanceIssuesEndpoint = [
-        'performance_issue_settings',
-        `/projects/${organization.slug}/${projectId}/performance-issues/configure/`,
-      ] as [string, string];
+    const performanceIssuesEndpoint = [
+      'performance_issue_settings',
+      `/projects/${organization.slug}/${projectId}/performance-issues/configure/`,
+    ] as [string, string];
 
-      endpoints.push(performanceIssuesEndpoint);
-    }
+    endpoints.push(performanceIssuesEndpoint);
 
     return endpoints;
   }
@@ -924,81 +922,79 @@ class ProjectPerformance extends DeprecatedAsyncView<Props, State> {
               </Access>
             </Form>
           </Feature>
-          <Feature features={['organizations:project-performance-settings-admin']}>
-            {isSuperUser && (
-              <Form
-                saveOnBlur
-                allowUndo
-                initialData={this.state.performance_issue_settings}
-                apiMethod="PUT"
-                onSubmitError={error => {
-                  if (error.status === 403) {
-                    addErrorMessage(
-                      t(
-                        'This action requires active super user access. Please re-authenticate to make changes.'
-                      )
-                    );
-                  }
-                }}
-                apiEndpoint={performanceIssuesEndpoint}
-              >
-                <JsonForm
-                  title={t(
-                    '### INTERNAL ONLY ### - Performance Issues Admin Detector Settings'
-                  )}
-                  fields={this.performanceIssueDetectorAdminFields}
-                  disabled={!isSuperUser}
-                />
-              </Form>
-            )}
+          {isSuperUser && (
             <Form
+              saveOnBlur
               allowUndo
               initialData={this.state.performance_issue_settings}
               apiMethod="PUT"
-              apiEndpoint={performanceIssuesEndpoint}
-              saveOnBlur
-              onSubmitSuccess={(option: {[key: string]: number}) => {
-                const [threshold_key, threshold_value] = Object.entries(option)[0];
-
-                trackAnalytics(
-                  'performance_views.project_issue_detection_threshold_changed',
-                  {
-                    organization,
-                    project_slug: project.slug,
-                    threshold_key,
-                    threshold_value,
-                  }
-                );
+              onSubmitError={error => {
+                if (error.status === 403) {
+                  addErrorMessage(
+                    t(
+                      'This action requires active super user access. Please re-authenticate to make changes.'
+                    )
+                  );
+                }
               }}
+              apiEndpoint={performanceIssuesEndpoint}
             >
-              <Access access={requiredScopes} project={project}>
-                {({hasAccess}) => (
-                  <div id={projectDetectorSettingsId}>
-                    <StyledPanelHeader>
-                      {t('Performance Issues - Detector Threshold Settings')}
-                    </StyledPanelHeader>
-                    <StyledJsonForm
-                      forms={this.project_owner_detector_settings(hasAccess)}
-                      collapsible
-                    />
-                    <StyledPanelFooter>
-                      <Actions>
-                        <Confirm
-                          message={t(
-                            'Are you sure you wish to reset all detector thresholds?'
-                          )}
-                          onConfirm={() => this.handleThresholdsReset()}
-                          disabled={!hasAccess || this.areAllConfigurationsDisabled}
-                        >
-                          <Button>{t('Reset All Thresholds')}</Button>
-                        </Confirm>
-                      </Actions>
-                    </StyledPanelFooter>
-                  </div>
+              <JsonForm
+                title={t(
+                  '### INTERNAL ONLY ### - Performance Issues Admin Detector Settings'
                 )}
-              </Access>
+                fields={this.performanceIssueDetectorAdminFields}
+                disabled={!isSuperUser}
+              />
             </Form>
-          </Feature>
+          )}
+          <Form
+            allowUndo
+            initialData={this.state.performance_issue_settings}
+            apiMethod="PUT"
+            apiEndpoint={performanceIssuesEndpoint}
+            saveOnBlur
+            onSubmitSuccess={(option: {[key: string]: number}) => {
+              const [threshold_key, threshold_value] = Object.entries(option)[0];
+
+              trackAnalytics(
+                'performance_views.project_issue_detection_threshold_changed',
+                {
+                  organization,
+                  project_slug: project.slug,
+                  threshold_key,
+                  threshold_value,
+                }
+              );
+            }}
+          >
+            <Access access={requiredScopes} project={project}>
+              {({hasAccess}) => (
+                <div id={projectDetectorSettingsId}>
+                  <StyledPanelHeader>
+                    {t('Performance Issues - Detector Threshold Settings')}
+                  </StyledPanelHeader>
+                  <StyledJsonForm
+                    forms={this.project_owner_detector_settings(hasAccess)}
+                    collapsible
+                  />
+                  <StyledPanelFooter>
+                    <Actions>
+                      <Confirm
+                        message={t(
+                          'Are you sure you wish to reset all detector thresholds?'
+                        )}
+                        onConfirm={() => this.handleThresholdsReset()}
+                        disabled={!hasAccess || this.areAllConfigurationsDisabled}
+                      >
+                        <Button>{t('Reset All Thresholds')}</Button>
+                      </Confirm>
+                    </Actions>
+                  </StyledPanelFooter>
+                </div>
+              )}
+            </Access>
+          </Form>
         </Fragment>
       </Fragment>
     );


### PR DESCRIPTION
Removed `organizations:project-performance-settings-admin` from the frontend. It was set to true by default and I have ensured that we've released to SH recently.

Corresponding BE pr: https://github.com/getsentry/sentry/pull/58270