### PR TITLE
ref(tsc): Convert OrganizationSettingsForm to FC

### DIFF
--- a/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
@@ -66,9 +66,17 @@ describe('OrganizationGeneralSettings', function () {
   });
 
   it('can enable "codecov access"', async function () {
-    defaultProps.organization.features.push('codecov-integration');
-    organization.codecovAccess = false;
-    render(<OrganizationGeneralSettings {...defaultProps} />);
+    const organizationWithCodecovFeature = Organization({
+      features: ['codecov-integration'],
+      codecovAccess: false,
+    });
+    render(
+      <OrganizationGeneralSettings
+        {...defaultProps}
+        organization={organizationWithCodecovFeature}
+      />,
+      {organization: organizationWithCodecovFeature}
+    );
     const mock = MockApiClient.addMockResponse({
       url: ENDPOINT,
       method: 'PUT',

--- a/static/app/views/settings/organizationGeneralSettings/index.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.tsx
@@ -110,12 +110,7 @@ function OrganizationGeneralSettings(props: Props) {
         <SettingsPageHeader title={t('Organization Settings')} />
         <PermissionAlert />
 
-        <OrganizationSettingsForm
-          {...props}
-          initialData={organization}
-          access={access}
-          onSave={handleSaveForm}
-        />
+        <OrganizationSettingsForm initialData={organization} onSave={handleSaveForm} />
 
         {access.has('org:admin') && !organization.isDefault && (
           <Panel>

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -40,7 +40,6 @@ describe('OrganizationSettingsForm', function () {
     render(
       <OrganizationSettingsForm
         {...routerProps}
-        access={new Set(['org:write'])}
         initialData={Organization()}
         onSave={onSave}
       />
@@ -107,7 +106,6 @@ describe('OrganizationSettingsForm', function () {
     render(
       <OrganizationSettingsForm
         {...routerProps}
-        access={new Set(['org:write'])}
         initialData={Organization()}
         onSave={onSave}
       />
@@ -143,7 +141,6 @@ describe('OrganizationSettingsForm', function () {
     render(
       <OrganizationSettingsForm
         {...routerProps}
-        access={new Set(['org:write'])}
         initialData={Organization({codecovAccess: false})}
         onSave={onSave}
       />,


### PR DESCRIPTION
Convert to FC and drop request as the received data was not used anymore.
Use `useOrganization` and `useLocation` instead of receiving them via props.

Ref https://github.com/getsentry/frontend-tsc/issues/2