### PR TITLE
fix(provisioning): avoid creating duplicate auth providers

### DIFF
--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -80,9 +80,9 @@ class DatabaseBackedAuthService(AuthService):
 
                 if user_id:
                     sso_enabled.send_robust(
-                        organization_id=self.org.id,
-                        user_id=self.user.id,
-                        provider=self.channel_name.value,
+                        organization_id=organization_id,
+                        user_id=user_id,
+                        provider=provider_key,
                         sender=type(self) if sender is None else sender,
                     )
 

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -35,6 +35,7 @@ from sentry.services.hybrid_cloud.auth import (
 )
 from sentry.services.hybrid_cloud.auth.serial import serialize_api_key, serialize_auth_provider
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.signals import sso_enabled
 from sentry.silo import unguarded_write
 from sentry.utils.auth import AuthUserPasswordExpired
 
@@ -52,20 +53,38 @@ class DatabaseBackedAuthService(AuthService):
             return None
 
     def enable_partner_sso(
-        self, *, organization_id: int, provider_key: str, provider_config: Mapping[str, Any]
+        self,
+        *,
+        organization_id: int,
+        provider_key: str,
+        provider_config: Mapping[str, Any],
+        user_id: Optional[int] = None,
+        sender: Optional[str] = None,
     ) -> None:
         with enforce_constraints(transaction.atomic(router.db_for_write(AuthProvider))):
-            auth_provider = AuthProvider.objects.create(
+            auth_provider_query = AuthProvider.objects.filter(
                 organization_id=organization_id, provider=provider_key, config=provider_config
             )
+            if not auth_provider_query.exists():
+                auth_provider = AuthProvider.objects.create(
+                    organization_id=organization_id, provider=provider_key, config=provider_config
+                )
 
-            AuditLogEntry.objects.create(
-                organization_id=organization_id,
-                actor_label=f"partner_provisioning_api:{provider_key}",
-                target_object=auth_provider.id,
-                event=audit_log.get_event_id("SSO_ENABLE"),
-                data=auth_provider.get_audit_log_data(),
-            )
+                AuditLogEntry.objects.create(
+                    organization_id=organization_id,
+                    actor_label=f"partner_provisioning_api:{provider_key}",
+                    target_object=auth_provider.id,
+                    event=audit_log.get_event_id("SSO_ENABLE"),
+                    data=auth_provider.get_audit_log_data(),
+                )
+
+                if user_id:
+                    sso_enabled.send_robust(
+                        organization_id=self.org.id,
+                        user_id=self.user.id,
+                        provider=self.channel_name.value,
+                        sender=type(self) if sender is None else sender,
+                    )
 
     def create_auth_identity(
         self, *, provider: str, config: Mapping[str, Any], user_id: int, ident: str

--- a/src/sentry/services/hybrid_cloud/auth/service.py
+++ b/src/sentry/services/hybrid_cloud/auth/service.py
@@ -99,7 +99,13 @@ class AuthService(RpcService):
     @rpc_method
     @abc.abstractmethod
     def enable_partner_sso(
-        self, *, organization_id: int, provider_key: str, provider_config: Mapping[str, Any]
+        self,
+        *,
+        organization_id: int,
+        provider_key: str,
+        provider_config: Mapping[str, Any],
+        user_id: Optional[int] = None,
+        sender: Optional[str] = None,
     ) -> None:
         pass
 

--- a/tests/sentry/hybrid_cloud/test_auth.py
+++ b/tests/sentry/hybrid_cloud/test_auth.py
@@ -57,4 +57,24 @@ def test_get_org_auth_config():
     ]
 
 
-# def test_enable_sso():
+@django_db_all(transaction=True)
+def test_enable_sso():
+    org = Factories.create_organization()
+    provider_key = "fly"
+    provider_config = {"id": "x123x"}
+    auth_service.enable_partner_sso(
+        organization_id=org.id, provider_key=provider_key, provider_config=provider_config
+    )
+    auth_provider_query = AuthProvider.objects.filter(
+        organization_id=org.id, provider=provider_key, config=provider_config
+    )
+    assert auth_provider_query.count() == 1
+
+    # Re-enabling SSO should not create a new auth provider
+    auth_service.enable_partner_sso(
+        organization_id=org.id, provider_key=provider_key, provider_config=provider_config
+    )
+    auth_provider_query = AuthProvider.objects.filter(
+        organization_id=org.id, provider=provider_key, config=provider_config
+    )
+    assert auth_provider_query.count() == 1

--- a/tests/sentry/hybrid_cloud/test_auth.py
+++ b/tests/sentry/hybrid_cloud/test_auth.py
@@ -55,3 +55,6 @@ def test_get_org_auth_config():
             has_api_key=False,
         ),
     ]
+
+
+# def test_enable_sso():


### PR DESCRIPTION

We designed provisioning flow to be idempotent but seems like this method was skipped. Fixing it here.