### PR TITLE
feat(crons): Show sample schedule data

### DIFF
--- a/static/app/views/monitors/components/monitorCreateForm.tsx
+++ b/static/app/views/monitors/components/monitorCreateForm.tsx
@@ -96,8 +96,12 @@ function MockTimelineVisualization(props: ScheduleConfig) {
   return (
     <TimelineContainer>
       <TimelineWidthTracker ref={elementRef} />
-      {isLoading || !start || !end || !timeWindowConfig ? (
-        <Placeholder />
+      {isLoading || !start || !end || !timeWindowConfig || !mockTimestamps ? (
+        <Fragment>
+          {/* TODO(davidenwang): Improve loading placeholder */}
+          <Placeholder height="40px" />
+          <TimelinePlaceholder />
+        </Fragment>
       ) : (
         <Fragment>
           <StyledGridLineTimeLabels
@@ -113,17 +117,13 @@ function MockTimelineVisualization(props: ScheduleConfig) {
             end={end}
             width={timelineWidth}
           />
-          {mockTimestamps && !isLoading ? (
-            <MockCheckInTimeline
-              width={timelineWidth}
-              mockTimestamps={mockTimestamps.slice(1, mockTimestamps.length - 1)}
-              start={start}
-              end={end}
-              timeWindowConfig={timeWindowConfig}
-            />
-          ) : (
-            <TimelinePlaceholder />
-          )}
+          <MockCheckInTimeline
+            width={timelineWidth}
+            mockTimestamps={mockTimestamps.slice(1, mockTimestamps.length - 1)}
+            start={start}
+            end={end}
+            timeWindowConfig={timeWindowConfig}
+          />
         </Fragment>
       )}
     </TimelineContainer>

--- a/static/app/views/monitors/components/overviewTimeline/checkInTimeline.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/checkInTimeline.tsx
@@ -76,9 +76,13 @@ export interface MockCheckInTimelineProps extends TimelineProps {
   mockTimestamps: Date[];
 }
 
-export function MockCheckInTimeline(props: MockCheckInTimelineProps) {
-  const {mockTimestamps, start, end, timeWindowConfig, width} = props;
-
+export function MockCheckInTimeline({
+  mockTimestamps,
+  start,
+  end,
+  timeWindowConfig,
+  width,
+}: MockCheckInTimelineProps) {
   const elapsedMs = end.getTime() - start.getTime();
   const msPerPixel = elapsedMs / width;
 

--- a/static/app/views/monitors/components/overviewTimeline/checkInTimeline.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/checkInTimeline.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import DateTime from 'sentry/components/dateTime';
+import {Tooltip} from 'sentry/components/tooltip';
 import {CheckInStatus} from 'sentry/views/monitors/types';
 import {getColorsFromStatus} from 'sentry/views/monitors/utils';
 import {getAggregateStatus} from 'sentry/views/monitors/utils/getAggregateStatus';
@@ -8,13 +10,16 @@ import {mergeBuckets} from 'sentry/views/monitors/utils/mergeBuckets';
 import {JobTickTooltip} from './jobTickTooltip';
 import {MonitorBucketData, TimeWindowOptions} from './types';
 
-export interface CheckInTimelineProps {
-  bucketedData: MonitorBucketData;
+interface TimelineProps {
   end: Date;
-  environment: string;
   start: Date;
   timeWindowConfig: TimeWindowOptions;
   width: number;
+}
+
+export interface CheckInTimelineProps extends TimelineProps {
+  bucketedData: MonitorBucketData;
+  environment: string;
 }
 
 function getBucketedCheckInsPosition(
@@ -61,6 +66,43 @@ export function CheckInTimeline(props: CheckInTimelineProps) {
               roundedRight={roundedRight}
             />
           </JobTickTooltip>
+        );
+      })}
+    </TimelineContainer>
+  );
+}
+
+export interface MockCheckInTimelineProps extends TimelineProps {
+  mockTimestamps: Date[];
+}
+
+export function MockCheckInTimeline(props: MockCheckInTimelineProps) {
+  const {mockTimestamps, start, end, timeWindowConfig, width} = props;
+
+  const elapsedMs = end.getTime() - start.getTime();
+  const msPerPixel = elapsedMs / width;
+
+  return (
+    <TimelineContainer>
+      {mockTimestamps.map(ts => {
+        const timestampMs = ts.getTime();
+        const left = getBucketedCheckInsPosition(timestampMs, start, msPerPixel);
+
+        return (
+          <Tooltip
+            key={left}
+            title={
+              <DateTime date={timestampMs} format={timeWindowConfig.dateLabelFormat} />
+            }
+            skipWrapper
+          >
+            <JobTick
+              style={{left}}
+              status={CheckInStatus.IN_PROGRESS}
+              roundedLeft
+              roundedRight
+            />
+          </Tooltip>
         );
       })}
     </TimelineContainer>

--- a/static/app/views/monitors/components/overviewTimeline/utils.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/utils.tsx
@@ -33,7 +33,7 @@ export function getConfigFromTimeRange(
   const subMinutePxBuckets = startEndMinutes < timelineWidth;
 
   for (const minutes of minuteRanges) {
-    if (minutes > timeLabelMinutes) {
+    if (minutes >= Math.floor(timeLabelMinutes)) {
       return {
         dateLabelFormat: getFormat({timeOnly: true, seconds: subMinutePxBuckets}),
         elapsedMinutes: startEndMinutes,


### PR DESCRIPTION
Creates new timeline component which allows for sample schedule data to be shown. Reuses logic of existing check in timeline

Result looks something like: (bottom timeline view)
<img width="830" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/7074d6be-54c9-4005-b6f4-92e2d244f935">
