### PR TITLE
fix(statistical-detectors): only consider backend transactions

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -694,6 +694,31 @@ def all_function_timeseries(
             continue
 
 
+BACKEND_TRANSACTION_OPS = [
+    # Common
+    "function.aws",
+    "function.aws.lambda",
+    "http.server",
+    "queue.process",
+    "serverless.function",
+    "task",
+    "websocket.server",
+    # Python
+    "asgi.server",
+    "celery.task",
+    "queue.task.celery",
+    "queue.task.rq",
+    "rq.task",
+    # Ruby
+    "queue.active_job",
+    "queue.delayed_job",
+    "queue.sidekiq",
+    "rails.action_cable",
+    "rails.request",
+    "sidekiq",
+]
+
+
 def query_transactions(
     org_ids: List[int],
     project_ids: List[int],
@@ -712,6 +737,11 @@ def query_transactions(
         use_case_id,
         org_ids[0],
         "transaction",
+    )
+    transaction_op_metric_id = indexer.resolve(
+        use_case_id,
+        org_ids[0],
+        "transaction.op",
     )
 
     # if our time range is more than an hour, use the hourly granularity
@@ -765,6 +795,11 @@ def query_transactions(
             Condition(Column("timestamp"), Op.GTE, start),
             Condition(Column("timestamp"), Op.LT, end),
             Condition(Column("metric_id"), Op.EQ, duration_metric_id),
+            Condition(
+                Column(f"tags_raw[{transaction_op_metric_id}]"),
+                Op.IN,
+                list(BACKEND_TRANSACTION_OPS),
+            ),
         ],
         limitby=LimitBy([Column("project_id")], transactions_per_project),
         orderby=[

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1028,6 +1028,7 @@ def _raw_snql_query(
         with thread_hub.start_span(op="snuba_snql.validation", description=referrer) as span:
             span.set_tag("snuba.referrer", referrer)
             body = request.serialize()
+            print("SNQL body", body)
 
         with thread_hub.start_span(op="snuba_snql.run", description=str(request)) as span:
             span.set_tag("snuba.referrer", referrer)

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -461,12 +461,13 @@ class TestTransactionsQuery(MetricsAPIBaseTestCase):
 
         for project in self.projects:
             for i in range(self.num_transactions):
+                # Store metrics for a backend transaction
                 self.store_metric(
                     self.org.id,
                     project.id,
                     "distribution",
                     TransactionMRI.DURATION.value,
-                    {"transaction": f"transaction_{i}"},
+                    {"transaction": f"transaction_{i}", "transaction.op": "http.server"},
                     self.hour_ago_seconds,
                     1.0,
                     UseCaseID.TRANSACTIONS,
@@ -476,7 +477,30 @@ class TestTransactionsQuery(MetricsAPIBaseTestCase):
                     project.id,
                     "distribution",
                     TransactionMRI.DURATION.value,
-                    {"transaction": f"transaction_{i}"},
+                    {"transaction": f"transaction_{i}", "transaction.op": "http.server"},
+                    self.hour_ago_seconds,
+                    9.5,
+                    UseCaseID.TRANSACTIONS,
+                )
+
+                # Store metrics for a frontend transaction, which should be
+                # ignored by the query
+                self.store_metric(
+                    self.org.id,
+                    project.id,
+                    "distribution",
+                    TransactionMRI.DURATION.value,
+                    {"transaction": f"fe_transaction_{i}", "transaction.op": "navigation"},
+                    self.hour_ago_seconds,
+                    1.0,
+                    UseCaseID.TRANSACTIONS,
+                )
+                self.store_metric(
+                    self.org.id,
+                    project.id,
+                    "distribution",
+                    TransactionMRI.DURATION.value,
+                    {"transaction": f"fe_transaction_{i}", "transaction.op": "navigation"},
                     self.hour_ago_seconds,
                     9.5,
                     UseCaseID.TRANSACTIONS,
@@ -492,7 +516,7 @@ class TestTransactionsQuery(MetricsAPIBaseTestCase):
             [p.id for p in self.projects],
             self.hour_ago,
             self.now,
-            self.num_transactions,
+            self.num_transactions + 1,  # detect if any extra transactions are returned
         )
         assert len(res) == len(self.projects) * self.num_transactions
         for trend_payload in res:


### PR DESCRIPTION
The p95 transaction duration detection should only run on backend transactions. Other types of transactions produce alternative metrics that are more meaningful (LCP for frontend transactions, for example).

The list of backend transaction `op`s is not exhaustive. It comes from an examination of our SDKs and source like our histogram outlier calculations: https://github.com/getsentry/sentry/blob/e523203841c1d26db86156af2d98993164f04bdf/src/sentry/relay/config/metric_extraction.py#L468C1-L468C34

More can be added as they are discovered.
