### PR TITLE
chore(hybrid-cloud): Adds organization owner member RPC method

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -564,6 +564,12 @@ class DatabaseBackedOrganizationService(OrganizationService):
     ) -> None:
         signal.signal.send_robust(None, organization_id=organization_id, **args)
 
+    def get_organization_owner_members(self, organization_id: int) -> List[RpcOrganizationMember]:
+        org: Organization = Organization.objects.get(id=organization_id)
+        owner_members = org.get_members_with_org_roles(roles=[roles.get_top_dog().id])
+
+        return list(map(serialize_member, owner_members))
+
 
 class OutboxBackedOrganizationSignalService(OrganizationSignalService):
     def schedule_signal(

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -4,7 +4,7 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 import abc
 from abc import abstractmethod
-from typing import Any, Iterable, Mapping, Optional, Union
+from typing import Any, Iterable, List, Mapping, Optional, Union
 
 from django.dispatch import Signal
 
@@ -320,6 +320,11 @@ class OrganizationService(RpcService):
         _organization_signal_service.schedule_signal(
             signal=signal, organization_id=organization_id, args=args
         )
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def get_organization_owner_members(self, organization_id: int) -> List[RpcOrganizationMember]:
+        pass
 
 
 class OrganizationSignalService(abc.ABC):


### PR DESCRIPTION
- Adds new method to `organization_service` to list organization owning members

This can be used to replace `get_default_owner()` checks from the Organization model in the future
