### PR TITLE
ref(sdk-crashes): Add enum for SdkName

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -31,7 +31,7 @@ from sentry.utils.locking.manager import LockManager
 from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 from sentry.utils.safe import get_path, safe_execute
 from sentry.utils.sdk import bind_organization_context, set_current_event_project
-from sentry.utils.sdk_crashes.sdk_crash_detection_config import SDKCrashDetectionConfig
+from sentry.utils.sdk_crashes.sdk_crash_detection_config import SDKCrashDetectionConfig, SdkName
 from sentry.utils.services import build_instance_from_options
 
 if TYPE_CHECKING:
@@ -1186,7 +1186,7 @@ def sdk_crash_monitoring(job: PostProcessJob):
         return None
 
     cocoa_config = SDKCrashDetectionConfig(
-        sdk_name="cocoa", project_id=cocoa_project_id, sample_rate=cocoa_sample_rate
+        sdk_name=SdkName.Cocoa, project_id=cocoa_project_id, sample_rate=cocoa_sample_rate
     )
 
     with metrics.timer("post_process.sdk_crash_monitoring.duration"):

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -10,7 +10,7 @@ from sentry.issues.grouptype import GroupCategory
 from sentry.utils.safe import get_path, set_path
 from sentry.utils.sdk_crashes.cocoa_sdk_crash_detector import CocoaSDKCrashDetector
 from sentry.utils.sdk_crashes.event_stripper import strip_event_data
-from sentry.utils.sdk_crashes.sdk_crash_detection_config import SDKCrashDetectionConfig
+from sentry.utils.sdk_crashes.sdk_crash_detection_config import SDKCrashDetectionConfig, SdkName
 from sentry.utils.sdk_crashes.sdk_crash_detector import SDKCrashDetector
 
 
@@ -37,7 +37,7 @@ class SDKCrashDetection:
     def __init__(
         self,
         sdk_crash_reporter: SDKCrashReporter,
-        sdk_crash_detectors: Mapping[str, SDKCrashDetector],
+        sdk_crash_detectors: Mapping[SdkName, SDKCrashDetector],
     ):
         """
         Initializes the SDK crash detection.
@@ -127,4 +127,4 @@ class SDKCrashDetection:
 _crash_reporter = SDKCrashReporter()
 _cocoa_sdk_crash_detector = CocoaSDKCrashDetector()
 
-sdk_crash_detection = SDKCrashDetection(_crash_reporter, {"cocoa": _cocoa_sdk_crash_detector})
+sdk_crash_detection = SDKCrashDetection(_crash_reporter, {SdkName.Cocoa: _cocoa_sdk_crash_detector})

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -1,11 +1,18 @@
+from enum import Enum, unique
+
 from typing_extensions import TypedDict
+
+
+@unique
+class SdkName(Enum):
+    Cocoa = "cocoa"
 
 
 class SDKCrashDetectionConfig(TypedDict):
     """The SDK crash detection configuration per SDK."""
 
     """The name of the SDK to detect crashes for."""
-    sdk_name: str
+    sdk_name: SdkName
     """The project to save the detected SDK crashes to"""
     project_id: int
     """The percentage of events to sample. 0.0 = 0%, 0.5 = 50% 1.0 = 100%."""

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -65,6 +65,7 @@ from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json
 from sentry.utils.cache import cache
+from sentry.utils.sdk_crashes.sdk_crash_detection_config import SdkName
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 pytestmark = [requires_snuba]
@@ -1682,7 +1683,9 @@ class SDKCrashMonitoringTestMixin(BasePostProgressGroupMixin):
 
         args = mock_sdk_crash_detection.detect_sdk_crash.call_args[-1]
         assert args["event"].project.id == event.project.id
-        assert args["configs"] == [{"sdk_name": "cocoa", "project_id": 1234, "sample_rate": 1.0}]
+        assert args["configs"] == [
+            {"sdk_name": SdkName.Cocoa, "project_id": 1234, "sample_rate": 1.0}
+        ]
 
     @with_feature("organizations:sdk-crash-detection")
     @override_options(

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -19,9 +19,9 @@ from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.safe import get_path, set_path
 from sentry.utils.sdk_crashes.sdk_crash_detection import sdk_crash_detection
-from sentry.utils.sdk_crashes.sdk_crash_detection_config import SDKCrashDetectionConfig
+from sentry.utils.sdk_crashes.sdk_crash_detection_config import SDKCrashDetectionConfig, SdkName
 
-sdk_configs = [SDKCrashDetectionConfig(sdk_name="cocoa", project_id=1234, sample_rate=1.0)]
+sdk_configs = [SDKCrashDetectionConfig(sdk_name=SdkName.Cocoa, project_id=1234, sample_rate=1.0)]
 
 
 @pytest.fixture
@@ -727,7 +727,7 @@ class SDKCrashReportTestMixin(BaseSDKCrashDetectionMixin, SnubaTestCase):
 
         configs = [
             SDKCrashDetectionConfig(
-                sdk_name="cocoa", project_id=cocoa_sdk_crashes_project.id, sample_rate=1.0
+                sdk_name=SdkName.Cocoa, project_id=cocoa_sdk_crashes_project.id, sample_rate=1.0
             )
         ]
         sdk_crash_event = sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)
@@ -802,8 +802,8 @@ def test_multiple_configs_first_one_picked(mock_sdk_crash_reporter, store_event)
     event = store_event(data=get_crash_event())
 
     configs = [
-        SDKCrashDetectionConfig(sdk_name="cocoa", project_id=1234, sample_rate=1.0),
-        SDKCrashDetectionConfig(sdk_name="cocoa", project_id=12345, sample_rate=1.0),
+        SDKCrashDetectionConfig(sdk_name=SdkName.Cocoa, project_id=1234, sample_rate=1.0),
+        SDKCrashDetectionConfig(sdk_name=SdkName.Cocoa, project_id=12345, sample_rate=1.0),
     ]
 
     sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)


### PR DESCRIPTION
Define an enum used in multiple places instead of a str.
