### PR TITLE
ref(feedback): display name in list when no email

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -66,11 +66,7 @@ export default function FeedbackItem({
         <Flex gap={space(2)} justify="space-between">
           <Flex column>
             <Flex align="center" gap={space(0.5)}>
-              <FeedbackItemUsername
-                feedbackIssue={feedbackItem}
-                feedbackEvent={eventData}
-                detailDisplay
-              />
+              <FeedbackItemUsername feedbackIssue={feedbackItem} detailDisplay />
               {feedbackItem.metadata.contact_email ? (
                 <CopyToClipboardButton
                   size="xs"

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -2,12 +2,11 @@ import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {FeedbackEvent, FeedbackIssue} from 'sentry/utils/feedback/types';
+import type {FeedbackIssue} from 'sentry/utils/feedback/types';
 
 interface Props {
   detailDisplay: boolean;
   feedbackIssue: FeedbackIssue;
-  feedbackEvent?: FeedbackEvent | undefined;
 }
 
 export default function FeedbackItemUsername({feedbackIssue, detailDisplay}: Props) {

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -10,12 +10,8 @@ interface Props {
   feedbackEvent?: FeedbackEvent | undefined;
 }
 
-export default function FeedbackItemUsername({
-  feedbackIssue,
-  feedbackEvent,
-  detailDisplay,
-}: Props) {
-  const name = feedbackEvent?.contexts?.feedback?.name;
+export default function FeedbackItemUsername({feedbackIssue, detailDisplay}: Props) {
+  const name = feedbackIssue.metadata.name;
   const email = feedbackIssue.metadata.contact_email;
 
   if (!email && !name) {
@@ -32,7 +28,7 @@ export default function FeedbackItemUsername({
     );
   }
 
-  return <strong>{email}</strong>;
+  return <strong>{name ?? email}</strong>;
 }
 
 const Purple = styled('span')`


### PR DESCRIPTION
- grab the name from the issues `metadata` object instead
- when the user doesn't have an email, show the name instead in the list

<img width="411" alt="SCR-20231031-npst" src="https://github.com/getsentry/sentry/assets/56095982/a9030c33-36fc-4387-9a9d-ae44711fe54a">

details view is still the same, showing "No Email" or "No Name"
<img width="682" alt="SCR-20231031-nqja" src="https://github.com/getsentry/sentry/assets/56095982/fbc66e15-1fe9-4848-baf7-1c065c5a0133">
<img width="302" alt="SCR-20231031-nqpu" src="https://github.com/getsentry/sentry/assets/56095982/185d5c6c-c9da-43bf-b094-8f70b4f2bc42">
