### PR TITLE
Enabled Python 3.10 and 3.11 for AWS Lambda integration

### DIFF
--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -21,6 +21,8 @@ SUPPORTED_RUNTIMES = [
     "python3.7",
     "python3.8",
     "python3.9",
+    "python3.10",
+    "python3.11",
 ]
 
 INVALID_LAYER_TEXT = "Invalid existing layer %s"


### PR DESCRIPTION
Added Python 3.10 and 3.11 to the `SUPPORTED_RUNTIMES` in the AWS Lambda integration.

Related docs PR: https://github.com/getsentry/sentry-docs/pull/8246