### PR TITLE
fix(ui) Make triangle loader work with dark mode

### DIFF
--- a/static/app/components/loadingTriangle.tsx
+++ b/static/app/components/loadingTriangle.tsx
@@ -37,7 +37,7 @@ const CircleBackground = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  background: ${p => p.theme.white};
+  background: ${p => p.theme.surface300};
   border-radius: 50%;
 `;
 


### PR DESCRIPTION
Will now look like:

![Screenshot 2023-10-30 at 2 50 56 PM](https://github.com/getsentry/sentry/assets/24086/25b2e823-4506-4073-8fb5-d3ba938b3e31)


Fixes #58378
