### PR TITLE
feat(feedback): add new feedback eventtype

### DIFF
--- a/src/sentry/eventtypes/__init__.py
+++ b/src/sentry/eventtypes/__init__.py
@@ -1,11 +1,12 @@
 from typing import Union
 
-from .base import DefaultEvent
-from .error import ErrorEvent
-from .generic import GenericEvent
-from .manager import EventTypeManager
-from .security import CspEvent, ExpectCTEvent, ExpectStapleEvent, HpkpEvent
-from .transaction import TransactionEvent
+from sentry.eventtypes.base import DefaultEvent
+from sentry.eventtypes.error import ErrorEvent
+from sentry.eventtypes.feedback import FeedbackEvent
+from sentry.eventtypes.generic import GenericEvent
+from sentry.eventtypes.manager import EventTypeManager
+from sentry.eventtypes.security import CspEvent, ExpectCTEvent, ExpectStapleEvent, HpkpEvent
+from sentry.eventtypes.transaction import TransactionEvent
 
 default_manager = EventTypeManager()
 default_manager.register(DefaultEvent)
@@ -16,6 +17,8 @@ default_manager.register(ExpectCTEvent)
 default_manager.register(ExpectStapleEvent)
 default_manager.register(TransactionEvent)
 default_manager.register(GenericEvent)
+default_manager.register(FeedbackEvent)
+
 
 get = default_manager.get
 register = default_manager.register
@@ -28,4 +31,6 @@ EventType = Union[
     ExpectCTEvent,
     ExpectStapleEvent,
     TransactionEvent,
+    GenericEvent,
+    FeedbackEvent,
 ]

--- a/src/sentry/eventtypes/feedback.py
+++ b/src/sentry/eventtypes/feedback.py
@@ -1,0 +1,11 @@
+from sentry.eventtypes.base import BaseEvent
+from sentry.utils.safe import get_path
+
+
+class FeedbackEvent(BaseEvent):
+    key = "feedback"
+
+    def extract_metadata(self, data):
+        contact_email = get_path(data, "contexts", "feedback", "contact_email")
+        message = get_path(data, "contexts", "feedback", "message")
+        return {"contact_email": contact_email, "message": message}

--- a/tests/sentry/eventtypes/test_feedback.py
+++ b/tests/sentry/eventtypes/test_feedback.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from unittest import TestCase
+
+from sentry.eventtypes.feedback import FeedbackEvent
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test(stable=True)
+class GetMetadataTest(TestCase):
+    def test_simple(self):
+        inst = FeedbackEvent()
+        data = {"contexts": {"feedback": {"message": "Foo", "contact_email": "test@test.com"}}}
+        assert inst.get_metadata(data) == {"message": "Foo", "contact_email": "test@test.com"}


### PR DESCRIPTION
Adds a new feedback event type. For now, only custom logic is metadata handling.
Relates to https://github.com/getsentry/team-replay/issues/222