### PR TITLE
ref(hc): Removing actor_id from RpcActor

### DIFF
--- a/src/sentry/integrations/notifications.py
+++ b/src/sentry/integrations/notifications.py
@@ -108,7 +108,7 @@ def get_integrations_by_channel_by_recipient(
             channels_to_integrations = _get_channel_and_integration_by_user(
                 recipient.id, organization, provider
             )
-        elif recipient.actor_type == ActorType.TEAM and recipient.actor_id is not None:
+        elif recipient.actor_type == ActorType.TEAM:
             channels_to_integrations = _get_channel_and_integration_by_team(
                 recipient.id, organization, provider
             )

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -844,10 +844,7 @@ class Group(Model):
 
         assigned_actor: RpcActor = group_assignee.assigned_actor()
 
-        try:
-            return assigned_actor.resolve()
-        except assigned_actor.type.DoesNotExist:
-            return None
+        return assigned_actor.resolve()
 
     @property
     def times_seen_with_pending(self) -> int:

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -39,6 +39,7 @@ from sentry.eventstore.models import GroupEvent
 from sentry.issues.grouptype import ErrorGroupType, GroupCategory, get_group_type_by_type_id
 from sentry.models.grouphistory import record_group_history_from_activity_type
 from sentry.models.organization import Organization
+from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.snuba.dataset import Dataset
 from sentry.types.activity import ActivityType
 from sentry.types.group import (
@@ -841,7 +842,7 @@ class Group(Model):
         except GroupAssignee.DoesNotExist:
             return None
 
-        assigned_actor = group_assignee.assigned_actor()
+        assigned_actor: RpcActor = group_assignee.assigned_actor()
 
         try:
             return assigned_actor.resolve()

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -128,7 +128,6 @@ class BaseNotification(abc.ABC):
         group = getattr(self, "group", None)
         params = {
             "organization_id": self.organization.id,
-            "actor_id": recipient.actor_id,
             "id": recipient.id,
             "actor_type": recipient.actor_type,
             "group_id": group.id if group else None,

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -181,14 +181,12 @@ class DigestNotification(ProjectNotification):
         )
 
         # Get every actor ID for every provider as a set.
-        actor_ids = set()
         team_ids = set()
         user_ids = set()
         combined_participants_by_provider = defaultdict(set)
         for participants_by_provider in participants_by_provider_by_event.values():
             for provider, participants in participants_by_provider.items():
                 for participant in participants:
-                    actor_ids.add(participant.actor_id)
                     if participant.actor_type == ActorType.TEAM:
                         team_ids.add(participant.id)
                     elif participant.actor_type == ActorType.USER:
@@ -204,7 +202,6 @@ class DigestNotification(ProjectNotification):
                 "project_id": self.project.id,
                 "target_type": self.target_type.value,
                 "target_identifier": self.target_identifier,
-                "actor_ids": actor_ids,
                 "team_ids": team_ids,
                 "user_ids": user_ids,
             },

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -392,9 +392,7 @@ def determine_eligible_recipients(
         ).first()
         if group_assignee:
             outcome = "match"
-            assignee_actor = RpcActor.from_orm_actor(
-                group_assignee.assigned_actor().resolve_to_actor()
-            )
+            assignee_actor = group_assignee.assigned_actor()
             suggested_assignees.append(assignee_actor)
 
         suspect_commit_users = None

--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -32,7 +32,7 @@ def send_issue_assigned_webhook(project, group, user, **kwargs):
     actor: RpcUser | Team = assignee.resolve()
 
     data = {
-        "assignee": {"type": assignee.type.__name__.lower(), "name": actor.name, "id": actor.id}
+        "assignee": {"type": str(assignee.actor_type).lower(), "name": actor.name, "id": actor.id}
     }
 
     org = project.organization

--- a/src/sentry/services/hybrid_cloud/actor.py
+++ b/src/sentry/services/hybrid_cloud/actor.py
@@ -154,7 +154,7 @@ class RpcActor(RpcModel):
             and self.actor_type == other.actor_type
         )
 
