### PR TITLE
ref(crons): Always show time zone on check-in table

### DIFF
--- a/static/app/views/monitors/components/monitorCheckIns.tsx
+++ b/static/app/views/monitors/components/monitorCheckIns.tsx
@@ -16,6 +16,7 @@ import Text from 'sentry/components/text';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconDownload} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -92,6 +93,10 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
     t('Expected At'),
   ];
 
+  const customTimezone =
+    monitor.config.timezone &&
+    monitor.config.timezone !== ConfigStore.get('user').options.timezone;
+
   return (
     <Fragment>
       <SectionHeading>{t('Recent Check-Ins')}</SectionHeading>
@@ -115,23 +120,20 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
                 </Status>
                 {checkIn.status !== CheckInStatus.MISSED ? (
                   <div>
-                    {monitor.config.timezone ? (
-                      <Tooltip
-                        title={
-                          <DateTime
-                            date={checkIn.dateCreated}
-                            forcedTimezone={monitor.config.timezone}
-                            timeZone
-                            timeOnly
-                            seconds
-                          />
-                        }
-                      >
-                        {<DateTime date={checkIn.dateCreated} timeOnly seconds />}
-                      </Tooltip>
-                    ) : (
-                      <DateTime date={checkIn.dateCreated} timeOnly seconds />
-                    )}
+                    <Tooltip
+                      disabled={!customTimezone}
+                      title={
+                        <DateTime
+                          date={checkIn.dateCreated}
+                          forcedTimezone={monitor.config.timezone ?? 'UTC'}
+                          timeZone
+                          timeOnly
+                          seconds
+                        />
+                      }
+                    >
+                      {<DateTime date={checkIn.dateCreated} timeZone timeOnly seconds />}
+                    </Tooltip>
                   </div>
                 ) : (
                   emptyCell
@@ -183,7 +185,21 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
                 ) : (
                   emptyCell
                 )}
-                <Timestamp date={checkIn.expectedTime} seconds />
+                <div>
+                  <Tooltip
+                    disabled={!customTimezone}
+                    title={
+                      <DateTime
+                        date={checkIn.expectedTime}
+                        forcedTimezone={monitor.config.timezone ?? 'UTC'}
+                        timeZone
+                        seconds
+                      />
+                    }
+                  >
+                    <Timestamp date={checkIn.expectedTime} timeZone seconds />
+                  </Tooltip>
+                </div>
               </Fragment>
             ))}
       </PanelTable>


### PR DESCRIPTION
![clipboard.png](https://i.imgur.com/zJfYZCq.png)

Never be ambiguous about timezones with Crons. They are inherintly
imporant for this product so we should always show them.

This also improves detection of when the user display timezone is
different from the timezone of the monitor itself