### PR TITLE
fix(stat-detectors): Hide Open in Discover for regressions

### DIFF
--- a/static/app/utils/issueTypeConfig/index.tsx
+++ b/static/app/utils/issueTypeConfig/index.tsx
@@ -33,6 +33,7 @@ const BASE_CONFIG: IssueTypeConfig = {
   similarIssues: {enabled: false},
   tags: {enabled: true},
   userFeedback: {enabled: false},
+  discover: {enabled: true},
   evidence: {title: t('Evidence')},
   resources: null,
   usesIssuePlatform: true,

--- a/static/app/utils/issueTypeConfig/performanceConfig.tsx
+++ b/static/app/utils/issueTypeConfig/performanceConfig.tsx
@@ -191,6 +191,7 @@ const performanceConfig: IssueCategoryConfigMapping = {
     stats: {enabled: false},
     tags: {enabled: false},
     replays: {enabled: false},
+    discover: {enabled: false},
   },
   [IssueType.PROFILE_FILE_IO_MAIN_THREAD]: {
     resources: {
@@ -281,6 +282,7 @@ const performanceConfig: IssueCategoryConfigMapping = {
     replays: {enabled: false},
     stats: {enabled: false},
     tags: {enabled: false},
+    discover: {enabled: false},
   },
 };
 

--- a/static/app/utils/issueTypeConfig/types.tsx
+++ b/static/app/utils/issueTypeConfig/types.tsx
@@ -26,6 +26,10 @@ export type IssueTypeConfig = {
    */
   attachments: DisabledWithReasonConfig;
   /**
+   * Is the "Open in Discover" button available for this issue
+   */
+  discover: DisabledWithReasonConfig;
+  /**
    * Is the Events tab show for this issue
    */
   events: DisabledWithReasonConfig;

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -94,10 +94,9 @@ export function Actions(props: Props) {
   const hasDeleteAccess = organization.access.includes('event:admin');
 
   const {
-    delete: deleteCap,
-    deleteAndDiscard: deleteDiscardCap,
-    share: shareCap,
-  } = getConfigForIssueType(group).actions;
+    actions: {delete: deleteCap, deleteAndDiscard: deleteDiscardCap, share: shareCap},
+    discover: discoverCap,
+  } = getConfigForIssueType(group);
 
   const getDiscoverUrl = () => {
     const {title, type, shortId} = group;
@@ -470,21 +469,23 @@ export function Actions(props: Props) {
       <div className="hidden-xs">
         <EnvironmentPageFilter position="bottom-end" size="sm" />
       </div>
-      <Feature
-        hookName="feature-disabled:open-in-discover"
-        features={['discover-basic']}
-        organization={organization}
-      >
-        <ActionButton
-          className="hidden-xs"
-          disabled={disabled}
-          to={disabled ? '' : getDiscoverUrl()}
-          onClick={() => trackIssueAction('open_in_discover')}
-          size="sm"
+      {discoverCap.enabled && (
+        <Feature
+          hookName="feature-disabled:open-in-discover"
+          features={['discover-basic']}
+          organization={organization}
         >
-          <GuideAnchor target="open_in_discover">{t('Open in Discover')}</GuideAnchor>
-        </ActionButton>
-      </Feature>
+          <ActionButton
+            className="hidden-xs"
+            disabled={disabled}
+            to={disabled ? '' : getDiscoverUrl()}
+            onClick={() => trackIssueAction('open_in_discover')}
+            size="sm"
+          >
+            <GuideAnchor target="open_in_discover">{t('Open in Discover')}</GuideAnchor>
+          </ActionButton>
+        </Feature>
+      )}
       {isResolved || isIgnored ? (
         <ActionButton
           priority="primary"


### PR DESCRIPTION
Hide the Open in Discover button for regression issues because function data aren't visible in Discover and there isn't an appropriate way to compare and contrast the events in a transaction flow from the regression issue.