### PR TITLE
feat(indexer): Pass use case id along with every message for COGS

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/common.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/common.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from dataclasses import dataclass
-from typing import Any, List, Mapping, MutableMapping, MutableSequence, Optional, Union
+from typing import Any, List, MutableMapping, MutableSequence, NamedTuple, Optional, Union
 
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.kafka.configuration import build_kafka_consumer_configuration
@@ -22,10 +22,14 @@ DEFAULT_QUEUED_MAX_MESSAGE_KBYTES = 50000
 DEFAULT_QUEUED_MIN_MESSAGES = 100000
 
 
+class IndexerOutputMessage(NamedTuple):
+    message: Union[RoutingPayload, KafkaPayload]
+    use_case_id: UseCaseID  # for cogs
+
+
 @dataclass(frozen=True)
 class IndexerOutputMessageBatch:
-    data: MutableSequence[Message[Union[RoutingPayload, KafkaPayload]]]
-    cogs_data: Mapping[UseCaseID, int]
+    data: MutableSequence[Message[IndexerOutputMessage]]
 
 
 def get_config(

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -18,15 +18,13 @@ from sentry.sentry_metrics.configuration import (
 )
 from sentry.sentry_metrics.consumers.indexer.common import (
     BatchMessages,
+    IndexerOutputMessage,
     IndexerOutputMessageBatch,
     get_config,
 )
 from sentry.sentry_metrics.consumers.indexer.multiprocess import SimpleProduceStep
 from sentry.sentry_metrics.consumers.indexer.processing import MessageProcessor
-from sentry.sentry_metrics.consumers.indexer.routing_producer import (
-    RoutingPayload,
-    RoutingProducerStep,
-)
+from sentry.sentry_metrics.consumers.indexer.routing_producer import RoutingProducerStep
 from sentry.sentry_metrics.consumers.indexer.slicing_router import SlicingRouter
 from sentry.utils.arroyo import RunTaskWithMultiprocessing
 
@@ -39,7 +37,7 @@ logger = logging.getLogger(__name__)
 class Unbatcher(ProcessingStep[Union[FilteredPayload, IndexerOutputMessageBatch]]):
     def __init__(
         self,
-        next_step: ProcessingStep[Union[KafkaPayload, RoutingPayload]],
+        next_step: ProcessingStep[IndexerOutputMessage],
     ) -> None:
         self.__next_step = next_step
         self.__closed = False


### PR DESCRIPTION
The previous approach (where use cases were pre-aggregated in the batching step was not right. The reason is we can't unbatch it later, which needs to happen in the step before we actually record the cogs data. The usageaccumulator library already does batching internally before producing the messages so we don't need to worry about calling record() too frequently, and can just do so once per message.
