### PR TITLE
feat(hybrid-cloud): Adds region selector dropdown behind feature flag

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1472,6 +1472,7 @@ register(
 )
 
 register("hybrid_cloud.outbox_rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("hybrid_cloud.multi-region-selector", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Decides whether an incoming transaction triggers an update of the clustering rule applied to it.
 register("txnames.bump-lifetime-sample-rate", default=0.1, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -164,6 +164,8 @@ class _ClientConfig:
             self.last_org and features.has("organizations:customer-domains", self.last_org)
         ):
             yield "organizations:customer-domains"
+        if options.get("hybrid_cloud.multi-region-selector"):
+            yield "organizations:multi-region-selector"
 
     @property
     def needs_upgrade(self) -> bool:

--- a/static/app/components/forms/apiForm.tsx
+++ b/static/app/components/forms/apiForm.tsx
@@ -25,7 +25,7 @@ function ApiForm({onSubmit, apiMethod, apiEndpoint, hostOverride, ...otherProps}
       const transformed = onSubmit?.(data);
       addLoadingMessage(t('Saving changes\u2026'));
 
-      const request_options: RequestOptions = {
+      const requestOptions: RequestOptions = {
         method: apiMethod,
         data: transformed ?? data,
         success: response => {
@@ -39,10 +39,10 @@ function ApiForm({onSubmit, apiMethod, apiEndpoint, hostOverride, ...otherProps}
       };
 
       if (hostOverride) {
-        request_options.host = hostOverride;
+        requestOptions.host = hostOverride;
       }
 
-      api.request(apiEndpoint, request_options);
+      api.request(apiEndpoint, requestOptions);
     },
     [api, onSubmit, apiMethod, apiEndpoint, hostOverride]
   );

--- a/static/app/views/organizationCreate/index.spec.tsx
+++ b/static/app/views/organizationCreate/index.spec.tsx
@@ -1,3 +1,4 @@
+import selectEvent from 'react-select-event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -9,6 +10,9 @@ describe('OrganizationCreate', function () {
   beforeEach(() => {
     ConfigStore.get('termsUrl');
     ConfigStore.get('privacyUrl');
+
+    // Set only a single region in the config store by default
+    ConfigStore.set('regions', [{name: '--monolith--', url: 'https://example.com'}]);
   });
 
   afterEach(() => {
@@ -46,12 +50,13 @@ describe('OrganizationCreate', function () {
     await userEvent.click(screen.getByText('Create Organization'));
 
     await waitFor(() => {
-      expect(orgCreateMock).toHaveBeenCalledWith(
-        '/organizations/',
-        expect.objectContaining({
-          data: {agreeTerms: true, defaultTeam: true, name: 'Good Burger'},
-        })
-      );
+      expect(orgCreateMock).toHaveBeenCalledWith('/organizations/', {
+        success: expect.any(Function),
+        error: expect.any(Function),
+        method: 'POST',
+        data: {agreeTerms: true, defaultTeam: true, name: 'Good Burger'},
+        host: undefined,
+      });
     });
     expect(window.location.assign).toHaveBeenCalledTimes(1);
     expect(window.location.assign).toHaveBeenCalledWith(
@@ -81,12 +86,136 @@ describe('OrganizationCreate', function () {
     await userEvent.click(screen.getByText('Create Organization'));
 
     await waitFor(() => {
-      expect(orgCreateMock).toHaveBeenCalledWith(
-        '/organizations/',
-        expect.objectContaining({
-          data: {agreeTerms: true, defaultTeam: true, name: 'Good Burger'},
-        })
-      );
+      expect(orgCreateMock).toHaveBeenCalledWith('/organizations/', {
+        data: {agreeTerms: true, defaultTeam: true, name: 'Good Burger'},
+        method: 'POST',
+        success: expect.any(Function),
+        error: expect.any(Function),
+        host: undefined,
+      });
+    });
+
+    expect(window.location.assign).toHaveBeenCalledTimes(1);
+    expect(window.location.assign).toHaveBeenCalledWith(
+      'https://org-slug.sentry.io/projects/new/'
+    );
+  });
+
+  function multiRegionSetup() {
+    const orgCreateMock = MockApiClient.addMockResponse({
+      url: '/organizations/',
+      method: 'POST',
+      body: Organization({
+        features: ['customer-domains'],
+      }),
+    });
+
+    ConfigStore.set('features', new Set(['organizations:multi-region-selector']));
+    ConfigStore.set('regions', [
+      {url: 'https://us.example.com', name: 'us'},
+      {
+        url: 'https://de.example.com',
+        name: 'de',
+      },
+    ]);
+
+    return orgCreateMock;
+  }
+
+  it('renders without region data and submits without host when only a single region is defined', async function () {
+    const orgCreateMock = multiRegionSetup();
+    // Set only a single region in the config store
+    ConfigStore.set('regions', [{name: '--monolith--', url: 'https://example.com'}]);
+
+    render(<OrganizationCreate />);
+    expect(screen.queryByLabelText('Data Storage')).not.toBeInTheDocument();
+    await userEvent.type(screen.getByPlaceholderText('e.g. My Company'), 'Good Burger');
+    await userEvent.click(screen.getByText('Create Organization'));
+
+    await waitFor(() => {
+      expect(orgCreateMock).toHaveBeenCalledWith('/organizations/', {
+        success: expect.any(Function),
+        error: expect.any(Function),
+        method: 'POST',
+        host: undefined,
+        data: {defaultTeam: true, name: 'Good Burger'},
+      });
+    });
+
+    expect(window.location.assign).toHaveBeenCalledTimes(1);
+    expect(window.location.assign).toHaveBeenCalledWith(
+      'https://org-slug.sentry.io/projects/new/'
+    );
+  });
+
+  it('renders with region data and selects US region as default when the feature flag is enabled', async function () {
+    const orgCreateMock = multiRegionSetup();
+    render(<OrganizationCreate />);
+    expect(screen.getByLabelText('Data Storage')).toBeInTheDocument();
+    await userEvent.type(screen.getByPlaceholderText('e.g. My Company'), 'Good Burger');
+    await userEvent.click(screen.getByText('Create Organization'));
+
+    const expectedHost = 'https://us.example.com';
+    await waitFor(() => {
+      expect(orgCreateMock).toHaveBeenCalledWith('/organizations/', {
+        success: expect.any(Function),
+        error: expect.any(Function),
+        method: 'POST',
+        host: expectedHost,
+        data: {defaultTeam: true, name: 'Good Burger', region: expectedHost},
+      });
+    });
+
+    expect(window.location.assign).toHaveBeenCalledTimes(1);
+    expect(window.location.assign).toHaveBeenCalledWith(
+      'https://org-slug.sentry.io/projects/new/'
+    );
+  });
+
+  it('renders without region data and submits without host when the feature flag is not enabled', async function () {
+    const orgCreateMock = multiRegionSetup();
+    ConfigStore.set('features', new Set());
+    render(<OrganizationCreate />);
+    expect(screen.queryByLabelText('Data Storage')).not.toBeInTheDocument();
+    await userEvent.type(screen.getByPlaceholderText('e.g. My Company'), 'Good Burger');
+    await userEvent.click(screen.getByText('Create Organization'));
+
+    await waitFor(() => {
+      expect(orgCreateMock).toHaveBeenCalledWith('/organizations/', {
+        success: expect.any(Function),
+        error: expect.any(Function),
+        method: 'POST',
+        host: undefined,
+        data: {defaultTeam: true, name: 'Good Burger'},
+      });
+    });
+
+    expect(window.location.assign).toHaveBeenCalledTimes(1);
+    expect(window.location.assign).toHaveBeenCalledWith(
+      'https://org-slug.sentry.io/projects/new/'
+    );
+  });
+
+  it('uses the host of the selected region when submitting', async function () {
+    const orgCreateMock = multiRegionSetup();
+    render(<OrganizationCreate />);
+    expect(screen.getByLabelText('Data Storage')).toBeInTheDocument();
+    await userEvent.type(screen.getByPlaceholderText('e.g. My Company'), 'Good Burger');
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Data Storage'}),
+      '🇪🇺 European Union (EU)'
+    );
+    await userEvent.click(screen.getByText('Create Organization'));
+
+    const expectedHost = 'https://de.example.com';
+    await waitFor(() => {
+      expect(orgCreateMock).toHaveBeenCalledWith('/organizations/', {
+        success: expect.any(Function),
+        error: expect.any(Function),
+        method: 'POST',
+        host: expectedHost,
+        data: {defaultTeam: true, name: 'Good Burger', region: expectedHost},
+      });
     });
 
     expect(window.location.assign).toHaveBeenCalledTimes(1);

--- a/static/app/views/organizationCreate/index.spec.tsx
+++ b/static/app/views/organizationCreate/index.spec.tsx
@@ -7,9 +7,12 @@ import ConfigStore from 'sentry/stores/configStore';
 import OrganizationCreate from 'sentry/views/organizationCreate';
 
 describe('OrganizationCreate', function () {
+  let oldRegions: any[] = [];
   beforeEach(() => {
     ConfigStore.get('termsUrl');
     ConfigStore.get('privacyUrl');
+
+    oldRegions = ConfigStore.get('regions');
 
     // Set only a single region in the config store by default
     ConfigStore.set('regions', [{name: '--monolith--', url: 'https://example.com'}]);
@@ -18,6 +21,7 @@ describe('OrganizationCreate', function () {
   afterEach(() => {
     MockApiClient.clearMockResponses();
     jest.resetAllMocks();
+    ConfigStore.set('regions', oldRegions);
   });
 
   it('renders without terms', function () {

--- a/static/app/views/organizationCreate/index.spec.tsx
+++ b/static/app/views/organizationCreate/index.spec.tsx
@@ -166,7 +166,7 @@ describe('OrganizationCreate', function () {
         error: expect.any(Function),
         method: 'POST',
         host: expectedHost,
-        data: {defaultTeam: true, name: 'Good Burger', region: expectedHost},
+        data: {defaultTeam: true, name: 'Good Burger'},
       });
     });
 
@@ -218,7 +218,7 @@ describe('OrganizationCreate', function () {
         error: expect.any(Function),
         method: 'POST',
         host: expectedHost,
-        data: {defaultTeam: true, name: 'Good Burger', region: expectedHost},
+        data: {defaultTeam: true, name: 'Good Burger'},
       });
     });
 

--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -13,7 +13,7 @@ import {OrganizationSummary} from 'sentry/types';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 enum RegionDisplayName {
-  US = '🇺🇸 United States of America (USA)',
+  US = '🇺🇸 United States of America (US)',
   DE = '🇪🇺 European Union (EU)',
 }
 

--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -37,7 +37,10 @@ function getDefaultRegionChoice(
     return undefined;
   }
 
-  const usRegion = regionChoices.find(([regionName, _]) => regionName === 'us');
+  const usRegion = regionChoices.find(
+    ([_, regionName]) => regionName === RegionDisplayName.US
+  );
+
   if (usRegion) {
     return usRegion;
   }

--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -56,6 +56,13 @@ function shouldDisplayRegions(): boolean {
   );
 }
 
+function removeRegionFromRequestForm(formData: Record<string, any>) {
+  const shallowFormDataCopy = {...formData};
+
+  delete shallowFormDataCopy.region;
+  return shallowFormDataCopy;
+}
+
 function OrganizationCreate() {
   const termsUrl = ConfigStore.get('termsUrl');
   const privacyUrl = ConfigStore.get('privacyUrl');
@@ -80,6 +87,7 @@ function OrganizationCreate() {
           apiEndpoint="/organizations/"
           apiMethod="POST"
           hostOverride={regionUrl}
+          onSubmit={removeRegionFromRequestForm}
           onSubmitSuccess={(createdOrg: OrganizationSummary) => {
             const hasCustomerDomain = createdOrg?.features.includes('customer-domains');
             let nextUrl = normalizeUrl(

--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -17,8 +17,8 @@ enum RegionDisplayName {
   DE = '🇪🇺 European Union (EU)',
 }
 
-function get_region_choices() {
-  const regions = ConfigStore.get('regions');
+function getRegionChoices(): [string, string][] {
+  const regions = ConfigStore.get('regions') ?? [];
 
   return regions.map(({name, url}) => {
     const regionName = name.toUpperCase();
@@ -30,20 +30,41 @@ function get_region_choices() {
   });
 }
 
-function should_display_regions(): boolean {
-  return ConfigStore.get('features').has('organizations:multi-region-selector');
+function getDefaultRegionChoice(
+  regionChoices: [string, string][]
+): [string, string] | undefined {
+  if (!shouldDisplayRegions()) {
+    return undefined;
+  }
+
+  const usRegion = regionChoices.find(([regionName, _]) => regionName === 'us');
+  if (usRegion) {
+    return usRegion;
+  }
+
+  return regionChoices[0];
+}
+
+function shouldDisplayRegions(): boolean {
+  const regionCount = (ConfigStore.get('regions') ?? []).length;
+  return (
+    ConfigStore.get('features').has('organizations:multi-region-selector') &&
+    regionCount > 1
+  );
 }
 
 function OrganizationCreate() {
   const termsUrl = ConfigStore.get('termsUrl');
   const privacyUrl = ConfigStore.get('privacyUrl');
-  const [regionUrl, setRegion] = useState<string | undefined>();
+  const regionChoices = getRegionChoices();
+  const [regionUrl, setRegion] = useState<string | undefined>(
+    getDefaultRegionChoice(regionChoices)?.[0]
+  );
 
   return (
     <SentryDocumentTitle title={t('Create Organization')}>
       <NarrowLayout showLogout>
         <h3>{t('Create a New Organization')}</h3>
-
         <p>
           {t(
             "Organizations represent the top level in your hierarchy. You'll be able to bundle a collection of teams within an organization as well as give organization-wide permissions to users."
@@ -86,15 +107,16 @@ function OrganizationCreate() {
             stacked
             required
           />
-          {should_display_regions() && (
+          {shouldDisplayRegions() && (
             <SelectField
               name="region"
               label="Data Storage"
               help="Where will this organization reside?"
-              choices={get_region_choices()}
+              defaultValue={getDefaultRegionChoice(regionChoices)?.[0]}
+              choices={regionChoices}
               onChange={setRegion}
-              stacked
               inline={false}
+              stacked
               required
             />
           )}


### PR DESCRIPTION
Implements a simple dropdown with default region mapping for our two expected regions, guarded behind a feature flag.

Automatically routes the provision request to the correct region when one is selected via the dropdown.

## Without the feature flag enabled, or with it enabled in monolith mode:
![image](https://github.com/getsentry/sentry/assets/5643012/98415d97-ad38-4a97-90c5-ed8b77bd0fd5)

## With the feature flag enabled and with multiple regions:
![image](https://github.com/getsentry/sentry/assets/5643012/3f8c622b-7f99-4a8a-8886-97853fa9b47c)
![image](https://github.com/getsentry/sentry/assets/5643012/d996e25c-3b02-4c1a-a031-49287b71b551)

