### PR TITLE
tests(hybrid-cloud): Stabilize Bitbucket Parser tests

### DIFF
--- a/tests/sentry/middleware/integrations/parsers/test_bitbucket.py
+++ b/tests/sentry/middleware/integrations/parsers/test_bitbucket.py
@@ -16,7 +16,7 @@ from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
 
 
-@control_silo_test()
+@control_silo_test(stable=True)
 class BitbucketRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     factory = RequestFactory()
@@ -56,6 +56,7 @@ class BitbucketRequestParserTest(TestCase):
                 parser.get_response()
                 assert get_response_from_control_silo.called
 
+    @override_regions(region_config)
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_routing_webhook(self):
         region_route = reverse(
@@ -75,14 +76,12 @@ class BitbucketRequestParserTest(TestCase):
             assert get_response_from_control_silo.called
 
         # Valid region
-
         OrganizationMapping.objects.get(organization_id=self.organization.id).update(
             region_name="us"
         )
-        with override_regions(self.region_config):
-            parser.get_response()
-            assert_webhook_outboxes(
-                factory_request=request,
-                webhook_identifier=WebhookProviderIdentifier.BITBUCKET,
-                region_names=[self.region.name],
-            )
+        parser.get_response()
+        assert_webhook_outboxes(
+            factory_request=request,
+            webhook_identifier=WebhookProviderIdentifier.BITBUCKET,
+            region_names=[self.region.name],
+        )

--- a/tests/sentry/middleware/integrations/parsers/test_bitbucket_server.py
+++ b/tests/sentry/middleware/integrations/parsers/test_bitbucket_server.py
@@ -1,7 +1,6 @@
 from unittest import mock
 from unittest.mock import MagicMock
 
-from django.db import router
 from django.http import HttpResponse
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
@@ -10,7 +9,6 @@ from sentry.middleware.integrations.parsers.bitbucket_server import BitbucketSer
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.silo.base import SiloMode
-from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import assert_webhook_outboxes, outbox_runner
 from sentry.testutils.region import override_regions
@@ -48,11 +46,9 @@ class BitbucketServerRequestParserTest(TestCase):
         parser = BitbucketServerRequestParser(request=request, response_handler=self.get_response)
 
         # Missing region
-
-        with unguarded_write(using=router.db_for_write(OrganizationMapping)):
-            OrganizationMapping.objects.get(organization_id=self.organization.id).update(
-                region_name="eu"
-            )
+        OrganizationMapping.objects.get(organization_id=self.organization.id).update(
+            region_name="eu"
+        )
         with mock.patch.object(
             parser, "get_response_from_control_silo"
         ) as get_response_from_control_silo:
@@ -60,10 +56,9 @@ class BitbucketServerRequestParserTest(TestCase):
             assert get_response_from_control_silo.called
 
         # Valid region
-        with unguarded_write(using=router.db_for_write(OrganizationMapping)):
-            OrganizationMapping.objects.get(organization_id=self.organization.id).update(
-                region_name="us"
-            )
+        OrganizationMapping.objects.get(organization_id=self.organization.id).update(
+            region_name="us"
+        )
         parser.get_response()
         assert_webhook_outboxes(
             factory_request=request,

--- a/tests/sentry/middleware/integrations/parsers/test_bitbucket_server.py
+++ b/tests/sentry/middleware/integrations/parsers/test_bitbucket_server.py
@@ -1,6 +1,7 @@
 from unittest import mock
 from unittest.mock import MagicMock
 
+from django.db import router
 from django.http import HttpResponse
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
@@ -9,6 +10,7 @@ from sentry.middleware.integrations.parsers.bitbucket_server import BitbucketSer
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import assert_webhook_outboxes, outbox_runner
 from sentry.testutils.region import override_regions
@@ -16,7 +18,7 @@ from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
 
 
-@control_silo_test()
+@control_silo_test(stable=True)
 class BitbucketServerRequestParserTest(TestCase):
     get_response = MagicMock(return_value=HttpResponse(content=b"no-error", status=200))
     factory = RequestFactory()
@@ -34,6 +36,7 @@ class BitbucketServerRequestParserTest(TestCase):
             provider="bitbucket_server",
         )
 
+    @override_regions(region_config)
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_routing_webhook(self):
         region_route = reverse(
@@ -45,9 +48,11 @@ class BitbucketServerRequestParserTest(TestCase):
         parser = BitbucketServerRequestParser(request=request, response_handler=self.get_response)
 
         # Missing region
-        OrganizationMapping.objects.get(organization_id=self.organization.id).update(
-            region_name="eu"
-        )
+
+        with unguarded_write(using=router.db_for_write(OrganizationMapping)):
+            OrganizationMapping.objects.get(organization_id=self.organization.id).update(
+                region_name="eu"
+            )
         with mock.patch.object(
             parser, "get_response_from_control_silo"
         ) as get_response_from_control_silo:
@@ -55,13 +60,13 @@ class BitbucketServerRequestParserTest(TestCase):
             assert get_response_from_control_silo.called
 
         # Valid region
-        OrganizationMapping.objects.get(organization_id=self.organization.id).update(
-            region_name="us"
-        )
-        with override_regions(self.region_config):
-            parser.get_response()
-            assert_webhook_outboxes(
-                factory_request=request,
-                webhook_identifier=WebhookProviderIdentifier.BITBUCKET_SERVER,
-                region_names=[self.region.name],
+        with unguarded_write(using=router.db_for_write(OrganizationMapping)):
+            OrganizationMapping.objects.get(organization_id=self.organization.id).update(
+                region_name="us"
             )
+        parser.get_response()
+        assert_webhook_outboxes(
+            factory_request=request,
+            webhook_identifier=WebhookProviderIdentifier.BITBUCKET_SERVER,
+            region_names=[self.region.name],
+        )


### PR DESCRIPTION
Used `eu` as a key for a missing region, but didn't override the region config for the testcase. Resolved for Bitbucket and Bitbucket Server.