### PR TITLE
feat(stat-detectors): Add hook to query replays for issue samples

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
@@ -39,7 +39,7 @@ export function getSampleEventQuery({
   transaction: string;
   addUpperBound?: boolean;
 }) {
-  const baseQuery = `event.type:transaction transaction:"${transaction}" transaction.duration:>=${
+  const baseQuery = `event.type:transaction transaction:["${transaction}"] transaction.duration:>=${
     durationBaseline * 0.5
   }ms`;
 

--- a/static/app/views/issueDetails/groupReplays/useReplaysForRegressionIssue.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysForRegressionIssue.spec.tsx
@@ -150,7 +150,7 @@ describe('useReplaysForRegressionIssue', () => {
           start: new Date(
             mockEvent.occurrence.evidenceData.breakpoint * 1000
           ).toISOString(),
-          end: new Date(Date.now()).toISOString(),
+          end: new Date().toISOString(),
         }),
       })
     );

--- a/static/app/views/issueDetails/groupReplays/useReplaysForRegressionIssue.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysForRegressionIssue.spec.tsx
@@ -1,0 +1,192 @@
+import {Location} from 'history';
+import {Event as EventFixture} from 'sentry-fixture/event';
+import {Organization} from 'sentry-fixture/organization';
+
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import {EventOccurrence, IssueCategory} from 'sentry/types';
+import {useLocation} from 'sentry/utils/useLocation';
+import useReplaysForRegressionIssue from 'sentry/views/issueDetails/groupReplays/useReplaysForRegressionIssue';
+
+jest.mock('sentry/utils/useLocation');
+
+describe('useReplaysForRegressionIssue', () => {
+  const location: Location = {
+    pathname: '',
+    search: '',
+    query: {},
+    hash: '',
+    state: undefined,
+    action: 'PUSH',
+    key: '',
+  };
+  jest.mocked(useLocation).mockReturnValue(location);
+
+  const organization = Organization({
+    features: ['session-replay'],
+  });
+
+  const mockEvent = {
+    ...EventFixture(),
+    occurrence: {
+      evidenceDisplay: {} as EventOccurrence['evidenceDisplay'],
+      detectionTime: 'mock-detection-time',
+      eventId: 'eventId',
+      fingerprint: ['fingerprint'],
+      id: 'id',
+      issueTitle: 'Transaction Duration Regression',
+      subtitle: 'Increased from 20.64ms to 36.24ms (P95)',
+      resourceId: '',
+      type: 1017,
+      evidenceData: {
+        transaction: 'mock-transaction',
+        aggregateRange2: 100,
+        breakpoint: Date.now() / 1000, // The breakpoint is stored in seconds
+      },
+    },
+  };
+
+  it('should fetch a list of replay ids', async () => {
+    const MOCK_GROUP = TestStubs.Group({issueCategory: IssueCategory.PERFORMANCE});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replay-count/`,
+      method: 'GET',
+      body: {
+        ['mock-transaction']: ['replay42', 'replay256'],
+      },
+    });
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(
+      useReplaysForRegressionIssue,
+      {
+        initialProps: {
+          group: MOCK_GROUP,
+          location,
+          organization,
+          event: mockEvent,
+        },
+      }
+    );
+
+    expect(result.current).toEqual({
+      eventView: null,
+      fetchError: undefined,
+      pageLinks: null,
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual({
+      eventView: expect.objectContaining({
+        query: 'id:[replay42,replay256]',
+      }),
+      fetchError: undefined,
+      pageLinks: null,
+    });
+  });
+
+  it('should return an empty EventView when there are no replay_ids returned from the count endpoint', async () => {
+    const MOCK_GROUP = TestStubs.Group({issueCategory: IssueCategory.PERFORMANCE});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replay-count/`,
+      method: 'GET',
+      body: {},
+    });
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(
+      useReplaysForRegressionIssue,
+      {
+        initialProps: {
+          group: MOCK_GROUP,
+          location,
+          organization,
+          event: mockEvent,
+        },
+      }
+    );
+
+    expect(result.current).toEqual({
+      eventView: null,
+      fetchError: undefined,
+      pageLinks: null,
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual({
+      eventView: expect.objectContaining({
+        query: 'id:[]',
+      }),
+      fetchError: undefined,
+      pageLinks: null,
+    });
+  });
+
+  it('queries using start and end date strings if passed in', async () => {
+    const MOCK_GROUP = TestStubs.Group({issueCategory: IssueCategory.PERFORMANCE});
+    const replayCountRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replay-count/`,
+      method: 'GET',
+      body: {
+        ['mock_transaction']: ['replay42', 'replay256'],
+      },
+    });
+
+    const {waitForNextUpdate} = reactHooks.renderHook(useReplaysForRegressionIssue, {
+      initialProps: {
+        group: MOCK_GROUP,
+        location,
+        organization,
+        event: mockEvent,
+      },
+    });
+
+    expect(replayCountRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/replay-count/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          start: new Date(
+            mockEvent.occurrence.evidenceData.breakpoint * 1000
+          ).toISOString(),
+          end: new Date(Date.now()).toISOString(),
+        }),
+      })
+    );
+
+    await waitForNextUpdate();
+  });
+
+  it('queries the transaction name with event type and duration filters', async () => {
+    const MOCK_GROUP = TestStubs.Group({issueCategory: IssueCategory.PERFORMANCE});
+    const replayCountRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replay-count/`,
+      method: 'GET',
+      body: {
+        ['mock_transaction']: ['replay42', 'replay256'],
+      },
+    });
+
+    const {waitForNextUpdate} = reactHooks.renderHook(useReplaysForRegressionIssue, {
+      initialProps: {
+        group: MOCK_GROUP,
+        location,
+        organization,
+        event: mockEvent,
+      },
+    });
+
+    expect(replayCountRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/replay-count/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query:
+            'event.type:transaction transaction:["mock-transaction"] transaction.duration:>=50ms',
+        }),
+      })
+    );
+
+    await waitForNextUpdate();
+  });
+});

--- a/static/app/views/issueDetails/groupReplays/useReplaysForRegressionIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysForRegressionIssue.tsx
@@ -23,7 +23,7 @@ function useReplaysForRegressionIssue({
   location: Location;
   organization: Organization;
 }) {
-  const now = useRef(new Date(Date.now()).toISOString());
+  const now = useRef(new Date().toISOString());
   const api = useApi();
 
   const [replayIds, setReplayIds] = useState<string[]>();

--- a/static/app/views/issueDetails/groupReplays/useReplaysForRegressionIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysForRegressionIssue.tsx
@@ -1,0 +1,99 @@
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import * as Sentry from '@sentry/react';
+import {Location} from 'history';
+
+import {getSampleEventQuery} from 'sentry/components/events/eventStatisticalDetector/eventComparison/eventDisplay';
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
+import {Event, type Group, type Organization} from 'sentry/types';
+import EventView from 'sentry/utils/discover/eventView';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {DEFAULT_SORT} from 'sentry/utils/replays/fetchReplayList';
+import useApi from 'sentry/utils/useApi';
+import useCleanQueryParamsOnRouteLeave from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
+import {REPLAY_LIST_FIELDS} from 'sentry/views/replays/types';
+
+function useReplaysForRegressionIssue({
+  group,
+  location,
+  organization,
+  event,
+}: {
+  event: Event;
+  group: Group;
+  location: Location;
+  organization: Organization;
+}) {
+  const now = useRef(new Date(Date.now()).toISOString());
+  const api = useApi();
+
+  const [replayIds, setReplayIds] = useState<string[]>();
+
+  const [fetchError, setFetchError] = useState();
+
+  const {transaction, aggregateRange2, breakpoint} = event.occurrence?.evidenceData ?? {};
+
+  const datetime = useMemo(
+    () => ({
+      start: new Date(breakpoint * 1000).toISOString(),
+      end: now.current,
+    }),
+    [breakpoint]
+  );
+
+  const fetchReplayIds = useCallback(async () => {
+    try {
+      const response = await api.requestPromise(
+        `/organizations/${organization.slug}/replay-count/`,
+        {
+          query: {
+            returnIds: true,
+            query: getSampleEventQuery({
+              transaction,
+              durationBaseline: aggregateRange2,
+              addUpperBound: false,
+            }),
+            data_source: 'search_issues',
+            project: ALL_ACCESS_PROJECTS,
+            ...datetime,
+          },
+        }
+      );
+      setReplayIds(response[transaction] || []);
+    } catch (error) {
+      Sentry.captureException(error);
+      setFetchError(error);
+    }
+  }, [api, organization.slug, transaction, aggregateRange2, datetime]);
+
+  const eventView = useMemo(() => {
+    if (!replayIds) {
+      return null;
+    }
+    return EventView.fromSavedQuery({
+      id: '',
+      name: '',
+      version: 2,
+      fields: REPLAY_LIST_FIELDS,
+      query: `id:[${String(replayIds)}]`,
+      projects: [],
+      orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
+      ...datetime,
+    });
+  }, [datetime, location.query.sort, replayIds]);
+
+  useCleanQueryParamsOnRouteLeave({
+    fieldsToClean: ['cursor'],
+    shouldClean: newLocation => newLocation.pathname.includes(`/issues/${group.id}/`),
+  });
+  useEffect(() => {
+    fetchReplayIds();
+  }, [fetchReplayIds]);
+
+  return {
+    eventView,
+    fetchError,
+    pageLinks: null,
+  };
+}
+
+export default useReplaysForRegressionIssue;


### PR DESCRIPTION
Adds a hook that queries replays for issues relevant for statistical detectors. The intention for this is to create a base component for the replay table and branch off the querying logic to this hook if the group is a statistical detector issue.

The code is mostly the same as the `useReplaysFromIssue` hook, but some properties have been hardcoded since this should only be used for statistical detectors, i.e. perf issues.