### PR TITLE
fix(suspect-commits): Get selected provider from integration rather than repo

### DIFF
--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -86,6 +86,12 @@ def find_commit_context_for_event_all_frames(
         else None
     )
 
+    selected_install, selected_provider = (
+        integration_to_install_mapping[selected_blame.code_mapping.organization_integration_id]
+        if selected_blame
+        else (None, None)
+    )
+
     _record_commit_context_all_frames_analytics(
         selected_blame=selected_blame,
         most_recent_blame=most_recent_blame,
@@ -95,14 +101,10 @@ def find_commit_context_for_event_all_frames(
         frames=valid_frames,
         file_blames=file_blames,
         num_successfully_mapped_frames=num_successfully_mapped_frames,
+        selected_provider=selected_provider,
     )
 
-    return (
-        selected_blame,
-        integration_to_install_mapping[selected_blame.code_mapping.organization_integration_id]
-        if selected_blame
-        else None,
-    )
+    return (selected_blame, selected_install)
 
 
 def find_commit_context_for_event(
@@ -357,14 +359,14 @@ def _get_blames_from_all_integrations(
     organization_id: int,
     project_id: int,
     extra: Mapping[str, Any],
-) -> tuple[list[FileBlameInfo], dict[str, IntegrationInstallation]]:
+) -> tuple[list[FileBlameInfo], dict[str, tuple[IntegrationInstallation, str]]]:
     """
     Calls get_commit_context_all_frames for each integration, using the file
     list provided for the integration ID, and returns a combined list of
     file blames.
     """
     file_blames: list[FileBlameInfo] = []
-    integration_to_install_mapping: dict[str, IntegrationInstallation] = {}
+    integration_to_install_mapping: dict[str, tuple[IntegrationInstallation, str]] = {}
 
     for integration_organization_id, files in integration_to_files_mapping.items():
         integration = integration_service.get_integration(
@@ -375,7 +377,10 @@ def _get_blames_from_all_integrations(
         install = integration.get_installation(organization_id=organization_id)
         if not isinstance(install, CommitContextMixin):
             continue
-        integration_to_install_mapping[integration_organization_id] = install
+        integration_to_install_mapping[integration_organization_id] = (
+            install,
+            integration.provider,
+        )
         try:
             blames = install.get_commit_context_all_frames(files)
             file_blames.extend(blames)
@@ -413,6 +418,7 @@ def _record_commit_context_all_frames_analytics(
     frames: Sequence[EventFrame],
     file_blames: Sequence[FileBlameInfo],
     num_successfully_mapped_frames: int,
+    selected_provider: Optional[str],
 ):
     if not selected_blame:
         reason = "commit_too_old" if most_recent_blame else "no_commit_found"
@@ -468,6 +474,6 @@ def _record_commit_context_all_frames_analytics(
         num_unique_commit_authors=len(unique_author_emails),
         num_successfully_mapped_frames=num_successfully_mapped_frames,
         selected_frame_index=selected_frame_index,
-        selected_provider=selected_blame.repo.provider,
+        selected_provider=selected_provider,
         selected_code_mapping_id=selected_blame.code_mapping.id,
     )

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -36,7 +36,6 @@ class TestCommitContextMixin(TestCase):
             organization_id=self.organization.id,
             name="example",
             integration_id=self.integration.id,
-            provider="github",
         )
         self.code_mapping = self.create_code_mapping(
             repo=self.repo,


### PR DESCRIPTION
Fixes SENTRY-1773

TIL that `provider` is optional for the Repository model. This stores the integration while iterating through installations so that we can get the provider later on.