### PR TITLE
fix replay context

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -23,7 +23,7 @@ def make_evidence(feedback):
     return evidence_data, evidence_display
 
 
-def _fix_for_issue_platform(event_data):
+def fix_for_issue_platform(event_data):
     # the issue platform has slightly different requirements than ingest
     # for event schema, so we need to massage the data a bit
     event_data["timestamp"] = ensure_aware(
@@ -32,9 +32,16 @@ def _fix_for_issue_platform(event_data):
     if "contexts" not in event_data:
         event_data["contexts"] = {}
 
-    if event_data.get("feedback"):
+    if event_data.get("feedback") and not event_data.get("contexts", {}).get("feedback"):
         event_data["contexts"]["feedback"] = event_data["feedback"]
         del event_data["feedback"]
+
+        if not event_data["contexts"].get("replay") and event_data["contexts"]["feedback"].get(
+            "replay_id"
+        ):
+            event_data["contexts"]["replay"] = {
+                "replay_id": event_data["contexts"]["feedback"].get("replay_id")
+            }
 
     if event_data.get("dist") is not None:
         del event_data["dist"]
@@ -79,7 +86,7 @@ def create_feedback_issue(event, project_id):
         "tags": event.get("tags", {}),
         **event,
     }
-    _fix_for_issue_platform(event_data)
+    fix_for_issue_platform(event_data)
 
     produce_occurrence_to_kafka(
         payload_type=PayloadType.OCCURRENCE, occurrence=occurrence, event_data=event_data

--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sentry.feedback.usecases.create_feedback import fix_for_issue_platform
+
+
+def test_fix_for_issue_platform():
+    event: dict[str, Any] = {
+        "feedback": {
+            "contact_email": "josh.ferge@sentry.io",
+            "name": "Josh Ferge",
+            "message": "josh ferge testing again!",
+            "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
+            "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+        },
+        "request": {
+            "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            "headers": {
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+            },
+        },
+        "event_id": "56b08cf7852c42cbb95e4a6998c66ad6",
+        "timestamp": 1698255009.574,
+        "environment": "prod",
+        "release": "frontend@daf1316f209d961443664cd6eb4231ca154db502",
+        "sdk": {
+            "integrations": [
+                "InboundFilters",
+                "FunctionToString",
+                "TryCatch",
+                "Breadcrumbs",
+                "GlobalHandlers",
+                "LinkedErrors",
+                "Dedupe",
+                "HttpContext",
+                "ExtraErrorData",
+                "BrowserTracing",
+                "BrowserProfilingIntegration",
+            ],
+            "name": "sentry.javascript.react",
+            "version": "7.75.0",
+        },
+        "tags": {
+            "transaction": "/feedback/",
+            "sentry_version": "23.11.0.dev0",
+            "isCustomerDomain": "yes",
+            "customerDomain.organizationUrl": "https://sentry.sentry.io",
+            "customerDomain.sentryUrl": "https://sentry.io",
+            "customerDomain.subdomain": "sentry",
+            "organization": "1",
+            "organization.slug": "sentry",
+            "plan": "am2_business_ent_auf",
+            "plan.name": "Business",
+            "plan.max_members": "null",
+            "plan.total_members": "414",
+            "plan.tier": "am2",
+            "timeOrigin.mode": "navigationStart",
+        },
+        "user": {
+            "ip_address": "72.164.175.154",
+            "email": "josh.ferge@sentry.io",
+            "id": 880461,
+            "isStaff": False,
+            "name": "Josh Ferge",
+        },
+        "contexts": {
+            "trace": {
+                "op": "navigation",
+                "span_id": "9ffadde1100e4d55",
+                "tags": {
+                    "routing.instrumentation": "react-router-v3",
+                    "from": "/issues/(searches/:searchId/)",
+                },
+                "trace_id": "8e51f44000d34b8d871cea7f0c3e394c",
+            },
+            "organization": {"id": "1", "slug": "sentry"},
+        },
+        "breadcrumbs": [],
+        "platform": "javascript",
+    }
+
+    fix_for_issue_platform(event)
+
+    assert event["contexts"]["replay"]["replay_id"] == "3d621c61593c4ff9b43f8490a78ae18e"
+    assert event["contexts"]["feedback"] == {
+        "contact_email": "josh.ferge@sentry.io",
+        "name": "Josh Ferge",
+        "message": "josh ferge testing again!",
+        "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
+        "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+    }
+
+
+def test_corrected_still_works():
+
+    event: dict[str, Any] = {
+        "request": {
+            "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            "headers": {
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+            },
+        },
+        "event_id": "56b08cf7852c42cbb95e4a6998c66ad6",
+        "timestamp": 1698255009.574,
+        "environment": "prod",
+        "release": "frontend@daf1316f209d961443664cd6eb4231ca154db502",
+        "sdk": {
+            "integrations": [
+                "InboundFilters",
+                "FunctionToString",
+                "TryCatch",
+                "Breadcrumbs",
+                "GlobalHandlers",
+                "LinkedErrors",
+                "Dedupe",
+                "HttpContext",
+                "ExtraErrorData",
+                "BrowserTracing",
+                "BrowserProfilingIntegration",
+            ],
+            "name": "sentry.javascript.react",
+            "version": "7.75.0",
+        },
+        "tags": {
+            "transaction": "/feedback/",
+            "sentry_version": "23.11.0.dev0",
+            "isCustomerDomain": "yes",
+            "customerDomain.organizationUrl": "https://sentry.sentry.io",
+            "customerDomain.sentryUrl": "https://sentry.io",
+            "customerDomain.subdomain": "sentry",
+            "organization": "1",
+            "organization.slug": "sentry",
+            "plan": "am2_business_ent_auf",
+            "plan.name": "Business",
+            "plan.max_members": "null",
+            "plan.total_members": "414",
+            "plan.tier": "am2",
+            "timeOrigin.mode": "navigationStart",
+        },
+        "user": {
+            "ip_address": "72.164.175.154",
+            "email": "josh.ferge@sentry.io",
+            "id": 880461,
+            "isStaff": False,
+            "name": "Josh Ferge",
+        },
+        "contexts": {
+            "trace": {
+                "op": "navigation",
+                "span_id": "9ffadde1100e4d55",
+                "tags": {
+                    "routing.instrumentation": "react-router-v3",
+                    "from": "/issues/(searches/:searchId/)",
+                },
+                "trace_id": "8e51f44000d34b8d871cea7f0c3e394c",
+            },
+            "organization": {"id": "1", "slug": "sentry"},
+            "feedback": {
+                "contact_email": "josh.ferge@sentry.io",
+                "name": "Josh Ferge",
+                "message": "josh ferge testing again!",
+                "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
+                "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            },
+            "replay": {
+                "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
+            },
+        },
+        "breadcrumbs": [],
+        "platform": "javascript",
+    }
+
+    fix_for_issue_platform(event)
+
+    assert event["contexts"]["replay"]["replay_id"] == "3d621c61593c4ff9b43f8490a78ae18e"
+    assert event["contexts"]["feedback"] == {
+        "contact_email": "josh.ferge@sentry.io",
+        "name": "Josh Ferge",
+        "message": "josh ferge testing again!",
+        "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
+        "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+    }


### PR DESCRIPTION
puts replay_id on the replay_context. can be removed once SDK upstream starts doing that. (may just happen automatically once we start using relay because of DSC)