### PR TITLE
feat(stats-detectors): Add stricter requirements for breakpoint detection

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -233,6 +233,9 @@ def _detect_transaction_change_points(
             # which was originally intended to detect a gradual regression
             # for the trends use case. That does not apply here.
             "allow_midpoint": "0",
+            "trend_percentage()": 0.5,
+            "min_change()": 200_000_000,
+            "validate_tail_hours": 12,
         }
 
         try:


### PR DESCRIPTION
- add % threshold of 50%
- add ms threshold of 200ms
- add last 12 hour check to avoid creating issues out of spikes

Fixes https://github.com/getsentry/sentry/issues/58597, https://github.com/getsentry/sentry/issues/56028