### PR TITLE
fix(crons): Better filtering on latest query

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -458,8 +458,10 @@ def _process_checkin(
                 if use_latest_checkin:
                     check_in = (
                         MonitorCheckIn.objects.select_for_update()
-                        .filter(monitor_environment=monitor_environment)
-                        .exclude(status__in=CheckInStatus.FINISHED_VALUES)
+                        .filter(
+                            monitor_environment=monitor_environment,
+                            status=CheckInStatus.IN_PROGRESS,
+                        )
                         .order_by("-date_added")[:1]
                         .get()
                     )

--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -237,8 +237,7 @@ def try_checkin_lookup(monitor: Monitor, checkin_id: str):
     # which is unfinished (thus still mutable)
     if checkin_id == "latest":
         checkin = (
-            MonitorCheckIn.objects.filter(monitor=monitor)
-            .exclude(status__in=CheckInStatus.FINISHED_VALUES)
+            MonitorCheckIn.objects.filter(monitor=monitor, status=CheckInStatus.IN_PROGRESS)
             .order_by("-date_added")
             .first()
         )


### PR DESCRIPTION
More efficient query for `latest` check-ins

Fixes SENTRY-16FK