### PR TITLE
fix(tests) Set system.url-prefix in notification acceptance test

### DIFF
--- a/tests/acceptance/test_account_settings.py
+++ b/tests/acceptance/test_account_settings.py
@@ -29,7 +29,9 @@ class AccountSettingsTest(AcceptanceTestCase):
             self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def test_account_notifications(self):
-        with self.feature("organizations:onboarding"):
+        with self.options({"system.url-prefix": self.browser.live_server_url}), self.feature(
+            "organizations:onboarding"
+        ):
             self.browser.get("/settings/account/notifications/")
             self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 


### PR DESCRIPTION
This will fix missing organization load events during acceptance tests.
