### PR TITLE
feat(browser-starfish): show resource size stats

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import FeatureBadge from 'sentry/components/featureBadge';
+import FileSize from 'sentry/components/fileSize';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
@@ -24,7 +25,14 @@ import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
 import {SampleList} from 'sentry/views/starfish/views/spanSummaryPage/sampleList';
 
-const {SPAN_SELF_TIME, SPAN_OP, SPAN_DESCRIPTION} = SpanMetricsField;
+const {
+  SPAN_SELF_TIME,
+  SPAN_OP,
+  SPAN_DESCRIPTION,
+  HTTP_DECODED_RESPONSE_BODY_LENGTH,
+  HTTP_RESPONSE_CONTENT_LENGTH,
+  HTTP_RESPONSE_TRANSFER_SIZE,
+} = SpanMetricsField;
 
 function ResourceSummary() {
   const organization = useOrganization();
@@ -34,6 +42,9 @@ function ResourceSummary() {
   } = useLocation();
   const {data: spanMetrics} = useSpanMetrics(groupId, {}, [
     `avg(${SPAN_SELF_TIME})`,
+    `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
+    `avg(${HTTP_DECODED_RESPONSE_BODY_LENGTH})`,
+    `avg(${HTTP_RESPONSE_TRANSFER_SIZE})`,
     'spm()',
     SPAN_OP,
     SPAN_DESCRIPTION,
@@ -82,6 +93,17 @@ function ResourceSummary() {
               </PageFilterBar>
             </PaddedContainer>
             <BlockContainer>
+              <Block title={t('Avg encoded size')}>
+                <FileSize bytes={spanMetrics?.[`avg(${HTTP_RESPONSE_CONTENT_LENGTH})`]} />
+              </Block>
+              <Block title={t('Avg decoded size')}>
+                <FileSize
+                  bytes={spanMetrics?.[`avg(${HTTP_DECODED_RESPONSE_BODY_LENGTH})`]}
+                />
+              </Block>
+              <Block title={t('Avg transfer size')}>
+                <FileSize bytes={spanMetrics?.[`avg(${HTTP_RESPONSE_TRANSFER_SIZE})`]} />
+              </Block>
               <Block title={DataTitles.avg}>
                 <DurationCell
                   milliseconds={spanMetrics?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]}

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -28,9 +28,16 @@ export enum SpanMetricsField {
   PROJECT_ID = 'project.id',
   RESOURCE_RENDER_BLOCKING_STATUS = 'resource.render_blocking_status',
   HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length',
+  HTTP_DECODED_RESPONSE_BODY_LENGTH = 'http.decoded_response_body_length',
+  HTTP_RESPONSE_TRANSFER_SIZE = 'http.response_transfer_size',
 }
 
-export type SpanNumberFields = 'span.self_time' | 'span.duration';
+export type SpanNumberFields =
+  | 'span.self_time'
+  | 'span.duration'
+  | SpanMetricsField.HTTP_DECODED_RESPONSE_BODY_LENGTH
+  | SpanMetricsField.HTTP_RESPONSE_CONTENT_LENGTH
+  | SpanMetricsField.HTTP_RESPONSE_TRANSFER_SIZE;
 
 export type SpanStringFields =
   | 'span.op'

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -33,8 +33,8 @@ export enum SpanMetricsField {
 }
 
 export type SpanNumberFields =
-  | 'span.self_time'
-  | 'span.duration'
+  | SpanMetricsField.SPAN_SELF_TIME
+  | SpanMetricsField.SPAN_DURATION
   | SpanMetricsField.HTTP_DECODED_RESPONSE_BODY_LENGTH
   | SpanMetricsField.HTTP_RESPONSE_CONTENT_LENGTH
   | SpanMetricsField.HTTP_RESPONSE_TRANSFER_SIZE;


### PR DESCRIPTION
Adds stats for avg resource encoded/decoded and transfer size.