### PR TITLE
feat(replays): New hybrid timeline design

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -47,18 +47,29 @@ function ReplayTimeline({}: Props) {
   const chapterFrames = replay.getChapterFrames();
   const networkFrames = replay.getNetworkFrames();
 
-  // start of the timeline is in the middle
+  // timeline is in the middle
   const initialTranslate = 0.5 / timelineScale;
+  const percentComplete = divide(currentTime, durationMs);
 
-  const translate =
-    initialTranslate - (currentTime > durationMs ? 1 : divide(currentTime, durationMs));
+  const starting = percentComplete < initialTranslate;
+  const ending = percentComplete + initialTranslate > 1;
+
+  const translate = () => {
+    if (starting) {
+      return 0;
+    }
+    if (ending) {
+      return initialTranslate - (1 - initialTranslate);
+    }
+    return initialTranslate - (currentTime > durationMs ? 1 : percentComplete);
+  };
 
   return hasNewTimeline ? (
     <VisiblePanel ref={panelRef} {...mouseTrackingProps}>
       <Stacked
         style={{
           width: `${toPercent(timelineScale)}`,
-          transform: `translate(${toPercent(translate)}, 0%)`,
+          transform: `translate(${toPercent(translate())}, 0%)`,
         }}
         ref={stackedRef}
       >

--- a/static/app/components/replays/player/useScrubberMouseTracking.tsx
+++ b/static/app/components/replays/player/useScrubberMouseTracking.tsx
@@ -1,6 +1,7 @@
 import {RefObject, useCallback} from 'react';
 
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {divide} from 'sentry/components/replays/utils';
 import useMouseTracking from 'sentry/utils/replays/hooks/useMouseTracking';
 
 type Opts<T extends Element> = {
@@ -39,7 +40,7 @@ export function useScrubberMouseTracking<T extends Element>({elem}: Opts<T>) {
 
 export function useTimelineScrubberMouseTracking<T extends Element>(
   {elem}: Opts<T>,
-  size: number
+  scale: number
 ) {
   const {replay, currentTime, setCurrentHoverTime} = useReplayContext();
   const durationMs = replay?.getDurationMs();
@@ -51,16 +52,30 @@ export function useTimelineScrubberMouseTracking<T extends Element>(
         return;
       }
       const {left, width} = params;
+      const initialTranslate = 0.5 / scale;
+      const percentComplete = divide(currentTime, durationMs);
+
+      const starting = percentComplete < initialTranslate;
+      const ending = percentComplete + initialTranslate > 1;
 
       if (left >= 0) {
-        const percent = (left - width / 2) / width;
-        const time = currentTime + (percent * durationMs) / size;
-        setCurrentHoverTime(time);
+        const time = () => {
+          let percent = left / width;
+          if (starting) {
+            return (percent * durationMs) / scale;
+          }
+          if (ending) {
+            return (percent * durationMs) / scale + (1 - 1 / scale) * durationMs;
+          }
+          percent = (left - width / 2) / width;
+          return currentTime + (percent * durationMs) / scale;
+        };
+        setCurrentHoverTime(time());
       } else {
         setCurrentHoverTime(undefined);
       }
     },
-    [durationMs, setCurrentHoverTime, currentTime, size]
+    [durationMs, setCurrentHoverTime, currentTime, scale]
   );
 
   const mouseTrackingProps = useMouseTracking({

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -125,7 +125,7 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   speed: number;
 
   /**
-   * Scale of the timeline width
+   * Scale of the timeline width, starts from 1x and increases by 0.5x
    */
   timelineScale: number;
 


### PR DESCRIPTION
The new timeline has a hybrid approach where it has a static time-index and a moving time-index for start and end when zoomed in. When zoomed in, timeline operates like normal with a moving time-index. Hover has also been updated to work with the new hybrid approach.

Timeline at 1x (no zoom):

https://github.com/getsentry/sentry/assets/55311782/447af5e5-9559-474d-a1e3-db0a54439419

Timeline at 2x:

https://github.com/getsentry/sentry/assets/55311782/c9a192f5-3e83-4f2c-a533-c6aa5ca9e1d3

Closes https://github.com/getsentry/sentry/issues/59006
Relates to https://github.com/getsentry/team-replay/issues/199

