### PR TITLE
fix(statistical-detectors): Feature flags in wrong place

### DIFF
--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -272,7 +272,12 @@ def test_detect_transaction_trends(
         for i, ts in enumerate(timestamps)
     ]
 
-    with override_options({"statistical_detectors.enable": True}), TaskRunner():
+    with override_options(
+        {
+            "statistical_detectors.enable": True,
+            "statistical_detectors.enable.projects.performance": [project.id],
+        }
+    ), TaskRunner():
         for ts in timestamps:
             detect_transaction_trends([organization.id], [project.id], ts)
     assert detect_transaction_change_points.apply_async.called


### PR DESCRIPTION
The feature flags are too early and prevented the task from querying the hourly data. Move the check to afterwards.