### PR TITLE
feat(consumers): Add option to enable dlq for sentry unified consumers

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3246,9 +3246,11 @@ KAFKA_INGEST_EVENTS = "ingest-events"
 KAFKA_INGEST_ATTACHMENTS = "ingest-attachments"
 KAFKA_INGEST_TRANSACTIONS = "ingest-transactions"
 KAFKA_INGEST_METRICS = "ingest-metrics"
+KAFKA_INGEST_METRICS_DLQ = "ingest-metrics-dlq"
 KAFKA_SNUBA_METRICS = "snuba-metrics"
 KAFKA_PROFILES = "profiles"
 KAFKA_INGEST_PERFORMANCE_METRICS = "ingest-performance-metrics"
+KAFKA_INGEST_GENERIC_METRICS_DLQ = "ingest-generic-metrics-dlq"
 KAFKA_SNUBA_GENERIC_METRICS = "snuba-generic-metrics"
 KAFKA_INGEST_REPLAY_EVENTS = "ingest-replay-events"
 KAFKA_INGEST_REPLAYS_RECORDINGS = "ingest-replay-recordings"
@@ -3294,12 +3296,15 @@ KAFKA_TOPICS: Mapping[str, Optional[TopicDefinition]] = {
     KAFKA_INGEST_TRANSACTIONS: {"cluster": "default"},
     # Topic for receiving metrics from Relay
     KAFKA_INGEST_METRICS: {"cluster": "default"},
+    # Topic for routing invalid messages from KAFKA_INGEST_METRICS
+    KAFKA_INGEST_METRICS_DLQ: {"cluster": "default"},
     # Topic for indexer translated metrics
     KAFKA_SNUBA_METRICS: {"cluster": "default"},
     # Topic for receiving profiles from Relay
     KAFKA_PROFILES: {"cluster": "default"},
     KAFKA_INGEST_PERFORMANCE_METRICS: {"cluster": "default"},
     KAFKA_SNUBA_GENERIC_METRICS: {"cluster": "default"},
+    KAFKA_INGEST_GENERIC_METRICS_DLQ: {"cluster": "default"},
     KAFKA_INGEST_REPLAY_EVENTS: {"cluster": "default"},
     KAFKA_INGEST_REPLAYS_RECORDINGS: {"cluster": "default"},
     KAFKA_INGEST_OCCURRENCES: {"cluster": "default"},

--- a/src/sentry/conf/types/consumer_definition.py
+++ b/src/sentry/conf/types/consumer_definition.py
@@ -23,3 +23,17 @@ class ConsumerDefinition(TypedDict, total=False):
     require_synchronization: bool
     synchronize_commit_group_default: str
     synchronize_commit_log_topic_default: str
+
+    dlq_topic: str
+    dlq_max_invalid_ratio: float | None
+    dlq_max_consecutive_count: int | None
+
+
+def validate_consumer_definition(consumer_definition: ConsumerDefinition) -> None:
+    if "dlq_topic" not in consumer_definition and (
+        "dlq_max_invalid_ratio" in consumer_definition
+        or "dlq_max_consecutive_count" in consumer_definition
+    ):
+        raise ValueError(
+            "Invalid consumer definition, dlq_max_invalid_ratio/dlq_max_consecutive_count is configured, but dlq_topic is not"
+        )

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -678,6 +678,12 @@ def profiles_consumer(**options):
     help="A file to touch roughly every second to indicate that the consumer is still alive. See https://getsentry.github.io/arroyo/strategies/healthcheck.html for more information.",
 )
 @click.option(
+    "--enable-dlq",
+    help="Enable dlq to route invalid messages to. See https://getsentry.github.io/arroyo/dlqs.html#arroyo.dlq.DlqPolicy for more information.",
+    is_flag=True,
+    default=False,
+)
+@click.option(
     "--log-level",
     type=click.Choice(["debug", "info", "warning", "error", "critical"], case_sensitive=False),
     help="log level to pass to the arroyo consumer",
@@ -748,6 +754,7 @@ def dev_consumer(consumer_names):
             max_poll_interval_ms=None,
             synchronize_commit_group=None,
             synchronize_commit_log_topic=None,
+            enable_dlq=False,
             healthcheck_file_path=None,
             validate_schema=True,
         )

--- a/tests/sentry/conf/test_consumer_definitions.py
+++ b/tests/sentry/conf/test_consumer_definitions.py
@@ -1,0 +1,29 @@
+from typing import List
+
+import pytest
+
+from sentry.conf.types.consumer_definition import ConsumerDefinition, validate_consumer_definition
+from sentry.consumers import KAFKA_CONSUMERS
+from sentry.testutils.cases import TestCase
+
+
+class ConsumersDefinitionTest(TestCase):
+    def test_exception_on_invalid_consumer_definition(self):
+        invalid_definitions: List[ConsumerDefinition] = [
+            {
+                "topic": "topic",
+                "strategy_factory": "sentry.sentry_metrics.consumers.indexer.parallel.MetricsConsumerStrategyFactory",
+                "static_args": {
+                    "ingest_profile": "release-health",
+                },
+                "dlq_max_invalid_ratio": 0.01,
+                "dlq_max_consecutive_count": 1000,
+            }
+        ]
+        for invalid_definition in invalid_definitions:
+            with pytest.raises(ValueError):
+                validate_consumer_definition(invalid_definition)
+
+    def test_kafka_consumer_definition_validity(self):
+        for definition in KAFKA_CONSUMERS.values():
+            validate_consumer_definition(definition)


### PR DESCRIPTION
Part of my efforts to add dlq to the sentry metrics consumers, see the final change here:
https://github.com/getsentry/sentry/pull/57998 

Next PR in the stack:
https://github.com/getsentry/sentry/pull/58675

### Overview

- Adds a `--enable-dql` for devserver option to specify which consumers to enable dlq
- Adds configuration about dlq topic for `ingest-metrics`, and `ingest-performance-metrics`