### PR TITLE
feat(perf): Add comment statement support to SQL parser

### DIFF
--- a/static/app/views/starfish/utils/sqlish/SQLishParser.spec.tsx
+++ b/static/app/views/starfish/utils/sqlish/SQLishParser.spec.tsx
@@ -16,6 +16,8 @@ describe('SQLishParser', function () {
       "WHERE$1 ILIKE ' % ' || 'text'", // Conditionals
       'SELECT id, name;', // Column lists
       'columns AS `tags[column]`', // ClickHouse backtics
+      'SELECT * FROM #temp', // Temporary tables
+      '# Fetches', // Comments
       'SELECT id, nam*', // Truncation
       'AND created >= :c1', // PHP-Style I
       'LIMIT $2', // PHP-style II

--- a/static/app/views/starfish/utils/sqlish/sqlish.pegjs
+++ b/static/app/views/starfish/utils/sqlish/sqlish.pegjs
@@ -36,4 +36,4 @@ Whitespace
   = Whitespace:[\n\t ]+ { return { type: 'Whitespace', content: Whitespace.join("") } }
 
 GenericToken
-  = GenericToken:[a-zA-Z0-9"'`_\-.=><:,*;!\[\]?$%|/\\@&~^+]+ { return { type: 'GenericToken', content: GenericToken.join('') } }
+  = GenericToken:[a-zA-Z0-9"'`_\-.=><:,*;!\[\]?$%|/\\@#&~^+]+ { return { type: 'GenericToken', content: GenericToken.join('') } }


### PR DESCRIPTION
Comes up in some SQL dialects for various reasons. Closes JAVASCRIPT-2NQW.
