### PR TITLE
ref: Removed unused feature organizations:getting-started-doc-with-product-selection

### DIFF
--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -351,7 +351,6 @@ detailed_project = {
             "profile-image-decode-main-thread-post-process-group",
             "performance-mep-bannerless-ui",
             "performance-uncompressed-assets-visible",
-            "getting-started-doc-with-product-selection",
             "performance-large-http-payload-visible",
             "performance-view",
             "promotion-mobperf-discount20",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1748,8 +1748,6 @@ SENTRY_FEATURES = {
     "organizations:device-classification": False,
     # Enables synthesis of device.class in ingest
     "organizations:device-class-synthesis": False,
-    # Enable the product selection feature in the getting started docs, regardless of the organization's strategy
-    "organizations:getting-started-doc-with-product-selection": False,
     # Enable the SDK selection feature in the onboarding
     "organizations:onboarding-sdk-selection": False,
     # Enable OpenAI suggestions in the issue details page

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -237,7 +237,6 @@ default_manager.add("organizations:escalating-issues-msteams", OrganizationFeatu
 default_manager.add("organizations:escalating-issues-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:escalating-metrics-backend", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:integrations-gh-invite", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:getting-started-doc-with-product-selection", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:integrations-deployment", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:integrations-feature-flag-integration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:onboarding-sdk-selection", OrganizationFeature, FeatureHandlerStrategy.REMOTE)


### PR DESCRIPTION
This PR removes the unused feature: `organizations:getting-started-doc-with-product-selection` from backend

Resolves https://github.com/getsentry/sentry/issues/55244