### PR TITLE
feat(starfish): updates Webvitals queries to query for profile id and change p95 to p75

### DIFF
--- a/static/app/views/performance/browser/webVitals/utils/types.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/types.tsx
@@ -16,6 +16,7 @@ export type TransactionSampleRow = {
   'measurements.fid': number | null;
   'measurements.lcp': number | null;
   'measurements.ttfb': number | null;
+  'profile.id': string;
   replayId: string;
   timestamp: string;
   transaction: string;

--- a/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsValuesTimeseriesQuery.tsx
@@ -27,7 +27,7 @@ export const useProjectWebVitalsValuesTimeseriesQuery = ({transaction}: Props) =
         'p75(measurements.ttfb)',
         'p75(measurements.fid)',
         'count()',
-        'p95(transaction.duration)',
+        'p75(transaction.duration)',
         'failure_count()',
         'eps()',
       ],
@@ -98,7 +98,7 @@ export const useProjectWebVitalsValuesTimeseriesQuery = ({transaction}: Props) =
       {key: 'p75(measurements.ttfb)', series: data.ttfb},
       {key: 'p75(measurements.fid)', series: data.fid},
       {key: 'count()', series: data.count},
-      {key: 'p95(transaction.duration)', series: data.duration},
+      {key: 'p75(transaction.duration)', series: data.duration},
       {key: 'failure_count()', series: data.errors},
       {key: 'eps()', series: data.eps},
     ];

--- a/static/app/views/performance/browser/webVitals/utils/useTransactionSamplesWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/useTransactionSamplesWebVitalsQuery.tsx
@@ -14,6 +14,7 @@ import {
 
 type Props = {
   transaction: string;
+  enabled?: boolean;
   limit?: number;
   orderBy?: WebVitals | null;
   query?: string;
@@ -24,6 +25,7 @@ export const useTransactionSamplesWebVitalsQuery = ({
   limit,
   transaction,
   query,
+  enabled,
 }: Props) => {
   const organization = useOrganization();
   const pageFilters = usePageFilters();
@@ -44,6 +46,7 @@ export const useTransactionSamplesWebVitalsQuery = ({
         'transaction.duration',
         'replayId',
         'timestamp',
+        'profile.id',
       ],
       name: 'Web Vitals',
       query: `transaction.op:pageload transaction:"${transaction}" ${query ? query : ''}`,
@@ -59,12 +62,12 @@ export const useTransactionSamplesWebVitalsQuery = ({
     location,
     orgSlug: organization.slug,
     options: {
-      enabled: pageFilters.isReady,
+      enabled: enabled && pageFilters.isReady,
       refetchOnWindowFocus: false,
     },
   });
 
-  const toInt = (item: ReactText) => (item ? parseInt(item.toString(), 10) : null);
+  const toNumber = (item: ReactText) => (item ? parseFloat(item.toString()) : null);
   const tableData: TransactionSampleRowWithScore[] =
     !isLoading && data?.data.length
       ? data.data
@@ -73,13 +76,14 @@ export const useTransactionSamplesWebVitalsQuery = ({
             'user.display': row['user.display']?.toString(),
             transaction: row.transaction?.toString(),
             'transaction.op': row['transaction.op']?.toString(),
-            'measurements.lcp': toInt(row['measurements.lcp']),
-            'measurements.fcp': toInt(row['measurements.fcp']),
-            'measurements.cls': toInt(row['measurements.cls']),
-            'measurements.ttfb': toInt(row['measurements.ttfb']),
-            'measurements.fid': toInt(row['measurements.fid']),
-            'transaction.duration': toInt(row['transaction.duration']),
+            'measurements.lcp': toNumber(row['measurements.lcp']),
+            'measurements.fcp': toNumber(row['measurements.fcp']),
+            'measurements.cls': toNumber(row['measurements.cls']),
+            'measurements.ttfb': toNumber(row['measurements.ttfb']),
+            'measurements.fid': toNumber(row['measurements.fid']),
+            'transaction.duration': toNumber(row['transaction.duration']),
             replayId: row.replayId?.toString(),
+            'profile.id': row.profileId?.toString(),
             timestamp: row.timestamp?.toString(),
           }))
           .map(row => {


### PR DESCRIPTION
updates Webvitals queries to query for profile id and change p95 to p75. Also updates result processing to use parseFloat instead of parseInt since parseInt was rounding cls values down to 0.