### PR TITLE
feat(browser-starfish): link resource samples to page load module

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -98,7 +98,7 @@ function ResourceSummary() {
           <ResourceSummaryCharts groupId={groupId} />
           <ResourceSummaryTable />
           <SampleList
-            isBrowser
+            transactionRoute="/performance/browser/pageloads/"
             groupId={groupId}
             transactionName={transaction as string}
           />

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -97,7 +97,11 @@ function ResourceSummary() {
           </HeaderContainer>
           <ResourceSummaryCharts groupId={groupId} />
           <ResourceSummaryTable />
-          <SampleList groupId={groupId} transactionName={transaction as string} />
+          <SampleList
+            isBrowser
+            groupId={groupId}
+            transactionName={transaction as string}
+          />
         </Layout.Main>
       </Layout.Body>
     </ModulePageProviders>

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -24,7 +24,6 @@ import SampleTable from 'sentry/views/starfish/views/spanSummaryPage/sampleList/
 type Props = {
   groupId: string;
   transactionName: string;
-  isBrowser?: boolean;
   onClose?: () => void;
   spanDescription?: string;
   transactionMethod?: string;

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -28,6 +28,7 @@ type Props = {
   onClose?: () => void;
   spanDescription?: string;
   transactionMethod?: string;
+  transactionRoute?: string;
 };
 
 export function SampleList({
@@ -36,7 +37,7 @@ export function SampleList({
   transactionMethod,
   spanDescription,
   onClose,
-  isBrowser,
+  transactionRoute = '/performance/summary/',
 }: Props) {
   const router = useRouter();
   const [highlightedSpanId, setHighlightedSpanId] = useState<string | undefined>(
@@ -77,15 +78,10 @@ export function SampleList({
       ? `${transactionMethod} ${transactionName}`
       : transactionName;
 
-  const link = isBrowser
-    ? `/performance/browser/pageloads/?${qs.stringify({
-        project: query.project,
-        transaction: transactionName,
-      })}`
-    : `/performance/summary/?${qs.stringify({
-        project: query.project,
-        transaction: transactionName,
-      })}`;
+  const link = `${transactionRoute}?${qs.stringify({
+    project: query.project,
+    transaction: transactionName,
+  })}`;
 
   function defaultOnClose() {
     router.replace({

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -24,6 +24,7 @@ import SampleTable from 'sentry/views/starfish/views/spanSummaryPage/sampleList/
 type Props = {
   groupId: string;
   transactionName: string;
+  isBrowser?: boolean;
   onClose?: () => void;
   spanDescription?: string;
   transactionMethod?: string;
@@ -35,6 +36,7 @@ export function SampleList({
   transactionMethod,
   spanDescription,
   onClose,
+  isBrowser,
 }: Props) {
   const router = useRouter();
   const [highlightedSpanId, setHighlightedSpanId] = useState<string | undefined>(
@@ -75,10 +77,15 @@ export function SampleList({
       ? `${transactionMethod} ${transactionName}`
       : transactionName;
 
-  const link = `/performance/summary/?${qs.stringify({
-    project: query.project,
-    transaction: transactionName,
-  })}`;
+  const link = isBrowser
+    ? `/performance/browser/pageloads/?${qs.stringify({
+        project: query.project,
+        transaction: transactionName,
+      })}`
+    : `/performance/summary/?${qs.stringify({
+        project: query.project,
+        transaction: transactionName,
+      })}`;
 
   function defaultOnClose() {
     router.replace({


### PR DESCRIPTION
When you click the page name in the resource span samples, it will now take you to the page load module.
<img width="742" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/5ead7e8a-76ac-4e97-9417-d4df39a0663e">
