### PR TITLE
style(replays): make archived replay font size consistent

### DIFF
--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -359,7 +359,7 @@ export function ReplayCell({
             <Row gap={0.5}>{t('Deleted Replay')}</Row>
             <Row gap={0.5}>
               {project ? <Avatar size={12} project={project} /> : null}
-              {getShortEventId(replay.id)}
+              <ArchivedId>{getShortEventId(replay.id)}</ArchivedId>
             </Row>
           </div>
         </Row>
@@ -406,6 +406,10 @@ export function ReplayCell({
     </Item>
   );
 }
+
+const ArchivedId = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
 
 const StyledIconDelete = styled(IconDelete)`
   margin: ${space(0.25)};


### PR DESCRIPTION
Deleted replays were showing the replay ID in a larger font, so I made the font sizes consistent:


Before:
<img width="515" alt="SCR-20231023-lvdg" src="https://github.com/getsentry/sentry/assets/56095982/859def3b-1275-47a1-85d1-d7656b9d3b6c">

After:
<img width="545" alt="SCR-20231023-lwbr-2" src="https://github.com/getsentry/sentry/assets/56095982/1b2cebf9-58cd-45a1-a03a-007e0cc09ff6">



<!-- Describe your PR here. -->