### PR TITLE
fix: allow FormPanel defaultValue for boolean field

### DIFF
--- a/static/app/components/forms/formPanel.tsx
+++ b/static/app/components/forms/formPanel.tsx
@@ -86,6 +86,10 @@ function FormPanel({
           }
 
           const {defaultValue: _, ...fieldWithoutDefaultValue} = field;
+          const fieldConfig =
+            field.type === 'boolean' || field.type === 'bool'
+              ? field
+              : fieldWithoutDefaultValue;
 
           // Allow the form panel disabled prop to override the fields
           // disabled prop, with fallback to the fields disabled state.
@@ -101,7 +105,7 @@ function FormPanel({
               key={field.name}
               {...otherProps}
               {...additionalFieldProps}
-              field={fieldWithoutDefaultValue}
+              field={fieldConfig}
               highlighted={otherProps.highlighted === `#${field.name}`}
             />
           );


### PR DESCRIPTION
This prevents removal of defaultValue from boolean fields in FormPanel.

In a JsonForm, the default value for boolean fields is not honored, and the value can be true when the field has not been toggled.
An example of this is the AddPolicyModal form in _admin.
This PR ensures that an untoggled boolean field will have value=defaultValue when not touched.
