### PR TITLE
fix(ui): Correctly display scopes when org:integrations present

### DIFF
--- a/static/app/utils/consolidatedScopes.spec.tsx
+++ b/static/app/utils/consolidatedScopes.spec.tsx
@@ -17,6 +17,17 @@ describe('ConsolidatedScopes', () => {
     );
   });
 
+  it('removes org:integrations scopes', () => {
+    scopes.push('org:integrations');
+    expect(toResourcePermissions(scopes)).toEqual(
+      expect.objectContaining({
+        Event: 'admin',
+        Release: 'admin',
+        Organization: 'read',
+      })
+    );
+  });
+
   it('exposes scopes, grouped by access level', () => {
     expect(toPermissions(scopes)).toEqual({
       admin: expect.arrayContaining(['Event', 'Release']),

--- a/static/app/utils/consolidatedScopes.tsx
+++ b/static/app/utils/consolidatedScopes.tsx
@@ -29,6 +29,7 @@ const DEFAULT_RESOURCE_PERMISSIONS: Permissions = {
 };
 
 const PROJECT_RELEASES = 'project:releases';
+const ORG_INTEGRATIONS = 'org:integrations';
 
 type PermissionLevelResources = {
   admin: string[];
@@ -88,6 +89,12 @@ function toResourcePermissions(scopes: string[]): Permissions {
     permissions.Release = 'admin';
     filteredScopes = scopes.filter((scope: string) => scope !== PROJECT_RELEASES); // remove project:releases
   }
+
+  // We have a special case with the org:integrations scope. This scope is
+  // added when selecting org:admin for hierarchy, but the reverse is not true.
+  // It doesn't indicate any specific org permission, so we can remove it
+  // entirely.
+  filteredScopes = filteredScopes.filter((scope: string) => scope !== ORG_INTEGRATIONS);
 
   topScopes(filteredScopes).forEach((scope: string | undefined) => {
     if (scope) {


### PR DESCRIPTION
Additional Fix for https://github.com/getsentry/sentry/issues/58020

Previously if you selected `admin` for you integration, upon creation the dropdown would incorrectly display your scopes as `read+write` despite the backend functioning as expected. 

This happened because of the way we mapped the scopes returned from the GET to the dropdowns. Because `org:integrations` does not actually indicate any specific level of org access, we can remove just remove it from the scopes list and nicely go back to how it worked before

### Before

https://github.com/getsentry/sentry/assets/67301797/8cc0a009-fc74-4cd4-a54f-8be274881810


### After

https://github.com/getsentry/sentry/assets/67301797/652b522f-804a-46d6-be7b-66121d236003
