### PR TITLE
ref(backup): Use local impl of lost_password_hash service

### DIFF
--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -439,7 +439,9 @@ class User(BaseModel, AbstractBaseUser):
                 SuperuserUserSerializer,
                 UserSerializer,
             )
-            from sentry.services.hybrid_cloud.lost_password_hash import lost_password_hash_service
+            from sentry.services.hybrid_cloud.lost_password_hash.impl import (
+                DatabaseLostPasswordHashService,
+            )
 
             serializer_cls = BaseUserSerializer
             if scope not in {ImportScope.Config, ImportScope.Global}:
@@ -453,9 +455,7 @@ class User(BaseModel, AbstractBaseUser):
             self.save(force_insert=True)
 
             if scope != ImportScope.Global:
-                # TODO(getsentry/team-ospo#190): the following is an RPC call which could fail for
-                # transient reasons (network etc). How do we handle that?
-                lost_password_hash_service.get_or_create(user_id=self.id)
+                DatabaseLostPasswordHashService().get_or_create(user_id=self.id)
 
             # TODO(getsentry/team-ospo#191): we need to send an email informing the user of their
             # new account with a resettable password - we'll need to figure out where in the process

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -30,6 +30,7 @@ from sentry.backup.scopes import ExportScope, ImportScope, RelocationScope
 from sentry.models.apitoken import DEFAULT_EXPIRATION, ApiToken, generate_token
 from sentry.models.authenticator import Authenticator
 from sentry.models.email import Email
+from sentry.models.lostpasswordhash import LostPasswordHash
 from sentry.models.options.option import ControlOption, Option
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
@@ -113,6 +114,7 @@ class SanitizationTests(ImportTestCase):
             )
 
             assert User.objects.filter(is_unclaimed=True).count() == 4
+            assert LostPasswordHash.objects.count() == 4
             assert User.objects.filter(is_managed=True).count() == 0
             assert User.objects.filter(is_staff=True).count() == 0
             assert User.objects.filter(is_superuser=True).count() == 0
@@ -151,6 +153,7 @@ class SanitizationTests(ImportTestCase):
             )
 
             assert User.objects.filter(is_unclaimed=True).count() == 4
+            assert LostPasswordHash.objects.count() == 4
             assert User.objects.filter(is_managed=True).count() == 0
             assert User.objects.filter(is_staff=True).count() == 0
             assert User.objects.filter(is_superuser=True).count() == 0
@@ -169,6 +172,7 @@ class SanitizationTests(ImportTestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             assert User.objects.count() == 4
             assert User.objects.filter(is_unclaimed=True).count() == 4
+            assert LostPasswordHash.objects.count() == 4
             assert User.objects.filter(is_managed=True).count() == 1
             assert User.objects.filter(is_staff=True).count() == 2
             assert User.objects.filter(is_superuser=True).count() == 2
@@ -215,6 +219,7 @@ class SanitizationTests(ImportTestCase):
             assert User.objects.count() == 4
             # We don't mark `Global`ly imported `User`s unclaimed.
             assert User.objects.filter(is_unclaimed=True).count() == 0
+            assert LostPasswordHash.objects.count() == 0
             assert User.objects.filter(is_managed=True).count() == 1
             assert User.objects.filter(is_staff=True).count() == 2
             assert User.objects.filter(is_superuser=True).count() == 2
@@ -1451,6 +1456,7 @@ class CollisionTests(ImportTestCase):
                 assert not User.objects.filter(username__iexact="owner-").exists()
 
                 assert User.objects.filter(is_unclaimed=True).count() == 0
+                assert LostPasswordHash.objects.count() == 0
                 assert User.objects.filter(is_unclaimed=False).count() == 1
 
                 assert UserEmail.objects.filter(email__icontains="existing@").exists()
@@ -1484,6 +1490,7 @@ class CollisionTests(ImportTestCase):
                 assert User.objects.filter(username__icontains="owner-").exists()
 
                 assert User.objects.filter(is_unclaimed=True).count() == 1
+                assert LostPasswordHash.objects.count() == 1
                 assert User.objects.filter(is_unclaimed=False).count() == 1
 
                 assert UserEmail.objects.filter(email__icontains="existing@").exists()
@@ -1523,6 +1530,7 @@ class CollisionTests(ImportTestCase):
                 assert not User.objects.filter(username__icontains="owner-").exists()
 
                 assert User.objects.filter(is_unclaimed=True).count() == 0
+                assert LostPasswordHash.objects.count() == 0
                 assert User.objects.filter(is_unclaimed=False).count() == 1
 
                 assert UserEmail.objects.filter(email__icontains="existing@").exists()
@@ -1587,6 +1595,7 @@ class CollisionTests(ImportTestCase):
                 assert User.objects.filter(username__icontains="owner-").exists()
 
                 assert User.objects.filter(is_unclaimed=True).count() == 1
+                assert LostPasswordHash.objects.count() == 1
                 assert User.objects.filter(is_unclaimed=False).count() == 1
 
                 assert UserEmail.objects.filter(email__icontains="existing@").exists()
@@ -1651,6 +1660,7 @@ class CollisionTests(ImportTestCase):
                 assert not User.objects.filter(username__iexact="owner-").exists()
 
                 assert User.objects.filter(is_unclaimed=True).count() == 0
+                assert LostPasswordHash.objects.count() == 0
                 assert User.objects.filter(is_unclaimed=False).count() == 1
 
                 assert UserEmail.objects.filter(email__icontains="existing@").exists()
@@ -1687,6 +1697,7 @@ class CollisionTests(ImportTestCase):
                 assert User.objects.filter(username__icontains="owner-").exists()
 
                 assert User.objects.filter(is_unclaimed=True).count() == 1
+                assert LostPasswordHash.objects.count() == 1
                 assert User.objects.filter(is_unclaimed=False).count() == 1
 
                 assert UserEmail.objects.filter(email__icontains="existing@").exists()


### PR DESCRIPTION
This will always be a local call, since the User model whose method it exists in is also in the control silo, so we should just use the service directly.

This PR also adds some test cases to ensure that passwords are reset for unclaimed users only.