### PR TITLE
fix(source-map-debugger): Normalize source map reference headers before access

### DIFF
--- a/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
+++ b/src/sentry/api/endpoints/source_map_debug_blue_thunder_edition.py
@@ -498,6 +498,7 @@ class ReleaseLookupData:
                             matching_file, headers = archive.get_file_by_url(
                                 potential_source_file_name
                             )
+                            headers = ArtifactBundleArchive.normalize_headers(headers)
                             self.source_file_lookup_result = "found"
                             self.found_source_file_name = potential_source_file_name
                             sourcemap_header = headers.get("sourcemap", headers.get("x-sourcemap"))

--- a/tests/sentry/api/endpoints/test_source_map_debug_blue_thunder_edition.py
+++ b/tests/sentry/api/endpoints/test_source_map_debug_blue_thunder_edition.py
@@ -924,7 +924,7 @@ class SourceMapDebugBlueThunderEditionEndpointTestCase(APITestCase):
                                     "type": "minified_source",
                                     "headers": {
                                         "content-type": "application/json",
-                                        "sourcemap": "data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibWFpbi5qcy",
+                                        "Sourcemap": "data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibWFpbi5qcy",
                                     },
                                 },
                             },


### PR DESCRIPTION
Potentially fixes a bug where we failed to look up the source map reference because we were looking for the uncapitalized version source map header (`"sourcemap"`) instead of the capitalized one (`"Sourcemap"`).

This PR fixes that by normalizing the headers to the lowercased version before accessing them.