### PR TITLE
fix(discover): failing test

### DIFF
--- a/src/sentry/search/events/datasets/spans_metrics.py
+++ b/src/sentry/search/events/datasets/spans_metrics.py
@@ -738,7 +738,10 @@ class SpansMetricsLayerDatasetConfig(DatasetConfig):
                         fields.with_default(
                             "span.self_time",
                             fields.MetricArg(
-                                "column", allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS
+                                "column",
+                                allowed_columns=constants.SPAN_METRIC_DURATION_COLUMNS.union(
+                                    constants.SPAN_METRIC_BYTES_COLUMNS
+                                ),
                             ),
                         ),
                     ],

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -152,6 +152,7 @@ class SpanMRI(Enum):
     DURATION = "d:spans/duration@millisecond"
     SELF_TIME = "d:spans/exclusive_time@millisecond"
     SELF_TIME_LIGHT = "d:spans/exclusive_time_light@millisecond"
+    RESPONSE_CONTENT_LENGTH = "d:spans/http.response_content_length@byte"
 
     # Derived
     ALL = "e:spans/all@none"

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -117,6 +117,7 @@ class SpanMetricKey(Enum):
     DURATION = "span.duration"
     SELF_TIME = "span.exclusive_time"
     SELF_TIME_LIGHT = "span.exclusive_time_light"
+    RESPONSE_CONTENT_LENGTH = "d:spans/http.response_content_length@byte"
 
     HTTP_ERROR_COUNT = "span.http_error_count"
     HTTP_ERROR_RATE = "span.http_error_rate"

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -117,7 +117,7 @@ class SpanMetricKey(Enum):
     DURATION = "span.duration"
     SELF_TIME = "span.exclusive_time"
     SELF_TIME_LIGHT = "span.exclusive_time_light"
-    RESPONSE_CONTENT_LENGTH = "d:spans/http.response_content_length@byte"
+    RESPONSE_CONTENT_LENGTH = "http.response_content_length"
 
     HTTP_ERROR_COUNT = "span.http_error_count"
     HTTP_ERROR_RATE = "span.http_error_rate"

--- a/tests/sentry/snuba/metrics/fields/test_base.py
+++ b/tests/sentry/snuba/metrics/fields/test_base.py
@@ -68,6 +68,7 @@ def get_entity_of_metric_mocked(_, metric_mri, use_case_id):
         TransactionMRI.MEASUREMENTS_LCP.value: EntityKey.MetricsDistributions,
         SpanMRI.SELF_TIME.value: EntityKey.MetricsDistributions,
         SpanMRI.SELF_TIME_LIGHT.value: EntityKey.MetricsDistributions,
+        SpanMRI.RESPONSE_CONTENT_LENGTH.value: EntityKey.MetricsDistributions,
     }[metric_mri]
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
@@ -213,8 +213,10 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
         )
 
         assert response.status_code == 200
+
         data = response.data["data"]
         assert len(data) == 2
+        assert not data[0][1][0]["count"]
         assert data[1][1][0]["count"] == 4.0
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
@@ -212,10 +212,9 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
             },
         )
 
-        data = response.data["data"]
         assert response.status_code == 200
+        data = response.data["data"]
         assert len(data) == 2
-        assert data[0][1][0]["count"] == 0.0
         assert data[1][1][0]["count"] == 4.0
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
@@ -192,7 +192,6 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
         assert "bar" in response.data
         assert response.data["Other"]["meta"]["dataset"] == "spansMetrics"
 
-    @pytest.mark.xfail(reason="Test does not pass")
     def test_resource_size(self):
         self.store_span_metric(
             4,


### PR DESCRIPTION
The test to ensure `http.response_content_length` is properly stored was failing in the metrics layer version of the test. This was because a bunch of enums were missing reference to this new metric.