### PR TITLE
fix(ui): Create field flag to skip populating prior choices

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -712,7 +712,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 # allowedValues for some reason doesn't pass enough info.
                 field["choices"] = self.make_choices(client.get_priorities())
                 field["default"] = defaults.get("priority", "")
-                # Don't restore the prior priority choices upon re-rendering b/c it's dependent on the project.
+                # Don't restore the prior priority choices upon re-rendering b/c they differ by project.
                 field["ignorePriorChoices"] = True
             elif field["name"] == "fixVersions":
                 field["choices"] = self.make_choices(client.get_versions(meta["key"]))

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -712,6 +712,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 # allowedValues for some reason doesn't pass enough info.
                 field["choices"] = self.make_choices(client.get_priorities())
                 field["default"] = defaults.get("priority", "")
+                # Don't restore the prior priority choices upon re-rendering b/c it's dependent on the project.
                 field["ignorePriorChoices"] = True
             elif field["name"] == "fixVersions":
                 field["choices"] = self.make_choices(client.get_versions(meta["key"]))

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -712,6 +712,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 # allowedValues for some reason doesn't pass enough info.
                 field["choices"] = self.make_choices(client.get_priorities())
                 field["default"] = defaults.get("priority", "")
+                field["ignorePriorChoices"] = True
             elif field["name"] == "fixVersions":
                 field["choices"] = self.make_choices(client.get_versions(meta["key"]))
             elif field["name"] == "labels":

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -839,7 +839,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
                 # allowedValues for some reason doesn't pass enough info.
                 field["choices"] = self.make_choices(client.get_priorities(project_id))
                 field["default"] = defaults.get("priority", "")
-                # Don't restore the prior fixVersions choices upon re-rendering b/c it's dependent on the project.
+                # Don't restore the prior priority choices upon re-rendering b/c it's dependent on the project.
                 field["ignorePriorChoices"] = True
             elif field["name"] == "fixVersions":
                 field["choices"] = self.make_choices(client.get_versions(project_id))

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -839,7 +839,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
                 # allowedValues for some reason doesn't pass enough info.
                 field["choices"] = self.make_choices(client.get_priorities(project_id))
                 field["default"] = defaults.get("priority", "")
-                # Don't restore the prior priority choices upon re-rendering b/c it's dependent on the project.
+                # Don't restore the prior priority choices upon re-rendering b/c they differ by project.
                 field["ignorePriorChoices"] = True
             elif field["name"] == "fixVersions":
                 field["choices"] = self.make_choices(client.get_versions(project_id))

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -839,6 +839,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
                 # allowedValues for some reason doesn't pass enough info.
                 field["choices"] = self.make_choices(client.get_priorities(project_id))
                 field["default"] = defaults.get("priority", "")
+                # Don't restore the prior fixVersions choices upon re-rendering b/c it's dependent on the project.
                 field["ignorePriorChoices"] = True
             elif field["name"] == "fixVersions":
                 field["choices"] = self.make_choices(client.get_versions(project_id))

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -839,6 +839,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
                 # allowedValues for some reason doesn't pass enough info.
                 field["choices"] = self.make_choices(client.get_priorities(project_id))
                 field["default"] = defaults.get("priority", "")
+                field["ignorePriorChoices"] = True
             elif field["name"] == "fixVersions":
                 field["choices"] = self.make_choices(client.get_versions(project_id))
             elif field["name"] == "labels":

--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -311,13 +311,20 @@ export default class AbstractExternalIssueForm<
     };
   };
 
