### PR TITLE
feat(bug reports): implement archive functionality for single feedbacks

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -10,7 +10,7 @@ import FeedbackItemUsername from 'sentry/components/feedback/feedbackItem/feedba
 import FeedbackViewers from 'sentry/components/feedback/feedbackItem/feedbackViewers';
 import ReplaySection from 'sentry/components/feedback/feedbackItem/replaySection';
 import TagsSection from 'sentry/components/feedback/feedbackItem/tagsSection';
-import onUpdateFeedback from 'sentry/components/feedback/feedbackItem/useUpdateFeedback';
+import useUpdateFeedback from 'sentry/components/feedback/feedbackItem/useUpdateFeedback';
 import ObjectInspector from 'sentry/components/objectInspector';
 import PanelItem from 'sentry/components/panels/panelItem';
 import {Flex} from 'sentry/components/profiling/flex';
@@ -30,7 +30,7 @@ interface Props {
 
 export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
   const organization = useOrganization();
-  const {onUpdate} = onUpdateFeedback({feedbackItem});
+  const {onSetStatus} = useUpdateFeedback({feedbackItem});
   const url = eventData?.tags.find(tag => tag.key === 'url');
 
   return (
@@ -86,7 +86,7 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
                         ? t('Unresolve')
                         : t('Resolve'),
                     onAction: () =>
-                      onUpdate(
+                      onSetStatus(
                         feedbackItem.status === GroupStatus.RESOLVED
                           ? GroupStatus.UNRESOLVED
                           : GroupStatus.RESOLVED
@@ -99,7 +99,7 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
                         ? t('Unarchive')
                         : t('Archive'),
                     onAction: () =>
-                      onUpdate(
+                      onSetStatus(
                         feedbackItem.status === GroupStatus.IGNORED
                           ? GroupStatus.UNRESOLVED
                           : GroupStatus.IGNORED

--- a/static/app/components/feedback/feedbackItem/useUpdateFeedback.tsx
+++ b/static/app/components/feedback/feedbackItem/useUpdateFeedback.tsx
@@ -44,6 +44,6 @@ export default function useUpdateFeedback({feedbackItem}: Props) {
   );
 
   return {
-    onSetStatus: (newStatus: GroupStatus) => handleUpdate(newStatus),
+    onSetStatus: handleUpdate,
   };
 }

--- a/static/app/components/feedback/feedbackItem/useUpdateFeedback.tsx
+++ b/static/app/components/feedback/feedbackItem/useUpdateFeedback.tsx
@@ -44,6 +44,6 @@ export default function useUpdateFeedback({feedbackItem}: Props) {
   );
 
   return {
-    onUpdate: (newStatus: GroupStatus) => handleUpdate(newStatus),
+    onSetStatus: (newStatus: GroupStatus) => handleUpdate(newStatus),
   };
 }

--- a/static/app/components/feedback/feedbackItem/useUpdateFeedback.tsx
+++ b/static/app/components/feedback/feedbackItem/useUpdateFeedback.tsx
@@ -37,7 +37,7 @@ export default function useUpdateFeedback({feedbackItem}: Props) {
         });
         addSuccessMessage(t('Updated feedback'));
       } catch {
-        addErrorMessage(t('An error occurred while archiving the feedback.'));
+        addErrorMessage(t('An error occurred while updating the feedback.'));
       }
     },
     [api, url]


### PR DESCRIPTION
The logic:

Clicking `Archive` -> `status: ignored`
From here, you can either click `Resolve` or `Unarchive`.

Click `Resolve` --> `status: resolved`
Click `Unarchive` -> `status: unresolved`

Page still doesn't refresh after status change yet -- fix to come 



https://github.com/getsentry/sentry/assets/56095982/834199ef-137e-4ec9-8379-305a8c8bd335

