### PR TITLE
ref(crons): Guard against duplicate create events

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -107,7 +107,8 @@ def _ensure_monitor_with_config(
                 "config": validated_config,
             },
         )
-        signal_monitor_created(project, None, True)
+        if created:
+            signal_monitor_created(project, None, True)
 
     # Update existing monitor
     if monitor and not created and monitor.config != validated_config:


### PR DESCRIPTION
Should have this here to ensure we don't duplicate these events if users are sending many upsert check-ins