### PR TITLE
tests(hybrid-cloud): Stabilize slack webhook tests

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -134,7 +134,7 @@ def _is_message(data: Mapping[str, Any]) -> bool:
 @region_silo_endpoint
 class SlackActionEndpoint(Endpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     authentication_classes = ()
     permission_classes = ()

--- a/src/sentry/integrations/slack/webhooks/command.py
+++ b/src/sentry/integrations/slack/webhooks/command.py
@@ -52,7 +52,7 @@ def is_team_linked_to_channel(organization: Organization, slack_request: SlackDM
 @region_silo_endpoint
 class SlackCommandsEndpoint(SlackDMEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     authentication_classes = ()
     permission_classes = ()

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -31,7 +31,7 @@ from .command import LINK_FROM_CHANNEL_MESSAGE
 @region_silo_endpoint
 class SlackEventEndpoint(SlackDMEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     """
     XXX(dcramer): a lot of this is copied from sentry-plugins right now, and will need refactoring

--- a/tests/sentry/integrations/slack/webhooks/commands/test_get.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_get.py
@@ -1,10 +1,10 @@
 from rest_framework import status
 
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import region_silo_test
 from tests.sentry.integrations.slack.webhooks.commands import SlackCommandsTest
 
 
-@control_silo_test
+@region_silo_test(stable=True)
 class SlackCommandsGetTest(SlackCommandsTest):
     method = "get"
 

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_user.py
@@ -7,13 +7,15 @@ from sentry.integrations.slack.views.unlink_identity import (
 )
 from sentry.integrations.slack.webhooks.base import NOT_LINKED_MESSAGE
 from sentry.testutils.helpers import get_response_text
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import control_silo_test, region_silo_test
 from sentry.utils import json
 from tests.sentry.integrations.slack.webhooks.commands import SlackCommandsTest
 
 
-@control_silo_test
-class SlackCommandsLinkUserTest(SlackCommandsTest):
+@control_silo_test(stable=True)
+class SlackLinkIdentityViewTest(SlackCommandsTest):
+    """Slack Linking Views are returned on Control Silo"""
+
     @responses.activate
     def test_link_user_identity(self):
         linking_url = build_linking_url(
@@ -27,6 +29,12 @@ class SlackCommandsLinkUserTest(SlackCommandsTest):
         data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
         assert SUCCESS_LINKED_MESSAGE in get_response_text(data)
 
+
+@region_silo_test(stable=True)
+class SlackCommandsLinkUserTest(SlackCommandsTest):
+    """Slash commands results are generated on Region Silo"""
+
+    @responses.activate
     def test_link_command(self):
         data = self.send_slack_message("link")
         assert "Link your Slack identity" in get_response_text(data)
@@ -37,8 +45,10 @@ class SlackCommandsLinkUserTest(SlackCommandsTest):
         assert "You are already linked as" in get_response_text(data)
 
 
-@control_silo_test
-class SlackCommandsUnlinkUserTest(SlackCommandsTest):
+@control_silo_test(stable=True)
+class SlackUnlinkIdentityViewTest(SlackCommandsTest):
+    """Slack Linking Views are returned on Control Silo"""
+
     @responses.activate
     def test_unlink_user_identity(self):
         self.link_user()
@@ -56,6 +66,11 @@ class SlackCommandsUnlinkUserTest(SlackCommandsTest):
         assert len(responses.calls) >= 1
         data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
         assert SUCCESS_UNLINKED_MESSAGE in get_response_text(data)
+
+
+@region_silo_test(stable=True)
+class SlackCommandsUnlinkUserTest(SlackCommandsTest):
+    """Slash commands results are generated on Region Silo"""
 
     def test_unlink_command(self):
         self.link_user()

--- a/tests/sentry/integrations/slack/webhooks/commands/test_post.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_post.py
@@ -2,11 +2,11 @@ from rest_framework import status
 
 from sentry.integrations.slack.message_builder.disconnected import DISCONNECTED_MESSAGE
 from sentry.testutils.helpers import get_response_text
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import region_silo_test
 from tests.sentry.integrations.slack.webhooks.commands import SlackCommandsTest
 
 
-@control_silo_test
+@region_silo_test(stable=True)
 class SlackCommandsPostTest(SlackCommandsTest):
     def test_invalid_signature(self):
         # The `get_error_response` method doesn't add a signature to the request.


### PR DESCRIPTION
Tagged most of these tests as `region_silo_test` since that is the silo where the business logic will actually execute. Had to break out the `IdentityView` tests though since they are returned from the control silo.