### PR TITLE
fix(spike-protection): project settings toggle

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -229,6 +229,7 @@ def format_options(attrs: dict[str, Any]) -> dict[str, Any]:
             options.get(f"sentry:{FilterTypes.ERROR_MESSAGES}", [])
         ),
         "feedback:branding": options.get("feedback:branding", "1") == "1",
+        "quotas:spike-protection-disabled": options.get("quotas:spike-protection-disabled"),
     }
 
 


### PR DESCRIPTION
Spike protection toggle in project setting is always on. I debug this and looks like the option is not passed to the frontend at all and frontend assumes "enabled" if options.disable-spike-protection does not exist. This PR fixes the issue by returning that option as part of the project serializer.

Before:

https://github.com/getsentry/sentry/assets/132939361/32a07120-b7a3-4128-8a4e-a047f054b00f

After:

https://github.com/getsentry/sentry/assets/132939361/f3704251-ec4b-48bd-8d37-2091cd3fb4f0