### PR TITLE
feat(monitors): Add waiting object status

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -467,6 +467,7 @@ class ObjectStatus:
     HIDDEN = 1
     PENDING_DELETION = 2
     DELETION_IN_PROGRESS = 3
+    WAITING = 4
 
     DISABLED = 1
 
@@ -477,6 +478,7 @@ class ObjectStatus:
             (cls.DISABLED, "disabled"),
             (cls.PENDING_DELETION, "pending_deletion"),
             (cls.DELETION_IN_PROGRESS, "deletion_in_progress"),
+            (cls.WAITING, "waiting"),
         )
 
 

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -506,10 +506,10 @@ class Quota(Service):
         Determines if a monitor seat assignment is accepted or rate limited. The Monitor status
         will be updated from ACTIVE to OK if the seat assignment is accepted.
         """
-        from sentry.monitors.models import MonitorStatus
+        from sentry.constants import ObjectStatus
         from sentry.utils.outcomes import Outcome
 
-        monitor.update(status=MonitorStatus.OK)
+        monitor.update(status=ObjectStatus.ACTIVE)
         return Outcome.ACCEPTED
 
     def unassign_monitor_seat(
@@ -519,9 +519,9 @@ class Quota(Service):
         """
         Disables a monitor seat assignment and sets the Monitor status to DISABLED
         """
-        from sentry.monitors.models import MonitorStatus
+        from sentry.constants import ObjectStatus
 
-        monitor.update(status=MonitorStatus.DISABLED)
+        monitor.update(status=ObjectStatus.DISABLED)
 
     def enable_seat_recreate(self, monitor: Monitor):
         """Sets the monitor's seat assignment to automatically be recreated at renewal."""


### PR DESCRIPTION
Adds an additional `WAITING` choice to ObjectStatus so that can be used by Monitor's `status` field