### PR TITLE
fix(discover): Add validation for empty equation

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -850,6 +850,8 @@ class BaseQueryBuilder:
                     resolved_orderby = bare_orderby
                 # Allow ordering equations directly with the raw alias (ie. equation|a + b)
                 elif is_equation(bare_orderby):
+                    if not strip_equation(bare_orderby):
+                        raise InvalidSearchQuery("Cannot sort by an empty equation")
                     resolved_orderby = self.equation_alias_map[strip_equation(bare_orderby)]
                     bare_orderby = resolved_orderby.alias
                 else:

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -828,3 +828,13 @@ class QueryBuilderTest(TestCase):
                 query="profile.id:foo",
                 selected_columns=["count()"],
             )
+
+    def test_orderby_raw_empty_equation(self):
+        with pytest.raises(InvalidSearchQuery, match=re.escape("Cannot sort by an empty equation")):
+            QueryBuilder(
+                Dataset.Discover,
+                self.params,
+                query="",
+                selected_columns=["count()"],
+                orderby="equation|",
+            )


### PR DESCRIPTION
Validate that the equation is not empty when stripped before attempting to resolve it as an orderby.

This should be accompanied by a PR to fix a state where the user can send this incorrect orderby in the widget builder in the future.

Fixes SENTRY-16YC