### PR TITLE
ref(backup): Simplify some import logic

### DIFF
--- a/src/sentry/backup/mixins.py
+++ b/src/sentry/backup/mixins.py
@@ -33,8 +33,8 @@ class OverwritableConfigMixin:
                     if getattr(self, uniq_field_name, None) is not None:
                         query[uniq_field_name] = getattr(self, uniq_field_name)
 
-                # If all of the fields in the unique set are NULL, we'll avoid a collision, so go
-                # ahead and write a new entry.
+                # If all of the fields in the unique set are NULL, we'll avoid a collision, so exit
+                # early and write a new entry.
                 if len(query) > 0:
                     existing = self.__class__.objects.filter(**query).first()  # type: ignore
                     if existing:

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -174,9 +174,9 @@ class BaseModel(models.Model):
         `write_relocation_import`, is that it is often useful to adjust just the normalization logic
         by itself without affecting the writing logic.
 
-        Overrides of this method should take care NOT to mutate the `pk_map`. Overrides should also
-        take care NOT to push the updated changes to the database (ie, no calls to `.save()` or
-        `.update()`), as this functionality is delegated to the `write_relocation_import()` method.
+        Overrides should take care NOT to push the updated changes to the database (ie, no calls to
+        `.save()` or `.update()`), as this functionality is delegated to the
+        `write_relocation_import()` method.
 
         The default normalization logic merely replaces foreign keys with their new values from the
         provided `pk_map`.

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -185,12 +185,12 @@ class Actor(Model):
         # fixtures/backup/model_dependencies/sorted.json), a viable solution here is to always null
         # out the `actor_id` field of the `Team` when we import it, then rely on that model's
         # `post_save()` hook to fill in the `Actor` model.
-        (actor, created) = Actor.objects.get_or_create(team=self.team, defaults=model_to_dict(self))
+        (actor, _) = Actor.objects.get_or_create(team=self.team, defaults=model_to_dict(self))
         if actor:
             self.pk = actor.pk
             self.save()
 
-        return (self.pk, ImportKind.Inserted if created else ImportKind.Existing)
+        return (self.pk, ImportKind.Inserted)
 
 
 def get_actor_id_for_user(user: Union[User, RpcUser]) -> int:

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -403,6 +403,9 @@ class User(BaseModel, AbstractBaseUser):
         if old_pk is None:
             return None
 
+        # Importing in any scope besides `Global` (which does a naive, blanket restore of all data)
+        # and `Config` (which is explicitly meant to import admin accounts) should strip all
+        # incoming users of their admin privileges.
         if scope not in {ImportScope.Config, ImportScope.Global}:
             self.is_staff = False
             self.is_superuser = False
@@ -449,14 +452,14 @@ class User(BaseModel, AbstractBaseUser):
 
             self.save(force_insert=True)
 
-            # TODO(getsentry/team-ospo#190): the following is an RPC call which could fail for
-            # transient reasons (network etc). How do we handle that?
-            lost_password_hash_service.get_or_create(user_id=self.id)
+            if scope != ImportScope.Global:
+                # TODO(getsentry/team-ospo#190): the following is an RPC call which could fail for
+                # transient reasons (network etc). How do we handle that?
+                lost_password_hash_service.get_or_create(user_id=self.id)
 
             # TODO(getsentry/team-ospo#191): we need to send an email informing the user of their
             # new account with a resettable password - we'll need to figure out where in the process
             # that actually goes, and how to prevent it from happening during the validation pass.
-
             return (self.pk, ImportKind.Inserted)
 
         # If there is no existing user with this `username`, no special renaming or merging

--- a/src/sentry/models/useremail.py
+++ b/src/sentry/models/useremail.py
@@ -102,10 +102,9 @@ class UserEmail(ControlOutboxProducingModel):
         if old_pk is None:
             return None
 
