### PR TITLE
fix(mep): Handle top events with project ids

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -1444,8 +1444,11 @@ class TopMetricsQueryBuilder(TimeseriesMetricQueryBuilder):
                     continue
 
                 value = event.get(field)
+                # Ensure the project id fields stay as numbers, clickhouse 20 can't handle it, but 21 can
+                if field in {"project_id", "project.id"}:
+                    value = int(value)
                 # TODO: Handle potential None case
-                if value is not None:
+                elif value is not None:
                     value = self.resolve_tag_value(str(value))
                 values.add(value)
 


### PR DESCRIPTION
- Clickhouse 20 can't handle doing an IN with mismatching types eg. `project_id in ['1']` but Clickhouse 21 can
- Updates the Metric Query Builder to ensure the project ids are ints