### PR TITLE
ref(metrics): Automatically infer the Dataset

### DIFF
--- a/tests/snuba/test_metrics_layer.py
+++ b/tests/snuba/test_metrics_layer.py
@@ -17,7 +17,7 @@ from snuba_sdk import (
 
 from sentry.api.utils import InvalidParams
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.snuba.metrics.naming_layer import TransactionMRI
+from sentry.snuba.metrics.naming_layer import SessionMRI, TransactionMRI
 from sentry.snuba.metrics_layer.query import run_query
 from sentry.testutils.cases import BaseMetricsTestCase, TestCase
 
@@ -374,3 +374,32 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
         # 30 since it's every 2 minutes.
         # # TODO(evanh): There's a flaky off by one error that comes from the interval rounding I don't care to fix right now, hence the 31 option.
         assert len(result["data"]) in [30, 31]
+
+    def test_automatic_dataset(self) -> None:
+        query = MetricsQuery(
+            query=Timeseries(
+                metric=Metric(
+                    None,
+                    SessionMRI.RAW_DURATION.value,
+                ),
+                aggregate="max",
+            ),
+            start=self.hour_ago,
+            end=self.now,
+            rollup=Rollup(interval=60, granularity=60),
+            scope=MetricsScope(
+                org_ids=[self.org_id],
+                project_ids=[self.project.id],
+                use_case_id=UseCaseID.SESSIONS.value,
+            ),
+        )
+
+        request = Request(
+            dataset="generic_metrics",
+            app_id="tests",
+            query=query,
+            tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
+        )
+        result = run_query(request)
+        assert request.dataset == "metrics"
+        assert len(result["data"]) == 0


### PR DESCRIPTION
If the use case ID of the request is for sessions, then switch the Dataset to
be metrics.

In theory the code using the layer should know which product it is, and
therefore which Dataset to use. However some of the code using this new layer
is feature agnostic, and it's easier to add this line here instead of changing
all the product code.