-    def resolve(self) -> Optional[Union[Team, RpcUser]]:
+    def resolve(self) -> Optional[Union["Team", "RpcUser"]]:
         from sentry.models.team import Team
 
         if self.actor_type == ActorType.TEAM:

--- a/src/sentry/services/hybrid_cloud/actor.py
+++ b/src/sentry/services/hybrid_cloud/actor.py
@@ -161,4 +161,3 @@ class RpcActor(RpcModel):
             return Team.objects.filter(id=self.id).first()
         if self.actor_type == ActorType.USER:
             return user_service.get_user(user_id=self.id)
-        return None

--- a/src/sentry/services/hybrid_cloud/actor.py
+++ b/src/sentry/services/hybrid_cloud/actor.py
@@ -7,10 +7,11 @@ from collections import defaultdict
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Iterable, List, MutableMapping, Optional, Union
 
-from sentry.models.actor import ACTOR_TYPES, get_actor_for_user, get_actor_id_for_user
+from sentry.models.actor import ACTOR_TYPES, get_actor_id_for_user
 from sentry.services.hybrid_cloud import RpcModel
 from sentry.services.hybrid_cloud.organization import RpcTeam
 from sentry.services.hybrid_cloud.user import RpcUser
+from sentry.services.hybrid_cloud.user.service import user_service
 
 if TYPE_CHECKING:
     from sentry.models.actor import Actor
@@ -31,9 +32,6 @@ class RpcActor(RpcModel):
 
     id: int
     """The id of the user/team this actor represents"""
-
-    actor_id: Optional[int]
-    """The id of the Actor record"""
 
     actor_type: ActorType
     """Whether this actor is a User or Team"""
