### PR TITLE
fix(alerts): UI flow on small width devices

### DIFF
--- a/static/app/views/alerts/filterBar.tsx
+++ b/static/app/views/alerts/filterBar.tsx
@@ -65,30 +65,28 @@ function FilterBar({
           />
         )}
         {onChangeDataset && (
-          <SegmentedControlWrapper>
-            <SegmentedControl<DatasetOption>
-              aria-label={t('Alert type')}
-              value={selectedDataset}
-              onChange={onChangeDataset}
+          <SegmentedControl<DatasetOption>
+            aria-label={t('Alert type')}
+            value={selectedDataset}
+            onChange={onChangeDataset}
+          >
+            <SegmentedControl.Item key={DatasetOption.ALL}>
+              {t('All')}
+            </SegmentedControl.Item>
+            <SegmentedControl.Item key={DatasetOption.ERRORS}>
+              {t('Errors')}
+            </SegmentedControl.Item>
+            <SegmentedControl.Item key={DatasetOption.SESSIONS}>
+              {t('Sessions')}
+            </SegmentedControl.Item>
+            <SegmentedControl.Item
+              textValue={t('Performance')}
+              key={DatasetOption.PERFORMANCE}
             >
-              <SegmentedControl.Item key={DatasetOption.ALL}>
-                {t('All')}
-              </SegmentedControl.Item>
-              <SegmentedControl.Item key={DatasetOption.ERRORS}>
-                {t('Errors')}
-              </SegmentedControl.Item>
-              <SegmentedControl.Item key={DatasetOption.SESSIONS}>
-                {t('Sessions')}
-              </SegmentedControl.Item>
-              <SegmentedControl.Item
-                textValue={t('Performance')}
-                key={DatasetOption.PERFORMANCE}
-              >
-                {t('Performance')}
-                {showMigrationWarning ? <StyledIconWarning /> : null}
-              </SegmentedControl.Item>
-            </SegmentedControl>
-          </SegmentedControlWrapper>
+              {t('Performance')}
+              {showMigrationWarning ? <StyledIconWarning /> : null}
+            </SegmentedControl.Item>
+          </SegmentedControl>
         )}
       </FilterButtons>
       <SearchBar
@@ -116,18 +114,14 @@ const FilterButtons = styled(ButtonBar)`
   @media (max-width: ${p => p.theme.breakpoints.large}) {
     display: flex;
     align-items: flex-start;
+    flex-wrap: wrap;
     gap: ${space(1.5)};
   }
 
   @media (min-width: ${p => p.theme.breakpoints.large}) {
     display: grid;
-    grid-auto-columns: minmax(auto, 300px);
+    grid-auto-columns: max-content;
   }
-`;
-
-const SegmentedControlWrapper = styled('div')`
-  width: max-content;
-  min-width: 345px;
 `;
 
 const StyledIconWarning = styled(IconWarning)`


### PR DESCRIPTION
Wrap list filters to 3 lines on smaller device width
 
![Screenshot 2023-10-23 at 14 32 41](https://github.com/getsentry/sentry/assets/7033940/8cbe16b3-d811-4df5-95ba-dec83c084e0d)

- closes https://github.com/getsentry/sentry/issues/58569