### PR TITLE
fix(source-map-debugger): Only show the source map debugger for frames with valid file ending

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -50,6 +50,13 @@ import {
   isExpandable,
 } from './utils';
 
+const VALID_SOURCE_MAP_DEBUGGER_FILE_ENDINGS = [
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.jsbundle', // React Native file ending
+];
+
 export interface DeprecatedLineProps {
   data: Frame;
   event: Event;
@@ -313,9 +320,15 @@ export class DeprecatedLine extends Component<Props, State> {
         lockAddress
       );
 
-    const shouldShowSourceMapDebuggerToggle =
+    const frameHasValidFileEndingForSourceMapDebugger =
+      VALID_SOURCE_MAP_DEBUGGER_FILE_ENDINGS.some(ending =>
+        (data.absPath || data.filename || '').endsWith(ending)
+      );
+
+    const shouldShowSourceMapDebuggerButton =
       !this.props.hideSourceMapDebugger &&
       data.inApp &&
+      frameHasValidFileEndingForSourceMapDebugger &&
       this.props.frameSourceResolutionResults &&
       (!this.props.frameSourceResolutionResults.frameIsResolved ||
         !hasContextSource(data));
@@ -358,7 +371,7 @@ export class DeprecatedLine extends Component<Props, State> {
               </Tag>
             ) : null}
             {this.renderShowHideToggle()}
-            {shouldShowSourceMapDebuggerToggle ? (
+            {shouldShowSourceMapDebuggerButton ? (
               <Fragment>
                 <SourceMapDebuggerModalButton
                   size="zero"


### PR DESCRIPTION
We'll only render the debugger button when the frame has a valid JS ending, ie one of `.js`, `.cjs`, `.mjs` or `.jsbundle`.

This will fix the debugger being wrongly shown for:
- Anonymous frames (eg `<anonymous>` or `?`)
- Frames with JS in html, ie `<img onload="alert()">`, showing up as the location of the page (eg `http://example.com/`)
- "React frames" which are just frames that show html elements (ie `div`, `a`)
- Frames which have already been properly resolved with the `ContextLines` integration to something like `.ts` or `.jsx`