-        # If we are merging users, ignore this import and use the merged user's data.
+        # If we are merging users, ignore the imported email and use the merged user's email
+        # instead.
         if pk_map.get_kind(get_model_name(User), old_user_id) == ImportKind.Existing:
-            # TODO(getsentry/team-ospo#190): Mutating `pk_map` here is a bit hacky, and we probably
-            # shouldn't do it.
             useremail = self.__class__.objects.get(user_id=self.user_id)
             pk_map.insert(get_model_name(self), self.pk, useremail.pk, ImportKind.Existing)
             return None
@@ -131,4 +130,8 @@ class UserEmail(ControlOutboxProducingModel):
                 setattr(useremail, f.name, getattr(self, f.name))
         useremail.save()
 
+        # If we've entered this method at all, we can be sure that the `UserEmail` was created as
+        # part of the import, since this is a new `User` (the "existing" `User` due to
+        # `--merge_users=true` case is handled in the `normalize_before_relocation_import()` method
+        # above).
         return (useremail.pk, ImportKind.Inserted)

--- a/src/sentry/models/userpermission.py
+++ b/src/sentry/models/userpermission.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import FrozenSet, List, Optional, Tuple
+from typing import FrozenSet, List
 
 from django.db import models
 
-from sentry.backup.dependencies import ImportKind
+from sentry.backup.dependencies import ImportKind, PrimaryKeyMap, get_model_name
 from sentry.backup.helpers import ImportFlags
+from sentry.backup.mixins import OverwritableConfigMixin
 from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models import FlexibleForeignKey, control_silo_only_model, sane_repr
 from sentry.db.models.outboxes import ControlOutboxProducingModel
@@ -14,7 +15,7 @@ from sentry.types.region import find_regions_for_user
 
 
 @control_silo_only_model
-class UserPermission(ControlOutboxProducingModel):
+class UserPermission(OverwritableConfigMixin, ControlOutboxProducingModel):
     """
     Permissions are applied to administrative users and control explicit scope-like permissions within the API.
 
@@ -52,16 +53,24 @@ class UserPermission(ControlOutboxProducingModel):
             )
         ]
 
-    def write_relocation_import(
-        self, _s: ImportScope, _f: ImportFlags
-    ) -> Optional[Tuple[int, ImportKind]]:
-        # Ensure that we never attempt to duplicate `UserPermission` entries, even when the
-        # `merge_users` flag is enabled, as they must always be globally unique per user.
-        (up, created) = self.__class__.objects.get_or_create(
-            user_id=self.user_id, permission=self.permission
-        )
-        if up:
-            self.pk = up.pk
-            self.save()
+    def normalize_before_relocation_import(
+        self, pk_map: PrimaryKeyMap, scope: ImportScope, flags: ImportFlags
+    ) -> int | None:
+        from sentry.models.user import User
 
-        return (self.pk, ImportKind.Inserted if created else ImportKind.Existing)
+        old_user_id = self.user_id
+        old_pk = super().normalize_before_relocation_import(pk_map, scope, flags)
+        if old_pk is None:
+            return None
+
+        # If we are merging users, ignore the imported permissions and use the merged user's
+        # permissions instead.
+        if pk_map.get_kind(get_model_name(User), old_user_id) == ImportKind.Existing:
+            model_name = get_model_name(self)
+            permissions = self.__class__.objects.filter(user_id=self.user_id).all()
+            for permission in permissions:
+                pk_map.insert(model_name, self.pk, permission.pk, ImportKind.Existing)
+
+            return None
+
+        return old_pk


### PR DESCRIPTION
Some of the user model logic was very difficult to follow, which this PR aims to simplify. In essence, there were too many placed where we marked models `ImportKind.Existing`, when really they should just be `ImoportKind.Inserted` due to `post_save` shenanigans.

Additionally, `UserPermission` and `UserEmail` logic has been cleaned up and looks more uniform now, and comments have been added where things get a bit subtle.
