### PR TITLE
feat(replay): Show SDK config in the tags list

### DIFF
--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -35,14 +35,6 @@ export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
     ...user,
   };
 
-  // Sort the tags by key
-  const tags = Object.keys(unorderedTags)
-    .sort()
-    .reduce((acc, key) => {
-      acc[key] = unorderedTags[key];
-      return acc;
-    }, {});
-
   const startedAt = new Date(apiResponse.started_at);
   invariant(isValidDate(startedAt), 'replay.started_at is invalid');
   const finishedAt = new Date(apiResponse.finished_at);
@@ -54,7 +46,7 @@ export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
     ...(apiResponse.duration !== undefined
       ? {duration: duration(apiResponse.duration * 1000)}
       : {}),
-    tags,
+    tags: unorderedTags,
   };
 }
 


### PR DESCRIPTION
Now we include a few more tags that show the sdk config that was used for a given replay.

On older SDK's the SDK config isn't available, so those extra values won't appear.

<img width="597" alt="SCR-20231023-kttk" src="https://github.com/getsentry/sentry/assets/187460/d719b1ab-cfc3-4a78-839e-9a07be989eca">
