### PR TITLE
test(hc): Partial silo mode fix for test_post_process

### DIFF
--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -44,7 +44,7 @@ from sentry.replays.lib import kafka as replays_kafka
 from sentry.rules import init_registry
 from sentry.rules.actions.base import EventAction
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.silo import unguarded_write
+from sentry.silo import SiloMode, unguarded_write
 from sentry.tasks.derive_code_mappings import SUPPORTED_LANGUAGES
 from sentry.tasks.merge import merge_groups
 from sentry.tasks.post_process import (
@@ -57,7 +57,7 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.testutils.performance_issues.store_transaction import PerfIssueTransactionTestMixin
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
@@ -1439,10 +1439,11 @@ class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
         return_value=github_blame_return_value,
     )
     def test_logic_fallback_no_scm(self, mock_get_commit_context):
-        with unguarded_write(using=router.db_for_write(Integration)):
-            Integration.objects.all().delete()
-        integration = Integration.objects.create(provider="bitbucket")
-        integration.add_organization(self.organization)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            with unguarded_write(using=router.db_for_write(Integration)):
+                Integration.objects.all().delete()
+            integration = Integration.objects.create(provider="bitbucket")
+            integration.add_organization(self.organization)
         with self.tasks():
             self.call_post_process_group(
                 is_new=True,
@@ -1856,7 +1857,7 @@ class PostProcessGroupErrorTest(
         )
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class PostProcessGroupPerformanceTest(
     TestCase,
     SnubaTestCase,
@@ -2029,7 +2030,7 @@ class TransactionClustererTestCase(TestCase, SnubaTestCase):
         ]
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class PostProcessGroupGenericTest(
     TestCase,
     SnubaTestCase,


### PR DESCRIPTION
Mark passing test classes as stable.

Assume control silo mode in test_logic_fallback_no_scm setup.

PostProcessGroupErrorTest is still unstable because, when region silo mode tests are run, test_replay_linkage reports an assertion failure when running in monolith mode.