### PR TITLE
fix(github): Correct default and allow empty array to MultiSelect

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -108,8 +108,8 @@ class GitHubIssueBasic(IssueBasicMixin):
             {
                 "name": "labels",
                 "label": "Labels",
-                "default": "",
-                "type": "select",
+                "default": [],
+                "type": "choice",
                 "multiple": True,
                 "required": False,
                 "choices": labels,

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -109,7 +109,7 @@ class GitHubIssueBasic(IssueBasicMixin):
                 "name": "labels",
                 "label": "Labels",
                 "default": [],
-                "type": "choice",
+                "type": "select",
                 "multiple": True,
                 "required": False,
                 "choices": labels,

--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -336,9 +336,7 @@ export default class AbstractExternalIssueForm<
   ) => {
     const initialData: {[key: string]: any} = (formFields || []).reduce(
       (accumulator, field: FormField) => {
-        accumulator[field.name] =
-          // Passing an empty array breaks MultiSelect.
-          field.multiple && field.default.length === 0 ? '' : field.default;
+        accumulator[field.name] = field.default;
         return accumulator;
       },
       {}


### PR DESCRIPTION
We previously defaulted to an empty string for multi-select fields because the MultiSelect component would error on empty arrays. However, after testing this we actually do allow empty arrays.

The frontend + backend changes are fine deploying in either order.

### Testing with No Labels
https://github.com/getsentry/sentry/assets/67301797/2c3866b9-85f8-4828-915b-33b75a8ba724

Fixes https://github.com/getsentry/sentry/issues/58851