### PR TITLE
debug(crons): Add kwargs to mark_checkin_timeout

### DIFF
--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -391,3 +391,55 @@ def mark_checkin_timeout(checkin_id: int, ts: datetime):
         )
 
         mark_failed(checkin, ts=most_recent_expected_ts)
+
+
+@instrumented_task(
+    name="sentry.monitors.tasks.mark_checkin_timeout",
+    max_retries=0,
+    record_timing=True,
+)
+def mark_checkin_timeout_verbose(checkin_id: int, ts: datetime, **kwargs):
+    logger.info("checkin.timeout", extra={"checkin_id": checkin_id})
+
+    checkin = (
+        MonitorCheckIn.objects.select_related("monitor_environment")
+        .select_related("monitor_environment__monitor")
+        .get(id=checkin_id)
+    )
+
+    monitor_environment = checkin.monitor_environment
+    monitor = monitor_environment.monitor
+
+    logger.info(
+        "monitor_environment.checkin-timeout",
+        extra={"monitor_environment_id": monitor_environment.id, "checkin_id": checkin.id},
+    )
+    affected = checkin.update(status=CheckInStatus.TIMEOUT)
+    if not affected:
+        return
+
+    # we only mark the monitor as failed if a newer checkin wasn't responsible for the state
+    # change
+    has_newer_result = MonitorCheckIn.objects.filter(
+        monitor_environment=monitor_environment,
+        date_added__gt=checkin.date_added,
+        status__in=[CheckInStatus.OK, CheckInStatus.ERROR],
+    ).exists()
+    if not has_newer_result:
+        # Similar to mark_missed we compute when the most recent check-in should
+        # have happened to use as our reference time for mark_failed.
+        #
+        # XXX(epurkhiser): For ScheduleType.INTERVAL this MAY compute an
+        # incorrect next_checkin from what the actual user task might expect,
+        # since we don't know the behavior of the users task scheduling in the
+        # scenario that it 1) doesn't complete, or 2) runs for longer than
+        # their configured time-out time.
+        #
+        # See `test_timeout_using_interval`
+        most_recent_expected_ts = get_prev_schedule(
+            checkin.date_added.astimezone(monitor.timezone),
+            ts.astimezone(monitor.timezone),
+            monitor.schedule,
+        )
+
+        mark_failed(checkin, ts=most_recent_expected_ts)


### PR DESCRIPTION
Add  `kwargs` to `mark_checkin_timeout` with  so we can see impact of missing check-ins