### PR TITLE
fix(hybridcloud) Read organization avatars from region domains

### DIFF
--- a/static/app/components/avatarChooser.tsx
+++ b/static/app/components/avatarChooser.tsx
@@ -41,6 +41,7 @@ type DefaultProps = {
   allowUpload?: boolean;
   defaultChoice?: DefaultChoice;
   type?: AvatarChooserType;
+  uploadDomain?: string;
 };
 
 type Props = {
@@ -71,6 +72,7 @@ class AvatarChooser extends Component<Props, State> {
     defaultChoice: {
       allowDefault: false,
     },
+    uploadDomain: '',
   };
 
   state: State = {
@@ -170,6 +172,7 @@ class AvatarChooser extends Component<Props, State> {
       title,
       help,
       defaultChoice,
+      uploadDomain,
     } = this.props;
     const {hasError, model, dataUrl} = this.state;
 
@@ -242,6 +245,7 @@ class AvatarChooser extends Component<Props, State> {
                   type={type!}
                   model={model}
                   savedDataUrl={savedDataUrl}
+                  uploadDomain={uploadDomain ?? ''}
                   updateDataUrlState={dataState => this.setState(dataState)}
                 />
               )}

--- a/static/app/components/avatarUploader.tsx
+++ b/static/app/components/avatarUploader.tsx
@@ -51,6 +51,7 @@ type Props = {
     | 'sentryAppSimple'
     | 'docIntegration';
   updateDataUrlState: (opts: {dataUrl?: string; savedDataUrl?: string | null}) => void;
+  uploadDomain: string;
   savedDataUrl?: string;
 };
 
@@ -351,9 +352,10 @@ class AvatarUploader extends Component<Props, State> {
   }
 
   get imageSrc() {
-    const {savedDataUrl, model, type} = this.props;
+    const {savedDataUrl, model, type, uploadDomain} = this.props;
     const uuid = model.avatar?.avatarUuid;
-    const photoUrl = uuid && `/${AVATAR_URL_MAP[type] || 'avatar'}/${uuid}/`;
+    const photoUrl =
+      uuid && `${uploadDomain}/${AVATAR_URL_MAP[type] || 'avatar'}/${uuid}/`;
 
     return savedDataUrl || this.state.objectURL || photoUrl;
   }
@@ -383,6 +385,7 @@ class AvatarUploader extends Component<Props, State> {
           <img
             ref={this.image}
             src={src}
+            crossOrigin="anonymous"
             onLoad={this.onImageLoad}
             onDragStart={e => e.preventDefault()}
           />

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -117,6 +117,7 @@ function OrganizationSettingsForm({initialData, onSave}: Props) {
         allowGravatar={false}
         endpoint={`${endpoint}avatar/`}
         model={initialData}
+        uploadDomain={initialData.links.regionUrl}
         onSave={updateOrganization}
         disabled={!access.has('org:write')}
       />


### PR DESCRIPTION
Organization avatars are provided by region silos, and we need to fetch images from those domains.

This will have no effect in single-tenant as in those environments `links.regionUrl` is the same as the root domain.
