### PR TITLE
Introduce `precision` arg to exactDuration formatter

### DIFF
--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -329,7 +329,7 @@ describe('getExactDuration', () => {
     expect(getExactDuration(0)).toEqual('0 milliseconds');
   });
 
-  it('should format in the right way', () => {
+  it('should format durations without extra suffixes', () => {
     expect(getExactDuration(2.030043848568126)).toEqual('2 seconds 30 milliseconds');
     expect(getExactDuration(0.2)).toEqual('200 milliseconds');
     expect(getExactDuration(13)).toEqual('13 seconds');
@@ -353,5 +353,17 @@ describe('getExactDuration', () => {
 
   it('should abbreviate label', () => {
     expect(getExactDuration(234235435, true)).toEqual('387wk 2d 1hr 23min 55s');
+  });
+
+  it('should pin/truncate to the min suffix if provided', () => {
+    expect(getExactDuration(0, false, 'seconds')).toEqual('0 seconds');
+    expect(getExactDuration(0.2, false, 'seconds')).toEqual('0 seconds');
+    expect(getExactDuration(2.030043848568126, false, 'seconds')).toEqual('2 seconds');
+    expect(getExactDuration(13, false, 'seconds')).toEqual('13 seconds');
+    expect(getExactDuration(60, false, 'seconds')).toEqual('1 minute');
+    expect(getExactDuration(121, false, 'seconds')).toEqual('2 minutes 1 second');
+    expect(getExactDuration(234235435.2, false, 'seconds')).toEqual(
+      '387 weeks 2 days 1 hour 23 minutes 55 seconds'
+    );
   });
 });

--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -355,7 +355,7 @@ describe('getExactDuration', () => {
     expect(getExactDuration(234235435, true)).toEqual('387wk 2d 1hr 23min 55s');
   });
 
-  it('should pin/truncate to the min suffix if provided', () => {
+  it('should pin/truncate to the min suffix precision if provided', () => {
     expect(getExactDuration(0, false, 'seconds')).toEqual('0 seconds');
     expect(getExactDuration(0.2, false, 'seconds')).toEqual('0 seconds');
     expect(getExactDuration(2.030043848568126, false, 'seconds')).toEqual('2 seconds');

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -187,7 +187,7 @@ const SUFFIX_ABBR = {
 };
 /**
  * Returns a human readable exact duration.
- * 'minDuration' arg will truncate the results to the specified amount
+ * 'precision' arg will truncate the results to the specified suffix
  *
  * e.g. 1 hour 25 minutes 15 seconds
  */

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -187,6 +187,7 @@ const SUFFIX_ABBR = {
 };
 /**
  * Returns a human readable exact duration.
+ * 'minDuration' arg will truncate the results to the specified amount
  *
  * e.g. 1 hour 25 minutes 15 seconds
  */

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -194,7 +194,7 @@ const SUFFIX_ABBR = {
 export function getExactDuration(
   seconds: number,
   abbreviation: boolean = false,
-  precision: string = 'milliseconds'
+  precision: keyof typeof SUFFIX_ABBR = 'milliseconds'
 ) {
   const minSuffix = ` ${precision}`;
 

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -194,9 +194,9 @@ const SUFFIX_ABBR = {
 export function getExactDuration(
   seconds: number,
   abbreviation: boolean = false,
-  minDuration: string = 'milliseconds'
+  precision: string = 'milliseconds'
 ) {
-  const minSuffix = ` ${minDuration}`;
+  const minSuffix = ` ${precision}`;
 
   const convertDuration = (secs: number, abbr: boolean): string => {
     // value in milliseconds
@@ -266,7 +266,7 @@ export function getExactDuration(
     return result;
   }
 
-  return `0${abbreviation ? SUFFIX_ABBR[minDuration] : minSuffix}`;
+  return `0${abbreviation ? SUFFIX_ABBR[precision] : minSuffix}`;
 }
 
 export function formatSecondsToClock(

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -176,12 +176,27 @@ export function getDuration(
   return `${label} ${tn('millisecond', 'milliseconds', result)}`;
 }
 
+const SUFFIX_ABBR = {
+  years: t('yr'),
+  weeks: t('wk'),
+  days: t('d'),
+  hours: t('hr'),
+  minutes: t('min'),
+  seconds: t('s'),
+  milliseconds: t('ms'),
+};
 /**
  * Returns a human readable exact duration.
  *
  * e.g. 1 hour 25 minutes 15 seconds
  */
-export function getExactDuration(seconds: number, abbreviation: boolean = false) {
+export function getExactDuration(
+  seconds: number,
+  abbreviation: boolean = false,
+  minDuration: string = 'milliseconds'
+) {
+  const minSuffix = ` ${minDuration}`;
+
   const convertDuration = (secs: number, abbr: boolean): string => {
     // value in milliseconds
     const msValue = round(secs * 1000);
@@ -194,35 +209,45 @@ export function getExactDuration(seconds: number, abbreviation: boolean = false)
       };
     };
 
-    if (value >= WEEK) {
+    if (value >= WEEK || (value && minSuffix === ' weeks')) {
       const {quotient, remainder} = divideBy(WEEK);
       const suffix = abbr ? t('wk') : ` ${tn('week', 'weeks', quotient)}`;
 
-      return `${quotient}${suffix} ${convertDuration(remainder / 1000, abbr)}`;
+      return `${quotient}${suffix} ${
+        minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)
+      }`;
     }
-    if (value >= DAY) {
+    if (value >= DAY || (value && minSuffix === ' days')) {
       const {quotient, remainder} = divideBy(DAY);
       const suffix = abbr ? t('d') : ` ${tn('day', 'days', quotient)}`;
 
-      return `${quotient}${suffix} ${convertDuration(remainder / 1000, abbr)}`;
+      return `${quotient}${suffix} ${
+        minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)
+      }`;
     }
-    if (value >= HOUR) {
+    if (value >= HOUR || (value && minSuffix === ' hours')) {
       const {quotient, remainder} = divideBy(HOUR);
       const suffix = abbr ? t('hr') : ` ${tn('hour', 'hours', quotient)}`;
 
-      return `${quotient}${suffix} ${convertDuration(remainder / 1000, abbr)}`;
+      return `${quotient}${suffix} ${
+        minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)
+      }`;
     }
-    if (value >= MINUTE) {
+    if (value >= MINUTE || (value && minSuffix === ' minutes')) {
       const {quotient, remainder} = divideBy(MINUTE);
       const suffix = abbr ? t('min') : ` ${tn('minute', 'minutes', quotient)}`;
 
-      return `${quotient}${suffix} ${convertDuration(remainder / 1000, abbr)}`;
+      return `${quotient}${suffix} ${
+        minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)
+      }`;
     }
-    if (value >= SECOND) {
+    if (value >= SECOND || (value && minSuffix === ' seconds')) {
       const {quotient, remainder} = divideBy(SECOND);
       const suffix = abbr ? t('s') : ` ${tn('second', 'seconds', quotient)}`;
 
-      return `${quotient}${suffix} ${convertDuration(remainder / 1000, abbr)}`;
+      return `${quotient}${suffix} ${
+        minSuffix === suffix ? '' : convertDuration(remainder / 1000, abbr)
+      }`;
     }
 
     if (value === 0) {
@@ -240,7 +265,7 @@ export function getExactDuration(seconds: number, abbreviation: boolean = false)
     return result;
   }
 
-  return `0${abbreviation ? t('ms') : ` ${t('milliseconds')}`}`;
+  return `0${abbreviation ? SUFFIX_ABBR[minDuration] : minSuffix}`;
 }
 
 export function formatSecondsToClock(


### PR DESCRIPTION
Allows us to specify a minimum duration that we care about for the `getExactDuration` formatter and truncates the remainder

Use case:
- I'm utilizing the `getExactDuration` formatter, but don't need millisecond precision. This allows me to pin the formatter to just seconds, or even minutes if necessary.

How does this differ from simply using `getDuration`?
- `getDuration` rounds the values, while `getExactDuration` does not. So specifying the minimum duration should _not_ round the value, but should truncate.