### PR TITLE
ref(bug reports): hide old user feedback on sidebar for sentry-test

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -347,13 +347,15 @@ function Sidebar({location, organization}: Props) {
   );
 
   const userFeedback = hasOrganization && (
-    <SidebarItem
-      {...sidebarItemProps}
-      icon={<IconSupport />}
-      label={t('User Feedback')}
-      to={`/organizations/${organization.slug}/user-feedback/`}
-      id="user-feedback"
-    />
+    <Feature features={['old-user-feedback']} organization={organization}>
+      <SidebarItem
+        {...sidebarItemProps}
+        icon={<IconSupport />}
+        label={t('User Feedback')}
+        to={`/organizations/${organization.slug}/user-feedback/`}
+        id="user-feedback"
+      />
+    </Feature>
   );
 
   const feedback = hasOrganization && (


### PR DESCRIPTION
For demo purposes, this flag is enabled for everyone EXCEPT sentry-test
<img width="1195" alt="SCR-20231023-oqtw" src="https://github.com/getsentry/sentry/assets/56095982/060367b6-c592-4305-8581-3edb876897e1">

<img width="216" alt="SCR-20231023-oqjh" src="https://github.com/getsentry/sentry/assets/56095982/5ad60a39-721a-45fc-a46a-28473695507d">
