### PR TITLE
feat(crons): Add endpoint to mock schedule

### DIFF
--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -22,4 +22,5 @@ class ApiOwner(Enum):
     REPLAY = "replay-backend"
     WEB_FRONTEND_SDKS = "team-web-sdk-frontend"
     FEEDBACK = "feedback-backend"
+    CRONS = "crons"
     UNOWNED = "unowned"

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -111,6 +111,9 @@ from sentry.monitors.endpoints.organization_monitor_index import OrganizationMon
 from sentry.monitors.endpoints.organization_monitor_index_stats import (
     OrganizationMonitorIndexStatsEndpoint,
 )
+from sentry.monitors.endpoints.organization_monitor_schedule_sample_data import (
+    OrganizationMonitorScheduleSampleDataEndpoint,
+)
 from sentry.monitors.endpoints.organization_monitor_stats import OrganizationMonitorStatsEndpoint
 from sentry.replays.endpoints.organization_replay_count import OrganizationReplayCountEndpoint
 from sentry.replays.endpoints.organization_replay_details import OrganizationReplayDetailsEndpoint
@@ -1481,6 +1484,11 @@ ORGANIZATION_URLS = [
         r"^(?P<organization_slug>[^\/]+)/monitors-stats/$",
         OrganizationMonitorIndexStatsEndpoint.as_view(),
         name="sentry-api-0-organization-monitor-index-stats",
+    ),
+    re_path(
+        r"^(?P<organization_slug>[^\/]+)/monitors-schedule-data/$",
+        OrganizationMonitorScheduleSampleDataEndpoint.as_view(),
+        name="sentry-api-0-organization-monitors-schedule-sample-data",
     ),
     re_path(
         r"^(?P<organization_slug>[^\/]+)/monitors/(?P<monitor_slug>[^\/]+)/$",

--- a/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
@@ -6,15 +6,20 @@ from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.models.organization import Organization
 from sentry.monitors.schedule import SCHEDULE_INTERVAL_MAP
 
 
 @region_silo_endpoint
 class OrganizationMonitorScheduleSampleDataEndpoint(OrganizationEndpoint):
-    def get(self, request: Request, organization: Organization) -> Response:
+    publish_status = {"GET": ApiPublishStatus.PRIVATE}
+    private = True
+    owner = ApiOwner.CRONS
+
+    def get(self, request: Request) -> Response:
         num_ticks = int(request.GET.get("numTicks", 0))
         schedule_type = request.GET.get("scheduleType")
         cron_schedule = request.GET.get("cronSchedule")

--- a/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
@@ -16,7 +16,6 @@ from sentry.monitors.schedule import SCHEDULE_INTERVAL_MAP
 @region_silo_endpoint
 class OrganizationMonitorScheduleSampleDataEndpoint(OrganizationEndpoint):
     publish_status = {"GET": ApiPublishStatus.PRIVATE}
-    private = True
     owner = ApiOwner.CRONS
 
     def get(self, request: Request) -> Response:

--- a/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
@@ -10,6 +10,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models.organization import Organization
 from sentry.monitors.schedule import SCHEDULE_INTERVAL_MAP
 
 
@@ -18,7 +19,7 @@ class OrganizationMonitorScheduleSampleDataEndpoint(OrganizationEndpoint):
     publish_status = {"GET": ApiPublishStatus.PRIVATE}
     owner = ApiOwner.CRONS
 
-    def get(self, request: Request) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         num_ticks = int(request.GET.get("numTicks", 0))
         schedule_type = request.GET.get("scheduleType")
         cron_schedule = request.GET.get("cronSchedule")

--- a/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+
+from croniter import croniter
+from dateutil import rrule
+from django.utils import timezone
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models.organization import Organization
+from sentry.monitors.schedule import SCHEDULE_INTERVAL_MAP
+
+
+@region_silo_endpoint
+class OrganizationMonitorScheduleSampleDataEndpoint(OrganizationEndpoint):
+    def get(self, request: Request, organization: Organization) -> Response:
+        num_ticks = int(request.GET.get("numTicks", 0))
+        schedule_type = request.GET.get("scheduleType")
+        cron_schedule = request.GET.get("cronSchedule")
+        interval = int(request.GET.get("interval", 0))
+        frequency = request.GET.get("frequency")
+
+        if not num_ticks or num_ticks > 100 or not schedule_type:
+            # return error
+            return self.respond([], status=400)
+
+        # Align the reference ts to the nearest hour
+        reference_ts = timezone.now().replace(minute=0, second=0, microsecond=0)
+        ticks = []
+        if schedule_type == "crontab":
+            if not cron_schedule:
+                return self.respond(ticks, status=400)
+
+            iterator = croniter(cron_schedule, reference_ts)
+            while len(ticks) < num_ticks:
+                ticks.append(iterator.get_next(datetime))
+
+        elif schedule_type == "interval":
+            if not interval or not frequency:
+                return self.respond(ticks, status=400)
+
+            rule = rrule.rrule(
+                freq=SCHEDULE_INTERVAL_MAP[frequency],
+                interval=interval,
+                dtstart=reference_ts,
+                count=num_ticks,
+            )
+            new_date = reference_ts
+            ticks.append(new_date)
+            while len(ticks) < num_ticks:
+                new_date = rule.after(new_date)
+                ticks.append(new_date)
+
+        return self.respond(ticks)

--- a/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
@@ -23,29 +23,29 @@ class OrganizationMonitorScheduleSampleDataEndpoint(OrganizationEndpoint):
         num_ticks = int(request.GET.get("numTicks", 0))
         schedule_type = request.GET.get("scheduleType")
         cron_schedule = request.GET.get("cronSchedule")
-        interval = int(request.GET.get("interval", 0))
-        frequency = request.GET.get("frequency")
+        interval = int(request.GET.get("intervalFrequency", 0))
+        unit = request.GET.get("intervalUnit")
 
         if not num_ticks or num_ticks > 100 or not schedule_type:
-            return self.respond([], status=400)
+            return Response([], status=400)
 
         # Align the reference ts to the nearest hour
         reference_ts = timezone.now().replace(minute=0, second=0, microsecond=0)
-        ticks = []
+        ticks: list[datetime] = []
         if schedule_type == "crontab":
-            if not cron_schedule:
-                return self.respond(ticks, status=400)
+            if not cron_schedule or not croniter.is_valid(cron_schedule):
+                return Response(ticks, status=400)
 
             iterator = croniter(cron_schedule, reference_ts)
             while len(ticks) < num_ticks:
                 ticks.append(iterator.get_next(datetime))
 
         elif schedule_type == "interval":
-            if not interval or not frequency:
-                return self.respond(ticks, status=400)
+            if not interval or not unit or unit not in SCHEDULE_INTERVAL_MAP or interval < 1:
+                return Response(ticks, status=400)
 
             rule = rrule.rrule(
-                freq=SCHEDULE_INTERVAL_MAP[frequency],
+                freq=SCHEDULE_INTERVAL_MAP[unit],
                 interval=interval,
                 dtstart=reference_ts,
                 count=num_ticks,
@@ -56,4 +56,4 @@ class OrganizationMonitorScheduleSampleDataEndpoint(OrganizationEndpoint):
                 new_date = rule.after(new_date)
                 ticks.append(new_date)
 
-        return self.respond(ticks)
+        return Response(ticks)

--- a/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from datetime import datetime
+from typing import cast
 
 from croniter import croniter
 from dateutil import rrule
@@ -12,6 +15,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.monitors.schedule import SCHEDULE_INTERVAL_MAP
+from sentry.monitors.types import IntervalUnit
 
 
 @region_silo_endpoint
@@ -45,7 +49,7 @@ class OrganizationMonitorScheduleSampleDataEndpoint(OrganizationEndpoint):
                 return Response(ticks, status=400)
 
             rule = rrule.rrule(
-                freq=SCHEDULE_INTERVAL_MAP[unit],
+                freq=SCHEDULE_INTERVAL_MAP[cast(IntervalUnit, unit)],
                 interval=interval,
                 dtstart=reference_ts,
                 count=num_ticks,

--- a/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
@@ -22,7 +22,6 @@ class OrganizationMonitorScheduleSampleDataEndpoint(OrganizationEndpoint):
         frequency = request.GET.get("frequency")
 
         if not num_ticks or num_ticks > 100 or not schedule_type:
-            # return error
             return self.respond([], status=400)
 
         # Align the reference ts to the nearest hour

--- a/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
@@ -34,7 +34,7 @@ class OrganizationMonitorScheduleSampleDataEndpoint(OrganizationEndpoint):
 
     def get(self, request: Request, organization: Organization) -> Response:
         # Convert query params to a form the validator can use
-        config_data = {}
+        config_data: dict[str, list | str] = {}
         for key, val in request.GET.lists():
             if key == "schedule" and len(val) > 1:
                 config_data[key] = [int(val[0]), val[1]]

--- a/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_schedule_sample_data.py
@@ -6,6 +6,7 @@ from typing import cast
 from croniter import croniter
 from dateutil import rrule
 from django.utils import timezone
+from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -14,8 +15,16 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.models.organization import Organization
+from sentry.monitors.models import ScheduleType
 from sentry.monitors.schedule import SCHEDULE_INTERVAL_MAP
 from sentry.monitors.types import IntervalUnit
+from sentry.monitors.validators import ConfigValidator
+
+MAX_TICKS = 100
+
+
+class SampleScheduleConfigValidator(ConfigValidator):
+    num_ticks = serializers.IntegerField(min_value=1, max_value=MAX_TICKS)
 
 
 @region_silo_endpoint
@@ -24,33 +33,35 @@ class OrganizationMonitorScheduleSampleDataEndpoint(OrganizationEndpoint):
     owner = ApiOwner.CRONS
 
     def get(self, request: Request, organization: Organization) -> Response:
-        num_ticks = int(request.GET.get("numTicks", 0))
-        schedule_type = request.GET.get("scheduleType")
-        cron_schedule = request.GET.get("cronSchedule")
-        interval = int(request.GET.get("intervalFrequency", 0))
-        unit = request.GET.get("intervalUnit")
+        # Convert query params to a form the validator can use
+        config_data = {}
+        for key, val in request.GET.lists():
+            if key == "schedule" and len(val) > 1:
+                config_data[key] = [int(val[0]), val[1]]
+            else:
+                config_data[key] = val[0]
 
-        if not num_ticks or num_ticks > 100 or not schedule_type:
-            return Response([], status=400)
+        validator = SampleScheduleConfigValidator(data=config_data)
+        if not validator.is_valid():
+            return self.respond(validator.errors, status=400)
+
+        config = validator.validated_data
+        num_ticks = config.get("num_ticks")
+        schedule_type = config.get("schedule_type")
+        schedule = config.get("schedule")
 
         # Align the reference ts to the nearest hour
         reference_ts = timezone.now().replace(minute=0, second=0, microsecond=0)
         ticks: list[datetime] = []
-        if schedule_type == "crontab":
-            if not cron_schedule or not croniter.is_valid(cron_schedule):
-                return Response(ticks, status=400)
-
-            iterator = croniter(cron_schedule, reference_ts)
+        if schedule_type == ScheduleType.CRONTAB:
+            iterator = croniter(schedule, reference_ts)
             while len(ticks) < num_ticks:
                 ticks.append(iterator.get_next(datetime))
 
-        elif schedule_type == "interval":
-            if not interval or not unit or unit not in SCHEDULE_INTERVAL_MAP or interval < 1:
-                return Response(ticks, status=400)
-
+        elif schedule_type == ScheduleType.INTERVAL:
             rule = rrule.rrule(
-                freq=SCHEDULE_INTERVAL_MAP[cast(IntervalUnit, unit)],
-                interval=interval,
+                freq=SCHEDULE_INTERVAL_MAP[cast(IntervalUnit, schedule[1])],
+                interval=schedule[0],
                 dtstart=reference_ts,
                 count=num_ticks,
             )
@@ -60,4 +71,4 @@ class OrganizationMonitorScheduleSampleDataEndpoint(OrganizationEndpoint):
                 new_date = rule.after(new_date)
                 ticks.append(new_date)
 
-        return Response(ticks)
+        return Response([int(ts.timestamp()) for ts in ticks])

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_schedule_sample_data.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_schedule_sample_data.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test(stable=True)
+class SampleScheduleDataTest(APITestCase):
+    endpoint = "sentry-api-0-organization-monitors-schedule-sample-data"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
+    @patch("django.utils.timezone.now")
+    def test_simple_crontab(self, mock_now):
+        mock_now.return_value = datetime(2023, 10, 26, 12, 32)
+
+        expected_ticks = [
+            datetime(2023, 10, 26, 13, 00),
+            datetime(2023, 10, 26, 14, 00),
+            datetime(2023, 10, 26, 15, 00),
+            datetime(2023, 10, 26, 16, 00),
+            datetime(2023, 10, 26, 17, 00),
+        ]
+
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={"numTicks": 5, "scheduleType": "crontab", "cronSchedule": "0 * * * *"},
+        )
+        assert response.data == expected_ticks
+
+    @patch("django.utils.timezone.now")
+    def test_simple_interval(self, mock_now):
+        mock_now.return_value = datetime(2023, 10, 26, 12, 32)
+
+        expected_ticks = [
+            datetime(2023, 10, 26, 12, 00),
+            datetime(2023, 10, 26, 13, 00),
+            datetime(2023, 10, 26, 14, 00),
+            datetime(2023, 10, 26, 15, 00),
+            datetime(2023, 10, 26, 16, 00),
+        ]
+
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={
+                "numTicks": 5,
+                "scheduleType": "interval",
+                "frequency": "hour",
+                "interval": 1,
+            },
+        )
+        assert response.data == expected_ticks
+
+    def test_missing_params(self):
+        # No params
+        self.get_error_response(
+            self.organization.slug,
+            qs_params={},
+            status_code=400,
+        )
+
+        # Missing num ticks
+        self.get_error_response(
+            self.organization.slug,
+            qs_params={"scheduleType": "crontab", "cronSchedule": "0 * * * *"},
+            status_code=400,
+        )
+
+        # Missing schedule info
+        self.get_error_response(
+            self.organization.slug,
+            qs_params={"scheduleType": "interval", "cronSchedule": "0 * * * *"},
+            status_code=400,
+        )
+        self.get_error_response(
+            self.organization.slug,
+            qs_params={"scheduleType": "crontab"},
+            status_code=400,
+        )

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_schedule_sample_data.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_schedule_sample_data.py
@@ -50,8 +50,8 @@ class SampleScheduleDataTest(APITestCase):
             qs_params={
                 "numTicks": 5,
                 "scheduleType": "interval",
-                "frequency": "hour",
-                "interval": 1,
+                "intervalUnit": "hour",
+                "intervalFrequency": 1,
             },
         )
         assert response.data == expected_ticks
