### PR TITLE
ref(linting): Add links to lists of linter error codes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -87,6 +87,12 @@ sentry =
 
 [flake8]
 # File filtering is taken care of in pre-commit.
+
+# B error codes come from flake8-bugbear. List of codes: https://github.com/PyCQA/flake8-bugbear#list-of-warnings
+# E error codes come from pycodestyle. List of codes: https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
+# F error codes come from flake8. List of codes: https://flake8.pycqa.org/en/latest/user/error-codes.html
+# S error codes come from sentry-flake8. List of codes: https://github.com/getsentry/sentry/blob/master/tools/flake8_plugin.py
+
 # E203 false positive, see https://github.com/PyCQA/pycodestyle/issues/373
 # B011 We don't use PYTHONOPTIMIZE.
 


### PR DESCRIPTION
We reference various error codes in our flake8 config, but we don't say what most of them mean. Rather than add a comment for each one, this adds links to the appropriate lists of codes so anyone who's curious can look them up.

Identical to the `getsentry` version of this PR at https://github.com/getsentry/getsentry/pull/11962.