### PR TITLE
chore(replay): Cleanup DOM Tab test, before we remove the tab itself

### DIFF
--- a/tests/acceptance/test_replay_detail.py
+++ b/tests/acceptance/test_replay_detail.py
@@ -81,14 +81,6 @@ class ReplayDetailTest(ReplaysAcceptanceTestCase):
             self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
 
-    def test_dom_events_tab(self):
-        with self.feature(FEATURE_NAME):
-            self.browser.get(self.path)
-            self.browser.wait_until_not('[data-test-id="loading-indicator"]')
-            self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
-            self.browser.click('[data-test-id="replay-details-dom-btn"]')
-            self.browser.wait_until_test_id("replay-details-dom-events-tab")
-
     def test_console_tab(self):
         with self.feature(FEATURE_NAME):
             self.browser.get(self.path)


### PR DESCRIPTION
The DOM tab is going away in https://github.com/getsentry/sentry/pull/58102, so we can remove the test for it.