### PR TITLE
ref(hc): Assign pending endpoint to silo

### DIFF
--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import pending_silo_endpoint
+from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationDataExportPermission, OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.models.organization import Organization
@@ -15,7 +15,7 @@ from sentry.utils import metrics
 from ..models import ExportedData
 
 
-@pending_silo_endpoint
+@region_silo_endpoint
 class DataExportDetailsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,


### PR DESCRIPTION
`pending_silo_endpoint` is still used in getsentry so the definition can't be removed yet.