### PR TITLE
fix(stat-detectors): Move diff to clickhouse and improve sorting

### DIFF
--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -27,7 +27,6 @@ SPAN_ANALYSIS_SCORE_THRESHOLD = 1
 RESPONSE_KEYS = [
     "span_op",
     "span_group",
-    "sample_event_id",
     "spm_before",
     "spm_after",
     "p95_before",

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -23,7 +23,7 @@ BUFFER = timedelta(hours=6)
 BASE_REFERRER = "api.organization-events-root-cause-analysis"
 SPAN_ANALYSIS = "span"
 GEO_ANALYSIS = "geo"
-SPAN_ANALYSIS_SCORE_THRESHOLD = 1
+SPAN_ANALYSIS_SCORE_THRESHOLD = 0
 RESPONSE_KEYS = [
     "span_op",
     "span_group",

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -114,15 +114,16 @@ def init_query_builder(params, transaction, regression_breakpoint, limit, span_s
         )
     )
 
-    score_column = Function(
-        "minus",
-        [
-            Function("multiply", [Column("spm_after"), Column("p95_after")]),
-            Function("multiply", [Column("spm_before"), Column("p95_before")]),
-        ],
-        "score",
+    builder.columns.append(
+        Function(
+            "minus",
+            [
+                Function("multiply", [Column("spm_after"), Column("p95_after")]),
+                Function("multiply", [Column("spm_before"), Column("p95_before")]),
+            ],
+            "score",
+        )
     )
-    builder.columns.append(score_column)
 
     builder.where.append(
         Or(

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -27,6 +27,7 @@ SPAN_ANALYSIS_SCORE_THRESHOLD = 1
 RESPONSE_KEYS = [
     "span_op",
     "span_group",
+    "span_description",
     "spm_before",
     "spm_after",
     "p95_before",
@@ -163,16 +164,14 @@ def fetch_span_analysis_results(
         span_score_threshold=span_score_threshold,
     )
 
-    span_analysis_results = [{key: row[key] for key in RESPONSE_KEYS} for row in span_data]
-
-    for result in span_analysis_results:
+    for result in span_data:
         result["span_description"] = get_span_description(
             EventID(project_id, result["sample_event_id"]),
             result["span_op"],
             result["span_group"],
         )
 
-    return span_analysis_results
+    return [{key: row[key] for key in RESPONSE_KEYS} for row in span_data]
 
 
 def fetch_geo_analysis_results(transaction_name, regression_breakpoint, params, limit):

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -243,12 +243,6 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             )
 
         assert response.status_code == 200, response.content
-
-        # Check that sample IDs are gathered, but remove them from the data
-        # for checking since they are randomized
-        assert all("sample_event_id" in row for row in response.data)
-        for row in response.data:
-            del row["sample_event_id"]
         assert response.data == [
             {
                 "span_op": "django.middleware",
@@ -331,10 +325,6 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             )
 
         assert response.status_code == 200, response.content
-
-        for row in response.data:
-            del row["sample_event_id"]
-
         assert len(response.data) == 1
         assert response.data == [
             {

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -254,6 +254,16 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                 "p95_before": 60.0,
                 "p95_after": 546.0,
             },
+            {
+                "p95_after": 60.0,
+                "p95_before": 60.0,
+                "score": 0.020833333333333336,
+                "span_description": "db span",
+                "span_group": "5ad8c5a1e8d0e5f7",
+                "span_op": "db",
+                "spm_after": 0.0006944444444444445,
+                "spm_before": 0.00034722222222222224,
+            },
         ]
 
     def test_results_are_limited(self):

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -254,15 +254,12 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                 "span_op": "django.middleware",
                 "span_group": "2b9cbb96dbf59baa",
                 "span_description": "middleware span",
-                "score_delta": 1578.0,
-                "freq_before": 1.0,
-                "freq_after": 3.0,
-                "freq_delta": 2.0,
-                "duration_delta": 486.0,
-                "duration_before": 60.0,
-                "duration_after": 546.0,
-                "is_new_span": False,
-            }
+                "score": 1.1166666666666667,
+                "spm_before": 0.00034722222222222224,
+                "spm_after": 0.0020833333333333333,
+                "p95_before": 60.0,
+                "p95_after": 546.0,
+            },
         ]
 
     def test_results_are_limited(self):
@@ -311,12 +308,12 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
                     "timestamp": iso_format(self.now - timedelta(hours=1)),
                     "op": "db",
                     "description": "db",
-                    "exclusive_time": 100.0,
+                    "exclusive_time": 10000.0,
                 },
             ],
             project_id=self.project.id,
             start_timestamp=self.now - timedelta(hours=1),
-            duration=200,
+            duration=10100,
         )
 
         with self.feature(FEATURES):
@@ -343,15 +340,12 @@ class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):
             {
                 "span_op": "db",
                 "span_group": "d77d5e503ad1439f",
-                "score_delta": 100.0,
-                "freq_before": 0,
-                "freq_after": 1.0,
-                "freq_delta": 1.0,
-                "duration_delta": 100.0,
-                "duration_before": 0,
-                "duration_after": 100.0,
+                "score": 6.944444444444445,
+                "spm_before": 0.0,
+                "spm_after": 0.0006944444444444445,
+                "p95_before": 0.0,
+                "p95_after": 10000.0,
                 "span_description": "db",
-                "is_new_span": True,
             }
         ]
 


### PR DESCRIPTION
There were issues with the way we were doing span analysis before. Some of the issues were:
- We were limited by a response of 10000 rows to do the analysis in python, meaning that our data was more inaccurate
- We would serialize a lot of objects, only to dump them in the end

The solution was to move the calculations into Clickhouse. This PR adds a bunch of data to the query so the response is only what we need, and we can analyze the full amount of spans. It calculates `tpm_before`, `tpm_after`, `p95_before` and `p95_after`, which are then used to calculate the impact of the span before/after for the sort order (i.e. `tpm_after * p95_after - tpm_before * p95_before`). We've found this to be more accurate in surfacing spans that aren't just one-offs with a large p95 delta because they're newly added spans.