### PR TITLE
fix(gitlab): Copy immutable querydict before modifying

### DIFF
--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -29,6 +29,8 @@ class GitlabIssueBasic(IssueBasicMixin):
 
         # XXX: In GitLab repositories are called projects but get_repository_choices
         # expects the param to be called 'repo', so we need to rename it here.
+        # Django QueryDicts are immutable, so we need to copy it first.
+        params = params.copy()
         params["repo"] = params.get("project") or defaults.get("project")
 
         default_project, project_choices = self.get_repository_choices(group, params, **kwargs)

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, List, MutableMapping, Sequence
+from typing import Any, Dict, List, Mapping, Sequence
 
 from django.urls import reverse
 
@@ -24,7 +24,7 @@ class GitlabIssueBasic(IssueBasicMixin):
     def get_persisted_default_config_fields(self) -> Sequence[str]:
         return ["project"]
 
-    def get_projects_and_default(self, group: Group, params: MutableMapping[str, Any], **kwargs):
+    def get_projects_and_default(self, group: Group, params: Mapping[str, Any], **kwargs):
         defaults = self.get_project_defaults(group.project_id)
 
         # XXX: In GitLab repositories are called projects but get_repository_choices

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -4,7 +4,7 @@ import enum
 import logging
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any, ClassVar, Dict, List, Mapping, MutableMapping, Sequence
+from typing import Any, ClassVar, Dict, List, Mapping, Sequence
 
 from sentry.integrations.utils import where_should_sync
 from sentry.models.group import Group
@@ -268,7 +268,7 @@ class IssueBasicMixin:
         """
         return ""
 
-    def get_repository_choices(self, group: Group, params: MutableMapping[str, Any], **kwargs):
+    def get_repository_choices(self, group: Group, params: Mapping[str, Any], **kwargs):
         """
         Returns the default repository and a set/subset of repositories of associated with the installation
         """


### PR DESCRIPTION
In this PR https://github.com/getsentry/sentry/pull/58679, I refactored some code. I didn't realize that Django query parameters are stored as a QueryDict which is immutable.

To fix it I make a copy before modifying. Also change argument types from `MutableMapping` -> `Mapping`

### In Action

https://github.com/getsentry/sentry/assets/67301797/e0af4d2c-8a84-480c-8071-699987b95ad6

Resolves https://github.com/getsentry/sentry/issues/59092
