### PR TITLE
ref(bug reports): display url in feedback details

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -122,7 +122,7 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
 
         <Section icon={<IconLink size="xs" />} title={t('Url')}>
           <ErrorBoundary mini>
-            <TextCopyInput size="sm">{url?.value ?? 'URL not found'}</TextCopyInput>
+            <TextCopyInput size="sm">{url?.value ?? t('URL not found')}</TextCopyInput>
           </ErrorBoundary>
         </Section>
 

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -28,6 +28,7 @@ interface Props {
 
 export default function FeedbackItem({feedbackItem, eventData}: Props) {
   const organization = useOrganization();
+  const url = eventData?.tags.find(tag => tag.key === 'url');
 
   return (
     <Fragment>
@@ -121,7 +122,7 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
 
         <Section icon={<IconLink size="xs" />} title={t('Url')}>
           <ErrorBoundary mini>
-            <TextCopyInput size="sm">{'TODO'}</TextCopyInput>
+            <TextCopyInput size="sm">{url?.value ?? 'URL not found'}</TextCopyInput>
           </ErrorBoundary>
         </Section>
 


### PR DESCRIPTION
Now that we have event tags, we can display the url if it exists. 

<img width="766" alt="SCR-20231023-nmlv" src="https://github.com/getsentry/sentry/assets/56095982/b217ff02-ea41-49d7-abd1-ae022742869b">
