### PR TITLE
test(github): Mock github enterprise server calls + refactor for DRY

### DIFF
--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from unittest.mock import patch
 from uuid import uuid4
 
-import pytest
+import responses
 
 from fixtures.github_enterprise import (
     PULL_REQUEST_CLOSED_EVENT_EXAMPLE,
@@ -12,29 +12,34 @@ from fixtures.github_enterprise import (
 )
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
-from sentry.models.integrations.integration import Integration
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test(stable=True)
 class WebhookTest(APITestCase):
-    def test_get(self):
-        url = "/extensions/github-enterprise/webhook/"
+    def setUp(self):
+        self.url = "/extensions/github-enterprise/webhook/"
+        self.metadata = {
+            "url": "35.232.149.196",
+            "id": "2",
+            "name": "test-app",
+            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
+            "private_key": "private_key",
+            "verify_ssl": True,
+        }
 
-        response = self.client.get(url)
+    def test_get(self):
+        response = self.client.get(self.url)
         assert response.status_code == 405
 
     def test_unknown_host_event(self):
         # No integration defined in the database, so event should be rejected
         # because we can't find metadata and secret for it
-        url = "/extensions/github-enterprise/webhook/"
-
         response = self.client.post(
-            path=url,
+            path=self.url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="push",
@@ -44,11 +49,8 @@ class WebhookTest(APITestCase):
         assert response.status_code == 400
 
     def test_unregistered_event(self):
-        project = self.project  # noqa force creation
-        url = "/extensions/github-enterprise/webhook/"
-
         response = self.client.post(
-            path=url,
+            path=self.url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="UnregisteredEvent",
@@ -60,18 +62,10 @@ class WebhookTest(APITestCase):
 
     @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_invalid_signature_event(self, mock_installation):
-        mock_installation.return_value = {
-            "url": "35.232.149.196",
-            "id": "2",
-            "name": "test-app",
-            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
-            "private_key": "private_key",
-            "verify_ssl": True,
-        }
-        url = "/extensions/github-enterprise/webhook/"
+        mock_installation.return_value = self.metadata
 
         response = self.client.post(
-            path=url,
+            path=self.url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="push",
@@ -84,18 +78,10 @@ class WebhookTest(APITestCase):
     @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_missing_signature_ok(self, mock_installation):
         # Old Github:e doesn't send a signature, so we have to accept that.
-        mock_installation.return_value = {
-            "url": "35.232.149.196",
-            "id": "2",
-            "name": "test-app",
-            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
-            "private_key": "private_key",
-            "verify_ssl": True,
-        }
-        url = "/extensions/github-enterprise/webhook/"
+        mock_installation.return_value = self.metadata
 
         response = self.client.post(
-            path=url,
+            path=self.url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="push",
@@ -107,16 +93,9 @@ class WebhookTest(APITestCase):
 
 @region_silo_test(stable=True)
 class PushEventWebhookTest(APITestCase):
-    @pytest.mark.skip(reason="Host has been taken down")
-    @patch("sentry.integrations.github_enterprise.client.get_jwt")
-    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
-    def test_simple(self, mock_get_installation_metadata, mock_get_jwt):
-        mock_get_jwt.return_value = b""
-
-        project = self.project  # force creation
-
-        url = "/extensions/github-enterprise/webhook/"
-        mock_get_installation_metadata.return_value = {
+    def setUp(self):
+        self.url = "/extensions/github-enterprise/webhook/"
+        self.metadata = {
             "url": "35.232.149.196",
             "id": "2",
             "name": "test-app",
@@ -124,15 +103,29 @@ class PushEventWebhookTest(APITestCase):
             "private_key": "private_key",
             "verify_ssl": True,
         }
-
         Repository.objects.create(
-            organization_id=project.organization.id,
+            organization_id=self.project.organization.id,
             external_id="35129377",
             provider="integrations:github_enterprise",
             name="baxterthehacker/public-repo",
         )
-        integration = Integration.objects.create(
+
+    @responses.activate
+    @patch("sentry.integrations.github_enterprise.client.get_jwt")
+    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
+    def test_simple(self, mock_get_installation_metadata, mock_get_jwt):
+        responses.add(
+            responses.POST,
+            "https://35.232.149.196/extensions/github-enterprise/webhook/",
+            status=204,
+        )
+
+        mock_get_jwt.return_value = b""
+        mock_get_installation_metadata.return_value = self.metadata
+
+        self.create_integration(
             external_id="35.232.149.196:12345",
+            organization=self.project.organization,
             provider="github_enterprise",
             metadata={
                 "domain_name": "35.232.149.196/baxterthehacker",
@@ -140,10 +133,9 @@ class PushEventWebhookTest(APITestCase):
                 "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
             },
         )
-        integration.add_organization(project.organization, self.user)
 
         response = self.client.post(
-            path=url,
+            path=self.url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="push",
@@ -184,46 +176,28 @@ class PushEventWebhookTest(APITestCase):
 
     @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_anonymous_lookup(self, mock_get_installation_metadata):
-        project = self.project  # force creation
+        mock_get_installation_metadata.return_value = self.metadata
 
-        url = "/extensions/github-enterprise/webhook/"
-        mock_get_installation_metadata.return_value = {
-            "url": "35.232.149.196",
-            "id": "2",
-            "name": "test-app",
-            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
-            "private_key": "private_key",
-            "verify_ssl": True,
-        }
-
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.create(
-                provider="github_enterprise",
-                external_id="35.232.149.196:12345",
-                name="octocat",
-                metadata={
-                    "domain_name": "35.232.149.196/baxterthehacker",
-                    "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
-                },
-            )
-            integration.add_organization(project.organization, self.user)
-
-        Repository.objects.create(
-            organization_id=project.organization.id,
-            external_id="35129377",
-            provider="integrations:github_enterprise",
-            name="baxterthehacker/public-repo",
+        self.create_integration(
+            external_id="35.232.149.196:12345",
+            organization=self.project.organization,
+            provider="github_enterprise",
+            name="octocat",
+            metadata={
+                "domain_name": "35.232.149.196/baxterthehacker",
+                "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
+            },
         )
 
         CommitAuthor.objects.create(
             external_id="github_enterprise:baxterthehacker",
-            organization_id=project.organization_id,
+            organization_id=self.project.organization_id,
             email="baxterthehacker@example.com",
             name="bàxterthehacker",
         )
 
         response = self.client.post(
-            path=url,
+            path=self.url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="push",
@@ -235,7 +209,7 @@ class PushEventWebhookTest(APITestCase):
         assert response.status_code == 204
 
         commit_list = list(
-            Commit.objects.filter(organization_id=project.organization_id)
+            Commit.objects.filter(organization_id=self.project.organization_id)
             .select_related("author")
             .order_by("-date_added")
         )
@@ -259,32 +233,22 @@ class PushEventWebhookTest(APITestCase):
         assert commit.author.email == "baxterthehacker@example.com"
         assert commit.date_added == datetime(2015, 5, 5, 23, 40, 15, tzinfo=timezone.utc)
 
-    @pytest.mark.skip(reason="Host has been taken down")
+    @responses.activate
     @patch("sentry.integrations.github_enterprise.client.get_jwt")
     @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_multiple_orgs(self, mock_get_installation_metadata, mock_get_jwt):
-        mock_get_jwt.return_value = b""
-
-        project = self.project  # force creation
-
-        url = "/extensions/github-enterprise/webhook/"
-        mock_get_installation_metadata.return_value = {
-            "url": "35.232.149.196",
-            "id": "2",
-            "name": "test-app",
-            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
-            "private_key": "private_key",
-            "verify_ssl": True,
-        }
-
-        Repository.objects.create(
-            organization_id=project.organization.id,
-            external_id="35129377",
-            provider="integrations:github_enterprise",
-            name="baxterthehacker/public-repo",
+        responses.add(
+            responses.POST,
+            "https://35.232.149.196/extensions/github-enterprise/webhook/",
+            status=204,
         )
-        integration = Integration.objects.create(
+
+        mock_get_jwt.return_value = b""
+        mock_get_installation_metadata.return_value = self.metadata
+
+        self.create_integration(
             external_id="35.232.149.196:12345",
+            organization=self.project.organization,
             provider="github_enterprise",
             metadata={
                 "domain_name": "35.232.149.196/baxterthehacker",
@@ -292,7 +256,6 @@ class PushEventWebhookTest(APITestCase):
                 "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
             },
         )
-        integration.add_organization(project.organization, self.user)
 
         org2 = self.create_organization()
         project2 = self.create_project(organization=org2, name="bar")
@@ -303,8 +266,10 @@ class PushEventWebhookTest(APITestCase):
             provider="integrations:github_enterprise",
             name="another/repo",
         )
-        integration = Integration.objects.create(
+
+        self.create_integration(
             external_id="35.232.149.196:99",
+            organization=org2,
             provider="github_enterprise",
             metadata={
                 "domain_name": "35.232.149.196/another",
@@ -316,10 +281,9 @@ class PushEventWebhookTest(APITestCase):
                 },
             },
         )
-        integration.add_organization(org2, self.user)
 
         response = self.client.post(
-            path=url,
+            path=self.url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="push",
@@ -331,7 +295,7 @@ class PushEventWebhookTest(APITestCase):
         assert response.status_code == 204
 
         commit_list = list(
-            Commit.objects.filter(organization_id=project.organization_id)
+            Commit.objects.filter(organization_id=self.project.organization_id)
             .select_related("author")
             .order_by("-date_added")
         )
@@ -348,12 +312,9 @@ class PushEventWebhookTest(APITestCase):
 
 @region_silo_test(stable=True)
 class PullRequestEventWebhook(APITestCase):
-    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
-    def test_opened(self, mock_get_installation_metadata):
-        project = self.project  # force creation
-
-        url = "/extensions/github-enterprise/webhook/"
-        mock_get_installation_metadata.return_value = {
+    def setUp(self):
+        self.url = "/extensions/github-enterprise/webhook/"
+        self.metadata = {
             "url": "35.232.149.196",
             "id": "2",
             "name": "test-app",
@@ -361,28 +322,29 @@ class PullRequestEventWebhook(APITestCase):
             "private_key": "private_key",
             "verify_ssl": True,
         }
-
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.create(
-                provider="github_enterprise",
-                external_id="35.232.149.196:234",
-                name="octocat",
-                metadata={
-                    "domain_name": "35.232.149.196/baxterthehacker",
-                    "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
-                },
-            )
-            integration.add_organization(project.organization, self.user)
-
-        repo = Repository.objects.create(
-            organization_id=project.organization.id,
+        self.create_integration(
+            external_id="35.232.149.196:234",
+            organization=self.project.organization,
+            provider="github_enterprise",
+            name="octocat",
+            metadata={
+                "domain_name": "35.232.149.196/baxterthehacker",
+                "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
+            },
+        )
+        self.repo = Repository.objects.create(
+            organization_id=self.project.organization.id,
             external_id="35129377",
             provider="integrations:github_enterprise",
             name="baxterthehacker/public-repo",
         )
 
+    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
+    def test_opened(self, mock_get_installation_metadata):
+        mock_get_installation_metadata.return_value = self.metadata
+
         response = self.client.post(
-            path=url,
+            path=self.url,
             data=PULL_REQUEST_OPENED_EVENT_EXAMPLE,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="pull_request",
@@ -394,7 +356,7 @@ class PullRequestEventWebhook(APITestCase):
         assert response.status_code == 204
 
         prs = PullRequest.objects.filter(
-            repository_id=repo.id, organization_id=project.organization.id
+            repository_id=self.repo.id, organization_id=self.project.organization.id
         )
 
         assert len(prs) == 1
@@ -408,43 +370,14 @@ class PullRequestEventWebhook(APITestCase):
 
     @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_edited(self, mock_get_installation_metadata):
-        project = self.project  # force creation
-
-        url = "/extensions/github-enterprise/webhook/"
-        mock_get_installation_metadata.return_value = {
-            "url": "35.232.149.196",
-            "id": "2",
-            "name": "test-app",
-            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
-            "private_key": "private_key",
-            "verify_ssl": True,
-        }
-
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.create(
-                provider="github_enterprise",
-                external_id="35.232.149.196:234",
-                name="octocat",
-                metadata={
-                    "domain_name": "35.232.149.196/baxterthehacker",
-                    "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
-                },
-            )
-            integration.add_organization(project.organization, self.user)
-
-        repo = Repository.objects.create(
-            organization_id=project.organization.id,
-            external_id="35129377",
-            provider="integrations:github_enterprise",
-            name="baxterthehacker/public-repo",
-        )
+        mock_get_installation_metadata.return_value = self.metadata
 
         pr = PullRequest.objects.create(
-            key="1", repository_id=repo.id, organization_id=project.organization.id
+            key="1", repository_id=self.repo.id, organization_id=self.project.organization.id
         )
 
         response = self.client.post(
-            path=url,
+            path=self.url,
             data=PULL_REQUEST_EDITED_EVENT_EXAMPLE,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="pull_request",
@@ -464,39 +397,10 @@ class PullRequestEventWebhook(APITestCase):
 
     @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_closed(self, mock_get_installation_metadata):
-        project = self.project  # force creation
-
-        url = "/extensions/github-enterprise/webhook/"
-        mock_get_installation_metadata.return_value = {
-            "url": "35.232.149.196",
-            "id": "2",
-            "name": "test-app",
-            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
-            "private_key": "private_key",
-            "verify_ssl": True,
-        }
-
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = Integration.objects.create(
-                provider="github_enterprise",
-                external_id="35.232.149.196:234",
-                name="octocat",
-                metadata={
-                    "domain_name": "35.232.149.196/baxterthehacker",
-                    "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
-                },
-            )
-            integration.add_organization(project.organization, self.user)
-
-        repo = Repository.objects.create(
-            organization_id=project.organization.id,
-            external_id="35129377",
-            provider="integrations:github_enterprise",
-            name="baxterthehacker/public-repo",
-        )
+        mock_get_installation_metadata.return_value = self.metadata
 
         response = self.client.post(
-            path=url,
+            path=self.url,
             data=PULL_REQUEST_CLOSED_EVENT_EXAMPLE,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="pull_request",
@@ -508,7 +412,7 @@ class PullRequestEventWebhook(APITestCase):
         assert response.status_code == 204
 
         prs = PullRequest.objects.filter(
-            repository_id=repo.id, organization_id=project.organization.id
+            repository_id=self.repo.id, organization_id=self.project.organization.id
         )
 
         assert len(prs) == 1


### PR DESCRIPTION
We originally hit the real GitHub Enterprise Server, but that caused problems when the instance went down. We disabled those tests entirely in https://github.com/getsentry/sentry/pull/46441. Now instead of disabling those tests, we re-enable them and mock the responses instead. Also refactor tests for DRY.

‼️ Note that no code has actually changed except adding mock responses

Closes [WOR-2878](https://getsentry.atlassian.net/browse/WOR-2878)

[WOR-2878]: https://getsentry.atlassian.net/browse/WOR-2878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