### PR TITLE
feat(replays): Replay layout timeline hovering

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -14,7 +14,7 @@ import {
   CompactTimelineScrubber,
   TimelineScrubber,
 } from 'sentry/components/replays/player/scrubber';
-import useScrubberMouseTracking from 'sentry/components/replays/player/useScrubberMouseTracking';
+import {useTimelineScrubberMouseTracking} from 'sentry/components/replays/player/useScrubberMouseTracking';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {divide} from 'sentry/components/replays/utils';
 import toPercent from 'sentry/utils/number/toPercent';
@@ -27,8 +27,7 @@ function ReplayTimeline({size}: Props) {
   const {replay, currentTime} = useReplayContext();
 
   const panelRef = useRef<HTMLDivElement>(null);
-  const mouseTrackingProps = useScrubberMouseTracking({elem: panelRef});
-  const panelWidth = useDimensions<HTMLDivElement>({elementRef: panelRef}).width;
+  const mouseTrackingProps = useTimelineScrubberMouseTracking({elem: panelRef}, size);
 
   const stackedRef = useRef<HTMLDivElement>(null);
   const {width} = useDimensions<HTMLDivElement>({elementRef: stackedRef});
@@ -62,7 +61,8 @@ function ReplayTimeline({size}: Props) {
         }}
         ref={stackedRef}
       >
-        <MajorGridlines durationMs={durationMs} width={panelWidth} />
+        <MinorGridlines durationMs={durationMs} width={width} />
+        <MajorGridlines durationMs={durationMs} width={width} />
         <CompactTimelineScrubber />
         <TimelineEventsContainer>
           <ReplayTimelineEvents

--- a/static/app/components/replays/player/useScrubberMouseTracking.tsx
+++ b/static/app/components/replays/player/useScrubberMouseTracking.tsx
@@ -37,4 +37,37 @@ export function useScrubberMouseTracking<T extends Element>({elem}: Opts<T>) {
   return mouseTrackingProps;
 }
 
+export function useTimelineScrubberMouseTracking<T extends Element>(
+  {elem}: Opts<T>,
+  size: number
+) {
+  const {replay, currentTime, setCurrentHoverTime} = useReplayContext();
+  const durationMs = replay?.getDurationMs();
+
+  const handlePositionChange = useCallback(
+    params => {
+      if (!params || durationMs === undefined) {
+        setCurrentHoverTime(undefined);
+        return;
+      }
+      const {left, width} = params;
+
+      if (left >= 0) {
+        const percent = (left - width / 2) / width;
+        const time = currentTime + (percent * durationMs) / (size / 100);
+        setCurrentHoverTime(time);
+      } else {
+        setCurrentHoverTime(undefined);
+      }
+    },
+    [durationMs, setCurrentHoverTime, currentTime, size]
+  );
+
+  const mouseTrackingProps = useMouseTracking({
+    elem,
+    onPositionChange: handlePositionChange,
+  });
+  return mouseTrackingProps;
+}
+
 export default useScrubberMouseTracking;


### PR DESCRIPTION
Brings back hovering on timeline

Relates to https://github.com/getsentry/team-replay/issues/199
