### PR TITLE
feat(ddm): Add support for metric unit in `MetricsBackend`

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1366,7 +1366,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enables transaction to metric dataset migration UI for alert rules
     "organizations:alert-migration-ui": False,
     # Enables the migration of alerts (checked in a migration script).
-    "organizations:alerts-migration-enabled": False,
+    "organizations:alerts-migration-enabled": True,
     # Enables tagging javascript errors from the browser console.
     "organizations:javascript-console-error-tag": False,
     # Enables the cron job to auto-enable codecov integrations.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1366,7 +1366,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enables transaction to metric dataset migration UI for alert rules
     "organizations:alert-migration-ui": False,
     # Enables the migration of alerts (checked in a migration script).
-    "organizations:alerts-migration-enabled": True,
+    "organizations:alerts-migration-enabled": False,
     # Enables tagging javascript errors from the browser console.
     "organizations:javascript-console-error-tag": False,
     # Enables the cron job to auto-enable codecov integrations.

--- a/src/sentry/metrics/base.py
+++ b/src/sentry/metrics/base.py
@@ -62,3 +62,14 @@ class MetricsBackend(local):
         unit: Optional[str] = None,
     ) -> None:
         raise NotImplementedError
+
+    def distribution(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+        unit: Optional[str] = None,
+    ) -> None:
+        raise NotImplementedError

--- a/src/sentry/metrics/base.py
+++ b/src/sentry/metrics/base.py
@@ -49,7 +49,6 @@ class MetricsBackend(local):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
-        unit: Optional[str] = None,
     ) -> None:
         raise NotImplementedError
 

--- a/src/sentry/metrics/base.py
+++ b/src/sentry/metrics/base.py
@@ -38,6 +38,7 @@ class MetricsBackend(local):
         tags: Optional[Tags] = None,
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         raise NotImplementedError
 
@@ -48,6 +49,7 @@ class MetricsBackend(local):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         raise NotImplementedError
 
@@ -58,5 +60,6 @@ class MetricsBackend(local):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         raise NotImplementedError

--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -48,6 +48,7 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         self._primary_backend.incr(key, instance, tags, amount, sample_rate)
         if self._is_allowed(key) or options.get("delightful_metrics.allow_all_incr"):
@@ -60,6 +61,7 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         self._primary_backend.timing(key, value, instance, tags, sample_rate)
         if self._is_allowed(key) or options.get("delightful_metrics.allow_all_timing"):
@@ -72,6 +74,7 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         self._primary_backend.gauge(key, value, instance, tags, sample_rate)
         if self._is_allowed(key) or options.get("delightful_metrics.allow_all_gauge"):

--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -63,13 +63,10 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
-        unit: Optional[str] = None,
     ) -> None:
-        self._primary_backend.timing(key, value, instance, tags, sample_rate, unit)
+        self._primary_backend.timing(key, value, instance, tags, sample_rate)
         if self._is_allowed(key) or options.get("delightful_metrics.allow_all_timing"):
-            self._minimetrics.timing(
-                key, value, instance, tags, self._minimetrics_sample_rate(), unit
-            )
+            self._minimetrics.timing(key, value, instance, tags, self._minimetrics_sample_rate())
 
     def gauge(
         self,

--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -50,9 +50,11 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         sample_rate: float = 1,
         unit: Optional[str] = None,
     ) -> None:
-        self._primary_backend.incr(key, instance, tags, amount, sample_rate)
+        self._primary_backend.incr(key, instance, tags, amount, sample_rate, unit)
         if self._is_allowed(key) or options.get("delightful_metrics.allow_all_incr"):
-            self._minimetrics.incr(key, instance, tags, amount, self._minimetrics_sample_rate())
+            self._minimetrics.incr(
+                key, instance, tags, amount, self._minimetrics_sample_rate(), unit
+            )
 
     def timing(
         self,
@@ -63,9 +65,11 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         sample_rate: float = 1,
         unit: Optional[str] = None,
     ) -> None:
-        self._primary_backend.timing(key, value, instance, tags, sample_rate)
+        self._primary_backend.timing(key, value, instance, tags, sample_rate, unit)
         if self._is_allowed(key) or options.get("delightful_metrics.allow_all_timing"):
