### PR TITLE
fix(jira server): Fetch priorities based on selected project

### DIFF
--- a/fixtures/integrations/jira/stub_client.py
+++ b/fixtures/integrations/jira/stub_client.py
@@ -17,7 +17,7 @@ class StubJiraApiClient(StubService):
     def get_issue_types(self, project_id):
         return self._get_stub_data("issue_types_response.json")
 
-    def get_priorities(self):
+    def get_priorities(self, project_id):
         return self._get_stub_data("priorities_response.json")
 
     def get_versions(self, project_id):

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -494,7 +494,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
         return "{}/browse/{}".format(self.model.metadata["base_url"], key)
 
     def get_persisted_default_config_fields(self) -> Sequence[str]:
-        return ["project", "issuetype", "priority", "labels"]
+        return ["project", "issuetype", "labels"]
 
     def get_persisted_user_default_config_fields(self):
         return ["reporter"]
@@ -837,7 +837,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
             if field["name"] == "priority":
                 # whenever priorities are available, put the available ones in the list.
                 # allowedValues for some reason doesn't pass enough info.
-                field["choices"] = self.make_choices(client.get_priorities())
+                field["choices"] = self.make_choices(client.get_priorities(project_id))
                 field["default"] = defaults.get("priority", "")
             elif field["name"] == "fixVersions":
                 field["choices"] = self.make_choices(client.get_versions(project_id))

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -1,7 +1,6 @@
 import copy
 from functools import cached_property
 from unittest import mock
-from unittest.mock import patch
 
 import pytest
 import responses
@@ -346,6 +345,99 @@ class JiraServerIntegrationTest(APITestCase):
                 "versions",
             ]
 
+    @responses.activate
+    def test_get_create_issue_config_with_project_having_subset_priorities(self):
+        """Test that a project that is limited to a subset of priorities
+        correctly returns the subset instead of all priorities
+        """
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "message",
+                "timestamp": self.min_ago,
+                "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
+            },
+            project_id=self.project.id,
+        )
+        group = event.group
+
+        responses.add(
+            responses.GET,
+            f"https://jira.example.org/rest/api/2/project/{DEFAULT_PROJECT_ID}/priorityscheme",
+            json={
+                "expand": "projectKeys",
+                "self": "https://jira.example.org/rest/api/2/priorityschemes/1",
+                "id": 1,
+                "name": "Default Priority Scheme",
+                "description": "The default priority scheme that applies to all projects",
+                # Exclude the "medium" priority (id 2)
+                "optionIds": ["1", "3"],
+                "defaultScheme": False,
+            },
+        )
+
+        responses.add(
+            responses.GET,
+            "https://jira.example.org/rest/api/2/priority",
+            json=[
+                {
+                    "self": "https://jira.example.org/rest/api/2/priority/1",
+                    "statusColor": "#f15C75",
+                    "description": "Serious problem that could block progress.",
+                    "iconUrl": "https://jira-integration.getsentry.net/images/icons/priorities/high.svg",
+                    "name": "High",
+                    "id": "1",
+                },
+                {
+                    "self": "https://jira.example.org/rest/api/2/priority/2",
+                    "statusColor": "#f79232",
+                    "description": "Has the potential to affect progress.",
+                    "iconUrl": "https://jira-integration.getsentry.net/images/icons/priorities/medium.svg",
+                    "name": "Medium",
+                    "id": "2",
+                },
+                {
+                    "self": "https://jira.example.org/rest/api/2/priority/3",
+                    "statusColor": "#707070",
+                    "description": "Minor problem or easily worked around.",
+                    "iconUrl": "https://jira-integration.getsentry.net/images/icons/priorities/low.svg",
+                    "name": "Low",
+                    "id": "3",
+                },
+            ],
+        )
+
+        def get_priorities_callthrough_client(installation: JiraServerIntegration):
+            """
+            This functions returns a lambda that when called upon, returns a
+            StubJiraApiClient. The only difference is we don't mock the function
+            call to get_priorities for the stub client.
+            """
+            mock_client = StubJiraApiClient()
+            # set the mock call to the real function
+            mock_client.get_priorities = installation.get_client().get_priorities
+            return lambda: mock_client
+
+        with mock.patch.object(
+            self.installation,
+            "get_client",
+            get_priorities_callthrough_client(installation=self.installation),
+        ):
+            # Initially all fields are present
+            fields = self.installation.get_create_issue_config(group, self.user)
+            priority_field = [field for field in fields if field["name"] == "priority"][0]
+            assert priority_field == {
+                "default": "",
+                "choices": [
+                    ("1", "High"),
+                    ("3", "Low"),
+                ],
+                "type": "select",
+                "name": "priority",
+                "label": "Priority",
+                "required": False,
+            }
+
     def test_get_create_issue_config_with_default_and_param(self):
         event = self.store_event(
             data={
@@ -449,7 +541,7 @@ class JiraServerIntegrationTest(APITestCase):
         assert fields[1]["name"] == "error"
         assert fields[1]["type"] == "blank"
 
-    @patch("sentry.integrations.jira_server.client.JiraServerClient.get_issue_fields")
+    @mock.patch("sentry.integrations.jira_server.client.JiraServerClient.get_issue_fields")
     def test_get_create_issue_config_with_default_project_deleted(self, mock_get_issue_fields):
         event = self.store_event(
             data={

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -415,7 +415,7 @@ class JiraServerIntegrationTest(APITestCase):
             """
             mock_client = StubJiraApiClient()
             # set the mock call to the real function
-            mock_client.get_priorities = installation.get_client().get_priorities  # type: ignore
+            setattr(mock_client, "get_priorities", installation.get_client().get_priorities)
             return lambda: mock_client
 
         with mock.patch.object(

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -415,7 +415,7 @@ class JiraServerIntegrationTest(APITestCase):
             """
             mock_client = StubJiraApiClient()
             # set the mock call to the real function
-            mock_client.get_priorities = installation.get_client().get_priorities
+            mock_client.get_priorities = installation.get_client().get_priorities  # type: ignore
             return lambda: mock_client
 
         with mock.patch.object(


### PR DESCRIPTION
‼️ Reverted b/c this runs into a permission issue of needing global/project admin permission. This is the relevant [Sentry Issue](https://sentry.sentry.io/issues/4575684693/events/669bdab1fb6846e194caa8c935b3e11b/?project=1&referrer=issue-list)


Previously, we fetched all priorities for a Jira Server instance and showed them when creating an alert rule action or manual issue. However, priorities are configured per project so this lead to an issue where the user could attempt to set a nonexistent priority for a project when creating an alert rule action or manual issue.

Note that I'll create a separate PR for the Jira fix.

### Before/After Manually Creating Issue

https://github.com/getsentry/sentry/assets/67301797/54b925b5-00f4-4f45-848a-b55b1845d779

https://github.com/getsentry/sentry/assets/67301797/799ed41b-ae44-465b-8400-15125ab47e05

### Before/After Creating Issue Alert Rule
Unfortunately we swallow the error in the backend and don't raise anything so there's no indication anything is wrong in the UI. Ideally, we would match the error display with manually creating the issue.

https://github.com/getsentry/sentry/assets/67301797/e962a0a1-1484-4ab2-88e3-07457fefb5a1

https://github.com/getsentry/sentry/assets/67301797/8d4a4388-e9cb-4737-85cd-5838190f6814

