### PR TITLE
feat(starfish): Style feature tag scores using badges

### DIFF
--- a/static/app/views/performance/browser/webVitals/components/pageOverviewFeaturedTagsList.tsx
+++ b/static/app/views/performance/browser/webVitals/components/pageOverviewFeaturedTagsList.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import {space} from 'sentry/styles/space';
+import {PerformanceBadge} from 'sentry/views/performance/browser/webVitals/components/performanceBadge';
 import {calculatePerformanceScore} from 'sentry/views/performance/browser/webVitals/utils/calculatePerformanceScore';
 import {useSlowestTagValuesQuery} from 'sentry/views/performance/browser/webVitals/utils/useSlowestTagValuesQuery';
 
@@ -40,7 +41,9 @@ export function PageOverviewFeaturedTagsList({transaction, tag, title}: Props) {
                   {row[tag]}
                 </TagButton>
               </TagValue>
-              <Score>{score.totalScore}</Score>
+              <Score>
+                <PerformanceBadge score={score.totalScore} />
+              </Score>
             </RowContainer>
           );
         })}
@@ -71,7 +74,7 @@ const TagValuesContainer = styled('div')`
 
 const RowContainer = styled('div')`
   display: grid;
-  grid-template-columns: 1fr 32px;
+  grid-template-columns: 1fr 75px;
   height: 32px;
 `;
 

--- a/static/app/views/performance/browser/webVitals/components/pageOverviewFeaturedTagsList.tsx
+++ b/static/app/views/performance/browser/webVitals/components/pageOverviewFeaturedTagsList.tsx
@@ -74,7 +74,7 @@ const TagValuesContainer = styled('div')`
 
 const RowContainer = styled('div')`
   display: grid;
-  grid-template-columns: 1fr 75px;
+  grid-template-columns: 1fr auto;
   height: 32px;
 `;
 


### PR DESCRIPTION
- Wrap score in a badge
- Auto-size score column width

N.B. This table has some _minor_ vertical alignment issues, the badge and tag value aren't perfectly vertically centred. We can fix soon!

**Before:**
<img width="306" alt="Screenshot 2023-10-26 at 11 01 34 AM" src="https://github.com/getsentry/sentry/assets/989898/c2d0fa82-a892-49e2-887a-01cd10ad8901">

**After:**
<img width="307" alt="Screenshot 2023-10-26 at 10 57 54 AM" src="https://github.com/getsentry/sentry/assets/989898/d8195c9b-9cdd-4474-8928-5b1feeeb4e43">
