### PR TITLE
ref(replays): remove badge from replay preview

### DIFF
--- a/static/app/components/events/eventReplay/replayPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.spec.tsx
@@ -173,7 +173,6 @@ describe('ReplayPreview', () => {
     );
 
     // Expect replay view to be rendered
-    expect(screen.getByText('Replays')).toBeVisible();
     expect(screen.getByTestId('player-container')).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -140,9 +140,6 @@ function ReplayPreview({orgSlug, replaySlug, eventTimestampMs, buttonProps}: Pro
             {t('Open Replay')}
           </LinkButton>
         </CTAOverlay>
-        <BadgeContainer>
-          <FeatureText>{t('Replays')}</FeatureText>
-        </BadgeContainer>
       </PlayerContainer>
     </ReplayContextProvider>
   );
@@ -168,25 +165,6 @@ const CTAOverlay = styled('div')`
   justify-content: center;
   align-items: center;
   background: rgba(255, 255, 255, 0.5);
-`;
-
-const BadgeContainer = styled('div')`
-  display: flex;
-  align-items: center;
-  position: absolute;
-  top: ${space(1)};
-  right: ${space(1)};
-  background: ${p => p.theme.background};
-  border-radius: 2.25rem;
-  padding: ${space(0.75)} ${space(0.75)} ${space(0.75)} ${space(1)};
-  box-shadow: ${p => p.theme.dropShadowLight};
-  gap: 0 ${space(0.25)};
-`;
-
-const FeatureText = styled('div')`
-  font-size: ${p => p.theme.fontSizeSmall};
-  line-height: 0;
-  color: ${p => p.theme.text};
 `;
 
 const StyledPlaceholder = styled(Placeholder)`


### PR DESCRIPTION
remove the 'replays' badge in the top right corner of the preview:

before:
<img width="842" alt="SCR-20231025-kbpy" src="https://github.com/getsentry/sentry/assets/56095982/a1b798f1-e9fc-41c2-b992-8678bfb33cd4">





after:
<img width="757" alt="SCR-20231025-kbgf" src="https://github.com/getsentry/sentry/assets/56095982/f623cd2a-1780-4b87-9c2e-769a696eab24">
<img width="859" alt="SCR-20231025-kbjy" src="https://github.com/getsentry/sentry/assets/56095982/befb02e7-7aa6-4828-82fe-c0634ee71077">
