### PR TITLE
ref(bug reports): BE feature flag for old user feedback in sidebar

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1796,6 +1796,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:user-feedback-ingest": False,
     # Enable User Feedback v2 UI
     "organizations:user-feedback-ui": False,
+    # Enable User Feedback v1
+    "organizations:old-user-feedback": False,
     # Adds additional filters and a new section to issue alert rules.
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -230,6 +230,7 @@ default_manager.add("organizations:transaction-metrics-extraction", Organization
 default_manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:user-feedback-ingest", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:user-feedback-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:old-user-feedback", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:widget-viewer-modal-minimap", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:u2f-superuser-form", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:api-auth-provider", OrganizationFeature, FeatureHandlerStrategy.REMOTE)


### PR DESCRIPTION
this flag will be used to show the User Feedback button on the sidebar for everyone EXCEPT the sentry-test org

on flagr `organizations:old-user-feedback`: https://flagr.getsentry.net/#/flags/491

<img width="1198" alt="SCR-20231023-oowm" src="https://github.com/getsentry/sentry/assets/56095982/791ef604-f05d-4f5c-9d75-d49fb8538473">
