### PR TITLE
ref: remove noop `objects = BaseManager()` assignments

### DIFF
--- a/src/sentry/models/groupbookmark.py
+++ b/src/sentry/models/groupbookmark.py
@@ -3,13 +3,7 @@ from django.db import models
 from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import (
-    BaseManager,
-    FlexibleForeignKey,
-    Model,
-    region_silo_only_model,
-    sane_repr,
-)
+from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 
 
@@ -27,8 +21,6 @@ class GroupBookmark(Model):
     # namespace related_name on User since we don't own the model
     user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE")
     date_added = models.DateTimeField(default=timezone.now, null=True)
-
-    objects = BaseManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/groupemailthread.py
+++ b/src/sentry/models/groupemailthread.py
@@ -2,13 +2,7 @@ from django.db import models
 from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import (
-    BaseManager,
-    FlexibleForeignKey,
-    Model,
-    region_silo_only_model,
-    sane_repr,
-)
+from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 
 
 @region_silo_only_model
@@ -27,8 +21,6 @@ class GroupEmailThread(Model):
     group = FlexibleForeignKey("sentry.Group", related_name="groupemail_set")
     msgid = models.CharField(max_length=100)
     date = models.DateTimeField(default=timezone.now, db_index=True)
-
-    objects = BaseManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/groupshare.py
+++ b/src/sentry/models/groupshare.py
@@ -5,13 +5,7 @@ from django.db import models
 from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import (
-    BaseManager,
-    FlexibleForeignKey,
-    Model,
-    region_silo_only_model,
-    sane_repr,
-)
+from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 
 
@@ -33,8 +27,6 @@ class GroupShare(Model):
     # Tracking the user that initiated the share.
     user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE", null=True)
     date_added = models.DateTimeField(default=timezone.now)
-
-    objects = BaseManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/projectbookmark.py
+++ b/src/sentry/models/projectbookmark.py
@@ -3,13 +3,7 @@ from django.db import models
 from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import (
-    BaseManager,
-    FlexibleForeignKey,
-    Model,
-    region_silo_only_model,
-    sane_repr,
-)
+from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.models.project import Project
 
@@ -25,8 +19,6 @@ class ProjectBookmark(Model):
     project = FlexibleForeignKey(Project, blank=True, null=True, db_constraint=False)
     user_id = HybridCloudForeignKey(settings.AUTH_USER_MODEL, on_delete="CASCADE")
     date_added = models.DateTimeField(default=timezone.now, null=True)
-
-    objects = BaseManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/rawevent.py
+++ b/src/sentry/models/rawevent.py
@@ -3,7 +3,6 @@ from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, NodeField, region_silo_only_model, sane_repr
-from sentry.db.models.manager import BaseManager
 from sentry.utils.canonical import CanonicalKeyView
 
 
@@ -21,8 +20,6 @@ class RawEvent(Model):
     data = NodeField(
         blank=True, null=True, ref_func=ref_func, ref_version=1, wrapper=CanonicalKeyView
     )
-
-    objects = BaseManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/reprocessingreport.py
+++ b/src/sentry/models/reprocessingreport.py
@@ -2,13 +2,7 @@ from django.db import models
 from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
-from sentry.db.models import (
-    BaseManager,
-    FlexibleForeignKey,
-    Model,
-    region_silo_only_model,
-    sane_repr,
-)
+from sentry.db.models import FlexibleForeignKey, Model, region_silo_only_model, sane_repr
 
 
 @region_silo_only_model
@@ -18,8 +12,6 @@ class ReprocessingReport(Model):
     project = FlexibleForeignKey("sentry.Project")
     event_id = models.CharField(max_length=32, null=True)
     datetime = models.DateTimeField(default=timezone.now)
-
-    objects = BaseManager()
 
     class Meta:
         app_label = "sentry"


### PR DESCRIPTION
the default `Model` gives us this for free -- this is needed to upgrade django-stubs + mypy