### PR TITLE
feat(profiling): load entry points using crossorigin

### DIFF
--- a/src/sentry/templates/sentry/bases/react_pipeline.html
+++ b/src/sentry/templates/sentry/bases/react_pipeline.html
@@ -15,5 +15,5 @@
 
 {% block scripts_main_entrypoint %}
     {% frontend_app_asset_url "sentry" "entrypoints/pipeline.js" as asset_url %}
-    {% script src=asset_url data-entry="true" %}{% endscript %}
+    {% script src=asset_url crossorigin="anonymous" data-entry="true" %}{% endscript %}
 {% endblock %}

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -57,16 +57,16 @@
   {% block scripts %}
   {% block scripts_main_entrypoint %}
     {% frontend_app_asset_url "sentry" "entrypoints/app.js" as asset_url %}
-    {% script src=asset_url data-entry="true" %}{% endscript %}
+    {% script src=asset_url crossorigin="anonymous" data-entry="true" %}{% endscript %}
   {% endblock %}
 
   {% injected_script_assets as injected_assets %}
   {% for asset_url in injected_assets %}
-    {% script src=asset_url %}{% endscript %}
+    {% script src=asset_url crossorigin="anonymous" %}{% endscript %}
   {% endfor %}
 
   {% asset_url 'sentry' 'js/ads.js' as asset_url %}
-  {% script src=asset_url %}{% endscript %}
+  {% script src=asset_url crossorigin="anonymous" %}{% endscript %}
   {% endblock %}
 </head>
 


### PR DESCRIPTION
Chunks loaded via webpack are already using crossorigin=anonymous loading, however the two entry chunks rendered via the django template were missing the attributes