### PR TITLE
fix(statistical-detectors): Move breakpoint feature flags to the brea…

### DIFF
--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -371,7 +371,12 @@ def test_detect_function_change_points(
         ]
     }
 
-    with override_options({"statistical_detectors.enable": True}):
+    with override_options(
+        {
+            "statistical_detectors.enable": True,
+            "statistical_detectors.enable.projects.profiling": [project.id],
+        }
+    ):
         detect_function_change_points([(project.id, fingerprint)], timestamp)
     assert mock_emit_function_regression_issue.called
 
@@ -605,9 +610,9 @@ class TestTransactionChangePointDetection(MetricsAPIBaseTestCase):
             timeseries
             for timeseries in query_transactions_timeseries(
                 [
-                    (self.projects[0].id, "transaction_1"),
-                    (self.projects[0].id, "transaction_2"),
-                    (self.projects[1].id, "transaction_1"),
+                    (self.projects[0], "transaction_1"),
+                    (self.projects[0], "transaction_2"),
+                    (self.projects[1], "transaction_1"),
                 ],
                 self.now,
                 "p95(transaction.duration)",
@@ -721,9 +726,7 @@ class TestTransactionChangePointDetection(MetricsAPIBaseTestCase):
         results = [
             timeseries
             for timeseries in query_transactions_timeseries(
-                [
-                    (self.projects[0].id, "transaction_1"),
-                ],
+                [(self.projects[0], "transaction_1")],
                 self.now,
                 "p95(transaction.duration)",
             )
@@ -752,7 +755,14 @@ class TestTransactionChangePointDetection(MetricsAPIBaseTestCase):
                 },
             ]
         }
-        with override_options({"statistical_detectors.enable": True}):
+        with override_options(
+            {
+                "statistical_detectors.enable": True,
+                "statistical_detectors.enable.projects.performance": [
+                    project.id for project in self.projects
+                ],
+            }
+        ):
             detect_transaction_change_points(
                 [
                     (self.projects[0].id, "transaction_1"),


### PR DESCRIPTION
…kpoint task

Having the breakpoint feature flags at the end of the EMA task means that there's no way to turn off the breakpoint detection stage immediately as it'll sit in the queue for 12 hours. Moving it into the task means even if the task has been dispatched, we can stop it from running.