### PR TITLE
feat(replays): Move timeline into replay controller component

### DIFF
--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -6,6 +6,7 @@ import screenfull from 'screenfull';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {CompositeSelect} from 'sentry/components/compactSelect/composite';
+import ReplayTimeline from 'sentry/components/replays/breadcrumbs/replayTimeline';
 import {PlayerScrubber} from 'sentry/components/replays/player/scrubber';
 import useScrubberMouseTracking from 'sentry/components/replays/player/useScrubberMouseTracking';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
@@ -185,13 +186,16 @@ function ReplayControls({
   return (
     <ButtonGrid ref={barRef} isCompact={isCompact}>
       <ReplayPlayPauseBar />
-      <TimeAndScrubber isCompact={isCompact}>
-        <Time>{formatTime(currentTime)}</Time>
-        <StyledScrubber ref={elem} {...mouseTrackingProps}>
-          <PlayerScrubber />
-        </StyledScrubber>
-        <Time>{durationMs ? formatTime(durationMs) : '--:--'}</Time>
-      </TimeAndScrubber>
+      <Container>
+        <ReplayTimeline />
+        <TimeAndScrubber isCompact={isCompact}>
+          <Time>{formatTime(currentTime)}</Time>
+          <StyledScrubber ref={elem} {...mouseTrackingProps}>
+            <PlayerScrubber />
+          </StyledScrubber>
+          <Time>{durationMs ? formatTime(durationMs) : '--:--'}</Time>
+        </TimeAndScrubber>
+      </Container>
       <ButtonBar gap={1}>
         <ReplayOptionsMenu speedOptions={speedOptions} />
         {showFullscreenButton ? (
@@ -214,6 +218,12 @@ const ButtonGrid = styled('div')<{isCompact: boolean}>`
   flex-direction: row;
   justify-content: space-between;
   ${p => (p.isCompact ? `flex-wrap: wrap;` : '')}
+`;
+
+const Container = styled('div')`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1;
 `;
 
 const TimeAndScrubber = styled('div')<{isCompact: boolean}>`

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -183,11 +183,13 @@ function ReplayControls({
   const elem = useRef<HTMLDivElement>(null);
   const mouseTrackingProps = useScrubberMouseTracking({elem});
 
+  const hasNewTimeline = organization.features.includes('session-replay-new-timeline');
+
   return (
     <ButtonGrid ref={barRef} isCompact={isCompact}>
       <ReplayPlayPauseBar />
       <Container>
-        <ReplayTimeline />
+        {hasNewTimeline ? <ReplayTimeline /> : null}
         <TimeAndScrubber isCompact={isCompact}>
           <Time>{formatTime(currentTime)}</Time>
           <StyledScrubber ref={elem} {...mouseTrackingProps}>

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -6,6 +6,7 @@ import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
+import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
 import BrowserOSIcons from 'sentry/views/replays/detail/browserOSIcons';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 
@@ -16,6 +17,8 @@ type Props = {
 function ReplayView({toggleFullscreen}: Props) {
   const organization = useOrganization();
   const hasNewTimeline = organization.features.includes('session-replay-new-timeline');
+  const isFullscreen = useIsFullscreen();
+
   return (
     <Fragment>
       <ContextContainer>
@@ -25,7 +28,11 @@ function ReplayView({toggleFullscreen}: Props) {
       <Panel>
         <ReplayPlayer />
       </Panel>
-      {hasNewTimeline ? null : <ReplayController toggleFullscreen={toggleFullscreen} />}
+      {isFullscreen ? (
+        <ReplayController toggleFullscreen={toggleFullscreen} />
+      ) : hasNewTimeline ? null : (
+        <ReplayController toggleFullscreen={toggleFullscreen} />
+      )}
     </Fragment>
   );
 }

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -28,11 +28,9 @@ function ReplayView({toggleFullscreen}: Props) {
       <Panel>
         <ReplayPlayer />
       </Panel>
-      {isFullscreen ? (
+      {isFullscreen || !hasNewTimeline ? (
         <ReplayController toggleFullscreen={toggleFullscreen} />
-      ) : hasNewTimeline ? null : (
-        <ReplayController toggleFullscreen={toggleFullscreen} />
-      )}
+      ) : null}
     </Fragment>
   );
 }

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -55,7 +55,6 @@ function ReplayLayout({layout = LayoutKey.TOPBAR}: Props) {
 
   const controller = hasNewTimeline ? (
     <ErrorBoundary>
-      <ReplayTimeline />
       <ReplayController toggleFullscreen={toggleFullscreen} />
     </ErrorBoundary>
   ) : null;


### PR DESCRIPTION
Move the timeline into the replay controller component

<img width="1497" alt="image" src="https://github.com/getsentry/sentry/assets/55311782/867b229e-befd-4e75-9ac1-25e97f27f38a">

Closes https://github.com/getsentry/team-replay/issues/198