### PR TITLE
feat(perf): Remove "New" badge from Queries view

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -47,7 +47,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useProjects from 'sentry/utils/useProjects';
 import {RELEASE_LEVEL as WEBVITALS_RELEASE_LEVEL} from 'sentry/views/performance/browser/webVitals/settings';
-import {RELEASE_LEVEL} from 'sentry/views/performance/database/settings';
 
 import {ProfilingOnboardingSidebar} from '../profiling/ProfilingOnboarding/profilingOnboardingSidebar';
 
@@ -239,9 +238,6 @@ function Sidebar({location, organization}: Props) {
               >
                 <SidebarItem
                   {...sidebarItemProps}
-                  isAlpha={RELEASE_LEVEL === 'alpha'}
-                  isBeta={RELEASE_LEVEL === 'beta'}
-                  isNew={RELEASE_LEVEL === 'new'}
                   label={
                     <GuideAnchor target="performance-database">
                       {t('Queries')}

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
-import FeatureBadge from 'sentry/components/featureBadge';
 import FeedbackWidget from 'sentry/components/feedback/widget/feedbackWidget';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
@@ -15,7 +14,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
 import {NoDataMessage} from 'sentry/views/performance/database/noDataMessage';
-import {RELEASE_LEVEL} from 'sentry/views/performance/database/settings';
 import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {ActionSelector} from 'sentry/views/starfish/views/spans/selectors/actionSelector';
@@ -49,10 +47,7 @@ function DatabaseLandingPage() {
             ]}
           />
 
-          <Layout.Title>
-            {t('Queries')}
-            <FeatureBadge type={RELEASE_LEVEL} />
-          </Layout.Title>
+          <Layout.Title>{t('Queries')}</Layout.Title>
         </Layout.HeaderContent>
       </Layout.Header>
 

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import Breadcrumbs from 'sentry/components/breadcrumbs';
-import FeatureBadge from 'sentry/components/featureBadge';
 import FeedbackWidget from 'sentry/components/feedback/widget/feedbackWidget';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
@@ -18,7 +17,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
-import {RELEASE_LEVEL} from 'sentry/views/performance/database/settings';
 import {AVG_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
 import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
@@ -139,10 +137,7 @@ function SpanSummaryPage({params}: Props) {
               },
             ]}
           />
-          <Layout.Title>
-            {t('Query Summary')}
-            <FeatureBadge type={RELEASE_LEVEL} />
-          </Layout.Title>
+          <Layout.Title>{t('Query Summary')}</Layout.Title>
         </Layout.HeaderContent>
       </Layout.Header>
 

--- a/static/app/views/performance/database/settings.ts
+++ b/static/app/views/performance/database/settings.ts
@@ -1,7 +1,3 @@
-import {BadgeType} from 'sentry/components/featureBadge';
-
-export const RELEASE_LEVEL: BadgeType = 'new';
-
 export const MIN_SDK_VERSION_BY_PLATFORM: {[platform: string]: string} = {
   'sentry.python': '1.29.2',
   'sentry.javascript': '7.63.0',

--- a/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
@@ -6,22 +6,17 @@ import QuestionTooltip from 'sentry/components/questionTooltip';
 import TextOverflow from 'sentry/components/textOverflow';
 import {space} from 'sentry/styles/space';
 import {MEPTag} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
-import {RELEASE_LEVEL} from 'sentry/views/performance/database/settings';
 
 import {
   GenericPerformanceWidgetProps,
   WidgetDataConstraint,
   WidgetDataProps,
 } from '../types';
-import {PerformanceWidgetSetting} from '../widgetDefinitions';
 
 export function WidgetHeader<T extends WidgetDataConstraint>(
   props: GenericPerformanceWidgetProps<T> & WidgetDataProps<T>
 ) {
-  const {title, titleTooltip, Subtitle, HeaderActions, InteractiveTitle, chartSetting} =
-    props;
-  const isStarfishDBWidget =
-    chartSetting === PerformanceWidgetSetting.MOST_TIME_SPENT_DB_QUERIES;
+  const {title, titleTooltip, Subtitle, HeaderActions, InteractiveTitle} = props;
   return (
     <WidgetHeaderContainer>
       <TitleContainer>
@@ -31,7 +26,6 @@ export function WidgetHeader<T extends WidgetDataConstraint>(
           ) : (
             <TextOverflow>{title}</TextOverflow>
           )}
-          {isStarfishDBWidget && <FeatureBadge type={RELEASE_LEVEL} />}
           <MEPTag />
           {titleTooltip && (
             <QuestionTooltip position="top" size="sm" title={titleTooltip} />


### PR DESCRIPTION
It's been more than a month since release! The feature is no longer "New", and importantly a lot of other actually _new_ features are coming out soon.
