### PR TITLE
fix(on-demand): Allow decimal apdex values

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -654,11 +654,11 @@ def _deep_sorted(value: Union[Any, Dict[Any, Any]]) -> Union[Any, Dict[Any, Any]
 TagsSpecsGenerator = Callable[[Project, Optional[Sequence[str]]], List[TagSpec]]
 
 
-def _get_threshold(arguments: Optional[Sequence[str]]) -> int:
+def _get_threshold(arguments: Optional[Sequence[str]]) -> float:
     if not arguments:
         raise Exception("Threshold parameter required.")
 
-    return int(arguments[0])
+    return float(arguments[0])
 
 
 def failure_tag_spec(_1: Project, _2: Optional[Sequence[str]]) -> List[TagSpec]:

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -410,6 +410,20 @@ def test_spec_apdex(_get_satisfactory_threshold_and_metric, default_project):
 
 
 @django_db_all
+@patch("sentry.snuba.metrics.extraction._get_satisfactory_threshold_and_metric")
+def test_spec_apdex_decimal(_get_satisfactory_threshold_and_metric, default_project):
+    _get_satisfactory_threshold_and_metric.return_value = 100, "transaction.duration"
+
+    spec = OnDemandMetricSpec("apdex(0.8)", "release:a")
+
+    assert spec._metric_type == "c"
+    assert spec.field_to_extract is None
+    assert spec.op == "on_demand_apdex"
+    assert spec.condition == {"name": "event.release", "op": "eq", "value": "a"}
+    assert spec.tags_conditions(default_project) == apdex_tag_spec(default_project, ["0.8"])
+
+
+@django_db_all
 def test_spec_epm(default_project):
     spec = OnDemandMetricSpec("epm()", "transaction.duration:>1s")
 


### PR DESCRIPTION
This PR fixes a problem in the on demand apdex implementation which was not supporting float values.