### PR TITLE
feat(browser-starfish): add span description hovers for css and js

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1626,14 +1626,12 @@ function buildRoutes() {
             () => import('sentry/views/performance/database/databaseLandingPage')
           )}
         />
-        <Route path="spans/">
-          <Route
-            path="span/:groupId/"
-            component={make(
-              () => import('sentry/views/performance/database/databaseSpanSummaryPage')
-            )}
-          />
-        </Route>
+        <Route
+          path="spans/span/:groupId/"
+          component={make(
+            () => import('sentry/views/performance/database/databaseSpanSummaryPage')
+          )}
+        />
       </Route>
       <Route path="browser/">
         <Route path="interactions/">

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1626,12 +1626,14 @@ function buildRoutes() {
             () => import('sentry/views/performance/database/databaseLandingPage')
           )}
         />
-        <Route
-          path="spans/span/:groupId/"
-          component={make(
-            () => import('sentry/views/performance/database/databaseSpanSummaryPage')
-          )}
-        />
+        <Route path="spans/">
+          <Route
+            path="span/:groupId/"
+            component={make(
+              () => import('sentry/views/performance/database/databaseSpanSummaryPage')
+            )}
+          />
+        </Route>
       </Route>
       <Route path="browser/">
         <Route path="interactions/">
@@ -1668,7 +1670,7 @@ function buildRoutes() {
             )}
           />
           <Route
