### PR TITLE
fix(statistical-detectors): use DURATION_LIGHT metric for timeseries query

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -378,8 +378,11 @@ def query_transactions_timeseries(
         project_ids = {p for p, _ in transaction_chunk}
         project_objects = Project.objects.filter(id__in=project_ids)
         org_ids = list({project.organization_id for project in project_objects})
+        # The only tag available on DURATION_LIGHT is `transaction`: as long as
+        # we don't filter on any other tags, DURATION_LIGHT's lower cardinality
+        # will be faster to query.
         duration_metric_id = indexer.resolve(
-            use_case_id, org_ids[0], str(TransactionMRI.DURATION.value)
+            use_case_id, org_ids[0], str(TransactionMRI.DURATION_LIGHT.value)
         )
         transaction_name_metric_id = indexer.resolve(
             use_case_id,
@@ -863,6 +866,9 @@ def query_transactions(
 
     # both the metric and tag that we are using are hardcoded values in sentry_metrics.indexer.strings
     # so the org_id that we are using does not actually matter here, we only need to pass in an org_id
+    #
+    # Because we filter on more than just `transaction`, we have to use DURATION here instead of
+    # DURATION_LIGHT.
     duration_metric_id = indexer.resolve(
         use_case_id, org_ids[0], str(TransactionMRI.DURATION.value)
     )

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -580,7 +580,7 @@ class TestTransactionChangePointDetection(MetricsAPIBaseTestCase):
                 self.org.id,
                 project_id,
                 "distribution",
-                TransactionMRI.DURATION.value,
+                TransactionMRI.DURATION_LIGHT.value,
                 {"transaction": transaction},
                 int((self.now - timedelta(minutes=minutes_ago)).timestamp()),
                 value,


### PR DESCRIPTION
The DURATION_LIGHT metric only extracts the `transaction` tag, making it a lower cardinality dataset (and therefore faster to query) when other tags aren't needed. The transaction duration timeseries query only filters on transaction, so switch it to use the faster metric.

Also added a note to the use of DURATION for the top transactions query - that one also filters on `transaction.op` so it isn't eligible for DURATION_LIGHT (a mistake made in https://github.com/getsentry/sentry/pull/58480).