### PR TITLE
fix(on-demand): Fix url tagging mapping

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -76,6 +76,8 @@ _SEARCH_TO_PROTOCOL_FIELDS = {
     "geo.subdivision": "user.geo.subdivision",
     "http.method": "request.method",
     "http.url": "request.url",
+    # url is a tag extracted by Sentry itself, on Relay it's received as `request.url`
+    "url": "request.url",
     "sdk.name": "sdk.name",
     "sdk.version": "sdk.version",
     # Subset of context fields


### PR DESCRIPTION
This PR adds `url` mapping to `request.url`. This is done since `tags.url` is not in the event payload that Relay receives but rather it's added by Sentry during processing. However, this is not a definitive change since it doesn't cover the edge case in which the SDK sends the `url` as tags.