### PR TITLE
fix: gravatar url sha256

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2224,7 +2224,7 @@ SENTRY_MAX_MESSAGE_LENGTH = 1024 * 8
 SENTRY_MAX_STACKTRACE_FRAMES = 100
 
 # Gravatar service base url
-SENTRY_GRAVATAR_BASE_URL = "https://secure.gravatar.com"
+SENTRY_GRAVATAR_BASE_URL = "https://gravatar.com"
 
 # Timeout (in seconds) for fetching remote source files (e.g. JS)
 SENTRY_SOURCE_FETCH_TIMEOUT = 5

--- a/src/sentry/utils/avatar.py
+++ b/src/sentry/utils/avatar.py
@@ -16,7 +16,7 @@ from django.utils.safestring import SafeString
 from PIL import Image
 
 from sentry.http import safe_urlopen
-from sentry.utils.hashlib import md5_text
+from sentry.utils.hashlib import sha256_text
 
 
 def get_gravatar_url(
@@ -26,7 +26,7 @@ def get_gravatar_url(
         email = ""
     gravatar_url = "{}/avatar/{}".format(
         settings.SENTRY_GRAVATAR_BASE_URL,
-        md5_text(email.lower()).hexdigest(),
+        sha256_text(email.strip().lower()).hexdigest(),
     )
 
     properties: MutableMapping[str, Union[int, str]] = {}


### PR DESCRIPTION
Gravatar URLs support SHA256.
MD5 gets flagged as a security issue in a lot of code scanning tools, so this will result in one less finding.