### PR TITLE
feat(plugins): Add Babel plugin to annotate frontend with React component names

### DIFF
--- a/babel.config.ts
+++ b/babel.config.ts
@@ -25,7 +25,7 @@ const config: TransformOptions = {
     '@emotion/babel-plugin',
     '@babel/plugin-transform-runtime',
     '@babel/plugin-transform-class-properties',
-    '@fullstory/babel-plugin-annotate-react',
+    ['@fullstory/babel-plugin-annotate-react', {'annotate-fragments': false}],
   ],
   env: {
     production: {

--- a/babel.config.ts
+++ b/babel.config.ts
@@ -25,7 +25,13 @@ const config: TransformOptions = {
     '@emotion/babel-plugin',
     '@babel/plugin-transform-runtime',
     '@babel/plugin-transform-class-properties',
-    ['@fullstory/babel-plugin-annotate-react', {'annotate-fragments': false}],
+    [
+      '@fullstory/babel-plugin-annotate-react',
+      {
+        'annotate-fragments': false,
+        ignoreComponents: [['noDataMessage.tsx', '*', '*']],
+      },
+    ],
   ],
   env: {
     production: {

--- a/babel.config.ts
+++ b/babel.config.ts
@@ -44,14 +44,14 @@ const config: TransformOptions = {
           },
         ],
         ['babel-plugin-add-react-displayname'],
-        ['@fullstory/babel-plugin-annotate-react', {'annotate-fragments': false}],
+        ['@fullstory/babel-plugin-annotate-react'],
       ],
     },
     development: {
       plugins: [
         '@emotion/babel-plugin',
         '@babel/plugin-transform-react-jsx-source',
-        ['@fullstory/babel-plugin-annotate-react', {'annotate-fragments': false}],
+        ['@fullstory/babel-plugin-annotate-react'],
         ...(process.env.SENTRY_UI_HOT_RELOAD ? ['react-refresh/babel'] : []),
       ],
     },

--- a/babel.config.ts
+++ b/babel.config.ts
@@ -25,6 +25,7 @@ const config: TransformOptions = {
     '@emotion/babel-plugin',
     '@babel/plugin-transform-runtime',
     '@babel/plugin-transform-class-properties',
+    '@fullstory/babel-plugin-annotate-react',
   ],
   env: {
     production: {

--- a/babel.config.ts
+++ b/babel.config.ts
@@ -25,13 +25,6 @@ const config: TransformOptions = {
     '@emotion/babel-plugin',
     '@babel/plugin-transform-runtime',
     '@babel/plugin-transform-class-properties',
-    [
-      '@fullstory/babel-plugin-annotate-react',
-      {
-        'annotate-fragments': false,
-        ignoreComponents: [['noDataMessage.tsx', '*', '*']],
-      },
-    ],
   ],
   env: {
     production: {
@@ -51,12 +44,14 @@ const config: TransformOptions = {
           },
         ],
         ['babel-plugin-add-react-displayname'],
+        ['@fullstory/babel-plugin-annotate-react', {'annotate-fragments': false}],
       ],
     },
     development: {
       plugins: [
         '@emotion/babel-plugin',
         '@babel/plugin-transform-react-jsx-source',
+        ['@fullstory/babel-plugin-annotate-react', {'annotate-fragments': false}],
         ...(process.env.SENTRY_UI_HOT_RELOAD ? ['react-refresh/babel'] : []),
       ],
     },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@emotion/css": "^11.10.5",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@fullstory/babel-plugin-annotate-react": "^2.3.0",
     "@monaco-editor/react": "^4.4.5",
     "@popperjs/core": "^2.11.5",
     "@react-aria/button": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,6 +1467,11 @@
   dependencies:
     tslib "^2.4.0"
 
+"@fullstory/babel-plugin-annotate-react@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@fullstory/babel-plugin-annotate-react/-/babel-plugin-annotate-react-2.3.0.tgz#ab4df27dbecaa3771a1b353b898ccf887876e9fb"
+  integrity sha512-gYLUL6Tu0exbvTIhK9nSCaztmqBlQAm07Fvtl/nKTc+lxwFkcX9vR8RrdTbyjJZKbPaA5EMlExQ6GeLCXkfm5g==
+
 "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
Adds the Fullstory Babel plugin that automatically annotates the DOM with React component names at build-time. This is a temporary addition to allow us to begin experimenting with the data internally, and may eventually be replaced with our own plugin.

Example of what the DOM looks like with automatic annotations:

One of the components in Sentry, with its CSS selector
![image](https://github.com/getsentry/sentry/assets/16740047/860ff782-1005-4657-b437-f2a4b937f675)

What it looks like in the DOM (look at the `data-element`, `data-component`, and `data-source-file` properties)
![image](https://github.com/getsentry/sentry/assets/16740047/1ed64b5d-aebf-49cc-a380-89ba0c35c536)

