### PR TITLE
chore(stats-detectors): Bump transaction EMA threshold to 0.2

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -297,7 +297,7 @@ def _detect_transaction_trends(
         min_data_points=6,
         short_moving_avg_factory=lambda: ExponentialMovingAverage(2 / 21),
         long_moving_avg_factory=lambda: ExponentialMovingAverage(2 / 41),
-        threshold=0.1,
+        threshold=0.2,
     )
 
     detector_store = redis.TransactionDetectorStore()

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -265,7 +265,7 @@ def test_detect_transaction_trends(
                 project_id=project.id,
                 group="/123",
                 count=100,
-                value=100 if i < n / 2 else 200,
+                value=100 if i < n / 2 else 300,
                 timestamp=ts,
             ),
         ]


### PR DESCRIPTION
Similar to #58745, bumping the transaction EMA threshold to 0.2 to reduce false positives.