### PR TITLE
feat(hybridcloud) Update unsubscribe links to work in siloed mode

### DIFF
--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -17,8 +17,10 @@ from sentry.types.region import get_region_by_name
 # but existing customers have been using these routes
 # on the main domain for a long time.
 REGION_PINNED_URL_NAMES = (
+    # These paths have organization scoped aliases
     "sentry-api-0-builtin-symbol-sources",
     "sentry-api-0-grouping-configs",
+    # These paths are used by relay which is implicitly region scoped
     "sentry-api-0-relays-index",
     "sentry-api-0-relay-register-challenge",
     "sentry-api-0-relay-register-response",
@@ -27,9 +29,14 @@ REGION_PINNED_URL_NAMES = (
     "sentry-api-0-relay-publickeys",
     "sentry-api-0-relays-healthcheck",
     "sentry-api-0-relays-details",
+    # Backwards compatibility for US cusstomers.
+    # New usage of these is region scoped.
     "sentry-error-page-embed",
     "sentry-release-hook",
     "sentry-api-0-projects",
+    "sentry-account-email-unsubscribe-incident",
+    "sentry-account-email-unsubscribe-issue",
+    "sentry-account-email-unsubscribe-project",
 )
 
 

--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -29,7 +29,7 @@ REGION_PINNED_URL_NAMES = (
     "sentry-api-0-relay-publickeys",
     "sentry-api-0-relays-healthcheck",
     "sentry-api-0-relays-details",
-    # Backwards compatibility for US cusstomers.
+    # Backwards compatibility for US customers.
     # New usage of these is region scoped.
     "sentry-error-page-embed",
     "sentry-release-hook",

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -94,8 +94,6 @@ def get_context(
     }
     # TODO: The unsubscribe system relies on `user_id` so it doesn't
     # work with Teams.
-
-    # TODO(mark) Would need to get the organization slug into each notification somehow.
     unsubscribe_key = notification.get_unsubscribe_key()
     if recipient_actor.actor_type == ActorType.USER and unsubscribe_key:
         context.update(

--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -11,7 +11,7 @@ from django.utils.safestring import SafeString
 from sentry.db.models import Model
 from sentry.notifications.helpers import get_reason_context
 from sentry.notifications.notifications.base import ProjectNotification
-from sentry.notifications.types import NotificationSettingTypes
+from sentry.notifications.types import NotificationSettingTypes, UnsubscribeContext
 from sentry.notifications.utils import send_activity_notification
 from sentry.notifications.utils.avatar import avatar_as_html
 from sentry.notifications.utils.participants import ParticipantMap, get_participants_for_group
@@ -106,8 +106,11 @@ class GroupActivityNotification(ActivityNotification, abc.ABC):
         """This is overridden by the activity subclasses."""
         return get_participants_for_group(self.group, self.activity.user_id)
 
-    def get_unsubscribe_key(self) -> tuple[str, int, str | None] | None:
-        return "issue", self.group.id, None
+    def get_unsubscribe_key(self) -> UnsubscribeContext | None:
+        return UnsubscribeContext(
+            key="issue",
+            resource_id=self.group.id,
+        )
 
     def get_base_context(self) -> MutableMapping[str, Any]:
         return {

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -17,6 +17,7 @@ from sentry.notifications.types import (
     NOTIFICATION_SETTING_TYPES,
     NotificationSettingEnum,
     NotificationSettingTypes,
+    UnsubscribeContext,
     get_notification_setting_type_name,
 )
 from sentry.notifications.utils.actions import MessageAction
@@ -121,7 +122,7 @@ class BaseNotification(abc.ABC):
         context = getattr(self, "context", None)
         return context["text_description"] if context else None
 
-    def get_unsubscribe_key(self) -> tuple[str, int, str | None] | None:
+    def get_unsubscribe_key(self) -> UnsubscribeContext | None:
         return None
 
     def get_log_params(self, recipient: RpcActor) -> Mapping[str, Any]:

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -17,7 +17,7 @@ from sentry.digests.utils import (
 from sentry.eventstore.models import Event
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.notify import notify
-from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
+from sentry.notifications.types import ActionTargetType, FallthroughChoiceType, UnsubscribeContext
 from sentry.notifications.utils import (
     NotificationRuleDetails,
     get_email_link_extra_params,
@@ -61,8 +61,10 @@ class DigestNotification(ProjectNotification):
         self.target_identifier = target_identifier
         self.fallthrough_choice = fallthrough_choice
 
-    def get_unsubscribe_key(self) -> tuple[str, int, str | None] | None:
-        return "project", self.project.id, "alert_digest"
+    def get_unsubscribe_key(self) -> UnsubscribeContext | None:
+        return UnsubscribeContext(
+            key="project", resource_id=self.project.id, referrer="alert_digest"
+        )
 
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         if not context:

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -357,3 +357,10 @@ class GroupSubscriptionStatus:
     is_disabled: bool
     is_active: bool
     has_only_inactive_subscriptions: bool
+
+
+@dataclass
+class UnsubscribeContext:
+    resource_id: int
+    key: str
+    referrer: str | None = None

--- a/src/sentry/utils/linksign.py
+++ b/src/sentry/utils/linksign.py
@@ -33,6 +33,13 @@ def generate_signed_link(user, viewname, referrer=None, args=None, kwargs=None):
     path = reverse(viewname, args=args, kwargs=kwargs)
     item = "{}|{}|{}".format(options.get("system.url-prefix"), path, base36_encode(user_id))
     signature = ":".join(get_signer().sign(item).rsplit(":", 2)[1:])
+    # TODO(mark) If this used region.to_url() we'd be good as new links would go to the region
+    # that the organization resides in.
+    # Alternative: Encode the region into the signed token so that we have it.
+    # We would need custom logic in the gateway to parse out the signature
+    # and do the right thing.
+    # Alternative: Make new URLs that have organization slug so we can proxy
+    # correctly. These links will break when an org is reslugged.
     signed_link = f"{absolute_uri(path)}?_={base36_encode(user_id)}:{signature}"
     if referrer:
         signed_link = signed_link + "&" + urlencode({"referrer": referrer})

--- a/src/sentry/web/frontend/unsubscribe_incident_notifications.py
+++ b/src/sentry/web/frontend/unsubscribe_incident_notifications.py
@@ -10,14 +10,14 @@ from sentry.web.frontend.unsubscribe_notifications import UnsubscribeBaseView
 class UnsubscribeIncidentNotificationsView(UnsubscribeBaseView):
     object_type = "incident"
 
-    def fetch_instance(self, incident_id):
+    def fetch_instance(self, incident_id) -> Incident:
         try:
             incident = Incident.objects.get(id=incident_id)
         except Incident.DoesNotExist:
             raise Http404
         return incident
 
-    def build_link(self, instance):
+    def build_link(self, instance) -> str:
         return absolute_uri(
             reverse(
                 "sentry-metric-alert",

--- a/src/sentry/web/frontend/unsubscribe_incident_notifications.py
+++ b/src/sentry/web/frontend/unsubscribe_incident_notifications.py
@@ -10,7 +10,7 @@ from sentry.web.frontend.unsubscribe_notifications import UnsubscribeBaseView
 class UnsubscribeIncidentNotificationsView(UnsubscribeBaseView):
     object_type = "incident"
 
-    def fetch_instance(self, incident_id) -> Incident:
+    def fetch_instance(self, incident_id):
         try:
             incident = Incident.objects.get(id=incident_id)
         except Incident.DoesNotExist:

--- a/src/sentry/web/frontend/unsubscribe_issue_notifications.py
+++ b/src/sentry/web/frontend/unsubscribe_issue_notifications.py
@@ -8,7 +8,7 @@ from sentry.web.frontend.unsubscribe_notifications import UnsubscribeBaseView
 class UnsubscribeIssueNotificationsView(UnsubscribeBaseView):
     object_type = "issue"
 
-    def fetch_instance(self, issue_id) -> Group:
+    def fetch_instance(self, issue_id):
         try:
             group = Group.objects.get_from_cache(id=issue_id)
         except Group.DoesNotExist:

--- a/src/sentry/web/frontend/unsubscribe_issue_notifications.py
+++ b/src/sentry/web/frontend/unsubscribe_issue_notifications.py
@@ -8,14 +8,14 @@ from sentry.web.frontend.unsubscribe_notifications import UnsubscribeBaseView
 class UnsubscribeIssueNotificationsView(UnsubscribeBaseView):
     object_type = "issue"
 
-    def fetch_instance(self, issue_id):
+    def fetch_instance(self, issue_id) -> Group:
         try:
             group = Group.objects.get_from_cache(id=issue_id)
         except Group.DoesNotExist:
             raise Http404
         return group
 
-    def build_link(self, instance):
+    def build_link(self, instance) -> str:
         return instance.get_absolute_url()
 
     def unsubscribe(self, instance, user):

--- a/src/sentry/web/frontend/unsubscribe_notifications.py
+++ b/src/sentry/web/frontend/unsubscribe_notifications.py
@@ -2,7 +2,8 @@ import abc
 from typing import Any
 
 from django.db import router, transaction
-from django.http import Http404, HttpResponseBase, HttpResponseRedirect
+from django.http import Http404, HttpResponseRedirect
+from django.http.response import HttpResponseBase
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from rest_framework.request import Request

--- a/src/sentry/web/frontend/unsubscribe_notifications.py
+++ b/src/sentry/web/frontend/unsubscribe_notifications.py
@@ -1,32 +1,26 @@
 import abc
+from typing import Any
 
 from django.db import router, transaction
-from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.http import Http404, HttpResponseBase, HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from rest_framework.request import Request
 
 from sentry.models.organizationmember import OrganizationMember
 from sentry.web.decorators import signed_auth_required
-from sentry.web.frontend.base import BaseView
+from sentry.web.frontend.base import BaseView, region_silo_view
 
 signed_auth_required_m = method_decorator(signed_auth_required)
 
 
-# All of the subclasses of this are using region resources.
-# That implies that this should be a region endpoint
-# There is also a view func that handles projects.
-# The projects func makes updates to settings which is unusual.
-# Having all the unsubscribe links go the regions seems better though.
-#
-# Will need to update URL generation to point at the regions and
-# have gateway handling for all the views so that old links work.
+@region_silo_view
 class UnsubscribeBaseView(BaseView, metaclass=abc.ABCMeta):
     auth_required = False
 
     @method_decorator(never_cache)
     @signed_auth_required_m
-    def handle(self, request: Request, **kwargs) -> HttpResponse:
+    def handle(self, request: Request, **kwargs) -> HttpResponseBase:
         with transaction.atomic(using=router.db_for_write(OrganizationMember)):
             if not getattr(request, "user_from_signed_request", False):
                 raise Http404
@@ -54,12 +48,12 @@ class UnsubscribeBaseView(BaseView, metaclass=abc.ABCMeta):
     def object_type(self):
         pass
 
-    @abc.abstractproperty
-    def fetch_instance(self, **kwargs):
+    @abc.abstractmethod
+    def fetch_instance(self, **kwargs) -> Any:
         pass
 
     @abc.abstractmethod
-    def build_link(self, instance):
+    def build_link(self, instance) -> str:
         pass
 
     @abc.abstractmethod

--- a/src/sentry/web/frontend/unsubscribe_notifications.py
+++ b/src/sentry/web/frontend/unsubscribe_notifications.py
@@ -13,6 +13,14 @@ from sentry.web.frontend.base import BaseView
 signed_auth_required_m = method_decorator(signed_auth_required)
 
 
+# All of the subclasses of this are using region resources.
+# That implies that this should be a region endpoint
+# There is also a view func that handles projects.
+# The projects func makes updates to settings which is unusual.
+# Having all the unsubscribe links go the regions seems better though.
+#
+# Will need to update URL generation to point at the regions and
+# have gateway handling for all the views so that old links work.
 class UnsubscribeBaseView(BaseView, metaclass=abc.ABCMeta):
     auth_required = False
 

--- a/src/sentry/web/frontend/unsubscribe_notifications.py
+++ b/src/sentry/web/frontend/unsubscribe_notifications.py
@@ -1,5 +1,4 @@
 import abc
-from typing import Any
 
 from django.db import router, transaction
 from django.http import Http404, HttpResponseRedirect
@@ -50,7 +49,7 @@ class UnsubscribeBaseView(BaseView, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def fetch_instance(self, **kwargs) -> Any:
+    def fetch_instance(self, **kwargs):
         pass
 
     @abc.abstractmethod

--- a/tests/sentry/utils/test_linksign.py
+++ b/tests/sentry/utils/test_linksign.py
@@ -1,42 +1,62 @@
-from django.test import override_settings
 from django.test.client import RequestFactory
 
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import region_silo_test
+from sentry.types.region import get_local_region
 from sentry.utils import linksign
 
 
-@control_silo_test(stable=True)
+@region_silo_test(stable=True)
 class LinkSignTestCase(TestCase):
-    @override_settings(ALLOWED_HOSTS=["something-else", "testserver"])
     def test_link_signing(self):
-        rf = RequestFactory()
+        base_url = get_local_region().to_url("/")
+        assert base_url.startswith("http://")
 
         url = linksign.generate_signed_link(self.user, "sentry")
-        assert url.startswith("http://")
+        assert url.startswith(base_url)
+
+        url = linksign.generate_signed_link(self.user.id, "sentry")
+        assert url.startswith(base_url)
+
+        url = linksign.generate_signed_link(
+            self.user.id,
+            "sentry-account-email-unsubscribe-project",
+            referrer="alert_view",
+            kwargs={"project_id": 1},
+        )
+
+        assert url.startswith(base_url)
+        assert "referrer=alert_view" in url
+        assert "notifications/unsubscribe" in url
+
+    def test_link_signing_custom_url_prefix(self):
+        if SiloMode.get_current_mode() != SiloMode.MONOLITH:
+            return
+        rf = RequestFactory()
+        # system.url-prefix only influences monolith behavior.
+        # in siloed deployments url templates are used
+        with self.options({"system.url-prefix": "https://sentry.io"}):
+            url = linksign.generate_signed_link(self.user, "sentry")
+            assert url.startswith("https://sentry.io")
+            req = rf.get("/" + url.split("/", 3)[-1])
+            signed_user = linksign.process_signature(req)
+            assert signed_user
+            assert signed_user.id == self.user.id
+
+    def test_process_signature(self):
+        rf = RequestFactory()
+        url = linksign.generate_signed_link(self.user, "sentry")
 
         req = rf.get("/" + url.split("/", 3)[-1])
         signed_user = linksign.process_signature(req)
         assert signed_user
         assert signed_user.id == self.user.id
 
-        with self.options({"system.url-prefix": "https://sentry.io"}):
-            url = linksign.generate_signed_link(self.user, "sentry")
-            assert url.startswith("https://")
-            req = rf.get("/" + url.split("/", 3)[-1])
-            signed_user = linksign.process_signature(req)
-            assert signed_user
-            assert signed_user.id == self.user.id
-
         req = rf.get("/what" + url.split("/", 3)[-1])
         signed_user = linksign.process_signature(req)
         assert signed_user is None
 
         req = rf.get("/" + url.split("/", 3)[-1] + "garbage")
-        signed_user = linksign.process_signature(req)
-        assert signed_user is None
-
-        rf.defaults["SERVER_NAME"] = "something-else"
-        req = rf.get("/" + url.split("/", 3)[-1])
         signed_user = linksign.process_signature(req)
         assert signed_user is None

--- a/tests/sentry/web/frontend/test_accounts.py
+++ b/tests/sentry/web/frontend/test_accounts.py
@@ -1,11 +1,16 @@
 from functools import cached_property
+from urllib.parse import urlparse
 
 from django.test import override_settings
 from django.urls import reverse
 
 from sentry.models.lostpasswordhash import LostPasswordHash
+from sentry.models.notificationsetting import NotificationSetting
+from sentry.notifications.types import NotificationSettingOptionValues
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, region_silo_test
+from sentry.utils import linksign
 
 
 @control_silo_test(stable=True)
@@ -93,3 +98,46 @@ class TestAccounts(TestCase):
         )
         assert resp.status_code == 200
         assert b"The password is too similar to the username." in resp.content
+
+
+@region_silo_test(stable=True)
+class EmailUnsubscribeProjectTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.signed_link = linksign.generate_signed_link(
+            self.user,
+            "sentry-account-email-unsubscribe-project",
+            kwargs={"project_id": self.project.id},
+        )
+
+    def test_get_invalid_link(self):
+        resp = self.client.get(f"/notifications/unsubscribe/{self.project.id}/?_=lol")
+        assert resp.status_code == 302
+        assert resp["Location"] == "/auth/login/"
+
+    def test_get(self):
+        url = urlparse(self.signed_link)
+        resp = self.client.get(f"{url.path}?{url.query}")
+        assert resp.status_code == 200
+        self.assertTemplateUsed("sentry/account/email_unsubscribe_project.html")
+
+    def test_post_cancel(self):
+        url = urlparse(self.signed_link)
+        resp = self.client.post(f"{url.path}?{url.query}", data={"cancel": "1"})
+        assert resp.status_code == 302
+        assert resp["Location"] == "/auth/login/"
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert NotificationSetting.objects.count() == 0, "No settings should be saved"
+
+    def test_post_success(self):
+        url = urlparse(self.signed_link)
+        resp = self.client.post(f"{url.path}?{url.query}")
+        assert resp.status_code == 302
+        assert resp["Location"] == "/auth/login/"
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            setting = NotificationSetting.objects.filter(
+                user_id=self.user.id,
+                scope_identifier=self.project.id,
+                value=NotificationSettingOptionValues.NEVER.value,
+            )
+            assert setting.get(), "Setting should be saved"

--- a/tests/sentry/web/frontend/test_unsubscribe_notifications.py
+++ b/tests/sentry/web/frontend/test_unsubscribe_notifications.py
@@ -1,3 +1,5 @@
+import abc
+
 from sentry.incidents.models import IncidentSubscription
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.testutils.cases import TestCase
@@ -10,9 +12,11 @@ class Base:
         def create_instance(self):
             raise NotImplementedError()
 
+        @abc.abstractproperty
         def view_name(self):
             raise NotImplementedError()
 
+        @abc.abstractmethod
         def assert_unsubscribed(self, instance, user):
             raise NotImplementedError()
 


### PR DESCRIPTION
Unsubscribe links were previously marked as `control` however upon further reflection I think that is the wrong silo assignment, and have changed unsubscribe to region. My reasoning was:

1. All of the records that are unsubscribed from live in the region. We would need more RPC methods to facilitate unsubscribes if the URLs resolved to control silo
2. We already have RPC methods for notification updates which is the only control silo resource required for unsubscribes.

Our unsubscribe links are valid for 10 days, and we'll need to have links work across the monolith/siloed boundary so I've added backwards compatibility via the monolith region pinning. After the silo split, new unsubscribe URLs will be generated using the `{region}.sentry.io` domains.