@@ -80,5 +80,37 @@ class SampleScheduleDataTest(APITestCase):
         self.get_error_response(
             self.organization.slug,
             qs_params={"scheduleType": "crontab"},
+            status_code=400,
+        )
+
+    def test_bad_params(self):
+        # Invalid crontab schedule
+        self.get_error_response(
+            self.organization.slug,
+            qs_params={"numTicks": 5, "scheduleType": "crontab", "cronSchedule": "0 * * *"},
+            status_code=400,
+        )
+
+        # Invalid interval unit
+        self.get_error_response(
+            self.organization.slug,
+            qs_params={
+                "numTicks": 5,
+                "scheduleType": "interval",
+                "intervalUnit": "second",
+                "intervalFrequency": "1",
+            },
+            status_code=400,
+        )
+
+        # Invalid interval frequency
+        self.get_error_response(
+            self.organization.slug,
+            qs_params={
+                "numTicks": 5,
+                "scheduleType": "interval",
+                "intervalUnit": "month",
+                "intervalFrequency": "-1",
+            },
             status_code=400,
         )

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_schedule_sample_data.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_schedule_sample_data.py
@@ -20,16 +20,16 @@ class SampleScheduleDataTest(APITestCase):
         mock_now.return_value = datetime(2023, 10, 26, 12, 32)
 
         expected_ticks = [
-            datetime(2023, 10, 26, 13, 00),
-            datetime(2023, 10, 26, 14, 00),
-            datetime(2023, 10, 26, 15, 00),
-            datetime(2023, 10, 26, 16, 00),
-            datetime(2023, 10, 26, 17, 00),
+            int(datetime(2023, 10, 26, 13, 00).timestamp()),
+            int(datetime(2023, 10, 26, 14, 00).timestamp()),
+            int(datetime(2023, 10, 26, 15, 00).timestamp()),
+            int(datetime(2023, 10, 26, 16, 00).timestamp()),
+            int(datetime(2023, 10, 26, 17, 00).timestamp()),
         ]
 
         response = self.get_success_response(
             self.organization.slug,
-            qs_params={"numTicks": 5, "scheduleType": "crontab", "cronSchedule": "0 * * * *"},
+            qs_params={"num_ticks": 5, "schedule_type": "crontab", "schedule": "0 * * * *"},
         )
         assert response.data == expected_ticks
 
