### PR TITLE
feat(stat-detectors): Add button for transaction summary if >14 days

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/breakpointChart.spec.tsx
+++ b/static/app/components/events/eventStatisticalDetector/breakpointChart.spec.tsx
@@ -1,0 +1,80 @@
+import {Event as MockEvent} from 'sentry-fixture/event';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import EventBreakpointChart from 'sentry/components/events/eventStatisticalDetector/breakpointChart';
+import {DAY} from 'sentry/utils/formatters';
+
+const DURATION_REGRESSION_TYPE = 1017;
+
+describe('Regression breakpoint chart', () => {
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        data: [],
+      },
+    });
+  });
+
+  it('does not show a Go to Transaction Summary button if the breakpoint is under 14 days old', () => {
+    const mockEvent = MockEvent({
+      occurrence: {
+        evidenceData: {
+          breakpoint: (Date.now() - DAY) / 1000,
+          transaction: '/api/0/transaction-test-endpoint/',
+        },
+        evidenceDisplay: [
+          {
+            name: 'Transaction',
+            value: '/api/0/transaction-test-endpoint/',
+            important: false,
+          },
+        ],
+        fingerprint: [],
+        id: '',
+        issueTitle: '',
+        resourceId: '',
+        subtitle: '',
+        detectionTime: '',
+        eventId: '',
+        type: DURATION_REGRESSION_TYPE,
+      },
+    });
+
+    render(<EventBreakpointChart event={mockEvent} />);
+
+    expect(screen.queryByText('Go to Transaction Summary')).not.toBeInTheDocument();
+  });
+
+  it('shows a Go to Transaction Summary button if the breakpoint is over 14 days old', async () => {
+    const mockEvent = MockEvent({
+      occurrence: {
+        evidenceData: {
+          breakpoint: (Date.now() - 15 * DAY) / 1000,
+          transaction: '/api/0/transaction-test-endpoint/',
+        },
+        evidenceDisplay: [
+          {
+            name: 'Transaction',
+            value: '/api/0/transaction-test-endpoint/',
+            important: false,
+          },
+        ],
+        fingerprint: [],
+        id: '',
+        issueTitle: '',
+        resourceId: '',
+        subtitle: '',
+        detectionTime: '',
+        eventId: '',
+        type: DURATION_REGRESSION_TYPE,
+      },
+    });
+
+    render(<EventBreakpointChart event={mockEvent} />);
+
+    expect(await screen.findByText('Go to Transaction Summary')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/eventStatisticalDetector/lineChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/lineChart.tsx
@@ -80,7 +80,7 @@ function LineChart({statsData, evidenceData, start, end, chartLabel}: ChartProps
             grid={{
               left: '10px',
               right: '10px',
-              top: '40px',
+              top: '20px',
               bottom: '0px',
             }}
             options={{


### PR DESCRIPTION
Since we try to center the breakpoint with 14 days of padding, if we exceed 14 days we want to give the user a clear way to navigate to the Transaction Summary page. We don't have particular designs around this so I'm open to suggestions if people feel like this looks misplaced. The button has a tooltip on hover to explain itself.

<img width="1120" alt="Screenshot 2023-10-23 at 3 10 54 PM" src="https://github.com/getsentry/sentry/assets/22846452/7f38d2ef-c100-47bf-b09d-a64b9fb4052d">

Closes #58620