### PR TITLE
ref(sus commits): Add caching for get_blame_for_files

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -698,6 +698,7 @@ class GitHubClientMixin(GithubProxyClient):
             "provider": "github",
             "organization_integration_id": self.org_integration_id,
         }
+        metrics.incr("sentry.integrations.github.get_blame_for_files")
         rate_limit = self.get_rate_limit(specific_resource="graphql")
         if rate_limit.remaining < MINIMUM_REQUESTS:
             metrics.incr("sentry.integrations.github.get_blame_for_files.rate_limit")

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -723,7 +723,7 @@ class GitHubClientMixin(GithubProxyClient):
                 "sentry.integrations.github.get_blame_for_files.got_cached",
                 extra=log_info,
             )
-        if not response:
+        else:
             try:
                 response = self.post(
                     path="/graphql",

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -716,10 +716,11 @@ class GitHubClientMixin(GithubProxyClient):
         file_path_mapping = generate_file_path_mapping(files)
 
         try:
-            response = self.post(
+            response = self.post_cached(
                 path="/graphql",
                 data={"query": create_blame_query(file_path_mapping, extra=log_info)},
                 allow_text=False,
+                cache_time=60,
             )
         except ValueError as e:
             logger.exception(e, log_info)

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -715,7 +715,7 @@ class GitHubClientMixin(GithubProxyClient):
             raise GitHubApproachingRateLimit()
 
         file_path_mapping = generate_file_path_mapping(files)
-        data = create_blame_query(file_path_mapping)
+        data = create_blame_query(file_path_mapping, extra=log_info)
         cache_key = self.get_cache_key("/graphql", data)
         response = self.check_cache(cache_key)
         if response:

--- a/src/sentry/integrations/gitlab/blame.py
+++ b/src/sentry/integrations/gitlab/blame.py
@@ -83,9 +83,10 @@ def _fetch_file_blame(
     project_id = file.repo.config.get("project_id")
     encoded_path = quote(file.path, safe="")
     request_path = GitLabApiClientPath.blame.format(project=project_id, path=encoded_path)
-    response = client.get(
+    response = client.get_cached(
         request_path,
         params={"ref": file.ref, "range[start]": file.lineno, "range[end]": file.lineno},
+        cache_time=60,
     )
 
     if not isinstance(response, SequenceApiResponse):

--- a/src/sentry/integrations/gitlab/blame.py
+++ b/src/sentry/integrations/gitlab/blame.py
@@ -18,7 +18,7 @@ from sentry.shared_integrations.client.base import BaseApiClient
 from sentry.shared_integrations.exceptions import ApiRateLimitedError
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.shared_integrations.response.sequence import SequenceApiResponse
-from sentry.utils import metrics
+from sentry.utils import json, metrics
 
 logger = logging.getLogger("sentry.integrations.gitlab")
 
@@ -83,11 +83,20 @@ def _fetch_file_blame(
     project_id = file.repo.config.get("project_id")
     encoded_path = quote(file.path, safe="")
     request_path = GitLabApiClientPath.blame.format(project=project_id, path=encoded_path)
-    response = client.get_cached(
-        request_path,
-        params={"ref": file.ref, "range[start]": file.lineno, "range[end]": file.lineno},
-        cache_time=60,
-    )
+    params = {"ref": file.ref, "range[start]": file.lineno, "range[end]": file.lineno}
+    cache_key = client.get_cache_key(request_path, json.dumps(params))
+    response = client.check_cache(cache_key)
+    if response:
+        logger.info(
+            "sentry.integrations.gitlab.get_blame_for_files.got_cached",
+            extra=extra,
+        )
+    else:
+        response = client.get(
+            request_path,
+            params=params,
+        )
+        client.set_cache(cache_key, response, 60)
 
     if not isinstance(response, SequenceApiResponse):
         raise ApiError("Response is not in expected format")

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -16,6 +16,7 @@ from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
 from sentry.silo.base import SiloMode
+from sentry.utils import metrics
 from sentry.utils.http import absolute_uri
 
 if TYPE_CHECKING:
@@ -334,6 +335,7 @@ class GitLabProxyApiClient(IntegrationProxyClient):
         return contents or []
 
     def get_blame_for_files(self, files: Sequence[SourceLineInfo]) -> list[FileBlameInfo]:
+        metrics.incr("sentry.integrations.gitlab.get_blame_for_files")
         return fetch_file_blames(
             self, files, extra={"provider": "gitlab", "org_integration_id": self.org_integration_id}
         )

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -339,11 +339,11 @@ class BaseApiClient(TrackResponseMixin):
         if kwargs.get("params", None):
             query = json.dumps(kwargs.get("params"))
         key = self.get_cache_prefix() + md5_text(self.build_url(path), query).hexdigest()
-
         result: BaseApiResponseX | None = cache.get(key)
         if result is None:
+            cache_time = kwargs.pop("cache_time", None) or self.cache_time
             result = self.request(method, path, *args, **kwargs)
-            cache.set(key, result, self.cache_time)
+            cache.set(key, result, cache_time)
         return result
 
     def get_cached(self, path: str, *args: Any, **kwargs: Any) -> BaseApiResponseX:
@@ -357,6 +357,9 @@ class BaseApiClient(TrackResponseMixin):
 
     def post(self, *args: Any, **kwargs: Any) -> BaseApiResponseX:
         return self.request("POST", *args, **kwargs)
+
+    def post_cached(self, path: str, *args: Any, **kwargs: Any) -> BaseApiResponseX:
+        return self._get_cached(path, "POST", *args, **kwargs)
 
     def put(self, *args: Any, **kwargs: Any) -> BaseApiResponseX:
         return self.request("PUT", *args, **kwargs)

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -334,16 +334,29 @@ class BaseApiClient(TrackResponseMixin):
     def delete(self, *args: Any, **kwargs: Any) -> BaseApiResponseX:
         return self.request("DELETE", *args, **kwargs)
 
+    def get_cache_key(self, path: str, query: str = "", data: str | None = "") -> str:
+        if not data:
+            return self.get_cache_prefix() + md5_text(self.build_url(path), query).hexdigest()
+        return self.get_cache_prefix() + md5_text(self.build_url(path), query, data).hexdigest()
+
+    def check_cache(self, cache_key: str) -> BaseApiResponseX | None:
+        return cache.get(cache_key)
+
+    def set_cache(self, cache_key: str, result: BaseApiResponseX, cache_time: int) -> None:
+        cache.set(cache_key, result, cache_time)
+
     def _get_cached(self, path: str, method: str, *args: Any, **kwargs: Any) -> BaseApiResponseX:
+        data = kwargs.get("data", None)
         query = ""
         if kwargs.get("params", None):
             query = json.dumps(kwargs.get("params"))
-        key = self.get_cache_prefix() + md5_text(self.build_url(path), query).hexdigest()
-        result: BaseApiResponseX | None = cache.get(key)
+
+        key = self.get_cache_key(path, query, data)
+        result: BaseApiResponseX | None = self.check_cache(key)
         if result is None:
             cache_time = kwargs.pop("cache_time", None) or self.cache_time
             result = self.request(method, path, *args, **kwargs)
-            cache.set(key, result, cache_time)
+            self.set_cache(key, result, cache_time)
         return result
 
     def get_cached(self, path: str, *args: Any, **kwargs: Any) -> BaseApiResponseX:
@@ -357,9 +370,6 @@ class BaseApiClient(TrackResponseMixin):
 
     def post(self, *args: Any, **kwargs: Any) -> BaseApiResponseX:
         return self.request("POST", *args, **kwargs)
-
-    def post_cached(self, path: str, *args: Any, **kwargs: Any) -> BaseApiResponseX:
-        return self._get_cached(path, "POST", *args, **kwargs)
 
     def put(self, *args: Any, **kwargs: Any) -> BaseApiResponseX:
         return self.request("PUT", *args, **kwargs)

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1373,6 +1373,9 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
             [self.file1, self.file2, self.file3], extra={}
         )
         assert self.github_client.check_cache(cache_key)["data"] == self.data
+        assert (
+            self.github_client.get_blame_for_files([self.file1, self.file2], extra={}) != response
+        )
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -98,7 +98,7 @@ class GitHubAppsClientTest(TestCase):
             assert gh_rate_limit.next_window() == "17:39:49"
 
     @responses.activate
-    def test_get_rate_limit_non_existant_resouce(self):
+    def test_get_rate_limit_non_existent_resource(self):
         with pytest.raises(AssertionError):
             self.github_client.get_rate_limit("foo")
 
@@ -1166,28 +1166,29 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
         """
         Tests that the correct commits are selected from the blame range when a full response is returned.
         """
-        file1 = SourceLineInfo(
+        self.file1 = SourceLineInfo(
             path="src/sentry/integrations/github/client_1.py",
             lineno=10,
             ref="master",
             repo=self.repo_1,
             code_mapping=None,  # type:ignore
         )
-        file2 = SourceLineInfo(
+        self.file2 = SourceLineInfo(
             path="src/sentry/integrations/github/client_1.py",
             lineno=20,
             ref="master",
             repo=self.repo_1,
             code_mapping=None,  # type:ignore
         )
-        file3 = SourceLineInfo(
+        self.file3 = SourceLineInfo(
             path="src/sentry/integrations/github/client_2.py",
             lineno=20,
             ref="master",
             repo=self.repo_1,
             code_mapping=None,  # type:ignore
         )
-        data = {
+
+        self.data = {
             "repository0": {
                 "ref0": {
                     "target": {
@@ -1251,21 +1252,28 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
             }
         }
 
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @responses.activate
+    def test_get_blame_for_files_full_response(self, get_jwt):
+        """
+        Tests that the correct commits are returned when a full response is returned
+        """
+
         responses.add(
             method=responses.POST,
             url="https://api.github.com/graphql",
             json={
-                "data": data,
+                "data": self.data,
             },
             content_type="application/json",
         )
 
-        response = self.github_client.get_blame_for_files([file1, file2, file3], extra={})
+        response = self.github_client.get_blame_for_files([self.file1, self.file2, self.file3], extra={})
         self.assertEqual(
             response,
             [
                 FileBlameInfo(
-                    **asdict(file1),
+                    **asdict(self.file1),
                     commit=CommitInfo(
                         commitId="123",
                         commitAuthorName="foo1",
@@ -1275,7 +1283,7 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
                     ),
                 ),
                 FileBlameInfo(
-                    **asdict(file2),
+                    **asdict(self.file2),
                     commit=CommitInfo(
                         commitId="456",
                         commitAuthorName="foo2",
@@ -1285,7 +1293,7 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
                     ),
                 ),
                 FileBlameInfo(
-                    **asdict(file3),
+                    **asdict(self.file3),
                     commit=CommitInfo(
                         commitId="789",
                         commitAuthorName="foo3",
@@ -1296,6 +1304,57 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
                 ),
             ],
         )
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @responses.activate
+    def test_get_cached_blame_for_files_full_response(self, get_jwt):
+        """
+        Tests that the cached commits are returned with full response
+        """
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/graphql",
+            json={
+                "data": self.data,
+            },
+            content_type="application/json",
+        )
+        cache_key = "integration.github.client:c5f94e3edae168469aeb9736536817c5"
+        assert cache.get(cache_key) is None
+        response = self.github_client.get_blame_for_files([self.file1, self.file2, self.file3])
+        self.assertEqual(
+            response,
+            [
+                FileBlameInfo(
+                    **asdict(self.file1),
+                    commit=CommitInfo(
+                        commitId="123",
+                        commitAuthorName="foo1",
+                        commitAuthorEmail="foo1@example.com",
+                        commitMessage="hello",
+                        committedDate=datetime(2022, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                    ),
+                ),
+                FileBlameInfo(
+                    **asdict(self.file3),
+                    commit=CommitInfo(
+                        commitId="456",
+                        commitAuthorName="foo2",
+                        commitAuthorEmail="foo2@example.com",
+                        commitMessage="hello",
+                        committedDate=datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                    ),
+                ),
+            ],
+        )
+        assert cache.get(cache_key) == response
+        # Calling a second time should work
+        response = self.github_client.get_blame_for_files([self.file1, self.file2, self.file3])
+        assert cache.get(cache_key) == response
+        # Calling again after the cache has been cleared should still work
+        cache.delete(cache_key)
+        response = self.github_client.get_blame_for_files([self.file1, self.file2, self.file3])
+        assert cache.get(cache_key) == response
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1347,14 +1347,14 @@ class GitHubClientFileBlameResponseTest(GitHubClientFileBlameBase):
                 ),
             ],
         )
-        assert cache.get(cache_key) == response
+        assert cache.get(cache_key)["data"] == self.data
         # Calling a second time should work
         response = self.github_client.get_blame_for_files([self.file1, self.file2, self.file3])
-        assert cache.get(cache_key) == response
+        assert cache.get(cache_key)["data"] == self.data
         # Calling again after the cache has been cleared should still work
         cache.delete(cache_key)
         response = self.github_client.get_blame_for_files([self.file1, self.file2, self.file3])
-        assert cache.get(cache_key) == response
+        assert cache.get(cache_key)["data"] == self.data
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -433,6 +433,8 @@ class GitLabBlameForFilesTest(GitLabClientTest):
         assert cache.get(self.cache_key2) == self.make_blame_response(id="2")
         assert cache.get(self.cache_key3) == self.make_blame_response(id="3")
 
+        assert resp != self.gitlab_client.get_blame_for_files(files=[self.file_1, self.file_2])
+
     @mock.patch(
         "sentry.integrations.gitlab.blame.logger.exception",
     )

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -407,7 +407,6 @@ class GitLabBlameForFilesTest(GitLabClientTest):
     def test_success_multiple_files(self):
         self.set_up_success_responses()
         resp = self.gitlab_client.get_blame_for_files(files=[self.file_1, self.file_2, self.file_3])
-
         assert resp == [self.blame_1, self.blame_2, self.blame_3]
 
     @responses.activate


### PR DESCRIPTION
Add caching for `get_blame_for_files` to help reduce the chance of hitting the rate limit. 

Closes #57437