### PR TITLE
fix(browser-starfish): ignore browser-extensions in resource module

### DIFF
--- a/static/app/views/performance/browser/resources/utils/useResourceDomansQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceDomansQuery.ts
@@ -7,6 +7,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
+import {DEFAULT_RESOURCE_FILTERS} from 'sentry/views/performance/browser/resources/utils/useResourcesQuery';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 
 const {SPAN_DOMAIN, SPAN_OP, TRANSACTION} = SpanMetricsField;
@@ -23,6 +24,7 @@ export const useResourceDomainsQuery = () => {
   const fields = [SPAN_DOMAIN, 'count()']; // count() is only here because an aggregation is required for the query to work
 
   const queryConditions = [
+    ...DEFAULT_RESOURCE_FILTERS,
     `${SPAN_OP}:${resourceFilters[SPAN_OP] || '[resource.script,resource.css]'}`,
     `has:${SPAN_DOMAIN}`,
     ...(resourceFilters[TRANSACTION]

--- a/static/app/views/performance/browser/resources/utils/useResourcePagesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcePagesQuery.ts
@@ -5,6 +5,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
+import {DEFAULT_RESOURCE_FILTERS} from 'sentry/views/performance/browser/resources/utils/useResourcesQuery';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 
 const {SPAN_DOMAIN, SPAN_OP} = SpanMetricsField;
@@ -22,6 +23,7 @@ export const useResourcePagesQuery = () => {
   const fields = ['transaction', 'count()']; // count() is only here because an aggregation is required for the query to work
 
   const queryConditions = [
+    ...DEFAULT_RESOURCE_FILTERS,
     `${SPAN_OP}:${resourceFilters[SPAN_OP] || 'resource.*'}`,
     ...(spanDomain ? [`${SPAN_DOMAIN}:${spanDomain}`] : []),
   ]; // TODO: We will need to consider other ops

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -26,6 +26,8 @@ type Props = {
   query?: string;
 };
 
+export const DEFAULT_RESOURCE_FILTERS = ['!span.description:"browser-extension://*"'];
+
 export const useResourcesQuery = ({sort, defaultResourceTypes, query, limit}: Props) => {
   const pageFilters = usePageFilters();
   const location = useLocation();
@@ -38,6 +40,7 @@ export const useResourcesQuery = ({sort, defaultResourceTypes, query, limit}: Pr
     }`,
     ...(!query
       ? [
+          ...DEFAULT_RESOURCE_FILTERS,
           ...(resourceFilters.transaction
             ? [`transaction:"${resourceFilters.transaction}"`]
             : []),


### PR DESCRIPTION
This PR excludes browser extensions from being displayed in the resource.

In this PR https://github.com/getsentry/relay/pull/2676 we grouped all extensions into one group, this gives us the flexibility to filter it out in FE queries now, and potentially use it in the future.