### PR TITLE
chore(stat-detectors): Disable Replays

### DIFF
--- a/static/app/utils/issueTypeConfig/performanceConfig.tsx
+++ b/static/app/utils/issueTypeConfig/performanceConfig.tsx
@@ -190,6 +190,7 @@ const performanceConfig: IssueCategoryConfigMapping = {
   [IssueType.PERFORMANCE_DURATION_REGRESSION]: {
     stats: {enabled: false},
     tags: {enabled: false},
+    replays: {enabled: false},
   },
   [IssueType.PROFILE_FILE_IO_MAIN_THREAD]: {
     resources: {


### PR DESCRIPTION
Disabling replays for now because they're not critical for EA.

I have work to enable them but I need to verify the difference between querying for replays from `search_issues` vs `discover`. My query works for `discover` but not `search_issues`. We can revisit it when there's more time.