### PR TITLE
ref(replays): make issue details replay route to errors tab

### DIFF
--- a/static/app/components/events/eventReplay/replayPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.spec.tsx
@@ -21,7 +21,7 @@ const mockReplayId = '761104e184c64d439ee1014b72b4d83b';
 
 const mockEventTimestampMs = new Date('2022-09-22T16:59:41Z').getTime();
 
-const mockButtonHref = `/organizations/${mockOrgSlug}/replays/761104e184c64d439ee1014b72b4d83b/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&t=62&t_main=console`;
+const mockButtonHref = `/organizations/${mockOrgSlug}/replays/761104e184c64d439ee1014b72b4d83b/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&t=62&t_main=errors`;
 
 // Mock screenfull library
 jest.mock('screenfull', () => ({

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -15,6 +15,7 @@ import {IconDelete, IconPlay} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
+import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
@@ -114,7 +115,7 @@ function ReplayPreview({orgSlug, replaySlug, eventTimestampMs, buttonProps}: Pro
     pathname: normalizeUrl(`/organizations/${orgSlug}/replays/${replayId}/`),
     query: {
       referrer: getRouteStringFromRoutes(routes),
-      t_main: 'errors',
+      t_main: TabKey.ERRORS,
       t: initialTimeOffsetMs / 1000,
     },
   };

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -114,7 +114,7 @@ function ReplayPreview({orgSlug, replaySlug, eventTimestampMs, buttonProps}: Pro
     pathname: normalizeUrl(`/organizations/${orgSlug}/replays/${replayId}/`),
     query: {
       referrer: getRouteStringFromRoutes(routes),
-      t_main: 'console',
+      t_main: 'errors',
       t: initialTimeOffsetMs / 1000,
     },
   };

--- a/static/app/components/replays/header/errorCounts.tsx
+++ b/static/app/components/replays/header/errorCounts.tsx
@@ -11,6 +11,7 @@ import {IconFire} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types';
+import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import {useLocation} from 'sentry/utils/useLocation';
 import type {ReplayError, ReplayRecord} from 'sentry/views/replays/types';
 
@@ -26,7 +27,7 @@ export default function ErrorCounts({replayErrors, replayRecord}: Props) {
     ({project}: {project?: Project}) => {
       return {
         pathname,
-        query: {...query, t_main: 'errors', f_e_project: project?.slug},
+        query: {...query, t_main: TabKey.ERRORS, f_e_project: project?.slug},
       };
     },
     [pathname, query]

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -29,6 +29,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import {spanOperationRelativeBreakdownRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {getShortEventId} from 'sentry/utils/events';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
@@ -314,7 +315,7 @@ export function ReplayCell({
     query: {
       referrer,
       ...eventView.generateQueryStringObject(),
-      t_main: 'errors',
+      t_main: TabKey.ERRORS,
     },
   };
 


### PR DESCRIPTION
Also fixed a few places where we weren't using `TabKey`.

https://github.com/getsentry/sentry/assets/56095982/62fb986c-1a93-444c-9592-170e98f81f73

Closes https://github.com/getsentry/team-replay/issues/258

