### PR TITLE
ref(replays): link mutation breadcrumb to the docs

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -88,7 +88,7 @@ function BreadcrumbItem({
         </TitleContainer>
 
         {typeof description === 'string' || isValidElement(description) ? (
-          <Description title={description} showOnlyOnOverflow>
+          <Description title={description} showOnlyOnOverflow isHoverable>
             {description}
           </Description>
         ) : (

--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -1,5 +1,6 @@
 import {ReactNode} from 'react';
 
+import ExternalLink from 'sentry/components/links/externalLink';
 import {Tooltip} from 'sentry/components/tooltip';
 import {
   IconCursorArrow,
@@ -124,13 +125,27 @@ const MAPPER_FOR_FRAME: Record<string, (frame) => Details> = {
   'replay.mutations': (frame: MutationFrame) => ({
     color: 'yellow300',
     description: frame.data.limit
-      ? t(
-          'A large number of mutations was detected (%s). Replay is now stopped to prevent poor performance for your customer.',
-          frame.data.count
+      ? tct(
+          'A large number of mutations was detected [count]. Replay is now stopped to prevent poor performance for your customer. [link]',
+          {
+            count: frame.data.count,
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/configuration/#mutation-limits">
+                {t('Read the docs.')}
+              </ExternalLink>
+            ),
+          }
         )
-      : t(
-          'A large number of mutations was detected (%s). This can slow down the Replay SDK and impact your customers.',
-          frame.data.count
+      : tct(
+          'A large number of mutations was detected [count]. This can slow down the Replay SDK and impact your customers. [link]',
+          {
+            count: frame.data.count,
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/configuration/#mutation-limits">
+                {t('Read the docs.')}
+              </ExternalLink>
+            ),
+          }
         ),
     tabKey: TabKey.BREADCRUMBS,
     title: 'Replay',

--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -131,7 +131,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame) => Details> = {
             count: frame.data.count,
             link: (
               <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/configuration/#mutation-limits">
-                {t('Read the docs.')}
+                {t('Learn more.')}
               </ExternalLink>
             ),
           }
@@ -142,7 +142,7 @@ const MAPPER_FOR_FRAME: Record<string, (frame) => Details> = {
             count: frame.data.count,
             link: (
               <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/configuration/#mutation-limits">
-                {t('Read the docs.')}
+                {t('Learn more.')}
               </ExternalLink>
             ),
           }

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -11,6 +11,7 @@ import JumpButtons from 'sentry/components/replays/jumpButtons';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import useJumpButtons from 'sentry/components/replays/useJumpButtons';
 import {t} from 'sentry/locale';
+import getFrameDetails from 'sentry/utils/replays/getFrameDetails';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import useExtractedDomNodes from 'sentry/utils/replays/hooks/useExtractedDomNodes';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -112,6 +113,12 @@ function Breadcrumbs() {
           style={style}
           expandPaths={Array.from(expandPathsRef.current?.get(index) || [])}
           onClick={() => {
+            const frameDetails = getFrameDetails(item);
+            frameDetails.title === 'Replay' &&
+              window.open(
+                'https://docs.sentry.io/platforms/javascript/session-replay/configuration/#mutation-limits',
+                '_blank'
+              );
             onClickTimestamp(item);
           }}
           onDimensionChange={handleDimensionChange}

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -11,7 +11,6 @@ import JumpButtons from 'sentry/components/replays/jumpButtons';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import useJumpButtons from 'sentry/components/replays/useJumpButtons';
 import {t} from 'sentry/locale';
-import getFrameDetails from 'sentry/utils/replays/getFrameDetails';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import useExtractedDomNodes from 'sentry/utils/replays/hooks/useExtractedDomNodes';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -113,12 +112,6 @@ function Breadcrumbs() {
           style={style}
           expandPaths={Array.from(expandPathsRef.current?.get(index) || [])}
           onClick={() => {
-            const frameDetails = getFrameDetails(item);
-            frameDetails.title === 'Replay' &&
-              window.open(
-                'https://docs.sentry.io/platforms/javascript/session-replay/configuration/#mutation-limits',
-                '_blank'
-              );
             onClickTimestamp(item);
           }}
           onDimensionChange={handleDimensionChange}


### PR DESCRIPTION
closes [#51656](https://github.com/getsentry/sentry/issues/51656)
<img width="559" alt="SCR-20231031-jpyp" src="https://github.com/getsentry/sentry/assets/56095982/c4231d6d-629b-4ec2-90c3-2945153b36b4">


