### PR TITLE
feat(mep): Add dataset reason to meta

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -336,6 +336,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     "units": units,
                     "isMetricsData": isMetricsData,
                     "tips": meta.get("tips", {}),
+                    "datasetReason": meta.get("datasetReason", discover.DEFAULT_DATASET_REASON),
                 }
                 if dataset is not None:
                     meta["dataset"] = DATASET_LABELS.get(dataset, "unknown")

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -57,6 +57,7 @@ __all__ = (
     "histogram_query",
     "check_multihistogram_fields",
 )
+DEFAULT_DATASET_REASON = "unchanged"
 
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -35,10 +35,11 @@ def query(
     on_demand_metrics_enabled: bool = False,
 ):
     metrics_compatible = not equations
+    dataset_reason = discover.DEFAULT_DATASET_REASON
 
     if metrics_compatible:
         try:
-            return metrics_query(
+            result = metrics_query(
                 selected_columns,
                 query,
                 params,
@@ -59,12 +60,16 @@ def query(
                 use_metrics_layer,
                 on_demand_metrics_enabled,
             )
+            result["meta"]["datasetReason"] = dataset_reason
+
+            return result
         # raise Invalid Queries since the same thing will happen with discover
         except InvalidSearchQuery as error:
             raise error
         # any remaining errors mean we should try again with discover
         except IncompatibleMetricsQuery as error:
             sentry_sdk.set_tag("performance.mep_incompatible", str(error))
+            dataset_reason = str(error)
             metrics_compatible = False
         except Exception as error:
             raise error
@@ -90,6 +95,7 @@ def query(
             has_metrics=has_metrics,
         )
         results["meta"]["isMetricsData"] = False
+        results["meta"]["datasetReason"] = dataset_reason
 
         return results
 


### PR DESCRIPTION
- This adds a datasetReason field to the meta response so that its easier to debug why the metricsEnhancedPerformance dataset flipped back to discover