### PR TITLE
fix(statistical-detectors): dedupe organization_ids

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -107,7 +107,7 @@ def run_detection() -> None:
 
             if len(performance_projects) >= PROJECTS_PER_BATCH:
                 detect_transaction_trends.delay(
-                    [p.organization_id for p in performance_projects],
+                    list({p.organization_id for p in performance_projects}),
                     [p.id for p in performance_projects],
                     now,
                 )
@@ -127,7 +127,7 @@ def run_detection() -> None:
     # make sure to dispatch a task to handle the remaining projects
     if performance_projects:
         detect_transaction_trends.delay(
-            [p.organization_id for p in performance_projects],
+            list({p.organization_id for p in performance_projects}),
             [p.id for p in performance_projects],
             now,
         )

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -164,12 +164,12 @@ def test_run_detection_options_multiple_batches(
     detect_transaction_trends.delay.assert_has_calls(
         [
             mock.call(
-                [project.organization_id for project in projects[:5]],
+                [organization.id],
                 [project.id for project in projects[:5]],
                 timestamp,
             ),
             mock.call(
-                [project.organization_id for project in projects[5:]],
+                [organization.id],
                 [project.id for project in projects[5:]],
                 timestamp,
             ),


### PR DESCRIPTION
Project `organization_id`s extracted from a list of projects to be checked for regressions can result in a lot of duplicates. All those dupes end up being serialized as job arguments and also as part of the top transaction names SnQL query. Deduplicate the organization IDs early to avoid the extra serialization.