### PR TITLE
fix(provisioning): user id instead of email for partner user

### DIFF
--- a/src/sentry/services/hybrid_cloud/app/impl.py
+++ b/src/sentry/services/hybrid_cloud/app/impl.py
@@ -232,12 +232,19 @@ class DatabaseBackedAppService(AppService):
         self,
         *,
         organization_id: int,
+        # TODO @athena: deprecate after landing integration_creator_id changes
         integration_creator: str,
         integration_name: str,
         integration_scopes: List[str],
+        # TODO @athena: make required after getsenry changes
+        integration_creator_id: Optional[int] = None,
     ) -> RpcSentryAppInstallation:
         # if the 'integration' already exists, don't recreate it...
-        admin_user = User.objects.get(email=integration_creator)
+        admin_user = (
+            User.objects.get(id=integration_creator_id)
+            if integration_creator_id
+            else User.objects.get(email=integration_creator)
+        )
 
         sentry_app_query = SentryApp.objects.filter(
             owner_id=organization_id,

--- a/src/sentry/services/hybrid_cloud/app/service.py
+++ b/src/sentry/services/hybrid_cloud/app/service.py
@@ -142,6 +142,7 @@ class AppService(RpcService):
         integration_creator: str,
         integration_name: str,
         integration_scopes: List[str],
+        integration_creator_id: Optional[int],
     ) -> RpcSentryAppInstallation:
         pass
 

--- a/tests/sentry/hybrid_cloud/test_app.py
+++ b/tests/sentry/hybrid_cloud/test_app.py
@@ -1,0 +1,28 @@
+from sentry.models.integrations.sentry_app import SentryApp
+from sentry.services.hybrid_cloud.app import app_service
+from sentry.testutils.factories import Factories
+from sentry.testutils.pytest.fixtures import django_db_all
+
+
+@django_db_all(transaction=True)
+def test_create_internal_integration_for_channel_request():
+    org = Factories.create_organization()
+    integration_creator = Factories.create_user(email="test@sentry.io")
+    app_service.create_internal_integration_for_channel_request(
+        organization_id=org.id,
+        # email is ignored if id is provided during transition time
+        integration_creator="another-test@sentry.io",
+        integration_name="Test Integration",
+        integration_scopes=["prject:read"],
+        integration_creator_id=integration_creator.id,
+    )
+    sentry_app_query = SentryApp.objects.all()
+    assert sentry_app_query.count() == 1
+    app_service.create_internal_integration_for_channel_request(
+        organization_id=org.id,
+        integration_creator="test@sentry.io",
+        integration_name="Test Integration",
+        integration_scopes=["prject:read"],
+    )
+    sentry_app_query = SentryApp.objects.all()
+    assert sentry_app_query.count() == 1


### PR DESCRIPTION
Before we got an email and found the user from that email which is really not necessary. This is one specific user for each partner, let's store user_id instead and get directly to user from id.