### PR TITLE
fix(hybridcloud) Enable CORS for uploaded avatars

### DIFF
--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -73,7 +73,6 @@ class AdditionalContext:
 additional_context = AdditionalContext()
 
 
-# TODO(hybridcloud) Make this view control silo only.
 @control_silo_view
 class AuthLoginView(BaseView):
     auth_required = False

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -45,7 +45,7 @@ from sentry.silo.base import SiloMode
 from sentry.utils import auth
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.auth import construct_link_with_query, is_valid_redirect
-from sentry.utils.http import absolute_uri, is_using_customer_domain
+from sentry.utils.http import absolute_uri, is_using_customer_domain, origin_from_request
 from sentry.web.frontend.generic import FOREVER_CACHE
 from sentry.web.helpers import render_to_response
 from sudo.views import redirect_to_sudo
@@ -757,4 +757,11 @@ class AvatarPhotoView(View):
 
         res = HttpResponse(photo_file, content_type="image/png")
         res["Cache-Control"] = FOREVER_CACHE
+
+        origin = origin_from_request(request)
+        if origin is None or origin == "null":
+            res["Access-Control-Allow-Origin"] = "*"
+        else:
+            res["Access-Control-Allow-Origin"] = origin
+
         return res

--- a/tests/sentry/web/frontend/test_organization_avatar.py
+++ b/tests/sentry/web/frontend/test_organization_avatar.py
@@ -20,5 +20,19 @@ class OrganizationAvatarTest(TestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         assert response["Cache-Control"] == FOREVER_CACHE
+        assert response["Access-Control-Allow-Origin"]
+        assert response.get("Vary") is None
+        assert response.get("Set-Cookie") is None
+
+    def test_origin_header(self):
+        org = self.create_organization()
+        photo = File.objects.create(name="test.png", type="avatar.file")
+        photo.putfile(BytesIO(b"test"))
+        avatar = OrganizationAvatar.objects.create(organization=org, file_id=photo.id)
+        url = reverse("sentry-organization-avatar-url", kwargs={"avatar_id": avatar.ident})
+        response = self.client.get(url, HTTP_ORIGIN="http://localhost")
+        assert response.status_code == 200
+        assert response["Cache-Control"] == FOREVER_CACHE
+        assert response["Access-Control-Allow-Origin"] == "http://localhost"
         assert response.get("Vary") is None
         assert response.get("Set-Cookie") is None

--- a/tests/sentry/web/frontend/test_sentryapp_avatar.py
+++ b/tests/sentry/web/frontend/test_sentryapp_avatar.py
@@ -31,6 +31,7 @@ class SentryAppAvatarTest(APITestCase):
         assert response["Cache-Control"] == FOREVER_CACHE
         assert response.get("Vary") == "Accept-Language, Cookie"
         assert response.get("Set-Cookie") is None
+        assert response["Access-Control-Allow-Origin"]
 
     def test_headers_control_file(self):
         sentry_app = self.create_sentry_app(name="Meow", organization=self.organization)
@@ -45,3 +46,4 @@ class SentryAppAvatarTest(APITestCase):
         assert response["Cache-Control"] == FOREVER_CACHE
         assert response.get("Vary") == "Accept-Language, Cookie"
         assert response.get("Set-Cookie") is None
+        assert response["Access-Control-Allow-Origin"]

--- a/tests/sentry/web/frontend/test_user_avatar.py
+++ b/tests/sentry/web/frontend/test_user_avatar.py
@@ -29,6 +29,7 @@ class UserAvatarTest(TestCase):
         assert response["Cache-Control"] == FOREVER_CACHE
         assert response.get("Vary") is None
         assert response.get("Set-Cookie") is None
+        assert response["Access-Control-Allow-Origin"]
 
     def test_headers_control_file(self):
         user = self.create_user(email="a@example.com")
@@ -42,3 +43,4 @@ class UserAvatarTest(TestCase):
         assert response["Cache-Control"] == FOREVER_CACHE
         assert response.get("Vary") is None
         assert response.get("Set-Cookie") is None
+        assert response["Access-Control-Allow-Origin"]


### PR DESCRIPTION
While this isn't necessary to *view* avatars, it is necessary for the upload cropper, as that UX puts the avatar image into a canvas element, and this requires CORS to be configured.