### PR TITLE
chore(statistical-detectors): Add metric to track ema relative change

### DIFF
--- a/src/sentry/statistical_detectors/algorithm.py
+++ b/src/sentry/statistical_detectors/algorithm.py
@@ -150,8 +150,8 @@ class MovingAverageCrossOverDetector(MovingAverageDetector):
 
 @dataclass(frozen=True)
 class MovingAverageRelativeChangeDetectorConfig(MovingAverageDetectorConfig):
-    change_metric: str
     threshold: float
+    change_metric: Optional[str] = None
 
 
 class MovingAverageRelativeChangeDetector(MovingAverageDetector):
@@ -205,7 +205,8 @@ class MovingAverageRelativeChangeDetector(MovingAverageDetector):
             and relative_change_old < self.threshold
             and relative_change_new > self.threshold
         ):
-            metrics.timing(self.change_metric, relative_change_new, tags={"type": "regression"})
+            if self.change_metric is not None:
+                metrics.timing(self.change_metric, relative_change_new, tags={"type": "regression"})
             return TrendType.Regressed
 
         elif (
@@ -213,7 +214,10 @@ class MovingAverageRelativeChangeDetector(MovingAverageDetector):
             and relative_change_old > -self.threshold
             and relative_change_new < -self.threshold
         ):
-            metrics.timing(self.change_metric, relative_change_new, tags={"type": "improvement"})
+            if self.change_metric is not None:
+                metrics.timing(
+                    self.change_metric, relative_change_new, tags={"type": "improvement"}
+                )
             return TrendType.Improved
 
         return TrendType.Unchanged

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -273,6 +273,7 @@ def _detect_transaction_trends(
     improved_count = 0
 
     detector_config = MovingAverageRelativeChangeDetectorConfig(
+        change_metric="statistical_detectors.rel_change.transactions",
         min_data_points=6,
         short_moving_avg_factory=lambda: ExponentialMovingAverage(2 / 21),
         long_moving_avg_factory=lambda: ExponentialMovingAverage(2 / 41),
@@ -595,6 +596,7 @@ def _detect_function_trends(
     improved_count = 0
 
     detector_config = MovingAverageRelativeChangeDetectorConfig(
+        change_metric="statistical_detectors.rel_change.functions",
         min_data_points=6,
         short_moving_avg_factory=lambda: ExponentialMovingAverage(2 / 21),
         long_moving_avg_factory=lambda: ExponentialMovingAverage(2 / 41),


### PR DESCRIPTION
To help tune these parameters better, produce a metric for the relative change in the ema detector so we can pick better results for less false positives.