### PR TITLE
ref(bug reports): bring back tags in feedback details

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -9,6 +9,7 @@ import Section from 'sentry/components/feedback/feedbackItem/feedbackItemSection
 import FeedbackItemUsername from 'sentry/components/feedback/feedbackItem/feedbackItemUsername';
 import FeedbackViewers from 'sentry/components/feedback/feedbackItem/feedbackViewers';
 import ReplaySection from 'sentry/components/feedback/feedbackItem/replaySection';
+import TagsSection from 'sentry/components/feedback/feedbackItem/tagsSection';
 import ObjectInspector from 'sentry/components/objectInspector';
 import PanelItem from 'sentry/components/panels/panelItem';
 import {Flex} from 'sentry/components/profiling/flex';
@@ -24,9 +25,10 @@ import useOrganization from 'sentry/utils/useOrganization';
 interface Props {
   eventData: Event | undefined;
   feedbackItem: HydratedFeedbackItem;
+  tags: Record<string, string>;
 }
 
-export default function FeedbackItem({feedbackItem, eventData}: Props) {
+export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
   const organization = useOrganization();
 
   return (
@@ -129,7 +131,7 @@ export default function FeedbackItem({feedbackItem, eventData}: Props) {
           <ReplaySection organization={organization} replayId={feedbackItem.replay_id} />
         ) : null}
 
-        {/* <TagsSection tags={feedbackItem.tags} /> */}
+        <TagsSection tags={tags} />
 
         <Section icon={<IconJson size="xs" />} title={t('Raw Issue Data')}>
           <ObjectInspector

--- a/static/app/components/feedback/feedbackItem/feedbackItemLoader.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemLoader.tsx
@@ -17,6 +17,7 @@ export default function FeedbackItemLoader({feedbackSlug}: Props) {
     isLoading: isIssueLoading,
     isError: isIssueError,
     issueData: issue,
+    tags,
     eventData: event,
   } = useFetchFeedbackIssue({feedbackId, organization});
 
@@ -25,6 +26,6 @@ export default function FeedbackItemLoader({feedbackSlug}: Props) {
   ) : isIssueError ? (
     <FeedbackErrorDetails error={t('Unable to load feedback')} />
   ) : (
-    <FeedbackItem feedbackItem={issue} eventData={event} />
+    <FeedbackItem feedbackItem={issue} eventData={event} tags={tags} />
   );
 }

--- a/static/app/components/feedback/hydrateEventTags.tsx
+++ b/static/app/components/feedback/hydrateEventTags.tsx
@@ -1,0 +1,34 @@
+import {Event} from 'sentry/types';
+
+export default function hydrateEventTags(
+  eventData: Event | undefined
+): Record<string, string> {
+  if (!eventData || !eventData.contexts) {
+    return {};
+  }
+  const context = eventData.contexts;
+
+  const unorderedTags = {
+    ...(context.browser?.name ? {'browser.name': context.browser.name} : {}),
+    ...(context.browser?.version ? {'browser.version': context.browser.version} : {}),
+    ...(context.device?.brand ? {'device.brand': context.device?.brand} : {}),
+    ...(context.device?.family ? {'device.family': context.device?.family} : {}),
+    ...(context.device?.model ? {'device.model': context.device?.model} : {}),
+    ...(context.device?.name ? {'device.name': context.device?.name} : {}),
+    ...(context.replay ? {replay: context.replay} : {}),
+    ...(context.os?.name ? {'os.name': context.os?.name} : {}),
+    ...(context.os?.version ? {'os.version': context.os?.version} : {}),
+    ...(eventData.sdk?.name ? {'sdk.name': eventData.sdk?.name} : {}),
+    ...(eventData.sdk?.version ? {'sdk.version': eventData.sdk?.version} : {}),
+  };
+
+  // Sort the tags by key
+  const tags: Record<string, string> = Object.keys(unorderedTags)
+    .sort()
+    .reduce((acc, key) => {
+      acc[key] = unorderedTags[key];
+      return acc;
+    }, {});
+
+  return tags;
+}

--- a/static/app/components/feedback/useFetchFeedbackIssue.tsx
+++ b/static/app/components/feedback/useFetchFeedbackIssue.tsx
@@ -1,3 +1,4 @@
+import hydrateEventTags from 'sentry/components/feedback/hydrateEventTags';
 import hydrateFeedbackRecord from 'sentry/components/feedback/hydrateFeedbackRecord';
 import {Event, Organization} from 'sentry/types';
 import {RawFeedbackItemResponse} from 'sentry/utils/feedback/item/types';
@@ -38,6 +39,7 @@ export default function useFetchFeedbackIssue(
   return {
     issueData: issueData ? hydrateFeedbackRecord(issueData) : undefined,
     eventData,
+    tags: hydrateEventTags(eventData),
     eventResult,
     ...issueResult,
   };


### PR DESCRIPTION
some tags are back! others, like `locale`, `replay,` and `platform`, are unavailable right now though


<img width="692" alt="SCR-20231023-ptwv" src="https://github.com/getsentry/sentry/assets/56095982/7fe879cc-4761-439d-95dd-89569342a421">
