### PR TITLE
fix(replays): Add check for PII scrubbed replay-id tag

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -873,7 +873,8 @@ def process_replay_link(job: PostProcessJob) -> None:
         # TODO: normalize this upstream in relay and javascript SDK. and eventually remove the tag
         # logic.
 
-        return get_path(event.data, "contexts", "replay", "replay_id") or event.get_tag("replayId")
+        context_replay_id = get_path(event.data, "contexts", "replay", "replay_id")
+        return context_replay_id or event.get_tag("replayId")
 
     if job["is_reprocessed"]:
         return

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -873,7 +873,16 @@ def process_replay_link(job: PostProcessJob) -> None:
         # logic.
 
         context_replay_id = get_path(event.data, "contexts", "replay", "replay_id")
-        return context_replay_id or event.get_tag("replayId")
+        if context_replay_id:
+            return context_replay_id
+
+        # Note: replay ids found in the tags are vulnerable to PII scrubbing. We check for the `*`
+        # character before returning the id.
+        tag_replay_id = event.get_tag("replayId")
+        if tag_replay_id and "*" not in tag_replay_id:
+            return tag_replay_id
+
+        return None
 
     if job["is_reprocessed"]:
         return

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -889,6 +889,8 @@ def process_replay_link(job: PostProcessJob) -> None:
 
     group_event = job["event"]
     replay_id = _get_replay_id(group_event)
+    if not replay_id:
+        return
 
     # Validate the UUID.
     try:

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1789,6 +1789,61 @@ class ReplayLinkageTestMixin(BasePostProgressGroupMixin):
             incr.assert_any_call("post_process.process_replay_link.id_sampled")
             incr.assert_any_call("post_process.process_replay_link.id_exists")
 
+    def test_replay_linkage_with_tag(self, incr, kafka_producer, kafka_publisher):
+        replay_id = uuid.uuid4().hex
+        event = self.create_event(
+            data={"message": "testing", "tags": {"replayId": replay_id}},
+            project_id=self.project.id,
+        )
+
+        with self.feature({"organizations:session-replay-event-linking": True}):
+            self.call_post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                event=event,
+            )
+            assert kafka_producer.return_value.publish.call_count == 1
+            assert kafka_producer.return_value.publish.call_args[0][0] == "ingest-replay-events"
+
+            ret_value = json.loads(kafka_producer.return_value.publish.call_args[0][1])
+
+            assert ret_value["type"] == "replay_event"
+            assert ret_value["start_time"]
+            assert ret_value["replay_id"] == replay_id
+            assert ret_value["project_id"] == self.project.id
+            assert ret_value["segment_id"] is None
+            assert ret_value["retention_days"] == 90
+
+            # convert ret_value_payload which is a list of bytes to a string
+            ret_value_payload = json.loads(bytes(ret_value["payload"]).decode("utf-8"))
+
+            assert ret_value_payload == {
+                "type": "event_link",
+                "replay_id": replay_id,
+                "error_id": event.event_id,
+                "timestamp": int(event.datetime.timestamp()),
+                "event_hash": str(uuid.UUID(md5((event.event_id).encode("utf-8")).hexdigest())),
+            }
+
+            incr.assert_any_call("post_process.process_replay_link.id_sampled")
+            incr.assert_any_call("post_process.process_replay_link.id_exists")
+
+    def test_replay_linkage_with_tag_pii_scrubbed(self, incr, kafka_producer, kafka_publisher):
+        event = self.create_event(
+            data={"message": "testing", "tags": {"replayId": "***"}},
+            project_id=self.project.id,
+        )
+
+        with self.feature({"organizations:session-replay-event-linking": True}):
+            self.call_post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                event=event,
+            )
+            assert kafka_producer.return_value.publish.call_count == 0
+
     def test_no_replay(self, incr, kafka_producer, kafka_publisher):
         event = self.create_event(
             data={"message": "testing"},


### PR DESCRIPTION
Old SDKs will submit the replayId in the `tags`.  This leaves the `replayId` vulnerable to PII scrubbing.  We verify the UUID is valid before submitting to snuba.