### PR TITLE
fix(browser-starfish): typo in metric name

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -183,7 +183,7 @@ SPAN_METRICS_NAMES = {
     "d:spans/frames_frozen@none": PREFIX + 407,
     "d:spans/frames_slow@none": PREFIX + 408,
     "d:spans/http.response_content_length@byte": PREFIX + 409,
-    "d:spans/http.decoded_response_body_length@byte": PREFIX + 410,
+    "d:spans/http.decoded_response_content_length@byte": PREFIX + 410,
     "d:spans/http.response_transfer_size@byte": PREFIX + 411,
 }
 


### PR DESCRIPTION
follow up to this PR https://github.com/getsentry/relay/pull/2638

I'm new to making changes in this area of code, any comments is much appreciated. 
I'm not sure if there is a specific order we should merge these changes?