### PR TITLE
feat(severity): Add support for backlog testing

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2101,6 +2101,12 @@ def _get_severity_score(event: Event) -> float | None:
         # we should update the model to account for three values: True, False, and None
         "handled": 0 if is_handled(event.data) is False else 1,
     }
+
+    if options.get("processing.severity-backlog-test.timeout"):
+        payload["trigger_timeout"] = True
+    if options.get("processing.severity-backlog-test.error"):
+        payload["trigger_error"] = True
+
     logger_data["payload"] = payload
 
     with metrics.timer(op):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -722,6 +722,22 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Enable sending the flag to the microservice to tell it to purposefully take longer than our
+# timeout, to see the effect on the overall error event processing backlog
+register(
+    "processing.severity-backlog-test.timeout",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# Enable sending the flag to the microservice to tell it to purposefully send back an error, to see
+# the effect on the overall error event processing backlog
+register(
+    "processing.severity-backlog-test.error",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # ## sentry.killswitches
 #


### PR DESCRIPTION
This adds two options, `processing.severity-backlog-test.timeout` and `processing.severity-backlog-test.error`, both defaulting to `False`, which enable the sending of the trigger values added in https://github.com/getsentry/timeseries-analysis-service/pull/96. Turning either one of these on will allow us to observe the effect that problems with the severity microservice might have on the overall event processing backlog. 

Related:

PR [adding the options](https://github.com/getsentry/sentry-options-automator/pull/320) to the options automator

PRs turning the timeout test [on](https://github.com/getsentry/sentry-options-automator/pull/322) and [off](https://github.com/getsentry/sentry-options-automator/pull/323)

PRs turning the error test [on](https://github.com/getsentry/sentry-options-automator/pull/324) and [off](https://github.com/getsentry/sentry-options-automator/pull/325)