### PR TITLE
fix(workflow): Restyle notification overrides and project picker

### DIFF
--- a/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
@@ -1,12 +1,12 @@
-import {Fragment, useState} from 'react';
-import type {WithRouterProps} from 'react-router';
-import {components} from 'react-select';
+import {useState} from 'react';
 import styled from '@emotion/styled';
+import keyBy from 'lodash/keyBy';
 
 import {Button} from 'sentry/components/button';
 import SelectControl from 'sentry/components/forms/controls/selectControl';
-import JsonForm from 'sentry/components/forms/jsonForm';
 import IdBadge from 'sentry/components/idBadge';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
@@ -14,12 +14,13 @@ import {IconAdd, IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
-import {Organization, Project} from 'sentry/types';
+import type {Organization, Project} from 'sentry/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import withSentryRouter from 'sentry/utils/withSentryRouter';
-import {NotificationOptionsObject} from 'sentry/views/settings/account/notifications/constants';
-import {NOTIFICATION_SETTING_FIELDS_V2} from 'sentry/views/settings/account/notifications/fields2';
-import {OrganizationSelectHeader} from 'sentry/views/settings/account/notifications/organizationSelectHeader';
+import useRouter from 'sentry/utils/useRouter';
+
+import type {NotificationOptionsObject} from './constants';
+import {NOTIFICATION_SETTING_FIELDS_V2} from './fields2';
+import {OrganizationSelectHeader} from './organizationSelectHeader';
 
 type Value = 'always' | 'never' | 'subscribe_only' | 'committed_only';
 
@@ -38,7 +39,7 @@ const getLabelForValue = (value: Value) => {
   }
 };
 
