### PR TITLE
fix(starfish): fix performance score config naming in relay project config

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -410,7 +410,7 @@ def _get_project_config(
         }
 
     if features.has("organizations:performance-calculate-score-relay", project.organization):
-        config["performanceScoreConfig"] = {
+        config["performanceScore"] = {
             "profiles": [
                 {
                     "name": "Desktop",

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -764,8 +764,8 @@ def test_performance_calculate_score(default_project):
         config = get_project_config(default_project, full_config=True).to_dict()["config"]
 
         validate_project_config(json.dumps(config), strict=False)
-        performance_score_config = config["performanceScoreConfig"]
-        assert performance_score_config == {
+        performance_score = config["performanceScore"]
+        assert performance_score == {
             "profiles": [
                 {
                     "name": "Desktop",


### PR DESCRIPTION
Performance Score config was named incorrectly in relay config.