### PR TITLE
Renamed 'account number' to correct name 'Account ID'

### DIFF
--- a/src/sentry/integrations/aws_lambda/client.py
+++ b/src/sentry/integrations/aws_lambda/client.py
@@ -33,7 +33,7 @@ class ProxyResponseSerializer(serializers.Serializer):
 
 def gen_aws_client(account_number, region, aws_external_id, service_name="lambda"):
     """
-    account_number - account number in AWS
+    account_number - account ID in AWS
     region - region in AWS
     aws_external_id - the external_id used to assume the role
 

--- a/static/app/views/integrationPipeline/awsLambdaCloudformation.spec.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaCloudformation.spec.tsx
@@ -34,7 +34,7 @@ describe('AwsLambdaCloudformation', () => {
 
     // Fill out fields
     await userEvent.type(
-      screen.getByRole('textbox', {name: 'AWS Account Number'}),
+      screen.getByRole('textbox', {name: 'AWS Account ID'}),
       '599817902985'
     );
 

--- a/static/app/views/integrationPipeline/awsLambdaCloudformation.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaCloudformation.tsx
@@ -123,9 +123,9 @@ export default class AwsLambdaCloudformation extends Component<Props, State> {
     // validate the account number
     let accountNumberError = '';
     if (!value) {
-      accountNumberError = t('Account number required');
+      accountNumberError = t('Account ID required');
     } else if (!testAccountNumber(value)) {
-      accountNumberError = t('Invalid account number');
+      accountNumberError = t('Invalid Account ID');
     }
     this.setState({accountNumberError});
   };
@@ -231,10 +231,10 @@ export default class AwsLambdaCloudformation extends Component<Props, State> {
                 error={accountNumberError}
                 inline={false}
                 stacked
-                label={t('AWS Account Number')}
+                label={t('AWS Account ID')}
                 showHelpInTooltip
                 help={t(
-                  'Your account number can be found on the right side of the header in AWS'
+                  'Your Account ID can be found on the right side of the header in AWS'
                 )}
               />
               <SelectField


### PR DESCRIPTION
In AWS it is called `Account ID` and not `Account number`.
Renamed all visible occurrences in AWS Lambda integration.

![Screenshot 2023-10-18 at 11 38 59](https://github.com/getsentry/sentry/assets/202325/b2429784-3196-4a4b-994a-99161bb3c2cb)
