### PR TITLE
feat(feedback): link to feedback page for feedback issues

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -597,13 +597,24 @@ class Group(Model):
         # Built manually in preference to django.urls.reverse,
         # because reverse has a measured performance impact.
         organization = self.organization
-        path = f"/organizations/{organization.slug}/issues/{self.id}/"
-        if event_id:
-            path += f"events/{event_id}/"
-        query = None
-        if params:
+
+        if self.issue_category == GroupCategory.FEEDBACK:
+            path = f"/organizations/{organization.slug}/feedback/"
+            slug = {"feedbackSlug": f"{self.project.slug}:{self.id}"}
+            params = {
+                **(params or {}),
+                **slug,
+            }
             query = urlencode(params)
-        return organization.absolute_url(path, query=query)
+            return organization.absolute_url(path, query=query)
+        else:
+            path = f"/organizations/{organization.slug}/issues/{self.id}/"
+            if event_id:
+                path += f"events/{event_id}/"
+            query = None
+            if params:
+                query = urlencode(params)
+            return organization.absolute_url(path, query=query)
 
     @property
     def qualified_short_id(self):

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -8,7 +8,7 @@ from django.core.cache import cache
 from django.db.models import ProtectedError
 from django.utils import timezone
 
-from sentry.issues.grouptype import ProfileFileIOGroupType
+from sentry.issues.grouptype import FeedbackGroup, ProfileFileIOGroupType
 from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.models.group import Group, GroupStatus, get_group_with_redirect
 from sentry.models.groupredirect import GroupRedirect
@@ -235,6 +235,20 @@ class GroupTest(TestCase, SnubaTestCase):
             group = self.create_group(id=group_id, project=project)
             actual = group.get_absolute_url(params)
             assert actual == expected
+
+    def test_get_absolute_url_feedback(self):
+        org_slug = "org1"
+        org = self.create_organization(slug=org_slug)
+        project = self.create_project(organization=org)
+        group_id = 23
+        params = None
+        expected = (
+            f"http://testserver/organizations/org1/feedback/?feedbackSlug={project.slug}%3A23"
+        )
+
+        group = self.create_group(id=group_id, project=project, type=FeedbackGroup.type_id)
+        actual = group.get_absolute_url(params)
+        assert actual == expected
 
     def test_get_absolute_url_event(self):
         project = self.create_project()


### PR DESCRIPTION
- If the group's category is feedback, let's link to the feedback permalink, which is a different URL than the issue link, e.g https://sentry.sentry.io/feedback/?feedbackSlug=javascript%3A4579431421