### PR TITLE
feat(backup): Add /relocations/ POST endpoint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,10 +90,14 @@ Makefile                                                 @getsentry/owners-sentr
 /static/app/components/sidebar/index.tsx                 @getsentry/open-source
 
 ## Relocation - getsentry/team-ospo#153
+/src/sentry/api/endpoints/relocation.py                  @getsentry/open-source
 /src/sentry/backup/                                      @getsentry/open-source
-/src/sentry/testutils/helpers/backups.py                 @getsentry/open-source
 /src/sentry/runner/commands/backup.py                    @getsentry/open-source
+/src/sentry/services/hybrid-cloud/import_export/         @getsentry/open-source
 /src/sentry/testutils/helpers/backups.py                 @getsentry/open-source
+/tests/sentry/api/endpoints/test_relocation.py           @getsentry/open-source
+/tests/sentry/backup                                     @getsentry/open-source
+/tests/sentry/runner/commands/test_backup.py             @getsentry/open-source
 
 ## Build & Releases
 /.github/workflows/release.yml                           @getsentry/release-approvers

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -19,6 +19,7 @@ class ApiOwner(Enum):
     GROWTH = "growth"
     OWNERS_INGEST = "owners-ingest"
     OWNERS_NATIVE = "owners-native"
+    RELOCATION = "open-source"
     REPLAY = "replay-backend"
     WEB_FRONTEND_SDKS = "team-web-sdk-frontend"
     FEEDBACK = "feedback-backend"

