### PR TITLE
fix(hybridcloud) Use user_id instead of user for conditions

### DIFF
--- a/src/social_auth/models.py
+++ b/src/social_auth/models.py
@@ -150,12 +150,12 @@ class UserSocialAuth(models.Model):
     def create_social_auth(cls, user, uid, provider):
         if not isinstance(uid, str):
             uid = str(uid)
-        return cls.objects.create(user=user, uid=uid, provider=provider)
+        return cls.objects.create(user_id=user.id, uid=uid, provider=provider)
 
     @classmethod
     def get_social_auth(cls, provider, uid, user):
         try:
-            instance = cls.objects.get(provider=provider, uid=uid, user=user)
+            instance = cls.objects.get(provider=provider, uid=uid, user_id=user.id)
             instance.user = user
             return instance
         except UserSocialAuth.DoesNotExist:


### PR DESCRIPTION
The social_auth adapters are using `user` instead of `user_id` for conditions which isn't compatible with `RpcUser`.

Fixes SENTRY-177N
