### PR TITLE
fix(integrations): frontend part of github installation sender check

### DIFF
--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -52,7 +52,7 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
   State
 > {
   disableErrorReport = false;
-  controlSiloApi = new Client({baseUrl: generateBaseControlSiloUrl() + '/api/0'});
+  controlSiloApi = new Client({baseUrl: generateBaseControlSiloUrl()});
 
   getEndpoints(): ReturnType<DeprecatedAsyncView['getEndpoints']> {
     return [['organizations', '/organizations/']];
@@ -122,9 +122,9 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
         Organization,
         {providers: IntegrationProvider[]},
       ] = await Promise.all([
-        this.controlSiloApi.requestPromise(`/organizations/${orgSlug}/`),
+        this.controlSiloApi.requestPromise(`/api/0/organizations/${orgSlug}/`),
         this.controlSiloApi.requestPromise(
-          `/organizations/${orgSlug}/config/integrations/?provider_key=${this.integrationSlug}`
+          `/api/0/organizations/${orgSlug}/config/integrations/?provider_key=${this.integrationSlug}`
         ),
       ]);
       // should never happen with a valid provider
@@ -136,7 +136,7 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
       if (this.integrationSlug === 'github') {
         const {installationId} = this.props.params;
         installationData = await this.controlSiloApi.requestPromise(
-          `/../../extensions/github/installation/${installationId}/`
+          `/extensions/github/installation/${installationId}/`
         );
       }
 

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -288,32 +288,44 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
       return null;
     }
 
+    if (!installationData) {
+      return (
+        <Alert type="warning" showIcon>
+          {t(
+            'We could not verify the authenticity of the installation request. We recommend to restart the installation process.'
+          )}
+        </Alert>
+      );
+    }
+
     const sender_url = `https://github.com/${installationData?.sender.login}`;
     const target_url = `https://github.com/${installationData?.account.login}`;
 
+    const alertText = tct(
+      `GitHub user [sender_login] has installed GitHub app to [account_type] [account_login]. Proceed if you want to attach this installation to your Sentry account.`,
+      {
+        account_type: <strong>{installationData?.account.type}</strong>,
+        account_login: (
+          <strong>
+            <ExternalLink href={target_url}>
+              {installationData?.account.login}
+            </ExternalLink>
+          </strong>
+        ),
+        sender_id: <strong>{installationData?.sender.id}</strong>,
+        sender_login: (
+          <strong>
+            <ExternalLink href={sender_url}>
+              {installationData?.sender.login}
+            </ExternalLink>
+          </strong>
+        ),
+      }
+    );
+
     return (
       <Alert type="info" showIcon>
-        {tct(
-          `GitHub user [sender_login] has installed GitHub app to [account_type] [account_login]. Proceed if you want to attach this installation to your Sentry account.`,
-          {
-            account_type: <strong>{installationData?.account.type}</strong>,
-            account_login: (
-              <strong>
-                <ExternalLink href={target_url}>
-                  {installationData?.account.login}
-                </ExternalLink>
-              </strong>
-            ),
-            sender_id: <strong>{installationData?.sender.id}</strong>,
-            sender_login: (
-              <strong>
-                <ExternalLink href={sender_url}>
-                  {installationData?.sender.login}
-                </ExternalLink>
-              </strong>
-            ),
-          }
-        )}
+        {alertText}
       </Alert>
     );
   }

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -281,8 +281,45 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
     );
   }
 
