### PR TITLE
fix(on-demand): Fix p100 and percentiles

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -126,9 +126,6 @@ class MetricsQueryBuilder(QueryBuilder):
         if not field:
             return None
 
-        if self.query is None:
-            return None
-
         if not should_use_on_demand_metrics(self.dataset, field, self.query):
             return None
 


### PR DESCRIPTION
This PR fixes the on-demand implementation in the following way:
* Fixes the percentiles check, which marked valid percentiles as not supported by standard metrics.
* Removes the query check which is unnecessary.
* Converts `p100` to `max` for the queries.