### PR TITLE
fix(workflow): Add project badge to email routing etc

### DIFF
--- a/static/app/views/settings/account/accountNotificationFineTuningV2.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuningV2.tsx
@@ -6,6 +6,7 @@ import EmptyMessage from 'sentry/components/emptyMessage';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
@@ -68,7 +69,15 @@ function AccountNotificationsByProject({projects, field}: ANBPProps) {
       // `name` key refers to field name
       // we use project.id because slugs are not unique across orgs
       name: project.id,
-      label: project.slug,
+      label: (
+        <ProjectBadge
+          project={project}
+          avatarSize={20}
+          displayName={project.slug}
+          avatarProps={{consistentWidth: true}}
+          disableLink
+        />
+      ),
     })),
   }));
 


### PR DESCRIPTION
Adds the project badge to each row on the email routing settings


before
<img width="689" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/2412a98c-c050-4f18-9acf-916155fe4aa2">

after
<img width="680" alt="image" src="https://github.com/getsentry/sentry/assets/1400464/07da08a1-3738-4fa2-b80f-42bf1bd128e2">


