### PR TITLE
feat(stats-detectors): Add per project ratelimit for ema detection

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1580,6 +1580,12 @@ register(
     default=14,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "statistical_detectors.ratelimit.ema",
+    type=Int,
+    default=-1,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "options_automator_slack_webhook_enabled",

--- a/src/sentry/statistical_detectors/algorithm.py
+++ b/src/sentry/statistical_detectors/algorithm.py
@@ -125,7 +125,7 @@ class MovingAverageCrossOverDetector(MovingAverageDetector):
         # number of data points before looking for a regression.
         stablized = self.count > self.config.min_data_points
 
-        score = self.moving_avg_short.value - self.moving_avg_long.value
+        score = abs(self.moving_avg_short.value - self.moving_avg_long.value)
 
         if (
             stablized

--- a/src/sentry/statistical_detectors/detector.py
+++ b/src/sentry/statistical_detectors/detector.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Generic, List, Mapping, Optional, TypeVar
+from typing import Any, Generic, List, Mapping, Optional, Tuple, TypeVar
 
 
 class TrendType(Enum):
@@ -55,5 +55,5 @@ class DetectorStore(ABC, Generic[T]):
 
 class DetectorAlgorithm(ABC, Generic[T]):
     @abstractmethod
-    def update(self, payload: DetectorPayload) -> Optional[TrendType]:
+    def update(self, payload: DetectorPayload) -> Tuple[Optional[TrendType], float]:
         ...

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -569,7 +569,7 @@ def detect_function_trends(project_ids: List[int], start: datetime, *args, **kwa
             continue
         heapq.heappush(regressions_by_project[payload.project_id], (score, payload))
 
-        while ratelimit >= 0 and len(regressions_by_project[payload.project_id]) >= ratelimit:
+        while ratelimit >= 0 and len(regressions_by_project[payload.project_id]) > ratelimit:
             heapq.heappop(regressions_by_project[payload.project_id])
 
     delay = 12  # hours

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -167,10 +167,10 @@ def detect_transaction_trends(
     delay = 12  # hours
     delayed_start = start + timedelta(hours=delay)
 
-    for trends in chunked(regressions, TRANSACTIONS_PER_BATCH):
+    for regression_chunk in chunked(regressions, TRANSACTIONS_PER_BATCH):
         detect_transaction_change_points.apply_async(
             args=[
-                [(payload.project_id, payload.group) for payload in trends],
+                [(payload.project_id, payload.group) for payload in regression_chunk],
                 delayed_start,
             ],
             # delay the check by delay hours because we want to make sure there

--- a/tests/sentry/statistical_detectors/test_algorithm.py
+++ b/tests/sentry/statistical_detectors/test_algorithm.py
@@ -261,7 +261,8 @@ def test_moving_average_cross_over_detector(
     )
 
     for payload in payloads:
-        trend_type = detector.update(payload)
+        trend_type, score = detector.update(payload)
+        assert score >= 0
         if trend_type == TrendType.Regressed:
             all_regressed.append(payload)
         elif trend_type == TrendType.Improved:
@@ -304,7 +305,7 @@ def test_moving_average_cross_over_detector_bad_order(
         value=100,
         timestamp=now,
     )
-    trend_type = detector.update(payload)
+    trend_type, _ = detector.update(payload)
     assert trend_type is not None
 
     payload = DetectorPayload(
@@ -314,7 +315,7 @@ def test_moving_average_cross_over_detector_bad_order(
         value=100,
         timestamp=now - timedelta(hours=1),
     )
-    trend_type = detector.update(payload)
+    trend_type, _ = detector.update(payload)
     assert trend_type is None
 
 
@@ -394,7 +395,8 @@ def test_moving_average_relative_change_detector(
     )
 
     for payload in payloads:
-        trend_type = detector.update(payload)
+        trend_type, score = detector.update(payload)
+        assert score >= 0
         if trend_type == TrendType.Regressed:
             all_regressed.append(payload)
         elif trend_type == TrendType.Improved:


### PR DESCRIPTION
As a precaution, we want to able to rate limit the number of possible regressions surfaced per project. This is to prevent too many 14 days queries from being made in the next step in the analysis. This change introduces an option `statistical_detectors.ratelimit.ema` that allows us to set a limit for the number of possible regressions per project. It defaults to -1 meaning no limit, and any non negative value is the number of possible regressions allowed per project.