+  /**
+   * Return integrationDetails fields overridden with choices from the cache. If
+   * the field is async, this is also required in order to populate the field choices
+   * with the webhook response.
+   */
   getCleanedFields = (): IssueConfigField[] => {
     const {fetchedFieldOptionsCache, integrationDetails} = this.state;
 
     const configsFromAPI = (integrationDetails || {})[this.getConfigName()];
     return (configsFromAPI || []).map(field => {
       const fieldCopy = {...field};
-      // Overwrite choices from cache as long as the field is not set to ignorePriorChoices.
+      // If the field has `ignorePriorChoices` set to True, we don't
+      // pull from the cache. This is used for fields that should not persist
+      // upon re-rendering, usually because they are dependent on another field.
       if (
         fetchedFieldOptionsCache?.hasOwnProperty(field.name) &&
         !field.ignorePriorChoices

--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -317,8 +317,11 @@ export default class AbstractExternalIssueForm<
     const configsFromAPI = (integrationDetails || {})[this.getConfigName()];
     return (configsFromAPI || []).map(field => {
       const fieldCopy = {...field};
-      // Overwrite choices from cache.
-      if (fetchedFieldOptionsCache?.hasOwnProperty(field.name)) {
+      // Overwrite choices from cache as long as the field is not set to ignorePriorChoices.
+      if (
+        fetchedFieldOptionsCache?.hasOwnProperty(field.name) &&
+        !field.ignorePriorChoices
+      ) {
         fieldCopy.choices = fetchedFieldOptionsCache[field.name];
       }
 

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -436,7 +436,10 @@ export type IssueConfigField = Field & {
   name: string;
   choices?: Choices;
   default?: string | number | Choice;
+  // When 'ignorePriorChoices' is true, the field will not restore its previous
+  // choice when re-rendering the modal.
   ignorePriorChoices?: boolean;
+  // Allows you to choose multiple choices in a select box
   multiple?: boolean;
   url?: string;
 };

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -436,6 +436,7 @@ export type IssueConfigField = Field & {
   name: string;
   choices?: Choices;
   default?: string | number | Choice;
+  ignorePriorChoices?: boolean;
   multiple?: boolean;
   url?: string;
 };

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
@@ -79,7 +79,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
 
   const renderComponent = (
     props: Partial<IssueAlertRuleAction> = {},
-    otherField = {
+    otherField: Record<string, any> = {
       label: 'Reporter',
       required: true,
       choices: [['a', 'a']],
@@ -149,21 +149,23 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
       await submitSuccess();
     });
 
-    it('should ignore error checking when default is empty array', function () {
-      renderComponent({
-        otherField: {
-          label: 'Labels',
-          required: false,
-          choices: [['bug', `bug`]],
-          default: [],
-          type: 'select',
-          multiple: true,
-          name: 'labels',
-        },
+    it('should ignore error checking when default is empty array', async function () {
+      renderComponent(undefined, {
+        label: 'Labels',
+        required: false,
+        choices: [['bug', `bug`]],
+        default: [],
+        type: 'select',
+        multiple: true,
+        name: 'labels',
       });
       expect(
         screen.queryAllByText(`Could not fetch saved option for Labels. Please reselect.`)
       ).toHaveLength(0);
+
+      await selectEvent.select(screen.getByRole('textbox', {name: 'Issue Type'}), 'Epic');
+      await selectEvent.select(screen.getByRole('textbox', {name: 'Labels'}), 'bug');
+      await submitSuccess();
     });
 
     it('should persist values when the modal is reopened', async function () {
@@ -171,9 +173,23 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
       await submitSuccess();
     });
 
+    it('should not persist values when specified by the field', async function () {
+      renderComponent(
+        {data: {reporter: 'a'}},
+        {
+          label: 'Reporter',
+          required: true,
+          choices: [['a', 'a']],
+          type: 'select',
+          name: 'reporter',
+          ignorePriorChoices: true,
+        }
+      );
+      await submitErrors(1);
+    });
+
     it('should get async options from URL', async function () {
-      renderComponent();
-      addMockConfigsAPICall({
+      renderComponent(undefined, {
         label: 'Assignee',
         required: true,
         url: 'http://example.com',

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
@@ -173,19 +173,26 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
       await submitSuccess();
     });
 
-    it('should not persist values when specified by the field', async function () {
-      renderComponent(
-        {data: {reporter: 'a'}},
-        {
-          label: 'Reporter',
-          required: true,
-          choices: [['a', 'a']],
-          type: 'select',
-          name: 'reporter',
-          ignorePriorChoices: true,
-        }
-      );
-      await submitErrors(1);
+    it('should not persist value when specified by ignorePriorChoices', async function () {
+      renderComponent();
+      await selectEvent.select(screen.getByRole('textbox', {name: 'Reporter'}), 'a');
+
+      addMockConfigsAPICall({
+        label: 'Reporter',
+        required: true,
+        choices: [['b', 'b']],
+        type: 'select',
+        name: 'reporter',
+        ignorePriorChoices: true,
+      });
+
+      await selectEvent.select(screen.getByRole('textbox', {name: 'Issue Type'}), 'Epic');
+      await expect(
+        selectEvent.select(screen.getByRole('textbox', {name: 'Reporter'}), 'a')
+      ).rejects.toThrow();
+
+      await selectEvent.select(screen.getByRole('textbox', {name: 'Reporter'}), 'b');
+      await submitSuccess();
     });
 
     it('should get async options from URL', async function () {

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -168,7 +168,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
         .filter(field => !fields.map(f => f.name).includes(field.name))
         .map(field => {
           // Overwrite defaults from cache as long as the field is not set to ignorePriorChoices.
-          if (instance.hasOwnProperty(field.name) && !field.ignorePriorChoices) {
+          if (instance.hasOwnProperty(field.name)) {
             field.default = instance[field.name] || field.default;
           }
           return field;

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -167,8 +167,8 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
         // Skip fields if they already exist.
         .filter(field => !fields.map(f => f.name).includes(field.name))
         .map(field => {
-          // Overwrite defaults from cache.
-          if (instance.hasOwnProperty(field.name)) {
+          // Overwrite defaults from cache as long as the field is not set to ignorePriorChoices.
+          if (instance.hasOwnProperty(field.name) && !field.ignorePriorChoices) {
             field.default = instance[field.name] || field.default;
           }
           return field;

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -167,9 +167,18 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
         // Skip fields if they already exist.
         .filter(field => !fields.map(f => f.name).includes(field.name))
         .map(field => {
-          // Overwrite defaults from cache as long as the field is not set to ignorePriorChoices.
+          // Overwrite defaults from cache.
           if (instance.hasOwnProperty(field.name)) {
-            field.default = instance[field.name] || field.default;
+            // It's possible that the choices field was not restored to its
+            // prior state if the field has ignorePriorChoices set to true, so
+            // we need to check that the prior value exists in the choices.
+            if (
+              instance[field.name] &&
+              field.choices &&
+              field.choices.some(item => item[0] === instance[field.name])
+            ) {
+              field.default = instance[field.name];
+            }
           }
           return field;
         })

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -130,6 +130,7 @@ class JiraServerIntegrationTest(APITestCase):
                     "type": "select",
                     "name": "priority",
                     "default": "",
+                    "ignorePriorChoices": True,
                 },
                 {
                     "label": "Fix Version/s",
@@ -436,6 +437,7 @@ class JiraServerIntegrationTest(APITestCase):
                 "name": "priority",
                 "label": "Priority",
                 "required": False,
+                "ignorePriorChoices": True,
             }
 
     def test_get_create_issue_config_with_default_and_param(self):


### PR DESCRIPTION
Closed b/c discovered the real bugfix in https://github.com/getsentry/sentry/pull/59334

## Summary
There's a very subtle bug here which happens when you save values and exit out of the ticket action modal. For all fields, we save the previous value as well as the list of possible choices in `fetchedFieldOptionsCache`. There are fields that when changed, re-render the form such as `Project` for Jira/Jira server. Upon re-rendering, we
1. Make a new request to fetch the configuration for the project
2. For each field check if it's in the cache. If so:
    - Populate the field with it's previous selection and the previous choices. 
    - If there was no previous selection, use field's default instead that is in the fetched configuration

The video below shows the bug in action. Before saving the modal, the `Priority` field is correctly set when we switch projects. After saving the modal, the field is set to `God Priority` which doesn't exist in the selected project `IS`.

https://github.com/getsentry/sentry/assets/67301797/cf9f5ead-60c7-4cbe-b2e0-8c3d696298fc

---

## First Attempt
I considered not pulling from the cache at all after re-fetching the configuration, but this runs into two problems. 

1. There are certain fields such as `Assignee` and `Reporter` which are async fields, meaning we call a webhook as you search instead of pre-populating the field at the start with a single request. This async system sets its webhook response for the field in `fetchedFieldOptionsCache`, which then populates the field info when we pull from the cache.

When we don't pull from the cache, nothing shows up in the dropdown box when you type. You can click a name and successfully save, but it looks very strange.

https://github.com/getsentry/sentry/assets/67301797/8afc4c69-c813-41e2-85ab-68dd87d58421

---

### Final Workaround
This approach is much quicker and simpler, although it requires future maintenance. We create a flag `ignorePriorChoices` in the backend that we check on the frontend. If true, we don't pull from the cache for that value.

Because we always used to pull from the cache, the default value would be set to the prior value and be guaranteed to be in the field's choices. Now that this flag exists, we need to add a check before setting the default value


https://github.com/getsentry/sentry/assets/67301797/64d3d683-bc6f-4f34-874d-f95c5ad70a7a

