### PR TITLE
feat(starfish): Adds Webvitals Page Overview redesign components

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1647,13 +1647,20 @@ function buildRoutes() {
             )}
           />
         </Route>
-        <Route
-          path="pageloads/"
-          component={make(
-            () =>
-              import('sentry/views/performance/browser/webVitals/webVitalsLandingPage')
-          )}
-        />
+        <Route path="pageloads/">
+          <IndexRoute
+            component={make(
+              () =>
+                import('sentry/views/performance/browser/webVitals/webVitalsLandingPage')
+            )}
+          />
+          <Route
+            path="overview/"
+            component={make(
+              () => import('sentry/views/performance/browser/webVitals/pageOverview')
+            )}
+          />
+        </Route>
         <Route path="resources/">
           <IndexRoute
             component={make(

--- a/static/app/views/performance/browser/webVitals/components/pageOverviewFeaturedTagsList.tsx
+++ b/static/app/views/performance/browser/webVitals/components/pageOverviewFeaturedTagsList.tsx
@@ -1,0 +1,99 @@
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import {space} from 'sentry/styles/space';
+import {calculatePerformanceScore} from 'sentry/views/performance/browser/webVitals/utils/calculatePerformanceScore';
+import {useSlowestTagValuesQuery} from 'sentry/views/performance/browser/webVitals/utils/useSlowestTagValuesQuery';
+
+type Props = {
+  tag: string;
+  transaction: string;
+  title?: string;
+};
+
+const LIMIT = 4;
+
+export function PageOverviewFeaturedTagsList({transaction, tag, title}: Props) {
+  const {data} = useSlowestTagValuesQuery({transaction, tag, limit: LIMIT});
+  const tagValues = data?.data ?? [];
+  return (
+    <Container>
+      <Title>{title ?? tag}</Title>
+      <TagValuesContainer>
+        {tagValues.map((row, index) => {
+          const score = calculatePerformanceScore({
+            lcp: row['p75(measurements.lcp)'] as number,
+            fcp: row['p75(measurements.fcp)'] as number,
+            cls: row['p75(measurements.cls)'] as number,
+            ttfb: row['p75(measurements.ttfb)'] as number,
+            fid: row['p75(measurements.fid)'] as number,
+          });
+          return (
+            <RowContainer key={`${tag}:${index}`}>
+              <TagValue>
+                <TagButton
+                  priority="link"
+                  onClick={() => {
+                    // TODO: need to pass in handler here to open detail panel
+                  }}
+                >
+                  {row[tag]}
+                </TagButton>
+              </TagValue>
+              <Score>{score.totalScore}</Score>
+            </RowContainer>
+          );
+        })}
+      </TagValuesContainer>
+    </Container>
+  );
+}
+
+const Container = styled('div')`
+  flex: 1;
+  margin-right: ${space(1)};
+`;
+
+const Title = styled('span')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  font-weight: bold;
+  display: block;
+  border-bottom: 1px solid ${p => p.theme.border};
+  padding-bottom: ${space(1)};
+  padding-left: ${space(0.75)};
+`;
+
+const TagValuesContainer = styled('div')`
+  > div:nth-child(odd) {
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
+`;
+
+const RowContainer = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr 32px;
+  height: 32px;
+`;
+
+const TagValue = styled('div')`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: ${space(0.75)};
+`;
+
+const Score = styled('div')`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: ${space(0.75)};
+  text-align: right;
+`;
+
+const TagButton = styled(Button)`
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
+  > span {
+    display: inline;
+  }
+`;

--- a/static/app/views/performance/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/performance/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -126,6 +126,7 @@ export function PageOverviewSidebar({projectScore, transaction}: Props) {
       <SidebarSpacer />
       <SectionHeading>
         {t('Throughput')}
+        {/* TODO: Add a proper tooltip */}
         <QuestionTooltip size="sm" title={undefined} />
       </SectionHeading>
       <ChartValue>{currentEps}</ChartValue>
@@ -153,6 +154,7 @@ export function PageOverviewSidebar({projectScore, transaction}: Props) {
       <SidebarSpacer />
       <SectionHeading>
         {t('Duration (P75)')}
+        {/* TODO: Add a proper tooltip */}
         <QuestionTooltip size="sm" title={undefined} />
       </SectionHeading>
       <ChartValue>{currentDuration}</ChartValue>
@@ -180,6 +182,7 @@ export function PageOverviewSidebar({projectScore, transaction}: Props) {
       <SidebarSpacer />
       <SectionHeading>
         {t('5XX Responses')}
+        {/* TODO: Add a proper tooltip */}
         <QuestionTooltip size="sm" title={undefined} />
       </SectionHeading>
       <ChartValue>{pageData?.data[0]['failure_count()']}</ChartValue>
@@ -202,6 +205,7 @@ export function PageOverviewSidebar({projectScore, transaction}: Props) {
       <SidebarSpacer />
       <SectionHeading>
         {t('Aggregate Spans')}
+        {/* TODO: Add a proper tooltip */}
         <QuestionTooltip size="sm" title={undefined} />
       </SectionHeading>
       <MiniAggregateWaterfallContainer>

--- a/static/app/views/performance/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/performance/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -1,0 +1,274 @@
+import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import ChartZoom from 'sentry/components/charts/chartZoom';
+import {LineChart, LineChartSeries} from 'sentry/components/charts/lineChart';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {getDuration} from 'sentry/utils/formatters';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useRouter from 'sentry/utils/useRouter';
+import {MiniAggregateWaterfall} from 'sentry/views/performance/browser/webVitals/components/miniAggregateWaterfall';
+import {ProjectScore} from 'sentry/views/performance/browser/webVitals/utils/calculatePerformanceScore';
+import {useProjectWebVitalsQuery} from 'sentry/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery';
+import {useProjectWebVitalsValuesTimeseriesQuery} from 'sentry/views/performance/browser/webVitals/utils/useProjectWebVitalsValuesTimeseriesQuery';
+import {SidebarSpacer} from 'sentry/views/performance/transactionSummary/utils';
+
+const CHART_HEIGHTS = 100;
+
+type Props = {
+  transaction: string;
+  projectScore?: ProjectScore;
+};
+
+export function PageOverviewSidebar({projectScore, transaction}: Props) {
+  const theme = useTheme();
+  const router = useRouter();
+  const pageFilters = usePageFilters();
+  const {period, start, end, utc} = pageFilters.selection.datetime;
+
+  const {data: pageData} = useProjectWebVitalsQuery({transaction});
+
+  const {data: seriesData, isLoading: isLoadingSeries} =
+    useProjectWebVitalsValuesTimeseriesQuery({transaction});
+
+  const throughtputData: LineChartSeries[] = [
+    {
+      data: !isLoadingSeries
+        ? seriesData.eps.map(({name, value}) => ({
+            name,
+            value,
+          }))
+        : [],
+      seriesName: 'Throughput',
+    },
+  ];
+
+  const durationData: LineChartSeries[] = [
+    {
+      data: !isLoadingSeries
+        ? seriesData.duration.map(({name, value}) => ({
+            name,
+            value,
+          }))
+        : [],
+      seriesName: 'Duration',
+    },
+  ];
+
+  const errorData: LineChartSeries[] = [
+    {
+      data: !isLoadingSeries
+        ? seriesData.errors.map(({name, value}) => ({
+            name,
+            value,
+          }))
+        : [],
+      seriesName: '5XX Responses',
+    },
+  ];
+
+  const epsDiff = !isLoadingSeries
+    ? seriesData.eps[seriesData.eps.length - 1].value / seriesData.eps[0].value
+    : undefined;
+  const initialEps = !isLoadingSeries
+    ? `${Math.round(seriesData.eps[0].value * 100) / 100}/s`
+    : undefined;
+  const currentEps = !isLoadingSeries
+    ? `${Math.round(seriesData.eps[seriesData.eps.length - 1].value * 100) / 100}/s`
+    : undefined;
+
+  const durationDiff = !isLoadingSeries
+    ? seriesData.duration[seriesData.duration.length - 1].value /
+      seriesData.duration[0].value
+    : undefined;
+  const initialDuration = !isLoadingSeries
+    ? getDuration(seriesData.duration[0].value / 1000, 2, true)
+    : undefined;
+  const currentDuration = !isLoadingSeries
+    ? getDuration(
+        seriesData.duration[seriesData.duration.length - 1].value / 1000,
+        2,
+        true
+      )
+    : undefined;
+
+  const diffToColor = (diff?: number, reverse?: boolean) => {
+    if (diff === undefined) {
+      return undefined;
+    }
+    if (diff > 1) {
+      if (reverse) {
+        return theme.red300;
+      }
+      return theme.green300;
+    }
+    if (diff < 1) {
+      if (reverse) {
+        return theme.green300;
+      }
+      return theme.red300;
+    }
+    return undefined;
+  };
+
+  return (
+    <Fragment>
+      <SectionHeading>
+        {t('Performance Score')}
+        <QuestionTooltip size="sm" title={undefined} />
+      </SectionHeading>
+      <SidebarPerformanceScoreValue>
+        {projectScore?.totalScore ?? '-'}
+      </SidebarPerformanceScoreValue>
+      <SidebarSpacer />
+      <SectionHeading>
+        {t('Throughput')}
+        <QuestionTooltip size="sm" title={undefined} />
+      </SectionHeading>
+      <ChartValue>{currentEps}</ChartValue>
+      <ChartSubText color={diffToColor(epsDiff)}>
+        {getChartSubText(epsDiff, initialEps, currentEps)}
+      </ChartSubText>
+      <ChartZoom router={router} period={period} start={start} end={end} utc={utc}>
+        {zoomRenderProps => (
+          <LineChart
+            {...zoomRenderProps}
+            height={CHART_HEIGHTS}
+            series={throughtputData}
+            xAxis={{show: false}}
+            grid={{
+              left: 0,
+              right: 15,
+              top: 10,
+              bottom: -10,
+            }}
+            yAxis={{axisLabel: {formatter: value => `${value}/s`}}}
+            tooltip={{valueFormatter: value => `${Math.round(value * 100) / 100}/s`}}
+          />
+        )}
+      </ChartZoom>
+      <SidebarSpacer />
+      <SectionHeading>
+        {t('Duration (P75)')}
+        <QuestionTooltip size="sm" title={undefined} />
+      </SectionHeading>
+      <ChartValue>{currentDuration}</ChartValue>
+      <ChartSubText color={diffToColor(durationDiff, true)}>
+        {getChartSubText(durationDiff, initialDuration, currentDuration)}
+      </ChartSubText>
+      <ChartZoom router={router} period={period} start={start} end={end} utc={utc}>
+        {zoomRenderProps => (
+          <LineChart
+            {...zoomRenderProps}
+            height={CHART_HEIGHTS}
+            series={durationData}
+            xAxis={{show: false}}
+            grid={{
+              left: 0,
+              right: 15,
+              top: 10,
+              bottom: -10,
+            }}
+            yAxis={{axisLabel: {formatter: getAxisLabelFormattedDuration}}}
+            tooltip={{valueFormatter: getFormattedDuration}}
+          />
+        )}
+      </ChartZoom>
+      <SidebarSpacer />
+      <SectionHeading>
+        {t('5XX Responses')}
+        <QuestionTooltip size="sm" title={undefined} />
+      </SectionHeading>
+      <ChartValue>{pageData?.data[0]['failure_count()']}</ChartValue>
+      <ChartZoom router={router} period={period} start={start} end={end} utc={utc}>
+        {zoomRenderProps => (
+          <LineChart
+            {...zoomRenderProps}
+            height={CHART_HEIGHTS}
+            series={errorData}
+            xAxis={{show: false}}
+            grid={{
+              left: 0,
+              right: 15,
+              top: 10,
+              bottom: -10,
+            }}
+          />
+        )}
+      </ChartZoom>
+      <SidebarSpacer />
+      <SectionHeading>
+        {t('Aggregate Spans')}
+        <QuestionTooltip size="sm" title={undefined} />
+      </SectionHeading>
+      <MiniAggregateWaterfallContainer>
+        <MiniAggregateWaterfall transaction={transaction} />
+      </MiniAggregateWaterfallContainer>
+    </Fragment>
+  );
+}
+
+const getFormattedDuration = (value: number) => {
+  if (value < 1000) {
+    return getDuration(value / 1000, 0, true);
+  }
+  return getDuration(value / 1000, 2, true);
+};
+
+const getAxisLabelFormattedDuration = (value: number) => {
+  return getDuration(value / 1000, 0, true);
+};
+
+const getChartSubText = (
+  diff?: number,
+  value?: string | number,
+  newValue?: string | number
+) => {
+  if (diff === undefined || value === undefined) {
+    return null;
+  }
+  if (diff > 1) {
+    const relativeDiff = Math.round((diff - 1) * 1000) / 10;
+    if (relativeDiff === Infinity) {
+      return `Up from ${value} to ${newValue}`;
+    }
+    return `Up ${relativeDiff}% from ${value}`;
+  }
+  if (diff < 1) {
+    const relativeDiff = Math.round((1 - diff) * 1000) / 10;
+    return `Down ${relativeDiff}% from ${value}`;
+  }
+  return t('No Change');
+};
+
+const SidebarPerformanceScoreValue = styled('div')`
+  font-weight: bold;
+  font-size: 32px;
+`;
+
+const ChartValue = styled('div')`
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+`;
+
+const ChartSubText = styled('div')<{color?: string}>`
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.color ?? p.theme.subText};
+`;
+
+const SectionHeading = styled('h4')`
+  display: inline-grid;
+  grid-auto-flow: column;
+  gap: ${space(1)};
+  align-items: center;
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin: 0;
+`;
+
+const MiniAggregateWaterfallContainer = styled('div')`
+  margin-top: ${space(1)};
+  margin-bottom: ${space(1)};
+`;

--- a/static/app/views/performance/browser/webVitals/components/webVitalMeters.tsx
+++ b/static/app/views/performance/browser/webVitals/components/webVitalMeters.tsx
@@ -117,7 +117,6 @@ const MeterBarContainer = styled('div')`
   padding: 0;
   cursor: pointer;
   min-width: 180px;
-  max-width: 280px;
 `;
 
 const MeterBarBody = styled('div')`

--- a/static/app/views/performance/browser/webVitals/components/webVitalsRingMeters.tsx
+++ b/static/app/views/performance/browser/webVitals/components/webVitalsRingMeters.tsx
@@ -1,0 +1,155 @@
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import {space} from 'sentry/styles/space';
+import PerformanceScoreRing from 'sentry/views/performance/browser/webVitals/components/performanceScoreRing';
+import {ProjectScore} from 'sentry/views/performance/browser/webVitals/utils/calculatePerformanceScore';
+import {WebVitals} from 'sentry/views/performance/browser/webVitals/utils/types';
+
+type Props = {
+  onClick?: (webVital: WebVitals) => void;
+  projectScore?: ProjectScore;
+  transaction?: string;
+};
+
+export default function WebVitalRingMeters({onClick, projectScore}: Props) {
+  const theme = useTheme();
+
+  if (!projectScore) {
+    return null;
+  }
+
+  const ringSegmentColors = theme.charts.getColorPalette(3);
+  const ringBackgroundColors = ringSegmentColors.map(color => `${color}50`);
+
+  return (
+    <Container>
+      <Flex>
+        <MeterBarContainer key="lcp">
+          <InteractionStateLayer />
+          <WebVitalScoreRing
+            backgroundColor={ringBackgroundColors[0]}
+            color={ringSegmentColors[0]}
+            score={projectScore.lcpScore}
+            webVital="lcp"
+            onClick={() => onClick?.('lcp')}
+          />
+        </MeterBarContainer>
+        <MeterBarContainer key="fcp">
+          <WebVitalScoreRing
+            backgroundColor={ringBackgroundColors[1]}
+            color={ringSegmentColors[1]}
+            score={projectScore.fcpScore}
+            webVital="fcp"
+            onClick={() => onClick?.('fcp')}
+          />
+        </MeterBarContainer>
+        <MeterBarContainer key="fid">
+          <WebVitalScoreRing
+            backgroundColor={ringBackgroundColors[2]}
+            color={ringSegmentColors[2]}
+            score={projectScore.fidScore}
+            webVital="fid"
+            onClick={() => onClick?.('fid')}
+          />
+        </MeterBarContainer>
+        <MeterBarContainer key="cls">
+          <WebVitalScoreRing
+            backgroundColor={ringBackgroundColors[3]}
+            color={ringSegmentColors[3]}
+            score={projectScore.clsScore}
+            webVital="cls"
+            onClick={() => onClick?.('cls')}
+          />
+        </MeterBarContainer>
+        <MeterBarContainer key="ttfb">
+          <WebVitalScoreRing
+            backgroundColor={ringBackgroundColors[4]}
+            color={ringSegmentColors[4]}
+            score={projectScore.ttfbScore}
+            webVital="ttfb"
+            onClick={() => onClick?.('ttfb')}
+          />
+        </MeterBarContainer>
+      </Flex>
+    </Container>
+  );
+}
+
+function WebVitalScoreRing({
+  color,
+  backgroundColor,
+  score,
+  webVital,
+  onClick,
+}: {
+  backgroundColor: string;
+  color: string;
+  score: number;
+  webVital: WebVitals;
+  onClick?: (webVital: WebVitals) => void;
+}) {
+  return (
+    <Button onClick={() => onClick?.(webVital)} priority="link">
+      <svg height={100} width={100}>
+        <PerformanceScoreRing
+          backgroundColors={[backgroundColor]}
+          maxValues={[100]}
+          segmentColors={[color]}
+          text={
+            <TextContainer>
+              <ScoreText>{score}</ScoreText>
+              <WebVitalText>{webVital.toUpperCase()}</WebVitalText>
+            </TextContainer>
+          }
+          values={[score]}
+          size={100}
+          barWidth={14}
+        />
+      </svg>
+    </Button>
+  );
+}
+
+const TextContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ScoreText = styled('div')`
+  font-size: ${space(3)};
+  font-weight: bold;
+  color: ${p => p.theme.textColor};
+`;
+
+const WebVitalText = styled('div')`
+  font-size: ${space(1.5)};
+  font-weight: bold;
+  color: ${p => p.theme.textColor};
+`;
+
+const Container = styled('div')`
+  margin: ${space(2)} 0;
+`;
+
+const Flex = styled('div')<{gap?: number}>`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  align-items: center;
+`;
+
+const MeterBarContainer = styled('div')`
+  flex: 1;
+  top: -6px;
+  position: relative;
+  padding: ${space(1)} 0;
+  width: 100px;
+  justify-content: center;
+  display: flex;
+`;

--- a/static/app/views/performance/browser/webVitals/pageOverview.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverview.tsx
@@ -17,6 +17,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {PageOverviewFeaturedTagsList} from 'sentry/views/performance/browser/webVitals/components/pageOverviewFeaturedTagsList';
 import {PageOverviewSidebar} from 'sentry/views/performance/browser/webVitals/components/pageOverviewSidebar';
 import {PerformanceScoreBreakdownChart} from 'sentry/views/performance/browser/webVitals/components/performanceScoreBreakdownChart';
 import WebVitalsRingMeters from 'sentry/views/performance/browser/webVitals/components/webVitalsRingMeters';
@@ -56,6 +57,9 @@ export default function PageOverview() {
     [projects, location.query.project]
   );
 
+  // TODO: When visiting page overview from a specific webvital detail panel in the landing page,
+  // we should automatically default this webvital state to the respective webvital so the detail
+  // panel in this page opens automatically.
   const [state, setState] = useState<{webVital: WebVitals | null}>({
     webVital: null,
   });
@@ -142,6 +146,19 @@ export default function PageOverview() {
               onClick={webVital => setState({...state, webVital})}
               transaction={transaction}
             />
+            {/* TODO: Need to pass in a handler function to each tag list here to handle opening detail panel for tags */}
+            <Flex>
+              <PageOverviewFeaturedTagsList
+                tag="browser.name"
+                transaction={transaction}
+              />
+              <PageOverviewFeaturedTagsList tag="release" transaction={transaction} />
+              {/* TODO: need a way to map country code to actual country name */}
+              <PageOverviewFeaturedTagsList
+                tag="geo.country_code"
+                transaction={transaction}
+              />
+            </Flex>
           </Layout.Main>
           <Layout.Side>
             <PageOverviewSidebar projectScore={projectScore} transaction={transaction} />
@@ -153,6 +170,7 @@ export default function PageOverview() {
             setState({...state, webVital: null});
           }}
         />
+        {/* TODO: Add the detail panel for tags here. Can copy foundation from PageOverviewWebVitalsDetailPanel above. */}
       </Tabs>
     </ModulePageProviders>
   );

--- a/static/app/views/performance/browser/webVitals/pageOverview.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverview.tsx
@@ -1,0 +1,176 @@
+import {useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+
+import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
+import Breadcrumbs from 'sentry/components/breadcrumbs';
+import {LinkButton} from 'sentry/components/button';
+import FeatureBadge from 'sentry/components/featureBadge';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
+import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
+import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
+import {TabList, Tabs} from 'sentry/components/tabs';
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {PageOverviewSidebar} from 'sentry/views/performance/browser/webVitals/components/pageOverviewSidebar';
+import {PerformanceScoreBreakdownChart} from 'sentry/views/performance/browser/webVitals/components/performanceScoreBreakdownChart';
+import WebVitalsRingMeters from 'sentry/views/performance/browser/webVitals/components/webVitalsRingMeters';
+import {PageOverviewWebVitalsDetailPanel} from 'sentry/views/performance/browser/webVitals/pageOverviewWebVitalsDetailPanel';
+import {calculatePerformanceScore} from 'sentry/views/performance/browser/webVitals/utils/calculatePerformanceScore';
+import {WebVitals} from 'sentry/views/performance/browser/webVitals/utils/types';
+import {useProjectWebVitalsQuery} from 'sentry/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery';
+import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
+
+enum LandingDisplayField {
+  OVERVIEW = 'overview',
+  SPANS = 'spans',
+}
+
+const LANDING_DISPLAYS = [
+  {
+    label: t('Overview'),
+    field: LandingDisplayField.OVERVIEW,
+  },
+  {
+    label: t('Spans'),
+    field: LandingDisplayField.SPANS,
+  },
+];
+
+export default function PageOverview() {
+  const organization = useOrganization();
+  const location = useLocation();
+  const {projects} = useProjects();
+  const transaction = location.query.transaction
+    ? Array.isArray(location.query.transaction)
+      ? location.query.transaction[0]
+      : location.query.transaction
+    : undefined;
+  const project = useMemo(
+    () => projects.find(p => p.id === String(location.query.project)),
+    [projects, location.query.project]
+  );
+
+  const [state, setState] = useState<{webVital: WebVitals | null}>({
+    webVital: null,
+  });
+
+  const {data: pageData, isLoading} = useProjectWebVitalsQuery({transaction});
+
+  if (transaction === undefined) {
+    // redirect user to webvitals landing page
+    window.location.href = normalizeUrl(
+      `/organizations/${organization.slug}/performance/browser/pageloads/`
+    );
+    return null;
+  }
+
+  const projectScore = isLoading
+    ? undefined
+    : calculatePerformanceScore({
+        lcp: pageData?.data[0]['p75(measurements.lcp)'] as number,
+        fcp: pageData?.data[0]['p75(measurements.fcp)'] as number,
+        cls: pageData?.data[0]['p75(measurements.cls)'] as number,
+        ttfb: pageData?.data[0]['p75(measurements.ttfb)'] as number,
+        fid: pageData?.data[0]['p75(measurements.fid)'] as number,
+      });
+
+  return (
+    <ModulePageProviders title={[t('Performance'), t('Web Vitals')].join(' — ')}>
+      <Tabs value={LandingDisplayField.OVERVIEW}>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Breadcrumbs
+              crumbs={[
+                {
+                  label: 'Performance',
+                  to: normalizeUrl(`/organizations/${organization.slug}/performance/`),
+                  preservePageFilters: true,
+                },
+                {
+                  label: 'Web Vitals',
+                  to: normalizeUrl(
+                    `/organizations/${organization.slug}/performance/browser/pageloads/`
+                  ),
+                  preservePageFilters: true,
+                },
+                ...(transaction ? [{label: 'Page Overview'}] : []),
+              ]}
+            />
+            <Layout.Title>
+              {transaction && project && <ProjectAvatar project={project} size={24} />}
+              {transaction ?? t('Page Loads')}
+              <FeatureBadge type="alpha" />
+            </Layout.Title>
+          </Layout.HeaderContent>
+          <Layout.HeaderActions />
+          <TabList hideBorder>
+            {LANDING_DISPLAYS.map(({label, field}) => (
+              <TabList.Item key={field}>{label}</TabList.Item>
+            ))}
+          </TabList>
+        </Layout.Header>
+        <Layout.Body>
+          <Layout.Main>
+            <TopMenuContainer>
+              {transaction && (
+                <ViewAllPagesButton
+                  to={{
+                    ...location,
+                    pathname: '/performance/browser/pageloads/',
+                    query: {...location.query, transaction: undefined},
+                  }}
+                >
+                  <IconChevron direction="left" /> {t('View All Pages')}
+                </ViewAllPagesButton>
+              )}
+              <PageFilterBar condensed>
+                <ProjectPageFilter />
+                <DatePageFilter />
+              </PageFilterBar>
+            </TopMenuContainer>
+            <Flex>
+              <PerformanceScoreBreakdownChart transaction={transaction} />
+            </Flex>
+            <WebVitalsRingMeters
+              projectScore={projectScore}
+              onClick={webVital => setState({...state, webVital})}
+              transaction={transaction}
+            />
+          </Layout.Main>
+          <Layout.Side>
+            <PageOverviewSidebar projectScore={projectScore} transaction={transaction} />
+          </Layout.Side>
+        </Layout.Body>
+        <PageOverviewWebVitalsDetailPanel
+          webVital={state.webVital}
+          onClose={() => {
+            setState({...state, webVital: null});
+          }}
+        />
+      </Tabs>
+    </ModulePageProviders>
+  );
+}
+
+const ViewAllPagesButton = styled(LinkButton)`
+  margin-right: ${space(1)};
+`;
+
+const TopMenuContainer = styled('div')`
+  display: flex;
+`;
+
+const Flex = styled('div')`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  gap: ${space(1)};
+  margin-top: ${space(1)};
+`;

--- a/static/app/views/performance/browser/webVitals/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverviewWebVitalsDetailPanel.tsx
@@ -1,0 +1,280 @@
+import {useMemo} from 'react';
+import {Link} from 'react-router';
+import styled from '@emotion/styled';
+
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  GridColumnHeader,
+  GridColumnOrder,
+  GridColumnSortBy,
+} from 'sentry/components/gridEditable';
+import {t} from 'sentry/locale';
+import {generateEventSlug} from 'sentry/utils/discover/urls';
+import {getShortEventId} from 'sentry/utils/events';
+import {getDuration} from 'sentry/utils/formatters';
+import {
+  PageErrorAlert,
+  PageErrorProvider,
+} from 'sentry/utils/performance/contexts/pageError';
+import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import {useRoutes} from 'sentry/utils/useRoutes';
+import {PerformanceBadge} from 'sentry/views/performance/browser/webVitals/components/performanceBadge';
+import {WebVitalDetailHeader} from 'sentry/views/performance/browser/webVitals/components/webVitalDescription';
+import {
+  calculatePerformanceScore,
+  PERFORMANCE_SCORE_MEDIANS,
+  PERFORMANCE_SCORE_P90S,
+} from 'sentry/views/performance/browser/webVitals/utils/calculatePerformanceScore';
+import {
+  TransactionSampleRowWithScore,
+  WebVitals,
+} from 'sentry/views/performance/browser/webVitals/utils/types';
+import {useProjectWebVitalsQuery} from 'sentry/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery';
+import {useTransactionSamplesWebVitalsQuery} from 'sentry/views/performance/browser/webVitals/utils/useTransactionSamplesWebVitalsQuery';
+import {generateReplayLink} from 'sentry/views/performance/transactionSummary/utils';
+import DetailPanel from 'sentry/views/starfish/components/detailPanel';
+
+type Column = GridColumnHeader;
+
+const columnOrder: GridColumnOrder[] = [
+  {key: 'id', width: COL_WIDTH_UNDEFINED, name: 'Event ID'},
+  {key: 'replayId', width: COL_WIDTH_UNDEFINED, name: 'Replay'},
+  {key: 'profile.id', width: COL_WIDTH_UNDEFINED, name: 'Profile'},
+  {key: 'webVital', width: COL_WIDTH_UNDEFINED, name: 'Web Vital'},
+  {key: 'score', width: COL_WIDTH_UNDEFINED, name: 'Score'},
+];
+
+const sort: GridColumnSortBy<keyof TransactionSampleRowWithScore> = {
+  key: 'score',
+  order: 'desc',
+};
+
+export function PageOverviewWebVitalsDetailPanel({
+  webVital,
+  onClose,
+}: {
+  onClose: () => void;
+  webVital: WebVitals | null;
+}) {
+  const location = useLocation();
+  const {projects} = useProjects();
+  const organization = useOrganization();
+  const routes = useRoutes();
+
+  const replayLinkGenerator = generateReplayLink(routes);
+
+  const project = useMemo(
+    () => projects.find(p => p.id === String(location.query.project)),
+    [projects, location.query.project]
+  );
+
+  const transaction = location.query.transaction
+    ? Array.isArray(location.query.transaction)
+      ? location.query.transaction[0]
+      : location.query.transaction
+    : undefined;
+
+  const {data: projectData} = useProjectWebVitalsQuery({transaction});
+
+  const projectScore = calculatePerformanceScore({
+    lcp: projectData?.data[0]['p75(measurements.lcp)'] as number,
+    fcp: projectData?.data[0]['p75(measurements.fcp)'] as number,
+    cls: projectData?.data[0]['p75(measurements.cls)'] as number,
+    ttfb: projectData?.data[0]['p75(measurements.ttfb)'] as number,
+    fid: projectData?.data[0]['p75(measurements.fid)'] as number,
+  });
+
+  // Do 3 queries filtering on LCP to get a spread of good, meh, and poor events
+  // We can't query by performance score yet, so we're using LCP as a best estimate
+  const {data: goodData, isLoading: isGoodTransactionWebVitalsQueryLoading} =
+    useTransactionSamplesWebVitalsQuery({
+      limit: 3,
+      transaction: transaction ?? '',
+      query: webVital
+        ? `measurements.${webVital}:<${PERFORMANCE_SCORE_P90S[webVital]}`
+        : undefined,
+      enabled: Boolean(webVital),
+    });
+
+  const {data: mehData, isLoading: isMehTransactionWebVitalsQueryLoading} =
+    useTransactionSamplesWebVitalsQuery({
+      limit: 3,
+      transaction: transaction ?? '',
+      query: webVital
+        ? `measurements.${webVital}:<${PERFORMANCE_SCORE_MEDIANS[webVital]} measurements.${webVital}:>=${PERFORMANCE_SCORE_P90S[webVital]}`
+        : undefined,
+      enabled: Boolean(webVital),
+    });
+
+  const {data: poorData, isLoading: isPoorTransactionWebVitalsQueryLoading} =
+    useTransactionSamplesWebVitalsQuery({
+      limit: 3,
+      transaction: transaction ?? '',
+      query: webVital
+        ? `measurements.${webVital}:>=${PERFORMANCE_SCORE_MEDIANS[webVital]}`
+        : undefined,
+      enabled: Boolean(webVital),
+    });
+
+  const data = [...goodData, ...mehData, ...poorData];
+
+  const isTransactionWebVitalsQueryLoading =
+    isGoodTransactionWebVitalsQueryLoading ||
+    isMehTransactionWebVitalsQueryLoading ||
+    isPoorTransactionWebVitalsQueryLoading;
+
+  const tableData: TransactionSampleRowWithScore[] = data.sort(
+    (a, b) => a[`${webVital}Score`] - b[`${webVital}Score`]
+  );
+
+  const renderHeadCell = (col: Column) => {
+    if (col.key === 'transaction') {
+      return <NoOverflow>{col.name}</NoOverflow>;
+    }
+    if (col.key === 'webVital') {
+      return <AlignRight>{`${webVital}`}</AlignRight>;
+    }
+    if (col.key === 'score') {
+      return <AlignCenter>{`${webVital} ${col.name}`}</AlignCenter>;
+    }
+    return <NoOverflow>{col.name}</NoOverflow>;
+  };
+
+  const getFormattedDuration = (value: number | null) => {
+    if (value === null) {
+      return null;
+    }
+    if (value < 1000) {
+      return getDuration(value / 1000, 0, true);
+    }
+    return getDuration(value / 1000, 2, true);
+  };
+
+  const renderBodyCell = (col: Column, row: TransactionSampleRowWithScore) => {
+    const {key} = col;
+    if (key === 'score') {
+      if (row[`measurements.${webVital}`] !== null) {
+        return (
+          <AlignCenter>
+            <PerformanceBadge score={row[`${webVital}Score`]} />
+          </AlignCenter>
+        );
+      }
+      return null;
+    }
+    if (col.key === 'webVital') {
+      if (row[key] === null) {
+        return <NoValue>{t('(no value)')}</NoValue>;
+      }
+      const value = row[`measurements.${webVital}`];
+      const formattedValue =
+        webVital === 'cls' ? value?.toFixed(2) : getFormattedDuration(value);
+      return <AlignRight>{formattedValue}</AlignRight>;
+    }
+    if (key === 'id') {
+      const eventSlug = generateEventSlug({...row, project: project?.slug});
+      const eventTarget = getTransactionDetailsUrl(organization.slug, eventSlug);
+      return (
+        <NoOverflow>
+          <Link to={eventTarget} onClick={onClose}>
+            {getShortEventId(row.id)}
+          </Link>
+        </NoOverflow>
+      );
+    }
+    if (key === 'replayId') {
+      const replayTarget =
+        row['transaction.duration'] !== null &&
+        replayLinkGenerator(
+          organization,
+          {
+            replayId: row.replayId,
+            id: row.id,
+            'transaction.duration': row['transaction.duration'],
+            timestamp: row.timestamp,
+          },
+          undefined
+        );
+
+      return (
+        <NoOverflow>
+          {row.replayId && replayTarget && (
+            <Link to={replayTarget}>{getShortEventId(row.replayId)}</Link>
+          )}
+        </NoOverflow>
+      );
+    }
+    if (key === 'profile.id') {
+      const eventSlug = generateEventSlug({...row, project: project?.slug});
+      const eventTarget = getTransactionDetailsUrl(organization.slug, eventSlug);
+      return (
+        <NoOverflow>
+          <Link to={eventTarget} onClick={onClose}>
+            {row['profile.id']}
+          </Link>
+        </NoOverflow>
+      );
+    }
+    return <AlignRight>{row[key]}</AlignRight>;
+  };
+
+  return (
+    <PageErrorProvider>
+      <DetailPanel detailKey={webVital ?? undefined} onClose={onClose}>
+        {webVital && (
+          <WebVitalDetailHeader
+            value={
+              webVital !== 'cls'
+                ? getDuration(
+                    (projectData?.data[0][`p75(measurements.${webVital})`] as number) /
+                      1000,
+                    2,
+                    true
+                  )
+                : (
+                    projectData?.data[0][`p75(measurements.${webVital})`] as number
+                  ).toFixed(2)
+            }
+            webVital={webVital}
+            score={projectScore[`${webVital}Score`]}
+          />
+        )}
+        <GridEditable
+          data={tableData}
+          isLoading={isTransactionWebVitalsQueryLoading}
+          columnOrder={columnOrder}
+          columnSortBy={[sort]}
+          grid={{
+            renderHeadCell,
+            renderBodyCell,
+          }}
+          location={location}
+        />
+        <PageErrorAlert />
+      </DetailPanel>
+    </PageErrorProvider>
+  );
+}
+
+const NoOverflow = styled('span')`
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const AlignRight = styled('span')<{color?: string}>`
+  text-align: right;
+  width: 100%;
+  ${p => (p.color ? `color: ${p.color};` : '')}
+`;
+
+const AlignCenter = styled('span')`
+  text-align: center;
+  width: 100%;
+`;
+
+const NoValue = styled('span')`
+  color: ${p => p.theme.gray300};
+`;

--- a/static/app/views/performance/browser/webVitals/utils/useSlowestTagValuesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/useSlowestTagValuesQuery.tsx
@@ -1,0 +1,52 @@
+import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+
+type Props = {
+  tag: string;
+  transaction: string;
+  limit?: number;
+  orderBy?: string;
+};
+
+export const useSlowestTagValuesQuery = ({tag, transaction, limit}: Props) => {
+  const organization = useOrganization();
+  const pageFilters = usePageFilters();
+  const location = useLocation();
+
+  const projectEventView = EventView.fromNewQueryWithPageFilters(
+    {
+      fields: [
+        tag,
+        'p75(measurements.lcp)',
+        'p75(measurements.fcp)',
+        'p75(measurements.cls)',
+        'p75(measurements.ttfb)',
+        'p75(measurements.fid)',
+        'count()',
+      ],
+      name: 'Web Vitals',
+      query:
+        'transaction.op:pageload' + (transaction ? ` transaction:"${transaction}"` : ''),
+      version: 2,
+      dataset: DiscoverDatasets.METRICS,
+      // We don't have performance scores yet, so sort by lcp for now as an estimate
+      orderby: '-p75_measurements_lcp',
+    },
+    pageFilters.selection
+  );
+
+  return useDiscoverQuery({
+    eventView: projectEventView,
+    limit: limit ?? 50,
+    location,
+    orgSlug: organization.slug,
+    options: {
+      enabled: pageFilters.isReady,
+      refetchOnWindowFocus: false,
+    },
+  });
+};


### PR DESCRIPTION
Adds a route to the new Webvitals Page Overview redesigned page.
Components include:
- a sidebar (including charts and a span aggregate waterfall
- main performance score breakdown chart
- webvital scores rings
- basic samples slideout panel

This new Page Overview remains unused until completion. Links will be updated later to point to the new Page Overview.
**TODO: Handlers for some buttons and links not implemented yet. Tags component needs completion including slideout panel.**

![image](https://github.com/getsentry/sentry/assets/83961295/2f00f0a8-e30a-462e-b39c-cb6b4b879afb)
