### PR TITLE
Add error message to logs

### DIFF
--- a/src/sentry/integrations/discord/requests/base.py
+++ b/src/sentry/integrations/discord/requests/base.py
@@ -127,7 +127,7 @@ class DiscordRequest:
             self._info("discord.authorize.unauthorized")
 
         raise DiscordRequestError(
-            error="Unauthorized access; invalid auth credentials",
+            "Unauthorized access; invalid auth credentials",
             status=status.HTTP_401_UNAUTHORIZED,
         )
 

--- a/src/sentry/integrations/discord/requests/base.py
+++ b/src/sentry/integrations/discord/requests/base.py
@@ -126,7 +126,10 @@ class DiscordRequest:
         else:
             self._info("discord.authorize.unauthorized")
 
-        raise DiscordRequestError(status=status.HTTP_401_UNAUTHORIZED)
+        raise DiscordRequestError(
+            error="Unauthorized access; invalid auth credentials",
+            status=status.HTTP_401_UNAUTHORIZED,
+        )
 
     def _validate_identity(self) -> None:
         self.user = self.get_identity_user()


### PR DESCRIPTION
Add a message to specify when auth log fails. 
Investigating https://github.com/getsentry/sentry/issues/58642