### PR TITLE
feat(eventuser): Migrate save_userreport away from EventUser

### DIFF
--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -1,38 +1,55 @@
+from typing import Dict
+
+from sentry import eventstore
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.models.eventuser import EventUser
+from sentry.eventstore.models import Event
 from sentry.models.group import Group
+from sentry.models.project import Project
 from sentry.models.userreport import UserReport
+from sentry.snuba.dataset import Dataset
+from sentry.utils.eventuser import EventUser
 
 
 @register(UserReport)
 class UserReportSerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
-        event_user_ids = {i.event_user_id for i in item_list if i.event_user_id}
-
-        # Avoid querying if there aren't any to actually query, it's possible
-        # for event_user_id to be None.
-        if event_user_ids:
-            queryset = list(EventUser.objects.filter(id__in=event_user_ids))
-            event_users = {e.id: d for e, d in zip(queryset, serialize(queryset, user))}
-        else:
-            event_users = {}
-
         attrs = {}
+
+        project = Project.objects.get(id=item_list[0].project_id)
+
+        events = eventstore.backend.get_events(
+            filter=eventstore.Filter(
+                event_ids=[item.event_id for item in item_list],
+                project_ids=[project.id],
+            ),
+            referrer="UserReportSerializer.get_attrs",
+            dataset=Dataset.Events,
+            tenant_ids={"organization_id": project.organization_id},
+        )
+
+        events_dict: Dict[str, Event] = {event.event_id: event for event in events}
         for item in item_list:
-            attrs[item] = {"event_user": event_users.get(item.event_user_id)}
+            attrs[item] = {
+                "event_user": EventUser.from_event(events_dict[item.event_id])
+                if events_dict.get(item.event_id)
+                else {}
+            }
 
         return attrs
 
     def serialize(self, obj, attrs, user, **kwargs):
         # TODO(dcramer): add in various context from the event
         # context == user / http / extra interfaces
+
         name = obj.name or obj.email
         email = obj.email
+        user = None
         if attrs["event_user"]:
             event_user = attrs["event_user"]
-            if isinstance(event_user, dict):
+            if isinstance(event_user, EventUser):
                 name = name or event_user.get("name")
                 email = email or event_user.get("email")
+                user = event_user.serialize()
         return {
             "id": str(obj.id),
             "eventID": obj.event_id,
@@ -40,7 +57,7 @@ class UserReportSerializer(Serializer):
             "email": email,
             "comments": obj.comments,
             "dateCreated": obj.date_added,
-            "user": attrs["event_user"],
+            "user": user,
             "event": {"id": obj.event_id, "eventID": obj.event_id},
         }
 

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -47,8 +47,8 @@ class UserReportSerializer(Serializer):
         if attrs["event_user"]:
             event_user = attrs["event_user"]
             if isinstance(event_user, EventUser):
