### PR TITLE
ref(participants): Fix user in team reassignment bug

### DIFF
--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -68,8 +68,14 @@ class GroupAssigneeManager(BaseManager):
         return (assignee_type, assignee_type_attr, other_type)
 
     def remove_old_assignees(
-        self, group: Group, previous_assignee: Optional[GroupAssignee]
+        self,
+        group: Group,
+        previous_assignee: Optional[GroupAssignee],
+        new_assignee_id: Optional[int] = None,
+        new_assignee_type: Optional[str] = None,
     ) -> None:
+        from sentry.models.team import Team
+
         if not features.has("organizations:participants-purge", group.organization):
             return
 
@@ -92,6 +98,14 @@ class GroupAssigneeManager(BaseManager):
             )
         elif previous_assignee.team:
             team_members = list(previous_assignee.team.member_set.values_list("user_id", flat=True))
+            if (
+                new_assignee_type
+                and new_assignee_type == "user"
+                and new_assignee_id in team_members
+            ):
+                for member in team_members:
+                    if member == new_assignee_id:
+                        team_members.remove(member)
             GroupSubscription.objects.filter(
                 group=group,
                 project=group.project,
@@ -103,6 +117,13 @@ class GroupAssigneeManager(BaseManager):
                 extra={"group_id": group.id, "team_id": previous_assignee.team.id},
             )
         else:
+            # if the new assignee is a team that the old assignee (a user) is in, don't remove them
+            if new_assignee_type == "team":
+                team = Team.objects.get(id=new_assignee_id)
+                team_members = list(team.member_set.values_list("user_id", flat=True))
+                if new_assignee_id in team_members:
+                    return
+
             GroupSubscription.objects.filter(
                 group=group,
                 project=group.project,
@@ -178,7 +199,7 @@ class GroupAssigneeManager(BaseManager):
                 sync_group_assignee_outbound(group, assigned_to.id, assign=True)
 
             if not created:  # aka re-assignment
-                self.remove_old_assignees(group, assignee)
+                self.remove_old_assignees(group, assignee, assigned_to_id, assignee_type)
 
         return {"new_assignment": created, "updated_assignment": bool(not created and affected)}
 

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -103,9 +103,8 @@ class GroupAssigneeManager(BaseManager):
                 and new_assignee_type == "user"
                 and new_assignee_id in team_members
             ):
-                for member in team_members:
-                    if member == new_assignee_id:
-                        team_members.remove(member)
+                team_members.remove(new_assignee_id)
+
             GroupSubscription.objects.filter(
                 group=group,
                 project=group.project,

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -121,7 +121,7 @@ class GroupAssigneeManager(BaseManager):
             if new_assignee_type == "team":
                 team = Team.objects.get(id=new_assignee_id)
                 team_members = list(team.member_set.values_list("user_id", flat=True))
-                if new_assignee_id in team_members:
+                if previous_assignee.user_id in team_members:
                     return
 
             GroupSubscription.objects.filter(

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1015,3 +1015,94 @@ class TestHandleAssignedTo(TestCase):
             assigned_by=None,
             had_to_deassign=True,
         )
+
+    @with_feature("organizations:participants-purge")
+    def test_user_in_reassigned_team(self):
+        # user to team (with user in it)
+        # team (with user in it) to user
+        user1 = self.create_user("foo@example.com")
+        user2 = self.create_user("bar@example.com")
+        team1 = self.create_team()
+        member1 = self.create_member(user=user1, organization=self.organization, role="member")
+        member2 = self.create_member(user=user2, organization=self.organization, role="member")
+        self.create_team_membership(team1, member1, role="admin")
+        self.create_team_membership(team1, member2, role="admin")
+
+        # assign the issue to the team
+        assigned_to = handle_assigned_to(
+            (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
+            None,
+            None,
+            self.group_list,
+            self.project_lookup,
+            self.user,
+        )
+
+        assert GroupAssignee.objects.filter(group=self.group, team=team1.id).exists()
+        assert GroupSubscription.objects.filter(
+            group=self.group,
+            project=self.group.project,
+            user_id=user1.id,
+            reason=GroupSubscriptionReason.assigned,
+        ).exists()
+        assert GroupSubscription.objects.filter(
+            group=self.group,
+            project=self.group.project,
+            user_id=user2.id,
+            reason=GroupSubscriptionReason.assigned,
+        ).exists()
+
+        # then assign it to user1
+        assigned_to = handle_assigned_to(
+            ActorTuple.from_actor_identifier(user1.id),
+            None,
+            None,
+            self.group_list,
+            self.project_lookup,
+            self.user,
+        )
+
+        assert GroupAssignee.objects.filter(group=self.group, user_id=user1.id).exists()
+        assert not GroupAssignee.objects.filter(group=self.group, team=team1.id).exists()
+        assert GroupSubscription.objects.filter(
+            group=self.group,
+            project=self.group.project,
+            user_id=user1.id,
+            reason=GroupSubscriptionReason.assigned,
+        ).exists()
+        assert not GroupSubscription.objects.filter(
+            group=self.group,
+            project=self.group.project,
+            user_id=user2.id,
+            reason=GroupSubscriptionReason.assigned,
+        ).exists()
+
+        assert assigned_to == {
+            "email": user1.email,
+            "id": str(user1.id),
+            "name": user1.username,
+            "type": "user",
+        }
+
+        # assign the issue back to the team
+        assigned_to = handle_assigned_to(
+            (ActorTuple.from_actor_identifier(f"team:{team1.id}")),
+            None,
+            None,
+            self.group_list,
+            self.project_lookup,
+            self.user,
+        )
+        assert GroupAssignee.objects.filter(group=self.group, team=team1.id).exists()
+        assert GroupSubscription.objects.filter(
+            group=self.group,
+            project=self.group.project,
+            user_id=user1.id,
+            reason=GroupSubscriptionReason.assigned,
+        ).exists()
+        assert GroupSubscription.objects.filter(
+            group=self.group,
+            project=self.group.project,
+            user_id=user2.id,
+            reason=GroupSubscriptionReason.assigned,
+        ).exists()

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1018,8 +1018,7 @@ class TestHandleAssignedTo(TestCase):
 
     @with_feature("organizations:participants-purge")
     def test_user_in_reassigned_team(self):
-        # user to team (with user in it)
-        # team (with user in it) to user
+        """Test that the correct participants are present when re-assigning from user to team and vice versa"""
         user1 = self.create_user("foo@example.com")
         user2 = self.create_user("bar@example.com")
         team1 = self.create_team()


### PR DESCRIPTION
Fixes a couple cases:
* If an issue is assigned to a user and then re-assigned to a team that the user is in, the user was being removed as a participant
* If an issue is assigned to a team and then re-assigned to a user (and the user is in that team), the user was being removed as a participant