### PR TITLE
remove unused feature frontend getting-started-doc-with-product-selection

### DIFF
--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -131,13 +131,6 @@ export function ProjectInstallPlatform({location, params}: Props) {
     projectAlertRulesIsError,
   ]);
 
-  // This is a feature flag that is currently only enabled for a subset of internal users until the feature is fully implemented,
-  // but the purpose of the feature is to make the product selection feature in documents available to all users
-  // and guide them to upgrade to a plan if one of the products is not available on their current plan.
-  const gettingStartedDocWithProductSelection = !!organization?.features.includes(
-    'getting-started-doc-with-product-selection'
-  );
-
   const platform: Platform = {
     key: currentPlatformKey,
     id: currentPlatform?.id,
@@ -177,7 +170,6 @@ export function ProjectInstallPlatform({location, params}: Props) {
   const showPerformancePrompt = performancePlatforms.includes(platform.id as PlatformKey);
   const isGettingStarted = window.location.href.indexOf('getting-started') > 0;
   const showDocsWithProductSelection =
-    gettingStartedDocWithProductSelection &&
     (platformProductAvailability[platform.key] ?? []).length > 0;
 
   return (


### PR DESCRIPTION
This PR removes the unused feature `getting-started-doc-with-product-selection`

Resolves https://github.com/getsentry/sentry/issues/55244