### PR TITLE
fix(crons): Silence noisy monitor

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -421,6 +421,7 @@ def configure_sdk():
     exclude_beat_tasks = [
         "flush-buffers",
         "sync-options",
+        "sync-options-control",
         "schedule-digests",
         "check-symbolicator-lpq-project-eligibility",  # defined in getsentry
     ]


### PR DESCRIPTION
Adds `sync-options-control` to excluded beat tasks