### PR TITLE
chore(metrics): Add TTID and TTFD tags for mobile spans

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -170,6 +170,8 @@ SHARED_TAG_STRINGS = {
     "span.main_thread": PREFIX + 255,
     "device.class": PREFIX + 256,
     "resource.render_blocking_status": PREFIX + 257,
+    "ttid": PREFIX + 257,
+    "ttfd": PREFIX + 258,
     # More Transactions
     "has_profile": PREFIX + 260,
     "query_hash": PREFIX + 261,

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -170,8 +170,8 @@ SHARED_TAG_STRINGS = {
     "span.main_thread": PREFIX + 255,
     "device.class": PREFIX + 256,
     "resource.render_blocking_status": PREFIX + 257,
-    "ttid": PREFIX + 257,
-    "ttfd": PREFIX + 258,
+    "ttid": PREFIX + 258,
+    "ttfd": PREFIX + 259,
     # More Transactions
     "has_profile": PREFIX + 260,
     "query_hash": PREFIX + 261,


### PR DESCRIPTION
See https://github.com/getsentry/relay/pull/2662.

I verified that no orgs use these string values yet, with

```sql
select * from sentry_stringindexer where string = 'ttfd';
select * from sentry_perfstringindexer where string = 'ttfd';
-- etc.
```