### PR TITLE
auth: ratelimit GET requests on /auth/login

### DIFF
--- a/src/sentry/api/endpoints/auth_login.py
+++ b/src/sentry/api/endpoints/auth_login.py
@@ -10,6 +10,7 @@ from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.user import DetailedSelfUserSerializer
 from sentry.models.organization import Organization
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import auth, metrics
 from sentry.utils.hashlib import md5_text
 from sentry.web.forms.accounts import AuthenticationForm
@@ -24,6 +25,12 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
     owner = ApiOwner.ENTERPRISE
     # Disable authentication and permission requirements.
     permission_classes = []
+    enforce_rate_limit = True
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(20, 1),  # 20 GET requests per second per IP
+        }
+    }
 
     def dispatch(self, request: Request, *args, **kwargs) -> Response:
         self.determine_active_organization(request)

--- a/src/sentry/api/endpoints/auth_login.py
+++ b/src/sentry/api/endpoints/auth_login.py
@@ -10,7 +10,6 @@ from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.user import DetailedSelfUserSerializer
 from sentry.models.organization import Organization
-from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import auth, metrics
 from sentry.utils.hashlib import md5_text
 from sentry.web.forms.accounts import AuthenticationForm
@@ -25,12 +24,6 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
     owner = ApiOwner.ENTERPRISE
     # Disable authentication and permission requirements.
     permission_classes = []
-    enforce_rate_limit = True
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(20, 1),  # 20 GET requests per second per IP
-        }
-    }
 
     def dispatch(self, request: Request, *args, **kwargs) -> Response:
         self.determine_active_organization(request)

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -26,6 +26,7 @@ from sentry.models.user import User
 from sentry.services.hybrid_cloud import coerce_id_from
 from sentry.services.hybrid_cloud.organization import RpcOrganization, organization_service
 from sentry.signals import join_request_link_viewed, user_signup
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import auth, json, metrics
 from sentry.utils.auth import (
     construct_link_with_query,
@@ -76,6 +77,13 @@ additional_context = AdditionalContext()
 @control_silo_view
 class AuthLoginView(BaseView):
     auth_required = False
+
+    enforce_rate_limit = True
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(20, 1),  # 20 GET requests per second per IP
+        }
+    }
 
     @method_decorator(never_cache)
     def handle(self, request: Request, *args, **kwargs) -> HttpResponse:

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -20,6 +20,7 @@ from sentry.models.user import User
 from sentry.receivers import create_default_projects
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -70,6 +71,16 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
         assert resp.context["login_form"].errors["__all__"] == [
             "Please enter a correct username and password. Note that both fields may be case-sensitive."
         ]
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    def test_login_ratelimited_ip_gets(self):
+        url = reverse("sentry-login")
+
+        with freeze_time("2000-01-01"):
+            for _ in range(25):
+                self.client.get(url)
+            resp = self.client.get(url)
+            assert resp.status_code == 429
 
     def test_login_ratelimited_user(self):
         self.client.get(self.path)


### PR DESCRIPTION
This path has seen the occasional large amount of GET requests that cause impact to the system. Adding a ratelimit here should reduce load on the system by handling the request in the middleware and short-circuiting any further request processing. 