### PR TITLE
test(hc): Fix freeze_time decorator on test classes

### DIFF
--- a/tests/sentry/rules/history/endpoints/test_project_rule_group_history.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_group_history.py
@@ -13,7 +13,7 @@ from sentry.testutils.skips import requires_snuba
 pytestmark = [requires_snuba]
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class RuleGroupHistorySerializerTest(TestCase):
     def test(self):
         current_date = datetime.now()
@@ -29,8 +29,8 @@ class RuleGroupHistorySerializerTest(TestCase):
         ]
 
 
+@region_silo_test(stable=True)
 @freeze_time()
-@region_silo_test
 class ProjectRuleGroupHistoryIndexEndpointTest(APITestCase):
     endpoint = "sentry-api-0-project-rule-group-history-index"
 

--- a/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
@@ -15,8 +15,8 @@ from sentry.types.activity import ActivityType
 pytestmark = [requires_snuba]
 
 
+@region_silo_test(stable=True)
 @freeze_time()
-@region_silo_test
 class ProjectRulePreviewEndpointTest(APITestCase):
     endpoint = "sentry-api-0-project-rule-preview"
     method = "post"

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -38,8 +38,8 @@ def get_hours(time: timedelta) -> int:
     return time.days * 24 + time.seconds // (60 * 60)
 
 
+@region_silo_test(stable=True)
 @freeze_time()
-@region_silo_test
 class ProjectRulePreviewTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
     def setUp(self):
         super().setUp()
@@ -528,8 +528,8 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
         assert result[self.group.id] == prev_two_hour
 
 
+@region_silo_test(stable=True)
 @freeze_time()
-@region_silo_test
 class FrequencyConditionTest(
     TestCase, SnubaTestCase, OccurrenceTestMixin, PerformanceIssueTestCase
 ):
@@ -874,8 +874,8 @@ class FrequencyConditionTest(
         assert group.id not in result
 
 
+@region_silo_test(stable=True)
 @freeze_time()
-@region_silo_test
 class GetEventsTest(TestCase, SnubaTestCase):
     def test_get_first_seen(self):
         prev_hour = timezone.now() - timedelta(hours=1)


### PR DESCRIPTION
Place `@freeze_time` inside the `@region_silo_test` so that it's correctly applied on both runs.