### PR TITLE
feat(functions): Add cpm function for functions dataset

### DIFF
--- a/src/sentry/search/events/builder/profile_functions.py
+++ b/src/sentry/search/events/builder/profile_functions.py
@@ -49,6 +49,8 @@ class ProfileFunctionsQueryBuilder(ProfileFunctionsQueryBuilderMixin, QueryBuild
 class ProfileFunctionsTimeseriesQueryBuilder(
     ProfileFunctionsQueryBuilderMixin, TimeseriesQueryBuilder
 ):
+    function_alias_prefix = "sentry_"
+
     @property
     def time_column(self) -> SelectType:
         return Function(

--- a/src/sentry/search/events/datasets/profile_functions.py
+++ b/src/sentry/search/events/datasets/profile_functions.py
@@ -241,6 +241,11 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                     default_result_type="integer",
                 ),
                 SnQLFunction(
+                    "cpm",  # calls per minute
+                    snql_aggregate=lambda args, alias: self._resolve_cpm(args, alias),
+                    default_result_type="integer",
+                ),
+                SnQLFunction(
                     "cpm_before",
                     required_args=[TimestampArg("timestamp")],
                     snql_aggregate=lambda args, alias: self._resolve_cpm_cond(args, alias, "less"),
@@ -518,6 +523,22 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                     [args["column"]],
                 ),
                 1,
+            ],
+            alias,
+        )
+
+    def _resolve_cpm(
+        self,
+        args: Mapping[str, Union[str, Column, SelectType, int, float]],
+        alias: str | None,
+    ) -> SelectType:
+        interval = (self.builder.params.end - self.builder.params.start).total_seconds()
+
+        return Function(
+            "divide",
+            [
+                Function("countMerge", [SnQLColumn("count")]),
+                Function("divide", [interval, 60]),
             ],
             alias,
         )


### PR DESCRIPTION
We want to render the throughput for functions, so add a cpm (calls per minute) aggregation.