### PR TITLE
feat(starfish): Make screen load charts bar charts

### DIFF
--- a/static/app/views/starfish/views/screens/screensTable.tsx
+++ b/static/app/views/starfish/views/screens/screensTable.tsx
@@ -196,11 +196,13 @@ export function useTableQuery({
   enabled,
   referrer,
   initialData,
+  limit,
 }: {
   eventView: EventView;
   enabled?: boolean;
   excludeOther?: boolean;
   initialData?: TableData;
+  limit?: number;
   referrer?: string;
 }) {
   const location = useLocation();
@@ -210,7 +212,7 @@ export function useTableQuery({
     eventView,
     location,
     orgSlug: organization.slug,
-    limit: 25,
+    limit: limit ?? 25,
     referrer,
     options: {
       refetchOnWindowFocus: false,


### PR DESCRIPTION

![Screenshot 2023-10-18 at 3 32 21 PM](https://github.com/getsentry/sentry/assets/63818634/6d0d0e6d-6c09-4f4f-8187-a01ad6e73634)

Shows the top 5 screens as a bar chart. As a follow up, will match the chart colours to each screen on the table.