### PR TITLE
ref(replays): accessible rage/dead click/error count colors

### DIFF
--- a/static/app/components/replays/header/errorCounts.tsx
+++ b/static/app/components/replays/header/errorCounts.tsx
@@ -102,7 +102,7 @@ const Count = styled('span')`
 `;
 
 const ErrorCount = styled(Count)`
-  color: ${p => p.theme.red400};
+  color: ${p => p.theme.gray300};
 `;
 
 const ColumnTooltipContent = styled(CountTooltipContent)`

--- a/static/app/components/replays/header/replayMetaData.tsx
+++ b/static/app/components/replays/header/replayMetaData.tsx
@@ -58,8 +58,8 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
       <KeyMetricData>
         {replayRecord?.count_dead_clicks ? (
           <Link to={breadcrumbTab}>
-            <ClickCount color="yellow300">
-              <IconCursorArrow size="sm" />
+            <ClickCount color="gray300">
+              <IconCursorArrow size="sm" color="yellow300" />
               {replayRecord.count_dead_clicks}
             </ClickCount>
           </Link>
@@ -71,9 +71,9 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
       <KeyMetricLabel>{t('Rage Clicks')}</KeyMetricLabel>
       <KeyMetricData>
         {replayRecord?.count_rage_clicks ? (
-          <Link to={breadcrumbTab} color="red300">
-            <ClickCount color="red300">
-              <IconCursorArrow size="sm" />
+          <Link to={breadcrumbTab}>
+            <ClickCount color="gray300">
+              <IconCursorArrow size="sm" color="red300" />
               {replayRecord.count_rage_clicks}
             </ClickCount>
           </Link>

--- a/static/app/components/replays/header/replayMetaData.tsx
+++ b/static/app/components/replays/header/replayMetaData.tsx
@@ -10,7 +10,6 @@ import {space} from 'sentry/styles/space';
 import EventView from 'sentry/utils/discover/eventView';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
-import {ColorOrAlias} from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import type {ReplayError, ReplayRecord} from 'sentry/views/replays/types';
@@ -58,7 +57,7 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
       <KeyMetricData>
         {replayRecord?.count_dead_clicks ? (
           <Link to={breadcrumbTab}>
-            <ClickCount color="gray300">
+            <ClickCount>
               <IconCursorArrow size="sm" color="yellow300" />
               {replayRecord.count_dead_clicks}
             </ClickCount>
@@ -72,7 +71,7 @@ function ReplayMetaData({replayErrors, replayRecord}: Props) {
       <KeyMetricData>
         {replayRecord?.count_rage_clicks ? (
           <Link to={breadcrumbTab}>
-            <ClickCount color="gray300">
+            <ClickCount>
               <IconCursorArrow size="sm" color="red300" />
               {replayRecord.count_rage_clicks}
             </ClickCount>
@@ -127,8 +126,8 @@ const Count = styled('span')`
   font-variant-numeric: tabular-nums;
 `;
 
-const ClickCount = styled(Count)<{color: ColorOrAlias}>`
-  color: ${p => p.theme[p.color]};
+const ClickCount = styled(Count)`
+  color: ${p => p.theme.gray300};
   display: flex;
   gap: ${space(0.75)};
   align-items: center;

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -107,9 +107,7 @@ function AccordionWidget({
   return (
     <StyledWidgetContainer>
       <StyledHeaderContainer>
-        <ClickColor color={clickColor}>
-          <IconCursorArrow />
-        </ClickColor>
+        <IconCursorArrow color={clickColor} />
         {header}
       </StyledHeaderContainer>
       {isLoading ? (
@@ -187,8 +185,8 @@ function AccordionItemHeader({
   selectorQuery: string;
 }) {
   const clickCount = (
-    <ClickColor color={clickColor}>
-      <IconCursorArrow size="xs" />
+    <ClickColor>
+      <IconCursorArrow size="xs" color={clickColor} />
       {count}
     </ClickColor>
   );
@@ -248,8 +246,8 @@ const SplitCardContainer = styled('div')`
   align-items: stretch;
 `;
 
-const ClickColor = styled(TextOverflow)<{color: ColorOrAlias}>`
-  color: ${p => p.theme[p.color]};
+const ClickColor = styled(TextOverflow)`
+  color: ${p => p.theme.gray400};
   display: grid;
   grid-template-columns: auto auto;
   gap: ${space(0.75)};

--- a/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/deadRageClick/deadRageSelectorCards.tsx
@@ -185,10 +185,10 @@ function AccordionItemHeader({
   selectorQuery: string;
 }) {
   const clickCount = (
-    <ClickColor>
+    <ClickCount>
       <IconCursorArrow size="xs" color={clickColor} />
       {count}
-    </ClickColor>
+    </ClickCount>
   );
   return (
     <StyledAccordionHeader>
@@ -246,7 +246,7 @@ const SplitCardContainer = styled('div')`
   align-items: stretch;
 `;
 
-const ClickColor = styled(TextOverflow)`
+const ClickCount = styled(TextOverflow)`
   color: ${p => p.theme.gray400};
   display: grid;
   grid-template-columns: auto auto;

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -14,7 +14,6 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconCursorArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {ColorOrAlias} from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -269,15 +268,15 @@ function renderClickCount<T>(column: GridColumnOrder<string>, dataRow: T) {
   const color = column.key === 'count_dead_clicks' ? 'yellow300' : 'red300';
 
   return (
-    <ClickColor color={color}>
-      <IconCursorArrow size="xs" />
+    <ClickColor>
+      <IconCursorArrow size="xs" color={color} />
       {dataRow[column.key]}
     </ClickColor>
   );
 }
 
-const ClickColor = styled(TextOverflow)<{color: ColorOrAlias}>`
-  color: ${p => p.theme[p.color]};
+const ClickColor = styled(TextOverflow)`
+  color: ${p => p.theme.gray400};
   display: grid;
   grid-template-columns: auto auto;
   gap: ${space(0.75)};

--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -268,14 +268,14 @@ function renderClickCount<T>(column: GridColumnOrder<string>, dataRow: T) {
   const color = column.key === 'count_dead_clicks' ? 'yellow300' : 'red300';
 
   return (
-    <ClickColor>
+    <ClickCount>
       <IconCursorArrow size="xs" color={color} />
       {dataRow[column.key]}
-    </ClickColor>
+    </ClickCount>
   );
 }
 
-const ClickColor = styled(TextOverflow)`
+const ClickCount = styled(TextOverflow)`
   color: ${p => p.theme.gray400};
   display: grid;
   grid-template-columns: auto auto;

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -589,7 +589,7 @@ export function ErrorCountCell({replay, showDropdownFilters}: Props) {
       <Container>
         {replay.count_errors ? (
           <ErrorCount>
-            <IconFire />
+            <IconFire color="red300" />
             {replay.count_errors}
           </ErrorCount>
         ) : (
@@ -665,7 +665,6 @@ const ErrorCount = styled(Count)`
   display: flex;
   align-items: center;
   gap: ${space(0.5)};
