### PR TITLE
feat(functions): Add regression score function for functions dataset

### DIFF
--- a/src/sentry/search/events/datasets/profile_functions.py
+++ b/src/sentry/search/events/datasets/profile_functions.py
@@ -241,6 +241,26 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                     default_result_type="integer",
                 ),
                 SnQLFunction(
+                    "cpm_before",
+                    required_args=[TimestampArg("timestamp")],
+                    snql_aggregate=lambda args, alias: self._resolve_cpm_cond(args, alias, "less"),
+                    default_result_type="integer",
+                ),
+                SnQLFunction(
+                    "cpm_after",
+                    required_args=[TimestampArg("timestamp")],
+                    snql_aggregate=lambda args, alias: self._resolve_cpm_cond(
+                        args, alias, "greater"
+                    ),
+                    default_result_type="integer",
+                ),
+                SnQLFunction(
+                    "cpm_delta",
+                    required_args=[TimestampArg("timestamp")],
+                    snql_aggregate=self._resolve_cpm_delta,
+                    default_result_type="integer",
+                ),
+                SnQLFunction(
                     "count_unique",
                     required_args=[ProfileFunctionColumnArg("column")],
                     snql_aggregate=lambda args, alias: Function("uniq", [args["column"]], alias),
@@ -405,6 +425,35 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                     default_result_type="duration",
                     redundant_grouping=True,
                 ),
+                SnQLFunction(
+                    "regression_score",
+                    required_args=[
+                        ProfileFunctionNumericColumn("column"),
+                        NumberRange("percentile", 0, 1),
+                        TimestampArg("timestamp"),
+                    ],
+                    snql_aggregate=lambda args, alias: Function(
+                        "minus",
+                        [
+                            Function(
+                                "multiply",
+                                [
+                                    self._resolve_cpm_cond(args, None, "greater"),
+                                    self._resolve_percentile_cond(args, None, "greater"),
+                                ],
+                            ),
+                            Function(
+                                "multiply",
+                                [
+                                    self._resolve_cpm_cond(args, None, "less"),
+                                    self._resolve_percentile_cond(args, None, "less"),
+                                ],
+                            ),
+                        ],
+                        alias,
+                    ),
+                    default_result_type="number",
+                ),
             ]
         }
 
@@ -469,6 +518,54 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                     [args["column"]],
                 ),
                 1,
+            ],
+            alias,
+        )
+
+    def _resolve_cpm_cond(
+        self,
+        args: Mapping[str, Union[str, Column, SelectType, int, float]],
+        alias: str | None,
+        cond: str,
+    ) -> SelectType:
+        if cond == "greater":
+            interval = (self.builder.params.end - args["timestamp"]).total_seconds()
+        elif cond == "less":
+            interval = (args["timestamp"] - self.builder.params.start).total_seconds()
+        else:
+            raise InvalidSearchQuery(f"Unsupported condition for cpm: {cond}")
+
+        return Function(
+            "divide",
+            [
+                Function(
+                    "countMergeIf",
+                    [
+                        SnQLColumn("count"),
+                        Function(
+                            cond,
+                            [
+                                self.builder.column("timestamp"),
+                                args["timestamp"],
+                            ],
+                        ),
+                    ],
+                ),
+                Function("divide", [interval, 60]),
+            ],
+            alias,
+        )
+
+    def _resolve_cpm_delta(
+        self,
+        args: Mapping[str, Union[str, Column, SelectType, int, float]],
+        alias: str,
+    ) -> SelectType:
+        return Function(
+            "minus",
+            [
+                self._resolve_cpm_cond(args, None, "greater"),
+                self._resolve_cpm_cond(args, None, "less"),
             ],
             alias,
         )

--- a/tests/sentry/search/events/builder/test_profile_functions.py
+++ b/tests/sentry/search/events/builder/test_profile_functions.py
@@ -10,13 +10,19 @@ from sentry.snuba.dataset import Dataset
 from sentry.testutils.factories import Factories
 from sentry.testutils.pytest.fixtures import django_db_all
 
-# pin a timestamp for now so tests results dont change
-now = datetime(2022, 10, 31, 0, 0, tzinfo=timezone.utc)
-today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+@pytest.fixture
+def now():
+    return datetime(2022, 10, 31, 0, 0, tzinfo=timezone.utc)
 
 
 @pytest.fixture
-def params():
+def today(now):
+    return now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+@pytest.fixture
+def params(now, today):
     organization = Factories.create_organization()
     team = Factories.create_team(organization=organization)
     project1 = Factories.create_project(organization=organization, teams=[team])

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -5783,9 +5783,7 @@ class OrganizationEventsProfileFunctionsDatasetEndpointTest(
             "p99()",
             "avg()",
             "sum()",
-            f"percentile_before(function.duration, 0.95, {int(mid.timestamp())})",
-            f"percentile_after(function.duration, 0.95, {int(mid.timestamp())})",
-            f"percentile_delta(function.duration, 0.95, {int(mid.timestamp())})",
+            f"regression_score(function.duration, 0.95, {int(mid.timestamp())})",
         ]
 
         response = self.do_request(
@@ -5823,9 +5821,7 @@ class OrganizationEventsProfileFunctionsDatasetEndpointTest(
             "p99()": "nanosecond",
             "avg()": "nanosecond",
             "sum()": "nanosecond",
-            f"percentile_before(function.duration, 0.95, {int(mid.timestamp())})": "nanosecond",
-            f"percentile_after(function.duration, 0.95, {int(mid.timestamp())})": "nanosecond",
-            f"percentile_delta(function.duration, 0.95, {int(mid.timestamp())})": "nanosecond",
+            f"regression_score(function.duration, 0.95, {int(mid.timestamp())})": None,
         }
 
 


### PR DESCRIPTION
This introduces a regression score function for the functions dataset that computes the calls per minute x p95 for the before and after periods then finds the difference between them.