### PR TITLE
feat(on-demand): Add environment support to on-demand metrics

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -209,8 +209,14 @@ def _convert_snuba_query_to_metric(
     If the passed snuba_query is a valid query for on-demand metric extraction,
     returns a tuple of (hash, MetricSpec) for the query. Otherwise, returns None.
     """
+
+    # TODO: extract into function, add safe access, check for case where name is empty or none
+    query_string = snuba_query.query
+    if snuba_query.environment is not None:
+        query_string = f"environment:{snuba_query.environment} {query_string}"
+
     return _convert_aggregate_and_query_to_metric(
-        project, snuba_query.dataset, snuba_query.aggregate, snuba_query.query, prefilling
+        project, snuba_query.dataset, snuba_query.aggregate, query_string, prefilling
     )
 
 
@@ -259,7 +265,12 @@ def _convert_widget_query_to_metric(
 
 
 def _convert_aggregate_and_query_to_metric(
-    project: Project, dataset: str, aggregate: str, query: str, prefilling: bool
+    project: Project,
+    dataset: str,
+    aggregate: str,
+    query: str,
+    prefilling: bool,
+    environment: Optional[str] = None,
 ) -> Optional[HashedMetricSpec]:
     """
     Converts an aggregate and a query to a metric spec with its hash value.
@@ -271,6 +282,7 @@ def _convert_aggregate_and_query_to_metric(
         on_demand_spec = OnDemandMetricSpec(
             field=aggregate,
             query=query,
+            environment=environment,
         )
 
         return on_demand_spec.query_hash, on_demand_spec.to_metric_spec(project)

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -130,7 +130,11 @@ class MetricsQueryBuilder(QueryBuilder):
             return None
 
         try:
-            return OnDemandMetricSpec(field, self.query)
+            environment = None
+            if self.params.environments:
+                environment = self.params.environments[0].name
+
+            return OnDemandMetricSpec(field, self.query, environment)
         except Exception as e:
             sentry_sdk.capture_exception(e)
             return None

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -170,6 +170,7 @@ class MetricsQueryBuilder(QueryBuilder):
             raise InvalidSearchQuery(
                 "The on demand metric query requires a time range to be executed"
             )
+
         where = [
             Condition(
                 lhs=Column(QUERY_HASH_KEY),
@@ -177,16 +178,6 @@ class MetricsQueryBuilder(QueryBuilder):
                 rhs=spec.query_hash,
             ),
         ]
-
-        if self.params.environments:
-            environment = self.params.environments[0].name
-            where.append(
-                Condition(
-                    Column("environment"),
-                    Op.EQ,
-                    environment,
-                )
-            )
 
         return MetricsQuery(
             select=[MetricField(spec.op, spec.mri, alias=alias)],

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -973,9 +973,9 @@ class OnDemandMetricSpec:
         return rule_condition
 
     def _extend_parsed_query(self, parsed_query_result: QueryParsingResult) -> QueryParsingResult:
-        conditions = parsed_query_result.conditions
+        conditions = cast(List[QueryToken], parsed_query_result.conditions)
 
-        new_conditions = []
+        new_conditions: List[QueryToken] = []
         if self.environment is not None:
             new_conditions.append(
                 SearchFilter(

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -813,7 +813,7 @@ class OnDemandMetricSpec:
     _metric_type: str
     _arguments: Sequence[str]
 
-    def __init__(self, field: str, query: str):
+    def __init__(self, field: str, query: str, environment: Optional[str] = None):
         self.field = field
         self.query = query
         self._arguments = []

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -23,7 +23,13 @@ from django.utils.functional import cached_property
 from typing_extensions import NotRequired
 
 from sentry.api import event_search
-from sentry.api.event_search import AggregateFilter, ParenExpression, SearchFilter
+from sentry.api.event_search import (
+    AggregateFilter,
+    ParenExpression,
+    SearchFilter,
+    SearchKey,
+    SearchValue,
+)
 from sentry.constants import APDEX_THRESHOLD_DEFAULT, DataCategory
 from sentry.discover.arithmetic import is_equation
 from sentry.exceptions import InvalidSearchQuery
@@ -816,6 +822,9 @@ class OnDemandMetricSpec:
     def __init__(self, field: str, query: str, environment: Optional[str] = None):
         self.field = field
         self.query = query
+        # For now, we just support the environment as extra, but in the future we might need more complex ways to
+        # combine extra values that are outside the query string.
+        self.environment = environment
         self._arguments = []
         self._eager_process()
 
@@ -946,6 +955,10 @@ class OnDemandMetricSpec:
 
             return aggregate_conditions
 
+        # We extend the parsed query with other conditions that we want to inject externally from the query. For now
+        # we support only the environment.
+        parsed_query = self._extend_parsed_query(parsed_query)
+
         # Third step is to generate the actual Relay rule that contains all rules nested.
         rule_condition = SearchQueryConverter(parsed_query.conditions).convert()
         if not aggregate_conditions:
@@ -958,6 +971,27 @@ class OnDemandMetricSpec:
         # In the other case, we can just flatten the conditions.
         rule_condition["inner"].append(aggregate_conditions)
         return rule_condition
+
+    def _extend_parsed_query(self, parsed_query_result: QueryParsingResult) -> QueryParsingResult:
+        conditions = parsed_query_result.conditions
+
+        new_conditions = []
+        if self.environment is not None:
+            new_conditions.append(
+                SearchFilter(
+                    key=SearchKey(name="environment"),
+                    operator="=",
+                    value=SearchValue(raw_value=self.environment),
+                )
+            )
+            new_conditions.append("AND")
+
+        extended_conditions = new_conditions + conditions
+        return QueryParsingResult(
+            # This transformation is equivalent to the syntax "new_conditions AND conditions" where conditions can be
+            # in parentheses or not.
+            conditions=extended_conditions
+        )
 
     @staticmethod
     def _aggregate_conditions(parsed_field) -> Optional[RuleCondition]:

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Optional, Sequence
 from unittest.mock import ANY
 
 import pytest
@@ -31,7 +31,7 @@ def create_alert(
     query: str,
     project: Project,
     dataset: Dataset = Dataset.PerformanceMetrics,
-    environment: Environment = None,
+    environment: Optional[Environment] = None,
 ) -> AlertRule:
     snuba_query = SnubaQuery.objects.create(
         aggregate=aggregate,
@@ -173,6 +173,8 @@ def test_get_metric_extraction_config_environment(default_project, default_envir
 
         no_env, default_env = config["metrics"]
 
+        # assert that the conditions are different
+        assert no_env["condition"] != default_env["condition"]
         # assert that environment is part of the hash
         assert no_env["tags"][0]["value"] != default_env["tags"][0]["value"]
 

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -11,6 +11,7 @@ from sentry.models.dashboard_widget import (
     DashboardWidgetQuery,
     DashboardWidgetTypes,
 )
+from sentry.models.environment import Environment
 from sentry.models.project import Project
 from sentry.models.transaction_threshold import ProjectTransactionThreshold, TransactionMetric
 from sentry.relay.config.metric_extraction import get_metric_extraction_config
@@ -26,7 +27,11 @@ ON_DEMAND_METRICS_PREFILL = "organizations:on-demand-metrics-prefill"
 
 
 def create_alert(
-    aggregate: str, query: str, project: Project, dataset: Dataset = Dataset.PerformanceMetrics
+    aggregate: str,
+    query: str,
+    project: Project,
+    dataset: Dataset = Dataset.PerformanceMetrics,
+    environment: Environment = None,
 ) -> AlertRule:
     snuba_query = SnubaQuery.objects.create(
         aggregate=aggregate,
@@ -34,7 +39,7 @@ def create_alert(
         dataset=dataset.value,
         time_window=300,
         resolution=60,
-        environment=None,
+        environment=environment,
         type=SnubaQuery.Type.PERFORMANCE.value,
     )
 
@@ -149,6 +154,27 @@ def test_get_metric_extraction_config_multiple_alerts_duplicated(default_project
 
         assert config
         assert len(config["metrics"]) == 1
+
+
+@django_db_all
+def test_get_metric_extraction_config_environment(default_project, default_environment):
+    with Feature(ON_DEMAND_METRICS):
+        create_alert("count()", "transaction.duration:>0", default_project)
+        create_alert("count()", "transaction.duration:>0", default_project, environment=None)
+        create_alert(
+            "count()", "transaction.duration:>0", default_project, environment=default_environment
+        )
+
+        config = get_metric_extraction_config(default_project)
+
+        assert config
+        # assert that the deduplication works with environments
+        assert len(config["metrics"]) == 2
+
+        no_env, default_env = config["metrics"]
+
+        # assert that environment is part of the hash
+        assert no_env["tags"][0]["value"] != default_env["tags"][0]["value"]
 
 
 @django_db_all

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -2028,10 +2028,12 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
             ],
         )
 
-    def test_run_query_with_on_demand_distribution(self):
+    def test_run_query_with_on_demand_distribution_and_environment(self):
         field = "p75(measurements.fp)"
         query_s = "transaction.duration:>0"
-        spec = OnDemandMetricSpec(field=field, query=query_s)
+        spec = OnDemandMetricSpec(field=field, query=query_s, environment="prod")
+
+        self.create_environment(project=self.project, name="prod")
 
         for hour in range(0, 5):
             self.store_transaction_metric(
@@ -2044,7 +2046,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
             )
 
         query = TimeseriesMetricQueryBuilder(
-            self.params,
+            {**self.params, "environment": ["prod"]},  # type:ignore
             dataset=Dataset.PerformanceMetrics,
             interval=3600,
             query=query_s,
@@ -2611,7 +2613,7 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
 
         self.create_environment(project=self.project, name="prod")
 
-        # We want to test also with "dev" that is not in the database, to check that we fall-back to avoiding the
+        # We want to test also with "dev" that is not in the database, to check that we fallback to avoiding the
         # environment filter at all.
         environments = ((None, 100), ("prod", 200), ("dev", 300))
         specs = []

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -2609,11 +2609,11 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         field = "count(measurements.fp)"
         query_s = "transaction.duration:>=100"
 
-        env_name = "prod"
-        self.create_environment(project=self.project, name=env_name)
+        self.create_environment(project=self.project, name="prod")
 
-        # We use different values to distinguish between the two.
-        environments = ((None, 100), (env_name, 200))
+        # We want to test also with "dev" that is not in the database, to check that we fall-back to avoiding the
+        # environment filter at all.
+        environments = ((None, 100), ("prod", 200), ("dev", 300))
         specs = []
         for environment, value in environments:
             spec = OnDemandMetricSpec(field=field, query=query_s, environment=environment)
@@ -2627,7 +2627,8 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
             )
             specs.append(spec)
 
-        for (environment, value), spec in zip(environments, specs):
+        expected_environments = ((None, 100), ("prod", 200), ("dev", 100))
+        for (environment, value), spec in zip(expected_environments, specs):
             params = (
                 self.params
                 if environment is None

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -172,7 +172,7 @@ def test_spec_simple_query_with_environment():
 
 def test_spec_query_with_parentheses_and_environment():
     spec = OnDemandMetricSpec(
-        "count()", "(transaction.duration:>1s OR http.status_code:200)", "production"
+        "count()", "(transaction.duration:>1s OR http.status_code:200)", "dev"
     )
 
     assert spec._metric_type == "c"
@@ -180,7 +180,7 @@ def test_spec_query_with_parentheses_and_environment():
     assert spec.op == "sum"
     assert spec.condition == {
         "inner": [
-            {"name": "event.environment", "op": "eq", "value": "production"},
+            {"name": "event.environment", "op": "eq", "value": "dev"},
             {
                 "inner": [
                     {"name": "event.duration", "op": "gt", "value": 1000.0},
@@ -197,7 +197,7 @@ def test_spec_complex_query_with_environment():
     spec = OnDemandMetricSpec(
         "count()",
         "transaction.duration:>1s AND http.status_code:200 OR os.browser:Chrome",
-        "production",
+        "staging",
     )
 
     assert spec._metric_type == "c"
@@ -207,7 +207,7 @@ def test_spec_complex_query_with_environment():
         "inner": [
             {
                 "inner": [
-                    {"name": "event.environment", "op": "eq", "value": "production"},
+                    {"name": "event.environment", "op": "eq", "value": "staging"},
                     {"name": "event.duration", "op": "gt", "value": 1000.0},
                     {"name": "event.contexts.response.status_code", "op": "eq", "value": "200"},
                 ],

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -96,7 +96,7 @@ class TestCreatesOndemandMetricSpec:
                 "apdex(10)",
                 "",
             ),  # apdex with specified threshold is on-demand metric even without query
-            ("count()", "transaction.duration:>0 my-transaction"),
+            ("count()", "transaction.duration:>0 my-transaction isSideLoaded"),
         ],
     )
     def test_creates_on_demand_spec(self, aggregate, query):


### PR DESCRIPTION
Includes the selected alert environment into the generated on-demand spec