### PR TITLE
fix(notifications): bug with missing users

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -978,15 +978,6 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
             cleaned_data["issuetype"] = {"id": issue_type}
 
         try:
-            logger.info(
-                "jira_server.create_issue",
-                extra={
-                    "organization_id": self.organization_id,
-                    "integration_id": self.model.id,
-                    "jira_project": jira_project,
-                    "cleaned_data": cleaned_data,
-                },
-            )
             response = client.create_issue(cleaned_data)
         except Exception as e:
             self.raise_error(e)

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -978,6 +978,15 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
             cleaned_data["issuetype"] = {"id": issue_type}
 
         try:
+            logger.info(
+                "jira_server.create_issue",
+                extra={
+                    "organization_id": self.organization_id,
+                    "integration_id": self.model.id,
+                    "jira_project": jira_project,
+                    "cleaned_data": cleaned_data,
+                },
+            )
             response = client.create_issue(cleaned_data)
         except Exception as e:
             self.raise_error(e)

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -689,7 +689,7 @@ def should_use_notifications_v2(organization: Organization):
     return features.has("organizations:notification-settings-v2", organization)
 
 
-def recipient_is_user(recipient: RpcActor | Team | RpcUser) -> bool:
+def recipient_is_user(recipient: RpcActor | Team | RpcUser | User) -> bool:
     from sentry.models.user import User
 
     if isinstance(recipient, RpcActor) and recipient.actor_type == ActorType.USER:
@@ -697,7 +697,7 @@ def recipient_is_user(recipient: RpcActor | Team | RpcUser) -> bool:
     return isinstance(recipient, (RpcUser, User))
 
 
-def recipient_is_team(recipient: RpcActor | Team | RpcUser) -> bool:
+def recipient_is_team(recipient: RpcActor | Team | RpcUser | User) -> bool:
     from sentry.models.team import Team
 
     if isinstance(recipient, RpcActor) and recipient.actor_type == ActorType.TEAM:

--- a/src/sentry/notifications/notificationcontroller.py
+++ b/src/sentry/notifications/notificationcontroller.py
@@ -8,6 +8,7 @@ from django.db.models import Q
 from sentry.models.notificationsettingoption import NotificationSettingOption
 from sentry.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.models.team import Team
+from sentry.models.user import User
 from sentry.notifications.helpers import (
     get_default_for_provider,
     get_type_defaults,
@@ -29,7 +30,7 @@ from sentry.types.integrations import (
     ExternalProviders,
 )
 
-Recipient = Union[RpcActor, Team, RpcUser]
+Recipient = Union[RpcActor, Team, RpcUser, User]
 
 
 def sort_settings_by_scope(setting: NotificationSettingOption | NotificationSettingProvider) -> int:
@@ -53,7 +54,7 @@ class NotificationController:
 
     def __init__(
         self,
-        recipients: Iterable[RpcActor] | Iterable[Team] | Iterable[RpcUser],
+        recipients: Iterable[RpcActor] | Iterable[Team] | Iterable[RpcUser] | Iterable[User],
         project_ids: Iterable[int] | None = None,
         organization_id: int | None = None,
         type: NotificationSettingEnum | None = None,

--- a/src/sentry/services/hybrid_cloud/notifications/impl.py
+++ b/src/sentry/services/hybrid_cloud/notifications/impl.py
@@ -265,6 +265,17 @@ class DatabaseBackedNotificationsService(NotificationsService):
             for actor, providers in participants.items()
         }
 
+    def get_users_for_weekly_reports(
+        self, *, organization_id: int, user_ids: List[int]
+    ) -> List[int]:
+        users = User.objects.filter(id__in=user_ids)
+        controller = NotificationController(
+            recipients=users,
+            organization_id=organization_id,
+            type=NotificationSettingEnum.REPORTS,
+        )
+        return controller.get_users_for_weekly_reports()
+
     class _NotificationSettingsQuery(
         FilterQueryDatabaseImpl[
             NotificationSetting, NotificationSettingFilterArgs, RpcNotificationSetting, None

--- a/src/sentry/services/hybrid_cloud/notifications/service.py
+++ b/src/sentry/services/hybrid_cloud/notifications/service.py
@@ -157,5 +157,12 @@ class NotificationsService(RpcService):
     ) -> MutableMapping[int, MutableMapping[int, str]]:
         pass
 
+    @rpc_method
+    @abstractmethod
+    def get_users_for_weekly_reports(
+        self, *, organization_id: int, user_ids: List[int]
+    ) -> List[int]:
+        pass
+
 
 notifications_service = NotificationsService.create_delegation()

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -167,6 +167,18 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
         deliver_reports(ctx)
         assert mock_send_email.call_count == 0
 
+    @mock.patch("sentry.tasks.weekly_reports.send_email")
+    def test_invited_member(self, mock_send_email):
+        ctx = OrganizationReportContext(0, 0, self.organization)
+
+        # create a member without a user
+        OrganizationMember.objects.create(
+            organization=self.organization, email="different.email@example.com", token="abc"
+        )
+
+        deliver_reports(ctx, use_notifications_v2=True)
+        assert mock_send_email.call_count == 1
+
     def test_organization_project_issue_summaries(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
This fixes a bug where we didn't filter out null users from the `OrganizationMember` query. This also moves the logic for generating the list of users to the control silo where it belongs as we didn't have a test for this logic with the new notification feature flag enabled.