### PR TITLE
fix(jira-server): adds project if missing in issue schema

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -977,6 +977,10 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
             # above clean method.)
             cleaned_data["issuetype"] = {"id": issue_type}
 
+        # sometimes the project is missing as well and we need to add it
+        if "project" not in cleaned_data:
+            cleaned_data["project"] = {"id": jira_project}
+
         try:
             logger.info(
                 "jira_server.create_issue",

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -594,20 +594,61 @@ class JiraServerIntegrationTest(APITestCase):
             },
         ]
 
+    def test_create_issue_no_project(self):
+        with mock.patch.object(StubJiraApiClient, "get_issue_fields") as mock_get_issue_fields:
+            mock_issue_fields = StubService.get_stub_data("jira", "issue_fields_response.json")
+            mock_issue_fields["values"] = list(
+                filter(lambda x: x["fieldId"] != "project", mock_issue_fields["values"])
+            )
+            mock_get_issue_fields.return_value = mock_issue_fields
+            with mock.patch.object(StubJiraApiClient, "create_issue") as mock_create_issue:
+                mock_create_issue.return_value = {"key": "APP-123"}
+                with mock.patch.object(self.installation, "get_client", get_client):
+                    assert self.installation.create_issue(
+                        {
+                            "title": "example summary",
+                            "description": "example bug report",
+                            "issuetype": "1",
+                            "project": "10000",
+                        }
+                    ) == {
+                        "title": "example summary",
+                        "description": "example bug report",
+                        "key": "APP-123",
+                    }
+                    mock_create_issue.assert_called_once_with(
+                        {
+                            "description": "example bug report",
+                            "issuetype": {"id": "1"},
+                            "project": {"id": "10000"},
+                            "summary": "example summary",
+                        }
+                    )
+
     def test_create_issue(self):
-        with mock.patch.object(self.installation, "get_client", get_client):
-            assert self.installation.create_issue(
-                {
+        with mock.patch.object(StubJiraApiClient, "create_issue") as mock_create_issue:
+            mock_create_issue.return_value = {"key": "APP-123"}
+            with mock.patch.object(self.installation, "get_client", get_client):
+                assert self.installation.create_issue(
+                    {
+                        "title": "example summary",
+                        "description": "example bug report",
+                        "issuetype": "1",
+                        "project": "10000",
+                    }
+                ) == {
                     "title": "example summary",
                     "description": "example bug report",
-                    "issuetype": "1",
-                    "project": "10000",
+                    "key": "APP-123",
                 }
-            ) == {
-                "title": "example summary",
-                "description": "example bug report",
-                "key": "APP-123",
-            }
+                mock_create_issue.assert_called_once_with(
+                    {
+                        "description": "example bug report",
+                        "issuetype": {"id": "1"},
+                        "project": {"id": "10000"},
+                        "summary": "example summary",
+                    }
+                )
 
     @responses.activate
     def test_create_issue_labels_and_option(self):


### PR DESCRIPTION
For some reason, one of our customers is having problems where the project isn't coming back as a require field from Jira Server but Jira Server is requiring it when creating an issue