### PR TITLE
fix(on-demand): p100 support

### DIFF
--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -278,6 +278,7 @@ OPERATIONS_PERCENTILES = (
     "p90",
     "p95",
     "p99",
+    "p100",
 )
 DERIVED_OPERATIONS = (
     "histogram",


### PR DESCRIPTION
Fixes an issue where `p100` was not a supported aggregate for on demand alerts