### PR TITLE
feat(statistical-detectors): register timeseries query window option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1586,6 +1586,12 @@ register(
     default=100,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "statistical_detectors.query.transactions.timeseries_days",
+    type=Int,
+    default=14,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "options_automator_slack_webhook_enabled",


### PR DESCRIPTION
Registers the `statistical_detectors.query.transactions.timeseries_days` option, containing an integer number of days of timeseries data to send to the breakpoint microservice. (More days is a tradeoff of scalability vs detection accuracy).

Spun out of https://github.com/getsentry/sentry/pull/58192 via https://github.com/getsentry/sentry/pull/58192/files#r1364475401.