### PR TITLE
Fix typo "breadpad"

### DIFF
--- a/static/app/views/settings/projectDebugFiles/utils.tsx
+++ b/static/app/views/settings/projectDebugFiles/utils.tsx
@@ -3,7 +3,7 @@ import {DebugFile, DebugFileFeature, DebugFileType} from 'sentry/types/debugFile
 
 const PRETTY_SYMBOL_TYPES = {
   proguard: t('ProGuard mapping'),
-  breakpad: t('Breadpad'),
+  breakpad: t('Breakpad'),
   macho: t('Mach-O'),
   elf: t('ELF'),
   pe: t('PE'),


### PR DESCRIPTION


<!-- Describe your PR here. -->
Debug Information Files should show Breakpad instead of Breadpad


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
