### PR TITLE
fix(alerts): Add alert environment to issue links

### DIFF
--- a/static/app/views/alerts/rules/metric/details/relatedIssues.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/relatedIssues.spec.tsx
@@ -11,7 +11,14 @@ describe('metric details -> RelatedIssues', () => {
   const project = Project();
 
   it('adds environment to query parameters', async () => {
-    const {routerContext, organization, router} = initializeOrg();
+    const {routerContext, organization, router} = initializeOrg({
+      router: {
+        location: {
+          pathname: '/mock-pathname/',
+          query: {environment: 'test-env'},
+        },
+      },
+    });
     const rule = MetricRule({
       projects: [project.slug],
       environment: 'production',
@@ -50,5 +57,9 @@ describe('metric details -> RelatedIssues', () => {
         environment: 'production',
       },
     });
+    // The links should contain the query parameters, our test environment isn't able to update it
+    expect(
+      screen.getByRole('link', {name: /Level: Warning RequestError fetchData/})
+    ).toHaveAttribute('href', expect.stringContaining('environment=test-env'));
   });
 });

--- a/static/app/views/alerts/rules/metric/details/relatedIssues.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/relatedIssues.spec.tsx
@@ -1,0 +1,54 @@
+import {Group} from 'sentry-fixture/group';
+import {MetricRule} from 'sentry-fixture/metricRule';
+import {Project} from 'sentry-fixture/project';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import RelatedIssues from './relatedIssues';
+
+describe('metric details -> RelatedIssues', () => {
+  const project = Project();
+
+  it('adds environment to query parameters', async () => {
+    const {routerContext, organization, router} = initializeOrg();
+    const rule = MetricRule({
+      projects: [project.slug],
+      environment: 'production',
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/?end=2017-10-17T02%3A41%3A20.000Z&environment=production&groupStatsPeriod=auto&limit=5&project=2&sort=freq&start=2017-10-17T02%3A41%3A20.000Z',
+      body: [Group()],
+    });
+
+    render(
+      <RelatedIssues
+        organization={organization}
+        projects={[project]}
+        rule={rule}
+        timePeriod={{
+          display: '',
+          start: new Date().toISOString(),
+          end: new Date().toISOString(),
+          label: '',
+          period: '1d',
+          usingPeriod: true,
+        }}
+      />,
+      {context: routerContext, organization}
+    );
+
+    expect(await screen.findByTestId('group')).toBeInTheDocument();
+    expect(router.replace).toHaveBeenCalledWith({
+      pathname: '/mock-pathname/',
+      query: {
+        environment: 'production',
+      },
+    });
+  });
+});

--- a/static/app/views/alerts/rules/metric/details/relatedIssues.tsx
+++ b/static/app/views/alerts/rules/metric/details/relatedIssues.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
@@ -11,6 +11,7 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {OrganizationSummary, Project} from 'sentry/types';
+import useRouter from 'sentry/utils/useRouter';
 import {
   RELATED_ISSUES_BOOLEAN_QUERY_ERROR,
   RelatedIssuesNotAvailable,
@@ -30,6 +31,20 @@ interface Props {
 }
 
 function RelatedIssues({rule, organization, projects, query, timePeriod}: Props) {
+  const router = useRouter();
+
+  // Add environment to the query parameters to be picked up by GlobalSelectionLink
+  // GlobalSelectionLink uses the current query parameters to build links to issue details
+  useEffect(() => {
+    const env = rule.environment ?? '';
+    if (env !== (router.location.query.environment ?? '')) {
+      router.replace({
+        pathname: router.location.pathname,
+        query: {...router.location.query, environment: env},
+      });
+    }
+  }, [rule.environment, router]);
+
   function renderErrorMessage({detail}: {detail: string}, retry: () => void) {
     if (
       detail === RELATED_ISSUES_BOOLEAN_QUERY_ERROR &&


### PR DESCRIPTION
Metric alerts display a list of issues, if you click one the environment the alert is using should persist. There isn't a great way to mash the environment all the way down to the link since right now that component expects you to use query parameters.

fixes #50084