### PR TITLE
Update getExactDuration formatter with minDuration

### DIFF
--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -327,6 +327,21 @@ describe('userDisplayName', function () {
 describe('getExactDuration', () => {
   it('should provide default value', () => {
     expect(getExactDuration(0)).toEqual('0 milliseconds');
+    expect(getExactDuration(0, false, 'seconds')).toEqual('0 seconds');
+    expect(getExactDuration(0, false, 'hours')).toEqual('0 hours');
+  });
+
+  it('should pin to the minimum duration value', () => {
+    expect(getExactDuration(65)).toEqual('1 minute 5 seconds');
+    expect(getExactDuration(65, false, 'minutes')).toEqual('1 minute');
+    expect(getExactDuration(3610, false, 'hours')).toEqual('1 hour');
+    expect(getExactDuration(234235435.123)).toEqual(
+      '387 weeks 2 days 1 hour 23 minutes 55 seconds 123 milliseconds'
+    );
+    expect(getExactDuration(234235435.123, false, 'minutes')).toEqual(
+      '387 weeks 2 days 1 hour 23 minutes'
+    );
+    expect(getExactDuration(234235435.123, true, 'min')).toEqual('387wk 2d 1hr 23min');
   });
 
   it('should format in the right way', () => {

--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -335,6 +335,7 @@ describe('getExactDuration', () => {
     expect(getExactDuration(13)).toEqual('13 seconds');
     expect(getExactDuration(60)).toEqual('1 minute');
     expect(getExactDuration(121)).toEqual('2 minutes 1 second');
+    expect(getExactDuration(120.01)).toEqual('2 minutes 10 milliseconds');
     expect(getExactDuration(234235435)).toEqual(
       '387 weeks 2 days 1 hour 23 minutes 55 seconds'
     );
@@ -353,5 +354,6 @@ describe('getExactDuration', () => {
 
   it('should abbreviate label', () => {
     expect(getExactDuration(234235435, true)).toEqual('387wk 2d 1hr 23min 55s');
+    expect(getExactDuration(0, true)).toEqual('0ms');
   });
 });

--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -335,7 +335,7 @@ describe('getExactDuration', () => {
     expect(getExactDuration(13)).toEqual('13 seconds');
     expect(getExactDuration(60)).toEqual('1 minute');
     expect(getExactDuration(121)).toEqual('2 minutes 1 second');
-    expect(getExactDuration(120.01)).toEqual('2 minutes 10 milliseconds');
+    expect(getExactDuration(120.1)).toEqual('2 minutes 100 milliseconds');
     expect(getExactDuration(234235435)).toEqual(
       '387 weeks 2 days 1 hour 23 minutes 55 seconds'
     );

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -147,6 +147,8 @@ export function getDuration(
   return `${label} ${tn('millisecond', 'milliseconds', result)}`;
 }
 
+type Level = [number, string];
+
 /**
  * Translates seconds into human readable format of seconds, minutes, hours, days, and years
  * e.g. 1 hour 25 minutes 15 seconds
@@ -163,7 +165,7 @@ export function getExactDuration(
   minDuration: string = 'milliseconds'
 ) {
   const operation = seconds < 0 ? Math.ceil : Math.floor;
-  const levels = [
+  const levels: Level[] = [
     [operation(seconds / 604800), abbreviation ? 'wk' : ' weeks'],
     [operation((seconds % 604800) / 86400), abbreviation ? 'd' : ' days'],
     [operation(((seconds % 604800) % 86400) / 3600), abbreviation ? 'hr' : ' hours'],
@@ -184,7 +186,7 @@ export function getExactDuration(
 
   for (let i = 0, max = levels.length; i < max; i++) {
     if (
-      (i === max - 1 || minDuration === (levels[i][1] as string).trim()) &&
+      (i === max - 1 || minDuration === levels[i][1].trim()) &&
       !returntext &&
       !levels[i][0]
     ) {
@@ -197,10 +199,10 @@ export function getExactDuration(
     returntext +=
       ' ' +
       levels[i][0] +
-      (!abbreviation && Math.abs(levels[i][0] as number) === 1
-        ? (levels[i][1] as string).substring(0, (levels[i][1] as string).length - 1) // strip the 's' from the end if its singular
+      (!abbreviation && Math.abs(levels[i][0]) === 1
+        ? (levels[i][1] as string).substring(0, levels[i][1].length - 1) // strip the 's' from the end if its singular
         : levels[i][1]);
-    if (minDuration === (levels[i][1] as string).trim()) {
+    if (minDuration === levels[i][1].trim()) {
       break;
     }
   }

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -196,12 +196,16 @@ export function getExactDuration(
     if (levels[i][0] === 0) {
       continue;
     }
+    const singular = levels[i][1].substring(0, levels[i][1].length - 1);
+    const duration = levels[i][1];
+    const quotient = levels[i][0];
+
     returntext +=
-      ' ' +
-      levels[i][0] +
-      (!abbreviation && Math.abs(levels[i][0]) === 1
-        ? (levels[i][1] as string).substring(0, levels[i][1].length - 1) // strip the 's' from the end if its singular
-        : levels[i][1]);
+      ' ' + quotient + abbreviation
+        ? // eslint-disable-next-line sentry/no-dynamic-translations
+          t(duration)
+        : // eslint-disable-next-line sentry/no-dynamic-translations
+          tn(singular, duration, levels[i][0]);
     if (minDuration === levels[i][1].trim()) {
       break;
     }

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -152,6 +152,8 @@ export function getDuration(
  *
  * NOTE: seconds input can be a decimal
  * @param  {number} seconds The number of seconds to be processed
+ * @param  {boolean} abbreviation abbreviates the suffix
+ * @param  {string} minDuration pins the response to desired suffix
  * @return {string}         The phrase describing the amount of time
  */
 export function getExactDuration(

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -148,6 +148,11 @@ export function getDuration(
 }
 
 type Level = [number, string];
+const SECS_IN_WKS = 604800;
+const SECS_IN_DAYS = 86400;
+const SECS_IN_HRS = 3600;
+const SECS_IN_MIN = 60;
+const MS_IN_S = 1000;
 
 /**
  * Translates seconds into human readable format of seconds, minutes, hours, days, and years
@@ -166,19 +171,27 @@ export function getExactDuration(
 ) {
   const operation = seconds < 0 ? Math.ceil : Math.floor;
   const levels: Level[] = [
-    [operation(seconds / 604800), abbreviation ? 'wk' : ' weeks'],
-    [operation((seconds % 604800) / 86400), abbreviation ? 'd' : ' days'],
-    [operation(((seconds % 604800) % 86400) / 3600), abbreviation ? 'hr' : ' hours'],
+    [operation(seconds / SECS_IN_WKS), abbreviation ? 'wk' : ' weeks'],
+    [operation((seconds % SECS_IN_WKS) / SECS_IN_DAYS), abbreviation ? 'd' : ' days'],
     [
-      operation((((seconds % 604800) % 86400) % 3600) / 60),
+      operation(((seconds % SECS_IN_WKS) % SECS_IN_DAYS) / SECS_IN_HRS),
+      abbreviation ? 'hr' : ' hours',
+    ],
+    [
+      operation((((seconds % SECS_IN_WKS) % SECS_IN_DAYS) % SECS_IN_HRS) / SECS_IN_MIN),
       abbreviation ? 'min' : ' minutes',
     ],
     [
-      operation((((seconds % 604800) % 86400) % 3600) % 60),
+      operation((((seconds % SECS_IN_WKS) % SECS_IN_DAYS) % SECS_IN_HRS) % SECS_IN_MIN),
       abbreviation ? 's' : ' seconds',
     ],
     [
-      operation((((((seconds * 1000) % 604800000) % 86400000) % 3600000) % 60000) % 1000),
+      operation(
+        (((((seconds * MS_IN_S) % (SECS_IN_WKS * MS_IN_S)) % (SECS_IN_DAYS * MS_IN_S)) %
+          (SECS_IN_HRS * MS_IN_S)) %
+          (SECS_IN_MIN * MS_IN_S)) %
+          MS_IN_S
+      ),
       abbreviation ? 'ms' : ' milliseconds',
     ],
   ];

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -149,12 +149,13 @@ export function getDuration(
 
 /**
  * Translates seconds into human readable format of seconds, minutes, hours, days, and years
+ * e.g. 1 hour 25 minutes 15 seconds
  *
- * NOTE: seconds input can be a decimal
- * @param  {number} seconds The number of seconds to be processed
- * @param  {boolean} abbreviation abbreviates the suffix
- * @param  {string} minDuration pins the response to desired suffix
- * @return {string}         The phrase describing the amount of time
+ * NOTE: seconds input can be a provided as a decimal
+ * @param  seconds      The number of seconds to be processed
+ * @param  abbreviation abbreviates the suffix
+ * @param  minDuration  pins the response to desired suffix
+ * @return {string}     The phrase describing the amount of time
  */
 export function getExactDuration(
   seconds: number,

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -154,7 +154,11 @@ export function getDuration(
  * @param  {number} seconds The number of seconds to be processed
  * @return {string}         The phrase describing the amount of time
  */
-export function getExactDuration(seconds: number, abbreviation: boolean = false) {
+export function getExactDuration(
+  seconds: number,
+  abbreviation: boolean = false,
+  minDuration = 'milliseconds'
+) {
   const operation = seconds < 0 ? Math.ceil : Math.floor;
   const levels = [
     [operation(seconds / 604800), abbreviation ? 'wk' : ' weeks'],
@@ -169,19 +173,20 @@ export function getExactDuration(seconds: number, abbreviation: boolean = false)
       abbreviation ? 's' : ' seconds',
     ],
     [
-      operation(
-        (((((seconds % 604800) % 86400) % 3600) % 60) -
-          operation(((((seconds % 31536000) % 604800) % 86400) % 3600) % 60)) *
-          1000
-      ),
+      operation((((((seconds * 1000) % 604800000) % 86400000) % 3600000) % 60000) % 1000),
       abbreviation ? 'ms' : ' milliseconds',
     ],
   ];
   let returntext = '';
 
   for (let i = 0, max = levels.length; i < max; i++) {
-    if (i === max - 1 && !returntext && !levels[i][0]) {
+    if (
+      (i === max - 1 || minDuration === (levels[i][1] as string).trim()) &&
+      !returntext &&
+      !levels[i][0]
+    ) {
       returntext = '0' + levels[i][1];
+      break;
     }
     if (levels[i][0] === 0) {
       continue;
@@ -189,9 +194,12 @@ export function getExactDuration(seconds: number, abbreviation: boolean = false)
     returntext +=
       ' ' +
       levels[i][0] +
-      (!abbreviation && Math.abs(levels[i][0]) === 1
+      (!abbreviation && Math.abs(levels[i][0] as number) === 1
         ? (levels[i][1] as string).substring(0, (levels[i][1] as string).length - 1) // strip the 's' from the end if its singular
         : levels[i][1]);
+    if (minDuration === (levels[i][1] as string).trim()) {
+      break;
+    }
   }
   return returntext.trim();
 }

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -160,7 +160,7 @@ export function getDuration(
 export function getExactDuration(
   seconds: number,
   abbreviation: boolean = false,
-  minDuration = 'milliseconds'
+  minDuration: string = 'milliseconds'
 ) {
   const operation = seconds < 0 ? Math.ceil : Math.floor;
   const levels = [

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -148,70 +148,44 @@ export function getDuration(
 }
 
 /**
- * Returns a human readable exact duration.
+ * Translates seconds into human readable format of seconds, minutes, hours, days, and years
  *
- * e.g. 1 hour 25 minutes 15 seconds
+ * @param  {number} seconds The number of seconds to be processed
+ * @return {string}         The phrase describing the amount of time
  */
 export function getExactDuration(seconds: number, abbreviation: boolean = false) {
-  const convertDuration = (secs: number, abbr: boolean): string => {
-    // value in milliseconds
-    const msValue = round(secs * 1000);
-    const value = round(Math.abs(secs * 1000));
+  const levels = [
+    [Math.floor(seconds / 31536000), abbreviation ? 'years' : 'yr'],
+    [Math.floor((seconds % 31536000) / 604800), abbreviation ? 'weeks' : 'wk'],
+    [Math.floor(((seconds % 31536000) % 604800) / 86400), abbreviation ? 'days' : 'd'],
+    [
+      Math.floor((((seconds % 31536000) % 604800) % 86400) / 3600),
+      abbreviation ? 'hours' : 'hr',
+    ],
+    [
+      Math.floor(((((seconds % 31536000) % 604800) % 86400) % 3600) / 60),
+      abbreviation ? 'minutes' : 'min',
+    ],
+    [
+      ((((seconds % 31536000) % 604800) % 86400) % 3600) % 60,
+      abbreviation ? 'seconds' : 's',
+    ],
+  ];
+  let returntext = '';
 
-    const divideBy = (time: number) => {
-      return {
-        quotient: msValue < 0 ? Math.ceil(msValue / time) : Math.floor(msValue / time),
-        remainder: msValue % time,
-      };
-    };
-
-    if (value >= WEEK) {
-      const {quotient, remainder} = divideBy(WEEK);
-      const suffix = abbr ? t('wk') : ` ${tn('week', 'weeks', quotient)}`;
-
-      return `${quotient}${suffix} ${convertDuration(remainder / 1000, abbr)}`;
+  for (let i = 0, max = levels.length; i < max; i++) {
+    if (levels[i][0] === 0) {
+      continue;
     }
-    if (value >= DAY) {
-      const {quotient, remainder} = divideBy(DAY);
-      const suffix = abbr ? t('d') : ` ${tn('day', 'days', quotient)}`;
-
-      return `${quotient}${suffix} ${convertDuration(remainder / 1000, abbr)}`;
-    }
-    if (value >= HOUR) {
-      const {quotient, remainder} = divideBy(HOUR);
-      const suffix = abbr ? t('hr') : ` ${tn('hour', 'hours', quotient)}`;
-
-      return `${quotient}${suffix} ${convertDuration(remainder / 1000, abbr)}`;
-    }
-    if (value >= MINUTE) {
-      const {quotient, remainder} = divideBy(MINUTE);
-      const suffix = abbr ? t('min') : ` ${tn('minute', 'minutes', quotient)}`;
-
-      return `${quotient}${suffix} ${convertDuration(remainder / 1000, abbr)}`;
-    }
-    if (value >= SECOND) {
-      const {quotient, remainder} = divideBy(SECOND);
-      const suffix = abbr ? t('s') : ` ${tn('second', 'seconds', quotient)}`;
-
-      return `${quotient}${suffix} ${convertDuration(remainder / 1000, abbr)}`;
-    }
-
-    if (value === 0) {
-      return '';
-    }
-
-    const suffix = abbr ? t('ms') : ` ${tn('millisecond', 'milliseconds', value)}`;
-
-    return `${msValue}${suffix}`;
-  };
-
-  const result = convertDuration(seconds, abbreviation).trim();
-
-  if (result.length) {
-    return result;
+    returntext +=
+      ' ' +
+      levels[i][0] +
+      ' ' +
+      (!abbreviation && levels[i][0] === 1
+        ? (levels[i][1] as string).substring(0, (levels[i][1] as string).length - 1) // strip the 's' from the end if its singular
+        : levels[i][1]);
   }
-
-  return `0${abbreviation ? t('ms') : ` ${t('milliseconds')}`}`;
+  return returntext.trim();
 }
 
 export function formatSecondsToClock(

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -150,38 +150,46 @@ export function getDuration(
 /**
  * Translates seconds into human readable format of seconds, minutes, hours, days, and years
  *
+ * NOTE: seconds input can be a decimal
  * @param  {number} seconds The number of seconds to be processed
  * @return {string}         The phrase describing the amount of time
  */
 export function getExactDuration(seconds: number, abbreviation: boolean = false) {
+  const operation = seconds < 0 ? Math.ceil : Math.floor;
   const levels = [
-    [Math.floor(seconds / 31536000), abbreviation ? 'years' : 'yr'],
-    [Math.floor((seconds % 31536000) / 604800), abbreviation ? 'weeks' : 'wk'],
-    [Math.floor(((seconds % 31536000) % 604800) / 86400), abbreviation ? 'days' : 'd'],
+    [operation(seconds / 604800), abbreviation ? 'wk' : ' weeks'],
+    [operation((seconds % 604800) / 86400), abbreviation ? 'd' : ' days'],
+    [operation(((seconds % 604800) % 86400) / 3600), abbreviation ? 'hr' : ' hours'],
     [
-      Math.floor((((seconds % 31536000) % 604800) % 86400) / 3600),
-      abbreviation ? 'hours' : 'hr',
+      operation((((seconds % 604800) % 86400) % 3600) / 60),
+      abbreviation ? 'min' : ' minutes',
     ],
     [
-      Math.floor(((((seconds % 31536000) % 604800) % 86400) % 3600) / 60),
-      abbreviation ? 'minutes' : 'min',
+      operation((((seconds % 604800) % 86400) % 3600) % 60),
+      abbreviation ? 's' : ' seconds',
     ],
     [
-      ((((seconds % 31536000) % 604800) % 86400) % 3600) % 60,
-      abbreviation ? 'seconds' : 's',
+      operation(
+        (((((seconds % 604800) % 86400) % 3600) % 60) -
+          operation(((((seconds % 31536000) % 604800) % 86400) % 3600) % 60)) *
+          1000
+      ),
+      abbreviation ? 'ms' : ' milliseconds',
     ],
   ];
   let returntext = '';
 
   for (let i = 0, max = levels.length; i < max; i++) {
+    if (i === max - 1 && !returntext && !levels[i][0]) {
+      returntext = '0' + levels[i][1];
+    }
     if (levels[i][0] === 0) {
       continue;
     }
     returntext +=
       ' ' +
       levels[i][0] +
-      ' ' +
-      (!abbreviation && levels[i][0] === 1
+      (!abbreviation && Math.abs(levels[i][0]) === 1
         ? (levels[i][1] as string).substring(0, (levels[i][1] as string).length - 1) // strip the 's' from the end if its singular
         : levels[i][1]);
   }


### PR DESCRIPTION
Updates the exact formatter algorithm to simply iterate rather than recurse
Also introduces a `minDuration` argument so we don't need to default to milliseconds on 0