### PR TITLE
feat(bug reports): Allow "check all" to really check all items

### DIFF
--- a/static/app/components/feedback/list/feedbackList.tsx
+++ b/static/app/components/feedback/list/feedbackList.tsx
@@ -38,12 +38,14 @@ export default function FeedbackList() {
     isRowLoaded,
     issues,
     loadMoreRows,
+    hits,
   } = useFetchFeedbackInfiniteListData();
 
   const {setParamValue} = useUrlParams('query');
   const clearSearchTerm = () => setParamValue('');
 
-  const {checked, uncheckAll, toggleChecked} = useListItemCheckboxState();
+  const {checkAll, isChecked, state, toggleChecked, uncheckAll} =
+    useListItemCheckboxState({hits, knownIds: issues.map(issue => issue.id)});
 
   const listRef = useRef<ReactVirtualizedList>(null);
 
@@ -76,7 +78,7 @@ export default function FeedbackList() {
         <FeedbackListItem
           feedbackItem={item}
           style={style}
-          isChecked={checked.includes(item.id)}
+          isChecked={'all' in state ? 'all-checked' : isChecked(item.id)}
           onChecked={() => {
             toggleChecked(item.id);
           }}
@@ -87,7 +89,7 @@ export default function FeedbackList() {
 
   return (
     <Fragment>
-      <FeedbackListHeader checked={checked} uncheckAll={uncheckAll} />
+      <FeedbackListHeader checkAll={checkAll} state={state} uncheckAll={uncheckAll} />
       <OverflowPanelItem noPadding>
         <InfiniteLoader
           isRowLoaded={isRowLoaded}

--- a/static/app/components/feedback/list/feedbackList.tsx
+++ b/static/app/components/feedback/list/feedbackList.tsx
@@ -44,8 +44,10 @@ export default function FeedbackList() {
   const {setParamValue} = useUrlParams('query');
   const clearSearchTerm = () => setParamValue('');
 
-  const {checkAll, isChecked, state, toggleChecked, uncheckAll} =
-    useListItemCheckboxState({hits, knownIds: issues.map(issue => issue.id)});
+  const checkboxState = useListItemCheckboxState({
+    hits,
+    knownIds: issues.map(issue => issue.id),
+  });
 
   const listRef = useRef<ReactVirtualizedList>(null);
 
@@ -77,11 +79,11 @@ export default function FeedbackList() {
       >
         <FeedbackListItem
           feedbackItem={item}
-          style={style}
-          isChecked={'all' in state ? 'all-checked' : isChecked(item.id)}
-          onChecked={() => {
-            toggleChecked(item.id);
+          isSelected={checkboxState.isSelected(item.id)}
+          onSelect={() => {
+            checkboxState.toggleSelected(item.id);
           }}
+          style={style}
         />
       </CellMeasurer>
     );
@@ -89,7 +91,7 @@ export default function FeedbackList() {
 
   return (
     <Fragment>
-      <FeedbackListHeader checkAll={checkAll} state={state} uncheckAll={uncheckAll} />
+      <FeedbackListHeader {...checkboxState} />
       <OverflowPanelItem noPadding>
         <InfiniteLoader
           isRowLoaded={isRowLoaded}

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -23,8 +23,8 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 interface Props {
   feedbackItem: FeedbackIssue;
-  isChecked: 'all-checked' | boolean;
-  onChecked: (isChecked: boolean) => void;
+  isSelected: 'all-selected' | boolean;
+  onSelect: (isSelected: boolean) => void;
   className?: string;
   style?: CSSProperties;
 }
@@ -38,15 +38,15 @@ function useIsSelectedFeedback({feedbackItem}: {feedbackItem: FeedbackIssue}) {
 }
 
 const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
-  ({className, feedbackItem, isChecked, onChecked, style}: Props, ref) => {
+  ({className, feedbackItem, isSelected, onSelect, style}: Props, ref) => {
     const organization = useOrganization();
-    const isSelected = useIsSelectedFeedback({feedbackItem});
+    const isOpen = useIsSelectedFeedback({feedbackItem});
     const hasReplayId = useFeedbackHasReplayId({feedbackId: feedbackItem.id});
 
     return (
       <CardSpacing className={className} style={style} ref={ref}>
         <LinkedFeedbackCard
-          data-selected={isSelected}
+          data-selected={isOpen}
           to={() => {
             const location = browserHistory.getCurrentLocation();
             return {
@@ -65,9 +65,9 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
           <InteractionStateLayer />
           <Flex column style={{gridArea: 'checkbox'}}>
             <Checkbox
-              disabled={isChecked === 'all-checked'}
-              checked={isChecked !== false}
-              onChange={e => onChecked(e.target.checked)}
+              disabled={isSelected === 'all-selected'}
+              checked={isSelected !== false}
+              onChange={e => onSelect(e.target.checked)}
               onClick={e => e.stopPropagation()}
             />
           </Flex>
@@ -84,7 +84,7 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
           </span>
           <Flex justify="center" style={{gridArea: 'unread'}}>
             {feedbackItem.hasSeen ? null : (
-              <IconCircleFill size="xs" color={isSelected ? 'white' : 'purple400'} />
+              <IconCircleFill size="xs" color={isOpen ? 'white' : 'purple400'} />
             )}
           </Flex>
           <div style={{gridArea: 'message'}}>

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -23,7 +23,7 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 interface Props {
   feedbackItem: FeedbackIssue;
-  isChecked: boolean;
+  isChecked: 'all-checked' | boolean;
   onChecked: (isChecked: boolean) => void;
   className?: string;
   style?: CSSProperties;
@@ -65,7 +65,8 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
           <InteractionStateLayer />
           <Flex column style={{gridArea: 'checkbox'}}>
             <Checkbox
-              checked={isChecked}
+              disabled={isChecked === 'all-checked'}
+              checked={isChecked !== false}
               onChange={e => onChecked(e.target.checked)}
               onClick={e => e.stopPropagation()}
             />

--- a/static/app/components/feedback/list/useListItemCheckboxState.tsx
+++ b/static/app/components/feedback/list/useListItemCheckboxState.tsx
@@ -1,4 +1,6 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
+
+import useFeedbackQueryKeys from 'sentry/components/feedback/useFeedbackQueryKeys';
 
 interface Props {
   hits: number;
@@ -50,7 +52,14 @@ interface Return {
 }
 
 export default function useListItemCheckboxState({hits, knownIds}: Props): Return {
+  const {getListQueryKey} = useFeedbackQueryKeys();
   const [state, setState] = useState<State>({ids: new Set()});
+
+  const listQueryKey = getListQueryKey();
+  useEffect(() => {
+    // Reset the state when the list changes
+    setState({ids: new Set()});
+  }, [listQueryKey]);
 
   const selectAll = useCallback(() => {
     // Record that the virtual "all" list is enabled.

--- a/static/app/components/feedback/list/useListItemCheckboxState.tsx
+++ b/static/app/components/feedback/list/useListItemCheckboxState.tsx
@@ -1,28 +1,61 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useState} from 'react';
 
-export default function useListItemCheckboxState() {
-  const [state, setState] = useState<Record<string, boolean>>({});
+interface Props {
+  hits: number;
+  knownIds: string[];
+}
 
-  const checked = useMemo(() => {
-    const isChecked = (feedbackId: string) => state[feedbackId];
+type State = {all: true} | {ids: Set<string>};
 
-    const feedbackIds = Object.keys(state);
-    return feedbackIds.filter(isChecked);
-  }, [state]);
+interface Return {
+  checkAll: () => void;
+  isChecked: (id: string) => boolean;
+  state: State & {total: number};
+  toggleChecked: (id: string) => void;
+  uncheckAll: () => void;
+}
+
+export default function useListItemCheckboxState({hits, knownIds}: Props): Return {
+  const [state, setState] = useState<State>({ids: new Set()});
 
   const toggleChecked = useCallback((id: string) => {
     setState(prev => {
-      prev[id] = !prev[id];
-      return {...prev};
+      if ('ids' in prev) {
+        if (prev.ids.has(id)) {
+          prev.ids.delete(id);
+        } else {
+          prev.ids.add(id);
+        }
+        return {...prev};
+      }
+      if ('all' in prev) {
+        // do nothing, user needs to unset {all: true} first
+      }
+      return prev;
     });
   }, []);
 
+  const checkAll = useCallback(() => {
+    if (hits === knownIds.length) {
+      setState({ids: new Set(knownIds)});
+    } else {
+      setState({all: true});
+    }
+  }, [hits, knownIds]);
+
   const uncheckAll = useCallback(() => {
-    setState({});
+    setState({ids: new Set()});
   }, []);
 
+  const isChecked = useCallback(
+    (id: string) => ('all' in state ? true : state.ids.has(id) === true),
+    [state]
+  );
+
   return {
-    checked,
+    checkAll,
+    isChecked,
+    state: {...state, total: hits},
     toggleChecked,
     uncheckAll,
   };

--- a/static/app/components/feedback/list/useListItemCheckboxState.tsx
+++ b/static/app/components/feedback/list/useListItemCheckboxState.tsx
@@ -1,62 +1,140 @@
-import {useCallback, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 
 interface Props {
   hits: number;
   knownIds: string[];
 }
 
-type State = {all: true} | {ids: Set<string>};
+/**
+ * We can either have a list of ids, or have all selected.
+ * When all is selected we may, or may not, have all ids loaded into the browser
+ */
+type State = {ids: Set<string>} | {all: true};
 
 interface Return {
-  checkAll: () => void;
-  isChecked: (id: string) => boolean;
-  state: State & {total: number};
-  toggleChecked: (id: string) => void;
-  uncheckAll: () => void;
+  /**
+   * How many ids are selected
+   */
+  countSelected: number;
+  /**
+   * Ensure nothing is selected, no matter the state prior
+   */
+  deselectAll: () => void;
+  /**
+   * True if all are selected
+   *
+   * When some are selected returns 'indeterminate'
+   */
+  isAllSelected: 'indeterminate' | boolean;
+  /**
+   * True if one or more are selected
+   */
+  isAnySelected: boolean;
+  /**
+   * True if this specific id is selected
+   */
+  isSelected: (id: string) => 'all-selected' | boolean;
+  /**
+   * Record that all are selected, wether or not all feedback ids are loaded or not
+   */
+  selectAll: () => void;
+  /**
+   * The list of specifically selected ids, or 'all' to save space
+   */
+  selectedIds: 'all' | string[];
+  /**
+   * Toggle if a feedback is selected or not
+   * It's not possible to toggle when all are selected, but not all are loaded
+   */
+  toggleSelected: (id: string) => void;
 }
 
 export default function useListItemCheckboxState({hits, knownIds}: Props): Return {
   const [state, setState] = useState<State>({ids: new Set()});
 
-  const toggleChecked = useCallback((id: string) => {
-    setState(prev => {
-      if ('ids' in prev) {
-        if (prev.ids.has(id)) {
-          prev.ids.delete(id);
-        } else {
-          prev.ids.add(id);
-        }
-        return {...prev};
-      }
-      if ('all' in prev) {
-        // do nothing, user needs to unset {all: true} first
-      }
-      return prev;
-    });
+  const selectAll = useCallback(() => {
+    // Record that the virtual "all" list is enabled.
+    setState({all: true});
   }, []);
 
-  const checkAll = useCallback(() => {
-    if (hits === knownIds.length) {
-      setState({ids: new Set(knownIds)});
-    } else {
-      setState({all: true});
-    }
-  }, [hits, knownIds]);
-
-  const uncheckAll = useCallback(() => {
+  const deselectAll = useCallback(() => {
     setState({ids: new Set()});
   }, []);
 
-  const isChecked = useCallback(
-    (id: string) => ('all' in state ? true : state.ids.has(id) === true),
-    [state]
+  const toggleSelected = useCallback(
+    (id: string) => {
+      setState(prev => {
+        if ('all' in prev && hits !== knownIds.length) {
+          // Unable to toggle individual items when "all" are selected, but not
+          // all items are loaded. We can't omit one item from this virtual list.
+        }
+
+        // If all is selected, then we're toggling this one off
+        if ('all' in prev) {
+          const ids = new Set(knownIds);
+          ids.delete(id);
+          return {ids};
+        }
+
+        // We have a list of ids, so we enable/disable as needed
+        const ids = prev.ids;
+        if (ids.has(id)) {
+          ids.delete(id);
+        } else {
+          ids.add(id);
+        }
+        return {ids};
+      });
+    },
+    [hits, knownIds]
   );
 
+  const isSelected = useCallback(
+    (id: string) => {
+      // If we are using the virtual "all", and we don't have everything loaded,
+      // return the sentinal value 'all-selected'
+      if ('all' in state && hits !== knownIds.length) {
+        return 'all-selected';
+      }
+      // If "all" is selected
+      if ('all' in state) {
+        return true;
+      }
+
+      // Otherwise true/value is fine
+      return state.ids.has(id);
+    },
+    [state, hits, knownIds]
+  );
+
+  const isAllSelected = useMemo(() => {
+    if ('all' in state) {
+      return true;
+    }
+
+    if (state.ids.size === 0) {
+      return false;
+    }
+    if (state.ids.size === hits) {
+      return true;
+    }
+    return 'indeterminate';
+  }, [state, hits]);
+
+  const isAnySelected = useMemo(() => 'all' in state || state.ids.size > 0, [state]);
+
+  const selectedIds = useMemo(() => {
+    return 'all' in state ? 'all' : Array.from(state.ids);
+  }, [state]);
+
   return {
-    checkAll,
-    isChecked,
-    state: {...state, total: hits},
-    toggleChecked,
-    uncheckAll,
+    countSelected: 'all' in state ? hits : selectedIds.length,
+    deselectAll,
+    isAllSelected,
+    isAnySelected,
+    isSelected,
+    selectAll,
+    selectedIds,
+    toggleSelected,
   };
 }

--- a/static/app/components/feedback/useFetchFeedbackInfiniteListData.tsx
+++ b/static/app/components/feedback/useFetchFeedbackInfiniteListData.tsx
@@ -20,6 +20,7 @@ export const EMPTY_INFINITE_LIST_DATA: ReturnType<
   isRowLoaded: () => false,
   issues: [],
   loadMoreRows: () => Promise.resolve(),
+  hits: 0,
 };
 
 export default function useFetchFeedbackInfiniteListData() {
@@ -57,6 +58,12 @@ export default function useFetchFeedbackInfiniteListData() {
     [hasNextPage, isFetching, fetchNextPage]
   );
 
+  const hits = useMemo(
+    () =>
+      data?.pages.map(([, , resp]) => Number(resp?.getResponseHeader('X-Hits'))) ?? [],
+    [data]
+  );
+
   return {
     error,
     hasNextPage,
@@ -70,5 +77,6 @@ export default function useFetchFeedbackInfiniteListData() {
     isRowLoaded,
     issues,
     loadMoreRows,
+    hits: Math.max(...hits),
   };
 }

--- a/static/app/components/feedback/useMutateFeedback.tsx
+++ b/static/app/components/feedback/useMutateFeedback.tsx
@@ -2,11 +2,12 @@ import {useCallback} from 'react';
 import first from 'lodash/first';
 
 import useFeedbackCache from 'sentry/components/feedback/useFeedbackCache';
+import useFeedbackQueryKeys from 'sentry/components/feedback/useFeedbackQueryKeys';
 import type {GroupStatus, Organization} from 'sentry/types';
 import {fetchMutation, MutateOptions, useMutation} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 
-type TFeedbackIds = string[];
+type TFeedbackIds = 'all' | string[];
 type TPayload = {hasSeen: boolean} | {status: GroupStatus};
 type TData = unknown;
 type TError = unknown;
@@ -22,6 +23,7 @@ export default function useMutateFeedback({feedbackIds, organization}: Props) {
   const api = useApi({
     persistInFlight: false,
   });
+  const {getListQueryKey} = useFeedbackQueryKeys();
   const {updateCached, invalidateCached} = useFeedbackCache();
 
   const mutation = useMutation<TData, TError, TVariables, TContext>({
@@ -29,15 +31,19 @@ export default function useMutateFeedback({feedbackIds, organization}: Props) {
       updateCached(ids, payload);
     },
     mutationFn: ([ids, payload]) => {
-      const url =
-        ids.length === 1
-          ? `/organizations/${organization.slug}/issues/${first(ids)}/`
-          : `/organizations/${organization.slug}/issues/`;
+      const isSingleId = ids !== 'all' && ids.length === 1;
+      const url = isSingleId
+        ? `/organizations/${organization.slug}/issues/${first(ids)}/`
+        : `/organizations/${organization.slug}/issues/`;
 
       // TODO: it would be excellent if `PUT /issues/` could return the same data
       // as `GET /issues/` when query params are set. IE: it should expand inbox & owners
       // Then we could push new data into the cache instead of re-fetching it again
-      const options = ids.length === 1 ? {} : {query: {id: ids}};
+      const options = isSingleId
+        ? {}
+        : ids === 'all'
+        ? getListQueryKey()[1]!
+        : {query: {id: ids}};
       return fetchMutation(api)(['PUT', url, options, payload]);
     },
     onSettled: (_resp, _error, [ids, _payload]) => {


### PR DESCRIPTION
This change allows the "check all" checkbox at the top of the new User Feedback list to really select all of the feedback items that match the current query filters (respecting archived or not, timeframe, and anything typed into a searchbox)

What this means is that, you can have 200 feedbacks in total, but only 15 loaded into the browser. When you click the checkbox it'll say "200 selected". If you then click "Archive" or "Mark as read" all 200 will be updated. This includes optimistic updates, and it'll trigger background refreshes, just as if a single item were updated. All the goodies. 

It might overfetch right now though, because the list cache doesnt take into account what's visible, it just clears the cache and marks everything for refetch. Something to follow up on. 

Note:
- If all the ids are loaded into the browser (because you've scrolled down for a while) then every checkbox will be clickable. So you can select all, but then deselect one, marking 199 as read.   I think there's an optimization to be made if all 200 are in the browser, we don't need to send 200 ids to the backend; something to follow up on. 
- If not all the ids are loaded, and you choose to 'select all'. Then the checkboxes for each item will become disabled. In this state you cannot uncheck a specific feedback, you need to uncheck all first.

