### PR TITLE
chore(hybrid-cloud): Adds organization and project RPC methods for signup fixes

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -7,6 +7,7 @@ from enum import IntEnum
 from typing import Any, List, Mapping, Optional, Sequence
 
 from django.dispatch import Signal
+from django.utils import timezone
 from pydantic import Field
 from typing_extensions import TypedDict
 
@@ -235,7 +236,7 @@ class RpcOrganization(RpcOrganizationSummary):
     status: int = Field(default_factory=_DefaultEnumHelpers.get_default_organization_status_value)
 
     default_role: str = ""
-    date_added: datetime = Field(default_factory=datetime.now)
+    date_added: datetime = Field(default_factory=timezone.now)
 
     def get_audit_log_data(self):
         return {

--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -2,6 +2,7 @@
 #     from __future__ import annotations
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
+from datetime import datetime
 from enum import IntEnum
 from typing import Any, List, Mapping, Optional, Sequence
 
@@ -234,6 +235,7 @@ class RpcOrganization(RpcOrganizationSummary):
     status: int = Field(default_factory=_DefaultEnumHelpers.get_default_organization_status_value)
 
     default_role: str = ""
+    date_added: datetime
 
     def get_audit_log_data(self):
         return {

--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -235,7 +235,7 @@ class RpcOrganization(RpcOrganizationSummary):
     status: int = Field(default_factory=_DefaultEnumHelpers.get_default_organization_status_value)
 
     default_role: str = ""
-    date_added: datetime
+    date_added: datetime = Field(default_factory=datetime.now)
 
     def get_audit_log_data(self):
         return {

--- a/src/sentry/services/hybrid_cloud/organization/serial.py
+++ b/src/sentry/services/hybrid_cloud/organization/serial.py
@@ -134,6 +134,7 @@ def serialize_rpc_organization(org: Organization) -> RpcOrganization:
         name=org.name,
         status=int(org.status),
         default_role=org.default_role,
+        date_added=org.date_added,
     )
 
     projects: List[Project] = Project.objects.filter(organization=org)

--- a/src/sentry/services/hybrid_cloud/project/impl.py
+++ b/src/sentry/services/hybrid_cloud/project/impl.py
@@ -94,8 +94,16 @@ class DatabaseBackedProjectService(ProjectService):
             )
 
             if add_org_default_team:
-                team = Team.objects.filter(organization_id=organization_id).first()
-                project.add_team(team)
+                team = (
+                    Team.objects.filter(organization_id=organization_id)
+                    .order_by("date_added")
+                    .first()
+                )
+
+                # Makes a best effort to add the default org team,
+                #  but doesn't block if one doesn't exist.
+                if team:
+                    project.add_team(team)
 
             project_created.send(
                 project=project,

--- a/src/sentry/services/hybrid_cloud/project/impl.py
+++ b/src/sentry/services/hybrid_cloud/project/impl.py
@@ -93,7 +93,7 @@ class DatabaseBackedProjectService(ProjectService):
                 platform=platform,
             )
 
-            if add_org_default_team is not None:
+            if add_org_default_team:
                 team = Team.objects.filter(organization_id=organization_id).first()
                 project.add_team(team)
 

--- a/src/sentry/services/hybrid_cloud/project/impl.py
+++ b/src/sentry/services/hybrid_cloud/project/impl.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from typing import List, Optional
 
+from django.db import router, transaction
+
 from sentry.api.serializers import ProjectSerializer
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
+from sentry.models.team import Team
 from sentry.services.hybrid_cloud import OptionValue
 from sentry.services.hybrid_cloud.auth import AuthenticationContext
 from sentry.services.hybrid_cloud.filter_query import OpaqueSerializedResponse
@@ -16,6 +19,7 @@ from sentry.services.hybrid_cloud.project import (
 )
 from sentry.services.hybrid_cloud.project.serial import serialize_project
 from sentry.services.hybrid_cloud.user import RpcUser
+from sentry.signals import project_created
 
 
 class DatabaseBackedProjectService(ProjectService):
@@ -72,3 +76,32 @@ class DatabaseBackedProjectService(ProjectService):
             user=as_user,
             serializer=ProjectSerializer(),
         )
+
+    def create_project_for_organization(
+        self,
+        *,
+        organization_id: int,
+        project_name: str,
+        platform: str,
+        user_id: int,
+        add_org_default_team: Optional[bool] = False,
+    ) -> RpcProject:
+        with transaction.atomic(router.db_for_write(Project)):
+            project = Project.objects.create(
+                name=project_name,
+                organization_id=organization_id,
+                platform=platform,
+            )
+
+            if add_org_default_team is not None:
+                team = Team.objects.filter(organization_id=organization_id).first()
+                project.add_team(team)
+
+            project_created.send(
+                project=project,
+                default_rules=True,
+                sender=self.create_project_for_organization,
+                user_id=user_id,
+            )
+
+            return serialize_project(project)

--- a/src/sentry/services/hybrid_cloud/project/service.py
+++ b/src/sentry/services/hybrid_cloud/project/service.py
@@ -62,5 +62,18 @@ class ProjectService(RpcService):
     ) -> List[OpaqueSerializedResponse]:
         pass
 
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def create_project_for_organization(
+        self,
+        *,
+        organization_id: int,
+        project_name: str,
+        platform: str,
+        user_id: int,
+        add_org_default_team: Optional[bool] = False,
+    ) -> RpcProject:
+        pass
+
 
 project_service = ProjectService.create_delegation()


### PR DESCRIPTION
- Updates the `RpcOrganization` model to include the `date_added` field
- Adds a new `create_project_for_organization` method to `project_service` for RPC based project creation

Both of these changes enable our trial signup flows in GetSentry to be silo safe!
