### PR TITLE
ref(compactSelect): Add `menuWiderThanTrigger` prop

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -12,7 +12,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
 import {useKeyboard} from '@react-aria/interactions';
-import {mergeProps} from '@react-aria/utils';
+import {mergeProps, useResizeObserver} from '@react-aria/utils';
 import {ListState} from '@react-stately/list';
 import {OverlayTriggerState} from '@react-stately/overlays';
 
@@ -143,6 +143,11 @@ export interface ControlProps
    * Title to display in the menu's header. Keep the title as short as possible.
    */
   menuTitle?: React.ReactNode;
+  /**
+   * Whether the menu should always be wider than the trigger. If true, then the menu
+   * will have a min width equal to the trigger's width. Defaults to false.
+   */
+  menuWiderThanTrigger?: boolean;
   menuWidth?: number | string;
   /**
    * Called when the clear button is clicked (applicable only when `clearable` is
@@ -208,6 +213,7 @@ export function Control({
   maxMenuHeight = '32rem',
   maxMenuWidth,
   menuWidth,
+  menuWiderThanTrigger = false,
   menuBody,
   menuFooter,
 
@@ -445,6 +451,31 @@ export function Control({
     [registerListState, saveSelectedOptions, overlayState, overlayIsOpen, search]
   );
 
+  // Calculate the current trigger element's width. This will be used as
+  // the min width for the menu.
+  const [triggerWidth, setTriggerWidth] = useState<number>();
+  // Update triggerWidth when its size changes using useResizeObserver
+  const updateTriggerWidth = useCallback(async () => {
+    if (!menuWiderThanTrigger) {
+      return;
+    }
+
+    // Wait until the trigger element finishes rendering, otherwise
+    // ResizeObserver might throw an infinite loop error.
+    await new Promise(resolve => window.setTimeout(resolve));
+    setTriggerWidth(triggerRef.current?.offsetWidth ?? 0);
+  }, [menuWiderThanTrigger, triggerRef]);
+
+  useResizeObserver({ref: triggerRef, onResize: updateTriggerWidth});
+  // If ResizeObserver is not available, manually update the width
+  // when any of [trigger, triggerLabel, triggerProps] changes.
+  useEffect(() => {
+    if (typeof window.ResizeObserver !== 'undefined') {
+      return;
+    }
+    updateTriggerWidth();
+  }, [updateTriggerWidth]);
+
   const theme = useTheme();
   return (
     <SelectContext.Provider value={contextValue}>
@@ -468,6 +499,7 @@ export function Control({
         >
           <StyledOverlay
             width={menuWidth ?? menuFullWidth}
+            minWidth={triggerWidth}
             maxWidth={maxMenuWidth}
             maxHeight={overlayProps.style.maxHeight}
             maxHeightProp={maxMenuHeight}
@@ -631,6 +663,7 @@ const StyledOverlay = styled(Overlay, {
   maxHeightProp: string | number;
   maxHeight?: string | number;
   maxWidth?: string | number;
+  minWidth?: string | number;
   width?: string | number;
 }>`
   /* Should be a flex container so that when maxHeight is set (to avoid page overflow),
@@ -640,6 +673,7 @@ const StyledOverlay = styled(Overlay, {
   overflow: hidden;
 
   ${p => p.width && `width: ${withUnits(p.width)};`}
+  ${p => p.minWidth && `min-width: ${withUnits(p.minWidth)};`}
   max-width: ${p => (p.maxWidth ? `min(${withUnits(p.maxWidth)}, 100%)` : `100%`)};
   max-height: ${p =>
     p.maxHeight


### PR DESCRIPTION
Add an optional prop to make the popup menu at least as wide as the trigger button. We already have this same prop for `<DropdownMenu />`.

**Without `menuWiderThanTrigger` ——**
<img width="304" alt="Screenshot 2023-10-17 at 3 38 54 PM" src="https://github.com/getsentry/sentry/assets/44172267/b34c71cd-2f7d-4bbd-b0e3-c42e5f80855e">

**With `menuWiderThanTrigger` enabled ——**
<img width="304" alt="Screenshot 2023-10-17 at 3 38 30 PM" src="https://github.com/getsentry/sentry/assets/44172267/675dd158-5062-4cb2-a5ec-685032ef75a7">
