### PR TITLE
ref(bug reports): unread items marked by dot

### DIFF
--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -10,7 +10,7 @@ import Link from 'sentry/components/links/link';
 import {Flex} from 'sentry/components/profiling/flex';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
-import {IconPlay} from 'sentry/icons';
+import {IconCircleFill, IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -79,6 +79,13 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
           <span style={{gridArea: 'time'}}>
             <TimeSince date={feedbackItem.timestamp} />
           </span>
+          {feedbackItem.hasSeen ? null : (
+            <span
+              style={{gridArea: 'unread', display: 'inline-flex', alignItems: 'center'}}
+            >
+              <IconCircleFill size="xs" color="purple300" />
+            </span>
+          )}
           <div style={{gridArea: 'message'}}>
             <TextOverflow>{feedbackItem.metadata.message}</TextOverflow>
           </div>
@@ -124,7 +131,7 @@ const LinkedFeedbackCard = styled(Link)`
   grid-template-rows: max-content 1fr max-content;
   grid-template-areas:
     'checkbox user time'
-    'right message message'
+    'unread message message'
     'right icons icons';
   gap: ${space(1)};
   place-items: stretch;

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -83,8 +83,7 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
             <span
               style={{
                 gridArea: 'unread',
-                display: 'inline-flex',
-                alignItems: 'center',
+                display: 'flex',
                 justifyContent: 'center',
               }}
             >

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -81,7 +81,12 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
           </span>
           {feedbackItem.hasSeen ? null : (
             <span
-              style={{gridArea: 'unread', display: 'inline-flex', alignItems: 'center'}}
+              style={{
+                gridArea: 'unread',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
             >
               <IconCircleFill size="xs" color="purple300" />
             </span>


### PR DESCRIPTION
unread items are marked with a dot, which doesn't go away until the user manually marks it as read (the dot does not automatically disappear upon clicking the feedback detail)

<img width="411" alt="SCR-20231025-mwdi" src="https://github.com/getsentry/sentry/assets/56095982/4b5088cc-56d2-4c23-8f55-4b3535bb4ce3">
