### PR TITLE
fix(health-checks): Improve list of health check globs

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -695,18 +695,14 @@ DS_DENYLIST = frozenset(
 # Also it covers: livez, readyz
 HEALTH_CHECK_GLOBS = [
     "*healthcheck*",
-    "*healthy*",
-    "live",
-    "live[z/-]*",
-    "*[/-]live",
-    "*[/-]live[z/-]*",
-    "ready",
-    "ready[z/-]*",
-    "*[/-]ready",
-    "*[/-]ready[z/-]*",
     "*heartbeat*",
     "*/health",
+    "*/healthy",
     "*/healthz",
+    "*/live",
+    "*/livez",
+    "*/ready",
+    "*/readyz",
     "*/ping",
 ]
 

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/MONOLITH.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-10-17T11:07:16.890029Z'
+created: '2023-10-31T14:18:43.292106Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -88,18 +88,14 @@ config:
       isEnabled: true
       patterns:
       - '*healthcheck*'
-      - '*healthy*'
-      - live
-      - live[z/-]*
-      - '*[/-]live'
-      - '*[/-]live[z/-]*'
-      - ready
-      - ready[z/-]*
-      - '*[/-]ready'
-      - '*[/-]ready[z/-]*'
       - '*heartbeat*'
       - '*/health'
+      - '*/healthy'
       - '*/healthz'
+      - '*/live'
+      - '*/livez'
+      - '*/ready'
+      - '*/readyz'
       - '*/ping'
   groupingConfig:
     enhancements: eJybzDRxc15qeXFJZU6qlZGBkbGugaGuoeEEAHJMCAM

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-10-17T11:07:17.137208Z'
+created: '2023-10-31T14:18:43.516229Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -88,18 +88,14 @@ config:
       isEnabled: true
       patterns:
       - '*healthcheck*'
-      - '*healthy*'
-      - live
-      - live[z/-]*
-      - '*[/-]live'
-      - '*[/-]live[z/-]*'
-      - ready
-      - ready[z/-]*
-      - '*[/-]ready'
-      - '*[/-]ready[z/-]*'
       - '*heartbeat*'
       - '*/health'
+      - '*/healthy'
       - '*/healthz'
+      - '*/live'
+      - '*/livez'
+      - '*/ready'
+      - '*/readyz'
       - '*/ping'
   groupingConfig:
     enhancements: eJybzDRxc15qeXFJZU6qlZGBkbGugaGuoeEEAHJMCAM


### PR DESCRIPTION
This PR improves the list of health check globs that are used in health checks inbound filters and bias.

The new list tightens up the matching since we have a lot of false positives with the previous implementation.