### PR TITLE
feat(starfish): Add profile_id to indexed spans query builder

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -124,6 +124,7 @@ SPAN_COLUMN_MAP = {
     "transaction.id": "transaction_id",
     "transaction.op": "transaction_op",
     "user": "user",
+    "profile_id": "profile_id",
 }
 
 SESSIONS_FIELD_LIST = [


### PR DESCRIPTION
This allows us to query profile_id with the indexed spans query builder.

CH query before was converting it into tags
```
 SELECT (arrayElement(tags.value, indexOf(tags.key, 'profile_id')) AS `_snuba_tags[profile_id]`), (project_id AS _snuba_project_id), `_snuba_tags[profile_id]`,
       _snuba_project_id, (count() AS _snuba_count)
  FROM spans_local
 WHERE greaterOrEquals((end_timestamp AS _snuba_timestamp), toDateTime('2023-10-18T01:17:01', 'Universal'))
   AND less(_snuba_timestamp, toDateTime('2023-11-01T01:17:01', 'Universal'))
   AND in(_snuba_project_id, [1])
 GROUP BY `_snuba_tags[profile_id]`,
          _snuba_project_id
 LIMIT 11
 OFFSET 0
 ```
 
 after
 ```
   SELECT (profile_id AS _snuba_profile_id), (project_id AS _snuba_project_id), (count() AS _snuba_count), _snuba_profile_id,
        _snuba_project_id
   FROM spans_local
  WHERE greaterOrEquals((end_timestamp AS _snuba_timestamp), toDateTime('2023-10-18T01:18:01', 'Universal'))
    AND less(_snuba_timestamp, toDateTime('2023-11-01T01:18:01', 'Universal'))
    AND in(_snuba_project_id, [1])
  GROUP BY _snuba_profile_id,
           _snuba_project_id
  LIMIT 11
 OFFSET 0
 ```