### PR TITLE
fix(crons): Correctly casts slugs to strings for events + occurrences

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -317,7 +317,7 @@ def create_issue_platform_occurrence(
             "sdk": None,
             "tags": {
                 "monitor.id": str(monitor_env.monitor.guid),
-                "monitor.slug": monitor_env.monitor.slug,
+                "monitor.slug": str(monitor_env.monitor.slug),
             },
             "trace_id": trace_id,
             "timestamp": current_timestamp.isoformat(),
@@ -332,7 +332,7 @@ def get_monitor_environment_context(monitor_environment: MonitorEnvironment):
 
     return {
         "id": str(monitor_environment.monitor.guid),
-        "slug": monitor_environment.monitor.slug,
+        "slug": str(monitor_environment.monitor.slug),
         "name": monitor_environment.monitor.name,
         "config": monitor_environment.monitor.config,
         "status": monitor_environment.get_status_display(),

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -82,7 +82,7 @@ class MarkFailedTestCase(TestCase):
                         },
                         "id": str(monitor.guid),
                         "name": monitor.name,
-                        "slug": monitor.slug,
+                        "slug": str(monitor.slug),
                     }
                 },
                 "logentry": {"formatted": "Monitor failure: test monitor (unknown)"},
@@ -326,7 +326,7 @@ class MarkFailedTestCase(TestCase):
                 "sdk": None,
                 "tags": {
                     "monitor.id": str(monitor.guid),
-                    "monitor.slug": monitor.slug,
+                    "monitor.slug": str(monitor.slug),
                 },
                 "trace_id": trace_id.hex,
             },
@@ -420,7 +420,7 @@ class MarkFailedTestCase(TestCase):
                         },
                         "id": str(monitor.guid),
                         "name": monitor.name,
-                        "slug": monitor.slug,
+                        "slug": str(monitor.slug),
                     }
                 },
                 "environment": monitor_environment.environment.name,
@@ -431,7 +431,7 @@ class MarkFailedTestCase(TestCase):
                 "sdk": None,
                 "tags": {
                     "monitor.id": str(monitor.guid),
-                    "monitor.slug": monitor.slug,
+                    "monitor.slug": str(monitor.slug),
                 },
                 "trace_id": None,
             },
@@ -528,7 +528,7 @@ class MarkFailedTestCase(TestCase):
                         },
                         "id": str(monitor.guid),
                         "name": monitor.name,
-                        "slug": monitor.slug,
+                        "slug": str(monitor.slug),
                     }
                 },
                 "environment": monitor_environment.environment.name,
@@ -539,7 +539,7 @@ class MarkFailedTestCase(TestCase):
                 "sdk": None,
                 "tags": {
                     "monitor.id": str(monitor.guid),
-                    "monitor.slug": monitor.slug,
+                    "monitor.slug": str(monitor.slug),
                 },
                 "trace_id": None,
             },


### PR DESCRIPTION
Fixes tags that only send numeric slugs, which are invalid due to https://github.com/getsentry/sentry/pull/58743