### PR TITLE
fix(ddm): use 10s granularity only for custom metrics

### DIFF
--- a/static/app/utils/metrics.tsx
+++ b/static/app/utils/metrics.tsx
@@ -139,7 +139,7 @@ export function useMetricsData({
   const useCase = getUseCaseFromMri(mri);
   const field = op ? `${op}(${mri})` : mri;
 
-  const interval = getMetricsInterval(datetime);
+  const interval = getMetricsInterval(datetime, mri);
 
   const queryToSend = {
     ...getDateTimeParams(datetime),
@@ -234,8 +234,8 @@ export function useMetricsDataZoom(props: MetricsQuery) {
   };
 }
 
-// Wraps getInterval since other users of this function do not have support for 10s granularity
-function getMetricsInterval(dateTimeObj: DateTimeObject) {
+// Wraps getInterval since other users of this function, and other metric use cases do not have support for 10s granularity
+function getMetricsInterval(dateTimeObj: DateTimeObject, mri: string) {
   const interval = getInterval(dateTimeObj, 'metrics');
 
   if (interval !== '1m') {
@@ -244,7 +244,7 @@ function getMetricsInterval(dateTimeObj: DateTimeObject) {
 
   const diffInMinutes = getDiffInMinutes(dateTimeObj);
 
-  if (diffInMinutes <= 60) {
+  if (diffInMinutes <= 60 && getUseCaseFromMri(mri) === 'custom') {
     return '10s';
   }
 


### PR DESCRIPTION
Fixes an issue where non-custom metric was queried using 10s granularity resulting in an empty result set