### PR TITLE
fix(alert-rule): Stop creating external issue for alert rule test notifcation

### DIFF
--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -108,4 +108,6 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             )
             return
         response = installation.create_issue(data)
-        create_link(integration, installation, event, response)
+
+        if not event.get_tag("sample_event") == "yes":
+            create_link(integration, installation, event, response)

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -1,7 +1,12 @@
 from unittest import mock
 
+from sentry.integrations.jira.integration import JiraIntegration
+from sentry.models.integrations.external_issue import ExternalIssue
+from sentry.models.integrations.integration import Integration
 from sentry.rules.actions.notify_event import NotifyEventAction
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba]
@@ -11,6 +16,9 @@ class ProjectRuleActionsEndpointTest(APITestCase):
     endpoint = "sentry-api-0-project-rule-actions"
     method = "POST"
 
+    def setUp(self):
+        self.login_as(self.user)
+
     @mock.patch.object(NotifyEventAction, "after")
     def test_actions(self, action):
         action_data = [
@@ -18,14 +26,33 @@ class ProjectRuleActionsEndpointTest(APITestCase):
                 "id": "sentry.rules.actions.notify_event.NotifyEventAction",
             }
         ]
-        self.login_as(self.user)
 
         self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
 
         assert action.called
 
-    def test_no_events(self):
-        self.login_as(self.user)
+    @mock.patch.object(JiraIntegration, "create_issue")
+    def test_sample_event_does_not_create_external_issue(self, mock_create_issue):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.jira_integration = Integration.objects.create(
+                provider="jira", name="Jira", external_id="jira:1"
+            )
+            self.jira_integration.add_organization(self.organization, self.user)
 
+        action_data = [
+            {
+                "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",
+                "dynamic_form_fields": {
+                    "fake_field": "fake_value",
+                },
+            }
+        ]
+
+        self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
+        assert mock_create_issue.call_count == 1
+        assert ExternalIssue.objects.count() == 0
+
+    def test_no_events(self):
         response = self.get_response(self.organization.slug, self.project.slug)
+        assert response.status_code == 400
         assert response.status_code == 400


### PR DESCRIPTION
After you click `Send Test Notification`, we actually create an external issue for the sample event. However, the sample event is not surfaced through the UI anywhere, and having an external issue actually stops you from sending multiple test events for different Jira issue types such as story, bug, etc.

![Screenshot 2023-10-17 at 7 51 03 PM](https://github.com/getsentry/sentry/assets/67301797/193fd900-9aca-46a6-8a70-02ddccf6b133)
