### PR TITLE
fix(feedback): Use tct for the entire "# selected" phrase

### DIFF
--- a/static/app/components/feedback/list/feedbackListHeader.tsx
+++ b/static/app/components/feedback/list/feedbackListHeader.tsx
@@ -9,7 +9,7 @@ import {Flex} from 'sentry/components/profiling/flex';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconEllipsis} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 interface Props {
@@ -37,9 +37,7 @@ function HasSelection({checked}) {
   return (
     <Flex gap={space(1)} align="center" justify="space-between" style={{flexGrow: 1}}>
       <span>
-        <strong>
-          {checked.length} {t('Selected')}
-        </strong>
+        <strong>{tct('[count] Selected', {count: checked.length})}</strong>
       </span>
       <Flex gap={space(1)} justify="flex-end">
         <ErrorBoundary mini>


### PR DESCRIPTION
The whole phrase should be translated, including the variable. This is in case some languages prefer it with the number on the right, for example