### PR TITLE
fix(discover): hardcoded timestamp in test

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
@@ -214,6 +214,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
 
         data = response.data["data"]
         assert response.status_code == 200
+        assert len(data) == 2
         assert data[0][1][0]["count"] == 0.0
         assert data[1][1][0]["count"] == 4.0
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
@@ -214,7 +214,8 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
 
         data = response.data["data"]
         assert response.status_code == 200
-        assert data == [(1697364000, [{"count": 0}]), (1697364060, [{"count": 4.0}])]
+        assert data[0][1][0]["count"] == 0.0
+        assert data[1][1][0]["count"] == 4.0
 
 
 class OrganizationEventsStatsSpansMetricsEndpointTestWithMetricLayer(


### PR DESCRIPTION
Fixes a test that uses a hardcoded timestamp, which causes issues as the time is based off of a "day ago".
This test shouldn't care about the timestamps in the result, so we can just compare the `count` values directly.