### PR TITLE
ref(hc): Remove alert rule update validation

### DIFF
--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -467,12 +467,6 @@ class AlertRule(Model):
         self._validate_actor()
         return super().save(**kwargs)
 
-    def update(self, **kwargs: Any):
-        with transaction.atomic(router.db_for_write(AlertRule)):
-            result = super().update(**kwargs)
-            self._validate_actor()
-            return result
-
     @property
     def created_by_id(self):
         try:


### PR DESCRIPTION
Addresses https://sentry.sentry.io/issues/4572534701/?alert_rule_id=14700499&alert_type=issue&notification_uuid=c9c9c261-7d4a-49d4-b634-35681b5a41c3&project=1&referrer=slack

Don't really need the update validation, only the save validation.