### PR TITLE
Offline Cardinality Limiter

### DIFF
--- a/tests/sentry/sentry_metrics/test_rh_metrics_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_rh_metrics_multiprocess_steps.py
@@ -14,7 +14,6 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.processing.strategies import MessageRejected
 from arroyo.types import BrokerValue, Message, Partition, Topic, Value
 
-from sentry.ratelimits.cardinality import CardinalityLimiter
 from sentry.sentry_metrics.configuration import IndexerStorage, UseCaseKey, get_ingest_config
 from sentry.sentry_metrics.consumers.indexer.batch import valid_metric_name
 from sentry.sentry_metrics.consumers.indexer.common import (
@@ -24,10 +23,6 @@ from sentry.sentry_metrics.consumers.indexer.common import (
     MetricsBatchBuilder,
 )
 from sentry.sentry_metrics.consumers.indexer.processing import MessageProcessor
-from sentry.sentry_metrics.indexer.limiters.cardinality import (
-    TimeseriesCardinalityLimiter,
-    cardinality_limiter_factory,
-)
 from sentry.sentry_metrics.indexer.mock import MockIndexer, RawSimpleIndexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
@@ -521,58 +516,6 @@ def test_process_messages_rate_limited(caplog, settings) -> None:
     compare_message_batches_ignoring_metadata(new_batch, expected_new_batch)
     assert "dropped_message" in caplog.text
     assert not new_batch.invalid_msg_meta
-
-
-@pytest.mark.django_db
-def test_process_messages_cardinality_limited(
-    caplog, settings, monkeypatch, set_sentry_option
-) -> None:
-    """
-    Test that the message processor correctly calls the cardinality limiter.
-    """
-    settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
-
-    # set any limit at all to ensure we actually use the underlying rate limiter
-    with set_sentry_option(
-        "sentry-metrics.cardinality-limiter.limits.releasehealth.per-org",
-        [{"window_seconds": 3600, "granularity_seconds": 60, "limit": 0}],
-    ), set_sentry_option("sentry-metrics.cardinality-limiter-rh.orgs-rollout-rate", 1.0):
-
-        class MockCardinalityLimiter(CardinalityLimiter):
-            def check_within_quotas(self, requested_quotas):
-                # Grant nothing, limit everything
-                return 123, []
-
-            def use_quotas(self, grants, timestamp):
-                pass
-
-        monkeypatch.setitem(
-            cardinality_limiter_factory.rate_limiters,
-            "releasehealth",
-            TimeseriesCardinalityLimiter("releasehealth", MockCardinalityLimiter()),
-        )
-
-        message_payloads = [counter_payload, distribution_payload, set_payload]
-        message_batch = [
-            Message(
-                BrokerValue(
-                    KafkaPayload(None, json.dumps(payload).encode("utf-8"), []),
-                    Partition(Topic("topic"), 0),
-                    i + 1,
-                    datetime.now(),
-                )
-            )
-            for i, payload in enumerate(message_payloads)
-        ]
-
-        last = message_batch[-1]
-        outer_message = Message(Value(message_batch, last.committable))
-
-        with caplog.at_level(logging.ERROR):
-            new_batch = MESSAGE_PROCESSOR.process_messages(outer_message=outer_message)
-
-        compare_message_batches_ignoring_metadata(new_batch, [])
-        assert not new_batch.invalid_msg_meta
 
 
 def test_valid_metric_name() -> None:


### PR DESCRIPTION
# Overview

Implements a navie offline cardinality limiter for performance testing.

### **How it works**

- For each `(use_case_id, org_id)` seen, create a `TimeseriesWindow` for that `(use_case_id, org_id)` if it does not already exists
- A `TimeseriesWindow` contains `window // granularity` number of time buckets, each bucket is a python `set`
- When checking for cardinality limits on a `TimeseriesWindow` given a set of hashes and a timestamp:
    
    Find the earliest bucket that the timestamp belongs to, for each hash:
    
    1. If the hash already exists in the bucket, continue
    2. If the hash does not exists in the bucket:
        1. If size of the bucket < limit, write the hash to all buckets it will be in
        2. Otherwise, reject the hash

### **Limitations**

**Lose all data when consumers are restarting**

Potential fix: Persists periodically, load from persistent medium on initialization

**Cannot change cardinality limiter quota without a redeployment**

Potential fix: Compare settings on each limit application, do something when settings change

**Only perform ttl eviction at beginning of limit operation, so it leaks memory when a `(use_case_id, org_id)` is never seen again**

Potential fix: Scan periodically to check if any `TimeseriesWindow` has completely outdated buckets, delete them if they are. Move those that survive to another collection that are scanned less often, and so on

**Could probably be faster if it use bloom filters instead of a python `set`s**

Not sure if constantly performing intersections/unions on bloom filters could be an issue