### PR TITLE
fix(dashboard): Widget validation should accept environment

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_widget_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_widget_details.py
@@ -36,6 +36,7 @@ class OrganizationDashboardWidgetDetailsEndpoint(OrganizationEndpoint):
                 "organization": organization,
                 "projects": self.get_projects(request, organization),
                 "displayType": request.data.get("displayType"),
+                "environment": request.GET.get("environment"),
             },
         )
         if not serializer.is_valid():

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -174,6 +174,7 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
             "end": datetime.now(),
             "project_id": [p.id for p in self.context.get("projects")],
             "organization_id": self.context.get("organization").id,
+            "environment": self.context.get("environment"),
         }
 
         try:

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -644,3 +644,24 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             data=data,
         )
         assert response.status_code == 200, response.data
+
+    def test_accepts_environment_for_filters_that_require_single_env(self):
+        mock_project = self.create_project()
+        self.create_environment(project=mock_project, name="mock_env")
+        data = {
+            "title": "Test Query",
+            "displayType": "table",
+            "widgetType": "discover",
+            "limit": 5,
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "release.stage:adopted",
+                    "fields": [],
+                    "columns": [],
+                    "aggregates": ["count()"],
+                }
+            ],
+        }
+        response = self.client.post(f"{self.url()}?environment=mock_env", data)
+        assert response.status_code == 200, response.data


### PR DESCRIPTION
Some filter parameters have a requirement that a single environment is selected (e.g. release.stage). This passes along environment so that it is taken into account when resolving the conditions