### PR TITLE
ref(source-map-debugger): Change wording and visibility

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -668,7 +668,6 @@ const SourceMapDebuggerButtonText = styled('span')`
 `;
 
 const SourceMapDebuggerModalButton = styled(Button)`
-  font-weight: normal;
   height: 20px;
   padding: 0 ${space(0.75)};
   font-size: ${p => p.theme.fontSizeSmall};

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -15,7 +15,7 @@ import {getThreadById} from 'sentry/components/events/interfaces/utils';
 import StrictClick from 'sentry/components/strictClick';
 import Tag from 'sentry/components/tag';
 import {SLOW_TOOLTIP_DELAY} from 'sentry/constants';
-import {IconChevron, IconOpen, IconRefresh} from 'sentry/icons';
+import {IconChevron, IconFix, IconRefresh} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import DebugMetaStore from 'sentry/stores/debugMetaStore';
 import {space} from 'sentry/styles/space';
@@ -375,7 +375,7 @@ export class DeprecatedLine extends Component<Props, State> {
               <Fragment>
                 <SourceMapDebuggerModalButton
                   size="zero"
-                  priority="primary"
+                  priority="default"
                   title={t(
                     'Click to learn how to show the original source code for this stack frame.'
                   )}
@@ -408,12 +408,10 @@ export class DeprecatedLine extends Component<Props, State> {
                     );
                   }}
                 >
+                  <IconFix size="xs" />
                   <SourceMapDebuggerButtonText>
-                    {hasContextSource(data)
-                      ? t('Not your source code?')
-                      : t('No source code?')}
+                    {t('Unminify Code')}
                   </SourceMapDebuggerButtonText>
-                  <IconOpen size="xs" />
                 </SourceMapDebuggerModalButton>
               </Fragment>
             ) : null}
@@ -666,7 +664,7 @@ const ToggleButton = styled(Button)`
 `;
 
 const SourceMapDebuggerButtonText = styled('span')`
-  margin-right: ${space(0.5)};
+  margin-left: ${space(0.5)};
 `;
 
 const SourceMapDebuggerModalButton = styled(Button)`


### PR DESCRIPTION
To end the bikeshedding on this delightful UI element once and for all, we will settle on the subtle default button variant with simple but expressive wording choice and a beautiful spanner icon.

![Screenshot 2023-10-30 at 17 23 49](https://github.com/getsentry/sentry/assets/8118419/d90de1cd-b075-42c7-83fb-9cf1a0a88716)

![Screenshot 2023-10-30 at 17 24 42](https://github.com/getsentry/sentry/assets/8118419/f9efbbf7-c203-4ae4-bdec-b0ca9158e361)

