### PR TITLE
feat(browser-starfish): make things more consistent in resource module

### DIFF
--- a/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
@@ -17,6 +17,7 @@ import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/render
 import {SpanDescriptionCell} from 'sentry/views/starfish/components/tableCells/spanDescriptionCell';
 import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {ModuleName, SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
+import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 
 const {
   SPAN_DESCRIPTION,
@@ -56,18 +57,18 @@ function ResourceTable({sort}: Props) {
   });
 
   const columnOrder: GridColumnOrder<keyof Row>[] = [
-    {key: SPAN_DESCRIPTION, width: COL_WIDTH_UNDEFINED, name: 'Resource name'},
-    {key: SPAN_OP, width: COL_WIDTH_UNDEFINED, name: 'Type'},
-    {key: `avg(${SPAN_SELF_TIME})`, width: COL_WIDTH_UNDEFINED, name: 'Avg Duration'},
+    {key: SPAN_DESCRIPTION, width: COL_WIDTH_UNDEFINED, name: t('Resource Description')},
+    {key: SPAN_OP, width: COL_WIDTH_UNDEFINED, name: t('Type')},
+    {key: `avg(${SPAN_SELF_TIME})`, width: COL_WIDTH_UNDEFINED, name: DataTitles.avg},
     {
       key: `${SPM}()`,
       width: COL_WIDTH_UNDEFINED,
-      name: t('Throughput'),
+      name: getThroughputTitle('http'),
     },
     {
       key: `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
       width: COL_WIDTH_UNDEFINED,
-      name: t('Avg Resource size'),
+      name: DataTitles['avg(http.response_content_length)'],
     },
   ];
   const tableData: Row[] = data.length

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceInfo.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceInfo.tsx
@@ -62,7 +62,7 @@ function ResourceInfo(props: Props) {
   return (
     <Fragment>
       <BlockContainer>
-        <Block title={t('Avg encoded size')}>
+        <Block title={DataTitles['avg(http.response_content_length)']}>
           <Tooltip
             isHoverable
             title={tooltips.avgContentLength}
@@ -72,7 +72,7 @@ function ResourceInfo(props: Props) {
             <ResourceSize bytes={avgContentLength} />
           </Tooltip>
         </Block>
-        <Block title={t('Avg decoded size')}>
+        <Block title={DataTitles['avg(http.decoded_response_content_length)']}>
           <Tooltip
             isHoverable
             title={tooltips.avgDecodedContentLength}
@@ -82,7 +82,7 @@ function ResourceInfo(props: Props) {
             <ResourceSize bytes={avgDecodedContentLength} />
           </Tooltip>
         </Block>
-        <Block title={t('Avg transfer size')}>
+        <Block title={DataTitles['avg(http.transfer_size)']}>
           <Tooltip
             isHoverable
             title={tooltips.avgTransferSize}

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
@@ -1,4 +1,3 @@
-import {t} from 'sentry/locale';
 import {Series} from 'sentry/types/echarts';
 import {formatBytesBase2} from 'sentry/utils';
 import getDynamicText from 'sentry/utils/getDynamicText';
@@ -7,7 +6,7 @@ import Chart from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {getDurationChartTitle} from 'sentry/views/starfish/views/spans/types';
+import {DataTitles, getDurationChartTitle} from 'sentry/views/starfish/views/spans/types';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
 
 const {SPAN_SELF_TIME, HTTP_RESPONSE_CONTENT_LENGTH} = SpanMetricsField;
@@ -35,7 +34,7 @@ function ResourceSummaryCharts(props: {groupId: string}) {
         </ChartPanel>
       </Block>
       <Block>
-        <ChartPanel title={t('Resource Size')}>
+        <ChartPanel title={DataTitles['avg(http.response_content_length)']}>
           <Chart
             height={160}
             data={[spanMetricsSeriesData?.[`avg(${HTTP_RESPONSE_CONTENT_LENGTH})`]]}

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
@@ -8,6 +8,7 @@ import GridEditable, {
   GridColumnOrder,
 } from 'sentry/components/gridEditable';
 import Pagination from 'sentry/components/pagination';
+import {t} from 'sentry/locale';
 import {RateUnits} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
@@ -16,6 +17,7 @@ import {useResourceSummarySort} from 'sentry/views/performance/browser/resources
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
+import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 
 type Row = {
   'avg(http.response_content_length)': number;
@@ -37,17 +39,17 @@ function ResourceSummaryTable() {
     {
       key: 'spm()',
       width: COL_WIDTH_UNDEFINED,
-      name: 'Throughput',
+      name: getThroughputTitle('http'),
     },
     {
       key: 'avg(span.self_time)',
       width: COL_WIDTH_UNDEFINED,
-      name: 'Avg Duration',
+      name: t('Avg Duration'),
     },
     {
       key: 'avg(http.response_content_length)',
       width: COL_WIDTH_UNDEFINED,
-      name: 'Avg Resource Size',
+      name: DataTitles['avg(http.response_content_length)'],
     },
   ];
 

--- a/static/app/views/starfish/views/spans/types.tsx
+++ b/static/app/views/starfish/views/spans/types.tsx
@@ -14,7 +14,10 @@ export type DataKey =
   | 'slowFrames'
   | 'ttid'
   | 'ttfd'
-  | 'count';
+  | 'count'
+  | 'avg(http.response_content_length)'
+  | 'avg(http.decoded_response_content_length)'
+  | 'avg(http.transfer_size)';
 
 export const DataTitles: Record<DataKey, string> = {
   change: t('Change'),
@@ -30,6 +33,9 @@ export const DataTitles: Record<DataKey, string> = {
   slowFrames: t('Slow Frames %'),
   ttid: t('Time To Initial Display'),
   ttfd: t('Time To Full Display'),
+  'avg(http.response_content_length)': t('Avg Encoded Size'),
+  'avg(http.decoded_response_content_length)': t('Avg Decoded Size'),
+  'avg(http.transfer_size)': t('Avg Transfer Size'),
 };
 
 export const getThroughputTitle = (spanOp?: string) => {


### PR DESCRIPTION
Fixes a bunch of naming inconsistencies by using a the shared `DataTitles` object