### PR TITLE
feat(hybridcloud) Add relay endpoints to region pinned list

### DIFF
--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -11,9 +11,17 @@ from sentry.silo import SiloMode
 from sentry.silo.base import SiloLimit
 from sentry.types.region import get_region_by_name
 
-REGION_PINNED_URLS = (
-    "/api/0/builtin-symbol-sources/",
-    "/api/0/grouping-configs/",
+REGION_PINNED_URL_NAMES = (
+    "sentry-api-0-builtin-symbol-sources",
+    "sentry-api-0-grouping-configs",
+    "sentry-api-0-relays-index",
+    "sentry-api-0-relay-register-challenge",
+    "sentry-api-0-relay-register-response",
+    "sentry-api-0-relay-projectconfigs",
+    "sentry-api-0-relay-projectids",
+    "sentry-api-0-relay-publickeys",
+    "sentry-api-0-relays-healthcheck",
+    "sentry-api-0-relays-details",
 )
 
 
@@ -46,9 +54,8 @@ def proxy_request_if_needed(
         org_slug = view_kwargs["organization_slug"]
         return proxy_request(request, org_slug)
 
-    if request.path in REGION_PINNED_URLS:
+    if request.resolver_match and request.resolver_match.url_name in REGION_PINNED_URL_NAMES:
         region = get_region_by_name(settings.SENTRY_MONOLITH_REGION)
 
         return proxy_region_request(request, region)
-
     return None

--- a/src/sentry/testutils/helpers/api_gateway.py
+++ b/src/sentry/testutils/helpers/api_gateway.py
@@ -10,9 +10,9 @@ from django.urls import re_path
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
+import sentry.api.urls as api_urls
 from sentry.api.base import Endpoint, control_silo_endpoint, region_silo_endpoint
 from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrganizationEndpoint
-from sentry.api.endpoints.rpc import RpcServiceEndpoint
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.region import override_regions
 from sentry.types.region import Region, RegionCategory, clear_global_regions
@@ -54,17 +54,7 @@ urlpatterns = [
         RegionEndpoint.as_view(),
         name="region-endpoint",
     ),
-    re_path(
-        r"^api/0/builtin-symbol-sources/$",
-        NoOrgRegionEndpoint.as_view(),
-        name="no-org-region-endpoint",
-    ),
-    re_path(
-        r"^rpc/(?P<service_name>\w+)/(?P<method_name>\w+)/$",
-        RpcServiceEndpoint.as_view(),
-        name="sentry-api-0-rpc-service",
-    ),
-]
+] + api_urls.urlpatterns
 
 
 def verify_request_body(body, headers):


### PR DESCRIPTION
We have several endpoints for configuring new relays and for relay to request data from sentry with. These endpoints are region bound, but have no organization scoping available.

Typically we would add `organization_slug` to paths like this to allow them to be proxied by control silo. I think that is the wrong approach for these endpoints as these endpoints are either only usable by superuser or by a relay instance. Relay instances would need to point to the region domain in order for ingestion to work, and superuser endpoints don't require as much backwards compatibility as customer endpoints do.

Binding requests to endpoints on the control silo to the monolith region is necesary for backwards compatibility.

Refs HC-507
Refs HC-508
Refs HC-509
Refs HC-510
