### PR TITLE
feat(stat-detectors): Link Replays to statistical detector issue details

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
@@ -39,7 +39,7 @@ export function getSampleEventQuery({
   transaction: string;
   addUpperBound?: boolean;
 }) {
-  const baseQuery = `event.type:transaction transaction:"${transaction}" transaction.duration:>=${
+  const baseQuery = `event.type:transaction transaction:["${transaction}"] transaction.duration:>=${
     durationBaseline * 0.5
   }ms`;
 

--- a/static/app/components/replays/useReplaysCount.spec.tsx
+++ b/static/app/components/replays/useReplaysCount.spec.tsx
@@ -371,4 +371,72 @@ describe('useReplaysCount', () => {
       '/profile': 0,
     });
   });
+
+  it('should accept start and end times and override statsPeriod', async () => {
+    const replayCountRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replay-count/`,
+      method: 'GET',
+      body: {},
+    });
+    const mockDate = new Date(Date.now());
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+      initialProps: {
+        organization,
+        transactionNames: mockTransactionNames,
+        datetime: {
+          start: mockDate,
+          end: mockDate,
+          statsPeriod: undefined,
+        },
+      },
+    });
+
+    expect(result.current).toEqual({});
+    expect(replayCountRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/replay-count/',
+      expect.objectContaining({
+        query: {
+          query: `transaction:["/home","/profile"]`,
+          data_source: 'discover',
+          project: -1,
+          start: mockDate,
+          end: mockDate,
+        },
+      })
+    );
+
+    await waitForNextUpdate();
+  });
+
+  it('passes along extra conditions and appends them to the query', async () => {
+    const replayCountRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replay-count/`,
+      method: 'GET',
+      body: {},
+    });
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+      initialProps: {
+        organization,
+        transactionNames: mockTransactionNames,
+        extraConditions: 'transaction.duration>:300ms',
+      },
+    });
+
+    expect(result.current).toEqual({});
+    expect(replayCountRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/replay-count/',
+      expect.objectContaining({
+        query: {
+          query: `transaction:["/home","/profile"] transaction.duration>:300ms`,
+          data_source: 'discover',
+          project: -1,
+          statsPeriod: '14d',
+        },
+      })
+    );
+
+    await waitForNextUpdate();
+  });
 });

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import * as Layout from 'sentry/components/layouts/thirds';
-import type {Group, Organization} from 'sentry/types';
+import {type Event, type Group, IssueType, type Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
 import useReplayList from 'sentry/utils/replays/hooks/useReplayList';
@@ -16,6 +16,7 @@ import type {ReplayListLocationQuery} from 'sentry/views/replays/types';
 
 type Props = {
   group: Group;
+  event?: Event;
 };
 
 const VISIBLE_COLUMNS = [
@@ -27,7 +28,7 @@ const VISIBLE_COLUMNS = [
   ReplayColumn.ACTIVITY,
 ];
 
-function GroupReplays({group}: Props) {
+function GroupReplays({group, event}: Props) {
   const organization = useOrganization();
   const location = useLocation<ReplayListLocationQuery>();
 
@@ -35,6 +36,10 @@ function GroupReplays({group}: Props) {
     group,
     location,
     organization,
+    transaction:
+      organization.features.includes('performance-duration-regression-visible') &&
+      group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION &&
+      event?.occurrence?.evidenceData?.transaction,
   });
 
   useEffect(() => {

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -29,17 +29,34 @@ const VISIBLE_COLUMNS = [
 ];
 
 function GroupReplays({group, event}: Props) {
+  const now = useMemo(() => Date.now(), []);
   const organization = useOrganization();
   const location = useLocation<ReplayListLocationQuery>();
+
+  const durationRegressionPayload = useMemo(
+    () =>
+      organization.features.includes('performance-duration-regression-visible') &&
+      group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION &&
+      event?.occurrence
+        ? {
+            transaction: event?.occurrence?.evidenceData?.transaction,
+            datetime: {
+              statsPeriod: undefined,
+              start: new Date(
+                event?.occurrence?.evidenceData?.breakpoint * 1000
+              ).toISOString(),
+              end: new Date(now).toISOString(),
+            },
+          }
+        : undefined,
+    [now, event?.occurrence, group.issueType, organization.features]
+  );
 
   const {eventView, fetchError, pageLinks} = useReplaysFromIssue({
     group,
     location,
     organization,
-    transaction:
-      organization.features.includes('performance-duration-regression-visible') &&
-      group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION &&
-      event?.occurrence?.evidenceData?.transaction,
+    ...durationRegressionPayload,
   });
 
   useEffect(() => {

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -2,6 +2,7 @@ import {useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
+import {getSampleEventQuery} from 'sentry/components/events/eventStatisticalDetector/eventComparison/eventDisplay';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {type Event, type Group, IssueType, type Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -39,7 +40,12 @@ function GroupReplays({group, event}: Props) {
       group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION &&
       event?.occurrence
         ? {
-            transaction: event?.occurrence?.evidenceData?.transaction,
+            customIdKey: event?.occurrence?.evidenceData?.transaction,
+            customIdQuery: getSampleEventQuery({
+              transaction: event.occurrence.evidenceData.transaction,
+              durationBaseline: event.occurrence.evidenceData.aggregateRange2,
+              addUpperBound: false,
+            }),
             datetime: {
               statsPeriod: undefined,
               start: new Date(

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
@@ -130,4 +130,81 @@ describe('useReplaysFromIssue', () => {
       pageLinks: null,
     });
   });
+
+  it('queries using start and end date strings if passed in', async () => {
+    const MOCK_GROUP = TestStubs.Group();
+    const replayCountRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replay-count/`,
+      method: 'GET',
+      body: {
+        ['mock_transaction']: ['replay42', 'replay256'],
+      },
+    });
+    const mockDate = new Date(Date.now()).toISOString();
+
+    const {waitForNextUpdate} = reactHooks.renderHook(useReplaysFromIssue, {
+      initialProps: {
+        group: MOCK_GROUP,
+        location,
+        organization,
+        datetime: {
+          statsPeriod: undefined,
+          start: mockDate,
+          end: mockDate,
+        },
+      },
+    });
+
+    expect(replayCountRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/replay-count/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          start: mockDate,
+          end: mockDate,
+        }),
+      })
+    );
+
+    await waitForNextUpdate();
+  });
+
+  it('allows for a custom query to be provided and uses a matching key to index the response', async () => {
+    const MOCK_GROUP = TestStubs.Group();
+    const replayCountRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replay-count/`,
+      method: 'GET',
+      body: {
+        ['mock_transaction']: ['replay42', 'replay256'],
+      },
+    });
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysFromIssue, {
+      initialProps: {
+        group: MOCK_GROUP,
+        location,
+        organization,
+        customIdQuery: 'transaction:["mock_transaction"]',
+        customIdKey: 'mock_transaction',
+      },
+    });
+
+    expect(replayCountRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/replay-count/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: 'transaction:["mock_transaction"]',
+        }),
+      })
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual({
+      eventView: expect.objectContaining({
+        query: 'id:[replay42,replay256]',
+      }),
+      fetchError: undefined,
+      pageLinks: null,
+    });
+  });
 });

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/react';
 import {Location} from 'history';
 
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
-import {type Group, IssueCategory, type Organization} from 'sentry/types';
+import {DateString, type Group, IssueCategory, type Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {DEFAULT_SORT} from 'sentry/utils/replays/fetchReplayList';
@@ -16,10 +16,16 @@ function useReplayFromIssue({
   location,
   organization,
   transaction,
+  datetime,
 }: {
   group: Group;
   location: Location;
   organization: Organization;
+  datetime?: {
+    end: DateString;
+    start: DateString;
+    statsPeriod: undefined;
+  };
   transaction?: string;
 }) {
   const api = useApi();
@@ -44,6 +50,7 @@ function useReplayFromIssue({
             data_source: dataSource,
             statsPeriod: '14d',
             project: ALL_ACCESS_PROJECTS,
+            ...datetime,
           },
         }
       );
@@ -52,7 +59,7 @@ function useReplayFromIssue({
       Sentry.captureException(error);
       setFetchError(error);
     }
-  }, [api, organization.slug, group.id, dataSource, transaction]);
+  }, [api, organization.slug, group.id, dataSource, transaction, datetime]);
 
   const eventView = useMemo(() => {
     if (!replayIds) {

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -15,10 +15,12 @@ function useReplayFromIssue({
   group,
   location,
   organization,
+  transaction,
 }: {
   group: Group;
   location: Location;
   organization: Organization;
+  transaction?: string;
 }) {
   const api = useApi();
 
@@ -36,19 +38,21 @@ function useReplayFromIssue({
         {
           query: {
             returnIds: true,
-            query: `issue.id:[${group.id}]`,
+            query: transaction
+              ? `transaction:["${transaction}"]`
+              : `issue.id:[${group.id}]`,
             data_source: dataSource,
             statsPeriod: '14d',
             project: ALL_ACCESS_PROJECTS,
           },
         }
       );
-      setReplayIds(response[group.id] || []);
+      setReplayIds(response[transaction ?? group.id] || []);
     } catch (error) {
       Sentry.captureException(error);
       setFetchError(error);
     }
-  }, [api, organization.slug, group.id, dataSource]);
+  }, [api, organization.slug, group.id, dataSource, transaction]);
 
   const eventView = useMemo(() => {
     if (!replayIds) {

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -15,18 +15,20 @@ function useReplayFromIssue({
   group,
   location,
   organization,
-  transaction,
   datetime,
+  customIdQuery,
+  customIdKey,
 }: {
   group: Group;
   location: Location;
   organization: Organization;
+  customIdKey?: string;
+  customIdQuery?: string;
   datetime?: {
     end: DateString;
     start: DateString;
     statsPeriod: undefined;
   };
-  transaction?: string;
 }) {
   const api = useApi();
 
@@ -44,9 +46,7 @@ function useReplayFromIssue({
         {
           query: {
             returnIds: true,
-            query: transaction
-              ? `transaction:["${transaction}"]`
-              : `issue.id:[${group.id}]`,
+            query: customIdQuery ?? `issue.id:[${group.id}]`,
             data_source: dataSource,
             statsPeriod: '14d',
             project: ALL_ACCESS_PROJECTS,
@@ -54,12 +54,20 @@ function useReplayFromIssue({
           },
         }
       );
-      setReplayIds(response[transaction ?? group.id] || []);
+      setReplayIds(response[customIdKey ?? group.id] || []);
     } catch (error) {
       Sentry.captureException(error);
       setFetchError(error);
     }
-  }, [api, organization.slug, group.id, dataSource, transaction, datetime]);
+  }, [
+    api,
+    organization.slug,
+    customIdQuery,
+    group.id,
+    dataSource,
+    datetime,
+    customIdKey,
+  ]);
 
   const eventView = useMemo(() => {
     if (!replayIds) {


### PR DESCRIPTION
Since the data for statistical detectors aren't on the events associated with the issue (e.g. for error issues, the error events are where the data is aggregated from), we need to query data using the transaction name. Additionally, for our tab pages we want to show data for events that occur after the breakpoint and have at least a certain amount of duration so it's relevant to the regression.

To accomplish this I've updated the replay hooks for `useReplayCount` and `useReplaysFromIssues` to accept a datetime object with start, end, and statsPeriod to override the default 14d query. I've also added a way to add extra conditions to `useReplayCount` and a custom query for `useReplaysFromIssues` to index into the replay IDs by transaction name.

Closes #58267 