### PR TITLE
fix(stat-detectors): Use 30d retention policy for span analysis

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
+++ b/static/app/components/events/eventStatisticalDetector/aggregateSpanDiff.tsx
@@ -149,6 +149,7 @@ function AggregateSpanDiff({event, projectId}: {event: Event; projectId: string}
   const {start, end} = useRelativeDateTime({
     anchor: breakpoint,
     relativeDays: 7,
+    retentionDays: 30,
   });
   const {data, isLoading, isError} = useFetchAdvancedAnalysis({
     transaction,


### PR DESCRIPTION
Span retention is only for 30d, so not passing this down messes with the spans per minute calculation.