### PR TITLE
chore: Update migration SQL dump action

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -85,7 +85,7 @@ jobs:
           echo 'EOF' >> "$GITHUB_OUTPUT"
 
       - name: Generate SQL for migration
-        uses: getsentry/action-migrations@f1dc34590460c0fe06ec11c00fec6c16a2159977 # main
+        uses: getsentry/action-migrations@4d8ed0388dfc0774302bbfd5204e518f9ac4f066 # main
         env:
           SENTRY_LOG_LEVEL: ERROR
         with:


### PR DESCRIPTION
Update the migration SQL dump action so that it can generate SQL for django apps that are not sentry. We need this as we move from a single migration history to using more django apps each with their own migration history.