### PR TITLE
perf(ui): Optimize CompactSelect to handle a very large number of options

### DIFF
--- a/static/app/components/compactSelect/utils.tsx
+++ b/static/app/components/compactSelect/utils.tsx
@@ -158,21 +158,21 @@ export function getHiddenOptions<Value extends React.Key>(
     currentIndex += 1;
   }
 
-  // Return the values of options that were removed.
-  return new Set([
-    ...itemsToHide,
-    ...remainingItems.slice(threshold[0]).reduce((acc: Value[], cur, index) => {
-      if ('options' in cur) {
-        return acc.concat(
-          index === 0
-            ? cur.options.slice(threshold[1]).map(o => o.value)
-            : cur.options.map(o => o.value)
-        );
+  for (let i = threshold[0]; i < remainingItems.length; i++) {
+    const item = remainingItems[i];
+    if ('options' in item) {
+      if (i === threshold[0]) {
+        itemsToHide.push(...item.options.slice(threshold[1]).map(opt => opt.value));
+      } else {
+        itemsToHide.push(...item.options.map(opt => opt.value));
       }
+    } else {
+      itemsToHide.push(item.value);
+    }
+  }
 
-      return acc.concat(cur.value);
-    }, []),
-  ]);
+  // Return the values of options that were removed.
+  return new Set(itemsToHide);
 }
 
 /**

--- a/static/app/components/compactSelect/utils.tsx
+++ b/static/app/components/compactSelect/utils.tsx
@@ -110,7 +110,7 @@ export function getHiddenOptions<Value extends React.Key>(
       .toLowerCase()
       .includes(search.toLowerCase());
 
-  const itemsToHide: Value[] = [];
+  const hiddenOptionsSet = new Set<Value>();
   const remainingItems = items
     .map<SelectOptionOrSection<Value> | null>(item => {
       if ('options' in item) {
@@ -120,7 +120,7 @@ export function getHiddenOptions<Value extends React.Key>(
               return opt;
             }
 
-            itemsToHide.push(opt.value);
+            hiddenOptionsSet.add(opt.value);
             return null;
           })
           .filter((opt): opt is SelectOption<Value> => !!opt);
@@ -132,7 +132,7 @@ export function getHiddenOptions<Value extends React.Key>(
         return item;
       }
 
-      itemsToHide.push(item.value);
+      hiddenOptionsSet.add(item.value);
       return null;
     })
     .flat()
@@ -161,18 +161,17 @@ export function getHiddenOptions<Value extends React.Key>(
   for (let i = threshold[0]; i < remainingItems.length; i++) {
     const item = remainingItems[i];
     if ('options' in item) {
-      if (i === threshold[0]) {
-        itemsToHide.push(...item.options.slice(threshold[1]).map(opt => opt.value));
-      } else {
-        itemsToHide.push(...item.options.map(opt => opt.value));
+      const startingIndex = i === threshold[0] ? threshold[1] : 0;
+      for (let j = startingIndex; j < item.options.length; j++) {
+        hiddenOptionsSet.add(item.options[j].value);
       }
     } else {
-      itemsToHide.push(item.value);
+      hiddenOptionsSet.add(item.value);
     }
   }
 
   // Return the values of options that were removed.
-  return new Set(itemsToHide);
+  return hiddenOptionsSet;
 }
 
 /**


### PR DESCRIPTION
For orgs that have 100k+ environments, CompactSelect was causing the page to become unresponsive. Profiling pointed to this part of the code as the main culprit, so I made some simple changes to make it run quicker. With these changes the dropdown loads and is at least usable with 70k items. There are probably more things we can do here, and we should definitely revisit environments soon so we don't have to deal with these kinds of numbers for a client side search.