### PR TITLE
feat(stats-detector-spanOnbreakdown): Updated design.

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
@@ -276,7 +276,7 @@ const StyledLegendWrapper = styled('div')`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: ${space(1.5)};
+  gap: ${space(3)};
 `;
 
 const SpanOpChange = styled('span')<{regressed: boolean}>`

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
@@ -83,6 +83,10 @@ class PieChart extends Component<Props> {
       );
   };
 
+  getSpanOpDurationChange = (op: string) => {
+    return this.props.data[op].oldBaseline / this.props.data[op].newBaseline - 1;
+  };
+
   render() {
     const {series, theme, ...props} = this.props;
     if (!series || !series.length) {
@@ -131,11 +135,7 @@ class PieChart extends Component<Props> {
           theme,
           data: [
             ...Object.keys(this.props.data).sort((a, b) => {
-              const changeA =
-                this.props.data[a].oldBaseline / this.props.data[a].newBaseline - 1;
-              const changeB =
-                this.props.data[b].oldBaseline / this.props.data[b].newBaseline - 1;
-              return changeA - changeB;
+              return this.getSpanOpDurationChange(a) - this.getSpanOpDurationChange(b);
             }),
           ],
           orient: 'vertical',
@@ -150,9 +150,6 @@ class PieChart extends Component<Props> {
                 color: theme.red300,
                 fontWeight: 600,
                 fontSize: 14,
-                backgroundColor: {
-                  image: new Image(),
-                },
               },
               greenText: {
                 color: theme.green300,
@@ -168,8 +165,7 @@ class PieChart extends Component<Props> {
           },
           itemWidth: 12,
           formatter: name => {
-            const change =
-              this.props.data[name].oldBaseline / this.props.data[name].newBaseline - 1;
+            const change = this.getSpanOpDurationChange(name);
             const oldValue = getDuration(
               this.props.data[name].oldBaseline / 1000,
               2,
@@ -188,10 +184,7 @@ class PieChart extends Component<Props> {
           },
           tooltip: {
             formatter: data => {
-              const change =
-                this.props.data[data.name].oldBaseline /
-                  this.props.data[data.name].newBaseline -
-                1;
+              const change = this.getSpanOpDurationChange(data.name);
               const changeText = change < 0 ? t('up') : t('down');
               const oldValue = getDuration(
                 this.props.data[data.name].oldBaseline / 1000,

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
@@ -1,11 +1,14 @@
 import {Component, createRef} from 'react';
 import {Theme, withTheme} from '@emotion/react';
+import styled from '@emotion/styled';
 import type {PieSeriesOption} from 'echarts';
 
 import BaseChart, {BaseChartProps} from 'sentry/components/charts/baseChart';
-import Legend from 'sentry/components/charts/components/legend';
 import PieSeries from 'sentry/components/charts/series/pieSeries';
+import CircleIndicator from 'sentry/components/circleIndicator';
+import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {ReactEchartsRef, Series} from 'sentry/types/echarts';
 import {formatPercentage, getDuration} from 'sentry/utils/formatters';
 
@@ -42,6 +45,7 @@ class PieChart extends Component<Props> {
   isInitialSelected = true;
   selected = 0;
   chart = createRef<ReactEchartsRef>();
+  pieChartSliceColors = [...this.props.theme.charts.getColorPalette(5)].reverse();
 
   // Select a series to highlight (e.g. shows details of series)
   // This is the same event as when you hover over a series in the chart
@@ -100,188 +104,181 @@ class PieChart extends Component<Props> {
     // Note, we only take the first series unit!
     const [firstSeries] = series;
 
+    // Attach a color to each operation. This allows us to match custom legend indicator
+    // colors to the op's pie chart color AND display the legend items sorted based on their
+    // percentage changes.
+    const operationToColorMap: {
+      [key: string]: {color: string; index: number};
+    } = {};
+    firstSeries.data.forEach((seriesRow, index) => {
+      operationToColorMap[seriesRow.name] = {
+        color: this.pieChartSliceColors[index],
+        index,
+      };
+    });
+
     return (
-      <BaseChart
-        ref={this.chart}
-        colors={[...theme.charts.getColorPalette(5)].reverse()}
-        // when legend highlights it does NOT pass dataIndex :(
-        onHighlight={({name}) => {
-          if (
-            !this.isInitialSelected ||
-            !name ||
-            firstSeries.data[this.selected].name === name
-          ) {
-            return;
-          }
-
-          // Unhighlight if not initial "highlight" event and
-          // if name exists (i.e. not dispatched from cDM) and
-          // highlighted series name is different than the initially selected series name
-          this.downplay(this.selected);
-          this.isInitialSelected = false;
-        }}
-        onMouseOver={({dataIndex}) => {
-          if (!this.isInitialSelected) {
-            return;
-          }
-          if (dataIndex === this.selected) {
-            return;
-          }
-          this.downplay(this.selected);
-          this.isInitialSelected = false;
-        }}
-        {...props}
-        legend={Legend({
-          theme,
-          data: [
-            ...Object.keys(this.props.data).sort((a, b) => {
+      <Wrapper>
+        <LegendWrapper>
+          {[...Object.keys(this.props.data)]
+            .sort((a, b) => {
               return this.getSpanOpDurationChange(a) - this.getSpanOpDurationChange(b);
-            }),
-          ],
-          orient: 'vertical',
-          show: true,
-          left: 185,
-          top: '35%',
-          textStyle: {
-            fontSize: 14,
-            fontWeight: 600,
-            rich: {
-              redText: {
-                color: theme.red300,
-                fontWeight: 600,
-                fontSize: 14,
-              },
-              greenText: {
-                color: theme.green300,
-                fontWeight: 600,
-                fontSize: 14,
-              },
-              smalltext: {
-                color: theme.textColor,
-                fontSize: 10,
-                verticalAlign: 'bottom',
-              },
-            },
-          },
-          itemWidth: 12,
-          formatter: name => {
-            const change = this.getSpanOpDurationChange(name);
-            const oldValue = getDuration(
-              this.props.data[name].oldBaseline / 1000,
-              0,
-              true
-            );
-            const newValue = getDuration(
-              this.props.data[name].newBaseline / 1000,
-              0,
-              true
-            );
-            const percentage = this.props.data ? formatPercentage(Math.abs(change)) : '';
-            const percentageText = change < 0 ? t('Up') : t('Down');
-            const textclass = change < 0 ? t('redText') : t('greenText');
-
-            return `${name}   {${textclass}|${percentageText} ${percentage}} {smalltext|(${oldValue} to ${newValue})}`;
-          },
-          tooltip: {
-            formatter: data => {
-              const change = this.getSpanOpDurationChange(data.name);
-              const changeText = change < 0 ? t('up') : t('down');
+            })
+            .map((op, index) => {
+              const change = this.getSpanOpDurationChange(op);
               const oldValue = getDuration(
-                this.props.data[data.name].oldBaseline / 1000,
+                this.props.data[op].oldBaseline / 1000,
                 2,
                 true
               );
               const newValue = getDuration(
-                this.props.data[data.name].newBaseline / 1000,
+                this.props.data[op].newBaseline / 1000,
                 2,
                 true
               );
-
-              const text = t(
-                `Total time for %s  went %s from %s to %s`,
-                data.name,
-                changeText,
-                oldValue,
-                newValue
+              const percentage = this.props.data
+                ? formatPercentage(Math.abs(change))
+                : '';
+              const percentageText = change < 0 ? t('up') : t('down');
+              return (
+                <StyledLegendWrapper
+                  key={index}
+                  onMouseEnter={() => this.highlight(operationToColorMap[op].index)}
+                  onMouseLeave={() => this.downplay(operationToColorMap[op].index)}
+                >
+                  <CircleIndicator color={operationToColorMap[op].color} size={10} />
+                  <span>
+                    {op}{' '}
+                    <Tooltip
+                      skipWrapper
+                      title={t(
+                        `Total time for %s went %s from %s to %s`,
+                        op,
+                        percentageText,
+                        oldValue,
+                        newValue
+                      )}
+                    >
+                      <SpanOpChange regressed>
+                        {percentageText} {percentage}
+                      </SpanOpChange>
+                    </Tooltip>
+                  </span>
+                </StyledLegendWrapper>
               );
+            })}
+        </LegendWrapper>
+        <BaseChart
+          ref={this.chart}
+          colors={this.pieChartSliceColors}
+          // when legend highlights it does NOT pass dataIndex :(
+          onHighlight={({name}) => {
+            if (
+              !this.isInitialSelected ||
+              !name ||
+              firstSeries.data[this.selected].name === name
+            ) {
+              return;
+            }
 
+            // Unhighlight if not initial "highlight" event and
+            // if name exists (i.e. not dispatched from cDM) and
+            // highlighted series name is different than the initially selected series name
+            this.downplay(this.selected);
+            this.isInitialSelected = false;
+          }}
+          onMouseOver={({dataIndex}) => {
+            if (!this.isInitialSelected) {
+              return;
+            }
+            if (dataIndex === this.selected) {
+              return;
+            }
+            this.downplay(this.selected);
+            this.isInitialSelected = false;
+          }}
+          {...props}
+          tooltip={{
+            formatter: data => {
               return [
                 '<div class="tooltip-series">',
-                `<div>
-                  <span
-                    class="tooltip-label"
-                    style="
-                      width: 200px !important;
-                      text-wrap: balance;
-                      text-align: center;
-                    "
-                  >
-                    <strong>${text}</strong>
-                  </span>
-                </div>`,
+                `<div><span class="tooltip-label">${data.marker}<strong>${data.name}</strong></span></div>`,
+                '</div>',
+                `<div class="tooltip-footer">${getDuration(
+                  this.props.data[data.name].oldBaseline / 1000,
+                  2,
+                  true
+                )} to ${getDuration(
+                  this.props.data[data.name].newBaseline / 1000,
+                  2,
+                  true
+                )}</div>`,
                 '</div>',
                 '<div class="tooltip-arrow"></div>',
               ].join('');
             },
-            show: true,
-          },
-        })}
-        tooltip={{
-          formatter: data => {
-            return [
-              '<div class="tooltip-series">',
-              `<div><span class="tooltip-label">${data.marker}<strong>${data.name}</strong></span></div>`,
-              '</div>',
-              `<div class="tooltip-footer">${getDuration(
-                this.props.data[data.name].oldBaseline / 1000,
-                2,
-                true
-              )} to ${getDuration(
-                this.props.data[data.name].newBaseline / 1000,
-                2,
-                true
-              )}</div>`,
-              '</div>',
-              '<div class="tooltip-arrow"></div>',
-            ].join('');
-          },
-        }}
-        series={[
-          PieSeries({
-            name: firstSeries.seriesName,
-            data: firstSeries.data,
-            avoidLabelOverlap: false,
-            label: {
-              position: 'inside',
-              formatter: params => {
-                return `${Math.round(Number(params.percent))}%`;
-              },
-              show: true,
-              color: theme.background,
-              fontSize: 12,
-              fontWeight: 600,
-            },
-            emphasis: {
+          }}
+          series={[
+            PieSeries({
+              name: firstSeries.seriesName,
+              data: firstSeries.data,
+              avoidLabelOverlap: false,
               label: {
+                position: 'inside',
+                formatter: params => {
+                  return `${Math.round(Number(params.percent))}%`;
+                },
                 show: true,
+                color: theme.background,
+                fontSize: 12,
+                fontWeight: 600,
               },
-            },
-            labelLine: {
-              show: false,
-            },
-            center: ['90', '100'],
-            radius: ['45%', '85%'],
-            itemStyle: {
-              borderColor: theme.background,
-              borderWidth: 2,
-            },
-          }),
-        ]}
-        xAxis={null}
-        yAxis={null}
-      />
+              emphasis: {
+                label: {
+                  show: true,
+                },
+              },
+              labelLine: {
+                show: false,
+              },
+              center: ['90', '100'],
+              radius: ['45%', '85%'],
+              itemStyle: {
+                borderColor: theme.background,
+                borderWidth: 2,
+              },
+            }),
+          ]}
+          xAxis={null}
+          yAxis={null}
+        />
+      </Wrapper>
     );
   }
 }
+
+const Wrapper = styled('div')`
+  position: relative;
+`;
+
+const LegendWrapper = styled('div')`
+  position: absolute;
+  top: 70px;
+  left: 185px;
+  z-index: 100;
+`;
+
+const StyledLegendWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.75)};
+`;
+
+const SpanOpChange = styled('span')<{regressed: boolean}>`
+  color: ${p => (p.regressed ? p.theme.red300 : p.theme.green300)};
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-transform: capitalize;
+`;
 
 export default withTheme(PieChart);

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
@@ -168,12 +168,12 @@ class PieChart extends Component<Props> {
             const change = this.getSpanOpDurationChange(name);
             const oldValue = getDuration(
               this.props.data[name].oldBaseline / 1000,
-              2,
+              0,
               true
             );
             const newValue = getDuration(
               this.props.data[name].newBaseline / 1000,
-              2,
+              0,
               true
             );
             const percentage = this.props.data ? formatPercentage(Math.abs(change)) : '';

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
@@ -146,24 +146,27 @@ class PieChart extends Component<Props> {
                   onMouseEnter={() => this.highlight(operationToColorMap[op].index)}
                   onMouseLeave={() => this.downplay(operationToColorMap[op].index)}
                 >
-                  <CircleIndicator color={operationToColorMap[op].color} size={10} />
                   <span>
-                    {op}{' '}
-                    <Tooltip
-                      skipWrapper
-                      title={t(
-                        `Total time for %s went %s from %s to %s`,
-                        op,
-                        percentageText,
-                        oldValue,
-                        newValue
-                      )}
-                    >
-                      <SpanOpChange regressed>
-                        {percentageText} {percentage}
-                      </SpanOpChange>
-                    </Tooltip>
+                    <StyledColorIndicator
+                      color={operationToColorMap[op].color}
+                      size={10}
+                    />
+                    {op}
                   </span>
+                  <Tooltip
+                    skipWrapper
+                    title={t(
+                      `Total time for %s went %s from %s to %s`,
+                      op,
+                      percentageText,
+                      oldValue,
+                      newValue
+                    )}
+                  >
+                    <SpanOpChange regressed>
+                      {percentageText} {percentage}
+                    </SpanOpChange>
+                  </Tooltip>
                 </StyledLegendWrapper>
               );
             })}
