### PR TITLE
fix(hybridcloud) Update integration.date_updated correctly

### DIFF
--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tuple
 
+from django.utils import timezone
+
 from sentry import analytics
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import AppPlatformEvent
@@ -259,6 +261,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
 
         if not integration_kwargs:
             return []
+        integration_kwargs["date_updated"] = timezone.now()
 
         integrations.update(**integration_kwargs)
 

--- a/tests/sentry/hybrid_cloud/test_integration.py
+++ b/tests/sentry/hybrid_cloud/test_integration.py
@@ -167,9 +167,11 @@ class IntegrationServiceTest(BaseIntegrationServiceTest):
             integration_ids=[i.id for i in integrations], metadata=new_metadata
         )
         for i in integrations:
+            original_time = i.date_updated
             assert i.metadata != new_metadata
             i.refresh_from_db()
             assert i.metadata == new_metadata
+            assert original_time != i.date_updated, "date_updated should change"
 
     def test_get_installation(self):
         api_integration1 = serialize_integration(integration=self.integration1)


### PR DESCRIPTION
When integrations are updated via hybridcloud services we should also update the date_updated attribute.

Fixes HC-939