### PR TITLE
ref(bug reports): rename sidebar to 'user feedback'

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -363,10 +363,11 @@ function Sidebar({location, organization}: Props) {
       <SidebarItem
         {...sidebarItemProps}
         icon={<IconMegaphone />}
-        label={t('Bug Reports')}
+        label={t('User Feedback')}
         to={`/organizations/${organization.slug}/feedback/`}
         id="feedback"
         isAlpha
+        variant="short"
       />
     </Feature>
   );

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -76,7 +76,7 @@ export type SidebarItemProps = {
    */
   isBeta?: boolean;
   /**
-   * Additional badge letting users know a tab is new.
+   * Specify the variant for the badge.
    */
   isNew?: boolean;
   /**
@@ -93,6 +93,10 @@ export type SidebarItemProps = {
    * Content to render at the end of the item.
    */
   trailingItems?: React.ReactNode;
+  /**
+   * Content to render at the end of the item.
+   */
+  variant?: 'badge' | 'indicator' | 'short' | undefined;
 };
 
 function SidebarItem({
@@ -115,6 +119,7 @@ function SidebarItem({
   organization,
   onClick,
   trailingItems,
+  variant,
   ...props
 }: SidebarItemProps) {
   const router = useRouter();
@@ -144,9 +149,9 @@ function SidebarItem({
 
   const badges = (
     <Fragment>
-      {showIsNew && <FeatureBadge type="new" />}
-      {isBeta && <FeatureBadge type="beta" />}
-      {isAlpha && <FeatureBadge type="alpha" />}
+      {showIsNew && <FeatureBadge type="new" variant={variant} />}
+      {isBeta && <FeatureBadge type="beta" variant={variant} />}
+      {isAlpha && <FeatureBadge type="alpha" variant={variant} />}
     </Fragment>
   );
 

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -51,11 +51,11 @@ export default function FeedbackListPage({}: Props) {
   });
 
   return (
-    <SentryDocumentTitle title={t(`Bug Reports`)} orgSlug={organization.slug}>
+    <SentryDocumentTitle title={t('User Feedback`')} orgSlug={organization.slug}>
       <FullViewport>
         <Layout.Header>
           <Layout.HeaderContent>
-            <Layout.Title>{t('Bug Reports')}</Layout.Title>
+            <Layout.Title>{t('User Feedback')}</Layout.Title>
           </Layout.HeaderContent>
         </Layout.Header>
         <PageFiltersContainer>


### PR DESCRIPTION
by the end of the week, the two tabs will be merged

<img width="212" alt="SCR-20231024-jqsk" src="https://github.com/getsentry/sentry/assets/56095982/966e94e2-177c-4748-855f-1b76a5da86ad">
