### PR TITLE
fix(integrations): Skip check if default is empty array

### DIFF
--- a/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
@@ -41,7 +41,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
     expect(closeModal).toHaveBeenCalledTimes(0);
   };
 
-  const addMockConfigsAPICall = (otherFields = {}) => {
+  const addMockConfigsAPICall = (otherField = {}) => {
     return MockApiClient.addMockResponse({
       url: '/organizations/org-slug/integrations/1/?ignored=Sprint',
       method: 'GET',
@@ -71,21 +71,24 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
             updatesForm: true,
             required: true,
           },
-          otherFields,
+          otherField,
         ],
       },
     });
   };
 
-  const renderComponent = (props: Partial<IssueAlertRuleAction> = {}) => {
-    const {organization, routerContext} = initializeOrg();
-    addMockConfigsAPICall({
+  const renderComponent = (
+    props: Partial<IssueAlertRuleAction> = {},
+    otherField = {
       label: 'Reporter',
       required: true,
       choices: [['a', 'a']],
       type: 'select',
       name: 'reporter',
-    });
+    }
+  ) => {
+    const {organization, routerContext} = initializeOrg();
+    addMockConfigsAPICall(otherField);
 
     const body = styled(c => c.children);
     return render(
@@ -144,6 +147,23 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
       await selectEvent.select(screen.getByRole('textbox', {name: 'Assignee'}), 'b');
 
       await submitSuccess();
+    });
+
+    it('should ignore error checking when default is empty array', function () {
+      renderComponent({
+        otherField: {
+          label: 'Labels',
+          required: false,
+          choices: [['bug', `bug`]],
+          default: [],
+          type: 'select',
+          multiple: true,
+          name: 'labels',
+        },
+      });
+      expect(
+        screen.queryAllByText(`Could not fetch saved option for Labels. Please reselect.`)
+      ).toHaveLength(0);
     });
 
     it('should persist values when the modal is reopened', async function () {

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -185,7 +185,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
       if (
         field.type === 'select' &&
         field.default &&
-        (!Array.isArray(field.default) || field.default.length > 0)
+        !(Array.isArray(field.default) && !field.default.length)
       ) {
         const fieldChoices = (field.choices || []) as Choices;
         const found = fieldChoices.find(([value, _]) =>

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -179,7 +179,14 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
   getErrors() {
     const errors: ExternalIssueFormErrors = {};
     for (const field of this.cleanFields()) {
-      if (field.type === 'select' && field.default) {
+      // If the field is a select and has a default value, make sure that the
+      // default value exists in the choices. Skip check if the default is not
+      // set, an empty string, or an empty array.
+      if (
+        field.type === 'select' &&
+        field.default &&
+        (!Array.isArray(field.default) || field.default.length > 0)
+      ) {
         const fieldChoices = (field.choices || []) as Choices;
         const found = fieldChoices.find(([value, _]) =>
           Array.isArray(field.default)


### PR DESCRIPTION
For ticket action fields, we a check to see if the default value is in the list of choices. We normally avoid this check by setting the default to an empty string.

For the GitHub action however, we need to set the default value to an array. This ends up triggering the check as all arrays are truth-y. This fix allows us to pass the default array without triggering the check so the user doesn't see the error below when opening the modal.

### Error when opening modal
<img width="608" alt="Screenshot 2023-10-30 at 11 48 33 AM" src="https://github.com/getsentry/sentry/assets/67301797/f6f4c05d-16e3-45d0-9888-8ade8282130c">
