### PR TITLE
chore(statistical-detectors): Remove tags from transaction regression…

### DIFF
--- a/static/app/utils/issueTypeConfig/performanceConfig.tsx
+++ b/static/app/utils/issueTypeConfig/performanceConfig.tsx
@@ -189,6 +189,7 @@ const performanceConfig: IssueCategoryConfigMapping = {
   },
   [IssueType.PERFORMANCE_DURATION_REGRESSION]: {
     stats: {enabled: false},
+    tags: {enabled: false},
   },
   [IssueType.PROFILE_FILE_IO_MAIN_THREAD]: {
     resources: {


### PR DESCRIPTION
… issues

We've decided that having tags the way they are is more confusing than useful. Let's remove it for now.