### PR TITLE
feat(starfish-web-vitals): Smaller ui iterations.

### DIFF
--- a/static/app/views/performance/browser/webVitals/components/pageOverviewFeaturedTagsList.tsx
+++ b/static/app/views/performance/browser/webVitals/components/pageOverviewFeaturedTagsList.tsx
@@ -52,13 +52,7 @@ export function PageOverviewFeaturedTagsList({transaction, tag, title, onClick}:
       <Title>{title ?? tag}</Title>
       <TagValuesContainer>
         {sortedTagValues.map((row, index) => {
-          const score = calculatePerformanceScore({
-            lcp: row['p75(measurements.lcp)'] as number,
-            fcp: row['p75(measurements.fcp)'] as number,
-            cls: row['p75(measurements.cls)'] as number,
-            ttfb: row['p75(measurements.ttfb)'] as number,
-            fid: row['p75(measurements.fid)'] as number,
-          });
+          const score = getPerformanceTotalScore(row);
           return (
             <RowContainer key={`${tag}:${index}`}>
               <TagValue>
@@ -70,7 +64,7 @@ export function PageOverviewFeaturedTagsList({transaction, tag, title, onClick}:
                 </TagButton>
               </TagValue>
               <Score>
-                <PerformanceBadge score={score.totalScore} />
+                <PerformanceBadge score={score} />
               </Score>
             </RowContainer>
           );

--- a/static/app/views/performance/browser/webVitals/components/pageOverviewFeaturedTagsList.tsx
+++ b/static/app/views/performance/browser/webVitals/components/pageOverviewFeaturedTagsList.tsx
@@ -4,6 +4,7 @@ import {Button} from 'sentry/components/button';
 import {COUNTRY_CODE_TO_NAME_MAP} from 'sentry/data/countryCodesMap';
 import {space} from 'sentry/styles/space';
 import {Tag} from 'sentry/types';
+import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import {PerformanceBadge} from 'sentry/views/performance/browser/webVitals/components/performanceBadge';
 import {calculatePerformanceScore} from 'sentry/views/performance/browser/webVitals/utils/calculatePerformanceScore';
 import {useSlowestTagValuesQuery} from 'sentry/views/performance/browser/webVitals/utils/useSlowestTagValuesQuery';
@@ -15,7 +16,7 @@ type Props = {
   title?: string;
 };
 
-const LIMIT = 4;
+const LIMIT = 10;
 
 function toReadableValue(tag, tagValue) {
   if (tag === 'geo.country_code') {
@@ -25,14 +26,32 @@ function toReadableValue(tag, tagValue) {
   return tagValue;
 }
 
+function getPerformanceTotalScore(row: TableDataRow): number {
+  const score = calculatePerformanceScore({
+    lcp: row['p75(measurements.lcp)'] as number,
+    fcp: row['p75(measurements.fcp)'] as number,
+    cls: row['p75(measurements.cls)'] as number,
+    ttfb: row['p75(measurements.ttfb)'] as number,
+    fid: row['p75(measurements.fid)'] as number,
+  });
+
+  return score.totalScore;
+}
+
 export function PageOverviewFeaturedTagsList({transaction, tag, title, onClick}: Props) {
   const {data} = useSlowestTagValuesQuery({transaction, tag, limit: LIMIT});
   const tagValues = data?.data ?? [];
+
+  // Sort the tag values in asc order of total performance score
+  const sortedTagValues = tagValues.sort(
+    (a, b) => getPerformanceTotalScore(a) - getPerformanceTotalScore(b)
+  );
+
   return (
     <Container>
       <Title>{title ?? tag}</Title>
       <TagValuesContainer>
-        {tagValues.map((row, index) => {
+        {sortedTagValues.map((row, index) => {
           const score = calculatePerformanceScore({
             lcp: row['p75(measurements.lcp)'] as number,
             fcp: row['p75(measurements.fcp)'] as number,

--- a/static/app/views/performance/browser/webVitals/components/webVitalDescription.tsx
+++ b/static/app/views/performance/browser/webVitals/components/webVitalDescription.tsx
@@ -56,7 +56,7 @@ type WebVitalDetailHeaderProps = {
   isProjectScoreCalculated: boolean;
   projectScore: ProjectScore;
   tag: Tag;
-  value: string;
+  value: React.ReactNode;
 };
 
 export function WebVitalDetailHeader({score, value, webVital}: Props) {

--- a/static/app/views/performance/browser/webVitals/pageOverWebVitalsTagDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverWebVitalsTagDetailPanel.tsx
@@ -11,7 +11,10 @@ import GridEditable, {
   GridColumnOrder,
   GridColumnSortBy,
 } from 'sentry/components/gridEditable';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {Tag} from 'sentry/types';
 import {EChartClickHandler, EChartHighlightHandler, Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
@@ -275,13 +278,32 @@ export function PageOverviewWebVitalsTagDetailPanel({
   const chartIsLoading =
     chartSeriesDataIsLoading || isSamplesTabledDataLoading || isRefetching;
 
+  const p75TransactionDuration = projectData?.data[0][`p75(transaction.duration)`];
+  const subTitle = p75TransactionDuration ? (
+    <SubtitleWrapper>
+      <span>{getDuration((p75TransactionDuration as number) / 1000, 2, true)}</span>
+      <QuestionTooltip
+        title={t(
+          `The p75(transaction.duration) of the route with %s as %s`,
+          tag?.key,
+          tag?.name
+        )}
+        size="xs"
+      />
+    </SubtitleWrapper>
+  ) : (
+    <LoadingIndicatorWrapper>
+      <LoadingIndicator mini />
+    </LoadingIndicatorWrapper>
+  );
+
   return (
     <PageErrorProvider>
       {tag && (
         <DetailPanel detailKey={tag?.key} onClose={onClose}>
           <Fragment>
             <WebVitalTagsDetailHeader
-              value="TBD"
+              value={subTitle}
               tag={tag}
               projectScore={projectScore}
               isProjectScoreCalculated={!projectDataLoading}
@@ -338,4 +360,16 @@ const NoOverflow = styled('span')`
 const AlignCenter = styled('span')`
   text-align: center;
   width: 100%;
+`;
+
+const SubtitleWrapper = styled('span')`
+  display: flex;
+  align-items: flex-start;
+  gap: ${space(0.5)};
+`;
+
+const LoadingIndicatorWrapper = styled('span')`
+  .loading.mini {
+    margin: 10px ${space(0.5)};
+  }
 `;

--- a/static/app/views/performance/browser/webVitals/pageOverview.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverview.tsx
@@ -33,6 +33,9 @@ import {WebVitals} from 'sentry/views/performance/browser/webVitals/utils/types'
 import {useProjectWebVitalsQuery} from 'sentry/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
 
+import {transactionSummaryRouteWithQuery} from '../../transactionSummary/utils';
+import {getProjectID} from '../../utils';
+
 import {PageOverviewWebVitalsTagDetailPanel} from './pageOverWebVitalsTagDetailPanel';
 
 export enum LandingDisplayField {
@@ -93,6 +96,16 @@ export default function PageOverview() {
     return null;
   }
 
+  const transactionSummaryTarget =
+    pageData?.data[0].project &&
+    transaction &&
+    transactionSummaryRouteWithQuery({
+      orgSlug: organization.slug,
+      transaction,
+      query: {...location.query},
+      projectID: getProjectID(pageData?.data[0] ?? {}, projects),
+    });
+
   const projectScore = isLoading
     ? undefined
     : calculatePerformanceScore({
@@ -142,7 +155,13 @@ export default function PageOverview() {
               <FeatureBadge type="alpha" />
             </Layout.Title>
           </Layout.HeaderContent>
-          <Layout.HeaderActions />
+          <Layout.HeaderActions>
+            {transactionSummaryTarget && (
+              <LinkButton to={transactionSummaryTarget} size="sm">
+                {t('View Transaction Summary')}
+              </LinkButton>
+            )}
+          </Layout.HeaderActions>
           <TabList hideBorder>
             {LANDING_DISPLAYS.map(({label, field}) => (
               <TabList.Item key={field}>{label}</TabList.Item>

--- a/static/app/views/performance/browser/webVitals/pageOverview.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverview.tsx
@@ -34,7 +34,6 @@ import {useProjectWebVitalsQuery} from 'sentry/views/performance/browser/webVita
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
 
 import {transactionSummaryRouteWithQuery} from '../../transactionSummary/utils';
-import {getProjectID} from '../../utils';
 
 import {PageOverviewWebVitalsTagDetailPanel} from './pageOverWebVitalsTagDetailPanel';
 
@@ -97,13 +96,14 @@ export default function PageOverview() {
   }
 
   const transactionSummaryTarget =
-    pageData?.data[0].project &&
+    project &&
+    !Array.isArray(location.query.project) && // Only navigate to transaction summary when one project is selected.
     transaction &&
     transactionSummaryRouteWithQuery({
       orgSlug: organization.slug,
       transaction,
       query: {...location.query},
-      projectID: getProjectID(pageData?.data[0] ?? {}, projects),
+      projectID: project.id,
     });
 
   const projectScore = isLoading

--- a/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery.tsx
@@ -29,7 +29,6 @@ export const useProjectWebVitalsQuery = ({transaction, tag}: Props = {}) => {
         'failure_count()',
         'p95(transaction.duration)',
         'eps()',
-        'project',
       ],
       name: 'Web Vitals',
       query:

--- a/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery.tsx
@@ -24,10 +24,12 @@ export const useProjectWebVitalsQuery = ({transaction, tag}: Props = {}) => {
         'p75(measurements.cls)',
         'p75(measurements.ttfb)',
         'p75(measurements.fid)',
+        'p75(transaction.duration)',
         'count()',
         'failure_count()',
         'p95(transaction.duration)',
         'eps()',
+        'project',
       ],
       name: 'Web Vitals',
       query:

--- a/static/app/views/performance/browser/webVitals/utils/useSlowestTagValuesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/useSlowestTagValuesQuery.tsx
@@ -30,7 +30,8 @@ export const useSlowestTagValuesQuery = ({tag, transaction, limit}: Props) => {
       ],
       name: 'Web Vitals',
       query:
-        'transaction.op:pageload' + (transaction ? ` transaction:"${transaction}"` : ''),
+        `transaction.op:pageload has:${tag}` +
+        (transaction ? ` transaction:"${transaction}"` : ''),
       version: 2,
       dataset: DiscoverDatasets.METRICS,
       // We don't have performance scores yet, so sort by lcp for now as an estimate


### PR DESCRIPTION
This pr completes ui tasks from the list: [link](https://www.notion.so/sentry/Web-Vitals-Module-TODO-List-0804a4f318454ac2b98611e0d94a7c7d)

- Adds p75 duration to web vital > tag > detail panel subtitle :
<img width="433" alt="Screenshot 2023-10-30 at 2 15 46 PM" src="https://github.com/getsentry/sentry/assets/60121741/cf469ed3-5975-416a-ab54-6e936879c559">

- Sorts tag list by performance score and increased limit to 10 rows:
<img width="450" alt="Screenshot 2023-10-30 at 2 16 47 PM" src="https://github.com/getsentry/sentry/assets/60121741/ca20fc51-7eaa-4ec6-84ab-7508786d6c44">

- Prevents getting empty tag values:
<img width="305" alt="Screenshot 2023-10-30 at 3 29 06 PM" src="https://github.com/getsentry/sentry/assets/60121741/c10d545c-bad3-451a-a56c-f1893c7c5206">

- Added a View transaction button to web vital > page overview header. 

