### PR TITLE
fix(functions): Units on function stats response

### DIFF
--- a/src/sentry/search/events/builder/profile_functions.py
+++ b/src/sentry/search/events/builder/profile_functions.py
@@ -57,10 +57,16 @@ class ProfileFunctionsTimeseriesQueryBuilder(
             column: get_function_alias(function_details.field)
             for column, function_details in self.function_alias_map.items()
         }
+        self.function_alias_map = {
+            alias_mappings.get(column, column): function_details
+            for column, function_details in self.function_alias_map.items()
+        }
         result["data"] = [
             {alias_mappings.get(k, k): v for k, v in item.items()}
             for item in result.get("data", [])
         ]
+        for item in result.get("meta", []):
+            item["name"] = alias_mappings.get(item["name"], item["name"])
         return result
 
     @property

--- a/src/sentry/search/events/datasets/profile_functions.py
+++ b/src/sentry/search/events/datasets/profile_functions.py
@@ -243,13 +243,13 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                 SnQLFunction(
                     "cpm",  # calls per minute
                     snql_aggregate=lambda args, alias: self._resolve_cpm(args, alias),
-                    default_result_type="integer",
+                    default_result_type="number",
                 ),
                 SnQLFunction(
                     "cpm_before",
                     required_args=[TimestampArg("timestamp")],
                     snql_aggregate=lambda args, alias: self._resolve_cpm_cond(args, alias, "less"),
-                    default_result_type="integer",
+                    default_result_type="number",
                 ),
                 SnQLFunction(
                     "cpm_after",
@@ -257,13 +257,13 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                     snql_aggregate=lambda args, alias: self._resolve_cpm_cond(
                         args, alias, "greater"
                     ),
-                    default_result_type="integer",
+                    default_result_type="number",
                 ),
                 SnQLFunction(
                     "cpm_delta",
                     required_args=[TimestampArg("timestamp")],
                     snql_aggregate=self._resolve_cpm_delta,
-                    default_result_type="integer",
+                    default_result_type="number",
                 ),
                 SnQLFunction(
                     "count_unique",


### PR DESCRIPTION
Using an alias prefix broke the units on the response. Make sure it is correctly mapped back to the expected aliases with the correct units set.