### PR TITLE
fix(replays): fix missing bracket case for dom element parsing

### DIFF
--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -82,7 +82,7 @@ export function hydratedSelectorData(data, clickType?): DeadRageSelectorItem[] {
       selector: constructSelector(d.element).selector,
       projectId: d.project_id,
     },
-    element: d.dom_element.split(/[#.]+/)[0],
+    element: d.dom_element.split(/[#.[]+/)[0],
     aria_label: getAriaLabel(d.dom_element),
     project_id: d.project_id,
   }));


### PR DESCRIPTION
missed a bracket! not all elements have classes or IDs 