### PR TITLE
fix(profiling): disallow 0 width

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -654,7 +654,7 @@ function Flamegraph(): ReactElement {
       newView.setConfigView(
         flamegraphView.configView.withHeight(newView.configView.height),
         {
-          width: {min: 0},
+          width: {min: 1},
         }
       );
 
@@ -698,7 +698,7 @@ function Flamegraph(): ReactElement {
       newView.setConfigView(
         flamegraphView.configView.withHeight(newView.configView.height),
         {
-          width: {min: 0},
+          width: {min: 1},
         }
       );
 
@@ -742,7 +742,7 @@ function Flamegraph(): ReactElement {
       newView.setConfigView(
         flamegraphView.configView.withHeight(newView.configView.height),
         {
-          width: {min: 0},
+          width: {min: 1},
         }
       );
 
@@ -778,8 +778,9 @@ function Flamegraph(): ReactElement {
       // Initialize configView to whatever the flamegraph configView is
       newView.setConfigView(
         flamegraphView.configView.withHeight(newView.configView.height),
-        {width: {min: 0}}
+        {width: {min: 1}}
       );
+
       return newView;
     },
     [spanChart, spansCanvas, flamegraph.inverted, flamegraphView, flamegraphTheme.SIZES]

--- a/static/app/utils/profiling/spanChart.tsx
+++ b/static/app/utils/profiling/spanChart.tsx
@@ -100,6 +100,10 @@ class SpanChart {
         const start = node.span.start_timestamp - transactionStart;
         const end = start + duration;
 
+        if (duration <= 0) {
+          continue;
+        }
+
         const spanChartNode: SpanChartNode = {
           duration: this.toFinalUnit(duration),
           start: this.toFinalUnit(start),


### PR DESCRIPTION
if you are lucky, configView will serialize to 0, which ends up as Infinity and ultimately as NaN and causes the browser to go into an infinite loop as it does `while NaN < 0`. I also removed 0 duration spans as there is nothing to render anyways

Fixes #59055