### PR TITLE
feat(browser-starfish): add tooltips for resource info

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -2,27 +2,22 @@ import styled from '@emotion/styled';
 
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import FeatureBadge from 'sentry/components/featureBadge';
-import FileSize from 'sentry/components/fileSize';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {t} from 'sentry/locale';
-import {RateUnits} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {PaddedContainer} from 'sentry/views/performance/browser/resources';
+import ResourceInfo from 'sentry/views/performance/browser/resources/resourceSummaryPage/resourceInfo';
 import ResourceSummaryCharts from 'sentry/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts';
 import ResourceSummaryTable from 'sentry/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
-import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
-import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
-import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
-import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
-import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {SampleList} from 'sentry/views/starfish/views/spanSummaryPage/sampleList';
 
 const {
@@ -92,30 +87,15 @@ function ResourceSummary() {
                 <DatePageFilter />
               </PageFilterBar>
             </PaddedContainer>
-            <BlockContainer>
-              <Block title={t('Avg encoded size')}>
-                <FileSize bytes={spanMetrics?.[`avg(${HTTP_RESPONSE_CONTENT_LENGTH})`]} />
-              </Block>
-              <Block title={t('Avg decoded size')}>
-                <FileSize
-                  bytes={spanMetrics?.[`avg(${HTTP_DECODED_RESPONSE_BODY_LENGTH})`]}
-                />
-              </Block>
-              <Block title={t('Avg transfer size')}>
-                <FileSize bytes={spanMetrics?.[`avg(${HTTP_RESPONSE_TRANSFER_SIZE})`]} />
-              </Block>
-              <Block title={DataTitles.avg}>
-                <DurationCell
-                  milliseconds={spanMetrics?.[`avg(${SpanMetricsField.SPAN_SELF_TIME})`]}
-                />
-              </Block>
-              <Block title={getThroughputTitle('http')}>
-                <ThroughputCell
-                  rate={spanMetrics?.[`${SpanFunction.SPM}()`] * 60}
-                  unit={RateUnits.PER_SECOND}
-                />
-              </Block>
-            </BlockContainer>
+            <ResourceInfo
+              avgContentLength={spanMetrics['avg(http.response_content_length)']}
+              avgDecodedContentLength={
+                spanMetrics['avg(http.decoded_response_body_length)']
+              }
+              avgTransferSize={spanMetrics['avg(http.response_transfer_size)']}
+              avgDuration={spanMetrics[`avg(${SPAN_SELF_TIME})`]}
+              throughput={spanMetrics['spm()']}
+            />
           </HeaderContainer>
           <ResourceSummaryCharts groupId={groupId} />
           <ResourceSummaryTable />

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceInfo.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceInfo.tsx
@@ -1,0 +1,83 @@
+import FileSize from 'sentry/components/fileSize';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t, tct} from 'sentry/locale';
+import {formatBytesBase2} from 'sentry/utils';
+import {RateUnits} from 'sentry/utils/discover/fields';
+import getDynamicText from 'sentry/utils/getDynamicText';
+import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
+import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
+import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
+import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
+
+type Props = {
+  avgContentLength: number;
+  avgDecodedContentLength: number;
+  avgDuration: number;
+  avgTransferSize: number;
+  throughput: number;
+};
+
+function ResourceInfo(props: Props) {
+  const {
+    avgContentLength,
+    avgDecodedContentLength,
+    avgDuration,
+    avgTransferSize,
+    throughput,
+  } = props;
+
+  const tooltips = {
+    avgContentLength: tct(
+      'On average, this resource is [bytes] when encoded (for example when gzipped).',
+      {
+        bytes: getDynamicText({
+          value: formatBytesBase2(avgContentLength),
+          fixed: 'xx KB',
+        }),
+      }
+    ),
+    avgDecodedContentLength: tct('On average, this resource is [bytes] when decoded.', {
+      bytes: getDynamicText({
+        value: formatBytesBase2(avgDecodedContentLength),
+        fixed: 'xx KB',
+      }),
+    }),
+    avgTransferSize: tct(
+      'On average, the total bytes transferred over the network (body + headers) for this resource is [bytes].',
+      {
+        bytes: getDynamicText({
+          value: formatBytesBase2(avgTransferSize),
+          fixed: 'xx KB',
+        }),
+      }
+    ),
+  };
+
+  return (
+    <BlockContainer>
+      <Block title={t('Avg encoded size')}>
+        <Tooltip isHoverable title={tooltips.avgContentLength} showUnderline>
+          <FileSize bytes={avgContentLength} />
+        </Tooltip>
+      </Block>
+      <Block title={t('Avg decoded size')}>
+        <Tooltip isHoverable title={tooltips.avgDecodedContentLength} showUnderline>
+          <FileSize bytes={avgDecodedContentLength} />
+        </Tooltip>
+      </Block>
+      <Block title={t('Avg transfer size')}>
+        <Tooltip isHoverable title={tooltips.avgTransferSize} showUnderline>
+          <FileSize bytes={avgTransferSize} />
+        </Tooltip>
+      </Block>
+      <Block title={DataTitles.avg}>
+        <DurationCell milliseconds={avgDuration} />
+      </Block>
+      <Block title={getThroughputTitle('http')}>
+        <ThroughputCell rate={throughput * 60} unit={RateUnits.PER_SECOND} />
+      </Block>
+    </BlockContainer>
+  );
+}
+
+export default ResourceInfo;


### PR DESCRIPTION
Two changes in this PR
1. Add tooltips to the encoded, decoded and transfer size to explain the difference.
2. Move the resource info into its own component, the resource summary index page was starting to get bloated. We can probs loop through the info rather then duplicate the JSX to clean it up more.

- A todo after the PR is to add some CTA if encoded body size 0. If it's zero we would suspect that the `timing-allow-origin` header is not set and it is a CORS request.