### PR TITLE
ref(hc): Add prefixes to RPC metrics tags

### DIFF
--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -491,9 +491,9 @@ class _RemoteSiloCall:
 
     def _metrics_tags(self, **additional_tags: str | int) -> Mapping[str, str | int | None]:
         return dict(
-            region=self.region.name if self.region else None,
-            service=self.service_name,
-            method=self.method_name,
+            rpc_destination_region=self.region.name if self.region else None,
+            rpc_service=self.service_name,
+            rpc_method=self.method_name,
             **additional_tags,
         )
 


### PR DESCRIPTION
This is mostly intended to reduce duplication around service/method tags which are used in a number of other places (ex: http method), causing overlaps in suggested filter values. Also updated the region tag while I'm in here to clarify that it's the destination region of the request.