### PR TITLE
fix(hybridcloud) Add backwards compat for /api/0/projects

### DIFF
--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -29,6 +29,7 @@ REGION_PINNED_URL_NAMES = (
     "sentry-api-0-relays-details",
     "sentry-error-page-embed",
     "sentry-release-hook",
+    "sentry-api-0-projects",
 )
 
 


### PR DESCRIPTION
This endpoint is region scoped and in the future will need to use the region domain. However, we need to provide backwards compatibility for existing customers in the US.

Refs HC-883