### PR TITLE
fix(stat-detectors): Disable Replays for Duration Regression issues

### DIFF
--- a/static/app/utils/issueTypeConfig/performanceConfig.tsx
+++ b/static/app/utils/issueTypeConfig/performanceConfig.tsx
@@ -189,6 +189,7 @@ const performanceConfig: IssueCategoryConfigMapping = {
   },
   [IssueType.PERFORMANCE_DURATION_REGRESSION]: {
     stats: {enabled: false},
+    replays: {enabled: false},
   },
   [IssueType.PROFILE_FILE_IO_MAIN_THREAD]: {
     resources: {


### PR DESCRIPTION
Disabling the tab for now because the changes to the replay-related hooks aren't semantic and consistent with the original hook implementations. e.g. useReplaysCount accepts transaction names, but we can't apply other filters such as duration like we do in the Sampled Events tab.

~I tested out a way to apply more filters such as the duration and realized the replay count endpoint actually rejects the query. It only accepts `issue.id`, `transaction`, or `replayId` as conditions~ This was a bug in my implementation that passed `transaction` twice.