### PR TITLE
fix(browser-starfish): misc fixes on resource module

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceInfo.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceInfo.tsx
@@ -1,3 +1,6 @@
+import {Fragment} from 'react';
+
+import Alert from 'sentry/components/alert';
 import FileSize from 'sentry/components/fileSize';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
@@ -53,30 +56,42 @@ function ResourceInfo(props: Props) {
     ),
   };
 
+  const hasNoData =
+    avgContentLength === 0 && avgDecodedContentLength === 0 && avgTransferSize === 0;
+
   return (
-    <BlockContainer>
-      <Block title={t('Avg encoded size')}>
-        <Tooltip isHoverable title={tooltips.avgContentLength} showUnderline>
-          <FileSize bytes={avgContentLength} />
-        </Tooltip>
-      </Block>
-      <Block title={t('Avg decoded size')}>
-        <Tooltip isHoverable title={tooltips.avgDecodedContentLength} showUnderline>
-          <FileSize bytes={avgDecodedContentLength} />
-        </Tooltip>
-      </Block>
-      <Block title={t('Avg transfer size')}>
-        <Tooltip isHoverable title={tooltips.avgTransferSize} showUnderline>
-          <FileSize bytes={avgTransferSize} />
-        </Tooltip>
-      </Block>
-      <Block title={DataTitles.avg}>
-        <DurationCell milliseconds={avgDuration} />
-      </Block>
-      <Block title={getThroughputTitle('http')}>
-        <ThroughputCell rate={throughput * 60} unit={RateUnits.PER_SECOND} />
-      </Block>
-    </BlockContainer>
+    <Fragment>
+      <BlockContainer>
+        <Block title={t('Avg encoded size')}>
+          <Tooltip isHoverable title={tooltips.avgContentLength} showUnderline>
+            <FileSize bytes={avgContentLength} />
+          </Tooltip>
+        </Block>
+        <Block title={t('Avg decoded size')}>
+          <Tooltip isHoverable title={tooltips.avgDecodedContentLength} showUnderline>
+            <FileSize bytes={avgDecodedContentLength} />
+          </Tooltip>
+        </Block>
+        <Block title={t('Avg transfer size')}>
+          <Tooltip isHoverable title={tooltips.avgTransferSize} showUnderline>
+            <FileSize bytes={avgTransferSize} />
+          </Tooltip>
+        </Block>
+        <Block title={DataTitles.avg}>
+          <DurationCell milliseconds={avgDuration} />
+        </Block>
+        <Block title={getThroughputTitle('http')}>
+          <ThroughputCell rate={throughput * 60} unit={RateUnits.PER_SECOND} />
+        </Block>
+      </BlockContainer>
+      {hasNoData && (
+        <Alert style={{width: '100%'}} type="warning" showIcon>
+          {t(
+            "We couldn't find any size information for this resource, this is likely because the `allow-timing-origin` header is not set"
+          )}
+        </Alert>
+      )}
+    </Fragment>
   );
 }
 

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import {Link} from 'react-router';
 
+import FileSize from 'sentry/components/fileSize';
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
   GridColumnHeader,
@@ -56,6 +57,9 @@ function ResourceSummaryTable() {
     }
     if (key === 'avg(span.self_time)') {
       return <DurationCell milliseconds={row[key]} />;
+    }
+    if (key === 'avg(http.response_content_length)') {
+      return <FileSize bytes={row[key]} />;
     }
     if (key === 'transaction') {
       return (

--- a/static/app/views/performance/browser/resources/utils/useResourceSummarySort.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceSummarySort.ts
@@ -28,7 +28,7 @@ export function useResourceSummarySort(
 
 const DEFAULT_SORT: Sort = {
   kind: 'desc',
-  field: SORTABLE_FIELDS[0],
+  field: SORTABLE_FIELDS[1],
 };
 
 function isAValidSort(sort: Sort): sort is ValidSort {


### PR DESCRIPTION
1. Ensure resource summary table uses the file size component so that sizes are formatted properly.
2. Adds a CTA if all the size information is 0.
![image](https://github.com/getsentry/sentry/assets/44422760/797c3eee-4008-4523-a71d-7dcb81456218)
3. Sets the default sort to throughput in the resource summary page (that way, its consistent with the resource page.