### PR TITLE
fix(ui): Switch to export instead of import/export tabList

### DIFF
--- a/static/app/components/tabs/index.tsx
+++ b/static/app/components/tabs/index.tsx
@@ -6,11 +6,10 @@ import {AriaTabListOptions} from '@react-aria/tabs';
 import {TabListState, TabListStateOptions} from '@react-stately/tabs';
 import {Orientation} from '@react-types/shared';
 
-import {TabList, TabListProps} from './tabList';
-import {TabPanels} from './tabPanels';
 import {tabsShouldForwardProp} from './utils';
 
-export {TabList, TabListProps, TabPanels};
+export {TabList, TabListProps} from './tabList';
+export {TabPanels} from './tabPanels';
 
 export interface TabsProps<T>
   extends Omit<

--- a/static/app/components/tabs/index.tsx
+++ b/static/app/components/tabs/index.tsx
@@ -8,7 +8,7 @@ import {Orientation} from '@react-types/shared';
 
 import {tabsShouldForwardProp} from './utils';
 
-export {TabList, TabListProps} from './tabList';
+export {TabList, type TabListProps} from './tabList';
 export {TabPanels} from './tabPanels';
 
 export interface TabsProps<T>


### PR DESCRIPTION
Fixes a warning in webpack

![image](https://github.com/getsentry/sentry/assets/1400464/02926167-6b40-4b49-b18a-95d2e661b6c8)
