### PR TITLE
fix(stat-detectors): Use absolute change in regression message

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
+++ b/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
@@ -110,10 +110,16 @@ function EventStatisticalDetectorRegressedFunctionMessage({
               ? t('a %s increase', formatPercentage(percentageChange - 1))
               : t('an increase'),
             before: (
-              <PerformanceDuration nanoseconds={evidenceData?.aggregateRange1 ?? 0} />
+              <PerformanceDuration
+                abbreviation
+                nanoseconds={evidenceData?.aggregateRange1 ?? 0}
+              />
             ),
             after: (
-              <PerformanceDuration nanoseconds={evidenceData?.aggregateRange2 ?? 0} />
+              <PerformanceDuration
+                abbreviation
+                nanoseconds={evidenceData?.aggregateRange2 ?? 0}
+              />
             ),
             date: <DateTime date={detectionTime} dateOnly />,
             time: <DateTime date={detectionTime} timeOnly />,

--- a/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
+++ b/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
@@ -62,14 +62,25 @@ function EventStatisticalDetectorRegressedPerformanceMessage({
     <DataSection>
       <div style={{display: 'inline'}}>
         {tct(
-          '[detected] Based on the transaction [transactionName], there was a [amount] increase in duration (P95) around [date] at [time]. Overall operation percentage changes indicate what may have changed in the regression.',
+          'Based on the transaction [transactionName], there was a [amount] increase in duration (P95) from [previousDuration] to [regressionDuration] around [date] at [time]. Overall operation percentage changes indicate what may have changed in the regression.',
           {
-            detected: <strong>{t('Detected:')}</strong>,
             transactionName: (
               <Link to={normalizeUrl(transactionSummaryLink)}>{transactionName}</Link>
             ),
             amount: formatPercentage(
               event?.occurrence?.evidenceData?.trendPercentage - 1
+            ),
+            previousDuration: (
+              <PerformanceDuration
+                abbreviation
+                milliseconds={event?.occurrence?.evidenceData?.aggregateRange1}
+              />
+            ),
+            regressionDuration: (
+              <PerformanceDuration
+                abbreviation
+                milliseconds={event?.occurrence?.evidenceData?.aggregateRange2}
+              />
             ),
             date: <DateTime date={detectionTime} dateOnly />,
             time: <DateTime date={detectionTime} timeOnly />,

--- a/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
+++ b/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
@@ -95,7 +95,6 @@ function EventStatisticalDetectorRegressedFunctionMessage({
 }: EventStatisticalDetectorMessageProps) {
   const evidenceData = event?.occurrence?.evidenceData;
   const percentageChange = evidenceData?.trendPercentage;
-  const absoluteChange = evidenceData?.aggregateRange2 - evidenceData?.aggregateRange1;
   const detectionTime = new Date(evidenceData?.breakpoint * 1000);
   const functionName = evidenceData?.function as string;
 
@@ -103,27 +102,17 @@ function EventStatisticalDetectorRegressedFunctionMessage({
     <DataSection>
       <div style={{display: 'inline'}}>
         {tct(
-          '[functionName] had [change] in duration (P95) from [before] to [after] around [date] at [time]. The example profiles may indicate what changed in the regression.',
+          '[functionName] had a [change] in duration (P95) from [before] to [after] around [date] at [time]. The example profiles may indicate what changed in the regression.',
           {
             functionName: <code>{functionName}</code>,
             change: defined(percentageChange)
-              ? t(
-                  'a %s (%s) increase',
-                  <PerformanceDuration abbreviation nanoseconds={absoluteChange} />,
-                  formatPercentage(percentageChange - 1)
-                )
+              ? t('a %s increase', formatPercentage(percentageChange - 1))
               : t('an increase'),
             before: (
-              <PerformanceDuration
-                abbreviation
-                nanoseconds={evidenceData?.aggregateRange1 ?? 0}
-              />
+              <PerformanceDuration nanoseconds={evidenceData?.aggregateRange1 ?? 0} />
             ),
             after: (
-              <PerformanceDuration
-                abbreviation
-                nanoseconds={evidenceData?.aggregateRange2 ?? 0}
-              />
+              <PerformanceDuration nanoseconds={evidenceData?.aggregateRange2 ?? 0} />
             ),
             date: <DateTime date={detectionTime} dateOnly />,
             time: <DateTime date={detectionTime} timeOnly />,


### PR DESCRIPTION
Makes the change clearer for the user, in addition to providing the percentage change.

<img width="1128" alt="Screenshot 2023-10-27 at 2 56 20 PM" src="https://github.com/getsentry/sentry/assets/22846452/700eddfc-c2db-4a9f-847e-3cc8c6ce43bb">