@@ -56,7 +54,6 @@ class RpcActor(RpcModel):
         Queries for actors are batched to increase efficiency. Users that are
         missing actors will have actors generated.
         """
-        from sentry.models.actor import Actor
         from sentry.models.team import Team
         from sentry.models.user import User
 
@@ -74,31 +71,19 @@ class RpcActor(RpcModel):
 
         if grouped_by_type[ActorType.TEAM]:
             team_ids = grouped_by_type[ActorType.TEAM]
-            actors = Actor.objects.filter(type=ACTOR_TYPES["team"], team__in=team_ids)
-            actors_by_team_id = {actor.team_id: actor for actor in actors}
             for team_id in team_ids:
-                actor = actors_by_team_id[team_id]
                 result.append(
                     RpcActor(
-                        actor_id=actor.id,
-                        id=actor.team_id,
+                        id=team_id,
                         actor_type=ActorType.TEAM,
-                        slug=team_slugs.get(actor.team_id),
+                        slug=team_slugs.get(team_id),
                     )
                 )
 
         if grouped_by_type[ActorType.USER]:
             user_ids = grouped_by_type[ActorType.USER]
-            actors = Actor.objects.filter(type=ACTOR_TYPES["user"], user_id__in=user_ids)
-            actors_by_user_id = {actor.user_id: actor for actor in actors}
             for user_id in user_ids:
-                if user_id in actors_by_user_id:
-                    actor = actors_by_user_id[user_id]
-                else:
-                    actor = get_actor_for_user(user_id)
-                result.append(
-                    RpcActor(actor_id=actor.id, id=actor.user_id, actor_type=ActorType.USER)
-                )
+                result.append(RpcActor(id=user_id, actor_type=ActorType.USER))
         return result
 
     @classmethod
@@ -127,12 +112,8 @@ class RpcActor(RpcModel):
 
     @classmethod
     def from_orm_user(cls, user: "User", fetch_actor: bool = True) -> "RpcActor":
-        actor_id = None
-        if fetch_actor:
-            actor_id = get_actor_id_for_user(user)
         return cls(
             id=user.id,
-            actor_id=actor_id,
             actor_type=ActorType.USER,
         )
 
@@ -172,3 +153,12 @@ class RpcActor(RpcModel):
             and self.id == other.id
             and self.actor_type == other.actor_type
         )
+
+    def resolve(self) -> Optional[Union[Team, RpcUser]]:
+        from sentry.models.team import Team
+
+        if self.actor_type == ActorType.TEAM:
+            return Team.objects.filter(id=self.id).first()
+        if self.actor_type == ActorType.USER:
+            return user_service.get_user(user_id=self.id)
+        return None

--- a/tests/sentry/hybrid_cloud/test_actor.py
+++ b/tests/sentry/hybrid_cloud/test_actor.py
@@ -1,4 +1,3 @@
-from sentry.models.actor import ACTOR_TYPES, Actor
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.testutils.factories import Factories
@@ -32,19 +31,6 @@ def test_many_from_object_rpc_users():
 
     assert actors[1].id == rpc_users[1].id
     assert actors[1].actor_type == ActorType.USER
-
-
-@django_db_all(transaction=True)
-def test_many_from_object_users_missing_actors():
-    users = [Factories.create_user(), Factories.create_user()]
-    # Clear all actors
-    Actor.objects.filter(type=ACTOR_TYPES["user"]).delete()
-
-    actors = RpcActor.many_from_object(users)
-    assert len(actors) == len(users)
-
-    actors = Actor.objects.filter(type=ACTOR_TYPES["user"])
-    assert len(actors) == 2, "Actors should be generated"
 
 
 @django_db_all(transaction=True)

--- a/tests/sentry/hybrid_cloud/test_actor.py
+++ b/tests/sentry/hybrid_cloud/test_actor.py
@@ -12,11 +12,9 @@ def test_many_from_object_users():
     assert len(actors) == len(users)
     assert all([isinstance(a, RpcActor) for a in actors])
     assert actors[0].id == users[0].id
-    assert actors[0].actor_id
     assert actors[0].actor_type == ActorType.USER
 
     assert actors[1].id == users[1].id
-    assert actors[1].actor_id
     assert actors[1].actor_type == ActorType.USER
 
 
@@ -30,11 +28,9 @@ def test_many_from_object_rpc_users():
     assert len(actors) == len(rpc_users)
     assert all([isinstance(a, RpcActor) for a in actors])
     assert actors[0].id == rpc_users[0].id
-    assert actors[0].actor_id
     assert actors[0].actor_type == ActorType.USER
 
     assert actors[1].id == rpc_users[1].id
-    assert actors[1].actor_id
     assert actors[1].actor_type == ActorType.USER
 
 
@@ -46,8 +42,6 @@ def test_many_from_object_users_missing_actors():
 
     actors = RpcActor.many_from_object(users)
     assert len(actors) == len(users)
-    assert actors[0].actor_id
-    assert actors[1].actor_id
 
     actors = Actor.objects.filter(type=ACTOR_TYPES["user"])
     assert len(actors) == 2, "Actors should be generated"
@@ -65,13 +59,11 @@ def test_many_from_object_teams():
     assert len(actors) == 2
     assert actors[0].id == teams[0].id
     assert actors[0].actor_type == ActorType.TEAM
-    assert actors[0].actor_id
     assert actors[0].slug
 
     assert len(actors) == 2
     assert actors[1].id == teams[1].id
     assert actors[1].actor_type == ActorType.TEAM
-    assert actors[1].actor_id
     assert actors[1].slug
 
 
@@ -87,11 +79,9 @@ def test_many_from_object_mixed():
     assert len(actors) == 2
     assert actors[0].id == teams[0].id
     assert actors[0].actor_type == ActorType.TEAM
-    assert actors[0].actor_id
     assert actors[0].slug
 
     assert len(actors) == 2
     assert actors[1].id == teams[1].id
     assert actors[1].actor_type == ActorType.TEAM
-    assert actors[1].actor_id
     assert actors[1].slug

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -201,7 +201,6 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             project_id=self.project.id,
             organization_id=self.organization.id,
             group_id=event.group_id,
-            actor_id=ANY,
             user_id=ANY,
             id=ANY,
             actor_type="User",

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -120,7 +120,6 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
             alert_id=self.rule.id,
             project_id=self.project.id,
             organization_id=self.organization.id,
-            actor_id=ANY,
             id=ANY,
             actor_type="User",
             group_id=None,


### PR DESCRIPTION
`GroupAssignee` appears to be one of the last places that directly requires this attribute, and resolving it can be done by other means anyways.