-  color: ${p => p.theme.red400};
 `;
 
 const Time = styled('span')`

--- a/static/app/views/replays/replayTable/tableCell.tsx
+++ b/static/app/views/replays/replayTable/tableCell.tsx
@@ -537,7 +537,7 @@ export function RageClickCountCell({replay, showDropdownFilters}: Props) {
       <Container>
         {replay.count_rage_clicks ? (
           <RageClickCount>
-            <IconCursorArrow size="sm" />
+            <IconCursorArrow size="sm" color="red300" />
             {replay.count_rage_clicks}
           </RageClickCount>
         ) : (
@@ -563,7 +563,7 @@ export function DeadClickCountCell({replay, showDropdownFilters}: Props) {
       <Container>
         {replay.count_dead_clicks ? (
           <DeadClickCount>
-            <IconCursorArrow size="sm" />
+            <IconCursorArrow size="sm" color="yellow300" />
             {replay.count_dead_clicks}
           </DeadClickCount>
         ) : (
@@ -653,14 +653,12 @@ const DeadClickCount = styled(Count)`
   display: flex;
   width: 40px;
   gap: ${space(0.5)};
-  color: ${p => p.theme.yellow300};
 `;
 
 const RageClickCount = styled(Count)`
   display: flex;
   width: 40px;
   gap: ${space(0.5)};
-  color: ${p => p.theme.red300};
 `;
 
 const ErrorCount = styled(Count)`


### PR DESCRIPTION
the click counts are now gray/black rather than red/yellow.

before:
<img width="505" alt="SCR-20231023-mjvk" src="https://github.com/getsentry/sentry/assets/56095982/e4ea5b03-e6e2-45af-ad9a-78308260bd18">

<img width="216" alt="SCR-20231023-mjxu" src="https://github.com/getsentry/sentry/assets/56095982/a3e26de4-8edb-4973-bd79-bcf390880d89">




after:

<img width="260" alt="SCR-20231023-nqjm" src="https://github.com/getsentry/sentry/assets/56095982/f84b9598-27e9-445e-95e0-52e522ee54a0">

<img width="1162" alt="SCR-20231023-nqci" src="https://github.com/getsentry/sentry/assets/56095982/d41cdbf3-2e04-4ee6-ab31-b83baf7c5775">

<img width="323" alt="SCR-20231024-ipps" src="https://github.com/getsentry/sentry/assets/56095982/41bd2e1d-a846-46e2-805e-cd0bcafb71bc">

<img width="267" alt="SCR-20231024-iqdc" src="https://github.com/getsentry/sentry/assets/56095982/d2880734-5c26-463f-a240-108db89748a7">


<!-- Describe your PR here. -->