### PR TITLE
feat(browser-starfish): add domain selector for img tab in resource module

### DIFF
--- a/static/app/views/performance/browser/resources/imageView/index.tsx
+++ b/static/app/views/performance/browser/resources/imageView/index.tsx
@@ -9,10 +9,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import ResourceTable from 'sentry/views/performance/browser/resources/imageView/resourceTable';
 import {useImageResourceSort} from 'sentry/views/performance/browser/resources/imageView/utils/useImageResourceSort';
 import {FilterOptionsContainer} from 'sentry/views/performance/browser/resources/jsCssView';
+import DomainSelector from 'sentry/views/performance/browser/resources/shared/domainSelector';
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
 
-const {RESOURCE_RENDER_BLOCKING_STATUS} = SpanIndexedField;
+const {RESOURCE_RENDER_BLOCKING_STATUS, SPAN_DOMAIN} = SpanIndexedField;
 
 function ImageView() {
   const sort = useImageResourceSort();
@@ -34,6 +35,7 @@ function ImageView() {
   return (
     <Fragment>
       <FilterOptionsContainer>
+        <DomainSelector value={filters[SPAN_DOMAIN] || ''} />
         <SwitchContainer>
           <SwitchButton
             toggle={handleBlockingToggle}

--- a/static/app/views/performance/browser/resources/imageView/utils/useIndexedResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/imageView/utils/useIndexedResourcesQuery.ts
@@ -13,6 +13,7 @@ const {
   HTTP_RESPONSE_CONTENT_LENGTH,
   SPAN_SELF_TIME,
   RESOURCE_RENDER_BLOCKING_STATUS,
+  SPAN_DOMAIN,
 } = SpanIndexedField;
 
 export const useIndexedResourcesQuery = () => {
@@ -27,6 +28,9 @@ export const useIndexedResourcesQuery = () => {
           `resource.render_blocking_status:${resourceFilters['resource.render_blocking_status']}`,
         ]
       : [`!resource.render_blocking_status:blocking`]),
+    ...(resourceFilters[SPAN_DOMAIN]
+      ? [`span.domain:${resourceFilters[SPAN_DOMAIN]}`]
+      : []),
   ];
 
   // TODO - we should be using metrics data here
@@ -71,7 +75,9 @@ export const useIndexedResourcesQuery = () => {
         | ''
         | 'non-blocking'
         | 'blocking',
-      [HTTP_RESPONSE_CONTENT_LENGTH]: row[HTTP_RESPONSE_CONTENT_LENGTH] as number,
+      [HTTP_RESPONSE_CONTENT_LENGTH]: parseFloat(
+        (row[HTTP_RESPONSE_CONTENT_LENGTH] as string) || '0'
+      ),
     })) ?? [];
 
   return {...result, data};

--- a/static/app/views/performance/browser/resources/imageView/utils/useIndexedResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/imageView/utils/useIndexedResourcesQuery.ts
@@ -75,6 +75,7 @@ export const useIndexedResourcesQuery = () => {
         | ''
         | 'non-blocking'
         | 'blocking',
+      // TODO - parseFloat here is temporary, we should be parsing from the backend
       [HTTP_RESPONSE_CONTENT_LENGTH]: parseFloat(
         (row[HTTP_RESPONSE_CONTENT_LENGTH] as string) || '0'
       ),

--- a/static/app/views/performance/browser/resources/index.tsx
+++ b/static/app/views/performance/browser/resources/index.tsx
@@ -21,7 +21,7 @@ import {
 } from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
 
-const {RESOURCE_TYPE} = BrowserStarfishFields;
+const {SPAN_OP} = BrowserStarfishFields;
 
 function ResourcesLandingPage() {
   const organization = useOrganization();
@@ -58,7 +58,7 @@ function ResourcesLandingPage() {
                 ...location,
                 query: {
                   ...location.query,
-                  [RESOURCE_TYPE]: key,
+                  [SPAN_OP]: key,
                 },
               });
             }}
