### PR TITLE
fix(issues): Remove jitter when collapsing participants

### DIFF
--- a/static/app/views/issueDetails/participantList.tsx
+++ b/static/app/views/issueDetails/participantList.tsx
@@ -81,7 +81,7 @@ export function ParticipantList({teams = [], users, children}: ParticipantListPr
           <motion.div
             variants={{
               open: {height: '100%', opacity: 1, marginTop: space(1)},
-              closed: {height: '0', opacity: 0},
+              closed: {height: '0', opacity: 0, marginTop: 0},
             }}
             initial="closed"
             animate="open"


### PR DESCRIPTION
there was a bit of a jump on exit. thanks @roggenkemper 


https://github.com/getsentry/sentry/assets/1400464/8a8c90a6-48cc-4c84-9224-94d52365aa9b

