### PR TITLE
style(replays): hide overflow on replay index

### DIFF
--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -633,6 +633,7 @@ const Item = styled('div')<{isArchived?: boolean; isWidget?: boolean}>`
       ? `padding: ${space(0.75)} ${space(1.5)} ${space(1.5)} ${space(1.5)};`
       : `padding: ${space(1.5)};`};
   ${p => (p.isArchived ? 'opacity: 0.5;' : '')};
+  overflow: scroll;
 `;
 
 const Count = styled('span')`


### PR DESCRIPTION
Thought of this to fix https://github.com/getsentry/sentry/issues/57682 but not sure this is the prettiest looking solution. But it's probably better than `GridEditable` :p

Before:
<img width="525" alt="overflow before" src="https://github.com/getsentry/sentry/assets/56095982/ff2a73aa-11fd-477f-b847-1e811a0416ef">

After: overflow is hidden & scrolling is allowed to see the full replay cell

https://github.com/getsentry/sentry/assets/56095982/4d8561af-191e-4247-b381-d8e211c790c4

