### PR TITLE
perf(ui): Limit environment options to prevent UI from becoming unresponsive

### DIFF
--- a/static/app/components/organizations/environmentPageFilter/index.tsx
+++ b/static/app/components/organizations/environmentPageFilter/index.tsx
@@ -157,10 +157,10 @@ export function EnvironmentPageFilter({
 
   const options = useMemo(
     () =>
-      // Restrict to first 100 environments for performance reasons.
+      // Restrict to first 1000 environments for performance reasons.
       // Projects can have tens of thousands of envs, which can cause downstream
       // components to become unresponsive.
-      environments.slice(0, 100).map(env => ({
+      environments.slice(0, 1000).map(env => ({
         value: env,
         label: env,
       })),

--- a/static/app/components/organizations/environmentPageFilter/index.tsx
+++ b/static/app/components/organizations/environmentPageFilter/index.tsx
@@ -157,7 +157,10 @@ export function EnvironmentPageFilter({
 
   const options = useMemo(
     () =>
-      environments.map(env => ({
+      // Restrict to first 100 environments for performance reasons.
+      // Projects can have tens of thousands of envs, which can cause downstream
+      // components to become unresponsive.
+      environments.slice(0, 100).map(env => ({
         value: env,
         label: env,
       })),


### PR DESCRIPTION
It's possible to have tens (even hundreds) of thousands of environments, which is causing sentry to become unusable for certain orgs. We currently load every environment from each project and send them as options to the CompactSelect component, which cannot handle that many items. We already have logic in that component which prevents them from being rendered, but even just keeping that track of that many items causes a slowdown.

We can (and probably should) try to make CompactSelect more performant, but this is a quick fix to limit the number of options so we can get orgs like this functioning again. 

The real long-term solution in my mind is to load the environment list async with pagination.