-                name = name or event_user.get("name")
-                email = email or event_user.get("email")
+                name = name or event_user.name
+                email = email or event_user.email
                 user = event_user.serialize()
         return {
             "id": str(obj.id),

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -1,28 +1,22 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
-from typing import Any, Mapping, Optional, Tuple
+from datetime import timedelta
 
 from django.db import IntegrityError, router
 from django.utils import timezone
-from snuba_sdk import Column, Condition, Entity, Op, Query, Request
 
 from sentry import analytics, eventstore, features
-from sentry.api.serializers import serialize
 from sentry.eventstore.models import Event
 from sentry.feedback.usecases.create_feedback import shim_to_feedback
-from sentry.models.eventuser import EventUser
+from sentry.models.eventuser import EventUser as EventUser_model
 from sentry.models.userreport import UserReport
 from sentry.signals import user_feedback_received
-from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.utils import metrics
 from sentry.utils.db import atomic_transaction
-from sentry.utils.snuba import raw_snql_query
+from sentry.utils.eventuser import EventUser
 
 logger = logging.getLogger(__name__)
-
-REFERRER = "sentry.ingest.userreport"
 
 
 class Conflict(Exception):
@@ -40,21 +34,23 @@ def save_userreport(project, report, start_time=None):
 
         event = eventstore.backend.get_event_by_id(project.id, report["event_id"])
 
-        # TODO(dcramer): we should probably create the user if they dont
-        # exist, and ideally we'd also associate that with the event
-        euser = find_event_user(report, event)
-
-        if features.has("organizations:eventuser-from-snuba", project.organization) and event:
-            try:
-                find_and_compare_eventuser_data(event, euser)
-            except Exception:
-                logger.exception(
-                    "Error when attempting to compare EventUser with Snuba results & Event data"
-                )
+        euser, eventuser_record = find_event_user(event, report)
 
         if euser and not euser.name and report.get("name"):
-            euser.update(name=report["name"])
+            euser.name = report["name"]
+
+        # TODO(nisanthan): Continue updating the EventUser record's name
+        # And record metrics to see how often this logic hits.
+        if eventuser_record and not eventuser_record.name and report.get("name"):
+            eventuser_record.update(name=report["name"])
+            analytics.record(
+                "eventuser_endpoint.request",
+                project_id=project.id,
+                endpoint="sentry.ingest.userreport.eventuser_record_name.update",
+            )
+
         if euser:
+            # TODO(nisanthan): Remove this eventually once UserReport model drops the event_user_id column
             report["event_user_id"] = euser.id
 
         if event:
@@ -108,12 +104,12 @@ def save_userreport(project, report, start_time=None):
         return report_instance
 
 
-def find_event_user(report_data, event):
+def find_eventuser_record(report_data, event):
     if not event:
         if not report_data.get("email"):
             return None
         try:
-            return EventUser.objects.filter(
+            return EventUser_model.objects.filter(
                 project_id=report_data["project_id"], email=report_data["email"]
             )[0]
         except IndexError:
@@ -125,181 +121,17 @@ def find_event_user(report_data, event):
         return None
 
     try:
-        return EventUser.for_tags(project_id=report_data["project_id"], values=[tag])[tag]
+        return EventUser_model.for_tags(project_id=report_data["project_id"], values=[tag])[tag]
     except KeyError:
         pass
 
 
-def find_and_compare_eventuser_data(event: Event, eventuser: EventUser):
-    """
-    Compare the EventUser record, the query results from Snuba and
-    the Event data property with each other.
-    Log the results of the comparisons.
-    """
-    try:
-        snuba_eventuser = find_eventuser_with_snuba(event)
-    except Exception:
-        return logger.exception("Error when attempting to fetch EventUser data from Snuba")
+def find_event_user(event: Event, report_data):
+    if not event:
+        return None, None
+    eventuser_record = find_eventuser_record(report_data, event)
+    eventuser = EventUser.from_event(event)
+    if eventuser_record:
+        eventuser.id = eventuser_record.id
 
-    # Compare Snuba result with EventUser record
-    snuba_eventuser_equality = _is_snuba_result_equal_to_eventuser(snuba_eventuser, eventuser)
-    # Compare Event data result with EventUser record
-    event_eventuser_equality = _is_event_data_equal_to_eventuser(event, eventuser)
-    # Compare Snuba result with Event data
-    snuba_event_equality = _is_event_data_equal_to_snuba_result(event, snuba_eventuser)
-
-    logger.info(
-        "EventUser equality checks with Snuba and Event.",
-        extra={
-            "eventuser": serialize(eventuser),
-            "dataset_results": snuba_eventuser,
-            "event_id": event.event_id,
-            "project_id": event.project_id,
-            "group_id": event.group_id,
-            "event.data.user": event.data.get("user", {}),
-            "snuba_eventuser_equality": snuba_eventuser_equality,
-            "event_eventuser_equality": event_eventuser_equality,
-            "snuba_event_equality": snuba_event_equality,
-        },
-    )
-
-    analytics.record(
-        "eventuser_equality.check",
-        event_id=event.event_id,
-        project_id=event.project_id,
-        group_id=event.group_id,
-        snuba_eventuser_equality=snuba_eventuser_equality,
-        event_eventuser_equality=event_eventuser_equality,
-        snuba_event_equality=snuba_event_equality,
-    )
-
-
-def find_eventuser_with_snuba(event: Event):
-    """
-    Query Snuba to get the EventUser information for an Event.
-    """
-    start_date, end_date = _start_and_end_dates(event.datetime)
-
-    query = _generate_entity_dataset_query(
-        event.project_id, event.group_id, event.event_id, start_date, end_date
-    )
-    request = Request(
-        dataset=Dataset.Events.value,
-        app_id=REFERRER,
-        query=query,
-        tenant_ids={"referrer": REFERRER, "organization_id": event.project.organization.id},
-    )
-    data_results = raw_snql_query(request, referrer=REFERRER)["data"]
-
-    if len(data_results) == 0:
-        logger.info(
-            "Errors dataset query to find EventUser did not return any results.",
-            extra={
-                "event_id": event.event_id,
-                "project_id": event.project_id,
-                "group_id": event.group_id,
-            },
-        )
-        return {}
-
-    return data_results[0]
-
-
-def _is_snuba_result_equal_to_eventuser(snuba_result: Mapping[str, Any], eventuser: EventUser):
-    EVENTUSER_TO_SNUBA_KEY_MAP = {
-        "project_id": ["project_id"],
-        "ident": ["user_id"],
-        "email": ["user_email"],
-        "username": ["user_name"],
-        "ip_address": ["ip_address_v6", "ip_address_v4"],
-    }
-
-    for eventuser_key, snuba_result_keys in EVENTUSER_TO_SNUBA_KEY_MAP.items():
-        value = getattr(eventuser, eventuser_key) if eventuser is not None else None
-        if value not in [snuba_result[key] for key in snuba_result_keys]:
-            return False
-
-    return True
-
-
-def get_nested_value(d, value):
-    """
-    Return the value from a nested object of a path in dot notation.
-    """
-    for key in value.split("."):
-        d = d.get(key, None)
-
-    return d
-
-
-def _is_event_data_equal_to_eventuser(event: Event, eventuser: EventUser):
-    EVENTUSER_TO_EVENT_DATA_KEY_MAP = {
-        "ident": ["user.id"],
-        "email": ["user.email"],
-        "username": ["user.username"],
-        "ip_address": ["user.ip_address"],
-    }
-    for eventuser_key, event_data_keys in EVENTUSER_TO_EVENT_DATA_KEY_MAP.items():
-        value = getattr(eventuser, eventuser_key) if eventuser is not None else None
-        if value not in [get_nested_value(event.data, key) for key in event_data_keys]:
-            return False
-
-    return True
-
-
-def _is_event_data_equal_to_snuba_result(event: Event, snuba_result: Mapping[str, Any]):
-    EVENT_DATA_TO_SNUBA_KEY_MAP = {
-        "user.id": ["user_id"],
-        "user.email": ["user_email"],
-        "user.username": ["user_name"],
-        "user.ip_address": ["ip_address_v6", "ip_address_v4"],
-    }
-
-    for event_data_key, snuba_result_keys in EVENT_DATA_TO_SNUBA_KEY_MAP.items():
-        if get_nested_value(event.data, event_data_key) not in [
-            snuba_result[key] for key in snuba_result_keys
-        ]:
-            return False
-
-    return True
-
-
-def _generate_entity_dataset_query(
-    project_id: Optional[int],
-    group_id: Optional[int],
-    event_id: str,
-    start_date: datetime,
-    end_date: datetime,
-) -> Query:
-    """This simply generates a query based on the passed parameters"""
-    where_conditions = [
-        Condition(Column("event_id"), Op.EQ, event_id),
-        Condition(Column("timestamp"), Op.GTE, start_date),
-        Condition(Column("timestamp"), Op.LT, end_date),
-    ]
-    if project_id:
-        where_conditions.append(Condition(Column("project_id"), Op.EQ, project_id))
-
-    if group_id:
-        where_conditions.append(Condition(Column("group_id"), Op.EQ, group_id))
-
-    return Query(
-        match=Entity(EntityKey.Events.value),
-        select=[
-            Column("project_id"),
-            Column("group_id"),
-            Column("ip_address_v6"),
-            Column("ip_address_v4"),
-            Column("event_id"),
-            Column("user_id"),
-            Column("user"),
-            Column("user_name"),
-            Column("user_email"),
-        ],
-        where=where_conditions,
-    )
-
-
-def _start_and_end_dates(time: datetime) -> Tuple[datetime, datetime]:
-    """Return the 10 min range start and end time range ."""
-    return time - timedelta(minutes=5), time + timedelta(minutes=5)
+    return eventuser, eventuser_record

--- a/src/sentry/utils/eventuser.py
+++ b/src/sentry/utils/eventuser.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Optional, Tuple
+
+from snuba_sdk import Column, Condition, Entity, Op, Query, Request
+
+from sentry.eventstore.models import Event
+from sentry.snuba.dataset import Dataset, EntityKey
+from sentry.utils.avatar import get_gravatar_url
+from sentry.utils.snuba import raw_snql_query
+
+logger = logging.getLogger(__name__)
+
+REFERRER = "sentry.utils.eventuser"
+
+
+@dataclass
+class EventUser:
+    project_id: Optional[int]
+    email: str
+    username: str
+    name: str
+    ip_address: str
+    id: Optional[int] = None
+
+    @staticmethod
+    def from_event(event: Event):
+        return EventUser(
+            id=None,
+            project_id=event.project_id if event else None,
+            email=event.data.get("user", {}).get("email") if event else None,
+            username=event.data.get("user", {}).get("username") if event else None,
+            name=event.data.get("user", {}).get("name") if event else None,
+            ip_address=event.data.get("user", {}).get("ip_address") if event else None,
+        )
+
+    def get_display_name(self):
+        return self.name or self.email or self.username
+
+    def serialize(self):
+        return {
+            "id": str(self.id),
+            "username": self.username,
+            "email": self.email,
+            "name": self.get_display_name(),
+            "ipAddress": self.ip_address,
+            "avatarUrl": get_gravatar_url(self.email, size=32),
+        }
+
+
+def find_eventuser_with_snuba(event: Event):
+    """
+    Query Snuba to get the EventUser information for an Event.
+    """
+    start_date, end_date = _start_and_end_dates(event.datetime)
+
+    query = _generate_entity_dataset_query(
+        event.project_id, event.group_id, event.event_id, start_date, end_date
+    )
+    request = Request(
+        dataset=Dataset.Events.value,
+        app_id=REFERRER,
+        query=query,
+        tenant_ids={"referrer": REFERRER, "organization_id": event.project.organization.id},
+    )
+    data_results = raw_snql_query(request, referrer=REFERRER)["data"]
+
+    if len(data_results) == 0:
+        logger.info(
+            "Errors dataset query to find EventUser did not return any results.",
+            extra={
+                "event_id": event.event_id,
+                "project_id": event.project_id,
+                "group_id": event.group_id,
+            },
+        )
+        return {}
+
+    return data_results[0]
+
+
+def _generate_entity_dataset_query(
+    project_id: Optional[int],
+    group_id: Optional[int],
+    event_id: str,
+    start_date: datetime,
+    end_date: datetime,
+) -> Query:
+    """This simply generates a query based on the passed parameters"""
+    where_conditions = [
+        Condition(Column("event_id"), Op.EQ, event_id),
+        Condition(Column("timestamp"), Op.GTE, start_date),
+        Condition(Column("timestamp"), Op.LT, end_date),
+    ]
+    if project_id:
+        where_conditions.append(Condition(Column("project_id"), Op.EQ, project_id))
+
+    if group_id:
+        where_conditions.append(Condition(Column("group_id"), Op.EQ, group_id))
+
+    return Query(
+        match=Entity(EntityKey.Events.value),
+        select=[
+            Column("project_id"),
+            Column("group_id"),
+            Column("ip_address_v6"),
+            Column("ip_address_v4"),
+            Column("event_id"),
+            Column("user_id"),
+            Column("user"),
+            Column("user_name"),
+            Column("user_email"),
+        ],
+        where=where_conditions,
+    )
+
+
+def _start_and_end_dates(time: datetime) -> Tuple[datetime, datetime]:
+    """Return the 10 min range start and end time range ."""
+    return time - timedelta(minutes=5), time + timedelta(minutes=5)

--- a/tests/acceptance/test_organization_user_feedback.py
+++ b/tests/acceptance/test_organization_user_feedback.py
@@ -19,7 +19,7 @@ class OrganizationUserFeedbackTest(AcceptanceTestCase):
         self.project.update(first_event=timezone.now())
 
     def test(self):
-        self.create_userreport(date_added=timezone.now(), group=self.group, project=self.project)
+        self.create_userreport(date_added=timezone.now(), project=self.project)
         self.browser.get(self.path)
         self.browser.wait_until_not('[data-test-id="loading-indicator"]')
         self.browser.wait_until('[data-test-id="user-feedback-list"]')

--- a/tests/acceptance/test_project_user_feedback.py
+++ b/tests/acceptance/test_project_user_feedback.py
@@ -19,10 +19,8 @@ class ProjectUserFeedbackTest(AcceptanceTestCase):
         self.project.update(first_event=timezone.now())
 
     def test(self):
-        group = self.create_group(project=self.project, message="Foo bar")
         self.create_userreport(
             date_added=timezone.now(),
-            group=group,
             project=self.project,
             event_id=self.event.event_id,
         )

--- a/tests/apidocs/endpoints/projects/test_user_feedback.py
+++ b/tests/apidocs/endpoints/projects/test_user_feedback.py
@@ -9,11 +9,9 @@ from sentry.testutils.silo import region_silo_test
 class ProjectUserFeedbackDocs(APIDocsTestCase):
     def setUp(self):
         event = self.create_event("a", message="oh no")
-        group = self.create_group(project=self.project, message="Foo bar")
         self.event_id = event.event_id
         self.create_userreport(
             date_added=timezone.now(),
-            group=group,
             project=self.project,
             event_id=self.event_id,
         )

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -1,10 +1,9 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import patch
 from uuid import uuid4
 
 from django.utils import timezone
 
-from sentry.models.eventuser import EventUser
 from sentry.models.group import GroupStatus
 from sentry.models.userreport import UserReport
 from sentry.testutils.cases import APITestCase, SnubaTestCase
@@ -57,11 +56,31 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         project = self.create_project()
-        group = self.create_group(project=project)
-        group2 = self.create_group(project=project, status=GroupStatus.RESOLVED)
+        event1 = self.store_event(
+            data={
+                "timestamp": iso_format(datetime.utcnow()),
+                "event_id": "a" * 32,
+                "message": "something went wrong",
+            },
+            project_id=project.id,
+        )
+        group = event1.group
+        event2 = self.store_event(
+            data={
+                "timestamp": iso_format(datetime.utcnow()),
+                "event_id": "c" * 32,
+                "message": "testing",
+            },
+            project_id=project.id,
+        )
+        group2 = event2.group
+        group2.status = GroupStatus.RESOLVED
+        group2.substatus = None
+        group2.save()
+
         report_1 = UserReport.objects.create(
             project_id=project.id,
-            event_id="a" * 32,
+            event_id=event1.event_id,
             name="Foo",
             email="foo@example.com",
             comments="Hello world",
@@ -80,7 +99,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
         # should not be included due to resolution
         UserReport.objects.create(
             project_id=project.id,
-            event_id="c" * 32,
+            event_id=event2.event_id,
             name="Baz",
             email="baz@example.com",
             comments="Hello world",
@@ -109,7 +128,15 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         project = self.create_project()
-        group = self.create_group(project=project, status=GroupStatus.RESOLVED)
+        event = self.store_event(
+            data={
+                "timestamp": iso_format(datetime.utcnow()),
+                "event_id": "a" * 32,
+                "message": "testing",
+            },
+            project_id=project.id,
+        )
+        group = event.group
         report_1 = UserReport.objects.create(
             project_id=project.id,
             event_id="a" * 32,
@@ -118,6 +145,10 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
             comments="Hello world",
             group_id=group.id,
         )
+
+        group.status = GroupStatus.RESOLVED
+        group.substatus = None
+        group.save()
 
         url = f"/api/0/projects/{project.organization.slug}/{project.slug}/user-feedback/"
 
@@ -275,45 +306,6 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         assert report.email == "foo@example.com"
         assert report.name == "Foo Bar"
         assert report.comments == "It broke!"
-
-    def test_already_present_with_matching_user(self):
-        self.login_as(user=self.user)
-
-        euser = EventUser.objects.get(project_id=self.project.id, email="foo@example.com")
-
-        UserReport.objects.create(
-            group_id=self.event.group.id,
-            project_id=self.project.id,
-            event_id=self.event.event_id,
-            name="foo",
-            email="bar@example.com",
-            comments="",
-        )
-
-        url = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/user-feedback/"
-
-        response = self.client.post(
-            url,
-            data={
-                "event_id": self.event.event_id,
-                "email": "foo@example.com",
-                "name": "Foo Bar",
-                "comments": "It broke!",
-            },
-        )
-
-        assert response.status_code == 200, response.content
-
-        report = UserReport.objects.get(id=response.data["id"])
-        assert report.project_id == self.project.id
-        assert report.group_id == self.event.group.id
-        assert report.email == "foo@example.com"
-        assert report.name == "Foo Bar"
-        assert report.comments == "It broke!"
-        assert report.event_user_id == euser.id
-
-        euser = EventUser.objects.get(id=euser.id)
-        assert euser.name == "Foo Bar"
 
     def test_already_present_after_deadline(self):
         self.login_as(user=self.user)

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -436,9 +436,6 @@ def test_userreport(django_cache, default_project, monkeypatch):
     mgr.normalize()
     mgr.save(default_project.id)
 
-    (evtuser,) = EventUser.objects.all()
-    assert not evtuser.name
-
     assert not UserReport.objects.all()
 
     assert process_userreport(
@@ -460,9 +457,6 @@ def test_userreport(django_cache, default_project, monkeypatch):
 
     (report,) = UserReport.objects.all()
     assert report.comments == "hello world"
-
-    (evtuser,) = EventUser.objects.all()
-    assert evtuser.name == "Hans Gans"
 
 
 @django_db_all

--- a/tests/sentry/utils/test_query.py
+++ b/tests/sentry/utils/test_query.py
@@ -67,14 +67,13 @@ class RangeQuerySetWrapperWithProgressBarApproxTest(RangeQuerySetWrapperTest):
 class BulkDeleteObjectsTest(TestCase):
     def setUp(self):
         super().setUp()
-        self.group = self.create_group(project=self.project, message="Foo bar")
         UserReport.objects.all().delete()
 
     def test_basic(self):
         total = 10
         records = []
         for i in range(total):
-            records.append(self.create_userreport(group=self.group, event_id=i))
+            records.append(self.create_userreport(project=self.project, event_id=str(i) * 32))
 
         result = bulk_delete_objects(UserReport, id__in=[r.id for r in records])
         assert result, "Could be more work to do"
@@ -84,7 +83,7 @@ class BulkDeleteObjectsTest(TestCase):
         total = 10
         records = []
         for i in range(total):
-            records.append(self.create_userreport(group=self.group, event_id=i))
+            records.append(self.create_userreport(project=self.project, event_id=str(i) * 32))
 
         result = bulk_delete_objects(UserReport, id__in=[r.id for r in records], limit=5)
         assert result, "Still more work to do"


### PR DESCRIPTION
## Objective:

We can replace EventUser with the Event. This PR also deletes the analytics gathering code bc we have enough to determine our Action Plan. I have moved the Snuba query code to a utils file. This query will eventually be called by several functions throughout the codebase. 