### PR TITLE
feat(metrics): Add ability for indexer cache to write new schema

### DIFF
--- a/tests/sentry/sentry_metrics/test_all_indexers.py
+++ b/tests/sentry/sentry_metrics/test_all_indexers.py
@@ -202,7 +202,12 @@ def test_static_and_non_static_strings_generic_metrics(indexer):
 
 
 def test_indexer(indexer, indexer_cache, use_case_id):
-    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
+            "sentry-metrics.indexer.write-new-cache-namespace": False,
+        }
+    ):
         org1_id = 1
         org2_id = 2
         strings = {"hello", "hey", "hi"}
@@ -257,7 +262,12 @@ def test_resolve_and_reverse_resolve(indexer, indexer_cache, use_case_id):
     """
     Test `resolve` and `reverse_resolve` methods
     """
-    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
+            "sentry-metrics.indexer.write-new-cache-namespace": False,
+        }
+    ):
         org1_id = 1
         strings = {"hello", "hey", "hi"}
 
@@ -285,7 +295,12 @@ def test_already_created_plus_written_results(indexer, indexer_cache, use_case_i
     Test that we correctly combine db read results with db write results
     for the same organization.
     """
-    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
+            "sentry-metrics.indexer.write-new-cache-namespace": False,
+        }
+    ):
         org_id = 1234
 
         raw_indexer = indexer
@@ -332,7 +347,12 @@ def test_already_cached_plus_read_results(indexer, indexer_cache, use_case_id) -
     Test that we correctly combine cached results with read results
     for the same organization.
     """
-    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
+            "sentry-metrics.indexer.write-new-cache-namespace": False,
+        }
+    ):
         org_id = 8
         cached = {
             f"{use_case_id.value}:{org_id}:beep": 10,
@@ -371,7 +391,12 @@ def test_already_cached_plus_read_results(indexer, indexer_cache, use_case_id) -
 
 
 def test_read_when_bulk_record(indexer, use_case_id):
-    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
+            "sentry-metrics.indexer.write-new-cache-namespace": False,
+        }
+    ):
         strings = {
             use_case_id: {
                 1: {"a"},
@@ -483,7 +508,12 @@ def test_bulk_reverse_resolve(indexer):
     Tests reverse resolve properly returns the corresponding strings
     in the proper order when given a combination of shared and non-shared ids.
     """
-    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
+            "sentry-metrics.indexer.write-new-cache-namespace": False,
+        }
+    ):
         org_id = 7
         use_case_id = UseCaseID.SESSIONS  # any use case would do
         static_indexer = StaticStringIndexer(indexer)

--- a/tests/sentry/sentry_metrics/test_indexer_cache.py
+++ b/tests/sentry/sentry_metrics/test_indexer_cache.py
@@ -22,7 +22,12 @@ def use_case_id() -> str:
 
 
 def test_cache(use_case_id: str) -> None:
-    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
+            "sentry-metrics.indexer.write-new-cache-namespace": False,
+        }
+    ):
         cache.clear()
         namespace = "test"
         assert indexer_cache.get(namespace, f"{use_case_id}:1:blah:123") is None
@@ -32,9 +37,67 @@ def test_cache(use_case_id: str) -> None:
         indexer_cache.delete(namespace, f"{use_case_id}:1:blah:123")
         assert indexer_cache.get(namespace, f"{use_case_id}:1:blah:123") is None
 
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
+            "sentry-metrics.indexer.write-new-cache-namespace": True,
+        }
+    ):
+        cache.clear()
+        namespace = "test"
+        assert indexer_cache.get(namespace, f"{use_case_id}:1:blah:123") is None
+        indexer_cache.set(namespace, f"{use_case_id}:1:blah:123", 1)
+        assert indexer_cache.get(namespace, f"{use_case_id}:1:blah:123") == 1
+
+        indexer_cache.delete(namespace, f"{use_case_id}:1:blah:123")
+        assert indexer_cache.get(namespace, f"{use_case_id}:1:blah:123") is None
+
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": True,
+            "sentry-metrics.indexer.write-new-cache-namespace": True,
+        }
+    ):
+        cache.clear()
+        namespace = "test"
+        assert indexer_cache.get(namespace, f"{use_case_id}:1:blah:123") is None
+        indexer_cache.set(namespace, f"{use_case_id}:1:blah:123", 1)
+        assert indexer_cache.get(namespace, f"{use_case_id}:1:blah:123") == 1
+
+        indexer_cache.delete(namespace, f"{use_case_id}:1:blah:123")
+        assert indexer_cache.get(namespace, f"{use_case_id}:1:blah:123") is None
+
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": True,
+            "sentry-metrics.indexer.write-new-cache-namespace": True,
+        }
+    ):
+        cache.clear()
+        namespace_1 = "1"
+        namespace_2 = "2"
+        assert indexer_cache.get(namespace_1, f"{use_case_id}:1:blah:123") is None
+        indexer_cache.set(namespace_1, f"{use_case_id}:1:blah:123", 1)
+        assert indexer_cache.get(namespace_1, f"{use_case_id}:1:blah:123") == 1
+
+        indexer_cache.delete(namespace_1, f"{use_case_id}:1:blah:123")
+        assert indexer_cache.get(namespace_1, f"{use_case_id}:1:blah:123") is None
+
+        assert indexer_cache.get(namespace_2, f"{use_case_id}:1:blah:123") is None
+        indexer_cache.set(namespace_2, f"{use_case_id}:1:blah:123", 2)
+        assert indexer_cache.get(namespace_2, f"{use_case_id}:1:blah:123") == 2
+
+        indexer_cache.delete(namespace_2, f"{use_case_id}:1:blah:123")
+        assert indexer_cache.get(namespace_2, f"{use_case_id}:1:blah:123") is None
+
 
 def test_cache_many(use_case_id: str) -> None:
-    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
+            "sentry-metrics.indexer.write-new-cache-namespace": False,
+        }
+    ):
         cache.clear()
         namespace = "test"
         values = {f"{use_case_id}:100:hello": 2, f"{use_case_id}:100:bye": 3}
@@ -53,7 +116,12 @@ def test_cache_many(use_case_id: str) -> None:
 
 
 def test_make_cache_key(use_case_id: str) -> None:
-    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
+            "sentry-metrics.indexer.write-new-cache-namespace": False,
+        }
+    ):
         cache.clear()
         namespace = "test"
         orgId = 1
@@ -64,7 +132,12 @@ def test_make_cache_key(use_case_id: str) -> None:
 
         assert key == f"indexer:test:org:str:{use_case_id}:{hashed}"
 
-    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": True}):
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": True,
+            "sentry-metrics.indexer.write-new-cache-namespace": False,
+        }
+    ):
         cache.clear()
         namespace = "test"
         orgId = 1
@@ -77,14 +150,24 @@ def test_make_cache_key(use_case_id: str) -> None:
 
 
 def test_formatted_results(use_case_id: str) -> None:
-    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
+            "sentry-metrics.indexer.write-new-cache-namespace": False,
+        }
+    ):
         cache.clear()
         namespace = "test"
         values = {f"{use_case_id}:1:::hello": 2, f"{use_case_id}:1:::bye": 3}
         results = {indexer_cache._make_cache_key(k): v for k, v in values.items()}
         assert indexer_cache._format_results(list(values.keys()), results) == values
 
-    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": True}):
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": True,
+            "sentry-metrics.indexer.write-new-cache-namespace": False,
+        }
+    ):
         cache.clear()
         namespace = "test"
         values = {
@@ -114,7 +197,12 @@ def test_ttl_jitter() -> None:
 
 
 def test_separate_namespacing() -> None:
-    with override_options({"sentry-metrics.indexer.read-new-cache-namespace": False}):
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": False,
+            "sentry-metrics.indexer.write-new-cache-namespace": False,
+        }
+    ):
         namespace = "test"
         indexer_cache.set(namespace, "sessions:3:what", 1)
         assert indexer_cache.get(namespace, "sessions:3:what") == 1


### PR DESCRIPTION
# This PR

- Read the sentry option `sentry-metrics.indexer.write-new-cache-namespace` (set to False default), and if it's True, write to the new cache schema along with the old cache schema.

**Previous change in this stack PR**
https://github.com/getsentry/sentry/pull/58178

# Motivation

<details>
  <summary>Click to expand</summary>

The indexer is making the following assumptions with Memcached:

1. We are only adding key/value pairs to Memcached during `bulk_record` (the indexer’s “write path”)
2. Key/value pairs are gone from Memcached after 2 hours

It’s very easy to break 1 or 2 inadvertently. For example, we are inserting key/value pairs back into the cache during a `resolve` cache miss. Doing so is justified as some strings could be more read heavy than write heavy, such as users with automated scripts that are scanning for a specific key to show up.

</details>

# Background

<details>
  <summary>Click to expand</summary>

**How accessing the cache works today in the Indexer**

| Method | Key exists? | Behaviour |
| --- | --- | --- |
| bulk_record | ✅ | - Use the value from cache <br>- Emit `CACHE_READ` in header |
| bulk_record | ❌ | - Fetch value from Postgres<br>- Emit DB_READ in header<br>- Write {string} → {id} to cache |
| resolve | ✅ | - Use value from cache |
| resolve | ❌ | - Fetch value from Postgres<br>- Write {string} → {id} to cache |

where `bulk_record` = the code path for writing indexed strings

and     `resolve`         = the code path for querying strings
</details>

# Goal

<details>
  <summary>Click to expand</summary>
We store a timestamp of when the cache is stored in the value, and also partition the key between the write and read path.

`(writer + string) → (integer + timestamp)`

### ******************************How this works******************************

- Creates a distinction between, and handles appropriately, both the read and write path of replenishing the cache
- Log a metric in this scenario
- Simultaneously makes us aware of, and mitigates, unexpected cache behaviors
- Actually fixes the issue where we were replenishing the cache on the read path

| Method | Key exists? | Timestamp valid? | Behaviour |
| --- | --- | --- | --- |
| bulk_record | ✅ | ✅ | - Use value from cache<br>- Emit CACHE_READ in header |
| bulk_record | ✅ | ❌ | - Fetch value from Postgres<br>- Emit DB_READ in header<br>- Write br:{string} → {id}:{timestamp} to cache<br>- Increment metric |
| bulk_record | ❌ | - | - Fetch value from Postgres<br>- Emit DB_READ in header<br>- Write br:{string} → {id}:{timestamp} to cache |
| resolve | ✅ | ✅ | - Use value from cache |
| resolve | ✅ | ❌ | - Use value from cache<br>- Write res:{string} → {id}:{timestamp} to cache<br>- Increment metric |
| resolve | ❌ | - | - Fetch value from Postgres<br>- Write res:{string} → {id}:{timestamp} to cache |

</details>

# Deployment Plan

<details>
  <summary>Click to expand</summary>

1. Deploy read paths that can toggle between reading from `(string) → (integer)` and `(writer + string) → (integer + timestamp)` via a sentry option
2. [THIS PR] Deploy `bulk_record` changes to write to both types of key/value pairs (`(string) → (integer)` and `(writer + string) → (integer + timestamp)`) on each `bulk_record` lookup
3. Toggle the option deployed in step 1 to read from `(writer + string) → (integer + timestamp)`
4. (observability) Deploy logic to emit metric when timestamp that is greater than 2-3 hours
5. (mitigation) Deploy logic to reject key/value pairs when timestamp is greater than 2-3 hours
6. Add back the `resolve` path cache replenishment

</details>

# Local Testing

<details>
  <summary>Click to expand</summary>

Started sentry with memcache and kcat on `snuba-generic-metrics`

```
kcat -b localhost:9092 -t snuba-generic-metrics -C \
  -f '\nKey (%K bytes): %k
  Value (%S bytes): %s
  Timestamp: %T
  Partition: %p
  Offset: %o
  Headers: %h\n'
```

Send first batch of 3 messages with the send_metrics script

```
python bin/send_metrics.py --use-cases custom
```

Confirm that all 3 values have fetch type of FIRST_SEEN ("f")

```
Key (-1 bytes):
  Value (495 bytes): {"tags":{"9223372036854776010":"production","9223372036854776017":"init","67563":"metric_e2e_custom_counter_v_AIXH44IB"},"version":2,"retention_days":90,"mapping_meta":{"h":{"9223372036854776010":"environment","9223372036854776017":"session.status"},"f":{"67563":"metric_e2e_custom_counter_k_AIXH44IB"},"c":{"65555":"c:custom/custom@none"}},"use_case_id":"custom","metric_id":65555,"org_id":1,"timestamp":1697664813,"project_id":3,"type":"c","value":1,"sentry_received_timestamp":1697664813.218}
  Timestamp: 1697664834437
  Partition: 0
  Offset: 408
  Headers: mapping_sources=cfh,metric_type=c

Key (-1 bytes):
  Value (491 bytes): {"tags":{"9223372036854776010":"production","9223372036854776017":"errored","67562":"metric_e2e_custom_set_v_AIXH44IB"},"version":2,"retention_days":90,"mapping_meta":{"h":{"9223372036854776010":"environment","9223372036854776017":"session.status"},"f":{"67562":"metric_e2e_custom_set_k_AIXH44IB"},"c":{"65556":"s:custom/error@none"}},"use_case_id":"custom","metric_id":65556,"org_id":1,"timestamp":1697664813,"project_id":3,"type":"s","value":[3],"sentry_received_timestamp":1697664813.218}
  Timestamp: 1697664834437
  Partition: 0
  Offset: 409
  Headers: mapping_sources=cfh,metric_type=s

Key (-1 bytes):
  Value (502 bytes): {"tags":{"9223372036854776010":"production","9223372036854776017":"healthy","67561":"metric_e2e_custom_dist_v_AIXH44IB"},"version":2,"retention_days":90,"mapping_meta":{"h":{"9223372036854776010":"environment","9223372036854776017":"session.status"},"c":{"65558":"d:custom/duration@second"},"f":{"67561":"metric_e2e_custom_dist_k_AIXH44IB"}},"use_case_id":"custom","metric_id":65558,"org_id":1,"timestamp":1697664813,"project_id":3,"type":"d","value":[4,5,6],"sentry_received_timestamp":1697664813.218}
  Timestamp: 1697664834437
  Partition: 0
  Offset: 410
  Headers: mapping_sources=cfh,metric_type=d
% Reached end of topic snuba-generic-metrics [0] at offset 411
```

Send the same batch of 3 messages with the send_metrics script

```
python bin/send_metrics.py --use-cases custom --rand-str AIXH44IB
```

Confirm that the new messages all have fetch type of CACHE_HIT ("c")

```
Key (-1 bytes):
  Value (485 bytes): {"tags":{"9223372036854776010":"production","9223372036854776017":"errored","67562":"metric_e2e_custom_set_v_AIXH44IB"},"version":2,"retention_days":90,"mapping_meta":{"h":{"9223372036854776010":"environment","9223372036854776017":"session.status"},"c":{"67562":"metric_e2e_custom_set_k_AIXH44IB","65556":"s:custom/error@none"}},"use_case_id":"custom","metric_id":65556,"org_id":1,"timestamp":1697664926,"project_id":3,"type":"s","value":[3],"sentry_received_timestamp":1697664926.943}
  Timestamp: 1697664948036
  Partition: 0
  Offset: 411
  Headers: mapping_sources=ch,metric_type=s

Key (-1 bytes):
  Value (496 bytes): {"tags":{"9223372036854776010":"production","9223372036854776017":"healthy","67561":"metric_e2e_custom_dist_v_AIXH44IB"},"version":2,"retention_days":90,"mapping_meta":{"h":{"9223372036854776010":"environment","9223372036854776017":"session.status"},"c":{"65558":"d:custom/duration@second","67561":"metric_e2e_custom_dist_k_AIXH44IB"}},"use_case_id":"custom","metric_id":65558,"org_id":1,"timestamp":1697664926,"project_id":3,"type":"d","value":[4,5,6],"sentry_received_timestamp":1697664926.943}
  Timestamp: 1697664948036
  Partition: 0
  Offset: 412
  Headers: mapping_sources=ch,metric_type=d

Key (-1 bytes):
  Value (489 bytes): {"tags":{"9223372036854776010":"production","9223372036854776017":"init","67563":"metric_e2e_custom_counter_v_AIXH44IB"},"version":2,"retention_days":90,"mapping_meta":{"h":{"9223372036854776010":"environment","9223372036854776017":"session.status"},"c":{"67563":"metric_e2e_custom_counter_k_AIXH44IB","65555":"c:custom/custom@none"}},"use_case_id":"custom","metric_id":65555,"org_id":1,"timestamp":1697664926,"project_id":3,"type":"c","value":1,"sentry_received_timestamp":1697664926.943}
  Timestamp: 1697664948036
  Partition: 0
  Offset: 413
  Headers: mapping_sources=ch,metric_type=c
% Reached end of topic snuba-generic-metrics [0] at offset 414
```

</details>