### PR TITLE
feat(starfish): Update screen load spans charts

### DIFF
--- a/static/app/views/starfish/views/screens/index.tsx
+++ b/static/app/views/starfish/views/screens/index.tsx
@@ -145,7 +145,8 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
   });
 
   const topTransactions =
-    topTransactionsData?.data?.slice(0, 5).map(datum => datum.transaction) ?? [];
+    topTransactionsData?.data?.slice(0, 5).map(datum => datum.transaction as string) ??
+    [];
 
   const topEventsQuery = new MutableSearch([
     'event.type:transaction',
@@ -170,10 +171,6 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
         query: topEventsQueryString,
         dataset: DiscoverDatasets.METRICS,
         version: 2,
-        interval: getInterval(
-          pageFilter.selection.datetime,
-          STARFISH_CHART_INTERVAL_FIDELITY
-        ),
       },
       location
     ),
@@ -316,6 +313,7 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
                 return {
                   title: t('%s by Release', CHART_TITLES[yAxis]),
                   yAxis: YAXIS_COLUMNS[yAxis],
+                  xAxisLabel: topTransactions,
                   series: Object.values(transformedReleaseEvents[YAXIS_COLUMNS[yAxis]]),
                 };
               })}
@@ -330,6 +328,7 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
                 return {
                   title: t('%s by Device Class', CHART_TITLES[yAxis]),
                   yAxis: YAXIS_COLUMNS[yAxis],
+                  xAxisLabel: topTransactions,
                   series: Object.values(transformedDeviceEvents[YAXIS_COLUMNS[yAxis]]),
                 };
               })}

