### PR TITLE
feat(crons): Show environment name in checkin table

### DIFF
--- a/static/app/views/monitors/components/monitorCheckIns.tsx
+++ b/static/app/views/monitors/components/monitorCheckIns.tsx
@@ -83,6 +83,7 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
   // XXX(epurkhiser): Attachmnets are still experimental and may not exist in
   // the future. For now hide these if they're not being used.
   const hasAttachments = checkInList?.some(checkin => checkin.attachmentId !== null);
+  const hasMultiEnv = monitorEnvs.length > 1;
 
   const headers = [
     t('Status'),
@@ -90,6 +91,7 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
     t('Duration'),
     t('Issues'),
     ...(hasAttachments ? [t('Attachment')] : []),
+    ...(hasMultiEnv ? [t('Environment')] : []),
     t('Expected At'),
   ];
 
@@ -187,6 +189,7 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
                 ) : (
                   emptyCell
                 )}
+                {!hasMultiEnv ? null : <div>{checkIn.environment}</div>}
                 <div>
                   <Tooltip
                     disabled={!customTimezone}

--- a/static/app/views/monitors/types.tsx
+++ b/static/app/views/monitors/types.tsx
@@ -111,6 +111,7 @@ export interface CheckIn {
   attachmentId: number | null;
   dateCreated: string;
   duration: number;
+  environment: string;
   expectedTime: string;
   id: string;
   status: CheckInStatus;


### PR DESCRIPTION
Looks like:

<img width="921" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/6cefff60-2bf6-4f55-a509-5da76366e6fd">

Fixes: https://github.com/getsentry/team-crons/issues/111
