### PR TITLE
fix(metrics): Map sdk fields correctly to Relay schema

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -99,8 +99,8 @@ _SEARCH_TO_PROTOCOL_FIELDS = {
     "transaction.op": "contexts.trace.op",
     "transaction.status": "contexts.trace.status",
     "http.status_code": "contexts.response.status_code",
-    "sdk.name": "contexts.sdk.name",
-    "sdk.version": "contexts.sdk.version",
+    "sdk.name": "sdk.name",
+    "sdk.version": "sdk.version",
     # Computed fields
     "transaction.duration": "duration",
     "release.build": "release.build",


### PR DESCRIPTION
The SDK fields do not reside in `contexts` in the payload, hence their mapping
is without that prefix.