-            self._minimetrics.timing(key, value, instance, tags, self._minimetrics_sample_rate())
+            self._minimetrics.timing(
+                key, value, instance, tags, self._minimetrics_sample_rate(), unit
+            )
 
     def gauge(
         self,
@@ -76,6 +80,8 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         sample_rate: float = 1,
         unit: Optional[str] = None,
     ) -> None:
-        self._primary_backend.gauge(key, value, instance, tags, sample_rate)
+        self._primary_backend.gauge(key, value, instance, tags, sample_rate, unit)
         if self._is_allowed(key) or options.get("delightful_metrics.allow_all_gauge"):
-            self._minimetrics.gauge(key, value, instance, tags, self._minimetrics_sample_rate())
+            self._minimetrics.gauge(
+                key, value, instance, tags, self._minimetrics_sample_rate(), unit
+            )

--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -82,3 +82,20 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
             self._minimetrics.gauge(
                 key, value, instance, tags, self._minimetrics_sample_rate(), unit
             )
+
+    def distribution(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+        unit: Optional[str] = None,
+    ) -> None:
+        self._primary_backend.distribution(key, value, instance, tags, sample_rate, unit)
+        # We share the same option between timing and distribution, since they are both distribution
+        # metrics.
+        if self._is_allowed(key) or options.get("delightful_metrics.allow_all_timing"):
+            self._minimetrics.distribution(
+                key, value, instance, tags, self._minimetrics_sample_rate(), unit
+            )

--- a/src/sentry/metrics/datadog.py
+++ b/src/sentry/metrics/datadog.py
@@ -41,6 +41,7 @@ class DatadogMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         tags = dict(tags or ())
 
@@ -61,6 +62,7 @@ class DatadogMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         tags = dict(tags or ())
 
@@ -81,6 +83,7 @@ class DatadogMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         tags = dict(tags or ())
 

--- a/src/sentry/metrics/datadog.py
+++ b/src/sentry/metrics/datadog.py
@@ -62,7 +62,6 @@ class DatadogMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
-        unit: Optional[str] = None,
     ) -> None:
         tags = dict(tags or ())
 

--- a/src/sentry/metrics/datadog.py
+++ b/src/sentry/metrics/datadog.py
@@ -95,3 +95,15 @@ class DatadogMetricsBackend(MetricsBackend):
         self.stats.gauge(
             self._get_key(key), value, sample_rate=sample_rate, tags=tags_list, host=self.host
         )
+
+    def distribution(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+        unit: Optional[str] = None,
+    ) -> None:
+        # We keep the same implementation for Datadog.
+        self.timing(key, value, instance, tags, sample_rate)

--- a/src/sentry/metrics/dogstatsd.py
+++ b/src/sentry/metrics/dogstatsd.py
@@ -21,6 +21,7 @@ class DogStatsdMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         tags = dict(tags or ())
 
@@ -39,6 +40,7 @@ class DogStatsdMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         tags = dict(tags or ())
 
@@ -57,6 +59,7 @@ class DogStatsdMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         tags = dict(tags or ())
 

--- a/src/sentry/metrics/dogstatsd.py
+++ b/src/sentry/metrics/dogstatsd.py
@@ -40,7 +40,6 @@ class DogStatsdMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
-        unit: Optional[str] = None,
     ) -> None:
         tags = dict(tags or ())
 

--- a/src/sentry/metrics/dogstatsd.py
+++ b/src/sentry/metrics/dogstatsd.py
@@ -69,3 +69,15 @@ class DogStatsdMetricsBackend(MetricsBackend):
 
         tags_list = [f"{k}:{v}" for k, v in tags.items()]
         statsd.gauge(self._get_key(key), value, sample_rate=sample_rate, tags=tags_list)
+
+    def distribution(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+        unit: Optional[str] = None,
+    ) -> None:
+        # We keep the same implementation for Datadog.
+        self.timing(key, value, instance, tags, sample_rate)

--- a/src/sentry/metrics/dummy.py
+++ b/src/sentry/metrics/dummy.py
@@ -37,3 +37,14 @@ class DummyMetricsBackend(MetricsBackend):
         unit: Optional[str] = None,
     ) -> None:
         pass
+
+    def distribution(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+        unit: Optional[str] = None,
+    ) -> None:
+        pass

