### PR TITLE
tests(hybrid-cloud): Add GH token to fixture 

### DIFF
--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from typing import Any, Mapping, Optional
 
 import pytest
@@ -99,7 +100,13 @@ class Fixtures:
     @assume_test_silo_mode(SiloMode.CONTROL)
     def integration(self):
         integration = Integration.objects.create(
-            provider="github", name="GitHub", external_id="github:1"
+            provider="github",
+            name="GitHub",
+            external_id="github:1",
+            metadata={
+                "access_token": "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
+                "expires_at": iso_format(datetime.utcnow() + timedelta(days=14)),
+            },
         )
         integration.add_organization(self.organization, self.user)
         return integration

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -64,7 +64,6 @@ from sentry.models.grouprelease import GroupRelease
 from sentry.models.groupresolution import GroupResolution
 from sentry.models.grouptombstone import GroupTombstone
 from sentry.models.integrations.external_issue import ExternalIssue
-from sentry.models.integrations.integration import Integration
 from sentry.models.project import Project
 from sentry.models.pullrequest import PullRequest, PullRequestCommit
 from sentry.models.release import Release
@@ -94,7 +93,6 @@ from sentry.utils import json
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.outcomes import Outcome
 from sentry.utils.samples import load_data
-from tests.sentry.integrations.github.test_repository import stub_installation_token
 
 pytestmark = [requires_snuba]
 
@@ -2489,9 +2487,6 @@ class AutoAssociateCommitTest(TestCase, EventManagerTestMixin):
         super().setUp()
         self.repo_name = "example"
         self.project = self.create_project(name="foo")
-        self.integration = Integration.objects.create(
-            provider="github", name=self.repo_name, external_id="654321"
-        )
         self.org_integration = self.integration.add_organization(
             self.project.organization, self.user
         )
@@ -2510,7 +2505,6 @@ class AutoAssociateCommitTest(TestCase, EventManagerTestMixin):
             source_root="/source/root",
             default_branch="main",
         )
-        stub_installation_token()
         responses.add(
             "GET",
             f"https://api.github.com/repos/{self.repo_name}/commits/{LATER_COMMIT_SHA}",

--- a/tests/sentry/tasks/integrations/test_link_all_repos.py
+++ b/tests/sentry/tasks/integrations/test_link_all_repos.py
@@ -1,16 +1,13 @@
-from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
 import responses
 from django.db import IntegrityError
-from django.utils import timezone
 
 from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.silo import SiloMode
-from sentry.snuba.sessions_v2 import isoformat_z
 from sentry.tasks.integrations.link_all_repos import link_all_repos
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -23,20 +20,7 @@ class LinkAllReposTestCase(IntegrationTestCase):
     base_url = "https://api.github.com"
     key = "github"
 
-    def setUp(self):
-        super().setUp()
-        self.installation_id = "github:1"
-        self.user_id = "user_1"
-        self.app_id = "app_1"
-        self.access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        self.expires_at = isoformat_z(timezone.now() + timedelta(days=365))
-
     def _add_responses(self):
-        responses.add(
-            responses.POST,
-            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
-            json={"token": self.access_token, "expires_at": self.expires_at},
-        )
         responses.add(
             responses.GET,
             self.base_url + "/installation/repositories?per_page=100",
@@ -79,11 +63,7 @@ class LinkAllReposTestCase(IntegrationTestCase):
 
     @responses.activate
     def test_link_all_repos_api_response_keyerror(self, _):
-        responses.add(
-            responses.POST,
-            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
-            json={"token": self.access_token, "expires_at": self.expires_at},
-        )
+
         responses.add(
             responses.GET,
             self.base_url + "/installation/repositories?per_page=100",
@@ -142,11 +122,7 @@ class LinkAllReposTestCase(IntegrationTestCase):
     @patch("sentry.tasks.integrations.link_all_repos.metrics")
     @responses.activate
     def test_link_all_repos_api_error(self, mock_metrics, _):
-        responses.add(
-            responses.POST,
-            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
-            json={"token": self.access_token, "expires_at": self.expires_at},
-        )
+
         responses.add(
             responses.GET,
             self.base_url + "/installation/repositories?per_page=100",
@@ -164,11 +140,7 @@ class LinkAllReposTestCase(IntegrationTestCase):
     @patch("sentry.integrations.github.integration.metrics")
     @responses.activate
     def test_link_all_repos_api_error_rate_limited(self, mock_metrics, _):
-        responses.add(
-            responses.POST,
-            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
-            json={"token": self.access_token, "expires_at": self.expires_at},
-        )
+
         responses.add(
             responses.GET,
             self.base_url + "/installation/repositories?per_page=100",

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -17,7 +17,6 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.pullrequest import PullRequest, PullRequestComment, PullRequestCommit
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions.base import ApiError
-from sentry.snuba.sessions_v2 import isoformat_z
 from sentry.tasks.commit_context import PR_COMMENT_WINDOW, process_commit_context
 from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -1060,18 +1059,8 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
             updated_at=iso_format(before_now(days=1)),
             group_ids=[],
         )
-        self.installation_id = "github:1"
-        self.user_id = "user_1"
-        self.app_id = "app_1"
-        self.access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-        self.expires_at = isoformat_z(timezone.now() + timedelta(days=365))
 
     def add_responses(self):
-        responses.add(
-            responses.POST,
-            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
-            json={"token": self.access_token, "expires_at": self.expires_at},
-        )
         responses.add(
             responses.GET,
             self.base_url + f"/repos/example/commits/{self.commit.key}/pulls",
@@ -1118,11 +1107,6 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
         self.pull_request.delete()
 
         responses.add(
-            responses.POST,
-            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
-            json={"token": self.access_token, "expires_at": self.expires_at},
-        )
-        responses.add(
             responses.GET,
             self.base_url + f"/repos/example/commits/{self.commit.key}/pulls",
             status=200,
@@ -1147,11 +1131,6 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
         """Captures exception if Github API call errors"""
 
         responses.add(
-            responses.POST,
-            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
-            json={"token": self.access_token, "expires_at": self.expires_at},
-        )
-        responses.add(
             responses.GET,
             self.base_url + f"/repos/example/commits/{self.commit.key}/pulls",
             status=400,
@@ -1175,11 +1154,6 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
     def test_gh_comment_commit_not_in_default_branch(self, get_jwt, mock_comment_workflow):
         """No comments on commit not in default branch"""
 
-        responses.add(
-            responses.POST,
-            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
-            json={"token": self.access_token, "expires_at": self.expires_at},
-        )
         responses.add(
             responses.GET,
             self.base_url + f"/repos/example/commits/{self.commit.key}/pulls",


### PR DESCRIPTION
Sort of a hybrid cloud fix, sort of just a testing infra fix but we were initializing integrations without tokens, so every request needed to first mock a token request. It's unnecessary copy pasting since the token refresh code is tested in its own right, and those separate tests don't need to make assertions that the tokens they're using are recent.

Also stabilizes hybrid cloud tests for `test_pr_comment.py`

