### PR TITLE
ref(auth): check_auth less bursty, does not refresh no op providers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -624,7 +624,6 @@ module = [
     "sentry.tasks.auth",
     "sentry.tasks.base",
     "sentry.tasks.beacon",
-    "sentry.tasks.check_auth",
     "sentry.tasks.codeowners.update_code_owners_schema",
     "sentry.tasks.commit_context",
     "sentry.tasks.deliver_from_outbox",

--- a/src/sentry/auth/__init__.py
+++ b/src/sentry/auth/__init__.py
@@ -1,5 +1,11 @@
+from typing import List
+
 from .manager import ProviderManager
 
 manager = ProviderManager()
 register = manager.register
 unregister = manager.unregister
+
+
+def find_providers_requiring_refresh() -> List[str]:
+    return [name for name, provider in manager if provider.requires_refresh]

--- a/src/sentry/auth/provider.py
+++ b/src/sentry/auth/provider.py
@@ -40,6 +40,7 @@ class Provider(PipelineProvider, abc.ABC):
     """
 
     is_partner = False
+    requires_refresh = True
 
     # All auth providers by default require the sso-basic feature
     required_feature = "organizations:sso-basic"

--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -237,6 +237,8 @@ class SAML2Provider(Provider, abc.ABC):
       constants to the Identity Provider attribute keys.
     """
 
+    # SAML does nothing with refresh state -- don't waste resources calling it in check_auth job.
+    requires_refresh = False
     required_feature = "organizations:sso-saml2"
 
     def get_auth_pipeline(self):

--- a/src/sentry/services/hybrid_cloud/access/service.py
+++ b/src/sentry/services/hybrid_cloud/access/service.py
@@ -4,6 +4,7 @@ from typing import FrozenSet, List, Optional
 
 from django.utils import timezone
 
+from sentry.auth import find_providers_requiring_refresh
 from sentry.services.hybrid_cloud import silo_mode_delegation
 from sentry.services.hybrid_cloud.auth import (
     RpcAuthIdentity,
@@ -13,7 +14,6 @@ from sentry.services.hybrid_cloud.auth import (
 )
 from sentry.services.hybrid_cloud.organization import RpcOrganizationMemberSummary
 from sentry.silo import SiloMode
-from sentry.tasks.check_auth import find_providers_requiring_refresh
 
 _SSO_BYPASS = RpcMemberSsoState(is_required=False, is_valid=True)
 _SSO_NONMEMBER = RpcMemberSsoState(is_required=False, is_valid=False)

--- a/src/sentry/tasks/check_auth.py
+++ b/src/sentry/tasks/check_auth.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import logging
 from datetime import timedelta
+from typing import List
 
 from django.db import router
 from django.utils import timezone
+from sentry_sdk import capture_exception
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.models.authidentity import AuthIdentity
@@ -12,43 +16,71 @@ from sentry.silo import unguarded_write
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
+from sentry.utils.env import in_test_environment
 
 logger = logging.getLogger("sentry.auth")
 
 AUTH_CHECK_INTERVAL = 3600 * 24
 
 
+def find_providers_requiring_refresh() -> List[str]:
+    from sentry.auth import manager
+
+    return [name for name, provider in manager if provider.requires_refresh]
+
+
 @instrumented_task(name="sentry.tasks.check_auth", queue="auth.control", silo_mode=SiloMode.CONTROL)
-def check_auth(**kwargs):
+def check_auth(chunk_size=100, **kwargs):
     """
-    Iterates over all accounts which have not been verified in the required
-    interval and creates a new job to verify them.
+    Checks for batches of auth identities and schedules them to refresh in a batched job.
+    That batched job can recursively trigger check_auth to continue processing auth identities if necessary.
+    Updates last_synced as it schedules batches so that further calls generally select non overlapping batches.
     """
     # TODO(dcramer): we should remove identities if they've been inactivate
     # for a reasonable interval
     now = timezone.now()
-    chunk_size = 100
     cutoff = now - timedelta(seconds=AUTH_CHECK_INTERVAL)
     identity_ids_list = list(
         AuthIdentity.objects.using_replica()
         .filter(last_synced__lte=cutoff)
-        .values_list("id", flat=True)
+        .values_list("id", flat=True)[:chunk_size]
     )
-    for n in range(0, len(identity_ids_list), chunk_size):
-        identity_ids_chunk = identity_ids_list[n : n + chunk_size]
-        with unguarded_write(router.db_for_write(AuthIdentity)):
-            AuthIdentity.objects.filter(id__in=identity_ids_chunk).update(last_synced=now)
 
-        for identity_id in identity_ids_chunk:
-            check_auth_identity.apply_async(
-                kwargs={"auth_identity_id": identity_id}, expires=AUTH_CHECK_INTERVAL
-            )
+    if identity_ids_list:
+        with unguarded_write(router.db_for_write(AuthIdentity)):
+            AuthIdentity.objects.filter(id__in=identity_ids_list).update(last_synced=now)
+        check_auth_identity.apply_async(
+            kwargs={"auth_identity_ids": identity_ids_list, "chunk_size": chunk_size},
+            expires=AUTH_CHECK_INTERVAL,
+        )
 
 
 @instrumented_task(
     name="sentry.tasks.check_auth_identity", queue="auth.control", silo_mode=SiloMode.CONTROL
 )
-def check_auth_identity(auth_identity_id, **kwargs):
+def check_auth_identity(
+    auth_identity_id: int | None = None,
+    auth_identity_ids: List[int] | None = None,
+    chunk_size=100,
+    **kwargs,
+):
+    if auth_identity_ids is None and isinstance(auth_identity_id, int):
+        auth_identity_ids = [auth_identity_id]
+
+    if auth_identity_ids is not None:
+        for ai_id in auth_identity_ids:
+            try:
+                check_single_auth_identity(ai_id)
+            except Exception:
+                capture_exception()
+                if in_test_environment():
+                    raise
+
+    # Reschedule to search for more chunks to process.
+    check_auth.apply_async(kwargs={"chunk_size": chunk_size})
+
+
+def check_single_auth_identity(auth_identity_id: int):
     try:
         auth_identity = AuthIdentity.objects.get(id=auth_identity_id)
     except AuthIdentity.DoesNotExist:
@@ -56,8 +88,11 @@ def check_auth_identity(auth_identity_id, **kwargs):
         return
 
     auth_provider = auth_identity.auth_provider
+    if auth_provider.provider not in find_providers_requiring_refresh():
+        # This provider does not currently require refresh, don't bother working it.
+        return
 
-    om: RpcOrganizationMember = organization_service.check_membership_by_id(
+    om: RpcOrganizationMember | None = organization_service.check_membership_by_id(
         organization_id=auth_provider.organization_id, user_id=auth_identity.user_id
     )
     if om is None:

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -1,10 +1,13 @@
+from datetime import timedelta
 from typing import Optional
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from django.contrib.auth.models import AnonymousUser
+from django.utils import timezone
 
 from sentry.auth import access
 from sentry.auth.access import Access, NoAccess
+from sentry.auth.providers.dummy import DummyProvider
 from sentry.constants import ObjectStatus
 from sentry.models.apikey import ApiKey
 from sentry.models.authidentity import AuthIdentity
@@ -355,6 +358,42 @@ class FromUserTest(AccessFactoryTestCase):
         for result in results:
             assert not result.sso_is_valid
             assert result.requires_sso
+
+    def test_last_verified_sso(self):
+        user = self.create_user()
+        organization = self.create_organization(owner=user)
+        ap = self.create_auth_provider(organization=organization, provider="dummy")
+        ai = self.create_auth_identity(auth_provider=ap, user=user)
+
+        om = organization_service.check_membership_by_id(
+            organization_id=organization.id, user_id=ai.user_id
+        )
+        assert om
+        setattr(om.flags, "sso:linked", True)
+        organization_service.update_membership_flags(organization_member=om)
+
+        request = self.make_request(user=user)
+        results = [self.from_user(user, organization), self.from_request(request, organization)]
+
+        for result in results:
+            assert result.sso_is_valid
+            assert result.requires_sso
+
+        # If the auth identity has not been updated in awhile, it is not valid.
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            ai.update(last_verified=timezone.now() - timedelta(days=10))
+
+        results = [self.from_user(user, organization), self.from_request(request, organization)]
+        for result in results:
+            assert not result.sso_is_valid
+            assert result.requires_sso
+
+        # but it is valid if the requires_fresh is False
+        with patch.object(DummyProvider, "requires_refresh", False):
+            results = [self.from_user(user, organization), self.from_request(request, organization)]
+            for result in results:
+                assert result.sso_is_valid
+                assert result.requires_sso
 
     def test_unlinked_sso_with_owner_from_team(self):
         organization = self.create_organization()

--- a/tests/sentry/tasks/test_check_auth.py
+++ b/tests/sentry/tasks/test_check_auth.py
@@ -37,7 +37,7 @@ class CheckAuthTest(TestCase):
         assert updated_ai.last_verified == ai.last_verified
 
         mock_check_auth_identity.apply_async.assert_called_once_with(
-            kwargs={"auth_identity_ids": [ai.id]}, expires=AUTH_CHECK_INTERVAL
+            kwargs={"auth_identity_ids": [ai.id], "chunk_size": 100}, expires=AUTH_CHECK_INTERVAL
         )
 
     def test_processes_recursively(self):

--- a/tests/sentry/tasks/test_check_auth.py
+++ b/tests/sentry/tasks/test_check_auth.py
@@ -16,8 +16,8 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 @control_silo_test(stable=True)
 class CheckAuthTest(TestCase):
-    @patch("sentry.tasks.check_auth.check_auth_identity")
-    def test_simple(self, mock_check_auth_identity):
+    @patch("sentry.tasks.check_auth.check_auth_identities")
+    def test_simple(self, mock_check_auth_identities):
         organization = self.create_organization(name="Test")
         user = self.create_user(email="bar@example.com")
         auth_provider = AuthProvider.objects.create(
@@ -36,7 +36,7 @@ class CheckAuthTest(TestCase):
         assert updated_ai.last_synced != ai.last_synced
         assert updated_ai.last_verified == ai.last_verified
 
-        mock_check_auth_identity.apply_async.assert_called_once_with(
+        mock_check_auth_identities.apply_async.assert_called_once_with(
             kwargs={"auth_identity_ids": [ai.id], "chunk_size": 100}, expires=AUTH_CHECK_INTERVAL
         )
 

--- a/tests/sentry/tasks/test_check_auth.py
+++ b/tests/sentry/tasks/test_check_auth.py
@@ -26,7 +26,6 @@ class CheckAuthTest(TestCase):
         self.create_member(
             user_id=user.id, organization=organization, flags=OrganizationMember.flags["sso:linked"]
         )
-
         ai = AuthIdentity.objects.create(
             auth_provider=auth_provider, user=user, last_synced=timezone.now() - timedelta(days=1)
         )
@@ -38,8 +37,40 @@ class CheckAuthTest(TestCase):
         assert updated_ai.last_verified == ai.last_verified
 
         mock_check_auth_identity.apply_async.assert_called_once_with(
-            kwargs={"auth_identity_id": ai.id}, expires=AUTH_CHECK_INTERVAL
+            kwargs={"auth_identity_ids": [ai.id]}, expires=AUTH_CHECK_INTERVAL
         )
+
+    def test_processes_recursively(self):
+        organization = self.create_organization(name="Test")
+        auth_provider = AuthProvider.objects.create(
+            organization_id=organization.id, provider="dummy"
+        )
+
+        orig_timing = timezone.now() - timedelta(days=1)
+        ais = [
+            AuthIdentity.objects.create(
+                auth_provider=auth_provider,
+                user=self.create_user(),
+                ident=f"user_{i}",
+                last_synced=orig_timing,
+                last_verified=orig_timing,
+            )
+            for i in range(10)
+        ]
+
+        for ai in ais:
+            self.create_member(
+                user_id=ai.user_id,
+                organization=organization,
+                flags=OrganizationMember.flags["sso:linked"],
+            )
+
+        with self.tasks():
+            check_auth(chunk_size=3)
+
+        for ai in ais:
+            ai.refresh_from_db()
+            assert ai.last_verified > orig_timing
 
 
 @control_silo_test(stable=True)
@@ -74,3 +105,24 @@ class CheckAuthIdentityTest(TestCase):
         updated_ai = AuthIdentity.objects.get(id=ai.id)
         assert updated_ai.last_synced != ai.last_synced
         assert updated_ai.last_verified != ai.last_verified
+
+    def test_skips_provider_that_does_not_require_refresh(self):
+        organization = self.create_organization(name="Test")
+        user = self.create_user(email="bar@example.com")
+        auth_provider = AuthProvider.objects.create(
+            organization_id=organization.id, provider="dummy"
+        )
+        ai = AuthIdentity.objects.create(
+            auth_provider=auth_provider,
+            user=user,
+            last_verified=timezone.now() - timedelta(days=1),
+            last_synced=timezone.now() - timedelta(days=1),
+        )
+
+        with patch.object(DummyProvider, "requires_refresh", False):
+            with self.auth_provider("dummy", DummyProvider):
+                check_auth_identity(auth_identity_id=ai.id)
+
+        updated_ai = AuthIdentity.objects.get(id=ai.id)
+        assert updated_ai.last_synced == ai.last_synced
+        assert updated_ai.last_verified == ai.last_verified


### PR DESCRIPTION
1.  check_auth runs a single job per auth identity needing processing every minute it finds groups of auth that need processing.  This tends to clump the processing quite a bit and result in a bursts of outboxes and processing that pressure the database and celery workers.  We instead process these now serially inside of a job that recursively processes batches one at a time.

2. check_auth currently does a lot of work updating and processing outboxes for auth providers that have no refresh logic associated with it merely to keep the `last_verified` attribute up to date.  However, for some auth providers, such as SAML, this verification process is entirely a no-op anyways.  Change check_auth to ignore those auth identities and produce far less noise in outbox and check_auth processing.