### PR TITLE
fix(stat-detectors): Update event comparison controls

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/eventDisplay.tsx
@@ -102,16 +102,14 @@ function useFetchSampleEvents({
   });
 }
 
-type EventDisplayProps = {
-  durationBaseline: number;
-  end: number;
-  eventSelectLabel: string;
-  project: Project;
-  start: number;
-  transaction: string;
-};
+interface NavButtonProps {
+  disabled: boolean;
+  icon: React.ReactNode;
+  onPaginate: () => void;
+  title: string;
+}
 
-function NavButton({title, disabled, icon, onPaginate}) {
+function NavButton({title, disabled, icon, onPaginate}: NavButtonProps) {
   return (
     <Tooltip title={title} disabled={disabled} skipWrapper>
       <div>
@@ -125,6 +123,15 @@ function NavButton({title, disabled, icon, onPaginate}) {
       </div>
     </Tooltip>
   );
+}
+
+interface EventDisplayProps {
+  durationBaseline: number;
+  end: number;
+  eventSelectLabel: string;
+  project: Project;
+  start: number;
+  transaction: string;
 }
 
 function EventDisplay({

--- a/static/app/components/events/eventStatisticalDetector/eventComparison/index.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventComparison/index.tsx
@@ -19,7 +19,7 @@ type EventComparisonProps = {
   project: Project;
 };
 
-function EventComparison({event, project, group}: EventComparisonProps) {
+function EventComparison({event, project}: EventComparisonProps) {
   const now = useMemo(() => Date.now(), []);
   const retentionPeriodMs = moment().subtract(90, 'days').valueOf();
   const {aggregateRange1, aggregateRange2, dataStart, breakpoint, transaction} =
@@ -38,7 +38,6 @@ function EventComparison({event, project, group}: EventComparisonProps) {
             end={breakpoint * 1000}
             transaction={transaction}
             durationBaseline={aggregateRange1}
-            group={group}
           />
         </StyledGridItem>
         <StyledGridItem position="right">
@@ -49,7 +48,6 @@ function EventComparison({event, project, group}: EventComparisonProps) {
             end={now}
             transaction={transaction}
             durationBaseline={aggregateRange2}
-            group={group}
           />
         </StyledGridItem>
       </StyledGrid>

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -23,7 +23,7 @@ import {
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Event, Group, IssueType, Organization} from 'sentry/types';
+import {Event, Group, Organization} from 'sentry/types';
 import {defined, formatBytesBase2} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {eventDetailsRoute, generateEventSlug} from 'sentry/utils/discover/urls';
@@ -249,8 +249,6 @@ export function GroupEventActions({event, group, projectSlug}: GroupEventActions
   const isReplayEnabled =
     organization.features.includes('session-replay') &&
     projectCanLinkToReplay(group.project);
-  const isDurationRegressionIssue =
-    group?.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION;
 
   const downloadJson = () => {
     const jsonUrl = `/api/0/projects/${organization.slug}/${projectSlug}/events/${event.id}/json/`;
@@ -311,7 +309,7 @@ export function GroupEventActions({event, group, projectSlug}: GroupEventActions
             key: 'copy-event-url',
             label: t('Copy Event Link'),
             hidden: xlargeViewport,
-            onAction: isDurationRegressionIssue ? copyEventDetailLink : copyLink,
+            onAction: copyLink,
           },
           {
             key: 'json',
@@ -353,7 +351,7 @@ export function GroupEventActions({event, group, projectSlug}: GroupEventActions
           },
         ]}
       />
-      {xlargeViewport && !isDurationRegressionIssue && (
+      {xlargeViewport && (
         <Button
           title={t('Copy link to this issue event')}
           size={BUTTON_SIZE}
@@ -362,7 +360,7 @@ export function GroupEventActions({event, group, projectSlug}: GroupEventActions
           icon={<IconLink />}
         />
       )}
-      {xlargeViewport && isDurationRegressionIssue && (
+      {xlargeViewport && (
         <Button
           title={t('Copy link to this event')}
           size={BUTTON_SIZE}
@@ -508,11 +506,11 @@ const ActionsWrapper = styled('div')`
   gap: ${space(0.5)};
 `;
 
-const StyledNavButton = styled(Button)`
+export const StyledNavButton = styled(Button)`
   border-radius: 0;
 `;
 
-const NavButtons = styled('div')`
+export const NavButtons = styled('div')`
   display: flex;
 
   > * {


### PR DESCRIPTION
- Replaces the group event carousel with just a button that opens the event
    - Deletes the relevant stat detector code from that component
- Adds pagination and increases amount of data to paginate
    - This is because we don't have true pagination on this component right now

<img width="569" alt="Screenshot 2023-10-26 at 5 31 51 PM" src="https://github.com/getsentry/sentry/assets/22846452/e9af0449-8d96-444e-aa14-856526971da4">

