### PR TITLE
test(hc): Mark TestDeprecationDecorator as no_silo_test

### DIFF
--- a/tests/sentry/helpers/test_deprecation.py
+++ b/tests/sentry/helpers/test_deprecation.py
@@ -13,7 +13,7 @@ from sentry.api.helpers.deprecation import deprecated
 from sentry.options import register
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import no_silo_test
 
 replacement_api = "replacement-api"
 test_date = datetime.fromisoformat("2020-01-01T00:00:00+00:00:00")
@@ -42,7 +42,7 @@ class DummyEndpoint(Endpoint):
 dummy_endpoint = DummyEndpoint.as_view()
 
 
-@control_silo_test
+@no_silo_test(stable=True)
 class TestDeprecationDecorator(APITestCase):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
The failure when running as control_silo_test seems to be attributable to the `timeiter` value being reused across test cases. Because the test uses only the DummyEndpoint and doesn't touch any persistent models, it should be safe to mark it as no_silo_test. (In a perfect world, it would be nice to refactor it to be robust against repeated runs, but no_silo_test is definitely the path of least resistance.)