### PR TITLE
chore(stats-detectors): Remove thresholds for regressions

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -233,8 +233,8 @@ def _detect_transaction_change_points(
             # which was originally intended to detect a gradual regression
             # for the trends use case. That does not apply here.
             "allow_midpoint": "0",
-            "trend_percentage()": 0.5,
-            "min_change()": 200_000_000,
+            # "trend_percentage()": 0.5,
+            # "min_change()": 200_000_000,
             "validate_tail_hours": 12,
         }
 

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -233,9 +233,12 @@ def _detect_transaction_change_points(
             # which was originally intended to detect a gradual regression
             # for the trends use case. That does not apply here.
             "allow_midpoint": "0",
+            # TODO: uncomment these thresholds below after the
+            # rollout is complete so that only severe regressions
+            # are promoted to issues.
             # "trend_percentage()": 0.5,
             # "min_change()": 200_000_000,
-            "validate_tail_hours": 12,
+            # "validate_tail_hours": 12,
         }
 
         try:
@@ -709,7 +712,10 @@ def _detect_function_change_points(
         request = {
             "data": data,
             "sort": "-trend_percentage()",
-            "min_change()": 100_000_000,  # require a minimum 100ms increase (in ns)
+            # TODO: uncomment this threshold below after the
+            # rollout is complete so that only severe regressions
+            # are promoted to issues.
+            # "min_change()": 100_000_000,  # require a minimum 100ms increase (in ns)
             # Disable the fall back to use the midpoint as the breakpoint
             # which was originally intended to detect a gradual regression
             # for the trends use case. That does not apply here.


### PR DESCRIPTION
Remove percentage and absolute change thresholds for transaction breakpoint detection. Commented them out for now so we can add them back later easily.