--- a/static/app/views/starfish/views/screens/screenBarChart.tsx
+++ b/static/app/views/starfish/views/screens/screenBarChart.tsx
@@ -8,6 +8,12 @@ import {CompactSelect, SelectOption} from 'sentry/components/compactSelect';
 import {space} from 'sentry/styles/space';
 import {Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
+import {
+  axisLabelFormatter,
+  getDurationUnit,
+  tooltipFormatter,
+} from 'sentry/utils/discover/charts';
+import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {LoadingScreen} from 'sentry/views/starfish/components/chart';
 import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
 
@@ -88,6 +94,26 @@ export function ScreensBarChart({
             truncate: 14,
             axisLabel: {
               interval: 0,
+            },
+          }}
+          yAxis={{
+            axisLabel: {
+              formatter(value: number) {
+                return axisLabelFormatter(
+                  value,
+                  aggregateOutputType(chartOptions[selectedDisplay].yAxis),
+                  undefined,
+                  getDurationUnit(chartOptions[selectedDisplay].series ?? [])
+                );
+              },
+            },
+          }}
+          tooltip={{
+            valueFormatter: (value, _seriesName) => {
+              return tooltipFormatter(
+                value,
+                aggregateOutputType(chartOptions[selectedDisplay].yAxis)
+              );
             },
           }}
         />

--- a/static/app/views/starfish/views/screens/screenBarChart.tsx
+++ b/static/app/views/starfish/views/screens/screenBarChart.tsx
@@ -2,6 +2,7 @@ import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {BarChart} from 'sentry/components/charts/barChart';
+import {BaseChartProps} from 'sentry/components/charts/baseChart';
 import TransitionChart from 'sentry/components/charts/transitionChart';
 import {CompactSelect, SelectOption} from 'sentry/components/compactSelect';
 import {space} from 'sentry/styles/space';
@@ -14,15 +15,18 @@ export type ChartSelectOptions = {
   title: string;
   yAxis: string;
   series?: Series[];
+  xAxisLabel?: string[];
 };
 
 export function ScreensBarChart({
   chartHeight,
   chartOptions,
   isLoading,
+  chartProps,
 }: {
   chartOptions: ChartSelectOptions[];
   chartHeight?: number;
+  chartProps?: BaseChartProps;
   isLoading?: boolean;
 }) {
   const [selectedDisplay, setChartSetting] = useState(0);
@@ -67,6 +71,7 @@ export function ScreensBarChart({
       >
         <LoadingScreen loading={Boolean(isLoading)} />
         <BarChart
+          {...chartProps}
           height={chartHeight ?? 180}
           series={chartOptions[selectedDisplay].series ?? []}
           grid={{
@@ -74,6 +79,16 @@ export function ScreensBarChart({
             right: '0',
             top: '16px',
             bottom: '0',
+            containLabel: true,
+          }}
+          xAxis={{
+            type: 'category',
+            axisTick: {show: true},
+            data: chartOptions[selectedDisplay].xAxisLabel,
+            truncate: 14,
+            axisLabel: {
+              interval: 0,
+            },
           }}
         />
       </TransitionChart>

--- a/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import Color from 'color';
 
@@ -14,6 +15,7 @@ import {tooltipFormatterUsingAggregateOutputType} from 'sentry/utils/discover/ch
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
@@ -26,6 +28,8 @@ import {
   OUTPUT_TYPE,
   YAXIS_COLUMNS,
 } from 'sentry/views/starfish/views/screens';
+import {ScreensBarChart} from 'sentry/views/starfish/views/screens/screenBarChart';
+import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
 export enum YAxis {
   WARM_START,
@@ -38,14 +42,6 @@ export enum YAxis {
   COUNT,
 }
 
-const DEVICE_CLASS_BREAKDOWN_INDEX = {
-  high: 0,
-  medium: 1,
-  low: 2,
-};
-
-const EMPTY = '';
-const UNKNOWN = 'unknown';
 type Props = {
   yAxes: YAxis[];
   additionalFilters?: string[];
@@ -54,6 +50,8 @@ type Props = {
 
 export function ScreenCharts({yAxes, additionalFilters, chartHeight}: Props) {
   const pageFilter = usePageFilters();
+  const location = useLocation();
+  const theme = useTheme();
 
   const yAxisCols = yAxes.map(val => YAXIS_COLUMNS[val]);
 
@@ -73,16 +71,15 @@ export function ScreenCharts({yAxes, additionalFilters, chartHeight}: Props) {
   useSynchronizeCharts();
   const {
     isLoading: seriesIsLoading,
-    data: releaseSeries,
+    data: releaseCountSeries,
     isError,
   } = useEventsStatsQuery({
     eventView: EventView.fromNewQueryWithPageFilters(
       {
         name: '',
-        fields: ['release', 'device.class', ...yAxisCols],
-        topEvents: '6',
-        orderby: yAxisCols[0],
-        yAxis: yAxisCols,
+        fields: ['release', 'count()'],
+        topEvents: '2',
+        yAxis: ['count()'],
         query: queryString,
         dataset: DiscoverDatasets.METRICS,
         version: 2,
@@ -99,104 +96,138 @@ export function ScreenCharts({yAxes, additionalFilters, chartHeight}: Props) {
     initialData: {},
   });
 
+  const {data: deviceClassEvents, isLoading: isDeviceClassEventsLoading} = useTableQuery({
+    eventView: EventView.fromNewQueryWithLocation(
+      {
+        name: '',
+        fields: ['device.class', 'release', ...yAxisCols],
+        orderby: yAxisCols[0],
+        yAxis: yAxisCols,
+        query: queryString,
+        dataset: DiscoverDatasets.METRICS,
+        version: 2,
+      },
+      location
+    ),
+    enabled: !isReleasesLoading,
+  });
+
   if (isReleasesLoading) {
     return <LoadingContainer />;
   }
 
-  const transformedReleaseSeries: {
+  function getTransformedRelease(series) {
+    return Object.keys(series).map((release, index) => {
+      const data =
+        series[release]?.data.map(datum => {
+          return {
+            name: datum[0] * 1000,
+            value: datum[1][0].count,
+          } as SeriesDataUnit;
+        }) ?? [];
+
+      return {
+        seriesName: release,
+        color: CHART_PALETTE[2][index],
+        data,
+      };
+    });
+  }
+
+  const transformedEvents: {
     [yAxisName: string]: {
-      [releaseVersion: string]: {[deviceClass: string]: Series | undefined};
+      [releaseVersion: string]: Series;
     };
   } = {};
+
   yAxes.forEach(val => {
-    transformedReleaseSeries[YAXIS_COLUMNS[val]] = {};
+    transformedEvents[YAXIS_COLUMNS[val]] = {};
     if (primaryRelease) {
-      transformedReleaseSeries[YAXIS_COLUMNS[val]][primaryRelease] = {};
+      transformedEvents[YAXIS_COLUMNS[val]][primaryRelease] = {
+        seriesName: primaryRelease,
+        data: Array(['high', 'medium', 'low', 'Unknown'].length).fill(0),
+      };
     }
     if (secondaryRelease) {
-      transformedReleaseSeries[YAXIS_COLUMNS[val]][secondaryRelease] = {};
+      transformedEvents[YAXIS_COLUMNS[val]][secondaryRelease] = {
+        seriesName: secondaryRelease,
+        data: Array(['high', 'medium', 'low', 'Unknown'].length).fill(0),
+      };
     }
   });
 
-  function renderCharts() {
-    if (defined(releaseSeries)) {
-      Object.keys(releaseSeries).forEach(seriesName => {
-        const [deviceClass, ...releaseArray] = seriesName.split(',');
-        const index = DEVICE_CLASS_BREAKDOWN_INDEX[deviceClass] ?? 3;
-        const release = releaseArray.join(',');
-        const isPrimary = release === primaryRelease;
+  const deviceClassIndex = Object.fromEntries(
+    ['high', 'medium', 'low', 'Unknown'].map((e, i) => [e, i])
+  );
 
-        if (release !== EMPTY) {
-          Object.keys(releaseSeries[seriesName]).forEach(yAxis => {
-            const label = `${deviceClass === EMPTY ? UNKNOWN : deviceClass}, ${release}`;
-            if (yAxis in transformedReleaseSeries) {
-              const data =
-                releaseSeries[seriesName][yAxis]?.data.map(datum => {
-                  return {
-                    name: datum[0] * 1000,
-                    value: datum[1][0].count,
-                  } as SeriesDataUnit;
-                }) ?? [];
+  if (defined(deviceClassEvents)) {
+    deviceClassEvents.data?.forEach(row => {
+      const deviceClass = row['device.class'];
+      const index = deviceClassIndex[deviceClass];
 
-              transformedReleaseSeries[yAxis][release][
-                deviceClass === EMPTY ? UNKNOWN : deviceClass
-              ] = {
-                seriesName: label,
-                color: isPrimary
-                  ? CHART_PALETTE[5][index]
-                  : Color(CHART_PALETTE[5][index]).lighten(0.5).string(),
-                data,
-              };
-            }
-          });
-        }
+      const release = row.release;
+      const isPrimary = release === primaryRelease;
+      yAxes.forEach(val => {
+        transformedEvents[YAXIS_COLUMNS[val]][release].data[index] = {
+          name: deviceClass,
+          value: row[YAXIS_COLUMNS[val]],
+          itemStyle: {
+            color: isPrimary ? theme.gray300 : Color(theme.gray300).lighten(0.5).string(),
+          },
+        } as SeriesDataUnit;
       });
-    }
+    });
+  }
 
+  function renderCharts() {
     return (
       <Fragment>
-        {yAxes.map((val, index) => {
-          return (
-            <ChartsContainerItem key={val}>
-              <MiniChartPanel title={CHART_TITLES[val]}>
-                <Chart
-                  height={chartHeight ?? 180}
-                  data={
-                    ['high', 'medium', 'low', UNKNOWN]
-                      .flatMap(deviceClass => {
-                        return [primaryRelease, secondaryRelease].map(r => {
-                          if (r) {
-                            return transformedReleaseSeries[yAxisCols[index]][r][
-                              deviceClass
-                            ];
-                          }
-                          return null;
-                        });
-                      })
-                      .filter(v => defined(v)) as Series[]
-                  }
-                  loading={seriesIsLoading}
-                  utc={false}
-                  grid={{
-                    left: '0',
-                    right: '0',
-                    top: '16px',
-                    bottom: '0',
-                  }}
-                  showLegend
-                  definedAxisTicks={2}
-                  isLineChart
-                  aggregateOutputFormat={OUTPUT_TYPE[val]}
-                  tooltipFormatterOptions={{
-                    valueFormatter: value =>
-                      tooltipFormatterUsingAggregateOutputType(value, OUTPUT_TYPE[val]),
-                  }}
-                  errored={isError}
-                />
-              </MiniChartPanel>
-            </ChartsContainerItem>
-          );
-        })}
+        <ChartsContainerItem>
+          <MiniChartPanel title={CHART_TITLES[YAxis.COUNT]}>
+            <Chart
+              height={chartHeight ?? 180}
+              data={
+                defined(releaseCountSeries)
+                  ? getTransformedRelease(releaseCountSeries)
+                  : []
+              }
+              loading={seriesIsLoading}
+              utc={false}
+              grid={{
+                left: '0',
+                right: '0',
+                top: '16px',
+                bottom: '0',
+              }}
+              showLegend
+              definedAxisTicks={2}
+              isLineChart
+              aggregateOutputFormat={OUTPUT_TYPE[YAxis.COUNT]}
+              tooltipFormatterOptions={{
+                valueFormatter: value =>
+                  tooltipFormatterUsingAggregateOutputType(
+                    value,
+                    OUTPUT_TYPE[YAxis.COUNT]
+                  ),
+              }}
+              errored={isError}
+            />
+          </MiniChartPanel>
+        </ChartsContainerItem>
+        <ChartsContainerItem key="deviceClass">
+          <ScreensBarChart
+            chartOptions={yAxes.map(yAxis => {
+              return {
+                title: CHART_TITLES[yAxis],
+                yAxis: YAXIS_COLUMNS[yAxis],
+                series: Object.values(transformedEvents[YAXIS_COLUMNS[yAxis]]),
+                xAxisLabel: ['high', 'medium', 'low', 'Unknown'],
+              };
+            })}
+            chartHeight={chartHeight ?? 180}
+            isLoading={isDeviceClassEventsLoading}
+          />
+        </ChartsContainerItem>
       </Fragment>
     );
   }

--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
@@ -66,6 +66,7 @@ function ScreenLoadSpans() {
   const {
     spanGroup,
     primaryRelease,
+    secondaryRelease,
     transaction: transactionName,
     spanDescription,
   } = location.query;
@@ -102,6 +103,7 @@ function ScreenLoadSpans() {
               <ScreenLoadSpansTable
                 transaction={transactionName}
                 primaryRelease={primaryRelease}
+                secondaryRelease={secondaryRelease}
               />
               {spanGroup && (
                 <SampleList

--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
@@ -89,13 +89,13 @@ function ScreenLoadSpans() {
                     <DatePageFilter />
                   </PageFilterBar>
                   <ReleaseComparisonSelector />
-                  <ScreenMetricsRibbon
-                    additionalFilters={[`transaction:${transactionName}`]}
-                  />
                 </Container>
               </StarfishPageFiltersContainer>
+              <ScreenMetricsRibbon
+                additionalFilters={[`transaction:${transactionName}`]}
+              />
               <ScreenCharts
-                yAxes={[YAxis.COUNT, YAxis.TTID, YAxis.TTFD]}
+                yAxes={[YAxis.TTID, YAxis.TTFD]}
                 additionalFilters={[`transaction:${transactionName}`]}
                 chartHeight={120}
               />
@@ -134,6 +134,7 @@ const Container = styled('div')`
   display: grid;
   grid-template-rows: auto auto auto;
   gap: ${space(2)};
+  padding-bottom: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     grid-template-rows: auto;

--- a/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
@@ -38,10 +38,15 @@ const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, PROJECT_ID} =
 
 type Props = {
   primaryRelease?: string;
+  secondaryRelease?: string;
   transaction?: string;
 };
 
-export function ScreenLoadSpansTable({transaction, primaryRelease}: Props) {
+export function ScreenLoadSpansTable({
+  transaction,
+  primaryRelease,
+  secondaryRelease,
+}: Props) {
   const location = useLocation();
   const {selection} = usePageFilters();
   const organization = useOrganization();
@@ -53,7 +58,11 @@ export function ScreenLoadSpansTable({transaction, primaryRelease}: Props) {
     `transaction:${transaction}`,
     'span.op:[file.read,file.write,ui.load,http.client,db,db.sql.room,db.sql.query,db.sql.transaction]',
   ]);
-  const queryStringPrimary = appendReleaseFilters(searchQuery, primaryRelease);
+  const queryStringPrimary = appendReleaseFilters(
+    searchQuery,
+    primaryRelease,
+    secondaryRelease
+  );
 
   const sort = fromSorts(
     decodeScalar(location.query[QueryParameterNames.SPANS_SORT])
@@ -69,9 +78,10 @@ export function ScreenLoadSpansTable({transaction, primaryRelease}: Props) {
       SPAN_OP,
       SPAN_GROUP,
       SPAN_DESCRIPTION,
-      `avg(${SPAN_SELF_TIME})`, // TODO: Update these to avgIf with primary release when available
+      `avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`,
+      `avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`,
       'count()',
-      'time_spent_percentage(local)',
+      'time_spent_percentage()',
       `sum(${SPAN_SELF_TIME})`,
     ],
     query: queryStringPrimary,
@@ -95,8 +105,13 @@ export function ScreenLoadSpansTable({transaction, primaryRelease}: Props) {
     [SPAN_OP]: t('Operation'),
     [SPAN_DESCRIPTION]: t('Span Description'),
     'count()': DataTitles.count,
-    [`avg(${SPAN_SELF_TIME})`]: DataTitles.avg,
-    'time_spent_percentage(local)': DataTitles.timeSpent,
+    'time_spent_percentage()': DataTitles.timeSpent,
+    [`avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`]: t(
+      'Avg Duration (Release 1)'
+    ),
+    [`avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`]: t(
+      'Avg Duration  (Release 2)'
+    ),
   };
 
   function renderBodyCell(column, row): React.ReactNode {

--- a/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
@@ -71,6 +71,8 @@ export function ScreenLoadSpansTable({transaction, primaryRelease}: Props) {
       SPAN_DESCRIPTION,
       `avg(${SPAN_SELF_TIME})`, // TODO: Update these to avgIf with primary release when available
       'count()',
+      'time_spent_percentage(local)',
+      `sum(${SPAN_SELF_TIME})`,
     ],
     query: queryStringPrimary,
     dataset: DiscoverDatasets.SPANS_METRICS,
@@ -94,6 +96,7 @@ export function ScreenLoadSpansTable({transaction, primaryRelease}: Props) {
     [SPAN_DESCRIPTION]: t('Span Description'),
     'count()': DataTitles.count,
     [`avg(${SPAN_SELF_TIME})`]: DataTitles.avg,
+    'time_spent_percentage(local)': DataTitles.timeSpent,
   };
 
   function renderBodyCell(column, row): React.ReactNode {

--- a/static/app/views/starfish/views/screens/screenMetricsRibbon.tsx
+++ b/static/app/views/starfish/views/screens/screenMetricsRibbon.tsx
@@ -106,7 +106,7 @@ export function ScreenMetricsRibbon({additionalFilters}: {additionalFilters?: st
         </MeterBarContainer>
         <MeterBarContainer key="release1 - ttfd">
           <MeterBarBody>
-            <MeterHeader>{t('Avg TTID')}</MeterHeader>
+            <MeterHeader>{t('Avg TTFD')}</MeterHeader>
             <MeterValueText>
               {isLoading
                 ? undefinedText
@@ -123,7 +123,7 @@ export function ScreenMetricsRibbon({additionalFilters}: {additionalFilters?: st
         </MeterBarContainer>
         <MeterBarContainer key="release2 - ttfd">
           <MeterBarBody>
-            <MeterHeader>{t('Avg TTID')}</MeterHeader>
+            <MeterHeader>{t('Avg TTFD')}</MeterHeader>
             <MeterValueText>
               {isLoading
                 ? undefinedText

--- a/static/app/views/starfish/views/screens/screenMetricsRibbon.tsx
+++ b/static/app/views/starfish/views/screens/screenMetricsRibbon.tsx
@@ -1,16 +1,17 @@
+import styled from '@emotion/styled';
+
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {NewQuery} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {formatAbbreviatedNumber, getDuration} from 'sentry/utils/formatters';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
-import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
-import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
 
 export function ScreenMetricsRibbon({additionalFilters}: {additionalFilters?: string[]}) {
   const {selection} = usePageFilters();
@@ -21,15 +22,25 @@ export function ScreenMetricsRibbon({additionalFilters}: {additionalFilters?: st
     ...(additionalFilters ?? []),
   ]);
 
-  const {primaryRelease, isLoading: isReleasesLoading} = useReleaseSelection();
+  const {
+    primaryRelease,
+    secondaryRelease,
+    isLoading: isReleasesLoading,
+  } = useReleaseSelection();
 
-  const queryStringPrimary = appendReleaseFilters(searchQuery, primaryRelease, undefined);
+  const queryStringPrimary = appendReleaseFilters(
+    searchQuery,
+    primaryRelease,
+    secondaryRelease
+  );
 
   const newQuery: NewQuery = {
     name: 'ScreenMetricsRibbon',
     fields: [
-      'avg(measurements.time_to_initial_display)', // TODO: Update these to avgIf with primary release when available
-      'avg(measurements.time_to_full_display)',
+      `avg_if(measurements.time_to_initial_display,release,${primaryRelease})`,
+      `avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`,
+      `avg_if(measurements.time_to_full_display,release,${primaryRelease})`,
+      `avg_if(measurements.time_to_full_display,release,${secondaryRelease})`,
       'count()',
     ],
     query: queryStringPrimary,
@@ -43,40 +54,148 @@ export function ScreenMetricsRibbon({additionalFilters}: {additionalFilters?: st
     enabled: !isReleasesLoading,
   });
 
-  return (
-    <BlockContainer>
-      <Block title={t('Count')}>
-        {!isLoading && data ? (
-          <CountCell count={data.data[0]?.['count()'] as number} />
-        ) : (
-          '-'
-        )}
-      </Block>
+  const undefinedText = '--';
 
-      <Block title={t('Avg TTID')}>
-        {!isLoading && data ? (
-          <DurationCell
-            milliseconds={
-              data.data[0]?.['avg(measurements.time_to_initial_display)'] as number
-            }
-          />
-        ) : (
-          '-'
-        )}
-      </Block>
-      <Block title={t('Avg TTFD')}>
-        {!isLoading &&
-        data &&
-        data.data[0]?.['avg(measurements.time_to_full_display)'] !== 0 ? (
-          <DurationCell
-            milliseconds={
-              data.data[0]?.['avg(measurements.time_to_full_display)'] as number
-            }
-          />
-        ) : (
-          '-'
-        )}
-      </Block>
-    </BlockContainer>
+  return (
+    <Container>
+      <Flex>
+        <MeterBarContainer key="count">
+          <MeterBarBody>
+            <MeterHeader>{t('Count')}</MeterHeader>
+            <MeterValueText>
+              {isLoading
+                ? undefinedText
+                : formatAbbreviatedNumber(data?.data[0]?.['count()'] as number)}
+            </MeterValueText>
+          </MeterBarBody>
+          <MeterBarFooter text={t('Overall')} />
+        </MeterBarContainer>
+        <MeterBarContainer key="release1 - ttid">
+          <MeterBarBody>
+            <MeterHeader>{t('Avg TTID')}</MeterHeader>
+            <MeterValueText>
+              {isLoading
+                ? undefinedText
+                : getDuration(
+                    (data?.data[0]?.[
+                      `avg_if(measurements.time_to_initial_display,release,${primaryRelease})`
+                    ] as number) / 1000,
+                    2,
+                    true
+                  )}
+            </MeterValueText>
+          </MeterBarBody>
+          <MeterBarFooter text={t('Release 1')} />
+        </MeterBarContainer>
+        <MeterBarContainer key="release2 - ttid">
+          <MeterBarBody>
+            <MeterHeader>{t('Avg TTID')}</MeterHeader>
+            <MeterValueText>
+              {isLoading
+                ? undefinedText
+                : getDuration(
+                    (data?.data[0]?.[
+                      `avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`
+                    ] as number) / 1000,
+                    2,
+                    true
+                  )}
+            </MeterValueText>
+          </MeterBarBody>
+          <MeterBarFooter text={t('Release 2')} />
+        </MeterBarContainer>
+        <MeterBarContainer key="release1 - ttfd">
+          <MeterBarBody>
+            <MeterHeader>{t('Avg TTID')}</MeterHeader>
+            <MeterValueText>
+              {isLoading
+                ? undefinedText
+                : getDuration(
+                    (data?.data[0]?.[
+                      `avg_if(measurements.time_to_full_display,release,${primaryRelease})`
+                    ] as number) / 1000,
+                    2,
+                    true
+                  )}
+            </MeterValueText>
+          </MeterBarBody>
+          <MeterBarFooter text={t('Release 1')} />
+        </MeterBarContainer>
+        <MeterBarContainer key="release2 - ttfd">
+          <MeterBarBody>
+            <MeterHeader>{t('Avg TTID')}</MeterHeader>
+            <MeterValueText>
+              {isLoading
+                ? undefinedText
+                : getDuration(
+                    (data?.data[0]?.[
+                      `avg_if(measurements.time_to_full_display,release,${secondaryRelease})`
+                    ] as number) / 1000,
+                    2,
+                    true
+                  )}
+            </MeterValueText>
+          </MeterBarBody>
+          <MeterBarFooter text={t('Release 2')} />
+        </MeterBarContainer>
+      </Flex>
+    </Container>
   );
 }
+
+const Container = styled('div')`
+  margin-bottom: ${space(2)};
+`;
+
+const Flex = styled('div')<{gap?: number}>`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  width: 100%;
+  gap: ${p => (p.gap ? `${p.gap}px` : space(1))};
+  align-items: center;
+  flex-wrap: wrap;
+`;
+
+const MeterBarContainer = styled('div')`
+  flex: 1;
+  position: relative;
+  padding: 0;
+  min-width: 180px;
+`;
+
+const MeterBarBody = styled('div')`
+  border: 1px solid ${p => p.theme.gray200};
+  border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
+  border-bottom: none;
+  padding: ${space(1)} 0 ${space(0.5)} 0;
+`;
+
+const MeterHeader = styled('div')`
+  font-size: 13px;
+  color: ${p => p.theme.textColor};
+  font-weight: bold;
+  display: inline-block;
+  white-space: nowrap;
+  text-align: center;
+  width: 100%;
+`;
+
+const MeterValueText = styled('div')`
+  font-size: ${p => p.theme.headerFontSize};
+  color: ${p => p.theme.textColor};
+  flex: 1;
+  text-align: center;
+`;
+
+function MeterBarFooter({text}: {text: string}) {
+  return <MeterBarFooterContainer>{text}</MeterBarFooterContainer>;
+}
+
+const MeterBarFooterContainer = styled('div')`
+  border-radius: 0 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius};
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  padding: ${space(0.5)};
+  text-align: center;
+  border: solid 1px;
+`;


### PR DESCRIPTION
A couple updates to the screen load spans page:
- changes the span ribbon to little cards with TTID/TTFD values for selected releases
- TTID chart is broken down by device class and release and is a bar chart
- adds columns for avg span self time for release 1 & release 2

![Screenshot 2023-10-30 at 2 30 05 PM](https://github.com/getsentry/sentry/assets/63818634/f073288a-8715-46db-ae1f-1b77f4ebb0c9)

Chart updates
- units in yaxis and tooltip for selectable bar charts
- truncated x-axis value, currently hardcoded to truncate at 14 characters for simplicity

![Screenshot 2023-10-30 at 2 27 27 PM](https://github.com/getsentry/sentry/assets/63818634/222ee284-0ece-4ab0-8c55-356392e67c9c)
