### PR TITLE
fix(hybridcloud) Fix a queue silo assignment

### DIFF
--- a/src/sentry/tasks/deletion/hybrid_cloud.py
+++ b/src/sentry/tasks/deletion/hybrid_cloud.py
@@ -92,7 +92,7 @@ def _chunk_watermark_batch(
 
 @instrumented_task(
     name="sentry.tasks.deletion.hybrid_cloud.schedule_hybrid_cloud_foreign_key_jobs_control",
-    queue="cleanup",
+    queue="cleanup.control",
     acks_late=True,
     silo_mode=SiloMode.CONTROL,
 )


### PR DESCRIPTION
Move foreign key cleanup task to the control queues so we don't have cross silo queue jobs.