--- a/src/sentry/metrics/dummy.py
+++ b/src/sentry/metrics/dummy.py
@@ -24,7 +24,6 @@ class DummyMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
-        unit: Optional[str] = None,
     ) -> None:
         pass
 

--- a/src/sentry/metrics/dummy.py
+++ b/src/sentry/metrics/dummy.py
@@ -13,6 +13,7 @@ class DummyMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         pass
 
@@ -23,6 +24,7 @@ class DummyMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         pass
 
@@ -33,5 +35,6 @@ class DummyMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         pass

--- a/src/sentry/metrics/logging.py
+++ b/src/sentry/metrics/logging.py
@@ -40,3 +40,14 @@ class LoggingBackend(MetricsBackend):
         unit: Optional[str] = None,
     ) -> None:
         logger.debug("%r: %+g", key, value, extra={"instance": instance, "tags": tags or {}})
+
+    def distribution(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+        unit: Optional[str] = None,
+    ) -> None:
+        logger.debug("%r: %+g", key, value, extra={"instance": instance, "tags": tags or {}})

--- a/src/sentry/metrics/logging.py
+++ b/src/sentry/metrics/logging.py
@@ -14,6 +14,7 @@ class LoggingBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         logger.debug("%r: %+g", key, amount, extra={"instance": instance, "tags": tags or {}})
 
