### PR TITLE
feat(starfish-web-vitals-tag-details): Open vital detail when navigating from landing page.

### DIFF
--- a/static/app/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -12,7 +12,7 @@ import {
 } from 'sentry/views/performance/browser/webVitals/utils/calculatePerformanceScore';
 import {WebVitals} from 'sentry/views/performance/browser/webVitals/utils/types';
 
-import {ORDER} from './performanceScoreChart';
+import {ORDER} from '../performanceScoreChart';
 
 const {
   lcp: LCP_WEIGHT,
@@ -32,7 +32,7 @@ type Props = {
   hideWebVitalLabels?: boolean;
 };
 
-function OverallProgressRing({
+function PerformanceScoreRingWithTooltips({
   projectScore,
   ringBackgroundColors,
   ringSegmentColors,
@@ -195,4 +195,4 @@ const TooltipValue = styled('span')`
   color: ${p => p.theme.gray300};
 `;
 
-export default OverallProgressRing;
+export default PerformanceScoreRingWithTooltips;

--- a/static/app/views/performance/browser/webVitals/components/webVitalDescription.tsx
+++ b/static/app/views/performance/browser/webVitals/components/webVitalDescription.tsx
@@ -16,8 +16,9 @@ import {getScoreColor} from 'sentry/views/performance/browser/webVitals/utils/ge
 import {WebVitals} from 'sentry/views/performance/browser/webVitals/utils/types';
 import {vitalSupportedBrowsers} from 'sentry/views/performance/vitalDetail/utils';
 
-import OverallProgressRing from '../overallProgressRing';
 import {ProjectScore} from '../utils/calculatePerformanceScore';
+
+import PerformanceScoreRingWithTooltips from './performanceScoreRingWithTooltips';
 
 type Props = {
   score: number;
@@ -104,7 +105,7 @@ export function WebVitalTagsDetailHeader({
       </span>
       {isProjectScoreCalculated && projectScore ? (
         <ProgressRingWrapper>
-          <OverallProgressRing
+          <PerformanceScoreRingWithTooltips
             hideWebVitalLabels
             projectScore={projectScore}
             text={

--- a/static/app/views/performance/browser/webVitals/pageOverWebVitalsTagDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverWebVitalsTagDetailPanel.tsx
@@ -139,7 +139,7 @@ export function PageOverviewWebVitalsTagDetailPanel({
 
     const commonProps = {
       style: (shouldHighlight
-        ? {textShadow: '0 0 0.01px black'}
+        ? {textShadow: '0 0 0.5px black'}
         : {}) satisfies CSSProperties,
       onMouseEnter: () => setHighlightedSampleId(row.id),
       onMouseLeave: () => setHighlightedSampleId(undefined),

--- a/static/app/views/performance/browser/webVitals/pageOverWebVitalsTagDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverWebVitalsTagDetailPanel.tsx
@@ -138,7 +138,9 @@ export function PageOverviewWebVitalsTagDetailPanel({
     const shouldHighlight = row.id === highlightedSampleId;
 
     const commonProps = {
-      style: (shouldHighlight ? {fontWeight: 'bold'} : {}) satisfies CSSProperties,
+      style: (shouldHighlight
+        ? {textShadow: '0 0 0.01px black'}
+        : {}) satisfies CSSProperties,
       onMouseEnter: () => setHighlightedSampleId(row.id),
       onMouseLeave: () => setHighlightedSampleId(undefined),
     };

--- a/static/app/views/performance/browser/webVitals/pageOverview.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverview.tsx
@@ -79,7 +79,7 @@ export default function PageOverview() {
   // we should automatically default this webvital state to the respective webvital so the detail
   // panel in this page opens automatically.
   const [state, setState] = useState<{webVital: WebVitals | null; tag?: Tag}>({
-    webVital: null,
+    webVital: (location.query.webVital as WebVitals) ?? null,
     tag: undefined,
   });
 

--- a/static/app/views/performance/browser/webVitals/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverviewWebVitalsDetailPanel.tsx
@@ -236,7 +236,7 @@ export function PageOverviewWebVitalsDetailPanel({
   return (
     <PageErrorProvider>
       <DetailPanel detailKey={webVital ?? undefined} onClose={onClose}>
-        {webVital && (
+        {webVital && projectData && (
           <WebVitalDetailHeader
             value={
               webVital !== 'cls'

--- a/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
+++ b/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
@@ -10,7 +10,7 @@ import {PerformanceScoreBreakdownChart} from 'sentry/views/performance/browser/w
 import {ProjectScore} from 'sentry/views/performance/browser/webVitals/utils/calculatePerformanceScore';
 import {WebVitals} from 'sentry/views/performance/browser/webVitals/utils/types';
 
-import OverallProgressRing from './overallProgressRing';
+import PerformanceScoreRingWithTooltips from './components/performanceScoreRingWithTooltips';
 
 type Props = {
   isProjectScoreLoading?: boolean;
@@ -58,7 +58,7 @@ export function PerformanceScoreChart({
         <PerformanceScoreLabel>{t('Performance Score')}</PerformanceScoreLabel>
         <PerformanceScoreSubtext>{performanceScoreSubtext}</PerformanceScoreSubtext>
         {!isProjectScoreLoading && projectScore && (
-          <OverallProgressRing
+          <PerformanceScoreRingWithTooltips
             projectScore={projectScore}
             text={score}
             width={220}

--- a/static/app/views/performance/browser/webVitals/utils/types.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/types.tsx
@@ -12,6 +12,7 @@ export type Row = {
 };
 
 export type TransactionSampleRow = {
+  browser: string;
   id: string;
   'measurements.cls': number | null;
   'measurements.fcp': number | null;

--- a/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
@@ -357,7 +357,11 @@ export function WebVitalsDetailPanel({
               )
                 ? {pathname: `${location.pathname}overview/`}
                 : {}),
-              query: {...location.query, transaction: row.transaction},
+              query: {
+                ...location.query,
+                transaction: row.transaction,
+                webVital,
+              },
             }}
             onClick={onClose}
           >


### PR DESCRIPTION
- Adding functionality.

- Minor refactoring: Includes removing table highlight jank, updating `TransactionSampleRow` type to include browser and adding the renamed performance score ring to the components folder.

https://github.com/getsentry/sentry/assets/60121741/36667442-5e06-4481-8e61-695d9ed59c51

