### PR TITLE
fix(crons): Fix trace_id for monitor occurrence events

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -297,31 +297,47 @@ def create_issue_platform_occurrence(
     else:
         trace_id = None
 
+    event_data = {
+        "contexts": {"monitor": get_monitor_environment_context(monitor_env)},
+        "environment": monitor_env.environment.name,
+        "event_id": occurrence.event_id,
+        "fingerprint": fingerprint
+        if fingerprint
+        else [
+            "monitor",
+            str(monitor_env.monitor.guid),
+            occurrence_data["reason"],
+        ],
+        "platform": "other",
+        "project_id": monitor_env.monitor.project_id,
+        "received": current_timestamp.isoformat(),
+        "sdk": None,
+        "tags": {
+            "monitor.id": str(monitor_env.monitor.guid),
+            "monitor.slug": str(monitor_env.monitor.slug),
+        },
+        "timestamp": current_timestamp.isoformat(),
+    }
+
+    if trace_id:
+        event_data["contexts"]["trace"] = {"trace_id": trace_id, "span_id": None}
+
+    import jsonschema
+
+    from sentry.issues.json_schemas import EVENT_PAYLOAD_SCHEMA
+
+    try:
+        jsonschema.validate(event_data, EVENT_PAYLOAD_SCHEMA)
+    except jsonschema.exceptions.ValidationError:
+        import traceback
+
+        traceback.print_exc()
+        raise
+
     produce_occurrence_to_kafka(
         payload_type=PayloadType.OCCURRENCE,
         occurrence=occurrence,
-        event_data={
-            "contexts": {"monitor": get_monitor_environment_context(monitor_env)},
-            "environment": monitor_env.environment.name,
-            "event_id": occurrence.event_id,
-            "fingerprint": fingerprint
-            if fingerprint
-            else [
-                "monitor",
-                str(monitor_env.monitor.guid),
-                occurrence_data["reason"],
-            ],
-            "platform": "other",
-            "project_id": monitor_env.monitor.project_id,
-            "received": current_timestamp.isoformat(),
-            "sdk": None,
-            "tags": {
-                "monitor.id": str(monitor_env.monitor.guid),
-                "monitor.slug": str(monitor_env.monitor.slug),
-            },
-            "trace_id": trace_id,
-            "timestamp": current_timestamp.isoformat(),
-        },
+        event_data=event_data,
     )
 
 

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -322,18 +322,6 @@ def create_issue_platform_occurrence(
     if trace_id:
         event_data["contexts"]["trace"] = {"trace_id": trace_id, "span_id": None}
 
-    import jsonschema
-
-    from sentry.issues.json_schemas import EVENT_PAYLOAD_SCHEMA
-
-    try:
-        jsonschema.validate(event_data, EVENT_PAYLOAD_SCHEMA)
-    except jsonschema.exceptions.ValidationError:
-        import traceback
-
-        traceback.print_exc()
-        raise
-
     produce_occurrence_to_kafka(
         payload_type=PayloadType.OCCURRENCE,
         occurrence=occurrence,

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -316,7 +316,11 @@ class MarkFailedTestCase(TestCase):
                         "id": str(monitor.guid),
                         "name": monitor.name,
                         "slug": monitor.slug,
-                    }
+                    },
+                    "trace": {
+                        "trace_id": trace_id.hex,
+                        "span_id": None,
+                    },
                 },
                 "environment": monitor_environment.environment.name,
                 "event_id": occurrence["event_id"],
@@ -328,7 +332,6 @@ class MarkFailedTestCase(TestCase):
                     "monitor.id": str(monitor.guid),
                     "monitor.slug": str(monitor.slug),
                 },
-                "trace_id": trace_id.hex,
             },
         ) == dict(event)
 

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -436,7 +436,6 @@ class MarkFailedTestCase(TestCase):
                     "monitor.id": str(monitor.guid),
                     "monitor.slug": str(monitor.slug),
                 },
-                "trace_id": None,
             },
         ) == dict(event)
 
@@ -544,7 +543,6 @@ class MarkFailedTestCase(TestCase):
                     "monitor.id": str(monitor.guid),
                     "monitor.slug": str(monitor.slug),
                 },
-                "trace_id": None,
             },
         ) == dict(event)
 


### PR DESCRIPTION
Passes event schema validation

Works on `devserver`
<img width="1142" alt="image" src="https://github.com/getsentry/sentry/assets/7078270/074f736b-69eb-4730-a1a8-f1b004e048aa">
