### PR TITLE
fix(issue-platform): insert occurrence into event stream after _get_or_create_group_environment is ran

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -56,14 +56,13 @@ def save_issue_occurrence(
         release = None
     group_info = save_issue_from_occurrence(occurrence, event, release)
     if group_info:
-        send_issue_occurrence_to_eventstream(event, occurrence, group_info)
         environment = event.get_environment()
         _get_or_create_group_environment(environment, release, [group_info])
         _increment_release_associated_counts(
             group_info.group.project, environment, release, [group_info]
         )
         _get_or_create_group_release(environment, release, event, [group_info])
-
+        send_issue_occurrence_to_eventstream(event, occurrence, group_info)
     return occurrence, group_info
 
 

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -86,7 +86,7 @@ class SaveIssueOccurrenceTest(OccurrenceTestMixin, TestCase):
         )
         assert release_project_env.new_issues_count == 0
         occurrence_data = self.build_occurrence_data(event_id=event.event_id)
-        with self.tasks():
+        with self.tasks(), mock.patch("sentry.issues.ingest.eventstream") as eventstream:
             occurrence, group_info = save_issue_occurrence(occurrence_data, event)
         assert group_info is not None
         group = group_info.group
@@ -100,6 +100,23 @@ class SaveIssueOccurrenceTest(OccurrenceTestMixin, TestCase):
         release_project_env.refresh_from_db()
         assert release_project_env.new_issues_count == 1
         assert GroupRelease.objects.filter(group_id=group.id, release_id=release.id).exists()
+        eventstream.insert.assert_called_once_with(
+            event=event.for_group(group_info.group),
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            primary_hash=occurrence.fingerprint[0],
+            received_timestamp=event.data.get("received") or event.datetime,
+            skip_consume=False,
+            group_states=[
+                {
+                    "id": group_info.group.id,
+                    "is_new": True,
+                    "is_regression": False,
+                    "is_new_group_environment": True,
+                }
+            ],
+        )
 
     def test_different_ids(self) -> None:
         create_default_projects()


### PR DESCRIPTION
At the moment environment filters do not work with issue platform issues at all, as far as I can tell. If an environment filter alert is set, the issues will never meet the criteria and the alert will never fire. 

This is because in post_process_group where rule logic gets fired, `is_new_group_environment` is set to False, because we insert the occurence into the event stream before we call `_get_or_create_group_environment`.

This PR switches the ordering so we call `send_issue_occurrence_to_eventstream` after `is_new_group_environment`.

With this change, `is_new_group_environment` will be set to True, and environment filters should work as expected.

I was replicating this locally which is how I could see this fix worked.

We likely need a fuller E2E test which looks at post_process calls after issue occurrence calls if we want to test this.