### PR TITLE
feat(feedback): add name to metadata

### DIFF
--- a/src/sentry/eventtypes/feedback.py
+++ b/src/sentry/eventtypes/feedback.py
@@ -8,4 +8,5 @@ class FeedbackEvent(BaseEvent):
     def extract_metadata(self, data):
         contact_email = get_path(data, "contexts", "feedback", "contact_email")
         message = get_path(data, "contexts", "feedback", "message")
-        return {"contact_email": contact_email, "message": message}
+        name = get_path(data, "contexts", "feedback", "name")
+        return {"contact_email": contact_email, "message": message, "name": name}

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -20,6 +20,10 @@ def make_evidence(feedback):
         evidence_display.append(
             IssueEvidence(name="message", value=feedback["message"], important=True)
         )
+    if feedback.get("name"):
+        evidence_data["name"] = feedback["name"]
+        evidence_display.append(IssueEvidence(name="name", value=feedback["name"], important=False))
+
     return evidence_data, evidence_display
 
 

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -136,6 +136,7 @@ def materialize_metadata(occurrence: IssueOccurrence, event: Event) -> Occurrenc
         # Or potentially, could add a method to GroupType called get_metadata
         event_metadata["contact_email"] = occurrence.evidence_data.get("contact_email")
         event_metadata["message"] = occurrence.evidence_data.get("message")
+        event_metadata["name"] = occurrence.evidence_data.get("name")
 
     return {
         "type": event_type.key,

--- a/tests/sentry/eventtypes/test_feedback.py
+++ b/tests/sentry/eventtypes/test_feedback.py
@@ -10,5 +10,17 @@ from sentry.testutils.silo import region_silo_test
 class GetMetadataTest(TestCase):
     def test_simple(self):
         inst = FeedbackEvent()
-        data = {"contexts": {"feedback": {"message": "Foo", "contact_email": "test@test.com"}}}
-        assert inst.get_metadata(data) == {"message": "Foo", "contact_email": "test@test.com"}
+        data = {
+            "contexts": {
+                "feedback": {
+                    "message": "Foo",
+                    "contact_email": "test@test.com",
+                    "name": "Name Test",
+                }
+            }
+        }
+        assert inst.get_metadata(data) == {
+            "message": "Foo",
+            "contact_email": "test@test.com",
+            "name": "Name Test",
+        }

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -338,7 +338,11 @@ class MaterializeMetadataTest(OccurrenceTestMixin, TestCase):
     def test_populates_feedback_metadata(self) -> None:
         occurrence = self.build_occurrence(
             type=FeedbackGroup.type_id,
-            evidence_data={"contact_email": "test@test.com", "message": "test"},
+            evidence_data={
+                "contact_email": "test@test.com",
+                "message": "test",
+                "name": "Name Test",
+            },
         )
         event = self.store_event(data={}, project_id=self.project.id)
         event.data.setdefault("metadata", {})
@@ -351,6 +355,7 @@ class MaterializeMetadataTest(OccurrenceTestMixin, TestCase):
             "dogs": "are great",
             "contact_email": "test@test.com",
             "message": "test",
+            "name": "Name Test",
         }
 
 


### PR DESCRIPTION
adds `name` to feedback issue metadata. Note that once ingestion is running we'll solely rely upon the logic in event type and delete the logic in `ingest.py` this will happen in the next few weeks.