### PR TITLE
feat(alerts): Convert duplicate alert to functional component

### DIFF
--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -16,7 +16,7 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import BuilderBreadCrumbs from 'sentry/views/alerts/builder/builderBreadCrumbs';
 import IssueRuleEditor from 'sentry/views/alerts/rules/issue';
 import MetricRulesCreate from 'sentry/views/alerts/rules/metric/create';
-import MetricRulesDuplicate from 'sentry/views/alerts/rules/metric/duplicate';
+import MetricRuleDuplicate from 'sentry/views/alerts/rules/metric/duplicate';
 import {AlertRuleType} from 'sentry/views/alerts/types';
 import {
   AlertType as WizardAlertType,
@@ -151,7 +151,7 @@ class Create extends Component<Props, State> {
                   {hasMetricAlerts &&
                     alertType === AlertRuleType.METRIC &&
                     (this.isDuplicateRule ? (
-                      <MetricRulesDuplicate
+                      <MetricRuleDuplicate
                         {...this.props}
                         eventView={eventView}
                         wizardTemplate={wizardTemplate}

--- a/static/app/views/alerts/rules/metric/duplicate.spec.tsx
+++ b/static/app/views/alerts/rules/metric/duplicate.spec.tsx
@@ -1,13 +1,16 @@
 import {Fragment} from 'react';
+import {Member} from 'sentry-fixture/member';
+import {MetricRule} from 'sentry-fixture/metricRule';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import GlobalModal from 'sentry/components/globalModal';
-import MetricRulesDuplicate from 'sentry/views/alerts/rules/metric/duplicate';
-import {AlertRuleTriggerType} from 'sentry/views/alerts/rules/metric/types';
 
-describe('Incident Rules Duplicate', function () {
+import MetricRuleDuplicate from './duplicate';
+import {Action, AlertRuleTriggerType} from './types';
+
+describe('MetricRuleDuplicate', function () {
   beforeEach(function () {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
@@ -49,12 +52,12 @@ describe('Incident Rules Duplicate', function () {
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/',
-      body: [TestStubs.Member()],
+      body: [Member()],
     });
   });
 
-  it('renders new alert form with values copied over', function () {
-    const rule = TestStubs.MetricRule();
+  it('renders new alert form with values copied over', async function () {
+    const rule = MetricRule();
     rule.triggers.push({
       label: AlertRuleTriggerType.WARNING,
       alertThreshold: 60,
@@ -75,8 +78,6 @@ describe('Incident Rules Duplicate', function () {
           },
         },
       },
-      project: rule.projects[0],
-      projects: rule.projects,
     });
 
     const req = MockApiClient.addMockResponse({
@@ -87,29 +88,24 @@ describe('Incident Rules Duplicate', function () {
     render(
       <Fragment>
         <GlobalModal />
-        <MetricRulesDuplicate
-          organization={organization}
-          project={project}
-          userTeamIds={[]}
-          {...routerProps}
-        />
+        <MetricRuleDuplicate project={project} userTeamIds={[]} {...routerProps} />
       </Fragment>
     );
 
-    // Duplicated alert has been called
-    expect(req).toHaveBeenCalled();
-
     // Has correct values copied from the duplicated alert
-    expect(screen.getByTestId('critical-threshold')).toHaveValue('70');
+    expect(await screen.findByTestId('critical-threshold')).toHaveValue('70');
     expect(screen.getByTestId('warning-threshold')).toHaveValue('60');
     expect(screen.getByTestId('resolve-threshold')).toHaveValue('50');
+
+    // Duplicated alert has been called
+    expect(req).toHaveBeenCalled();
 
     // Has the updated alert rule name
     expect(screen.getByTestId('alert-name')).toHaveValue(`${rule.name} copy`);
   });
 
-  it('duplicates slack actions', function () {
-    const rule = TestStubs.MetricRule();
+  it('duplicates slack actions', async function () {
+    const rule = MetricRule();
     rule.triggers[0].actions.push({
       id: '13',
       alertRuleTriggerId: '12',
@@ -120,7 +116,9 @@ describe('Incident Rules Duplicate', function () {
       integrationId: 1,
       sentryAppId: null,
       desc: 'Send a Slack notification to #feed-ecosystem',
-    });
+      options: null,
+      // TODO(scttcper): Action shouldn't required unsaved properties
+    } as Action);
 
     const {organization, project, routerProps} = initializeOrg({
       organization: {
@@ -135,8 +133,6 @@ describe('Incident Rules Duplicate', function () {
           },
         },
       },
-      project: rule.projects[0],
-      projects: rule.projects,
     });
 
     const req = MockApiClient.addMockResponse({
@@ -144,23 +140,16 @@ describe('Incident Rules Duplicate', function () {
       body: rule,
     });
 
-    render(
-      <MetricRulesDuplicate
-        organization={organization}
-        project={project}
-        userTeamIds={[]}
-        {...routerProps}
-      />
-    );
-
-    // Duplicated alert has been called
-    expect(req).toHaveBeenCalled();
+    render(<MetricRuleDuplicate project={project} userTeamIds={[]} {...routerProps} />);
 
     // Still has a selected slack action
-    expect(screen.getByText('Slack')).toBeInTheDocument();
+    expect(await screen.findByText('Slack')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('optional: channel ID or user ID')).toHaveValue(
       'ABC123'
     );
     expect(screen.getByText(/Enter a channel or user ID/)).toBeInTheDocument();
+
+    // Duplicated alert has been called
+    expect(req).toHaveBeenCalled();
   });
 });

--- a/static/app/views/alerts/rules/metric/duplicate.tsx
+++ b/static/app/views/alerts/rules/metric/duplicate.tsx
@@ -1,56 +1,56 @@
-import {RouteComponentProps} from 'react-router';
+import type {RouteComponentProps} from 'react-router';
 import pick from 'lodash/pick';
 
 import * as Layout from 'sentry/components/layouts/thirds';
-import {Organization, Project} from 'sentry/types';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import type {Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {uniqueId} from 'sentry/utils/guid';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {
   DuplicateActionFields,
   DuplicateMetricFields,
   DuplicateTriggerFields,
 } from 'sentry/views/alerts/rules/metric/constants';
-import {MetricRule} from 'sentry/views/alerts/rules/metric/types';
-import {WizardRuleTemplate} from 'sentry/views/alerts/wizard/options';
-import DeprecatedAsyncView from 'sentry/views/deprecatedAsyncView';
+import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
+import type {WizardRuleTemplate} from 'sentry/views/alerts/wizard/options';
 
 import RuleForm from './ruleForm';
 
-type Props = {
-  organization: Organization;
+interface MetricRuleDuplicateProps extends RouteComponentProps<{}, {}> {
   project: Project;
   userTeamIds: string[];
   eventView?: EventView;
   sessionId?: string;
   wizardTemplate?: WizardRuleTemplate;
-} & RouteComponentProps<{}, {}>;
-
-type State = {
-  duplicateTargetRule?: MetricRule;
-} & DeprecatedAsyncView['state'];
+}
 
 /**
- * Show metric rules form with values from an existing rule. Redirects to alerts list after creation.
+ * Show metric rules form with values from an existing rule.
  */
+function MetricRuleDuplicate({
+  project,
+  sessionId,
+  userTeamIds,
+  ...otherProps
+}: MetricRuleDuplicateProps) {
+  const organization = useOrganization();
+  const {
+    data: duplicateTargetRule,
+    isLoading,
+    isError,
+    refetch,
+  } = useApiQuery<MetricRule>(
+    [
+      `/organizations/${organization.slug}/alert-rules/${otherProps.location.query.duplicateRuleId}/`,
+    ],
+    {staleTime: 0}
+  );
 
-class MetricRulesDuplicate extends DeprecatedAsyncView<Props, State> {
-  getEndpoints(): ReturnType<DeprecatedAsyncView['getEndpoints']> {
-    const {
-      organization,
-      location: {query},
-    } = this.props;
-
-    return [
-      [
-        'duplicateTargetRule',
-        `/organizations/${organization.slug}/alert-rules/${query.duplicateRuleId}/`,
-      ],
-    ];
-  }
-
-  handleSubmitSuccess = (data: any) => {
-    const {router, organization, project} = this.props;
+  const handleSubmitSuccess = (data: any) => {
     const alertRuleId: string | undefined = data
       ? (data.id as string | undefined)
       : undefined;
@@ -63,48 +63,48 @@ class MetricRulesDuplicate extends DeprecatedAsyncView<Props, State> {
           pathname: `/organizations/${organization.slug}/alerts/rules/`,
           query: {project: project.id},
         };
-    router.push(normalizeUrl(target));
+    otherProps.router.push(normalizeUrl(target));
   };
 
-  renderBody() {
-    const {project, sessionId, userTeamIds, ...otherProps} = this.props;
-    const {duplicateTargetRule} = this.state;
-
-    if (!duplicateTargetRule) {
-      return this.renderLoading();
-    }
-
-    return (
-      <Layout.Main>
-        <RuleForm
-          onSubmitSuccess={this.handleSubmitSuccess}
-          rule={
-            {
-              ...pick(duplicateTargetRule, DuplicateMetricFields),
-              triggers: duplicateTargetRule.triggers.map(trigger => ({
-                ...pick(trigger, DuplicateTriggerFields),
-                actions: trigger.actions.map(action => ({
-                  inputChannelId: null,
-                  integrationId: action.integrationId ?? undefined,
-                  options: null,
-                  sentryAppId: undefined,
-                  unsavedId: uniqueId(),
-                  unsavedDateCreated: new Date().toISOString(),
-                  ...pick(action, DuplicateActionFields),
-                })),
-              })),
-              name: duplicateTargetRule.name + ' copy',
-            } as MetricRule
-          }
-          sessionId={sessionId}
-          project={project}
-          userTeamIds={userTeamIds}
-          isDuplicateRule
-          {...otherProps}
-        />
-      </Layout.Main>
-    );
+  if (isLoading) {
+    return <LoadingIndicator />;
   }
+
+  if (isError) {
+    return <LoadingError onRetry={refetch} />;
+  }
+
+  return (
+    <Layout.Main>
+      <RuleForm
+        organization={organization}
+        onSubmitSuccess={handleSubmitSuccess}
+        rule={
+          {
+            ...pick(duplicateTargetRule, DuplicateMetricFields),
+            triggers: duplicateTargetRule.triggers.map(trigger => ({
+              ...pick(trigger, DuplicateTriggerFields),
+              actions: trigger.actions.map(action => ({
+                inputChannelId: null,
+                integrationId: action.integrationId ?? undefined,
+                options: null,
+                sentryAppId: undefined,
+                unsavedId: uniqueId(),
+                unsavedDateCreated: new Date().toISOString(),
+                ...pick(action, DuplicateActionFields),
+              })),
+            })),
+            name: duplicateTargetRule.name + ' copy',
+          } as MetricRule
+        }
+        sessionId={sessionId}
+        project={project}
+        userTeamIds={userTeamIds}
+        isDuplicateRule
+        {...otherProps}
+      />
+    </Layout.Main>
+  );
 }
 
-export default MetricRulesDuplicate;
+export default MetricRuleDuplicate;


### PR DESCRIPTION
Just loads the metric alert and sets up the form with defaults