-export type NotificationSettingsByProjectsBaseProps = {
+interface NotificationSettingsByEntityProps {
   entityType: 'project' | 'organization';
   handleAddNotificationOption: (
     notificationOption: Omit<NotificationOptionsObject, 'id'>
@@ -46,24 +47,18 @@ export type NotificationSettingsByProjectsBaseProps = {
   handleRemoveNotificationOption: (id: string) => void;
   notificationOptions: NotificationOptionsObject[];
   notificationType: string;
-};
-
-type Props = {
   organizations: Organization[];
-} & NotificationSettingsByProjectsBaseProps &
-  WithRouterProps;
+}
 
-function NotificationSettingsByEntity(props: Props) {
-  const {
-    entityType,
-    handleAddNotificationOption,
-    handleRemoveNotificationOption,
-    notificationOptions,
-    notificationType,
-    organizations,
-    router,
-    location,
-  } = props;
+function NotificationSettingsByEntity({
+  entityType,
+  handleAddNotificationOption,
+  handleRemoveNotificationOption,
+  notificationOptions,
+  notificationType,
+  organizations,
+}: NotificationSettingsByEntityProps) {
+  const router = useRouter();
   const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
   const [selectedValue, setSelectedValue] = useState<Value | null>(null);
 
@@ -73,12 +68,17 @@ function NotificationSettingsByEntity(props: Props) {
   )?.id;
 
   const orgId =
-    location?.query?.organizationId ?? orgFromSubdomain ?? organizations[0]?.id;
+    router.location?.query?.organizationId ?? orgFromSubdomain ?? organizations[0]?.id;
   const orgSlug =
     organizations.find(({id}) => id === orgId)?.slug || organizations[0]?.slug;
 
   // loads all the projects for an org
-  const {data: projects} = useApiQuery<Project[]>(
+  const {
+    data: projects,
+    isLoading,
+    isError,
+    refetch,
+  } = useApiQuery<Project[]>(
     [
       `/organizations/${orgSlug}/projects/`,
       {
@@ -93,10 +93,12 @@ function NotificationSettingsByEntity(props: Props) {
 
   // always loading all projects even though we only need it sometimes
   const entities = entityType === 'project' ? projects || [] : organizations;
+  // create maps by the project id for constant time lookups
+  const entityById = keyBy<Organization | Project>(entities, 'id');
 
   const handleOrgChange = (organizationId: string) => {
     router.replace({
-      ...location,
+      ...router.location,
       query: {organizationId},
     });
   };
@@ -122,81 +124,44 @@ function NotificationSettingsByEntity(props: Props) {
       option => option.type === notificationType && option.scopeType === entityType
     );
     return matchedOptions.map(option => {
-      const entity = (entities as any[]).find(
-        ({id}) => id.toString() === option.scopeIdentifier.toString()
-      );
+      const entity = entityById[`${option.scopeIdentifier}`];
       if (!entity) {
         return null;
       }
-      const handleDelete = async (id: string) => {
-        await handleRemoveNotificationOption(id);
-      };
+
       const idBadgeProps =
         entityType === 'project'
           ? {project: entity as Project}
-          : {
-              organization: entity as Organization,
-            };
+          : {organization: entity as Organization};
+
       return (
         <Item key={entity.id}>
-          <IdBadge
-            {...idBadgeProps}
-            avatarSize={20}
-            displayName={entity.slug}
-            avatarProps={{consistentWidth: true}}
-            disableLink
-          />
-          {getLabelForValue(option.value)}
-          <Button
-            aria-label={t('Delete')}
-            size="sm"
-            priority="default"
-            icon={<IconDelete />}
-            onClick={() => handleDelete(option.id)}
-          />
+          <div style={{marginLeft: space(2)}}>
+            <IdBadge
+              {...idBadgeProps}
+              avatarSize={20}
+              displayName={entity.slug}
+              avatarProps={{consistentWidth: true}}
+              disableLink
+            />
+          </div>
+          <div style={{marginLeft: space(2)}}>{getLabelForValue(option.value)}</div>
+          <RemoveButtonWrapper>
+            <Button
+              aria-label={t('Delete')}
+              size="sm"
+              priority="default"
+              icon={<IconDelete />}
+              onClick={() => handleRemoveNotificationOption(option.id)}
+            />
+          </RemoveButtonWrapper>
         </Item>
       );
     });
   };
 
-  const customValueContainer = containerProps => {
-    // if no value set, we want to return the default component that is rendered
-    const entity = entityById[selectedEntityId || ''];
-    if (!entity) {
-      return <components.ValueContainer {...containerProps} />;
-    }
-    const idBadgeProps =
-      entityType === 'project'
-        ? {project: entity as Project}
-        : {
-            organization: entity as Organization,
-          };
-    return (
-      <components.ValueContainer {...containerProps}>
-        <IdBadge
-          {...idBadgeProps}
-          avatarSize={20}
-          displayName={entity.slug}
-          avatarProps={{consistentWidth: true}}
-          disableLink
-        />
-      </components.ValueContainer>
-    );
-  };
-
-  const handleSelectProject = ({value}: {value: string}) => {
-    setSelectedEntityId(value);
-  };
-  const handleSelectValue = ({value}: {value: string}) => {
-    setSelectedValue(value as Value);
-  };
-
-  // create maps by the project id for constant time lookups
-  const entityById: Record<string, Organization | Project> = Object.fromEntries(
-    entities.map(entity => [entity.id, entity])
-  );
-  const entityOptions: {label: string; value: Value}[] = (entities as any[])
-    .filter(({id}: Project | Organization) => {
+  const entityOptions = entities
+    .filter(({id}) => {
       const match = notificationOptions.find(
         option =>
           option.scopeType === entityType &&
@@ -205,35 +170,51 @@ function NotificationSettingsByEntity(props: Props) {
       );
       return !match;
     })
-    .map(({slug, id}) => ({label: slug, value: id}));
-  const customOptionProject = entityProps => {
-    const entity = entityById[entityProps.value];
-    // Should never happen for a dropdown item
-    if (!entity) {
-      return null;
-    }
-    const idBadgeProps =
-      entityType === 'project'
-        ? {project: entity as Project}
-        : {
-            organization: entity as Organization,
-          };
-    return (
-      <components.Option {...entityProps}>
-        <IdBadge
-          {...idBadgeProps}
-          avatarSize={20}
-          displayName={entity.slug}
-          avatarProps={{consistentWidth: true}}
-          disableLink
-        />
-      </components.Option>
-    );
-  };
+    .map(obj => {
+      const entity = entityById[obj.id];
+      const idBadgeProps =
+        entityType === 'project'
+          ? {project: entity as Project}
+          : {organization: entity as Organization};
+
+      return {
+        label: entityType === 'project' ? obj.slug : obj.name,
+        value: obj.id,
+        leadingItems: (
+          <IdBadge
+            {...idBadgeProps}
+            avatarSize={20}
+            avatarProps={{consistentWidth: true}}
+            disableLink
+            hideName
+          />
+        ),
+      };
+    })
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+  // Group options when displaying projects
+  const groupedEntityOptions =
+    entityType === 'project'
+      ? [
+          {
+            label: t('My Projects'),
+            options: entityOptions.filter(
+              project => (entityById[project.value] as Project).isMember
+            ),
+          },
+          {
+            label: t('All Projects'),
+            options: entityOptions.filter(
+              project => !(entityById[project.value] as Project).isMember
+            ),
+          },
+        ]
+      : entityOptions;
 
   const valueOptions = NOTIFICATION_SETTING_FIELDS_V2[notificationType].choices;
   return (
-    <Fragment>
+    <MinHeight>
       <Panel>
         <StyledPanelHeader>
           {entityType === 'project' ? (
@@ -246,49 +227,60 @@ function NotificationSettingsByEntity(props: Props) {
             t('Settings for Organizations')
           )}
         </StyledPanelHeader>
-        <Item>
+        <ControlItem>
           {/* TODO: enable search for sentry projects */}
           <SelectControl
             placeholder={
               entityType === 'project'
-                ? t('Sentry project\u2026')
-                : t('Sentry organization\u2026')
+                ? t('Project\u2026')
+                : t('Sentry Organization\u2026')
             }
             name={entityType}
-            options={entityOptions}
-            components={{
-              Option: customOptionProject,
-              ValueContainer: customValueContainer,
+            options={groupedEntityOptions}
+            onChange={({value}: {value: string}) => {
+              setSelectedEntityId(value);
             }}
-            onChange={handleSelectProject}
             value={selectedEntityId}
           />
           <SelectControl
-            placeholder={t('Select\u2026')}
+            placeholder={t('Value\u2026')}
             value={selectedValue}
             name="value"
             choices={valueOptions}
-            onChange={handleSelectValue}
+            onChange={({value}: {value: string}) => {
+              setSelectedValue(value as Value);
+            }}
           />
-          <AddProjectWrapper>
-            <Button
-              disabled={!selectedEntityId || !selectedValue}
-              size="sm"
-              priority="primary"
-              onClick={handleAdd}
-              icon={<IconAdd />}
-              aria-label={t('Add override')}
-            />
-          </AddProjectWrapper>
-        </Item>
-        <PanelBody>{renderOverrides()}</PanelBody>
+          <Button
+            disabled={!selectedEntityId || !selectedValue}
+            size="md"
+            priority="primary"
+            onClick={handleAdd}
+            icon={<IconAdd />}
+            aria-label={t('Add override')}
+          />
+        </ControlItem>
+        {isLoading && (
+          <PanelBody>
+            <LoadingIndicator />
+          </PanelBody>
+        )}
+        {isError && (
+          <PanelBody>
+            <LoadingError onRetry={refetch} />
+          </PanelBody>
+        )}
+        <StyledPanelBody>{renderOverrides()}</StyledPanelBody>
       </Panel>
-    </Fragment>
+    </MinHeight>
   );
 }
 
-// loading all projects and orgs
-export default withSentryRouter(NotificationSettingsByEntity);
+export default NotificationSettingsByEntity;
+
+const MinHeight = styled('div')`
+  min-height: 400px;
+`;
 
 const StyledPanelHeader = styled(PanelHeader)`
   flex-wrap: wrap;
@@ -298,21 +290,24 @@ const StyledPanelHeader = styled(PanelHeader)`
   }
 `;
 
-export const StyledJsonForm = styled(JsonForm)`
-  ${Panel} {
-    border: 0;
-    margin-bottom: 0;
+const StyledPanelBody = styled(PanelBody)`
+  & > div:not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.innerBorder};
   }
 `;
 
-const AddProjectWrapper = styled('div')``;
-
 const Item = styled('div')`
-  min-height: 60px;
-  padding: ${space(2)};
-
   display: grid;
   grid-column-gap: ${space(1)};
-  align-items: center;
   grid-template-columns: 2.5fr 1fr min-content;
+  align-items: center;
+  padding: ${space(1.5)} ${space(2)};
+`;
+
+const ControlItem = styled(Item)`
+  border-bottom: 1px solid ${p => p.theme.innerBorder};
+`;
+
+const RemoveButtonWrapper = styled('div')`
+  margin: 0 ${space(0.5)};
 `;

--- a/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
@@ -76,6 +76,7 @@ function NotificationSettingsByEntity({
   const {
     data: projects,
     isLoading,
+    isSuccess,
     isError,
     refetch,
   } = useApiQuery<Project[]>(
@@ -270,7 +271,7 @@ function NotificationSettingsByEntity({
             <LoadingError onRetry={refetch} />
           </PanelBody>
         )}
-        <StyledPanelBody>{renderOverrides()}</StyledPanelBody>
+        {isSuccess && <StyledPanelBody>{renderOverrides()}</StyledPanelBody>}
       </Panel>
     </MinHeight>
   );

--- a/static/app/views/settings/account/notifications/notificationSettingsByTypeV2.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByTypeV2.spec.tsx
@@ -170,8 +170,8 @@ describe('NotificationSettingsByType', function () {
   it('adds a project override and removes it', async function () {
     renderComponent({});
 
-    await selectEvent.select(screen.getByText('Sentry project\u2026'), 'foo');
-    await selectEvent.select(screen.getByText('Select\u2026'), 'On');
+    await selectEvent.select(screen.getByText('Project\u2026'), 'foo');
+    await selectEvent.select(screen.getByText('Value\u2026'), 'On');
 
     const addSettingMock = MockApiClient.addMockResponse({
       url: `/users/me/notification-options/`,


### PR DESCRIPTION
- Groups projects by my projects / all projects
- Adjusts some padding and adds a border on each row
- Adds a minimum height since the dropdown gets weird at the bottom of the page
- Adds loading/error states

before
![Screenshot 2023-10-23 at 3 10 23 PM](https://github.com/getsentry/sentry/assets/1400464/446ad93c-0946-4f54-ac51-60be5cf2e70c)

after - the alignment looks maybe a little funky but lets try it out
![Screenshot 2023-10-23 at 3 10 32 PM](https://github.com/getsentry/sentry/assets/1400464/bd3c1945-c112-4021-aa39-e1ff3d1eb280)

projects before
<img width="848" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/859514a9-f5c9-4e0f-a49c-782e4ae1023b">

grouped projects after
![Screenshot 2023-10-23 at 3 13 08 PM](https://github.com/getsentry/sentry/assets/1400464/8dfa725e-a173-43ad-90c0-ee1098214b7f)