-            path="resource/:groupId/"
+            path="spans/span/:groupId/"
             component={make(
               () =>
                 import(

--- a/static/app/views/performance/browser/resources/index.tsx
+++ b/static/app/views/performance/browser/resources/index.tsx
@@ -29,7 +29,10 @@ function ResourcesLandingPage() {
   const filters = useResourceModuleFilters();
 
   return (
-    <ModulePageProviders title={[t('Performance'), t('Resources')].join(' — ')}>
+    <ModulePageProviders
+      title={[t('Performance'), t('Resources')].join(' — ')}
+      baseURL="/performance/browser/resources"
+    >
       <Layout.Header>
         <Layout.HeaderContent>
           <Breadcrumbs

--- a/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import {Link} from 'react-router';
+import styled from '@emotion/styled';
 
 import FileSize from 'sentry/components/fileSize';
 import GridEditable, {
@@ -13,8 +14,10 @@ import {RateUnits} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {ValidSort} from 'sentry/views/performance/browser/resources/utils/useResourceSort';
 import {useResourcesQuery} from 'sentry/views/performance/browser/resources/utils/useResourcesQuery';
+import {FullSpanDescription} from 'sentry/views/starfish/components/fullQueryDescription';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
+import {WiderHovercard} from 'sentry/views/starfish/components/tableCells/spanDescriptionCell';
 import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 
@@ -76,9 +79,25 @@ function ResourceTable({sort}: Props) {
     const {key} = col;
     if (key === SPAN_DESCRIPTION) {
       return (
-        <Link to={`/performance/browser/resources/resource/${row['span.group']}`}>
-          {row[key]}
-        </Link>
+        <DescriptionWrapper>
+          <WiderHovercard
+            position="right"
+            body={
+              <Fragment>
+                {t('Example')}
+                <FullSpanDescription
+                  group={row['span.group']}
+                  shortDescription={row['span.description']}
+                  language="http"
+                />
+              </Fragment>
+            }
+          >
+            <Link to={`/performance/browser/resources/resource/${row['span.group']}`}>
+              {row[key]}
+            </Link>{' '}
+          </WiderHovercard>
+        </DescriptionWrapper>
       );
     }
     if (key === 'spm()') {
@@ -139,13 +158,10 @@ function ResourceTable({sort}: Props) {
   );
 }
 
-export const getActionName = (transactionOp: string) => {
-  switch (transactionOp) {
-    case 'ui.action.click':
-      return 'Click';
-    default:
-      return transactionOp;
+const DescriptionWrapper = styled('div')`
+  .inline-flex {
+    display: inline-flex;
   }
-};
+`;
 
 export default ResourceTable;

--- a/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
@@ -1,6 +1,4 @@
 import {Fragment} from 'react';
-import {Link} from 'react-router';
-import styled from '@emotion/styled';
 
 import FileSize from 'sentry/components/fileSize';
 import GridEditable, {
@@ -14,15 +12,20 @@ import {RateUnits} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {ValidSort} from 'sentry/views/performance/browser/resources/utils/useResourceSort';
 import {useResourcesQuery} from 'sentry/views/performance/browser/resources/utils/useResourcesQuery';
-import {FullSpanDescription} from 'sentry/views/starfish/components/fullQueryDescription';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
-import {WiderHovercard} from 'sentry/views/starfish/components/tableCells/spanDescriptionCell';
+import {SpanDescriptionCell} from 'sentry/views/starfish/components/tableCells/spanDescriptionCell';
 import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
-import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
+import {ModuleName, SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 
-const {SPAN_DESCRIPTION, SPAN_OP, SPAN_SELF_TIME, HTTP_RESPONSE_CONTENT_LENGTH} =
-  SpanMetricsField;
+const {
+  SPAN_DESCRIPTION,
+  SPAN_OP,
+  SPAN_SELF_TIME,
+  HTTP_RESPONSE_CONTENT_LENGTH,
+  PROJECT_ID,
+  SPAN_GROUP,
+} = SpanMetricsField;
 
 const {SPM} = SpanFunction;
 
@@ -30,6 +33,7 @@ type Row = {
   'avg(http.response_content_length)': number;
   'avg(span.self_time)': number;
   'http.decoded_response_content_length': number;
+  'project.id': number;
   'resource.render_blocking_status': string;
   'span.description': string;
   'span.domain': string;
@@ -79,25 +83,12 @@ function ResourceTable({sort}: Props) {
     const {key} = col;
     if (key === SPAN_DESCRIPTION) {
       return (
-        <DescriptionWrapper>
-          <WiderHovercard
-            position="right"
-            body={
-              <Fragment>
-                {t('Example')}
-                <FullSpanDescription
-                  group={row['span.group']}
-                  shortDescription={row['span.description']}
-                  language="http"
-                />
-              </Fragment>
-            }
-          >
-            <Link to={`/performance/browser/resources/resource/${row['span.group']}`}>
-              {row[key]}
-            </Link>{' '}
-          </WiderHovercard>
-        </DescriptionWrapper>
+        <SpanDescriptionCell
+          moduleName={ModuleName.HTTP}
+          projectId={row[PROJECT_ID]}
+          description={row[SPAN_DESCRIPTION]}
+          group={row[SPAN_GROUP]}
+        />
       );
     }
     if (key === 'spm()') {
@@ -157,11 +148,5 @@ function ResourceTable({sort}: Props) {
     </Fragment>
   );
 }
-
-const DescriptionWrapper = styled('div')`
-  .inline-flex {
-    display: inline-flex;
-  }
-`;
 
 export default ResourceTable;

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -16,6 +16,7 @@ const {
   SPAN_SELF_TIME,
   RESOURCE_RENDER_BLOCKING_STATUS,
   HTTP_RESPONSE_CONTENT_LENGTH,
+  PROJECT_ID,
 } = SpanMetricsField;
 
 type Props = {
@@ -58,6 +59,7 @@ export const useResourcesQuery = ({sort, defaultResourceTypes}: Props) => {
         SPAN_GROUP,
         SPAN_DOMAIN,
         `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
+        'project.id',
       ],
       name: 'Resource module - resource table',
       query: queryConditions.join(' '),
@@ -86,6 +88,7 @@ export const useResourcesQuery = ({sort, defaultResourceTypes}: Props) => {
       | 'non-blocking'
       | 'blocking',
     [SPAN_DOMAIN]: row[SPAN_DOMAIN][0]?.toString(),
+    [PROJECT_ID]: row[PROJECT_ID] as number,
     [`avg(http.response_content_length)`]: row[
       `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`
     ] as number,

--- a/static/app/views/performance/database/modulePageProviders.tsx
+++ b/static/app/views/performance/database/modulePageProviders.tsx
@@ -9,13 +9,14 @@ import {RoutingContextProvider} from 'sentry/views/starfish/utils/routingContext
 interface Props {
   children: React.ReactNode;
   title: string;
+  baseURL?: string;
 }
 
-export function ModulePageProviders({title, children}: Props) {
+export function ModulePageProviders({title, children, baseURL}: Props) {
   const organization = useOrganization();
 
   return (
-    <RoutingContextProvider value={{baseURL: '/performance/database'}}>
+    <RoutingContextProvider value={{baseURL: baseURL || '/performance/database'}}>
       <PageFiltersContainer>
         <SentryDocumentTitle title={title} orgSlug={organization.slug}>
           <Layout.Page>

--- a/static/app/views/starfish/components/fullQueryDescription.tsx
+++ b/static/app/views/starfish/components/fullQueryDescription.tsx
@@ -8,7 +8,7 @@ import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatte
 
 const formatter = new SQLishFormatter();
 
-export function FullQueryDescription({group, shortDescription}: Props) {
+export function FullSpanDescription({group, shortDescription, language}: Props) {
   const {
     data: fullSpan,
     isLoading,
@@ -26,7 +26,7 @@ export function FullQueryDescription({group, shortDescription}: Props) {
       <LoadingIndicator mini hideMessage relative />
     </PaddedSpinner>
   ) : (
-    <CodeSnippet language="sql">
+    <CodeSnippet language={language || 'sql'}>
       {formatter.toString(description, {maxLineLength: LINE_LENGTH})}
     </CodeSnippet>
   );
@@ -34,6 +34,7 @@ export function FullQueryDescription({group, shortDescription}: Props) {
 
 interface Props {
   group?: string;
+  language?: string;
   shortDescription?: string;
 }
 

--- a/static/app/views/starfish/components/fullSpanDescription.tsx
+++ b/static/app/views/starfish/components/fullSpanDescription.tsx
@@ -8,7 +8,7 @@ import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatte
 
 const formatter = new SQLishFormatter();
 
-export function FullSpanDescription({group, shortDescription, language = 'sql'}: Props) {
+export function FullSpanDescription({group, shortDescription, language}: Props) {
   const {
     data: fullSpan,
     isLoading,
@@ -22,22 +22,32 @@ export function FullSpanDescription({group, shortDescription, language = 'sql'}:
     return null;
   }
 
-  return isLoading && isFetching ? (
-    <PaddedSpinner>
-      <LoadingIndicator mini hideMessage relative />
-    </PaddedSpinner>
-  ) : (
+  if (isLoading && isFetching) {
+    return (
+      <PaddedSpinner>
+        <LoadingIndicator mini hideMessage relative />
+      </PaddedSpinner>
+    );
+  }
+
+  if (snippetLanguage === 'sql') {
+    return (
+      <CodeSnippet language={snippetLanguage}>
+        {formatter.toString(description, {maxLineLength: LINE_LENGTH})}
+      </CodeSnippet>
+    );
+  }
+
+  return (
     <CodeSnippet language={snippetLanguage}>
-      {snippetLanguage === 'sql'
-        ? formatter.toString(description, {maxLineLength: LINE_LENGTH})
-        : description}
+      {formatter.toString(description, {maxLineLength: LINE_LENGTH})}
     </CodeSnippet>
   );
 }
 
 interface Props {
   group?: string;
-  language?: string;
+  language?: 'sql' | 'http';
   shortDescription?: string;
 }
 

--- a/static/app/views/starfish/components/fullSpanDescription.tsx
+++ b/static/app/views/starfish/components/fullSpanDescription.tsx
@@ -17,7 +17,6 @@ export function FullSpanDescription({group, shortDescription, language}: Props) 
   } = useFullSpanFromTrace(group, Boolean(group));
 
   const description = fullSpan?.description ?? shortDescription;
-  const snippetLanguage = language ?? 'sql';
 
   if (!description) {
     return null;
@@ -31,15 +30,15 @@ export function FullSpanDescription({group, shortDescription, language}: Props) 
     );
   }
 
-  if (snippetLanguage === 'sql') {
+  if (language === 'sql') {
     return (
-      <CodeSnippet language={snippetLanguage}>
+      <CodeSnippet language={language}>
         {formatter.toString(description, {maxLineLength: LINE_LENGTH})}
       </CodeSnippet>
     );
   }
 
-  if (snippetLanguage) {
+  if (language) {
     return <CodeSnippet language={snippetLanguage}>{description}</CodeSnippet>;
   }
 

--- a/static/app/views/starfish/components/fullSpanDescription.tsx
+++ b/static/app/views/starfish/components/fullSpanDescription.tsx
@@ -39,7 +39,7 @@ export function FullSpanDescription({group, shortDescription, language}: Props) 
   }
 
   if (language) {
-    return <CodeSnippet language={snippetLanguage}>{description}</CodeSnippet>;
+    return <CodeSnippet language={language}>{description}</CodeSnippet>;
   }
 
   return <Fragment>{description}</Fragment>;

--- a/static/app/views/starfish/components/fullSpanDescription.tsx
+++ b/static/app/views/starfish/components/fullSpanDescription.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
@@ -38,11 +39,11 @@ export function FullSpanDescription({group, shortDescription, language}: Props) 
     );
   }
 
-  return (
-    <CodeSnippet language={snippetLanguage}>
-      {formatter.toString(description, {maxLineLength: LINE_LENGTH})}
-    </CodeSnippet>
-  );
+  if (snippetLanguage) {
+    return <CodeSnippet language={snippetLanguage}>{description}</CodeSnippet>;
+  }
+
+  return <Fragment>{description}</Fragment>;
 }
 
 interface Props {

--- a/static/app/views/starfish/components/fullSpanDescription.tsx
+++ b/static/app/views/starfish/components/fullSpanDescription.tsx
@@ -8,7 +8,7 @@ import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatte
 
 const formatter = new SQLishFormatter();
 
-export function FullSpanDescription({group, shortDescription, language}: Props) {
+export function FullSpanDescription({group, shortDescription, language = 'sql'}: Props) {
   const {
     data: fullSpan,
     isLoading,
@@ -16,6 +16,7 @@ export function FullSpanDescription({group, shortDescription, language}: Props) 
   } = useFullSpanFromTrace(group, Boolean(group));
 
   const description = fullSpan?.description ?? shortDescription;
+  const snippetLanguage = language ?? 'sql';
 
   if (!description) {
     return null;
@@ -26,8 +27,10 @@ export function FullSpanDescription({group, shortDescription, language}: Props) 
       <LoadingIndicator mini hideMessage relative />
     </PaddedSpinner>
   ) : (
-    <CodeSnippet language={language || 'sql'}>
-      {formatter.toString(description, {maxLineLength: LINE_LENGTH})}
+    <CodeSnippet language={snippetLanguage}>
+      {snippetLanguage === 'sql'
+        ? formatter.toString(description, {maxLineLength: LINE_LENGTH})
+        : description}
     </CodeSnippet>
   );
 }

--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {Hovercard} from 'sentry/components/hovercard';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {FullSpanDescription} from 'sentry/views/starfish/components/fullSpanDescription';
 import {SpanDescriptionLink} from 'sentry/views/starfish/components/spanDescriptionLink';
 import {ModuleName} from 'sentry/views/starfish/types';
@@ -48,7 +49,13 @@ export function SpanDescriptionCell({
       <DescriptionWrapper>
         <WiderHovercard
           position="right"
-          body={<FullSpanDescription group={group} shortDescription={description} />}
+          body={
+            <FullSpanDescription
+              group={group}
+              shortDescription={description}
+              language="sql"
+            />
+          }
         >
           {descriptionLink}
         </WiderHovercard>
@@ -63,7 +70,7 @@ export function SpanDescriptionCell({
           position="right"
           body={
             <Fragment>
-              {t('Example')}
+              <TitleWrapper>{t('Example')}</TitleWrapper>
               <FullSpanDescription
                 group={group}
                 shortDescription={description}
@@ -103,6 +110,10 @@ export const WiderHovercard = styled(
     width: auto;
     max-width: 550px;
   }
+`;
+
+const TitleWrapper = styled('div')`
+  margin-bottom: ${space(1)};
 `;
 
 const DescriptionWrapper = styled('div')`

--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Hovercard} from 'sentry/components/hovercard';
-import {FullQueryDescription} from 'sentry/views/starfish/components/fullQueryDescription';
+import {FullSpanDescription} from 'sentry/views/starfish/components/fullQueryDescription';
 import {SpanDescriptionLink} from 'sentry/views/starfish/components/spanDescriptionLink';
 import {ModuleName} from 'sentry/views/starfish/types';
 import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatter';
@@ -45,7 +45,7 @@ export function SpanDescriptionCell({
     <DescriptionWrapper>
       <WiderHovercard
         position="right"
-        body={<FullQueryDescription group={group} shortDescription={description} />}
+        body={<FullSpanDescription group={group} shortDescription={description} />}
       >
         {descriptionLink}
       </WiderHovercard>

--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -1,6 +1,8 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Hovercard} from 'sentry/components/hovercard';
+import {t} from 'sentry/locale';
 import {FullSpanDescription} from 'sentry/views/starfish/components/fullSpanDescription';
 import {SpanDescriptionLink} from 'sentry/views/starfish/components/spanDescriptionLink';
 import {ModuleName} from 'sentry/views/starfish/types';
@@ -60,11 +62,14 @@ export function SpanDescriptionCell({
         <WiderHovercard
           position="right"
           body={
-            <FullSpanDescription
-              group={group}
-              shortDescription={description}
-              language="http"
-            />
+            <Fragment>
+              {t('Example')}
+              <FullSpanDescription
+                group={group}
+                shortDescription={description}
+                language="http"
+              />
+            </Fragment>
           }
         >
           {descriptionLink}

--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Hovercard} from 'sentry/components/hovercard';
-import {FullSpanDescription} from 'sentry/views/starfish/components/fullQueryDescription';
+import {FullSpanDescription} from 'sentry/views/starfish/components/fullSpanDescription';
 import {SpanDescriptionLink} from 'sentry/views/starfish/components/spanDescriptionLink';
 import {ModuleName} from 'sentry/views/starfish/types';
 import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatter';
@@ -41,18 +41,39 @@ export function SpanDescriptionCell({
     />
   );
 
-  return ModuleName.DB ? (
-    <DescriptionWrapper>
-      <WiderHovercard
-        position="right"
-        body={<FullSpanDescription group={group} shortDescription={description} />}
-      >
-        {descriptionLink}
-      </WiderHovercard>
-    </DescriptionWrapper>
-  ) : (
-    descriptionLink
-  );
+  if (moduleName === ModuleName.DB) {
+    return (
+      <DescriptionWrapper>
+        <WiderHovercard
+          position="right"
+          body={<FullSpanDescription group={group} shortDescription={description} />}
+        >
+          {descriptionLink}
+        </WiderHovercard>
+      </DescriptionWrapper>
+    );
+  }
+
+  if (moduleName === ModuleName.HTTP) {
+    return (
+      <DescriptionWrapper>
+        <WiderHovercard
+          position="right"
+          body={
+            <FullSpanDescription
+              group={group}
+              shortDescription={description}
+              language="http"
+            />
+          }
+        >
+          {descriptionLink}
+        </WiderHovercard>
+      </DescriptionWrapper>
+    );
+  }
+
+  return descriptionLink;
 }
 
 const NULL_DESCRIPTION = <span>&lt;null&gt;</span>;

--- a/static/app/views/starfish/queries/useIndexedSpans.tsx
+++ b/static/app/views/starfish/queries/useIndexedSpans.tsx
@@ -22,6 +22,8 @@ export const useIndexedSpans = (
   const location = useLocation();
   const eventView = getEventView(filters, location);
 
+  eventView.sorts = [{field: 'timestamp', kind: 'desc'}];
+
   return useSpansQuery<SpanIndexedFieldTypes[]>({
     eventView,
     limit,


### PR DESCRIPTION
On hover, show an example resource description as per https://github.com/getsentry/sentry/issues/58723

<img width="819" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/3d467e29-cb2b-44d2-9333-1f44d4a42047">
