### PR TITLE
fix(dashboard): Pass environment in more validation cases

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -128,6 +128,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
                 "organization": organization,
                 "request": request,
                 "projects": self.get_projects(request, organization),
+                "environment": self.request.GET.getlist("environment"),
             },
         )
 

--- a/src/sentry/api/endpoints/organization_dashboard_widget_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_widget_details.py
@@ -36,7 +36,7 @@ class OrganizationDashboardWidgetDetailsEndpoint(OrganizationEndpoint):
                 "organization": organization,
                 "projects": self.get_projects(request, organization),
                 "displayType": request.data.get("displayType"),
-                "environment": request.GET.get("environment"),
+                "environment": request.GET.getlist("environment"),
             },
         )
         if not serializer.is_valid():

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -154,6 +154,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 "organization": organization,
                 "request": request,
                 "projects": self.get_projects(request, organization),
+                "environment": self.request.GET.getlist("environment"),
             },
         )
 

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -1442,6 +1442,33 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             in response.content.decode()
         )
 
+    def test_update_dashboard_with_widget_filter_requiring_environment(self):
+        mock_project = self.create_project()
+        self.create_environment(project=mock_project, name="mock_env")
+        data = {
+            "title": "Dashboard",
+            "widgets": [
+                {
+                    "displayType": "line",
+                    "interval": "5m",
+                    "title": "Widget",
+                    "queries": [
+                        {
+                            "name": "Transactions",
+                            "fields": ["count()"],
+                            "columns": [],
+                            "aggregates": ["count()"],
+                            "conditions": "release.stage:adopted",
+                        }
+                    ],
+                }
+            ],
+        }
+        response = self.do_request(
+            "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
+        )
+        assert response.status_code == 200, response.data
+
 
 @region_silo_test(stable=True)
 class OrganizationDashboardVisitTest(OrganizationDashboardDetailsTestCase):

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -838,3 +838,28 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
             DashboardWidgetDisplayTypes.LINE_CHART
         )
         assert widget_data["layout"] is None
+
+    def test_post_dashboard_with_widget_filter_requiring_environment(self):
+        mock_project = self.create_project()
+        self.create_environment(project=mock_project, name="mock_env")
+        data = {
+            "title": "Dashboard",
+            "widgets": [
+                {
+                    "displayType": "line",
+                    "interval": "5m",
+                    "title": "Widget",
+                    "queries": [
+                        {
+                            "name": "Transactions",
+                            "fields": ["count()"],
+                            "columns": [],
+                            "aggregates": ["count()"],
+                            "conditions": "release.stage:adopted",
+                        }
+                    ],
+                }
+            ],
+        }
+        response = self.do_request("post", f"{self.url}?environment=mock_env", data=data)
+        assert response.status_code == 201, response.data


### PR DESCRIPTION
Passes environment to context for creation and update actions on dashboards. Also replaces .get with .getlist because environment should be a list