### PR TITLE
ref(sdk-crashes): Move is_sdk_frame to base class

### DIFF
--- a/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
@@ -24,6 +24,7 @@ class CocoaSDKCrashDetector(SDKCrashDetector):
             # the frames contain the full paths required for detecting system frames in is_system_library_frame.
             # Therefore, we require at least sentry-cocoa 8.2.0.
             min_sdk_version="8.2.0",
+            system_library_paths={"/System/Library/", "/usr/lib/"},
         )
         super().__init__(config)
 
@@ -73,17 +74,6 @@ class CocoaSDKCrashDetector(SDKCrashDetector):
             filenameMatchers = ["Sentry**"]
             for matcher in filenameMatchers:
                 if glob_match(filename, matcher, ignorecase=True):
-                    return True
-
-        return False
-
-    def is_system_library_frame(self, frame: Mapping[str, Any]) -> bool:
-        system_library_paths = {"/System/Library/", "/usr/lib/"}
-
-        for field in self.fields_containing_paths:
-            for system_library_path in system_library_paths:
-                field_with_path = frame.get(field)
-                if field_with_path and field_with_path.startswith(system_library_path):
                     return True
 
         return False

--- a/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
@@ -1,6 +1,5 @@
 from typing import Any, Mapping, Sequence
 
-from sentry.utils.glob import glob_match
 from sentry.utils.sdk_crashes.sdk_crash_detector import SDKCrashDetector, SDKCrashDetectorConfig
 
 
@@ -25,6 +24,13 @@ class CocoaSDKCrashDetector(SDKCrashDetector):
             # Therefore, we require at least sentry-cocoa 8.2.0.
             min_sdk_version="8.2.0",
             system_library_paths={"/System/Library/", "/usr/lib/"},
+            sdk_frame_function_matchers={
+                r"*sentrycrash*",
+                r"*\[Sentry*",
+                r"*(Sentry*)*",  # Objective-C class extension categories
+                r"SentryMX*",  # MetricKit Swift classes
+            },
+            sdk_frame_filename_matchers={"Sentry**"},
         )
         super().__init__(config)
 
@@ -52,28 +58,5 @@ class CocoaSDKCrashDetector(SDKCrashDetector):
 
             if not self.is_system_library_frame(frame):
                 return False
-
-        return False
-
-    def is_sdk_frame(self, frame: Mapping[str, Any]) -> bool:
-
-        function = frame.get("function")
-        if function:
-            function_matchers = [
-                r"*sentrycrash*",
-                r"*\[Sentry*",
-                r"*(Sentry*)*",  # Objective-C class extension categories
-                r"SentryMX*",  # MetricKit Swift classes
-            ]
-            for matcher in function_matchers:
-                if glob_match(function, matcher, ignorecase=True):
-                    return True
-
-        filename = frame.get("filename")
-        if filename:
-            filenameMatchers = ["Sentry**"]
-            for matcher in filenameMatchers:
-                if glob_match(filename, matcher, ignorecase=True):
-                    return True
 
         return False

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
@@ -14,6 +14,8 @@ class SDKCrashDetectorConfig:
 
     min_sdk_version: str
 
+    system_library_paths: Set[str]
+
 
 class SDKCrashDetector(ABC):
     """
@@ -77,6 +79,11 @@ class SDKCrashDetector(ABC):
         """
         raise NotImplementedError
 
-    @abstractmethod
     def is_system_library_frame(self, frame: Mapping[str, Any]) -> bool:
-        raise NotImplementedError
+        for field in self.fields_containing_paths:
+            for system_library_path in self.config.system_library_paths:
+                field_with_path = frame.get(field)
+                if field_with_path and field_with_path.startswith(system_library_path):
+                    return True
+
+        return False


### PR DESCRIPTION
Move the method is_sdk_frame to the base class and add its parameters to the config.

This PR is based on https://github.com/getsentry/sentry/pull/59082.
