### PR TITLE
fix(stats-detectors): Chunk hourly metrics query

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -246,7 +246,7 @@ def _detect_transaction_change_points(
 def get_all_transaction_payloads(
     org_ids: List[int], project_ids: List[int], start: datetime, end: datetime
 ) -> Generator[DetectorPayload, None, None]:
-    projects_per_query = options.get("statistical_detectors.query.batch-size")
+    projects_per_query = options.get("statistical_detectors.query.batch_size")
     assert projects_per_query > 0
 
     for chunked_project_ids in chunked(project_ids, projects_per_query):

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -243,6 +243,22 @@ def _detect_transaction_change_points(
             continue
 
 
+def get_all_transaction_payloads(
+    org_ids: List[int], project_ids: List[int], start: datetime, end: datetime
+) -> Generator[DetectorPayload, None, None]:
+    projects_per_query = options.get("statistical_detectors.query.batch-size")
+    assert projects_per_query > 0
+
+    for chunked_project_ids in chunked(project_ids, projects_per_query):
+        try:
+            yield from query_transactions(
+                org_ids, chunked_project_ids, start, end, TRANSACTIONS_PER_PROJECT
+            )
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            continue
+
+
 def _detect_transaction_trends(
     org_ids: List[int], project_ids: List[int], start: datetime
 ) -> Generator[Tuple[Optional[TrendType], DetectorPayload], None, None]:
@@ -268,9 +284,7 @@ def _detect_transaction_trends(
     start = start - timedelta(hours=1)
     start = start.replace(minute=0, second=0, microsecond=0)
     end = start + timedelta(hours=1)
-    all_transaction_payloads = query_transactions(
-        org_ids, project_ids, start, end, TRANSACTIONS_PER_PROJECT
-    )
+    all_transaction_payloads = get_all_transaction_payloads(org_ids, project_ids, start, end)
 
     projects = Project.objects.filter(id__in=project_ids).select_related("organization")
     project_by_id = {project.id: project for project in projects}
@@ -933,11 +947,7 @@ def query_transactions(
         query=query,
         tenant_ids={
             "referrer": Referrer.STATISTICAL_DETECTORS_FETCH_TOP_TRANSACTION_NAMES.value,
-            # HACK: the allocation policy is going to reject this query unless there is an org_id
-            # passed in. The allocation policy will be updated to handle cross-org queries better
-            # As it is now (09-13-2023), this query will likely be throttled (i.e be slower) by the allocation
-            # policy as soon as we start scanning more than just the sentry org
-            "organization_id": -42069,
+            "cross_org_query": 1,
             "use_case_id": use_case_id.value,
         },
     )


### PR DESCRIPTION
We've been fetching last hour `p95` transaction duration for all projects. As we increase the number of projects, we need to split the query to stay within 10,000 limit

Fixes SENTRY-170X