### PR TITLE
fix(on-demand): Hide error message on empty query strings

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -957,9 +957,9 @@ class OnDemandMetricSpec:
             # Third step is to generate the actual Relay rule that contains all rules nested. We assume that the query
             # being passed here, can be satisfied ONLY by on demand metrics.
             rule_condition = SearchQueryConverter(parsed_query.conditions).convert()
-        except Exception as e:
+        except Exception as exc:
             if not parsed_query.is_empty():
-                logger.error(f"Error while converting search query: {e}")
+                logger.error(f"Error while converting search query '{self.query}'", exc_info=exc)
 
             return None
 

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -957,8 +957,7 @@ class OnDemandMetricSpec:
             # Third step is to generate the actual Relay rule that contains all rules nested. We assume that the query
             # being passed here, can be satisfied ONLY by on demand metrics.
             rule_condition = SearchQueryConverter(parsed_query.conditions).convert()
-        except Exception as e:
-            logger.error(f"Error while converting search query: {e}")
+        except Exception:
             return None
 
         # If we don't have to merge the aggregate, we can just return the parsed rules.

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -957,7 +957,10 @@ class OnDemandMetricSpec:
             # Third step is to generate the actual Relay rule that contains all rules nested. We assume that the query
             # being passed here, can be satisfied ONLY by on demand metrics.
             rule_condition = SearchQueryConverter(parsed_query.conditions).convert()
-        except Exception:
+        except Exception as e:
+            if not parsed_query.is_empty():
+                logger.error(f"Error while converting search query: {e}")
+
             return None
 
         # If we don't have to merge the aggregate, we can just return the parsed rules.


### PR DESCRIPTION
This PR enables the error message only for non empty queries that fail to be parsed.