### PR TITLE
fix(ui): Hide project selector upsell when there is only one project

### DIFF
--- a/static/app/components/organizations/projectPageFilter/menuFooter.tsx
+++ b/static/app/components/organizations/projectPageFilter/menuFooter.tsx
@@ -5,6 +5,7 @@ import {Button} from 'sentry/components/button';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 
 interface FeatureRenderProps {
   hasFeature: boolean;
@@ -24,6 +25,7 @@ function ProjectPageFilterMenuFooter({
   showNonMemberProjects,
 }: ProjectPageFilterMenuFooterProps) {
   const organization = useOrganization();
+  const {projects} = useProjects();
 
   return (
     <Fragment>
@@ -35,7 +37,7 @@ function ProjectPageFilterMenuFooter({
       >
         {({renderShowAllButton}: FeatureRenderProps) => {
           // if our hook is adding renderShowAllButton, render that
-          if (showNonMemberProjects && renderShowAllButton) {
+          if (showNonMemberProjects && renderShowAllButton && projects.length > 1) {
             return renderShowAllButton({
               onButtonClick: () => handleChange([]),
               canShowAllProjects: showNonMemberProjects,


### PR DESCRIPTION
hides the upsell button when there is only 0 or 1 projects in the org
