### PR TITLE
fix(browser-starfish): resource module fails to load decode size

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -22,9 +22,8 @@ import {SampleList} from 'sentry/views/starfish/views/spanSummaryPage/sampleList
 
 const {
   SPAN_SELF_TIME,
-  SPAN_OP,
   SPAN_DESCRIPTION,
-  HTTP_DECODED_RESPONSE_BODY_LENGTH,
+  HTTP_DECODED_RESPONSE_CONTENT_LENGTH,
   HTTP_RESPONSE_CONTENT_LENGTH,
   HTTP_RESPONSE_TRANSFER_SIZE,
 } = SpanMetricsField;
@@ -38,10 +37,9 @@ function ResourceSummary() {
   const {data: spanMetrics} = useSpanMetrics(groupId, {}, [
     `avg(${SPAN_SELF_TIME})`,
     `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
-    `avg(${HTTP_DECODED_RESPONSE_BODY_LENGTH})`,
+    `avg(${HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`,
     `avg(${HTTP_RESPONSE_TRANSFER_SIZE})`,
     'spm()',
-    SPAN_OP,
     SPAN_DESCRIPTION,
   ]);
 
@@ -88,11 +86,11 @@ function ResourceSummary() {
               </PageFilterBar>
             </PaddedContainer>
             <ResourceInfo
-              avgContentLength={spanMetrics['avg(http.response_content_length)']}
+              avgContentLength={spanMetrics[`avg(${HTTP_RESPONSE_CONTENT_LENGTH})`]}
               avgDecodedContentLength={
-                spanMetrics['avg(http.decoded_response_body_length)']
+                spanMetrics[`avg(${HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`]
               }
-              avgTransferSize={spanMetrics['avg(http.response_transfer_size)']}
+              avgTransferSize={spanMetrics[`avg(${HTTP_RESPONSE_TRANSFER_SIZE})`]}
               avgDuration={spanMetrics[`avg(${SPAN_SELF_TIME})`]}
               throughput={spanMetrics['spm()']}
             />

--- a/static/app/views/performance/browser/resources/utils/useResourceSort.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceSort.ts
@@ -36,7 +36,7 @@ export function useResourceSort(
 
 const DEFAULT_SORT: Sort = {
   kind: 'desc',
-  field: SORTABLE_FIELDS[0],
+  field: SORTABLE_FIELDS[2],
 };
 
 function isAValidSort(sort: Sort): sort is ValidSort {

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -28,14 +28,14 @@ export enum SpanMetricsField {
   PROJECT_ID = 'project.id',
   RESOURCE_RENDER_BLOCKING_STATUS = 'resource.render_blocking_status',
   HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length',
-  HTTP_DECODED_RESPONSE_BODY_LENGTH = 'http.decoded_response_body_length',
+  HTTP_DECODED_RESPONSE_CONTENT_LENGTH = 'http.decoded_response_content_length',
   HTTP_RESPONSE_TRANSFER_SIZE = 'http.response_transfer_size',
 }
 
 export type SpanNumberFields =
   | SpanMetricsField.SPAN_SELF_TIME
   | SpanMetricsField.SPAN_DURATION
-  | SpanMetricsField.HTTP_DECODED_RESPONSE_BODY_LENGTH
+  | SpanMetricsField.HTTP_DECODED_RESPONSE_CONTENT_LENGTH
   | SpanMetricsField.HTTP_RESPONSE_CONTENT_LENGTH
   | SpanMetricsField.HTTP_RESPONSE_TRANSFER_SIZE;
 


### PR DESCRIPTION
Couple of fixes.
1. Main fix is now the decoded body size is fetched properly
2. Update the default sort to be throughput
3. Remove the unused SPAN_OP param from the resource summary query.