### PR TITLE
feat(provisioning): Default team RPC

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -20,7 +20,7 @@ from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.outbox import ControlOutbox, OutboxCategory, OutboxScope, outbox_context
 from sentry.models.scheduledeletion import RegionScheduledDeletion
-from sentry.models.team import Team
+from sentry.models.team import Team, TeamStatus
 from sentry.services.hybrid_cloud import OptionValue, logger
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.services.hybrid_cloud.organization import (
@@ -367,6 +367,21 @@ class DatabaseBackedOrganizationService(OrganizationService):
         # It might be nice to return an RpcTeamMember to represent what we just
         # created, but doing so would require a list of project IDs. We can implement
         # that if a return value is needed in the future.
+
+    def get_or_create_default_team(
+        self,
+        *,
+        organization_id: int,
+        new_team_slug: str,
+    ) -> RpcTeam:
+        team_query = Team.objects.filter(
+            organization_id=organization_id, status=TeamStatus.ACTIVE
+        ).order_by("date_added")
+        if team_query.exists():
+            team = team_query[0]
+        else:
+            team = Team.objects.create(organization_id=organization_id, slug=new_team_slug)
+        return serialize_rpc_team(team)
 
     def get_or_create_team_member(
         self,

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -241,6 +241,16 @@ class OrganizationService(RpcService):
     ) -> None:
         pass
 
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def get_or_create_default_team(
+        self,
+        *,
+        organization_id: int,
+        new_team_slug: str,
+    ) -> RpcTeam:
+        pass
+
     @regional_rpc_method(resolve=UnimplementedRegionResolution("organization", "get_team_members"))
     @abstractmethod
     def get_team_members(self, *, team_id: int) -> Iterable[RpcOrganizationMember]:

--- a/tests/sentry/hybrid_cloud/test_team.py
+++ b/tests/sentry/hybrid_cloud/test_team.py
@@ -1,4 +1,5 @@
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
+from sentry.models.team import Team, TeamStatus
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.testutils.factories import Factories
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -32,3 +33,33 @@ def test_get_or_create_team_member():
     member_query = OrganizationMemberTeam.objects.all()
     assert member_query.count() == 1
     assert member_query[0].role == "admin"
+
+
+@django_db_all(transaction=True)
+@region_silo_test(stable=True)
+def test_get_or_create_default_team():
+    org = Factories.create_organization()
+    Factories.create_organization()
+    team = Factories.create_team(org)
+    team.update(status=TeamStatus.PENDING_DELETION)
+    assert Team.objects.all().count() == 1
+
+    rpc_team = organization_service.get_or_create_default_team(
+        organization_id=org.id,
+        new_team_slug="test-team",
+    )
+    # There are two teams but only one is ACTIVE
+    assert rpc_team.slug == "test-team"
+    assert Team.objects.all().count() == 2
+
+    # Creating another team to make sure the first one is always returned
+    Factories.create_team(org)
+    assert Team.objects.all().count() == 3
+
+    rpc_team = organization_service.get_or_create_default_team(
+        organization_id=org.id,
+        new_team_slug="test-another-team",
+    )
+    # Default team exists so not creating a new team
+    assert rpc_team.slug == "test-team"
+    assert Team.objects.all().count() == 3


### PR DESCRIPTION
Making provisioning API control silo safe by calling RPC for region silo objects. 

Previous PR:
Team member

This PR:
Default team
