### PR TITLE
ref(crons): Move save out of `update_config`

### DIFF
--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -174,8 +174,10 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
             # Update monitor configuration during checkin if config is changed
             if update_monitor and monitor_data["config"] != monitor.config:
                 monitor.update_config(
-                    request.data.get("monitor_config", {}), monitor_data["config"]
+                    request.data.get("monitor_config", {}),
+                    monitor_data["config"],
                 )
+                monitor.save()
 
             try:
                 monitor_environment = MonitorEnvironment.objects.ensure_environment(

--- a/tests/sentry/monitors/test_models.py
+++ b/tests/sentry/monitors/test_models.py
@@ -252,6 +252,7 @@ class MonitorEnvironmentTestCase(TestCase):
         assert validator.is_valid()
         validated_config = validator.validated_data
         monitor.update_config(new_config, validated_config)
+        monitor.save()
 
         assert monitor.config == {
             "schedule": "0 0 1 2 *",


### PR DESCRIPTION
It's probably better to be explicit here.

I would like to make some other changes to the monitor outside of just
updating the config in some places. So I don't want to call save twice.