### PR TITLE
fix(perf-issues): Remove query from similar spans link

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -346,6 +346,7 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
         relatedErrors={errors}
         scrollToHash={this.scrollIntoView}
         resetCellMeasureCache={this.props.resetCellMeasureCache}
+        isSpanInEmbeddedTree={this.props.isSpanInEmbeddedTree}
       />
     );
   }

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -90,6 +90,7 @@ type Props = {
   childTransactions: QuickTraceEvent[] | null;
   event: Readonly<EventTransaction>;
   isRoot: boolean;
+  isSpanInEmbeddedTree: boolean;
   organization: Organization;
   relatedErrors: TraceErrorOrIssue[] | null;
   resetCellMeasureCache: () => void;
@@ -255,7 +256,7 @@ function SpanDetail(props: Props) {
   }
 
   function renderViewSimilarSpansButton() {
-    const {span, organization, event} = props;
+    const {span, organization, event, isSpanInEmbeddedTree} = props;
 
     if (isGapSpan(span) || !span.op || !span.hash) {
       return null;
@@ -266,7 +267,7 @@ function SpanDetail(props: Props) {
     const target = spanDetailsRouteWithQuery({
       orgSlug: organization.slug,
       transaction: transactionName,
-      query: location.query,
+      query: isSpanInEmbeddedTree ? '' : location.query,
       spanSlug: {op: span.op, group: span.hash},
       projectID: event.projectID,
     });


### PR DESCRIPTION
### Summary
This removes the query from the 'similar spans' link when the button is in an embedded tree. In this case it's embedded inside performance issues, which have issue filters in their query. In the long term we should likely diverge the query key names or have context aware parsing of the query when the user switches between areas of the product.

