### PR TITLE
fix(replays): fix network onboarding url

### DIFF
--- a/static/app/views/replays/detail/network/details/onboarding.tsx
+++ b/static/app/views/replays/detail/network/details/onboarding.tsx
@@ -174,7 +174,8 @@ function SetupInstructions({
   }
 
   function trimUrl(oldUrl: string): string {
-    return oldUrl.substring(0, oldUrl.indexOf('?'));
+    const end = oldUrl.indexOf('?') > 0 ? oldUrl.indexOf('?') : oldUrl.length;
+    return oldUrl.substring(0, end);
   }
 
   const urlSnippet = `


### PR DESCRIPTION
We were trimming until `?` in the URL but not all URLs have it

<img width="747" alt="SCR-20231024-njaa" src="https://github.com/getsentry/sentry/assets/56095982/73820a3a-3ab5-475d-90a9-681951e2ed51">