@@ -38,20 +38,19 @@ class SampleScheduleDataTest(APITestCase):
         mock_now.return_value = datetime(2023, 10, 26, 12, 32)
 
         expected_ticks = [
-            datetime(2023, 10, 26, 12, 00),
-            datetime(2023, 10, 26, 13, 00),
-            datetime(2023, 10, 26, 14, 00),
-            datetime(2023, 10, 26, 15, 00),
-            datetime(2023, 10, 26, 16, 00),
+            int(datetime(2023, 10, 26, 12, 00).timestamp()),
+            int(datetime(2023, 10, 26, 13, 00).timestamp()),
+            int(datetime(2023, 10, 26, 14, 00).timestamp()),
+            int(datetime(2023, 10, 26, 15, 00).timestamp()),
+            int(datetime(2023, 10, 26, 16, 00).timestamp()),
         ]
 
         response = self.get_success_response(
             self.organization.slug,
             qs_params={
-                "numTicks": 5,
-                "scheduleType": "interval",
-                "intervalUnit": "hour",
-                "intervalFrequency": 1,
+                "num_ticks": 5,
+                "schedule_type": "interval",
+                "schedule": [1, "hour"],
             },
         )
         assert response.data == expected_ticks
@@ -67,19 +66,19 @@ class SampleScheduleDataTest(APITestCase):
         # Missing num ticks
         self.get_error_response(
             self.organization.slug,
-            qs_params={"scheduleType": "crontab", "cronSchedule": "0 * * * *"},
+            qs_params={"schedule_type": "crontab", "schedule": "0 * * * *"},
             status_code=400,
         )
 
-        # Missing schedule info
+        # Invalid schedule info
         self.get_error_response(
             self.organization.slug,
-            qs_params={"scheduleType": "interval", "cronSchedule": "0 * * * *"},
+            qs_params={"schedule_type": "interval", "schedule": "* * * * *"},
             status_code=400,
         )
         self.get_error_response(
             self.organization.slug,
-            qs_params={"scheduleType": "crontab"},
+            qs_params={"schedule_type": "crontab"},
             status_code=400,
         )
 
@@ -87,7 +86,7 @@ class SampleScheduleDataTest(APITestCase):
         # Invalid crontab schedule
         self.get_error_response(
             self.organization.slug,
-            qs_params={"numTicks": 5, "scheduleType": "crontab", "cronSchedule": "0 * * *"},
+            qs_params={"num_ticks": 5, "schedule_type": "crontab", "schedule": "0 * * *"},
             status_code=400,
         )
 


### PR DESCRIPTION
Adds an endpoint which generates timestamps for when expected check-ins should occur. 

No documentation provided as this is intended for use only within the product for certain schedule visualizations and shouldn't be useful to end users of our API. 

Will be leveraged for the new sign-up flow visualization, and for the future where we can use this to show the user when next check-ins are expected on a timeline view.