### PR TITLE
feat(team-workflow): Update Slack linking message to include workflow alerts

### DIFF
--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -8,7 +8,7 @@ from django.http import Http404, HttpResponse
 from django.utils.decorators import method_decorator
 from rest_framework.request import Request
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.models.integrations.external_actor import ExternalActor
 from sentry.models.integrations.integration import Integration
 from sentry.models.organizationmember import OrganizationMember
@@ -33,9 +33,7 @@ ALLOWED_METHODS = ["GET", "POST"]
 ALREADY_LINKED_TITLE = "Already linked"
 ALREADY_LINKED_MESSAGE = "The {slug} team has already been linked to a Slack channel."
 SUCCESS_LINKED_TITLE = "Team linked"
-SUCCESS_LINKED_MESSAGE = (
-    "The {slug} team will now receive issue alert notifications in the {channel_name} channel."
-)
+SUCCESS_LINKED_MESSAGE = "The {slug} team will now receive issue alert{workflow_addon} notifications in the {channel_name} channel."
 
 
 def build_team_linking_url(
@@ -202,7 +200,13 @@ class SlackLinkTeamView(BaseView):
             actor=RpcActor(id=team.id, actor_type=ActorType.TEAM),
             organization_id_for_team=team.organization_id,
         )
-        message = SUCCESS_LINKED_MESSAGE.format(slug=team.slug, channel_name=channel_name)
+        message = SUCCESS_LINKED_MESSAGE.format(
+            slug=team.slug,
+            workflow_addon=" and workflow"
+            if features.has("organizations:team-workflow-notifications", team.organization)
+            else "",
+            channel_name=channel_name,
+        )
         integration_service.send_message(
             integration_id=integration.id,
             organization_id=team.organization_id,


### PR DESCRIPTION
This PR updates the Slack message received upon linking a team so that it includes "workflow alerts" (feature flagged until Team Workflow Notifications is GA'd).

Closes #58874.