### PR TITLE
fix(suspect-commits): Stop making sentry issues for expected errors

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -27,6 +27,7 @@ from sentry.services.hybrid_cloud.integration import RpcIntegration
 from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.shared_integrations.client.base import BaseApiResponseX
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
+from sentry.shared_integrations.exceptions import ApiRateLimitedError
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.shared_integrations.response.mapping import MappingApiResponse
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
@@ -665,17 +666,29 @@ class GitHubClientMixin(GithubProxyClient):
             sentry_sdk.capture_exception(e)
             return []
 
-        if contents.get("errors"):
-            err_message = ", ".join(
-                [error.get("message", "") for error in contents.get("errors", [])]
-            )
-            raise ApiError(err_message)
+        errors = contents.get("errors", [])
+        if len(errors) > 0:
+            if any([error for error in errors if error.get("type") == "RATE_LIMITED"]):
+                raise ApiRateLimitedError("GitHub rate limit exceeded")
 
-        ref = contents.get("data", {}).get("repository", {}).get("ref")
-        if ref is None:
-            raise ApiError("Branch does not exist in GitHub.")
+            # When data is present, it means that the query was at least partially successful,
+            # usually a missing repo/branch/file which is expected with wrong configurations.
+            # If data is not present, the query may be formed incorrectly, so raise an error.
+            if not contents.get("data"):
+                err_message = ", ".join([error.get("message", "") for error in errors])
+                raise ApiError(err_message)
 
-        return ref.get("target", {}).get("blame", {}).get("ranges", [])
+        response_data = contents.get("data")
+        if not isinstance(response_data, dict):
+            raise ApiError("GitHub returned no data.", 404)
+        response_repo = response_data.get("repository")
+        if not isinstance(response_repo, dict):
+            raise ApiError("Repository does not exist in GitHub.", 404)
+        response_ref = response_repo.get("ref")
+        if not isinstance(response_ref, dict):
+            raise ApiError("Branch does not exist in GitHub.", 404)
+
+        return response_ref.get("target", {}).get("blame", {}).get("ranges", [])
 
     def get_blame_for_files(self, files: Sequence[SourceLineInfo]) -> Sequence[FileBlameInfo]:
         rate_limit = self.get_rate_limit(specific_resource="graphql")

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -16,6 +16,7 @@ from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.pullrequest import PullRequest, PullRequestComment, PullRequestCommit
 from sentry.models.repository import Repository
+from sentry.shared_integrations.exceptions import ApiRateLimitedError
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.snuba.sessions_v2 import isoformat_z
 from sentry.tasks.commit_context import PR_COMMENT_WINDOW, process_commit_context
@@ -122,6 +123,68 @@ class TestCommitContext(TestCommitContextMixin):
             organization=self.event.project.organization,
             type=GroupOwnerType.SUSPECT_COMMIT.value,
         ).context == {"commitId": self.commit.id}
+
+    @patch("sentry.integrations.utils.commit_context.logger.exception")
+    @patch("sentry.analytics.record")
+    @patch(
+        "sentry.integrations.github.GitHubIntegration.get_commit_context",
+        side_effect=ApiError(text="integration_failed"),
+    )
+    def test_failed_to_fetch_commit_context_apierror(
+        self, mock_get_commit_context, mock_record, mock_logger_exception
+    ):
+        with self.tasks():
+            assert not GroupOwner.objects.filter(group=self.event.group).exists()
+            event_frames = get_frame_paths(self.event)
+            process_commit_context(
+                event_id=self.event.event_id,
+                event_platform=self.event.platform,
+                event_frames=event_frames,
+                group_id=self.event.group_id,
+                project_id=self.event.project_id,
+            )
+
+        assert mock_logger_exception.call_count == 1
+        mock_record.assert_called_with(
+            "integrations.failed_to_fetch_commit_context",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            code_mapping_id=self.code_mapping.id,
+            group_id=self.event.group_id,
+            provider="github",
+            error_message="integration_failed",
+        )
+
+    @patch("sentry.integrations.utils.commit_context.logger.exception")
+    @patch("sentry.analytics.record")
+    @patch(
+        "sentry.integrations.github.GitHubIntegration.get_commit_context",
+        side_effect=ApiRateLimitedError("exceeded rate limit"),
+    )
+    def test_failed_to_fetch_commit_context_rate_limit(
+        self, mock_get_commit_context, mock_record, mock_logger_exception
+    ):
+        with self.tasks():
+            assert not GroupOwner.objects.filter(group=self.event.group).exists()
+            event_frames = get_frame_paths(self.event)
+            process_commit_context(
+                event_id=self.event.event_id,
+                event_platform=self.event.platform,
+                event_frames=event_frames,
+                group_id=self.event.group_id,
+                project_id=self.event.project_id,
+            )
+
+        assert not mock_logger_exception.called
+        mock_record.assert_called_with(
+            "integrations.failed_to_fetch_commit_context",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            code_mapping_id=self.code_mapping.id,
+            group_id=self.event.group_id,
+            provider="github",
+            error_message="exceeded rate limit",
+        )
 
     @patch("sentry.analytics.record")
     @patch(


### PR DESCRIPTION
The suspect commit errors are extremely noisy (see a [list of them here](https://sentry.sentry.io/discover/homepage/?display=top5&field=issue&field=title&field=count%28%29&name=All+Events&project=1&query=transaction%3Asentry.tasks.process_commit_context&sort=-count&statsPeriod=14d&yAxis=count%28%29)), so this is an attempt at filtering out ones we don't care about.

Changes are:

1. Modifies the GitHub client to add status codes to ApiError, because GraphQL will always return with a 200 when properly authenticated. This means parsing the errors array for a rate limit message or adding 404 when data does not exist.
2.  Modifies the `except` block to use `logger.warning` for 401, 403, 404, and 429 responses. 
3. Replaces the old logic which used `sentry_sdk.capure_exception` and `logger.error` with a single `logger.exception`.