### PR TITLE
fix(stat-detectors): Update span anlaysis table 

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
@@ -112,7 +112,6 @@ function NumericChange({
   afterRawValue: number;
   beforeRawValue: number;
   columnKey: string;
-  isDuration?: boolean;
 }) {
   const organization = useOrganization();
   const location = useLocation();

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -14,6 +14,7 @@ import {EventEvidence} from 'sentry/components/events/eventEvidence';
 import {EventExtraData} from 'sentry/components/events/eventExtraData';
 import EventReplay from 'sentry/components/events/eventReplay';
 import {EventSdk} from 'sentry/components/events/eventSdk';
+import AggregateSpanDiff from 'sentry/components/events/eventStatisticalDetector/aggregateSpanDiff';
 import EventSpanOpBreakdown from 'sentry/components/events/eventStatisticalDetector/aggregateSpanOps/spanOpBreakdown';
 import EventBreakpointChart from 'sentry/components/events/eventStatisticalDetector/breakpointChart';
 import {EventAffectedTransactions} from 'sentry/components/events/eventStatisticalDetector/eventAffectedTransactions';
@@ -200,6 +201,9 @@ function PerformanceDurationRegressionIssueDetailsContent({
         </ErrorBoundary>
         <ErrorBoundary mini>
           <EventSpanOpBreakdown event={event} />
+        </ErrorBoundary>
+        <ErrorBoundary mini>
+          <AggregateSpanDiff event={event} projectId={project.id} />
         </ErrorBoundary>
         <ErrorBoundary mini>
           <EventComparison event={event} group={group} project={project} />


### PR DESCRIPTION
* Updates to account for new endpoint response
* uses built in field renderers
* Renders each change in the same column

When we would render a change of 0% (due to rounding), I made the change show as a single value with "No significant change". I wasn't sure if I should do the same with newly added spans because it felt a little unclear to just have a number with "New" next to it, although I'm willing to go either way.

![Screenshot 2023-10-25 at 3 17 40 PM](https://github.com/getsentry/sentry/assets/22846452/e0f01de8-49ad-4552-a1ea-f1c5b84d7791)

Closes #58761
