### PR TITLE
feat(stats-detector-tags-navigation): Changed navigation target.

### DIFF
--- a/static/app/views/issueDetails/groupTags.spec.tsx
+++ b/static/app/views/issueDetails/groupTags.spec.tsx
@@ -52,6 +52,28 @@ describe('GroupTags', function () {
     });
   });
 
+  it('navigates to performance tags summary heatmap when tag key is clicked', async function () {
+    render(
+      <GroupTags
+        {...routerProps}
+        group={group}
+        environments={['dev']}
+        baseUrl={`/organizations/${organization.slug}/issues/${group.id}/`}
+      />,
+      {context: routerContext, organization}
+    );
+
+    await screen.findAllByTestId('tag-title');
+    await userEvent.click(screen.getByText('browser'));
+
+    expect(router.push).toHaveBeenCalledWith({
+      pathname: '/organizations/org-slug/performance/summary/tags/',
+      query: expect.objectContaining({
+        tagKey: 'browser',
+      }),
+    });
+  });
+
   it('shows an error message when the request fails', async function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/tags/',

--- a/static/app/views/issueDetails/groupTags.spec.tsx
+++ b/static/app/views/issueDetails/groupTags.spec.tsx
@@ -3,6 +3,7 @@ import {Tags} from 'sentry-fixture/tags';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import {IssueType} from 'sentry/types';
 import GroupTags from 'sentry/views/issueDetails/groupTags';
 
 describe('GroupTags', function () {
@@ -52,11 +53,11 @@ describe('GroupTags', function () {
     });
   });
 
-  it('navigates to performance tags summary heatmap when tag key is clicked', async function () {
+  it('navigates correctly when duration regression issue > tags key is clicked', async function () {
     render(
       <GroupTags
         {...routerProps}
-        group={group}
+        group={{...group, issueType: IssueType.PERFORMANCE_DURATION_REGRESSION}}
         environments={['dev']}
         baseUrl={`/organizations/${organization.slug}/issues/${group.id}/`}
       />,

--- a/static/app/views/issueDetails/groupTags.tsx
+++ b/static/app/views/issueDetails/groupTags.tsx
@@ -111,16 +111,26 @@ function GroupTags({group, baseUrl, environments, event}: GroupTagsProps) {
   }
 
   const getTagKeyTarget = (tag: SimpleTag) => {
+    const pathname =
+      group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION
+        ? generateTagsRoute({orgSlug: organization.slug})
+        : `${baseUrl}tags/${tag.key}/`;
+
+    const query =
+      group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION
+        ? {
+            ...extractSelectionParameters(location.query),
+            start: (beforeDateTime as Date).toISOString(),
+            end: (afterDateTime as Date).toISOString(),
+            statsPeriod: undefined,
+            tagKey: tag.key,
+            transaction,
+          }
+        : extractSelectionParameters(location.query);
+
     return {
-      pathname: generateTagsRoute({orgSlug: organization.slug}),
-      query: {
-        ...extractSelectionParameters(location.query),
-        start: (beforeDateTime as Date).toISOString(),
-        end: (afterDateTime as Date).toISOString(),
-        statsPeriod: undefined,
-        tagKey: tag.key,
-        transaction,
-      },
+      pathname,
+      query,
     };
   };
 


### PR DESCRIPTION
For issue: https://github.com/getsentry/sentry/issues/58268

Clicking on tag key in **Duration regression > Tags**, takes us to `/performance/summary/tags/` heatmap: 

https://github.com/getsentry/sentry/assets/60121741/e2fdb9d9-e81a-4b65-908b-121c1abf4652


