### PR TITLE
feat(hybridcloud) Update release webhook generation to include region

### DIFF
--- a/src/sentry/api/endpoints/project_releases_token.py
+++ b/src/sentry/api/endpoints/project_releases_token.py
@@ -10,12 +10,12 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, StrictProjectPermission
 from sentry.models.options.project_option import ProjectOption
-from sentry.utils.http import absolute_uri
+from sentry.types.region import get_local_region
 
 
 def _get_webhook_url(project, plugin_id, token):
-
-    return absolute_uri(
+    region = get_local_region()
+    return region.to_url(
         reverse(
             "sentry-release-hook",
             kwargs={

--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -11,6 +11,11 @@ from sentry.silo import SiloMode
 from sentry.silo.base import SiloLimit
 from sentry.types.region import get_region_by_name
 
+# Backwards compatibility for URLs that don't
+# have enough context to route via organization.
+# New usage of these endpoints uses region domains,
+# but existing customers have been using these routes
+# on the main domain for a long time.
 REGION_PINNED_URL_NAMES = (
     "sentry-api-0-builtin-symbol-sources",
     "sentry-api-0-grouping-configs",
@@ -23,6 +28,7 @@ REGION_PINNED_URL_NAMES = (
     "sentry-api-0-relays-healthcheck",
     "sentry-api-0-relays-details",
     "sentry-error-page-embed",
+    "sentry-release-hook",
 )
 
 

--- a/src/sentry/web/frontend/release_webhook.py
+++ b/src/sentry/web/frontend/release_webhook.py
@@ -15,10 +15,12 @@ from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.plugins.base import plugins
 from sentry.utils import json
+from sentry.web.frontend.base import region_silo_view
 
 logger = logging.getLogger("sentry.webhooks")
 
 
+@region_silo_view
 class ReleaseWebhookView(View):
     def verify(self, plugin_id, project_id, token, signature):
         return constant_time_compare(

--- a/tests/sentry/api/endpoints/test_project_release_token.py
+++ b/tests/sentry/api/endpoints/test_project_release_token.py
@@ -2,8 +2,11 @@ from django.urls import reverse
 
 from sentry.models.options.project_option import ProjectOption
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
+from sentry.types.region import get_local_region
 
 
+@region_silo_test(stable=True)
 class ReleaseTokenGetTest(APITestCase):
     def test_simple(self):
         project = self.create_project(name="foo")
@@ -38,6 +41,22 @@ class ReleaseTokenGetTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["token"] is not None
         assert ProjectOption.objects.get_value(project, "sentry:release-token") is not None
+
+    def test_generate_region_webhookurl(self):
+        project = self.create_project(name="foo")
+
+        url = reverse(
+            "sentry-api-0-project-releases-token",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+
+        self.login_as(user=self.user)
+
+        response = self.client.get(url)
+        assert response.status_code == 200, response.content
+
+        region = get_local_region()
+        assert response.data["webhookUrl"].startswith(region.to_url("/"))
 
     def test_regenerates_token(self):
         project = self.create_project(name="foo")


### PR DESCRIPTION
- New release webhooks will need to use region domains to work.
- Allow regionless requests to be forwarded to the monolith region to maintain compatiblity with existing customers.