@@ -78,11 +78,11 @@ function ResourcesLandingPage() {
             </PageFilterBar>
           </PaddedContainer>
 
-          {(!filters[RESOURCE_TYPE] ||
-            filters[RESOURCE_TYPE] === 'resource.script' ||
-            filters[RESOURCE_TYPE] === 'resource.css') && <JSCSSView />}
+          {(!filters[SPAN_OP] ||
+            filters[SPAN_OP] === 'resource.script' ||
+            filters[SPAN_OP] === 'resource.css') && <JSCSSView />}
 
-          {filters[RESOURCE_TYPE] === 'resource.img' && <ImageView />}
+          {filters[SPAN_OP] === 'resource.img' && <ImageView />}
         </Layout.Main>
       </Layout.Body>
     </ModulePageProviders>

--- a/static/app/views/performance/browser/resources/jsCssView/index.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/index.tsx
@@ -2,15 +2,13 @@ import {Fragment, MouseEventHandler} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
-import SelectControl, {
-  ControlProps,
-} from 'sentry/components/forms/controls/selectControl';
 import SwitchButton from 'sentry/components/switchButton';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import ResourceTable from 'sentry/views/performance/browser/resources/jsCssView/resourceTable';
-import {useResourceDomainsQuery} from 'sentry/views/performance/browser/resources/utils/useResourceDomansQuery';
+import DomainSelector from 'sentry/views/performance/browser/resources/shared/domainSelector';
+import SelectControlWithProps from 'sentry/views/performance/browser/resources/shared/selectControlWithProps';
 import {
   BrowserStarfishFields,
   useResourceModuleFilters,
@@ -18,8 +16,12 @@ import {
 import {useResourcePagesQuery} from 'sentry/views/performance/browser/resources/utils/useResourcePagesQuery';
 import {useResourceSort} from 'sentry/views/performance/browser/resources/utils/useResourceSort';
 
-const {RESOURCE_TYPE, SPAN_DOMAIN, TRANSACTION, RESOURCE_RENDER_BLOCKING_STATUS} =
-  BrowserStarfishFields;
+const {
+  SPAN_OP: RESOURCE_TYPE,
+  SPAN_DOMAIN,
+  TRANSACTION,
+  RESOURCE_RENDER_BLOCKING_STATUS,
+} = BrowserStarfishFields;
 
 type Option = {
   label: string;
@@ -113,40 +115,6 @@ function PageSelector({value}: {value?: string}) {
       }}
     />
   );
-}
-
-function DomainSelector({value}: {value?: string}) {
-  const location = useLocation();
-  const {data} = useResourceDomainsQuery();
-
-  const options: Option[] = [
-    {value: '', label: 'All'},
-    ...data.map(domain => ({
-      value: domain,
-      label: domain,
-    })),
-  ];
-
-  return (
-    <SelectControlWithProps
-      inFieldLabel={`${t('Domain')}:`}
-      options={options}
-      value={value}
-      onChange={newValue => {
-        browserHistory.push({
-          ...location,
-          query: {
-            ...location.query,
-            [SPAN_DOMAIN]: newValue?.value,
-          },
-        });
-      }}
-    />
-  );
-}
-
-function SelectControlWithProps(props: ControlProps & {options: Option[]}) {
-  return <SelectControl {...props} />;
 }
 
 const SwitchContainer = styled('div')`

--- a/static/app/views/performance/browser/resources/shared/domainSelector.tsx
+++ b/static/app/views/performance/browser/resources/shared/domainSelector.tsx
@@ -1,0 +1,43 @@
+import {browserHistory} from 'react-router';
+
+import {t} from 'sentry/locale';
+import {useLocation} from 'sentry/utils/useLocation';
+import SelectControlWithProps, {
+  Option,
+} from 'sentry/views/performance/browser/resources/shared/selectControlWithProps';
+import {useResourceDomainsQuery} from 'sentry/views/performance/browser/resources/utils/useResourceDomansQuery';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
+
+const {SPAN_DOMAIN} = SpanMetricsField;
+
+export function DomainSelector({value}: {value?: string}) {
+  const location = useLocation();
+  const {data} = useResourceDomainsQuery();
+
+  const options: Option[] = [
+    {value: '', label: 'All'},
+    ...data.map(domain => ({
+      value: domain,
+      label: domain,
+    })),
+  ];
+
+  return (
+    <SelectControlWithProps
+      inFieldLabel={`${t('Domain')}:`}
+      options={options}
+      value={value}
+      onChange={newValue => {
+        browserHistory.push({
+          ...location,
+          query: {
+            ...location.query,
+            [SPAN_DOMAIN]: newValue?.value,
+          },
+        });
+      }}
+    />
+  );
+}
+
+export default DomainSelector;

--- a/static/app/views/performance/browser/resources/shared/selectControlWithProps.tsx
+++ b/static/app/views/performance/browser/resources/shared/selectControlWithProps.tsx
@@ -1,0 +1,14 @@
+import SelectControl, {
+  ControlProps,
+} from 'sentry/components/forms/controls/selectControl';
+
+export type Option = {
+  label: string;
+  value: string;
+};
+
+function SelectControlWithProps(props: ControlProps & {options: Option[]}) {
+  return <SelectControl {...props} />;
+}
+
+export default SelectControlWithProps;

--- a/static/app/views/performance/browser/resources/utils/useResourceDomansQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceDomansQuery.ts
@@ -9,7 +9,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 
-const {SPAN_DOMAIN, SPAN_OP} = SpanMetricsField;
+const {SPAN_DOMAIN, SPAN_OP, TRANSACTION} = SpanMetricsField;
 
 /**
  * Gets a list of pages that have a resource.
@@ -18,14 +18,16 @@ export const useResourceDomainsQuery = () => {
   const location = useLocation();
   const pageFilters = usePageFilters();
   const {slug: orgSlug} = useOrganization();
-  const {transaction} = useResourceModuleFilters();
+  const resourceFilters = useResourceModuleFilters();
 
   const fields = [SPAN_DOMAIN, 'count()']; // count() is only here because an aggregation is required for the query to work
 
   const queryConditions = [
-    `${SPAN_OP}:resource.*`,
+    `${SPAN_OP}:${resourceFilters[SPAN_OP] || '[resource.script,resource.css]'}`,
     `has:${SPAN_DOMAIN}`,
-    ...(transaction ? [`transaction:${transaction}`] : []),
+    ...(resourceFilters[TRANSACTION]
+      ? [`transaction:${resourceFilters[TRANSACTION]}`]
+      : []),
   ];
 
   const eventView = EventView.fromNewQueryWithPageFilters(

--- a/static/app/views/performance/browser/resources/utils/useResourceFilters.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceFilters.ts
@@ -3,7 +3,7 @@ import pick from 'lodash/pick';
 import {useLocation} from 'sentry/utils/useLocation';
 
 export enum BrowserStarfishFields {
-  RESOURCE_TYPE = 'type',
+  SPAN_OP = 'span.op',
   TRANSACTION = 'transaction',
   SPAN_DOMAIN = 'span.domain',
   GROUP_ID = 'groupId',
@@ -18,10 +18,7 @@ export type ModuleFilters = {
     | 'blocking'
     | '!blocking';
   [BrowserStarfishFields.SPAN_DOMAIN]?: string;
-  [BrowserStarfishFields.RESOURCE_TYPE]?:
-    | 'resource.script'
-    | 'resource.css'
-    | 'resource.img';
+  [BrowserStarfishFields.SPAN_OP]?: 'resource.script' | 'resource.css' | 'resource.img';
   [BrowserStarfishFields.TRANSACTION]?: string;
   [BrowserStarfishFields.SPAN_DOMAIN]?: string;
 };
@@ -31,7 +28,7 @@ export const useResourceModuleFilters = () => {
 
   return pick(location.query, [
     BrowserStarfishFields.SPAN_DOMAIN,
-    BrowserStarfishFields.RESOURCE_TYPE,
+    BrowserStarfishFields.SPAN_OP,
     BrowserStarfishFields.TRANSACTION,
     BrowserStarfishFields.GROUP_ID,
     BrowserStarfishFields.DESCRIPTION,

--- a/static/app/views/performance/browser/resources/utils/useResourcePagesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcePagesQuery.ts
@@ -22,7 +22,7 @@ export const useResourcePagesQuery = () => {
   const fields = ['transaction', 'count()']; // count() is only here because an aggregation is required for the query to work
 
   const queryConditions = [
-    `${SPAN_OP}:${resourceFilters.type || 'resource.*'}`,
+    `${SPAN_OP}:${resourceFilters[SPAN_OP] || 'resource.*'}`,
     ...(spanDomain ? [`${SPAN_DOMAIN}:${spanDomain}`] : []),
   ]; // TODO: We will need to consider other ops
 

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -31,7 +31,7 @@ export const useResourcesQuery = ({sort, defaultResourceTypes}: Props) => {
 
   const queryConditions = [
     `${SPAN_OP}:${
-      resourceFilters.type || `[${defaultResourceTypes?.join(',')}]` || 'resource.*'
+      resourceFilters[SPAN_OP] || `[${defaultResourceTypes?.join(',')}]` || 'resource.*'
     }`,
     ...(resourceFilters.transaction
       ? [`transaction:"${resourceFilters.transaction}"`]

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -26,6 +26,7 @@ export enum SpanMetricsField {
   SPAN_DURATION = 'span.duration',
   SPAN_SELF_TIME = 'span.self_time',
   PROJECT_ID = 'project.id',
+  TRANSACTION = 'transaction',
   RESOURCE_RENDER_BLOCKING_STATUS = 'resource.render_blocking_status',
   HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length',
   HTTP_DECODED_RESPONSE_CONTENT_LENGTH = 'http.decoded_response_content_length',


### PR DESCRIPTION
Work towards https://github.com/getsentry/sentry/issues/58723

1. Adds a domain selector to the img tab in the resource module (TODO, add some domain wide charts at the top?)
![image](https://github.com/getsentry/sentry/assets/44422760/7529696d-37e4-48c1-825f-b749b7ce7954)
2. Does some refactoring so that the domain selector is shared.
3. some more refactoring to clean things up a bit.