### PR TITLE
feat(perf): Add performance score project config

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1654,6 +1654,8 @@ SENTRY_FEATURES = {
     "organizations:performance-database-view": False,
     # Enable removing the fallback for metrics compatibility
     "organizations:performance-remove-metrics-compatibility-fallback": False,
+    # Enable performance score calculation for transactions in relay
+    "organizations:performance-calculate-score-relay": False,
     # Enable the new Related Events feature
     "organizations:related-events": False,
     # Enable usage of external relays, for use with Relay. See

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -170,6 +170,7 @@ default_manager.add("organizations:performance-database-view", OrganizationFeatu
 default_manager.add("organizations:performance-remove-metrics-compatibility-fallback", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-statistical-detectors-ema", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:performance-statistical-detectors-breakpoint", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:performance-calculate-score-relay", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:profiling-ui-frames", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:profiling-using-transactions", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -409,6 +409,26 @@ def _get_project_config(
             ),
         }
 
+    if features.has("organizations:performance-calculate-score-relay", project.organization):
+        config["performanceScoreConfig"] = {
+            "profiles": [
+                {
+                    "name": "Desktop",
+                    "score_components": [
+                        {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600},
+                        {"measurement": "lcp", "weight": 0.30, "p10": 1200, "p50": 2400},
+                        {"measurement": "fid", "weight": 0.30, "p10": 100, "p50": 300},
+                        {"measurement": "cls", "weight": 0.25, "p10": 0.1, "p50": 0.25},
+                    ],
+                    "condition": {
+                        "op": "eq",
+                        "name": "event.contexts.browser.name",
+                        "value": "Chrome",
+                    },
+                }
+            ]
+        }
+
     config["spanAttributes"] = project.get_option("sentry:span_attributes")
     with Hub.current.start_span(op="get_filter_settings"):
         if filter_settings := get_filter_settings(project):

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -418,7 +418,8 @@ def _get_project_config(
                         {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600},
                         {"measurement": "lcp", "weight": 0.30, "p10": 1200, "p50": 2400},
                         {"measurement": "fid", "weight": 0.30, "p10": 100, "p50": 300},
-                        {"measurement": "cls", "weight": 0.25, "p10": 0.1, "p50": 0.25},
+                        {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25},
+                        {"measurement": "ttfb", "weight": 0.10, "p10": 200, "p50": 400},
                     ],
                     "condition": {
                         "op": "eq",

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -414,7 +414,7 @@ def _get_project_config(
             "profiles": [
                 {
                     "name": "Desktop",
-                    "score_components": [
+                    "scoreComponents": [
                         {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600},
                         {"measurement": "lcp", "weight": 0.30, "p10": 1200, "p50": 2400},
                         {"measurement": "fid", "weight": 0.30, "p10": 100, "p50": 300},

--- a/src/sentry/relay/config/measurements.py
+++ b/src/sentry/relay/config/measurements.py
@@ -45,6 +45,15 @@ BUILTIN_MEASUREMENTS: Sequence[BuiltinMeasurementKey] = [
     {"name": "ttfb", "unit": "millisecond"},
     {"name": "time_to_full_display", "unit": "millisecond"},
     {"name": "time_to_initial_display", "unit": "millisecond"},
+    {"name": "score.cls", "unit": "ratio"},
+    {"name": "score.fcp", "unit": "ratio"},
+    {"name": "score.fid", "unit": "ratio"},
+    {"name": "score.lcp", "unit": "ratio"},
+    {"name": "score.total", "unit": "ratio"},
+    {"name": "score.weight.cls", "unit": "ratio"},
+    {"name": "score.weight.fcp", "unit": "ratio"},
+    {"name": "score.weight.fid", "unit": "ratio"},
+    {"name": "score.weight.lcp", "unit": "ratio"},
 ]
 
 

--- a/src/sentry/relay/config/measurements.py
+++ b/src/sentry/relay/config/measurements.py
@@ -49,11 +49,13 @@ BUILTIN_MEASUREMENTS: Sequence[BuiltinMeasurementKey] = [
     {"name": "score.fcp", "unit": "ratio"},
     {"name": "score.fid", "unit": "ratio"},
     {"name": "score.lcp", "unit": "ratio"},
+    {"name": "score.ttfb", "unit": "ratio"},
     {"name": "score.total", "unit": "ratio"},
     {"name": "score.weight.cls", "unit": "ratio"},
     {"name": "score.weight.fcp", "unit": "ratio"},
     {"name": "score.weight.fid", "unit": "ratio"},
     {"name": "score.weight.lcp", "unit": "ratio"},
+    {"name": "score.weight.ttfb", "unit": "ratio"},
 ]
 
 


### PR DESCRIPTION
### Summary
This config will be used behind a feature flag in order to opt organizations into beginning to compute performance score measurements, to be used in starfish.


