### PR TITLE
feat(replays): Replay layout timeline size consistent when full screening

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -21,13 +21,16 @@ import toPercent from 'sentry/utils/number/toPercent';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import useOrganization from 'sentry/utils/useOrganization';
 
-type Props = {size: number};
+type Props = {};
 
-function ReplayTimeline({size}: Props) {
-  const {replay, currentTime} = useReplayContext();
+function ReplayTimeline({}: Props) {
+  const {replay, currentTime, timelineSize} = useReplayContext();
 
   const panelRef = useRef<HTMLDivElement>(null);
-  const mouseTrackingProps = useTimelineScrubberMouseTracking({elem: panelRef}, size);
+  const mouseTrackingProps = useTimelineScrubberMouseTracking(
+    {elem: panelRef},
+    timelineSize
+  );
 
   const stackedRef = useRef<HTMLDivElement>(null);
   const {width} = useDimensions<HTMLDivElement>({elementRef: stackedRef});
@@ -45,7 +48,7 @@ function ReplayTimeline({size}: Props) {
   const networkFrames = replay.getNetworkFrames();
 
   // start of the timeline is in the middle
-  const initialTranslatePercentage = 50 / size;
+  const initialTranslatePercentage = 50 / timelineSize;
 
   const translatePercentage = toPercent(
     initialTranslatePercentage -
@@ -56,7 +59,7 @@ function ReplayTimeline({size}: Props) {
     <VisiblePanel ref={panelRef} {...mouseTrackingProps}>
       <Stacked
         style={{
-          width: `${size}%`,
+          width: `${timelineSize}%`,
           transform: `translate(${translatePercentage}, 0%)`,
         }}
         ref={stackedRef}

--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -24,12 +24,12 @@ import useOrganization from 'sentry/utils/useOrganization';
 type Props = {};
 
 function ReplayTimeline({}: Props) {
-  const {replay, currentTime, timelineSize} = useReplayContext();
+  const {replay, currentTime, timelineScale} = useReplayContext();
 
   const panelRef = useRef<HTMLDivElement>(null);
   const mouseTrackingProps = useTimelineScrubberMouseTracking(
     {elem: panelRef},
-    timelineSize
+    timelineScale
   );
 
   const stackedRef = useRef<HTMLDivElement>(null);
@@ -48,19 +48,17 @@ function ReplayTimeline({}: Props) {
   const networkFrames = replay.getNetworkFrames();
 
   // start of the timeline is in the middle
-  const initialTranslatePercentage = 50 / timelineSize;
+  const initialTranslate = 0.5 / timelineScale;
 
-  const translatePercentage = toPercent(
-    initialTranslatePercentage -
-      (currentTime > durationMs ? 1 : divide(currentTime, durationMs))
-  );
+  const translate =
+    initialTranslate - (currentTime > durationMs ? 1 : divide(currentTime, durationMs));
 
   return hasNewTimeline ? (
     <VisiblePanel ref={panelRef} {...mouseTrackingProps}>
       <Stacked
         style={{
-          width: `${timelineSize}%`,
-          transform: `translate(${translatePercentage}, 0%)`,
+          width: `${toPercent(timelineScale)}`,
+          transform: `translate(${toPercent(translate)}, 0%)`,
         }}
         ref={stackedRef}
       >

--- a/static/app/components/replays/player/useScrubberMouseTracking.tsx
+++ b/static/app/components/replays/player/useScrubberMouseTracking.tsx
@@ -54,7 +54,7 @@ export function useTimelineScrubberMouseTracking<T extends Element>(
 
       if (left >= 0) {
         const percent = (left - width / 2) / width;
-        const time = currentTime + (percent * durationMs) / (size / 100);
+        const time = currentTime + (percent * durationMs) / size;
         setCurrentHoverTime(time);
       } else {
         setCurrentHoverTime(undefined);

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -115,9 +115,9 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   setSpeed: (speed: number) => void;
 
   /**
-   * Set the timeline to the specific size
+   * Set the timeline width to the specific scale, starting at 1x and growing larger
    */
-  setTimelineSize: (size: number) => void;
+  setTimelineScale: (size: number) => void;
 
   /**
    * The speed for normal playback
@@ -125,9 +125,9 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   speed: number;
 
   /**
-   * Size of timeline as a percentage of the original size
+   * Scale of the timeline width
    */
-  timelineSize: number;
+  timelineScale: number;
 
   /**
    * Start or stop playback
@@ -163,9 +163,9 @@ const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
   setCurrentHoverTime: () => {},
   setCurrentTime: () => {},
   setSpeed: () => {},
-  setTimelineSize: () => {},
+  setTimelineScale: () => {},
   speed: 1,
-  timelineSize: 100,
+  timelineScale: 1,
   togglePlayPause: () => {},
   toggleSkipInactive: () => {},
 });
@@ -232,7 +232,7 @@ export function Provider({
   const [buffer, setBufferTime] = useState({target: -1, previous: -1});
   const playTimer = useRef<number | undefined>(undefined);
   const didApplyInitialOffset = useRef(false);
-  const [timelineSize, setTimelineSize] = useState(100);
+  const [timelineScale, setTimelineScale] = useState(1);
 
   const isFinished = replayerRef.current?.getCurrentTime() === finishedAtMS;
 
@@ -538,9 +538,9 @@ export function Provider({
         setCurrentHoverTime,
         setCurrentTime,
         setSpeed,
-        setTimelineSize,
+        setTimelineScale,
         speed,
-        timelineSize,
+        timelineScale,
         togglePlayPause,
         toggleSkipInactive,
         ...value,

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -115,9 +115,19 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   setSpeed: (speed: number) => void;
 
   /**
+   * Set the timeline to the specific size
+   */
+  setTimelineSize: (size: number) => void;
+
+  /**
    * The speed for normal playback
    */
   speed: number;
+
+  /**
+   * Size of timeline as a percentage of the original size
+   */
+  timelineSize: number;
 
   /**
    * Start or stop playback
@@ -153,7 +163,9 @@ const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
   setCurrentHoverTime: () => {},
   setCurrentTime: () => {},
   setSpeed: () => {},
+  setTimelineSize: () => {},
   speed: 1,
+  timelineSize: 300,
   togglePlayPause: () => {},
   toggleSkipInactive: () => {},
 });
@@ -220,6 +232,7 @@ export function Provider({
   const [buffer, setBufferTime] = useState({target: -1, previous: -1});
   const playTimer = useRef<number | undefined>(undefined);
   const didApplyInitialOffset = useRef(false);
+  const [timelineSize, setTimelineSize] = useState(300);
 
   const isFinished = replayerRef.current?.getCurrentTime() === finishedAtMS;
 
@@ -525,7 +538,9 @@ export function Provider({
         setCurrentHoverTime,
         setCurrentTime,
         setSpeed,
+        setTimelineSize,
         speed,
+        timelineSize,
         togglePlayPause,
         toggleSkipInactive,
         ...value,

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -165,7 +165,7 @@ const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
   setSpeed: () => {},
   setTimelineSize: () => {},
   speed: 1,
-  timelineSize: 300,
+  timelineSize: 100,
   togglePlayPause: () => {},
   toggleSkipInactive: () => {},
 });
@@ -232,7 +232,7 @@ export function Provider({
   const [buffer, setBufferTime] = useState({target: -1, previous: -1});
   const playTimer = useRef<number | undefined>(undefined);
   const didApplyInitialOffset = useRef(false);
-  const [timelineSize, setTimelineSize] = useState(300);
+  const [timelineSize, setTimelineSize] = useState(100);
 
   const isFinished = replayerRef.current?.getCurrentTime() === finishedAtMS;
 

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -147,7 +147,9 @@ function ReplayOptionsMenu({speedOptions}: {speedOptions: number[]}) {
 }
 
 function TimelineSizeBar() {
-  const {timelineSize, setTimelineSize} = useReplayContext();
+  const {timelineScale, setTimelineScale, replay} = useReplayContext();
+  const durationMs = replay?.getDurationMs();
+  const maxScale = durationMs ? Math.ceil(durationMs / 60000) : 10;
   return (
     <ButtonBar merged>
       <Button
@@ -155,18 +157,18 @@ function TimelineSizeBar() {
         title={t('Zoom out')}
         icon={<IconSubtract size="xs" />}
         borderless
-        onClick={() => setTimelineSize(Math.max(timelineSize - 50, 100))}
+        onClick={() => setTimelineScale(Math.max(timelineScale - 0.5, 1))}
         aria-label={t('Zoom out')}
-        disabled={timelineSize === 100 ? true : false}
+        disabled={timelineScale === 1}
       />
       <Button
         size="xs"
         title={t('Zoom in')}
         icon={<IconAdd size="xs" />}
         borderless
-        onClick={() => setTimelineSize(Math.min(timelineSize + 50, 1000))}
+        onClick={() => setTimelineScale(Math.min(timelineScale + 0.5, maxScale))}
         aria-label={t('Zoom in')}
-        disabled={timelineSize === 1000 ? true : false}
+        disabled={timelineScale === maxScale}
       />
     </ButtonBar>
   );

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -146,7 +146,8 @@ function ReplayOptionsMenu({speedOptions}: {speedOptions: number[]}) {
   );
 }
 
-function TimelineSizeBar({size, setSize}) {
+function TimelineSizeBar() {
+  const {timelineSize, setTimelineSize} = useReplayContext();
   return (
     <ButtonBar merged>
       <Button
@@ -154,7 +155,7 @@ function TimelineSizeBar({size, setSize}) {
         title={t('Zoom out')}
         icon={<IconSubtract size="xs" />}
         borderless
-        onClick={() => setSize(Math.max(size - 50, 100))}
+        onClick={() => setTimelineSize(Math.max(timelineSize - 50, 100))}
         aria-label={t('Zoom out')}
       />
       <Button
@@ -162,7 +163,7 @@ function TimelineSizeBar({size, setSize}) {
         title={t('Zoom in')}
         icon={<IconAdd size="xs" />}
         borderless
-        onClick={() => setSize(Math.min(size + 50, 1000))}
+        onClick={() => setTimelineSize(Math.min(timelineSize + 50, 1000))}
         aria-label={t('Zoom in')}
       />
     </ButtonBar>
@@ -180,7 +181,6 @@ function ReplayControls({
   const isFullscreen = useIsFullscreen();
   const {currentTime, replay} = useReplayContext();
   const durationMs = replay?.getDurationMs();
-  const [size, setSize] = useState(300);
 
   // If the browser supports going fullscreen or not. iPhone Safari won't do
   // it. https://caniuse.com/fullscreen
@@ -221,10 +221,10 @@ function ReplayControls({
           <TimeAndScrubberGrid isCompact={isCompact}>
             <Time style={{gridArea: 'currentTime'}}>{formatTime(currentTime)}</Time>
             <div style={{gridArea: 'timeline'}}>
-              <ReplayTimeline size={size} />
+              <ReplayTimeline />
             </div>
             <div style={{gridArea: 'timelineSize'}}>
-              <TimelineSizeBar size={size} setSize={setSize} />
+              <TimelineSizeBar />
             </div>
             <StyledScrubber
               style={{gridArea: 'scrubber'}}

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -157,6 +157,7 @@ function TimelineSizeBar() {
         borderless
         onClick={() => setTimelineSize(Math.max(timelineSize - 50, 100))}
         aria-label={t('Zoom out')}
+        disabled={timelineSize === 100 ? true : false}
       />
       <Button
         size="xs"
@@ -165,6 +166,7 @@ function TimelineSizeBar() {
         borderless
         onClick={() => setTimelineSize(Math.min(timelineSize + 50, 1000))}
         aria-label={t('Zoom in')}
+        disabled={timelineSize === 1000 ? true : false}
       />
     </ButtonBar>
   );

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -41,7 +41,7 @@ function ReplayLayout({layout = LayoutKey.TOPBAR}: Props) {
 
   const timeline = hasNewTimeline ? null : (
     <ErrorBoundary mini>
-      <ReplayTimeline size={100} />
+      <ReplayTimeline />
     </ErrorBoundary>
   );
 


### PR DESCRIPTION
The timeline size was resetting to the default size when full screened, so moved the timeline states to replay context to keep size consistent. The default size has also been changed to 1x, with the largest size being the amount of minutes a replay is

Relates to https://github.com/getsentry/team-replay/issues/199
Closes https://github.com/getsentry/sentry/issues/59005
