### PR TITLE
feat(metrics): Add dlq to metrics/gen-metrics consumer definitions

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -212,6 +212,9 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
         "static_args": {
             "ingest_profile": "release-health",
         },
+        "dlq_topic": settings.KAFKA_INGEST_METRICS_DLQ,
+        "dlq_max_invalid_ratio": 0.01,
+        "dlq_max_consecutive_count": 1000,
     },
     "ingest-generic-metrics": {
         "topic": settings.KAFKA_INGEST_PERFORMANCE_METRICS,
@@ -220,6 +223,9 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
         "static_args": {
             "ingest_profile": "performance",
         },
+        "dlq_topic": settings.KAFKA_INGEST_GENERIC_METRICS_DLQ,
+        "dlq_max_invalid_ratio": 0.01,
+        "dlq_max_consecutive_count": 1000,
     },
     "generic-metrics-last-seen-updater": {
         "topic": settings.KAFKA_SNUBA_GENERIC_METRICS,


### PR DESCRIPTION
Part of my efforts to add dlq to the sentry metrics consumers, see the final change here:
https://github.com/getsentry/sentry/pull/57998 

Previous PR in the stack:
https://github.com/getsentry/sentry/pull/58675

Next PR in the stack:
https://github.com/getsentry/sentry/pull/58840

### Overview

Add dlq to metrics and generic metrics definitions, this does not enable DLQ, only adds the configuration for it. We need to pass in the `--enable-dlq` flag for it to spin up the producer.

Configures the DLQ to:
- Allow a maximum of 1% invalid messages
- Allow a maximum of 1000 consecutive invalid messages

Crash loop normally otherwise