### PR TITLE
fix(stat-detectors): EventID in Sampled Events links to Transactions

### DIFF
--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -116,7 +116,13 @@ function AllEventsTable(props: Props) {
     <EventsTable
       eventView={eventView}
       location={location}
-      issueId={issueId}
+      issueId={
+        // Unset the issueId for regressions because we want to
+        // link to events in the Transaction page
+        group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION
+          ? undefined
+          : issueId
+      }
       organization={organization}
       routes={routes}
       excludedTags={excludedTags}


### PR DESCRIPTION
Since the duration regression issues are focused on a transaction, we don't want the current behaviour where we link to events in the issue when clicking the event ID. We want redirect to the Event Details page in Transaction Summary