### PR TITLE
feat(dev): Add option to block logs for certain endpoints

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3606,6 +3606,15 @@ SENTRY_SSO_EXPIRY_SECONDS = os.environ.get("SENTRY_SSO_EXPIRY_SECONDS", None)
 # eg. DEVSERVER_LOGS_ALLOWLIST = {"server", "webpack", "worker"}
 DEVSERVER_LOGS_ALLOWLIST = None
 
+# Filter for logs of incoming requests, which matches on substrings. For example, to prevent the
+# server from logging
+#
+#   `POST 200 /api/0/relays/projectconfigs/?version=3 HTTP/1.1 1915`,
+#
+# add "/api/0/relays/projectconfigs/" to the list, or to suppress logging of all requests to
+# `relays/xxx` endpoints, add "/api/0/relays/".
+DEVSERVER_REQUEST_LOG_EXCLUDES: list[str] = []
+
 LOG_API_ACCESS = not IS_DEV or os.environ.get("SENTRY_LOG_API_ACCESS")
 
 VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON = True

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import shutil
 import threading
 import types
@@ -413,6 +414,18 @@ Alternatively, run without --workers.
         uwsgi_overrides["log-format"] = "%(method) %(status) %(uri) %(proto) %(size)"
     else:
         uwsgi_overrides["log-format"] = "[%(ltime)] %(method) %(status) %(uri) %(proto) %(size)"
+
+    # Prevent logging of requests to specified endpoints.
+    #
+    # TODO: According to the docs, the final `log-drain` value is evaluated as a regex (and indeed,
+    # joining the options with `|` works), but no amount of escaping, not escaping, escaping the
+    # escaping, using raw strings, or any combo thereof seems to actually work if you include a
+    # regex pattern string in the list. Docs are here:
+    # https://uwsgi-docs.readthedocs.io/en/latest/Options.html?highlight=log-format#log-drain
+    if settings.DEVSERVER_REQUEST_LOG_EXCLUDES:
+        filters = settings.DEVSERVER_REQUEST_LOG_EXCLUDES
+        filter_pattern = "|".join(map(lambda s: re.escape(s), filters))
+        uwsgi_overrides["log-drain"] = filter_pattern
 
     server_port = os.environ["SENTRY_BACKEND_PORT"]
     if settings.USE_SILOS:


### PR DESCRIPTION
This adds a new server setting, `DEVSERVER_REQUEST_LOG_EXCLUDES`, which blocks the devserver from logging requests to a given list of endpoints, in order to prevent things like this:

![image](https://github.com/getsentry/sentry/assets/14812505/c04ef9b6-a1b9-4abc-8f60-54d34171db20)

The match is a simple substring match, with, for example, `"/api/0/relays/"` blocking logging of requests to `/api/0/relays/projectconfigs/`, `/api/0/relays/register/challenge/`, and `/api/0/relays/register/response/`. Because of the way it's implemented, it actually effects all logs which come straight from uwsgi (rather than through a django logger), rather than just logs of incoming requests. That said, in practice, request logs like the above are the only instances (that I've found) of such straight-from-uwsgi logs.
