### PR TITLE
feat(agg-spans): Support http.method filter

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -104,7 +104,6 @@ class BaseAggregateSpans:
             the md5 hash of the value A-C-D and for span E would be md5 hash of the value A-C1-E.
         """
         key = span_tree["key"]
-        description = span_tree["description"]
         start_timestamp = span_tree["start_timestamp_ms"]
         if root_prefix is None:
             prefix = key
@@ -151,7 +150,7 @@ class BaseAggregateSpans:
                 "parent_node_fingerprint": parent_node_fingerprint,
                 "group": span_tree["group"],
                 "op": span_tree["op"],
-                "description": description if span_tree["group"] == NULL_GROUP else description,
+                "description": "" if span_tree["group"] == NULL_GROUP else span_tree["description"],
                 "start_timestamp": start_timestamp,
                 "start_ms": start_timestamp,  # TODO: Remove after updating frontend, duplicated for backward compatibility
                 "avg(exclusive_time)": span_tree["exclusive_time"],
@@ -263,9 +262,7 @@ class AggregateNodestoreSpans(BaseAggregateSpans):
                         "group": span.get("sentry_tags", {}).get("group")
                         or span.get("data", {}).get("span.group", NULL_GROUP),
                         "group_raw": span["hash"],
-                        "description": span.get("sentry_tags", {}).get("description")
-                        or span.get("data", {}).get("span.description")
-                        or span.get("description", ""),
+                        "description": span.get("sentry_tags", {}).get("description", ""),
                         "op": span.get("op", ""),
                         "start_timestamp_ms": span["start_timestamp"]
                         * 1000,  # timestamp is unix timestamp, convert to ms

--- a/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
+++ b/tests/snuba/api/endpoints/test_organization_spans_aggregation.py
@@ -251,6 +251,9 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
                         "span.group": "B",
                         "span.description": "connect",
                     },
+                    "sentry_tags": {
+                        "description": "connect",
+                    },
                 },
                 {
                     "same_process_as_parent": True,
@@ -266,6 +269,9 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
                         "span.group": "C",
                         "span.description": "connect",
                     },
+                    "sentry_tags": {
+                        "description": "connect",
+                    },
                 },
                 {
                     "same_process_as_parent": True,
@@ -280,6 +286,9 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
                         "offset": 0.057,
                         "span.group": "D",
                         "span.description": "resolve_orderby",
+                    },
+                    "sentry_tags": {
+                        "description": "resolve_orderby",
                     },
                 },
                 {
@@ -330,6 +339,9 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
                         "span.group": "B",
                         "span.description": "connect",
                     },
+                    "sentry_tags": {
+                        "description": "connect",
+                    },
                 },
                 {
                     "same_process_as_parent": True,
@@ -344,6 +356,9 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
                         "offset": 0.015,
                         "span.group": "C",
                         "span.description": "connect",
+                    },
+                    "sentry_tags": {
+                        "description": "connect",
                     },
                 },
                 {
@@ -360,6 +375,9 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
                         "span.group": "D",
                         "span.description": "resolve_orderby",
                     },
+                    "sentry_tags": {
+                        "description": "resolve_orderby",
+                    },
                 },
                 {
                     "same_process_as_parent": True,
@@ -374,6 +392,9 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
                         "offset": 1.055,
                         "span.group": "D",
                         "span.description": "resolve_orderby",
+                    },
+                    "sentry_tags": {
+                        "description": "resolve_orderby",
                     },
                 },
                 {
@@ -489,7 +510,7 @@ class OrganizationSpansAggregationTest(APITestCase, SnubaTestCase):
             data = response.data
             root_fingerprint = hashlib.md5(b"e238e6c2e2466b07-C-discover.snql").hexdigest()[:16]
             assert root_fingerprint in data
-            assert data[root_fingerprint]["description"] == "resolve_columns"
+            assert data[root_fingerprint]["description"] == ""
             assert data[root_fingerprint]["count()"] == 2
 
     @mock.patch("sentry.api.endpoints.organization_spans_aggregation.raw_snql_query")


### PR DESCRIPTION
Allow passing an http.method filter to the aggregate span waterfall.
Also, return empty span descriptions if it is not a parameterized
span description to avoid confusion and restrict getting descriptions
from "sentry_tags"