### PR TITLE
feat(hybridcloud) Make error embed view use region URLs

### DIFF
--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -22,6 +22,7 @@ REGION_PINNED_URL_NAMES = (
     "sentry-api-0-relay-publickeys",
     "sentry-api-0-relays-healthcheck",
     "sentry-api-0-relays-details",
+    "sentry-error-page-embed",
 )
 
 

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -154,7 +154,7 @@ class ProjectOption(Model):
     key = models.CharField(max_length=64)
     value = PickledObjectField()
 
-    objects = ProjectOptionManager()
+    objects: ProjectOptionManager = ProjectOptionManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -107,7 +107,7 @@ def parse_uri_match(value: str) -> ParsedUriMatch:
 
 
 def is_valid_origin(
-    origin: str, project: Project | None = None, allowed: frozenset[str] | None = None
+    origin: str | None, project: Project | None = None, allowed: frozenset[str] | None = None
 ) -> bool:
     """
     Given an ``origin`` which matches a base URI (e.g. http://example.com)

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django import forms
 from django.db import IntegrityError, router
 from django.http import HttpRequest, HttpResponse
@@ -6,6 +8,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
+from django_stubs_ext import StrOrPromise
 
 from sentry import eventstore
 from sentry.models.options.project_option import ProjectOption
@@ -13,10 +16,12 @@ from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey
 from sentry.models.userreport import UserReport
 from sentry.signals import user_feedback_received
+from sentry.types.region import get_local_region
 from sentry.utils import json
 from sentry.utils.db import atomic_transaction
-from sentry.utils.http import absolute_uri, is_valid_origin, origin_from_request
+from sentry.utils.http import is_valid_origin, origin_from_request
 from sentry.utils.validators import normalize_event_id
+from sentry.web.frontend.base import region_silo_view
 from sentry.web.helpers import render_to_response, render_to_string
 
 GENERIC_ERROR = _("An unknown error occurred while submitting your report. Please try again.")
@@ -34,7 +39,7 @@ DEFAULT_COMMENTS_LABEL = _("What happened?")
 DEFAULT_CLOSE_LABEL = _("Close")
 DEFAULT_SUBMIT_LABEL = _("Submit Crash Report")
 
-DEFAULT_OPTIONS = {
+DEFAULT_OPTIONS: dict[str, StrOrPromise] = {
     "title": DEFAULT_TITLE,
     "subtitle": DEFAULT_SUBTITLE,
     "subtitle2": DEFAULT_SUBTITLE2,
@@ -66,6 +71,7 @@ class UserReportForm(forms.ModelForm):
         fields = ("name", "email", "comments")
 
 
+@region_silo_view
 class ErrorPageEmbedView(View):
     def _get_project_key(self, request: HttpRequest):
         try:
@@ -187,6 +193,8 @@ class ErrorPageEmbedView(View):
         elif request.method == "POST":
             return self._smart_response(request, {"errors": dict(form.errors)}, status=400)
 
+        region = get_local_region()
+        endpoint = region.to_url(request.get_full_path())
         show_branding = (
             ProjectOption.objects.get_value(
                 project=key.project, key="feedback:branding", default="1"
@@ -211,7 +219,7 @@ class ErrorPageEmbedView(View):
         )
 
         context = {
-            "endpoint": mark_safe("*/" + json.dumps(absolute_uri(request.get_full_path())) + ";/*"),
+            "endpoint": mark_safe("*/" + json.dumps(endpoint) + ";/*"),
             "template": mark_safe("*/" + json.dumps(template) + ";/*"),
             "strings": mark_safe(
                 "*/"

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -9,8 +9,11 @@ from sentry.models.environment import Environment
 from sentry.models.userreport import UserReport
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.silo import region_silo_test
+from sentry.types.region import get_local_region
 
 
+@region_silo_test(stable=True)
 @override_settings(ROOT_URLCONF="sentry.conf.urls")
 class ErrorPageEmbedTest(TestCase):
     def setUp(self):
@@ -74,6 +77,21 @@ class ErrorPageEmbedTest(TestCase):
         assert resp.status_code == 200, resp.content
         assert resp["Access-Control-Allow-Origin"] == "*"
         self.assertTemplateUsed(resp, "sentry/error-page-embed.html")
+
+    def test_endpoint_reflects_region_url(self):
+        resp = self.client.get(
+            self.path_with_qs,
+            HTTP_REFERER="http://example.com",
+            HTTP_ACCEPT="text/html, text/javascript",
+        )
+        assert resp.status_code == 200, resp.content
+        assert resp["Access-Control-Allow-Origin"] == "*"
+        self.assertTemplateUsed(resp, "sentry/error-page-embed.html")
+
+        region = get_local_region()
+        region_url = region.to_url(self.path_with_qs)
+        body = resp.content.decode("utf8")
+        assert f'endpoint = /**/"{region_url}";/**/' in body
 
     def test_uses_locale_from_header(self):
         resp = self.client.get(
@@ -175,6 +193,7 @@ class ErrorPageEmbedTest(TestCase):
         assert resp.status_code == 400, resp.content
 
 
+@region_silo_test(stable=True)
 @override_settings(ROOT_URLCONF="sentry.conf.urls")
 class ErrorPageEmbedEnvironmentTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
The error-embed view needs to submit to a region domain instead of the root application domain. I've also pinned the historical root domain path to the monolith region for backwards compatibility.

Refs HC-518