### PR TITLE
fix(issues): Fix infinite react rerenders in issue list

### DIFF
--- a/static/app/components/replays/useReplaysCount.tsx
+++ b/static/app/components/replays/useReplaysCount.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 
 import {DateString, IssueCategory, Organization} from 'sentry/types';
 import {ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
@@ -115,21 +115,22 @@ function useReplaysCount({
     }
   );
 
-  return useMemo(() => {
+  useEffect(() => {
     if (isFetched) {
-      const merged = {
+      setLastData(last => ({
         ...zeroCounts,
-        ...lastData,
+        ...last,
         ...data,
-      };
-      setLastData(merged);
-      return merged;
+      }));
     }
+  }, [isFetched, zeroCounts, data]);
+
+  return useMemo<CountState>(() => {
     return {
       ...lastData,
       ...data,
     };
-  }, [isFetched, zeroCounts, lastData, data]);
+  }, [lastData, data]);
 }
 
 function makeReplayCountsQueryKey({


### PR DESCRIPTION
just pulls the setstate out of the useMemo to prevent the useMemo rerunning a ton of times

fixes JAVASCRIPT-2PB6