### PR TITLE
fix(replays): only show overflow on replay cell

### DIFF
--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -377,8 +377,6 @@ export function ReplayCell({
           <Link to={detailsTab} onClick={trackNavigationEvent}>
             {getShortEventId(replay.id)}
           </Link>
-        </Row>
-        <Row gap={0.5}>
           <IconCalendar color="gray300" size="xs" />
           <TimeSince date={replay.started_at} />
         </Row>

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -352,7 +352,7 @@ export function ReplayCell({
 
   if (replay.is_archived) {
     return (
-      <Item isArchived={replay.is_archived}>
+      <Item isArchived={replay.is_archived} isReplayCell>
         <Row gap={1}>
           <StyledIconDelete color="gray500" size="md" />
           <div>
@@ -387,7 +387,7 @@ export function ReplayCell({
   );
 
   return (
-    <Item isWidget={isWidget}>
+    <Item isWidget={isWidget} isReplayCell>
       <UserBadge
         avatarSize={24}
         displayName={
@@ -625,7 +625,11 @@ export function ActivityCell({replay, showDropdownFilters}: Props) {
   );
 }
 
-const Item = styled('div')<{isArchived?: boolean; isWidget?: boolean}>`
+const Item = styled('div')<{
+  isArchived?: boolean;
+  isReplayCell?: boolean;
+  isWidget?: boolean;
+}>`
   display: flex;
   align-items: center;
   gap: ${space(1)};
@@ -634,7 +638,7 @@ const Item = styled('div')<{isArchived?: boolean; isWidget?: boolean}>`
       ? `padding: ${space(0.75)} ${space(1.5)} ${space(1.5)} ${space(1.5)};`
       : `padding: ${space(1.5)};`};
   ${p => (p.isArchived ? 'opacity: 0.5;' : '')};
-  overflow: scroll;
+  ${p => (p.isReplayCell ? 'overflow: scroll;' : '')};
 `;
 
 const Count = styled('span')`

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -638,7 +638,7 @@ const Item = styled('div')<{
       ? `padding: ${space(0.75)} ${space(1.5)} ${space(1.5)} ${space(1.5)};`
       : `padding: ${space(1.5)};`};
   ${p => (p.isArchived ? 'opacity: 0.5;' : '')};
-  ${p => (p.isReplayCell ? 'overflow: scroll;' : '')};
+  ${p => (p.isReplayCell ? 'overflow: auto;' : '')};
 `;
 
 const Count = styled('span')`

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -370,15 +370,17 @@ export function ReplayCell({
   const subText = (
     <Cols>
       <Row gap={1}>
-        <Row gap={0.75}>
+        <Row gap={0.5}>
           {/* Avatar is used instead of ProjectBadge because using ProjectBadge increases spacing, which doesn't look as good */}
           {project ? <Avatar size={12} project={project} /> : null}
           {project ? project.slug : null}
           <Link to={detailsTab} onClick={trackNavigationEvent}>
             {getShortEventId(replay.id)}
           </Link>
-          <IconCalendar color="gray300" size="xs" />
-          <TimeSince date={replay.started_at} />
+          <Row gap={0.5}>
+            <IconCalendar color="gray300" size="xs" />
+            <TimeSince date={replay.started_at} />
+          </Row>
         </Row>
       </Row>
     </Cols>

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -370,7 +370,7 @@ export function ReplayCell({
   const subText = (
     <Cols>
       <Row gap={1}>
-        <Row gap={0.5}>
+        <Row gap={0.75}>
           {/* Avatar is used instead of ProjectBadge because using ProjectBadge increases spacing, which doesn't look as good */}
           {project ? <Avatar size={12} project={project} /> : null}
           {project ? project.slug : null}


### PR DESCRIPTION
Only apply `overflow: scroll` to the replay cell, not all the table cells. Also fixed some overflow with the calendar icon and the shortId.

Before:
<img width="237" alt="SCR-20231023-litu" src="https://github.com/getsentry/sentry/assets/56095982/22f80a47-e622-4c69-ac4b-d5aed80753e5">

After:

https://github.com/getsentry/sentry/assets/56095982/ffc2e4b4-ad43-4776-9bbe-9908b4848cd6


Fixes https://github.com/getsentry/sentry/issues/58618