### PR TITLE
ref(metrics): Return all the mappings that happen in the layer

### DIFF
--- a/src/sentry/snuba/metrics_layer/query.py
+++ b/src/sentry/snuba/metrics_layer/query.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import Any, Mapping, Sequence, Union
+from typing import Any, Mapping, Union
 
 from snuba_sdk import (
     AliasedExpression,
@@ -13,11 +13,11 @@ from snuba_sdk import (
     Request,
 )
 
-from sentry.models.project import Project
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.sentry_metrics.utils import resolve_weak, string_to_use_case_id
-from sentry.snuba.metrics.fields.base import _get_entity_of_metric_mri, org_id_from_projects
+from sentry.snuba.dataset import EntityKey
 from sentry.snuba.metrics.naming_layer.mapping import get_mri, get_public_name_from_mri
+from sentry.snuba.metrics.naming_layer.mri import parse_mri
 from sentry.snuba.metrics.utils import to_intervals
 from sentry.utils import metrics
 from sentry.utils.snuba import raw_snql_query
@@ -59,7 +59,7 @@ def run_query(request: Request) -> Mapping[str, Any]:
 
     # Resolves MRI or public name in metrics_query
     try:
-        resolved_metrics_query = resolve_metrics_query(metrics_query)
+        resolved_metrics_query, mappings = resolve_metrics_query(metrics_query)
         request.query = resolved_metrics_query
     except Exception as e:
         metrics.incr(
@@ -81,7 +81,12 @@ def run_query(request: Request) -> Mapping[str, Any]:
         raise e
 
     # If we normalized the start/end, return those values in the response so the caller is aware
-    results = {**snuba_results, "modified_start": start, "modified_end": end}
+    results = {
+        **snuba_results,
+        "modified_start": start,
+        "modified_end": end,
+        "indexer_mappings": mappings,
+    }
     metrics.incr(
         "metrics_layer.query",
         tags={"referrer": request.tenant_ids["referrer"] or "unknown", "status": "success"},
@@ -89,24 +94,51 @@ def run_query(request: Request) -> Mapping[str, Any]:
     return results
 
 
-def resolve_metrics_query(metrics_query: MetricsQuery) -> MetricsQuery:
+RELEASE_HEALTH_ENTITIES = {
+    "c": EntityKey.MetricsCounters,
+    "d": EntityKey.MetricsDistributions,
+    "s": EntityKey.MetricsSets,
+}
+
+GENERIC_ENTITIES = {
+    "c": EntityKey.GenericMetricsCounters,
+    "d": EntityKey.GenericMetricsDistributions,
+    "s": EntityKey.GenericMetricsSets,
+}
+
+
+def _resolve_metrics_entity(mri: str) -> EntityKey:
+    parsed_mri = parse_mri(mri)
+    if parsed_mri is None:
+        raise ValueError(f"{mri} is not a valid MRI")
+
+    if parsed_mri.namespace == "sessions":
+        return RELEASE_HEALTH_ENTITIES[parsed_mri.entity]
+
+    return GENERIC_ENTITIES[parsed_mri.entity]
+
+
+def resolve_metrics_query(
+    metrics_query: MetricsQuery,
+) -> tuple[MetricsQuery, Mapping[str : str | int]]:
     assert metrics_query.query is not None
     metric = metrics_query.query.metric
     scope = metrics_query.scope
-
+    mappings = {}
     if not metric.public_name and metric.mri:
         public_name = get_public_name_from_mri(metric.mri)
         metrics_query = metrics_query.set_query(
             metrics_query.query.set_metric(metrics_query.query.metric.set_public_name(public_name))
         )
+        mappings[metric.mri] = public_name
     elif not metric.mri and metric.public_name:
         mri = get_mri(metric.public_name)
         metrics_query = metrics_query.set_query(
             metrics_query.query.set_metric(metrics_query.query.metric.set_mri(mri))
         )
+        mappings[metric.public_name] = mri
 
-    projects = get_projects(scope.project_ids)
-    org_id = org_id_from_projects(projects)
+    org_id = scope.org_ids[0]
     use_case_id = string_to_use_case_id(scope.use_case_id)
     metric_id = resolve_weak(
         use_case_id, org_id, metrics_query.query.metric.mri
@@ -114,43 +146,44 @@ def resolve_metrics_query(metrics_query: MetricsQuery) -> MetricsQuery:
     metrics_query = metrics_query.set_query(
         metrics_query.query.set_metric(metrics_query.query.metric.set_id(metric_id))
     )
+    mappings[metrics_query.query.metric.mri] = metric_id
 
     if not metrics_query.query.metric.entity:
-        entity = _get_entity_of_metric_mri(
-            projects, metrics_query.query.metric.mri, use_case_id
-        )  # TODO: will need reimplement this as this runs old metrics query
+        entity = _resolve_metrics_entity(metrics_query.query.metric.mri)
         metrics_query = metrics_query.set_query(
             metrics_query.query.set_metric(metrics_query.query.metric.set_entity(entity.value))
         )
 
-    new_groupby = resolve_groupby(metrics_query.query.groupby, use_case_id, org_id)
+    new_groupby, new_mappings = resolve_groupby(metrics_query.query.groupby, use_case_id, org_id)
     metrics_query = metrics_query.set_query(metrics_query.query.set_groupby(new_groupby))
-    new_groupby = resolve_groupby(metrics_query.groupby, use_case_id, org_id)
+    mappings.update(new_mappings)
+    new_groupby, new_mappings = resolve_groupby(metrics_query.groupby, use_case_id, org_id)
     metrics_query = metrics_query.set_groupby(new_groupby)
+    mappings.update(new_mappings)
 
-    metrics_query = metrics_query.set_query(
-        metrics_query.query.set_filters(
-            resolve_filters(metrics_query.query.filters, use_case_id, org_id)
-        )
-    )
-    metrics_query = metrics_query.set_filters(
-        resolve_filters(metrics_query.filters, use_case_id, org_id)
-    )
-    return metrics_query
+    new_filters, new_mappings = resolve_filters(metrics_query.query.filters, use_case_id, org_id)
+    metrics_query = metrics_query.set_query(metrics_query.query.set_filters(new_filters))
+    mappings.update(new_mappings)
+    new_filters, new_mappings = resolve_filters(metrics_query.filters, use_case_id, org_id)
+    metrics_query = metrics_query.set_filters(new_filters)
+    mappings.update(new_mappings)
+
+    return metrics_query, mappings
 
 
 def resolve_groupby(
     groupby: list[Column] | None, use_case_id: UseCaseID, org_id: int
-) -> list[Column] | None:
+) -> tuple[list[Column] | None, Mapping[str, str | int]]:
     """
     Go through the groupby columns and resolve any that need to be resolved.
     We also return a reverse mapping of the resolved columns to the original
     so that we can edit the results
     """
     if not groupby:
-        return groupby
+        return groupby, {}
 
     new_groupby = []
+    mappings = {}
     for col in groupby:
         resolved = resolve_weak(use_case_id, org_id, col.name)
         if resolved > -1:
@@ -159,22 +192,26 @@ def resolve_groupby(
             new_groupby.append(
                 AliasedExpression(exp=replace(col, name=f"tags_raw[{resolved}]"), alias=col.name)
             )
+            mappings[col.name] = resolved
         else:
             new_groupby.append(col)
 
-    return new_groupby
+    return new_groupby, mappings
 
 
 def resolve_filters(
     filters: list[Condition | BooleanCondition], use_case_id: UseCaseID, org_id: int
-) -> list[Condition | BooleanCondition] | None:
+) -> tuple[list[Condition | BooleanCondition] | None, Mapping[str, str | int]]:
     if not filters:
-        return filters
+        return filters, {}
+
+    mappings = {}
 
     def resolve_exp(exp: FilterTypes) -> FilterTypes:
         if isinstance(exp, Column):
             resolved = resolve_weak(use_case_id, org_id, exp.name)
             if resolved > -1:
+                mappings[exp.name] = resolved
                 return replace(exp, name=f"tags_raw[{resolved}]")
         elif isinstance(exp, CurriedFunction):
             return replace(exp, parameters=[resolve_exp(p) for p in exp.parameters])
@@ -185,12 +222,4 @@ def resolve_filters(
         return exp
 
     new_filters = [resolve_exp(exp) for exp in filters]
-    return new_filters
-
-
-def get_projects(project_ids: Sequence[int]) -> Sequence[Project]:
-    try:
-        projects = list(Project.objects.filter(id__in=project_ids))
-        return projects
-    except Project.DoesNotExist:
-        raise Exception("Requested project does not exist")
+    return new_filters, mappings

--- a/src/sentry/snuba/metrics_layer/query.py
+++ b/src/sentry/snuba/metrics_layer/query.py
@@ -121,7 +121,7 @@ def _resolve_metrics_entity(mri: str) -> EntityKey:
 
 def _resolve_metrics_query(
     metrics_query: MetricsQuery,
-) -> tuple[MetricsQuery, Mapping[str, int]]:
+) -> tuple[MetricsQuery, Mapping[str, str | int]]:
     """
     Returns an updated metrics query with all the indexer resolves complete. Also returns a mapping
     that shows all the strings that were resolved and what they were resolved too.
@@ -129,12 +129,13 @@ def _resolve_metrics_query(
     assert metrics_query.query is not None
     metric = metrics_query.query.metric
     scope = metrics_query.scope
-    mappings = {}
+    mappings: dict[str, str | int] = {}
     if not metric.public_name and metric.mri:
         public_name = get_public_name_from_mri(metric.mri)
         metrics_query = metrics_query.set_query(
             metrics_query.query.set_metric(metrics_query.query.metric.set_public_name(public_name))
         )
+        mappings[public_name] = metric.mri
     elif not metric.mri and metric.public_name:
         mri = get_mri(metric.public_name)
         metrics_query = metrics_query.set_query(

--- a/tests/snuba/test_metrics_layer.py
+++ b/tests/snuba/test_metrics_layer.py
@@ -253,7 +253,7 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
         assert rows[1]["aggregate_value"] == 59
         assert rows[1]["transaction"] == "transaction_1"
 
-    def test_interval_return(self) -> None:
+    def test_meta_data_in_response(self) -> None:
         query = MetricsQuery(
             query=Timeseries(
                 metric=Metric(
@@ -261,6 +261,8 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
                     TransactionMRI.DURATION.value,
                 ),
                 aggregate="max",
+                filters=[Condition(Column("status_code"), Op.EQ, "200")],
+                groupby=[Column("transaction")],
             ),
             start=self.hour_ago.replace(minute=16, second=59),
             end=self.now.replace(minute=16, second=59),
@@ -280,6 +282,11 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
         result = run_query(request)
         assert result["modified_start"] == self.hour_ago.replace(minute=16, second=0)
         assert result["modified_end"] == self.now.replace(minute=17, second=0)
+        assert result["indexer_mappings"] == {
+            "d:transactions/duration@millisecond": 9223372036854775909,
+            "status_code": 10000,
+            "transaction": 9223372036854776020,
+        }
 
     def test_bad_query(self) -> None:
         query = MetricsQuery(

--- a/tests/snuba/test_metrics_layer.py
+++ b/tests/snuba/test_metrics_layer.py
@@ -28,7 +28,7 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
     def ts(self, dt: datetime) -> int:
         return int(dt.timestamp())
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
 
         self.metrics: Mapping[str, Literal["counter", "set", "distribution"]] = {


### PR DESCRIPTION
Whenever a string is resolved in the run_query function, record it and return
it in the response so the caller can do any reverse resolving or analysis they
might want too.

Also remove unnecessary DB calls:
- Replace the get_entity function with a hardcoded version
- Replace the Project model call by using the org ID in the scope
    - When we start allowing multiple org_ids, this might have to change