### PR TITLE
ref(bug reports): better search bar placeholder and email alignment

### DIFF
--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -2,6 +2,7 @@ import {CSSProperties} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
+import {t} from 'sentry/locale';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -13,7 +14,7 @@ interface Props {
   style?: CSSProperties;
 }
 
-export default function ReplaysSearch({className, style}: Props) {
+export default function FeedbackSearch({className, style}: Props) {
   const {selection} = usePageFilters();
   const {pathname, query} = useLocation();
   const organization = useOrganization();
@@ -21,6 +22,7 @@ export default function ReplaysSearch({className, style}: Props) {
   return (
     <SearchContainer className={className} style={style}>
       <ReplaySearchBar
+        placeholder={t('Search Feedback')}
         disabled
         organization={organization}
         pageFilters={selection}

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -71,9 +71,11 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
           <Flex column style={{gridArea: 'right'}}>
             {''}
           </Flex>
-          <strong style={{gridArea: 'user'}}>
-            <FeedbackItemUsername feedbackItem={feedbackItem} detailDisplay={false} />
-          </strong>
+          <TextOverflow>
+            <strong style={{gridArea: 'user'}}>
+              <FeedbackItemUsername feedbackItem={feedbackItem} detailDisplay={false} />
+            </strong>
+          </TextOverflow>
           <span style={{gridArea: 'time'}}>
             <TimeSince date={feedbackItem.timestamp} />
           </span>

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -72,9 +72,9 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
             {''}
           </Flex>
           <TextOverflow>
-            <strong style={{gridArea: 'user'}}>
+            <span style={{gridArea: 'user'}}>
               <FeedbackItemUsername feedbackItem={feedbackItem} detailDisplay={false} />
-            </strong>
+            </span>
           </TextOverflow>
           <span style={{gridArea: 'time'}}>
             <TimeSince date={feedbackItem.timestamp} />

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -72,10 +72,11 @@ function getSupportedTags(supportedTags: TagCollection) {
 type Props = React.ComponentProps<typeof SmartSearchBar> & {
   organization: Organization;
   pageFilters: PageFilters;
+  placeholder: string;
 };
 
 function ReplaySearchBar(props: Props) {
-  const {organization, pageFilters} = props;
+  const {organization, pageFilters, placeholder} = props;
   const api = useApi();
   const projectIdStrings = pageFilters.projects?.map(String);
   const tags = useTags();
@@ -113,9 +114,10 @@ function ReplaySearchBar(props: Props) {
       {...props}
       onGetTagValues={getTagValues}
       supportedTags={getSupportedTags(tags)}
-      placeholder={t(
-        'Search for users, duration, clicked elements, count_errors, and more'
-      )}
+      placeholder={
+        placeholder ??
+        t('Search for users, duration, clicked elements, count_errors, and more')
+      }
       prepareQuery={prepareQuery}
       maxQueryLength={MAX_QUERY_LENGTH}
       searchSource="replay_index"

--- a/static/app/views/replays/list/replaySearchBar.tsx
+++ b/static/app/views/replays/list/replaySearchBar.tsx
@@ -72,7 +72,7 @@ function getSupportedTags(supportedTags: TagCollection) {
 type Props = React.ComponentProps<typeof SmartSearchBar> & {
   organization: Organization;
   pageFilters: PageFilters;
-  placeholder: string;
+  placeholder?: string;
 };
 
 function ReplaySearchBar(props: Props) {


### PR DESCRIPTION
Search bar is not functional still but let's add a better placeholder

<img width="1176" alt="SCR-20231020-kuub" src="https://github.com/getsentry/sentry/assets/56095982/c85f0abe-2a8e-464e-a0f1-d406d2aed0b0">

And add `TextOverflow` to the list email so the times are always aligned

<img width="420" alt="SCR-20231020-kydr" src="https://github.com/getsentry/sentry/assets/56095982/bf53aea8-e240-48e7-83b6-7da0b62a85ef">

