### PR TITLE
fix(stat-detectors): Slice span analysis results earlier

### DIFF
--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -153,7 +153,7 @@ def fetch_geo_analysis_results(transaction_name, regression_breakpoint, params, 
             orderby=["-tpm()"],
         )
 
-        return geo_code_durations[:limit]
+        return geo_code_durations
 
     # For each country code in the second half, compare it to the first half
     geo_results = [get_geo_data("before"), get_geo_data("after")]
@@ -192,7 +192,7 @@ def fetch_geo_analysis_results(transaction_name, regression_breakpoint, params, 
             )
 
     analysis_results.sort(key=lambda x: x["score"], reverse=True)
-    return analysis_results
+    return analysis_results[:limit]
 
 
 @region_silo_endpoint


### PR DESCRIPTION
We're seeing significant performance impacts just around getting the span descriptions for the results. We don't need to fetch the descriptions for all of the results, only the ones we're limiting to