### PR TITLE
fix(starfish): Pass webvital to charts in Webvitals module

### DIFF
--- a/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
@@ -106,6 +106,7 @@ export default function WebVitalsLandingPage() {
               projectScore={projectScore}
               transaction={transaction}
               isProjectScoreLoading={isLoading}
+              webVital={state.webVital}
             />
           </PerformanceScoreChartContainer>
           <WebVitalMeters


### PR DESCRIPTION
Forgot to pass the current webvital to the performance score charts. This enables the performance score ring to dynamically  shade segments depending on the selected webvital.