### PR TITLE
fix(compactSelect): Remove inherited bottom margin

### DIFF
--- a/static/app/styles/text.tsx
+++ b/static/app/styles/text.tsx
@@ -9,8 +9,9 @@ const textStyles = () => css`
   h5,
   h6,
   p,
-  ul,
-  ol,
+  /* Exclude ol/ul elements inside interactive selectors/menus */
+  ul:not([role='listbox'], [role='grid']),
+  ol:not([role='listbox'], [role='grid']),
   table,
   dl,
   blockquote,


### PR DESCRIPTION
**Before ——**
<img width="189" alt="Screenshot 2023-10-31 at 11 56 01 AM" src="https://github.com/getsentry/sentry/assets/44172267/e2c676f8-bb00-4390-a6e7-ec7a7e74ef2c">

**After ——**
<img width="189" alt="Screenshot 2023-10-31 at 11 55 19 AM" src="https://github.com/getsentry/sentry/assets/44172267/7442ebdf-cfd4-4051-aa03-f3805e7092a3">
