### PR TITLE
fix(browser-starfish): resource size not being populated resource summary

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
@@ -7,6 +7,7 @@ import GridEditable, {
   GridColumnHeader,
   GridColumnOrder,
 } from 'sentry/components/gridEditable';
+import Pagination from 'sentry/components/pagination';
 import {RateUnits} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
@@ -29,7 +30,7 @@ function ResourceSummaryTable() {
   const location = useLocation();
   const {groupId} = useParams();
   const sort = useResourceSummarySort();
-  const {data, isLoading} = useResourcePagesQuery(groupId, {sort});
+  const {data, isLoading, pageLinks} = useResourcePagesQuery(groupId, {sort});
 
   const columnOrder: GridColumnOrder<keyof Row>[] = [
     {key: 'transaction', width: COL_WIDTH_UNDEFINED, name: 'Found on page'},
@@ -102,6 +103,7 @@ function ResourceSummaryTable() {
         }}
         location={location}
       />
+      <Pagination pageLinks={pageLinks} />
     </Fragment>
   );
 }

--- a/static/app/views/performance/browser/resources/utils/useResourceSummarySort.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceSummarySort.ts
@@ -1,13 +1,20 @@
 import {fromSorts} from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
+
+const {HTTP_RESPONSE_CONTENT_LENGTH, SPAN_SELF_TIME} = SpanMetricsField;
 
 type Query = {
   sort?: string;
 };
 
-const SORTABLE_FIELDS = ['avg(span.self_time)', 'spm()'] as const;
+const SORTABLE_FIELDS = [
+  `avg(${SPAN_SELF_TIME})`,
+  'spm()',
+  `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
+] as const;
 
 export type ValidSort = Sort & {
   field: (typeof SORTABLE_FIELDS)[number];

--- a/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanTransactionMetrics.tsx
@@ -20,7 +20,6 @@ export type SpanTransactionMetrics = {
   'time_spent_percentage()': number;
   transaction: string;
   'transaction.method': string;
-  'transaction.op': string;
 };
 
 export const useSpanTransactionMetrics = (
@@ -76,7 +75,6 @@ function getEventView(
         `sum(${SPAN_SELF_TIME})`,
         `avg(${SPAN_SELF_TIME})`,
         'time_spent_percentage()',
-        'transaction.op',
         'http_error_count()',
         ...extraFields,
       ],


### PR DESCRIPTION
1. Fixes the resources summary avg size column not being populated, this was because we were grouping by transaction.op. I removed this grouping. This does touch db module, but it shouldn't require transaction.op now that we aren't filtering out non http transactions. 

2. Misc fixes to resources summary table, allow sorting by size and pagination