### PR TITLE
ref(hc): Fixing alert rule copying issue

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -596,6 +596,9 @@ def snapshot_alert_rule(alert_rule, user=None):
         alert_rule_snapshot.id = None
         alert_rule_snapshot.status = AlertRuleStatus.SNAPSHOT.value
         alert_rule_snapshot.snuba_query = snuba_query_snapshot
+        if alert_rule.owner:
+            alert_rule_snapshot.user_id = alert_rule.owner.user_id
+            alert_rule_snapshot.team_id = alert_rule.owner.team_id
         alert_rule_snapshot.save()
         AlertRuleActivity.objects.create(
             alert_rule=alert_rule_snapshot,

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -41,6 +41,7 @@ from sentry.incidents.logic import (
     get_incident_aggregates,
     get_incident_subscribers,
     get_triggers_for_alert_rule,
+    snapshot_alert_rule,
     subscribe_to_incident,
     translate_aggregate_field,
     update_alert_rule,
@@ -66,7 +67,7 @@ from sentry.incidents.models import (
     IncidentType,
     TriggerStatus,
 )
-from sentry.models.actor import ActorTuple, get_actor_id_for_user
+from sentry.models.actor import ActorTuple, get_actor_for_user, get_actor_id_for_user
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.services.hybrid_cloud.integration.serial import serialize_integration
@@ -710,6 +711,14 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert (
             old_subscription_id != self.alert_rule.snuba_query.subscriptions.get().subscription_id
         )
+
+    def test_snapshot_alert_rule_with_only_owner(self):
+        # Force the alert rule into an invalid state
+        AlertRule.objects.filter(id=self.alert_rule.id).update(
+            user_id=None, team_id=None, owner=get_actor_for_user(self.user)
+        )
+        self.alert_rule.refresh_from_db()
+        snapshot_alert_rule(self.alert_rule, self.user)
 
     def test_empty_query(self):
         alert_rule = update_alert_rule(self.alert_rule, query="")


### PR DESCRIPTION
Addresses this edge case for historical data: https://sentry.sentry.io/issues/4572127351/?project=1&query=release%3Abackend%40d02ac0f9f494293a77b2bb583f6d5668c0bb9b96&referrer=release-issue-stream