### PR TITLE
Always upload Release as Artifact Bundles

### DIFF
--- a/src/sentry/api/endpoints/organization_release_assemble.py
+++ b/src/sentry/api/endpoints/organization_release_assemble.py
@@ -2,7 +2,6 @@ import jsonschema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
@@ -63,16 +62,12 @@ class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
         checksum = data.get("checksum", None)
         chunks = data.get("chunks", [])
 
-        upload_as_artifact_bundle = False
-        is_release_bundle_migration = False
-        project_ids = []
-        if features.has("organizations:sourcemaps-upload-release-as-artifact-bundle", organization):
-            upload_as_artifact_bundle = True
-            is_release_bundle_migration = True
-            # NOTE: this list of projects can be further refined based on the
-            # `project` embedded in the bundle manifest.
-            project_ids = [project.id for project in release.projects.all()]
-            metrics.incr("sourcemaps.upload.release_as_artifact_bundle")
+        upload_as_artifact_bundle = True
+        is_release_bundle_migration = True
+        # NOTE: this list of projects can be further refined based on the
+        # `project` embedded in the bundle manifest.
+        project_ids = [project.id for project in release.projects.all()]
+        metrics.incr("sourcemaps.upload.release_as_artifact_bundle")
 
         assemble_task = (
             AssembleTask.ARTIFACT_BUNDLE

--- a/tests/sentry/api/endpoints/test_organization_release_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_release_assemble.py
@@ -11,7 +11,6 @@ from sentry.models.files.fileblobowner import FileBlobOwner
 from sentry.silo import SiloMode
 from sentry.tasks.assemble import ChunkFileState, assemble_artifacts
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
@@ -83,9 +82,9 @@ class OrganizationReleaseAssembleTest(APITestCase):
                 "version": self.release.version,
                 "chunks": [blob1.checksum],
                 "checksum": total_checksum,
-                "project_ids": [],
-                "upload_as_artifact_bundle": False,
-                "is_release_bundle_migration": False,
+                "project_ids": [self.project.id],
+                "upload_as_artifact_bundle": True,
+                "is_release_bundle_migration": True,
             }
         )
 
@@ -101,7 +100,9 @@ class OrganizationReleaseAssembleTest(APITestCase):
             version=self.release.version,
             checksum=total_checksum,
             chunks=[blob1.checksum],
-            upload_as_artifact_bundle=False,
+            project_ids=[self.project.id],
+            upload_as_artifact_bundle=True,
+            is_release_bundle_migration=True,
         )
 
         response = self.client.post(
@@ -123,7 +124,9 @@ class OrganizationReleaseAssembleTest(APITestCase):
             version=self.release.version,
             checksum=total_checksum,
             chunks=[blob1.checksum],
-            upload_as_artifact_bundle=False,
+            project_ids=[self.project.id],
+            upload_as_artifact_bundle=True,
+            is_release_bundle_migration=True,
         )
 
         response = self.client.post(
@@ -136,7 +139,6 @@ class OrganizationReleaseAssembleTest(APITestCase):
         assert response.data["state"] == ChunkFileState.ERROR
 
     @patch("sentry.tasks.assemble.assemble_artifacts")
-    @with_feature("organizations:sourcemaps-upload-release-as-artifact-bundle")
     def test_assemble_as_artifact_bundle(self, mock_assemble_artifacts):
         bundle_file = self.create_artifact_bundle_zip(
             org=self.organization.slug, release=self.release.version


### PR DESCRIPTION
We have been turning this feature flag up and it is now fully enabled for some time.

This now removes that feature flag in favor of always creating Artifact Bundles, as we have seen that the feature flag can have a very low number of false negatives.

The rest of the code is kept as is, and the legacy code paths can be removed at a later point in time.