### PR TITLE
feat(hc): Add __str__ implementation for RpcUser

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/model.py
+++ b/src/sentry/services/hybrid_cloud/user/model.py
@@ -68,6 +68,9 @@ class RpcUser(RpcModel):
         # TODO: Remove the need for this
         return hash((self.id, self.pk))
 
+    def __str__(self):  # API compatibility with ORM User
+        return self.get_username()
+
     def by_email(self, email: str) -> "RpcUser":
         if email == self.email:
             return self


### PR DESCRIPTION
This matches the implementation in [`django.contrib.auth.base_user.AbstractBaseUser`](https://github.com/django/django/blob/main/django/contrib/auth/base_user.py#L54-L55).

Project transfer emails specifically rely upon this behavior, but there are likely other usages:
- https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/project_transfer.py#L88
- https://github.com/getsentry/sentry/blob/master/src/sentry/templates/sentry/emails/transfer_project.txt#L5

Fixes HC-919