@@ -271,8 +274,9 @@ const LegendWrapper = styled('div')`
 
 const StyledLegendWrapper = styled('div')`
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  gap: ${space(0.75)};
+  gap: ${space(1.5)};
 `;
 
 const SpanOpChange = styled('span')<{regressed: boolean}>`
@@ -280,6 +284,10 @@ const SpanOpChange = styled('span')<{regressed: boolean}>`
   text-decoration-line: underline;
   text-decoration-style: dotted;
   text-transform: capitalize;
+`;
+
+const StyledColorIndicator = styled(CircleIndicator)`
+  margin-right: ${space(0.5)};
 `;
 
 export default withTheme(PieChart);

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
@@ -104,7 +104,7 @@ class PieChart extends Component<Props> {
     // Note, we only take the first series unit!
     const [firstSeries] = series;
 
-    // Attach a color to each operation. This allows us to match custom legend indicator
+    // Attach a color and index to each operation. This allows us to match custom legend indicator
     // colors to the op's pie chart color AND display the legend items sorted based on their
     // percentage changes.
     const operationToColorMap: {
@@ -263,7 +263,8 @@ const Wrapper = styled('div')`
 
 const LegendWrapper = styled('div')`
   position: absolute;
-  top: 70px;
+  top: 50%;
+  transform: translateY(-60%);
   left: 185px;
   z-index: 100;
 `;

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
@@ -268,7 +268,7 @@ const LegendWrapper = styled('div')`
   position: absolute;
   top: 50%;
   transform: translateY(-60%);
-  left: 185px;
+  left: 195px;
   z-index: 100;
 `;
 

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/pieChart.tsx
@@ -163,7 +163,7 @@ class PieChart extends Component<Props> {
                       newValue
                     )}
                   >
-                    <SpanOpChange regressed>
+                    <SpanOpChange regressed={change < 0}>
                       {percentageText} {percentage}
                     </SpanOpChange>
                   </Tooltip>
@@ -229,12 +229,12 @@ class PieChart extends Component<Props> {
               label: {
                 position: 'inside',
                 formatter: params => {
-                  return `${Math.round(Number(params.percent))}%`;
+                  return `${params.name} ${Math.round(Number(params.percent))}%`;
                 },
                 show: true,
                 color: theme.background,
-                fontSize: 12,
-                fontWeight: 600,
+                width: 40,
+                overflow: 'break',
               },
               emphasis: {
                 label: {

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/spanOpBreakdown.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/spanOpBreakdown.tsx
@@ -6,7 +6,6 @@ import moment from 'moment';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {DataSection} from 'sentry/components/events/styles';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Event} from 'sentry/types';
@@ -168,15 +167,7 @@ function EventSpanOpBreakdown({event}: {event: Event}) {
   return (
     <Wrapper>
       <DataSection>
-        <TitleWrapper>
-          <strong>{t('Operation Breakdown')}</strong>
-          <QuestionTooltip
-            title={t(
-              'Percentage of total transaction duration spent on each span operation along with, changes in the total duration of each span operation.'
-            )}
-            size="sm"
-          />
-        </TitleWrapper>
+        <strong>{t('Operation Breakdown:')}</strong>
         <PieChart data={spanOpDiffs} series={series} />
       </DataSection>
     </Wrapper>
@@ -190,12 +181,6 @@ const EmptyStateWrapper = styled('div')`
   justify-content: center;
   align-items: center;
   margin: ${space(1.5)} ${space(4)};
-`;
-
-const TitleWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${space(0.5)};
 `;
 
 const Wrapper = styled('div')`

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/spanOpBreakdown.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/spanOpBreakdown.tsx
@@ -168,15 +168,15 @@ function EventSpanOpBreakdown({event}: {event: Event}) {
   return (
     <Wrapper>
       <DataSection>
-        <strong>
-          {t('Operation Breakdown')}{' '}
+        <TitleWrapper>
+          <strong>{t('Operation Breakdown')}</strong>
           <QuestionTooltip
             title={t(
               'Percentage of total transaction duration spent on each span operation along with, changes in the total duration of each span operation.'
             )}
             size="sm"
           />
-        </strong>
+        </TitleWrapper>
         <PieChart data={spanOpDiffs} series={series} />
       </DataSection>
     </Wrapper>
@@ -190,6 +190,12 @@ const EmptyStateWrapper = styled('div')`
   justify-content: center;
   align-items: center;
   margin: ${space(1.5)} ${space(4)};
+`;
+
+const TitleWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
 `;
 
 const Wrapper = styled('div')`

--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/spanOpBreakdown.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanOps/spanOpBreakdown.tsx
@@ -6,6 +6,7 @@ import moment from 'moment';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {DataSection} from 'sentry/components/events/styles';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Event} from 'sentry/types';
@@ -167,7 +168,15 @@ function EventSpanOpBreakdown({event}: {event: Event}) {
   return (
     <Wrapper>
       <DataSection>
-        <strong>{t('Operation Breakdown:')}</strong>
+        <strong>
+          {t('Operation Breakdown')}{' '}
+          <QuestionTooltip
+            title={t(
+              'Percentage of total transaction duration spent on each span operation along with, changes in the total duration of each span operation.'
+            )}
+            size="sm"
+          />
+        </strong>
         <PieChart data={spanOpDiffs} series={series} />
       </DataSection>
     </Wrapper>


### PR DESCRIPTION
For issue: https://github.com/getsentry/sentry/issues/56015

Updated the spanOpbreakdown designs: 

Before: 
<img width="441" alt="Screenshot 2023-10-20 at 10 30 04 AM" src="https://github.com/getsentry/sentry/assets/60121741/c6c8760f-3c97-496a-b1bb-2e1aa386da85">

After: 
<img width="414" alt="Screenshot 2023-10-20 at 1 37 35 PM" src="https://github.com/getsentry/sentry/assets/60121741/ddccf0b2-d500-439b-b53b-18a92d16ecb7">


