### PR TITLE
chore(stats-detectors): Narrow transaction ops to just endpoints

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -859,23 +859,11 @@ BACKEND_TRANSACTION_OPS = [
     "function.aws",
     "function.aws.lambda",
     "http.server",
-    "queue.process",
     "serverless.function",
-    "task",
-    "websocket.server",
     # Python
     "asgi.server",
-    "celery.task",
-    "queue.task.celery",
-    "queue.task.rq",
-    "rq.task",
     # Ruby
-    "queue.active_job",
-    "queue.delayed_job",
-    "queue.sidekiq",
-    "rails.action_cable",
     "rails.request",
-    "sidekiq",
 ]
 
 


### PR DESCRIPTION
We're narrowing the transactions to be tracked to just endpoints so remove all non endpoint related ops from the list.