--- a/src/sentry/api/endpoints/relocation.py
+++ b/src/sentry/api/endpoints/relocation.py
@@ -1,0 +1,115 @@
+import logging
+
+from django.db import router
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.permissions import SuperuserPermission
+from sentry.models.files.file import File
+from sentry.models.relocation import Relocation, RelocationFile
+from sentry.models.user import MAX_USERNAME_LENGTH
+from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.utils.db import atomic_transaction
+
+# Relocation input files are uploaded as tarballs, and chunked and stored using the normal
+# `File`/`AbstractFile` mechanism, which has a hard limit of 2GiB, because we need to represent the
+# offset into it as a 32-bit int. This means that the largest tarball we are able to import at this
+# time is 2GiB. When validating this tarball, we will need to make a "composite object" from the
+# uploaded blobs in Google Cloud Storage, which has a limit of 32 components. Thus, we get our blob
+# size of the maximum overall file size (2GiB) divided by the maximum number of blobs (32): 64MiB
+# per blob.
+#
+# Note that the actual production file size limit, set by uwsgi, is currently 209715200 bytes, or
+# ~200MB, so we should never see more than ~4 blobs in
+RELOCATION_BLOB_SIZE = int((2**31) / 32)
+
+ERR_DUPLICATE_RELOCATION = "An in-progress relocation already exists for this owner"
+ERR_FEATURE_DISABLED = "This feature is not yet enabled"
+
+logger = logging.getLogger(__name__)
+
+
+class RelocationPostSerializer(serializers.Serializer):
+    file = serializers.FileField(required=True)
+    orgs = serializers.ListField(required=True, allow_empty=False)
+    owner = serializers.CharField(
+        max_length=MAX_USERNAME_LENGTH, required=True, allow_blank=False, allow_null=False
+    )
+
+
+@region_silo_endpoint
+class RelocationEndpoint(Endpoint):
+    owner = ApiOwner.RELOCATION
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    permission_classes = (SuperuserPermission,)
+
+    def post(self, request: Request) -> Response:
+        """
+        Upload an encrypted export tarball for relocation.
+        ``````````````````````````````````````````````````
+
+        Upload an encrypted relocation tarball for relocation.
+
+        This is currently an experimental API, and for the time being is only meant to be called by
+        admins.
+
+        :param file file: the multipart encoded tarball file.
+        :param string owner: the username of the "owner" of this relocation; not necessarily
+                             identical to the user who made the API call.
+        :param list[string] orgs: A list of org slugs from those included in the associated
+                                  encrypted backup tarball that should be imported.
+        :auth: required
+        """
+
+        logger.info("relocation.start")
+        if not features.has("relocation:enabled"):
+            return Response({"detail": ERR_DUPLICATE_RELOCATION}, status=400)
+
+        serializer = RelocationPostSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        validated = serializer.validated_data
+        fileobj = validated.get("file")
+        owner_username = validated.get("owner")
+        org_slugs = validated.get("orgs")
+        try:
+            owner = user_service.get_by_username(username=owner_username)[0]
+        except IndexError:
+            return Response({"detail": f"Could not find user `{owner_username}`"}, status=400)
+
+        # Quickly check that this `owner` does not have more than one active `Relocation` in flight.
+        if Relocation.objects.filter(
+            owner=owner.id, status=Relocation.Status.IN_PROGRESS.value
+        ).exists():
+            return Response({"detail": ERR_DUPLICATE_RELOCATION}, status=409)
+
+        # TODO(getsentry/team-ospo#203): check import size, and maybe do throttle based on that
+        # information.
+
+        file = File.objects.create(name="raw-relocation-data.tar", type="relocation.file")
+        file.putfile(fileobj, blob_size=RELOCATION_BLOB_SIZE, logger=logger)
+
+        with atomic_transaction(
+            using=(router.db_for_write(Relocation), router.db_for_write(RelocationFile))
+        ):
+            relocation: Relocation = Relocation.objects.create(
+                creator=request.user.id,
+                owner=owner.id,
+                want_org_slugs=org_slugs,
+                step=Relocation.Step.UPLOADING.value,
+            )
+            RelocationFile.objects.create(
+                relocation=relocation,
+                file=file,
+                kind=RelocationFile.Kind.RAW_USER_DATA.value,
+            )
+
+        return Response(status=201)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -37,6 +37,7 @@ from sentry.api.endpoints.release_thresholds.release_threshold_index import (
 from sentry.api.endpoints.release_thresholds.release_threshold_status_index import (
     ReleaseThresholdStatusIndexEndpoint,
 )
+from sentry.api.endpoints.relocation import RelocationEndpoint
 from sentry.api.endpoints.source_map_debug_blue_thunder_edition import (
     SourceMapDebugBlueThunderEditionEndpoint,
 )
@@ -3026,6 +3027,13 @@ urlpatterns = [
     re_path(
         r"^internal/",
         include(INTERNAL_URLS),
+    ),
+    # Relocation
+    # TODO(getsentry/team-ospo#169): Add URL endpoint to pull encryption public key.
+    re_path(
+        r"^relocation/$",
+        RelocationEndpoint.as_view(),
+        name="sentry-api-0-relocation",
     ),
     # Catch all
     re_path(

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -895,6 +895,7 @@ CELERY_QUEUES_REGION = [
     Queue("transactions.name_clusterer", routing_key="transactions.name_clusterer"),
     Queue("auto_enable_codecov", routing_key="auto_enable_codecov"),
     Queue("weekly_escalating_forecast", routing_key="weekly_escalating_forecast"),
+    Queue("relocation", routing_key="relocation"),
     Queue("recap_servers", routing_key="recap_servers"),
     Queue("performance.statistical_detector", routing_key="performance.statistical_detector"),
     Queue("profiling.statistical_detector", routing_key="profiling.statistical_detector"),
@@ -1863,6 +1864,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Metrics: Enable creation of investigation dynamic sampling rules (rules that
     # temporary boost the sample rate of particular transactions)
     "organizations:investigation-bias": False,
+    # Controls whether or not the relocation endpoints can be used.
+    "relocation:enabled": False,
     # Don't add feature defaults down here! Please add them in their associated
     # group sorted alphabetically.
 }

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -62,6 +62,7 @@ register_permanent_features(default_manager)
 # Features that don't use resource scoping
 default_manager.add("auth:register", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:create", SystemFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("relocation:enabled", SystemFeature, FeatureHandlerStrategy.REMOTE)
 
 # Organization scoped features that are in development or in customer trials.
 default_manager.add("organizations:javascript-console-error-tag", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/tests/sentry/api/endpoints/test_relocation.py
+++ b/tests/sentry/api/endpoints/test_relocation.py
@@ -1,0 +1,259 @@
+import tempfile
+from pathlib import Path
+from typing import Tuple
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from sentry.backup.helpers import create_encrypted_export_tarball
+from sentry.models.relocation import Relocation, RelocationFile
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.factories import get_fixture_path
+from sentry.testutils.helpers.backups import generate_rsa_key_pair
+from sentry.testutils.silo import region_silo_test
+from sentry.utils import json
+
+FRESH_INSTALL_PATH = get_fixture_path("backup", "fresh-install.json")
+
+
+@region_silo_test
+class RelocationCreateTest(APITestCase):
+    endpoint = "sentry-api-0-relocation"
+
+    def setUp(self):
+        super().setUp()
+        self.owner = self.create_user(
+            email="owner", is_superuser=False, is_staff=True, is_active=True
+        )
+        self.superuser = self.create_user(
+            "superuser", is_superuser=True, is_staff=True, is_active=True
+        )
+        self.login_as(user=self.superuser, superuser=True)
+
+    def tmp_keys(self, tmp_dir: str) -> Tuple[Path, Path]:
+        (priv_key_pem, pub_key_pem) = generate_rsa_key_pair()
+        tmp_priv_key_path = Path(tmp_dir).joinpath("key")
+        with open(tmp_priv_key_path, "wb") as f:
+            f.write(priv_key_pem)
+
+        tmp_pub_key_path = Path(tmp_dir).joinpath("key.pub")
+        with open(tmp_pub_key_path, "wb") as f:
+            f.write(pub_key_pem)
+
+        return (tmp_priv_key_path, tmp_pub_key_path)
+
+    def test_success_simple(self):
+        relocation_count = Relocation.objects.count()
+        relocation_file_count = RelocationFile.objects.count()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with self.feature("relocation:enabled"), open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    url = reverse("sentry-api-0-relocation")
+                    response = self.client.post(
+                        url,
+                        {
+                            "owner": self.owner.username,
+                            "file": SimpleUploadedFile(
+                                "export.tar",
+                                create_encrypted_export_tarball(data, p).getvalue(),
+                                content_type="application/tar",
+                            ),
+                            "orgs": ["testing", "foo"],
+                        },
+                        format="multipart",
+                    )
+
+        assert response.status_code == 201
+        assert Relocation.objects.count() == relocation_count + 1
+        assert RelocationFile.objects.count() == relocation_file_count + 1
+
+    def test_success_relocation_for_same_owner_already_completed(self):
+        Relocation.objects.create(
+            creator=self.superuser.id,
+            owner=self.owner.id,
+            want_org_slugs=["not-relevant-to-this-test"],
+            step=Relocation.Step.COMPLETED.value,
+            status=Relocation.Status.FAILURE.value,
+        )
+        Relocation.objects.create(
+            creator=self.superuser.id,
+            owner=self.owner.id,
+            want_org_slugs=["not-relevant-to-this-test"],
+            step=Relocation.Step.COMPLETED.value,
+            status=Relocation.Status.SUCCESS.value,
+        )
+        relocation_count = Relocation.objects.count()
+        relocation_file_count = RelocationFile.objects.count()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with self.feature("relocation:enabled"), open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    url = reverse("sentry-api-0-relocation")
+                    response = self.client.post(
+                        url,
+                        {
+                            "owner": self.owner.username,
+                            "file": SimpleUploadedFile(
+                                "export.tar",
+                                create_encrypted_export_tarball(data, p).getvalue(),
+                                content_type="application/tar",
+                            ),
+                            "orgs": ["testing", "foo"],
+                        },
+                        format="multipart",
+                    )
+
+        assert response.status_code == 201
+        assert Relocation.objects.count() == relocation_count + 1
+        assert RelocationFile.objects.count() == relocation_file_count + 1
+
+    def test_fail_feature_disabled(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    url = reverse("sentry-api-0-relocation")
+                    response = self.client.post(
+                        url,
+                        {
+                            "owner": self.owner.username,
+                            "file": SimpleUploadedFile(
+                                "export.tar",
+                                create_encrypted_export_tarball(data, p).getvalue(),
+                                content_type="application/tar",
+                            ),
+                            "orgs": ["testing", "foo"],
+                        },
+                        format="multipart",
+                    )
+
+        assert response.status_code == 400
+
+    def test_fail_missing_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with self.feature("relocation:enabled"):
+                url = reverse("sentry-api-0-relocation")
+                response = self.client.post(
+                    url,
+                    {
+                        "owner": self.owner.username,
+                        "orgs": ["testing", "foo"],
+                    },
+                    format="multipart",
+                )
+
+        assert response.status_code == 400
+        assert response.data.get("file") is not None
+        assert response.data.get("file")[0].code == "required"
+
+    def test_fail_missing_orgs(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with self.feature("relocation:enabled"), open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    url = reverse("sentry-api-0-relocation")
+                    response = self.client.post(
+                        url,
+                        {
+                            "owner": self.owner.username,
+                            "file": SimpleUploadedFile(
+                                "export.tar",
+                                create_encrypted_export_tarball(data, p).getvalue(),
+                                content_type="application/tar",
+                            ),
+                        },
+                        format="multipart",
+                    )
+
+        assert response.status_code == 400
+        assert response.data.get("orgs") is not None
+        assert response.data.get("orgs")[0].code == "required"
+
+    def test_fail_missing_owner(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with self.feature("relocation:enabled"), open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    url = reverse("sentry-api-0-relocation")
+                    response = self.client.post(
+                        url,
+                        {
+                            "file": SimpleUploadedFile(
+                                "export.tar",
+                                create_encrypted_export_tarball(data, p).getvalue(),
+                                content_type="application/tar",
+                            ),
+                            "orgs": ["testing", "foo"],
+                        },
+                        format="multipart",
+                    )
+
+        assert response.status_code == 400
+        assert response.data.get("owner") is not None
+        assert response.data.get("owner")[0].code == "required"
+
+    def test_fail_nonexistent_owner(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with self.feature("relocation:enabled"), open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    url = reverse("sentry-api-0-relocation")
+                    response = self.client.post(
+                        url,
+                        {
+                            "owner": "doesnotexist",
+                            "file": SimpleUploadedFile(
+                                "export.tar",
+                                create_encrypted_export_tarball(data, p).getvalue(),
+                                content_type="application/tar",
+                            ),
+                            "orgs": ["testing", "foo"],
+                        },
+                        format="multipart",
+                    )
+
+        assert response.status_code == 400
+        assert response.data.get("detail") is not None
+        assert "`doesnotexist`" in response.data.get("detail")
+
+    def test_fail_relocation_for_same_owner_already_in_progress(self):
+        Relocation.objects.create(
+            creator=self.superuser.id,
+            owner=self.owner.id,
+            want_org_slugs=["not-relevant-to-this-test"],
+            step=Relocation.Step.UPLOADING.value,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with self.feature("relocation:enabled"), open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    url = reverse("sentry-api-0-relocation")
+                    simple_file = SimpleUploadedFile(
+                        "export.tar",
+                        create_encrypted_export_tarball(data, p).getvalue(),
+                        content_type="application/tar",
+                    )
+                    simple_file.name = None
+                    response = self.client.post(
+                        url,
+                        {
+                            "owner": self.owner.username,
+                            "file": simple_file,
+                            "orgs": ["testing", "foo"],
+                        },
+                        format="multipart",
+                    )
+
+        assert response.status_code == 409


### PR DESCRIPTION
This endpoint allows users (currently only those with superuser permissions) to create a new relocation by uploading a file and some arguments as a multipart form/data.

Issue: getsentry/team-ospo#169
Issue: getsentry/team-ospo#203