### PR TITLE
feat(hc): Add some random skew to help even out check_auth load

### DIFF
--- a/src/sentry/tasks/check_auth.py
+++ b/src/sentry/tasks/check_auth.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import timedelta
+from random import randrange
 
 from django.db import router
 from django.utils import timezone
@@ -26,9 +27,10 @@ def check_auth(**kwargs):
     """
     # TODO(dcramer): we should remove identities if they've been inactivate
     # for a reasonable interval
+    auth_check_interval = AUTH_CHECK_INTERVAL - randrange(3600)
     now = timezone.now()
     chunk_size = 100
-    cutoff = now - timedelta(seconds=AUTH_CHECK_INTERVAL)
+    cutoff = now - timedelta(seconds=auth_check_interval)
     identity_ids_list = list(
         AuthIdentity.objects.using_replica()
         .filter(last_synced__lte=cutoff)
@@ -41,7 +43,7 @@ def check_auth(**kwargs):
 
         for identity_id in identity_ids_chunk:
             check_auth_identity.apply_async(
-                kwargs={"auth_identity_id": identity_id}, expires=AUTH_CHECK_INTERVAL
+                kwargs={"auth_identity_id": identity_id}, expires=auth_check_interval
             )
 
 

--- a/tests/sentry/tasks/test_check_auth.py
+++ b/tests/sentry/tasks/test_check_auth.py
@@ -9,7 +9,12 @@ from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organizationmember import OrganizationMember
 from sentry.silo import SiloMode
-from sentry.tasks.check_auth import AUTH_CHECK_INTERVAL, check_auth, check_auth_identity
+from sentry.tasks.check_auth import (
+    AUTH_CHECK_INTERVAL,
+    AUTH_CHECK_SKEW,
+    check_auth,
+    check_auth_identity,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
@@ -38,7 +43,7 @@ class CheckAuthTest(TestCase):
         assert updated_ai.last_verified == ai.last_verified
 
         mock_check_auth_identity.apply_async.assert_called_once_with(
-            kwargs={"auth_identity_id": ai.id}, expires=AUTH_CHECK_INTERVAL
+            kwargs={"auth_identity_id": ai.id}, expires=AUTH_CHECK_INTERVAL - AUTH_CHECK_SKEW
         )
 
 


### PR DESCRIPTION
The `check_auth` job currently performs almost all of it's work during one hour of the day.

This change adds up to 2 hours of skew to the filter which will result in slightly more total job runs (since some will be run after 22 hours instead of 24 hours). The tradeoff is that this new randomness should level out the load from these jobs over time.