### PR TITLE
ref(issues): Write user and team ids to alert rules

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -545,6 +545,8 @@ def create_alert_rule(
             include_all_projects=include_all_projects,
             owner=actor,
             comparison_delta=comparison_delta,
+            user_id=actor.user_id if actor else None,
+            team_id=actor.team_id if actor else None,
         )
 
         if user:
@@ -702,6 +704,8 @@ def update_alert_rule(
         if owner is not None and not isinstance(owner, Actor):
             owner = owner.resolve_to_actor()
         updated_fields["owner"] = owner
+        updated_fields["team_id"] = owner.team_id
+        updated_fields["user_id"] = owner.user_id
     if comparison_delta is not NOT_SET:
         resolution = DEFAULT_ALERT_RULE_RESOLUTION
         if comparison_delta is not None:

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -704,8 +704,8 @@ def update_alert_rule(
         if owner is not None and not isinstance(owner, Actor):
             owner = owner.resolve_to_actor()
         updated_fields["owner"] = owner
-        updated_fields["team_id"] = owner.team_id
-        updated_fields["user_id"] = owner.user_id
+        updated_fields["team_id"] = owner.team_id if owner else None
+        updated_fields["user_id"] = owner.user_id if owner else None
     if comparison_delta is not NOT_SET:
         resolution = DEFAULT_ALERT_RULE_RESOLUTION
         if comparison_delta is not None:

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import namedtuple
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 from uuid import uuid4
 
 from django.conf import settings
@@ -457,6 +457,11 @@ class AlertRule(Model):
         default_manager_name = "objects_with_snapshots"
 
     __repr__ = sane_repr("id", "name", "date_added")
+
+    def save(self, **kwargs: Any) -> None:
+        if self.owner_id is not None and self.team_id is None and self.user_id is None:
+            raise ValueError("AlertRule with owner requires either team_id or user_id")
+        return super().save(**kwargs)
 
     @property
     def created_by_id(self):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -1223,6 +1223,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
         )
         other_alert_rule = self.create_alert_rule(projects=[other_project])
         other_alert_rule.owner = other_team.actor
+        other_alert_rule.team_id = other_team.id
         other_alert_rule.save()
 
         with self.feature("organizations:incidents"):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -1212,6 +1212,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
         project = self.create_project(name="boo", organization=self.organization, teams=[team])
         alert_rule = self.create_alert_rule(projects=[project])
         alert_rule.owner = team.actor
+        alert_rule.team_id = team.id
         alert_rule.save()
 
         other_user = self.create_user()


### PR DESCRIPTION
Next step for removing Actor from `AlertRule` model.  Follow up will be a backfill migration to fill user and team ids on existing rows.