### PR TITLE
fix(alerts): Dataset selector in Safari

### DIFF
--- a/static/app/views/alerts/filterBar.tsx
+++ b/static/app/views/alerts/filterBar.tsx
@@ -127,6 +127,7 @@ const FilterButtons = styled(ButtonBar)`
 
 const SegmentedControlWrapper = styled('div')`
   width: max-content;
+  min-width: 345px;
 `;
 
 const StyledIconWarning = styled(IconWarning)`


### PR DESCRIPTION
This is a quick fix to make the alerts dataset selector look nicer in Safari. 
We'll look into a better solution that will support more dynamic content in a follow-up.

<img width="1512" alt="image" src="https://github.com/getsentry/sentry/assets/9060071/5ab175f9-4fed-44bd-a85b-0f7c95ce1691">
