### PR TITLE
Revert "Add Papercut label"

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -267,7 +267,7 @@
   color: 'ffa0df'
   description: ''
 
-# Bug bash-y Things
+# Hacktoberfest
 - name: 'Hacktoberfest :jack_o_lantern:'
   color: 'ffa500'
   description: ''
@@ -275,11 +275,8 @@
   color: 'e99695'
   description: Accept for Hacktoberfest - will merge later
 
+# Hackweek
 - name: 'Hackweek :zap:'
-  color: 'F91A8A'
-  description: ''
-
-- name: 'Papercut'
   color: 'F91A8A'
   description: ''
 


### PR DESCRIPTION
This reverts commit ff80fbb58298197b5563ca9cb8313a409c72245b, which was accidentally pushed directly to `master` (post-mortem on that happening separately).