### PR TITLE
feat(feedback): shim user reports to feedback if flag enabled

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -1,8 +1,11 @@
 import datetime
 from uuid import uuid4
 
+import jsonschema
+
 from sentry.issues.grouptype import FeedbackGroup
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
+from sentry.issues.json_schemas import EVENT_PAYLOAD_SCHEMA
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.utils.dates import ensure_aware
 
@@ -87,6 +90,9 @@ def create_feedback_issue(event, project_id):
         **event,
     }
     fix_for_issue_platform(event_data)
+
+    # make sure event data is valid for issue platform
+    jsonschema.validate(event_data, EVENT_PAYLOAD_SCHEMA)
 
     produce_occurrence_to_kafka(
         payload_type=PayloadType.OCCURRENCE, occurrence=occurrence, event_data=event_data

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -335,7 +335,7 @@ def _shim_to_feedback(report, event, project):
 
         else:
             feedback_event["timestamp"] = datetime.utcnow().timestamp()
-            feedback_event["platform"] = "unknown"
+            feedback_event["platform"] = "other"
 
         create_feedback_issue(feedback_event, project.id)
     except Exception:

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -310,6 +310,7 @@ def _start_and_end_dates(time: datetime) -> Tuple[datetime, datetime]:
 def _shim_to_feedback(report, event, project):
     """
     takes user reports from the legacy user report endpoint and
+    user reports that come from relay envelope ingestion and
     creates a new User Feedback from it.
     User feedbacks are an event type, so we try and grab as much from the
     legacy user report and event to create the new feedback.

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -320,15 +320,18 @@ def _shim_to_feedback(report, event, project):
                 "name": report.get("name", ""),
                 "email": report["email"],
                 "message": report["comments"],
-            }
+            },
+            "contexts": {},
         }
 
         if event:
             feedback_event["feedback"]["crash_report_event_id"] = event.event_id
 
             if get_path(event.data, "contexts", "replay", "replay_id"):
-                feedback_event["contexts"]["replay"] = event.contexts["replay"]
-                feedback_event["feedback"]["replay_id"] = event.contexts["replay"]["replay_id"]
+                feedback_event["contexts"]["replay"] = event.data["contexts"]["replay"]
+                feedback_event["feedback"]["replay_id"] = event.data["contexts"]["replay"][
+                    "replay_id"
+                ]
             feedback_event["timestamp"] = event.datetime.timestamp()
 
             feedback_event["platform"] = event.platform

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from datetime import datetime, timedelta
 from typing import Any, Mapping, Optional, Tuple
@@ -9,12 +11,14 @@ from snuba_sdk import Column, Condition, Entity, Op, Query, Request
 from sentry import analytics, eventstore, features
 from sentry.api.serializers import serialize
 from sentry.eventstore.models import Event
+from sentry.feedback.usecases.create_feedback import create_feedback_issue
 from sentry.models.eventuser import EventUser
 from sentry.models.userreport import UserReport
 from sentry.signals import user_feedback_received
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.utils import metrics
 from sentry.utils.db import atomic_transaction
+from sentry.utils.safe import get_path
 from sentry.utils.snuba import raw_snql_query
 
 logger = logging.getLogger(__name__)
@@ -98,6 +102,9 @@ def save_userreport(project, report, start_time=None):
                 report_instance.notify()
 
         user_feedback_received.send(project=project, sender=save_userreport)
+
+        if features.has("organizations:user-feedback-ingest", project.organization, actor=None):
+            _shim_to_feedback(report, event, project)
 
         return report_instance
 
@@ -298,3 +305,40 @@ def _generate_entity_dataset_query(
 def _start_and_end_dates(time: datetime) -> Tuple[datetime, datetime]:
     """Return the 10 min range start and end time range ."""
     return time - timedelta(minutes=5), time + timedelta(minutes=5)
+
+
+def _shim_to_feedback(report, event, project):
+    """
+    takes user reports from the legacy user report endpoint and
+    creates a new User Feedback from it.
+    User feedbacks are an event type, so we try and grab as much from the
+    legacy user report and event to create the new feedback.
+    """
+    try:
+        feedback_event: dict[str, Any] = {
+            "feedback": {
+                "name": report.get("name", ""),
+                "email": report["email"],
+                "message": report["comments"],
+            }
+        }
+
+        if event:
+            feedback_event["feedback"]["crash_report_event_id"] = event.event_id
+
+            if get_path(event.data, "contexts", "replay", "replay_id"):
+                feedback_event["contexts"]["replay"] = event.contexts["replay"]
+                feedback_event["feedback"]["replay_id"] = event.contexts["replay"]["replay_id"]
+            feedback_event["timestamp"] = event.datetime.timestamp()
+
+            feedback_event["platform"] = event.platform
+
+        else:
+            feedback_event["timestamp"] = datetime.utcnow().timestamp()
+            feedback_event["platform"] = "unknown"
+
+        create_feedback_issue(feedback_event, project.id)
+    except Exception:
+        logger.exception(
+            "Error attempting to create new User Feedback from Shiming old User Report"
+        )

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -318,7 +318,7 @@ def _shim_to_feedback(report, event, project):
         feedback_event: dict[str, Any] = {
             "feedback": {
                 "name": report.get("name", ""),
-                "email": report["email"],
+                "contact_email": report["email"],
                 "message": report["comments"],
             },
             "contexts": {},

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -418,7 +418,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == 1
         mock_event_data = mock_produce_occurrence_to_kafka.call_args_list[0][1]["event_data"]
 
-        assert mock_event_data["contexts"]["feedback"]["email"] == "foo@example.com"
+        assert mock_event_data["contexts"]["feedback"]["contact_email"] == "foo@example.com"
         assert mock_event_data["contexts"]["feedback"]["message"] == "It broke!"
         assert mock_event_data["contexts"]["feedback"]["name"] == "Foo Bar"
         assert mock_event_data["contexts"]["feedback"]["replay_id"] == replay_id
@@ -454,7 +454,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == 1
         mock_event_data = mock_produce_occurrence_to_kafka.call_args_list[0][1]["event_data"]
 
-        assert mock_event_data["contexts"]["feedback"]["email"] == "foo@example.com"
+        assert mock_event_data["contexts"]["feedback"]["contact_email"] == "foo@example.com"
         assert mock_event_data["contexts"]["feedback"]["message"] == "It broke!"
         assert mock_event_data["contexts"]["feedback"]["name"] == "Foo Bar"
         assert mock_event_data["platform"] == "other"


### PR DESCRIPTION
NOTE: the `_shim_to_feedback` function is a bit jank. This is because this is still pre-alpha, and schema hasn't been completely ironed out. Once it is ironed out, I'll rewrite this to use better python typing, and less dictionary jank

- shims old user reports into Feedback events, for the new User Feedback feature
- Only runs if the ingestion flag for new Feedbacks is turned on
- Attempts to grab information from the user report, and its associated event if it exists
- Still missing some fields, but wanted to get this out there & confirm overall flow works. Can do further analysis on what else we can grab, as seeing production data will help with this.
- If the shim fails, it will catch the exception and continue gracefully
- We're also now validating the schema inside our `create_feedback` function, as the current validation does not run in tests which makes it hard to debug/verify, and this isn't expensive to do.
- Adds tests to the user report endpoint, although this code will also run in ingestion. I think the coverage here is sufficient as the data in ingestion will be the same from what I see.