### PR TITLE
ref(participants): Fix reassignment

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -838,10 +838,6 @@ def handle_assigned_to(
     if assigned_actor:
         for group in group_list:
             resolved_actor: RpcUser | Team = assigned_actor.resolve()
-
-            if features.has("organizations:participants-purge", group.organization):
-                GroupAssignee.objects.deassign(group, acting_user, resolved_actor, extra=extra)
-
             assignment = GroupAssignee.objects.assign(
                 group, resolved_actor, acting_user, extra=extra
             )

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -68,20 +68,23 @@ class GroupAssigneeManager(BaseManager):
         return (assignee_type, assignee_type_attr, other_type)
 
     def remove_old_assignees(
-        self, group: Group, previous_assignee: Optional(GroupAssignee)
+        self, group: Group, previous_assignee: Optional[GroupAssignee]
     ) -> None:
-        if features.has("organizations:participants-purge", group.organization):
+        if (
+            features.has("organizations:participants-purge", group.organization)
+            and previous_assignee
+        ):
             if (
                 features.has("organizations:team-workflow-notifications", group.organization)
-                and previous_assignee.team_id
+                and previous_assignee.team
             ):
                 GroupSubscription.objects.filter(
                     group=group,
                     project=group.project,
-                    team=previous_assignee.team_id,
+                    team=previous_assignee.team,
                     reason=GroupSubscriptionReason.assigned,
                 ).delete()
-            elif previous_assignee.team_id:
+            elif previous_assignee.team:
                 team_members = list(
                     previous_assignee.team.member_set.values_list("user_id", flat=True)
                 )

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -112,7 +112,7 @@ class GroupAssigneeManager(BaseManager):
             ).delete()
             logger.info(
                 "groupassignee.remove",
-                extra={"group_id": group.id, "team_id": previous_assignee.user_id},
+                extra={"group_id": group.id, "user_id": previous_assignee.user_id},
             )
 
     def assign(

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -70,10 +70,10 @@ class GroupAssigneeManager(BaseManager):
     def remove_old_assignees(
         self, group: Group, previous_assignee: Optional[GroupAssignee]
     ) -> None:
-        if not (
-            features.has("organizations:participants-purge", group.organization)
-            and previous_assignee
-        ):
+        if not features.has("organizations:participants-purge", group.organization):
+            return
+
+        if not previous_assignee:
             return
 
         if (

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -244,8 +244,6 @@ class ProjectOwnership(Model):
         We combine the schemas from IssueOwners and CodeOwners.
 
         """
-        from django.db.models import Q
-
         from sentry import analytics
         from sentry.models.activity import ActivityIntegration
         from sentry.models.groupassignee import GroupAssignee
@@ -314,10 +312,13 @@ class ProjectOwnership(Model):
                         },
                     )
                     return
-
-            if not GroupAssignee.objects.filter(
-                Q(user_id=owner.id) | Q(team=owner.id), group=group
-            ).exists():
+            if (
+                isinstance(owner, Team)
+                and not GroupAssignee.objects.filter(group=group, team=owner.id).exists()
+            ) or (
+                isinstance(owner, User)
+                and not GroupAssignee.objects.filter(group=group, user_id=owner.id).exists()
+            ):
                 assignment = GroupAssignee.objects.assign(
                     group,
                     owner,

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -250,6 +250,7 @@ class ProjectOwnership(Model):
         from sentry.models.groupowner import GroupOwner, GroupOwnerType
         from sentry.models.team import Team
         from sentry.models.user import User
+        from sentry.services.hybrid_cloud.user import RpcUser
 
         # If event is passed in, then this is not called from the force auto-assign API, else it is
         force_autoassign = True
@@ -316,7 +317,7 @@ class ProjectOwnership(Model):
                 isinstance(owner, Team)
                 and not GroupAssignee.objects.filter(group=group, team=owner.id).exists()
             ) or (
-                isinstance(owner, User)
+                isinstance(owner, RpcUser)
                 and not GroupAssignee.objects.filter(group=group, user_id=owner.id).exists()
             ):
                 assignment = GroupAssignee.objects.assign(

--- a/src/sentry/testutils/helpers/slack.py
+++ b/src/sentry/testutils/helpers/slack.py
@@ -97,6 +97,16 @@ def send_notification(provider, *args_list):
         send_notification_as_slack(*args_list, {})
 
 
+def get_channel(index=0):
+    """Get the channel ID the Slack message went to"""
+    assert len(responses.calls) >= 1
+    data = parse_qs(responses.calls[index].request.body)
+    assert "channel" in data
+    channel = json.loads(data["channel"][0])
+
+    return channel
+
+
 def get_attachment(index=0):
     assert len(responses.calls) >= 1
     data = parse_qs(responses.calls[index].request.body)

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -581,17 +581,17 @@ class TestHandleAssignedTo(TestCase):
         )
 
     @patch("sentry.analytics.record")
+    @with_feature("organizations:participants-purge")
     def test_unassign_user_with_feature_flag(self, mock_record: Mock) -> None:
         # first assign the issue
-        with self.feature("organizations:participants-purge"):
-            assigned_to = handle_assigned_to(
-                ActorTuple.from_actor_identifier(self.user.id),
-                None,
-                None,
-                self.group_list,
-                self.project_lookup,
-                self.user,
-            )
+        assigned_to = handle_assigned_to(
+            ActorTuple.from_actor_identifier(self.user.id),
+            None,
+            None,
+            self.group_list,
+            self.project_lookup,
+            self.user,
+        )
 
         assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
         assert GroupSubscription.objects.filter(
@@ -602,10 +602,9 @@ class TestHandleAssignedTo(TestCase):
         ).exists()
 
         # then unassign it
-        with self.feature("organizations:participants-purge"):
-            assigned_to = handle_assigned_to(
-                None, None, None, self.group_list, self.project_lookup, self.user
-            )
+        assigned_to = handle_assigned_to(
+            None, None, None, self.group_list, self.project_lookup, self.user
+        )
 
         assert not GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
         assert not GroupSubscription.objects.filter(
@@ -626,6 +625,7 @@ class TestHandleAssignedTo(TestCase):
         )
 
     @patch("sentry.analytics.record")
+    @with_feature("organizations:participants-purge")
     def test_unassign_team_with_feature_flag(self, mock_record: Mock) -> None:
         user1 = self.create_user("foo@example.com")
         user2 = self.create_user("bar@example.com")
@@ -636,15 +636,14 @@ class TestHandleAssignedTo(TestCase):
         self.create_team_membership(team1, member2, role="admin")
 
         # first assign the issue to team1
-        with self.feature("organizations:participants-purge"):
-            assigned_to = handle_assigned_to(
-                (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
-                None,
-                None,
-                self.group_list,
-                self.project_lookup,
-                self.user,
-            )
+        assigned_to = handle_assigned_to(
+            (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
+            None,
+            None,
+            self.group_list,
+            self.project_lookup,
+            self.user,
+        )
 
         assert GroupAssignee.objects.filter(group=self.group, team_id=team1.id).exists()
         assert GroupSubscription.objects.filter(
@@ -661,10 +660,9 @@ class TestHandleAssignedTo(TestCase):
         ).exists()
 
         # then unassign it
-        with self.feature("organizations:participants-purge"):
-            assigned_to = handle_assigned_to(
-                None, None, None, self.group_list, self.project_lookup, self.user
-            )
+        assigned_to = handle_assigned_to(
+            None, None, None, self.group_list, self.project_lookup, self.user
+        )
 
         assert not GroupAssignee.objects.filter(group=self.group, team_id=team1.id).exists()
         assert not GroupSubscription.objects.filter(
@@ -691,6 +689,8 @@ class TestHandleAssignedTo(TestCase):
         )
 
     @patch("sentry.analytics.record")
+    @with_feature("organizations:participants-purge")
+    @with_feature("organizations:team-workflow-notifications")
     def test_unassign_team_with_both_feature_flags(self, mock_record: Mock) -> None:
         user1 = self.create_user("foo@example.com")
         user2 = self.create_user("bar@example.com")
@@ -701,17 +701,14 @@ class TestHandleAssignedTo(TestCase):
         self.create_team_membership(team1, member2, role="admin")
 
         # first assign the issue to team1
-        with self.feature("organizations:participants-purge"), self.feature(
-            "organizations:team-workflow-notifications"
-        ):
-            assigned_to = handle_assigned_to(
-                (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
-                None,
-                None,
-                self.group_list,
-                self.project_lookup,
-                self.user,
-            )
+        assigned_to = handle_assigned_to(
+            (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
+            None,
+            None,
+            self.group_list,
+            self.project_lookup,
+            self.user,
+        )
 
         assert GroupAssignee.objects.filter(group=self.group, team_id=team1.id).exists()
         assert GroupSubscription.objects.filter(
@@ -722,12 +719,9 @@ class TestHandleAssignedTo(TestCase):
         ).exists()
 
         # then unassign it
-        with self.feature("organizations:participants-purge"), self.feature(
-            "organizations:team-workflow-notifications"
-        ):
-            assigned_to = handle_assigned_to(
-                None, None, None, self.group_list, self.project_lookup, self.user
-            )
+        assigned_to = handle_assigned_to(
+            None, None, None, self.group_list, self.project_lookup, self.user
+        )
 
         assert not GroupAssignee.objects.filter(group=self.group, team_id=team1.id).exists()
         assert not GroupSubscription.objects.filter(
@@ -811,6 +805,7 @@ class TestHandleAssignedTo(TestCase):
         )
 
     @patch("sentry.analytics.record")
+    @with_feature("organizations:participants-purge")
     def test_reassign_team(self, mock_record: Mock) -> None:
         user1 = self.create_user("foo@example.com")
         user2 = self.create_user("bar@example.com")
@@ -829,15 +824,14 @@ class TestHandleAssignedTo(TestCase):
         self.create_team_membership(team2, member4, role="admin")
 
         # first assign the issue to team1
-        with self.feature("organizations:participants-purge"):
-            assigned_to = handle_assigned_to(
-                (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
-                None,
-                None,
-                self.group_list,
-                self.project_lookup,
-                self.user,
-            )
+        assigned_to = handle_assigned_to(
+            (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
+            None,
+            None,
+            self.group_list,
+            self.project_lookup,
+            self.user,
+        )
 
         assert GroupAssignee.objects.filter(group=self.group, team=team1.id).exists()
         assert GroupSubscription.objects.filter(
@@ -854,15 +848,14 @@ class TestHandleAssignedTo(TestCase):
         ).exists()
 
         # then assign it to team2
-        with self.feature("organizations:participants-purge"):
-            assigned_to = handle_assigned_to(
-                ActorTuple.from_actor_identifier(f"team:{team2.id}"),
-                None,
-                None,
-                self.group_list,
-                self.project_lookup,
-                self.user,
-            )
+        assigned_to = handle_assigned_to(
+            ActorTuple.from_actor_identifier(f"team:{team2.id}"),
+            None,
+            None,
+            self.group_list,
+            self.project_lookup,
+            self.user,
+        )
 
         assert not GroupAssignee.objects.filter(group=self.group, team=team1.id).exists()
         assert not GroupSubscription.objects.filter(
@@ -907,6 +900,8 @@ class TestHandleAssignedTo(TestCase):
         )
 
     @patch("sentry.analytics.record")
+    @with_feature("organizations:participants-purge")
+    @with_feature("organizations:team-workflow-notifications")
     def test_reassign_team_with_both_flags(self, mock_record: Mock) -> None:
         user1 = self.create_user("foo@example.com")
         user2 = self.create_user("bar@example.com")
@@ -925,15 +920,14 @@ class TestHandleAssignedTo(TestCase):
         self.create_team_membership(team2, member4, role="admin")
 
         # first assign the issue to team1
-        with self.feature("organizations:team-workflow-notifications"):
-            assigned_to = handle_assigned_to(
-                (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
-                None,
-                None,
-                self.group_list,
-                self.project_lookup,
-                self.user,
-            )
+        assigned_to = handle_assigned_to(
+            (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
+            None,
+            None,
+            self.group_list,
+            self.project_lookup,
+            self.user,
+        )
 
         assert GroupAssignee.objects.filter(group=self.group, team=team1.id).exists()
         assert GroupSubscription.objects.filter(
@@ -944,17 +938,14 @@ class TestHandleAssignedTo(TestCase):
         ).exists()
 
         # then assign it to team2
-        with self.feature("organizations:participants-purge"), self.feature(
-            "organizations:team-workflow-notifications"
-        ):
-            assigned_to = handle_assigned_to(
-                ActorTuple.from_actor_identifier(f"team:{team2.id}"),
-                None,
-                None,
-                self.group_list,
-                self.project_lookup,
-                self.user,
-            )
+        assigned_to = handle_assigned_to(
+            ActorTuple.from_actor_identifier(f"team:{team2.id}"),
+            None,
+            None,
+            self.group_list,
+            self.project_lookup,
+            self.user,
+        )
 
         assert not GroupAssignee.objects.filter(group=self.group, team=team1.id).exists()
         assert not GroupSubscription.objects.filter(

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -581,16 +581,17 @@ class TestHandleAssignedTo(TestCase):
         )
 
     @patch("sentry.analytics.record")
-    def test_unassign_with_feature_flag(self, mock_record: Mock) -> None:
+    def test_unassign_user_with_feature_flag(self, mock_record: Mock) -> None:
         # first assign the issue
-        assigned_to = handle_assigned_to(
-            ActorTuple.from_actor_identifier(self.user.id),
-            None,
-            None,
-            self.group_list,
-            self.project_lookup,
-            self.user,
-        )
+        with self.feature("organizations:participants-purge"):
+            assigned_to = handle_assigned_to(
+                ActorTuple.from_actor_identifier(self.user.id),
+                None,
+                None,
+                self.group_list,
+                self.project_lookup,
+                self.user,
+            )
 
         assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
         assert GroupSubscription.objects.filter(
@@ -611,6 +612,128 @@ class TestHandleAssignedTo(TestCase):
             group=self.group,
             project=self.group.project,
             user_id=self.user.id,
+            reason=GroupSubscriptionReason.assigned,
+        ).exists()
+
+        assert assigned_to is None
+        mock_record.assert_called_with(
+            "manual.issue_assignment",
+            group_id=self.group.id,
+            organization_id=self.group.project.organization_id,
+            project_id=self.group.project_id,
+            assigned_by=None,
+            had_to_deassign=True,
+        )
+
+    @patch("sentry.analytics.record")
+    def test_unassign_team_with_feature_flag(self, mock_record: Mock) -> None:
+        user1 = self.create_user("foo@example.com")
+        user2 = self.create_user("bar@example.com")
+        team1 = self.create_team()
+        member1 = self.create_member(user=user1, organization=self.organization, role="member")
+        member2 = self.create_member(user=user2, organization=self.organization, role="member")
+        self.create_team_membership(team1, member1, role="admin")
+        self.create_team_membership(team1, member2, role="admin")
+
+        # first assign the issue to team1
+        with self.feature("organizations:participants-purge"):
+            assigned_to = handle_assigned_to(
+                (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
+                None,
+                None,
+                self.group_list,
+                self.project_lookup,
+                self.user,
+            )
+
+        assert GroupAssignee.objects.filter(group=self.group, team_id=team1.id).exists()
+        assert GroupSubscription.objects.filter(
+            group=self.group,
+            project=self.group.project,
+            user_id=user1.id,
+            reason=GroupSubscriptionReason.assigned,
+        ).exists()
+        assert GroupSubscription.objects.filter(
+            group=self.group,
+            project=self.group.project,
+            user_id=user2.id,
+            reason=GroupSubscriptionReason.assigned,
+        ).exists()
+
+        # then unassign it
+        with self.feature("organizations:participants-purge"):
+            assigned_to = handle_assigned_to(
+                None, None, None, self.group_list, self.project_lookup, self.user
+            )
+
+        assert not GroupAssignee.objects.filter(group=self.group, team_id=team1.id).exists()
+        assert not GroupSubscription.objects.filter(
+            group=self.group,
+            project=self.group.project,
+            user_id=user1.id,
+            reason=GroupSubscriptionReason.assigned,
+        ).exists()
+        assert not GroupSubscription.objects.filter(
+            group=self.group,
+            project=self.group.project,
+            user_id=user2.id,
+            reason=GroupSubscriptionReason.assigned,
+        ).exists()
+
+        assert assigned_to is None
+        mock_record.assert_called_with(
+            "manual.issue_assignment",
+            group_id=self.group.id,
+            organization_id=self.group.project.organization_id,
+            project_id=self.group.project_id,
+            assigned_by=None,
+            had_to_deassign=True,
+        )
+
+    @patch("sentry.analytics.record")
+    def test_unassign_team_with_both_feature_flags(self, mock_record: Mock) -> None:
+        user1 = self.create_user("foo@example.com")
+        user2 = self.create_user("bar@example.com")
+        team1 = self.create_team()
+        member1 = self.create_member(user=user1, organization=self.organization, role="member")
+        member2 = self.create_member(user=user2, organization=self.organization, role="member")
+        self.create_team_membership(team1, member1, role="admin")
+        self.create_team_membership(team1, member2, role="admin")
+
+        # first assign the issue to team1
+        with self.feature("organizations:participants-purge"), self.feature(
+            "organizations:team-workflow-notifications"
+        ):
+            assigned_to = handle_assigned_to(
+                (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
+                None,
+                None,
+                self.group_list,
+                self.project_lookup,
+                self.user,
+            )
+
+        assert GroupAssignee.objects.filter(group=self.group, team_id=team1.id).exists()
+        assert GroupSubscription.objects.filter(
+            group=self.group,
+            project=self.group.project,
+            team_id=team1.id,
+            reason=GroupSubscriptionReason.assigned,
+        ).exists()
+
+        # then unassign it
+        with self.feature("organizations:participants-purge"), self.feature(
+            "organizations:team-workflow-notifications"
+        ):
+            assigned_to = handle_assigned_to(
+                None, None, None, self.group_list, self.project_lookup, self.user
+            )
+
+        assert not GroupAssignee.objects.filter(group=self.group, team_id=team1.id).exists()
+        assert not GroupSubscription.objects.filter(
+            group=self.group,
+            project=self.group.project,
+            user_id=team1.id,
             reason=GroupSubscriptionReason.assigned,
         ).exists()
 
@@ -684,7 +807,7 @@ class TestHandleAssignedTo(TestCase):
             organization_id=self.group.project.organization_id,
             project_id=self.group.project_id,
             assigned_by=None,
-            had_to_deassign=False,
+            had_to_deassign=True,
         )
 
     @patch("sentry.analytics.record")
@@ -706,14 +829,15 @@ class TestHandleAssignedTo(TestCase):
         self.create_team_membership(team2, member4, role="admin")
 
         # first assign the issue to team1
-        assigned_to = handle_assigned_to(
-            (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
-            None,
-            None,
-            self.group_list,
-            self.project_lookup,
-            self.user,
-        )
+        with self.feature("organizations:participants-purge"):
+            assigned_to = handle_assigned_to(
+                (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
+                None,
+                None,
+                self.group_list,
+                self.project_lookup,
+                self.user,
+            )
 
         assert GroupAssignee.objects.filter(group=self.group, team=team1.id).exists()
         assert GroupSubscription.objects.filter(
@@ -779,7 +903,7 @@ class TestHandleAssignedTo(TestCase):
             organization_id=self.group.project.organization_id,
             project_id=self.group.project_id,
             assigned_by=None,
-            had_to_deassign=False,
+            had_to_deassign=True,
         )
 
     @patch("sentry.analytics.record")
@@ -859,5 +983,5 @@ class TestHandleAssignedTo(TestCase):
             organization_id=self.group.project.organization_id,
             project_id=self.group.project_id,
             assigned_by=None,
-            had_to_deassign=False,
+            had_to_deassign=True,
         )

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from sentry.models.actor import ActorTuple
 from sentry.models.avatars.user_avatar import UserAvatar
 from sentry.models.groupassignee import GroupAssignee
@@ -404,6 +406,39 @@ class ProjectOwnershipTestCase(TestCase):
         assert len(GroupAssignee.objects.all()) == 1
         assignee = GroupAssignee.objects.get(group=self.event.group)
         assert assignee.user_id == self.user.id
+
+    @patch("sentry.models.GroupAssignee.objects.assign")
+    def test_handle_skip_auto_assignment_same_assignee(self, mock_assign):
+        """Test that if an issue has already been assigned, we skip the assignment
+        on a future event with auto-assignment if the assignee won't change.
+        """
+        self.code_mapping = self.create_code_mapping(project=self.project)
+
+        rule_c = Rule(Matcher("path", "*.py"), [Owner("team", self.team.slug)])
+
+        self.create_codeowners(
+            self.project, self.code_mapping, raw="*.py @tiger-team", schema=dump_schema([rule_c])
+        )
+
+        self.event = self.store_event(
+            data=self.python_event_data(),
+            project_id=self.project.id,
+        )
+
+        GroupOwner.objects.create(
+            group=self.event.group,
+            type=GroupOwnerType.CODEOWNERS.value,
+            user_id=None,
+            team_id=self.team.id,
+            project=self.project,
+            organization=self.project.organization,
+            context={"rule": str(rule_c)},
+        )
+        GroupAssignee.objects.create(group=self.event.group, project=self.project, team=self.team)
+
+        # ensure we skip calling assign
+        ProjectOwnership.handle_auto_assignment(self.project.id, self.event)
+        mock_assign.assert_not_called()
 
     def test_handle_auto_assignment_when_codeowners_and_issueowners_exists(self):
         self.code_mapping = self.create_code_mapping(project=self.project2)


### PR DESCRIPTION
Re-revert of https://github.com/getsentry/sentry/pull/58544 that moves `remove_old_assignees` into the `if affected` block so it only runs if something with assignment changes, and also checks if the auto assign from codeowners is the same as the existing assignee before calling `GroupAssignee.assign`. 

I had also noticed that the team re-assignment notifications weren't sending, 
but I tested locally again after fixing the aforementioned problems and they appear to be sending now (I am in the `#sentry` team and not the `#snuba` team and have workflow notifications on for only subscribed issues):
<img width="452" alt="Screenshot 2023-10-24 at 10 56 12 AM" src="https://github.com/getsentry/sentry/assets/29959063/1c9f1ae8-b86d-4bc2-97c1-cd1613884fb6">