+  renderCallout() {
+    const {installationData} = this.state;
+
+    if (this.integrationSlug !== 'github') {
+      return null;
+    }
+
+    const sender_url = `https://github.com/${installationData?.sender.login}`;
+    const target_url = `https://github.com/${installationData?.account.login}`;
+
+    return (
+      <Alert type="info" showIcon>
+        {tct(
+          `GitHub user [sender_login] has installed GitHub app to [account_type] [account_login]. Proceed if you want to attach this installation to your Sentry account.`,
+          {
+            account_type: <strong>{installationData?.account.type}</strong>,
+            account_login: (
+              <strong>
+                <ExternalLink href={target_url}>
+                  {installationData?.account.login}
+                </ExternalLink>
+              </strong>
+            ),
+            sender_id: <strong>{installationData?.sender.id}</strong>,
+            sender_login: (
+              <strong>
+                <ExternalLink href={sender_url}>
+                  {installationData?.sender.login}
+                </ExternalLink>
+              </strong>
+            ),
+          }
+        )}
+      </Alert>
+    );
+  }
+
   renderBody() {
-    const {selectedOrgSlug, installationData} = this.state;
+    const {selectedOrgSlug} = this.state;
     const options = this.state.organizations.map((org: Organization) => ({
       value: org.slug,
       label: (
@@ -295,42 +332,10 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
       ),
     }));
 
-    let integrationAlert;
-    if (this.integrationSlug === 'github') {
-      const sender_url = `https://github.com/${installationData?.sender.login}`;
-      const target_url = `https://github.com/${installationData?.account.login}`;
-
-      integrationAlert = (
-        <Alert type="info" showIcon>
-          {tct(
-            `GitHub user [sender_login] has installed GitHub app to [account_type] [account_login]. Proceed if you want to attach this installation to your Sentry account.`,
-            {
-              account_type: <strong>{installationData?.account.type}</strong>,
-              account_login: (
-                <strong>
-                  <ExternalLink href={target_url}>
-                    {installationData?.account.login}
-                  </ExternalLink>
-                </strong>
-              ),
-              sender_id: <strong>{installationData?.sender.id}</strong>,
-              sender_login: (
-                <strong>
-                  <ExternalLink href={sender_url}>
-                    {installationData?.sender.login}
-                  </ExternalLink>
-                </strong>
-              ),
-            }
-          )}
-        </Alert>
-      );
-    }
-
     return (
       <NarrowLayout>
         <h3>{t('Finish integration installation')}</h3>
-        {integrationAlert}
+        {this.renderCallout()}
         <p>
           {tct(
             `Please pick a specific [organization:organization] to link with

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -53,7 +53,7 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
   State
 > {
   disableErrorReport = false;
-  controlSiloApi = new Client({baseUrl: generateBaseControlSiloUrl()});
+  controlSiloApi = new Client({baseUrl: generateBaseControlSiloUrl() + '/api/0'});
 
   getEndpoints(): ReturnType<DeprecatedAsyncView['getEndpoints']> {
     return [['organizations', '/organizations/']];
@@ -123,9 +123,9 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
         Organization,
         {providers: IntegrationProvider[]},
       ] = await Promise.all([
-        this.controlSiloApi.requestPromise(`/api/0/organizations/${orgSlug}/`),
+        this.controlSiloApi.requestPromise(`/organizations/${orgSlug}/`),
         this.controlSiloApi.requestPromise(
-          `/api/0/organizations/${orgSlug}/config/integrations/?provider_key=${this.integrationSlug}`
+          `/organizations/${orgSlug}/config/integrations/?provider_key=${this.integrationSlug}`
         ),
       ]);
       // should never happen with a valid provider
@@ -137,8 +137,10 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
       if (this.integrationSlug === 'github') {
         const {installationId} = this.props.params;
         try {
+          // The API endpoint /extensions/github/installation is not prefixed with /api/0
+          // so we have to use this workaround.
           installationData = await this.controlSiloApi.requestPromise(
-            `/extensions/github/installation/${installationId}/`
+            `/../../extensions/github/installation/${installationId}/`
           );
         } catch (_err) {
           addErrorMessage(t('Failed to retrieve GitHub installation details'));


### PR DESCRIPTION
At the final step of the GitHub app installation that started from GitHub side, add a callout about who requested the installation and to which GitHub user/organization.
Backend part in https://github.com/getsentry/sentry/pull/57971

Examples:
<img width="753" alt="image" src="https://github.com/getsentry/sentry/assets/1127549/623c294a-a81f-41bd-9480-8c072617e4bf">
<img width="753" alt="image" src="https://github.com/getsentry/sentry/assets/1127549/b2dd173f-3840-4879-b93c-b2799e9b9b69">
<img width="753" alt="image" src="https://github.com/getsentry/sentry/assets/1127549/d3ae5b96-7e30-46ba-93c4-431c4214a26a">

If 10 minutes have passed:
<img width="750" alt="image" src="https://github.com/getsentry/sentry/assets/1127549/df0f537a-4916-4c9d-b535-d7dd53553a4c">
