### PR TITLE
fix(source-map-debugger): Show source map debugger for frames with `.js.gz` file endings

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -55,6 +55,7 @@ const VALID_SOURCE_MAP_DEBUGGER_FILE_ENDINGS = [
   '.mjs',
   '.cjs',
   '.jsbundle', // React Native file ending
+  '.js.gz', // file ending idiomatic for Ember.js
 ];
 
 export interface DeprecatedLineProps {


### PR DESCRIPTION
The `.js.gz` file ending seems to be common in ember and old angular applications.