### PR TITLE
Automatically finish stuck reprocessing

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -454,7 +454,9 @@ class GroupSerializerBase(Serializer, ABC):
             status_label = "pending_merge"
         elif status == GroupStatus.REPROCESSING:
             status_label = "reprocessing"
-            status_details["pendingEvents"], status_details["info"] = get_progress(attrs["id"])
+            status_details["pendingEvents"], status_details["info"] = get_progress(
+                attrs["id"], obj.project.id
+            )
         else:
             status_label = "unresolved"
         return status_details, status_label


### PR DESCRIPTION
We expect reprocessing to make some process every now and then by bumping its counter key TTL. If that hasn't happened in a while, we assume its stuck and will just call finish on it.

This should in theory solve https://github.com/getsentry/symbolicator/issues/1319