### PR TITLE
fix(ui): Set a higher min project selector width

### DIFF
--- a/static/app/components/organizations/projectPageFilter/index.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.tsx
@@ -331,11 +331,11 @@ export function ProjectPageFilter({
         0
       );
 
-    // Calculate an appropriate width for the menu. It should be between 20 (22 if
-    // there's a desynced message) and 28em. Within that range, the width is a function
-    // of the length of the longest slug. The project slugs take up to (longestSlugLength
-    // * 0.6)em of horizontal space (each character occupies roughly 0.6em). We also need
-    // to add 12em to account for padding, trailing buttons, and the checkbox.
+    // Calculate an appropriate width for the menu. It should be between 22  and 28em.
+    // Within that range, the width is a function of the length of the longest slug.
+    // The project slugs take up to (longestSlugLength * 0.6)em of horizontal space
+    // (each character occupies roughly 0.6em).
+    // We also need to add 12em to account for padding, trailing buttons, and the checkbox.
     const minWidthEm = 22;
     return `${Math.max(minWidthEm, Math.min(28, longestSlugLength * 0.6 + 12))}em`;
   }, [options]);

--- a/static/app/components/organizations/projectPageFilter/index.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.tsx
@@ -336,11 +336,9 @@ export function ProjectPageFilter({
     // of the length of the longest slug. The project slugs take up to (longestSlugLength
     // * 0.6)em of horizontal space (each character occupies roughly 0.6em). We also need
     // to add 12em to account for padding, trailing buttons, and the checkbox.
-    return `${Math.max(
-      desynced ? 22 : 20,
-      Math.min(28, longestSlugLength * 0.6 + 12)
-    )}em`;
-  }, [options, desynced]);
+    const minWidthEm = 22;
+    return `${Math.max(minWidthEm, Math.min(28, longestSlugLength * 0.6 + 12))}em`;
+  }, [options]);
 
   const [stagedValue, setStagedValue] = useState<number[]>(value);
   const selectionLimitExceeded = useMemo(() => {


### PR DESCRIPTION
We switch between 20 and 22em, just always use 22em as the minimum

prevents overflow with these buttons
![image](https://github.com/getsentry/sentry/assets/1400464/7bb7e4c5-c354-4092-ba04-256df3e08cb2)
