### PR TITLE
fix(starfish-db-widget-empty-state): Updated render logic to display empty state

### DIFF
--- a/static/app/views/performance/database/noDataMessage.tsx
+++ b/static/app/views/performance/database/noDataMessage.tsx
@@ -22,7 +22,7 @@ export function NoDataMessage({Wrapper = DivWrapper}: Props) {
 
   const selectedProjectIds = selection.projects.map(projectId => projectId.toString());
 
-  const {data: projectSpanMetricsCounts, isLoading} = useProjectSpanMetricCounts({
+  const {data: projectSpanMetricsCounts} = useProjectSpanMetricCounts({
     query: 'span.module:db',
     statsPeriod: SAMPLE_STATS_PERIOD,
     enabled: pageFilterIsReady,
@@ -42,7 +42,7 @@ export function NoDataMessage({Wrapper = DivWrapper}: Props) {
   const hasMoreIneligibleProjectsThanVisible =
     ineligibleProjects.length > MAX_LISTED_PROJECTS;
 
-  if (isLoading) {
+  if (!projectSpanMetricsCounts) {
     return null;
   }
 


### PR DESCRIPTION
Before:
<img width="400" alt="Screenshot 2023-10-23 at 4 56 56 PM" src="https://github.com/getsentry/sentry/assets/60121741/dc13d80a-ccfa-4dfc-8d57-66ea992bf03a">

After:
<img width="400" alt="Screenshot 2023-10-23 at 4 56 40 PM" src="https://github.com/getsentry/sentry/assets/60121741/33791c19-ad94-47a6-b7ee-4aa39b4898de">