@@ -24,6 +25,7 @@ class LoggingBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         logger.debug(
             "%r: %g ms", key, value * 1000, extra={"instance": instance, "tags": tags or {}}
@@ -36,5 +38,6 @@ class LoggingBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         logger.debug("%r: %+g", key, value, extra={"instance": instance, "tags": tags or {}})

--- a/src/sentry/metrics/logging.py
+++ b/src/sentry/metrics/logging.py
@@ -25,7 +25,6 @@ class LoggingBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
-        unit: Optional[str] = None,
     ) -> None:
         logger.debug(
             "%r: %g ms", key, value * 1000, extra={"instance": instance, "tags": tags or {}}

--- a/src/sentry/metrics/middleware.py
+++ b/src/sentry/metrics/middleware.py
@@ -131,7 +131,7 @@ class MiddlewareWrapper(MetricsBackend):
             current_tags.update(tags)
         current_tags = _filter_tags(key, current_tags)
 
-        return self.inner.incr(key, instance, current_tags, amount, sample_rate)
+        return self.inner.incr(key, instance, current_tags, amount, sample_rate, unit)
 
     def timing(
         self,
@@ -162,4 +162,20 @@ class MiddlewareWrapper(MetricsBackend):
             current_tags.update(tags)
         current_tags = _filter_tags(key, current_tags)
 
-        return self.inner.gauge(key, value, instance, current_tags, sample_rate)
+        return self.inner.gauge(key, value, instance, current_tags, sample_rate, unit)
+
+    def distribution(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+        unit: Optional[str] = None,
+    ) -> None:
+        current_tags = get_current_global_tags()
+        if tags is not None:
+            current_tags.update(tags)
+        current_tags = _filter_tags(key, current_tags)
+
+        return self.inner.distribution(key, value, instance, current_tags, sample_rate, unit)

--- a/src/sentry/metrics/middleware.py
+++ b/src/sentry/metrics/middleware.py
@@ -140,7 +140,6 @@ class MiddlewareWrapper(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
-        unit: Optional[str] = None,
     ) -> None:
         current_tags = get_current_global_tags()
         if tags is not None:

--- a/src/sentry/metrics/middleware.py
+++ b/src/sentry/metrics/middleware.py
@@ -124,6 +124,7 @@ class MiddlewareWrapper(MetricsBackend):
         tags: Optional[Tags] = None,
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         current_tags = get_current_global_tags()
         if tags is not None:
@@ -139,6 +140,7 @@ class MiddlewareWrapper(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         current_tags = get_current_global_tags()
         if tags is not None:
@@ -154,6 +156,7 @@ class MiddlewareWrapper(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         current_tags = get_current_global_tags()
         if tags is not None:

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -116,6 +116,7 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
+        unit: str = "none",
     ) -> None:
         if self._keep_metric(sample_rate):
             sentry_sdk.metrics.incr(

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -109,6 +109,15 @@ class MiniMetricsMetricsBackend(MetricsBackend):
     def _keep_metric(sample_rate: float) -> bool:
         return random.random() < sample_rate
 
+    @staticmethod
+    def _to_minimetrics_unit(unit: Optional[str], default: Optional[str] = None) -> str:
+        if unit is None and default is None:
+            return "none"
+        elif unit is None:
+            return default
+        else:
+            return unit
+
     def incr(
         self,
         key: str,
@@ -116,13 +125,14 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
-        unit: str = "none",
+        unit: Optional[str] = None,
     ) -> None:
         if self._keep_metric(sample_rate):
             sentry_sdk.metrics.incr(
                 key=self._get_key(key),
                 value=amount,
                 tags=tags,
+                unit=self._to_minimetrics_unit(unit=unit),
             )
 
     def timing(
@@ -132,10 +142,14 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         if self._keep_metric(sample_rate):
             sentry_sdk.metrics.distribution(
-                key=self._get_key(key), value=value, tags=tags, unit="second"
+                key=self._get_key(key),
+                value=value,
+                tags=tags,
+                unit=self._to_minimetrics_unit(unit=unit, default="second"),
             )
 
     def gauge(
@@ -145,7 +159,13 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         if self._keep_metric(sample_rate):
             # XXX: make this into a gauge later
-            sentry_sdk.metrics.incr(key=self._get_key(key), value=value, tags=tags)
+            sentry_sdk.metrics.incr(
+                key=self._get_key(key),
+                value=value,
+                tags=tags,
+                unit=self._to_minimetrics_unit(unit=unit),
+            )

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -148,6 +148,7 @@ class MiniMetricsMetricsBackend(MetricsBackend):
                 key=self._get_key(key),
                 value=value,
                 tags=tags,
+                # Timing is defaulted to seconds.
                 unit="second",
             )
 
@@ -163,6 +164,23 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         if self._keep_metric(sample_rate):
             # XXX: make this into a gauge later
             sentry_sdk.metrics.incr(
+                key=self._get_key(key),
+                value=value,
+                tags=tags,
+                unit=self._to_minimetrics_unit(unit=unit),
+            )
+
+    def distribution(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+        unit: Optional[str] = None,
+    ) -> None:
+        if self._keep_metric(sample_rate):
+            sentry_sdk.metrics.distribution(
                 key=self._get_key(key),
                 value=value,
                 tags=tags,

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -142,14 +142,13 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
-        unit: Optional[str] = None,
     ) -> None:
         if self._keep_metric(sample_rate):
             sentry_sdk.metrics.distribution(
                 key=self._get_key(key),
                 value=value,
                 tags=tags,
-                unit=self._to_minimetrics_unit(unit=unit, default="second"),
+                unit="second",
             )
 
     def gauge(

--- a/src/sentry/metrics/statsd.py
+++ b/src/sentry/metrics/statsd.py
@@ -48,3 +48,14 @@ class StatsdMetricsBackend(MetricsBackend):
         unit: Optional[str] = None,
     ) -> None:
         self.client.gauge(self._full_key(self._get_key(key)), value, sample_rate)
+
+    def distribution(
+        self,
+        key: str,
+        value: float,
+        instance: Optional[str] = None,
+        tags: Optional[Tags] = None,
+        sample_rate: float = 1,
+        unit: Optional[str] = None,
+    ) -> None:
+        self.timing(key, value, instance, tags, sample_rate)

--- a/src/sentry/metrics/statsd.py
+++ b/src/sentry/metrics/statsd.py
@@ -35,7 +35,6 @@ class StatsdMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
-        unit: Optional[str] = None,
     ) -> None:
         self.client.timing(self._full_key(self._get_key(key)), value, sample_rate)
 

--- a/src/sentry/metrics/statsd.py
+++ b/src/sentry/metrics/statsd.py
@@ -24,6 +24,7 @@ class StatsdMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         self.client.incr(self._full_key(self._get_key(key)), amount, sample_rate)
 
@@ -34,6 +35,7 @@ class StatsdMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         self.client.timing(self._full_key(self._get_key(key)), value, sample_rate)
 
@@ -44,5 +46,6 @@ class StatsdMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        unit: Optional[str] = None,
     ) -> None:
         self.client.gauge(self._full_key(self._get_key(key)), value, sample_rate)

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -263,7 +263,7 @@ def test_unit_is_correctly_propagated_for_incr(sentry_sdk, unit, expected_unit):
 def test_unit_is_correctly_propagated_for_timing(sentry_sdk, unit, expected_unit):
     backend = MiniMetricsMetricsBackend(prefix="")
 
-    params = {"key": "sentrytest.unit", "value": 10.0, "tags": {"x": "bar"}, "unit": unit}
+    params = {"key": "sentrytest.unit", "value": 10.0, "tags": {"x": "bar"}}
 
     backend.timing(**params)
     assert sentry_sdk.metrics.distribution.call_args.kwargs == {**params, "unit": expected_unit}

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -286,6 +286,23 @@ def test_unit_is_correctly_propagated_for_gauge(sentry_sdk, unit, expected_unit)
     assert sentry_sdk.metrics.incr.call_args.kwargs == {**params, "unit": expected_unit}
 
 
+@pytest.mark.skipif(not have_minimetrics, reason="no minimetrics")
+@override_options(
+    {
+        "delightful_metrics.minimetrics_sample_rate": 1.0,
+    }
+)
+@patch("sentry.metrics.minimetrics.sentry_sdk")
+@pytest.mark.parametrize("unit,expected_unit", [(None, "none"), ("second", "second")])
+def test_unit_is_correctly_propagated_for_distribution(sentry_sdk, unit, expected_unit):
+    backend = MiniMetricsMetricsBackend(prefix="")
+
+    params = {"key": "sentrytest.unit", "value": 15.0, "tags": {"x": "bar"}, "unit": unit}
+
+    backend.distribution(**params)
+    assert sentry_sdk.metrics.distribution.call_args.kwargs == {**params, "unit": expected_unit}
+
+
 def test_did_you_remove_type_ignore():
     from importlib.metadata import version
 

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -78,8 +78,8 @@ def hub():
             dsn="http://foo@example.invalid/42",
             transport=DummyTransport,
             _experiments={
-                "enable_metrics": True,  # type: ignore
-                "before_emit_metric": before_emit_metric,
+                "enable_metrics": True,
+                "before_emit_metric": before_emit_metric,  # type:ignore
             },
         )
     )
@@ -265,7 +265,7 @@ def test_unit_is_correctly_propagated_for_timing(sentry_sdk, unit, expected_unit
 
     params = {"key": "sentrytest.unit", "value": 10.0, "tags": {"x": "bar"}}
 
-    backend.timing(**params)
+    backend.timing(**params)  # type:ignore
     assert sentry_sdk.metrics.distribution.call_args.kwargs == {**params, "unit": expected_unit}
 
 

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -231,6 +231,7 @@ def test_composite_backend_does_not_recurse(hub):
     assert len(hub.client.metrics_aggregator.buckets) == 0
 
 
+@pytest.mark.skipif(not have_minimetrics, reason="no minimetrics")
 @override_options(
     {
         "delightful_metrics.minimetrics_sample_rate": 1.0,
@@ -251,6 +252,7 @@ def test_unit_is_correctly_propagated_for_incr(sentry_sdk, unit, expected_unit):
     assert sentry_sdk.metrics.incr.call_args.kwargs == {**params, "unit": expected_unit}
 
 
+@pytest.mark.skipif(not have_minimetrics, reason="no minimetrics")
 @override_options(
     {
         "delightful_metrics.minimetrics_sample_rate": 1.0,
@@ -267,6 +269,7 @@ def test_unit_is_correctly_propagated_for_timing(sentry_sdk, unit, expected_unit
     assert sentry_sdk.metrics.distribution.call_args.kwargs == {**params, "unit": expected_unit}
 
 
+@pytest.mark.skipif(not have_minimetrics, reason="no minimetrics")
 @override_options(
     {
         "delightful_metrics.minimetrics_sample_rate": 1.0,


### PR DESCRIPTION
This PR adds the support for `unit` in our internal `MetricsBackend` abstraction and introduces a new distribution type to expose the distribution type with a `unit`. I didn't add `unit` to timing since that will default to seconds and we do not want the API users to change this.

Closes https://github.com/getsentry/sentry/issues/58571