### PR TITLE
chore(alert-rules): Exclude sync sentence when link not set

### DIFF
--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -374,8 +374,8 @@ function RuleNode({
               <TicketRuleModal
                 {...deps}
                 formFields={node.formFields || {}}
-                link={node.link}
-                ticketType={node.ticketType}
+                link={node.link!}
+                ticketType={node.ticketType!}
                 instance={data}
                 index={index}
                 onSubmitAction={updateParentFromTicketRule}

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -20,13 +20,13 @@ type Props = {
   index: number;
   // The AlertRuleAction from DB.
   instance: IssueAlertRuleAction;
+  link: string | null;
   onSubmitAction: (
     data: {[key: string]: string},
     fetchedFieldOptionsCache: Record<string, Choices>
   ) => void;
   organization: Organization;
-  link?: string;
-  ticketType?: string;
+  ticketType: string;
 } & AbstractExternalIssueForm['props'];
 
 type State = {

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -200,17 +200,26 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
   renderBodyText = () => {
     // `ticketType` already includes indefinite article.
     const {ticketType, link} = this.props;
-    return (
-      <BodyText>
-        {tct(
-          'When this alert is triggered [ticketType] will be created with the following fields. It will also [linkToDocs] with the new Sentry Issue.',
-          {
-            linkToDocs: <ExternalLink href={link}>{t('stay in sync')}</ExternalLink>,
-            ticketType,
-          }
-        )}
-      </BodyText>
-    );
+
+    let body: React.ReactNode;
+    if (link) {
+      body = tct(
+        'When this alert is triggered [ticketType] will be created with the following fields. It will also [linkToDocs] with the new Sentry Issue.',
+        {
+          linkToDocs: <ExternalLink href={link}>{t('stay in sync')}</ExternalLink>,
+          ticketType,
+        }
+      );
+    } else {
+      body = tct(
+        'When this alert is triggered [ticketType] will be created with the following fields.',
+        {
+          ticketType,
+        }
+      );
+    }
+
+    return <BodyText>{body}</BodyText>;
   };
 
   render() {

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -204,9 +204,9 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
     let body: React.ReactNode;
     if (link) {
       body = tct(
-        'When this alert is triggered [ticketType] will be created with the following fields. It will also [linkToDocs] with the new Sentry Issue.',
+        'When this alert is triggered [ticketType] will be created with the following fields. It will also [linkToDocs:stay in sync] with the new Sentry Issue.',
         {
-          linkToDocs: <ExternalLink href={link}>{t('stay in sync')}</ExternalLink>,
+          linkToDocs: <ExternalLink href={link} />,
           ticketType,
         }
       );


### PR DESCRIPTION
The new GitHub + GitHub Enterprise alert rule actions don't have issue syncing. This change removes the second sentence about issue syncing that pops up when you click on the action's settings. The example below shows what it looks like with Jira.

<img width="610" alt="Screenshot 2023-10-23 at 11 57 17 AM" src="https://github.com/getsentry/sentry/assets/67301797/0c24ea2a-969a-458e-b8f7-d17f03e214ca">
