### PR TITLE
feat(bug reports): [WIP] add alert configuration for feedback

### DIFF
--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -32,7 +32,8 @@ export type AlertType =
   | 'cls'
   | 'custom'
   | 'crash_free_sessions'
-  | 'crash_free_users';
+  | 'crash_free_users'
+  | 'feedback_issues';
 
 export enum MEPAlertsQueryType {
   ERROR = 0,
@@ -46,7 +47,7 @@ export enum MEPAlertsDataset {
   METRICS_ENHANCED = 'metricsEnhanced',
 }
 
-export type MetricAlertType = Exclude<AlertType, 'issues'>;
+export type MetricAlertType = Exclude<AlertType, 'issues' | 'feedback_issues'>;
 
 export const DatasetMEPAlertQueryTypes: Record<Dataset, MEPAlertsQueryType> = {
   [Dataset.ERRORS]: MEPAlertsQueryType.ERROR,
@@ -70,6 +71,7 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
   custom: t('Custom Metric'),
   crash_free_sessions: t('Crash Free Session Rate'),
   crash_free_users: t('Crash Free User Rate'),
+  feedback_issues: t('Feedback Issues'),
 };
 
 type AlertWizardCategory = {
@@ -100,6 +102,10 @@ export const getAlertWizardCategories = (org: Organization): AlertWizardCategory
       'fid',
       'cls',
     ],
+  },
+  {
+    categoryHeading: t('Feedback'),
+    options: ['feedback_issues'],
   },
   {
     categoryHeading: t('Other'),

--- a/static/app/views/alerts/wizard/panelContent.tsx
+++ b/static/app/views/alerts/wizard/panelContent.tsx
@@ -147,4 +147,14 @@ export const AlertWizardPanelContent: Record<AlertType, PanelContent> = {
     ],
     illustration: diagramCrashFreeUsers,
   },
+  feedback_issues: {
+    description: t(
+      'Feedback issues are written reports submitted by users on your site. Set an alert for new feedback or when a feedback state changes.'
+    ),
+    examples: [
+      t('When a feedback is received, send an email to yourself.'),
+      t('When a feedback is resolved, send a Slack notification to the team.'),
+    ],
+    illustration: diagramIssues,
+  },
 };


### PR DESCRIPTION
Add Feedback as an alert category, based on the issue alert template.

Need a new illustration for the initial page (right now it's using the issues illustration):

<img width="1106" alt="SCR-20231025-oxsk" src="https://github.com/getsentry/sentry/assets/56095982/974eabff-bb25-419e-9729-86c0e216c1ed">
