### PR TITLE
feat(starfish): Separate samples for release 1 and release 2

### DIFF
--- a/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
@@ -16,13 +16,14 @@ import {SpanSample} from 'sentry/views/starfish/queries/useSpanSamples';
 
 type Keys =
   | 'transaction_id'
+  | 'profile_id'
   | 'timestamp'
   | 'duration'
   | 'p95_comparison'
   | 'avg_comparison';
-type TableColumnHeader = GridColumnHeader<Keys>;
+export type SamplesTableColumnHeader = GridColumnHeader<Keys>;
 
-const COLUMN_ORDER: TableColumnHeader[] = [
+const DEFAULT_COLUMN_ORDER: SamplesTableColumnHeader[] = [
   {
     key: 'transaction_id',
     name: 'Event ID',
@@ -54,6 +55,7 @@ type Props = {
   avg: number;
   data: SpanTableRow[];
   isLoading: boolean;
+  columnOrder?: SamplesTableColumnHeader[];
   highlightedSpanId?: string;
   onMouseLeaveSample?: () => void;
   onMouseOverSample?: (sample: SpanSample) => void;
@@ -66,6 +68,7 @@ export function SpanSamplesTable({
   highlightedSpanId,
   onMouseLeaveSample,
   onMouseOverSample,
+  columnOrder,
 }: Props) {
   const location = useLocation();
 
@@ -116,6 +119,19 @@ export function SpanSamplesTable({
       );
     }
 
+    if (column.key === 'profile_id') {
+      return row.profile_id ? (
+        <Link
+          {...commonProps}
+          to={`/profiling/profile/${row['project.name']}/${row.profile_id}/flamechart/`}
+        >
+          {row.profile_id.slice(0, 8)}
+        </Link>
+      ) : (
+        <div {...commonProps}>(no value)</div>
+      );
+    }
+
     if (column.key === 'duration') {
       return (
         <DurationCell containerProps={commonProps} milliseconds={row['span.self_time']} />
@@ -140,7 +156,7 @@ export function SpanSamplesTable({
       <GridEditable
         isLoading={isLoading}
         data={data}
-        columnOrder={COLUMN_ORDER}
+        columnOrder={columnOrder ?? DEFAULT_COLUMN_ORDER}
         columnSortBy={[]}
         grid={{
           renderHeadCell,

--- a/static/app/views/starfish/queries/useSpanMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.tsx
@@ -13,6 +13,7 @@ import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 const {SPAN_GROUP} = SpanMetricsField;
 
 export type SpanSummaryQueryFilters = {
+  release?: string;
   'transaction.method'?: string;
   transactionName?: string;
 };
@@ -65,7 +66,7 @@ function getEventView(
         queryFilters?.['transaction.method']
           ? ` transaction.method:${queryFilters?.['transaction.method']}`
           : ''
-      }`,
+      }${queryFilters?.release ? ` release:${queryFilters?.release}` : ''}`,
       fields,
       dataset: DiscoverDatasets.SPANS_METRICS,
       version: 2,

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -79,7 +79,7 @@ function getEventView(
         queryFilters?.['transaction.method']
           ? ` transaction.method:${queryFilters?.['transaction.method']}`
           : ''
-      }`,
+      }${queryFilters?.release ? ` release:${queryFilters?.release}` : ''}`,
       fields: [],
       yAxis,
       dataset: DiscoverDatasets.SPANS_METRICS,

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -94,6 +94,7 @@ export enum SpanIndexedField {
   SPAN_DOMAIN = 'span.domain',
   TIMESTAMP = 'timestamp',
   PROJECT = 'project',
+  PROFILE_ID = 'profile_id',
 }
 
 export type SpanIndexedFieldTypes = {
@@ -111,6 +112,7 @@ export type SpanIndexedFieldTypes = {
   [SpanIndexedField.SPAN_DOMAIN]: string[];
   [SpanIndexedField.TIMESTAMP]: string;
   [SpanIndexedField.PROJECT]: string;
+  [SpanIndexedField.PROFILE_ID]: string;
 };
 
 export type Op = SpanIndexedFieldTypes[SpanIndexedField.SPAN_OP];

--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
@@ -24,9 +24,9 @@ import {
   ScreenCharts,
   YAxis,
 } from 'sentry/views/starfish/views/screens/screenLoadSpans/charts';
+import {ScreenLoadSpanSamples} from 'sentry/views/starfish/views/screens/screenLoadSpans/samples';
 import {ScreenLoadSpansSidebar} from 'sentry/views/starfish/views/screens/screenLoadSpans/sidebar';
 import {ScreenLoadSpansTable} from 'sentry/views/starfish/views/screens/screenLoadSpans/table';
-import {SampleList} from 'sentry/views/starfish/views/spanSummaryPage/sampleList';
 
 type Query = {
   primaryRelease: string;
@@ -103,7 +103,7 @@ function ScreenLoadSpans() {
                 secondaryRelease={secondaryRelease}
               />
               {spanGroup && (
-                <SampleList
+                <ScreenLoadSpanSamples
                   groupId={spanGroup}
                   transactionName={transactionName}
                   spanDescription={spanDescription}

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/index.tsx
@@ -1,0 +1,192 @@
+import {useCallback, useMemo} from 'react';
+import styled from '@emotion/styled';
+import omit from 'lodash/omit';
+import * as qs from 'query-string';
+
+import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
+import Link from 'sentry/components/links/link';
+import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {
+  PageErrorAlert,
+  PageErrorProvider,
+} from 'sentry/utils/performance/contexts/pageError';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+import useRouter from 'sentry/utils/useRouter';
+import DetailPanel from 'sentry/views/starfish/components/detailPanel';
+import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {ScreenLoadSampleList} from 'sentry/views/starfish/views/screens/screenLoadSpans/samples/sampleList';
+import SampleInfo from 'sentry/views/starfish/views/spanSummaryPage/sampleList/sampleInfo';
+
+type Props = {
+  groupId: string;
+  transactionName: string;
+  onClose?: () => void;
+  spanDescription?: string;
+  transactionMethod?: string;
+  transactionRoute?: string;
+};
+
+export function ScreenLoadSpanSamples({
+  groupId,
+  transactionName,
+  transactionMethod,
+  spanDescription,
+  onClose,
+  transactionRoute = '/performance/summary/',
+}: Props) {
+  const router = useRouter();
+
+  const {primaryRelease, secondaryRelease} = useReleaseSelection();
+
+  // A a transaction name is required to show the panel, but a transaction
+  // method is not
+  const detailKey = transactionName
+    ? [groupId, transactionName, transactionMethod].filter(Boolean).join(':')
+    : undefined;
+
+  const organization = useOrganization();
+  const {query} = useLocation();
+  const {projects} = useProjects();
+
+  const project = useMemo(
+    () => projects.find(p => p.id === String(query.project)),
+    [projects, query.project]
+  );
+
+  const onOpenDetailPanel = useCallback(() => {
+    if (query.transaction) {
+      trackAnalytics('starfish.panel.open', {organization});
+    }
+  }, [organization, query.transaction]);
+
+  const label =
+    transactionMethod && !transactionName.startsWith(transactionMethod)
+      ? `${transactionMethod} ${transactionName}`
+      : transactionName;
+
+  const link = `${transactionRoute}?${qs.stringify({
+    project: query.project,
+    transaction: transactionName,
+  })}`;
+
+  function defaultOnClose() {
+    router.replace({
+      pathname: router.location.pathname,
+      query: omit(router.location.query, 'transaction', 'transactionMethod'),
+    });
+  }
+
+  return (
+    <PageErrorProvider>
+      <DetailPanel
+        detailKey={detailKey}
+        onClose={() => {
+          onClose ? onClose() : defaultOnClose();
+        }}
+        onOpen={onOpenDetailPanel}
+      >
+        <HeaderContainer>
+          {project && (
+            <SpanSummaryProjectAvatar
+              project={project}
+              direction="left"
+              size={40}
+              hasTooltip
+              tooltip={project.slug}
+            />
+          )}
+          <TitleContainer>
+            {spanDescription && <SpanDescription>{spanDescription}</SpanDescription>}
+            <Title>
+              <Link to={link}>{label}</Link>
+            </Title>
+          </TitleContainer>
+        </HeaderContainer>
+        <PageErrorAlert />
+
+        <SampleInfo
+          groupId={groupId}
+          transactionName={transactionName}
+          transactionMethod={transactionMethod}
+          displayedMetrics={[
+            'count()',
+            `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
+            'time_spent_percentage()',
+          ]}
+        />
+
+        <ChartsContainer>
+          <ChartsContainerItem key="release1">
+            <ScreenLoadSampleList
+              groupId={groupId}
+              transactionName={transactionName}
+              transactionMethod={transactionMethod}
+              release={primaryRelease}
+            />
+          </ChartsContainerItem>
+          <ChartsContainerItem key="release2">
+            <ScreenLoadSampleList
+              groupId={groupId}
+              transactionName={transactionName}
+              transactionMethod={transactionMethod}
+              release={secondaryRelease}
+            />
+          </ChartsContainerItem>
+        </ChartsContainer>
+      </DetailPanel>
+    </PageErrorProvider>
+  );
+}
+
+const SpanSummaryProjectAvatar = styled(ProjectAvatar)`
+  padding-right: ${space(1)};
+`;
+
+const HeaderContainer = styled('div')`
+  width: 100%;
+  padding-bottom: ${space(2)};
+  padding-top: ${space(1)};
+
+  display: grid;
+  grid-template-rows: auto auto auto;
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    grid-template-rows: auto;
+    grid-template-columns: auto 1fr auto;
+  }
+`;
+
+const TitleContainer = styled('div')`
+  width: 100%;
+  position: relative;
+  height: 40px;
+`;
+
+const Title = styled('h4')`
+  position: absolute;
+  bottom: 0;
+  margin-bottom: 0;
+`;
+
+const SpanDescription = styled('div')`
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 35vw;
+`;
+
+const ChartsContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  gap: ${space(2)};
+  align-items: top;
+`;
+
+const ChartsContainerItem = styled('div')`
+  flex: 1;
+`;

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/index.tsx
@@ -5,6 +5,7 @@ import * as qs from 'query-string';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import Link from 'sentry/components/links/link';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
@@ -17,8 +18,7 @@ import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
 import DetailPanel from 'sentry/views/starfish/components/detailPanel';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {ScreenLoadSampleList} from 'sentry/views/starfish/views/screens/screenLoadSpans/samples/sampleList';
+import {ScreenLoadSampleContainer} from 'sentry/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer';
 import SampleInfo from 'sentry/views/starfish/views/spanSummaryPage/sampleList/sampleInfo';
 
 type Props = {
@@ -112,28 +112,26 @@ export function ScreenLoadSpanSamples({
           groupId={groupId}
           transactionName={transactionName}
           transactionMethod={transactionMethod}
-          displayedMetrics={[
-            'count()',
-            `avg(${SpanMetricsField.SPAN_SELF_TIME})`,
-            'time_spent_percentage()',
-          ]}
+          displayedMetrics={['count()', 'time_spent_percentage()']}
         />
 
         <ChartsContainer>
           <ChartsContainerItem key="release1">
-            <ScreenLoadSampleList
+            <ScreenLoadSampleContainer
               groupId={groupId}
               transactionName={transactionName}
               transactionMethod={transactionMethod}
               release={primaryRelease}
+              sectionTitle={t('Release 1')}
             />
           </ChartsContainerItem>
           <ChartsContainerItem key="release2">
-            <ScreenLoadSampleList
+            <ScreenLoadSampleContainer
               groupId={groupId}
               transactionName={transactionName}
               transactionMethod={transactionMethod}
               release={secondaryRelease}
+              sectionTitle={t('Release 2')}
             />
           </ChartsContainerItem>
         </ChartsContainer>

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/sampleList.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/sampleList.tsx
@@ -1,0 +1,79 @@
+import {Fragment, useCallback, useState} from 'react';
+import debounce from 'lodash/debounce';
+
+import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
+import useRouter from 'sentry/utils/useRouter';
+import DurationChart from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart';
+import SampleTable from 'sentry/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable';
+
+type Props = {
+  groupId: string;
+  transactionName: string;
+  release?: string;
+  transactionMethod?: string;
+};
+
+export function ScreenLoadSampleList({
+  groupId,
+  transactionName,
+  transactionMethod,
+  release,
+}: Props) {
+  const router = useRouter();
+  const [highlightedSpanId, setHighlightedSpanId] = useState<string | undefined>(
+    undefined
+  );
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debounceSetHighlightedSpanId = useCallback(
+    debounce(id => {
+      setHighlightedSpanId(id);
+    }, 10),
+    []
+  );
+
+  return (
+    <Fragment>
+      <DurationChart
+        groupId={groupId}
+        transactionName={transactionName}
+        transactionMethod={transactionMethod}
+        onClickSample={span => {
+          router.push(
+            `/performance/${span.project}:${span['transaction.id']}/#span-${span.span_id}`
+          );
+        }}
+        onMouseOverSample={sample => debounceSetHighlightedSpanId(sample.span_id)}
+        onMouseLeaveSample={() => debounceSetHighlightedSpanId(undefined)}
+        highlightedSpanId={highlightedSpanId}
+        release={release}
+      />
+      <SampleTable
+        highlightedSpanId={highlightedSpanId}
+        transactionMethod={transactionMethod}
+        onMouseLeaveSample={() => setHighlightedSpanId(undefined)}
+        onMouseOverSample={sample => setHighlightedSpanId(sample.span_id)}
+        groupId={groupId}
+        transactionName={transactionName}
+        release={release}
+        columnOrder={[
+          {
+            key: 'transaction_id',
+            name: 'Event ID',
+            width: COL_WIDTH_UNDEFINED,
+          },
+          {
+            key: 'profile_id',
+            name: 'Profile ID',
+            width: COL_WIDTH_UNDEFINED,
+          },
+          {
+            key: 'duration',
+            name: 'Span Duration',
+            width: COL_WIDTH_UNDEFINED,
+          },
+        ]}
+      />
+    </Fragment>
+  );
+}

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
@@ -1,22 +1,37 @@
 import {Fragment, useCallback, useState} from 'react';
+import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
+import {space} from 'sentry/styles/space';
 import useRouter from 'sentry/utils/useRouter';
+import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
+import {
+  SpanSummaryQueryFilters,
+  useSpanMetrics,
+} from 'sentry/views/starfish/queries/useSpanMetrics';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {DataTitles} from 'sentry/views/starfish/views/spans/types';
+import {Block} from 'sentry/views/starfish/views/spanSummaryPage/block';
 import DurationChart from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart';
 import SampleTable from 'sentry/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable';
+
+const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
 
 type Props = {
   groupId: string;
   transactionName: string;
   release?: string;
+  sectionSubtitle?: string;
+  sectionTitle?: string;
   transactionMethod?: string;
 };
 
-export function ScreenLoadSampleList({
+export function ScreenLoadSampleContainer({
   groupId,
   transactionName,
   transactionMethod,
+  sectionTitle,
   release,
 }: Props) {
   const router = useRouter();
@@ -32,8 +47,39 @@ export function ScreenLoadSampleList({
     []
   );
 
+  const filters: SpanSummaryQueryFilters = {
+    transactionName,
+  };
+
+  if (transactionMethod) {
+    filters['transaction.method'] = transactionMethod;
+  }
+
+  if (release) {
+    filters.release = release;
+  }
+
+  const {data: spanMetrics} = useSpanMetrics(
+    groupId,
+    filters,
+    [`avg(${SPAN_SELF_TIME})`, SPAN_OP],
+    'api.starfish.span-summary-panel-samples-table-avg'
+  );
+
   return (
     <Fragment>
+      {sectionTitle && <SectionTitle>{sectionTitle}</SectionTitle>}
+      {release && <SectionSubtitle>{release}</SectionSubtitle>}
+      <Block title={DataTitles.avg} alignment="left">
+        <DurationCell
+          containerProps={{
+            style: {
+              textAlign: 'left',
+            },
+          }}
+          milliseconds={spanMetrics?.[`avg(${SPAN_SELF_TIME})`]}
+        />
+      </Block>
       <DurationChart
         groupId={groupId}
         transactionName={transactionName}
@@ -77,3 +123,11 @@ export function ScreenLoadSampleList({
     </Fragment>
   );
 }
+
+const SectionTitle = styled('div')`
+  ${p => p.theme.text.cardTitle}
+`;
+
+const SectionSubtitle = styled('div')`
+  margin-bottom: ${space(1)};
+`;

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -127,7 +127,7 @@ function DurationChart({
       emphasis: {disabled: true},
       label: {
         position: 'insideEndBottom',
-        formatter: () => 'Average',
+        formatter: () => `Average`,
         fontSize: 14,
         color: theme.chartLabel,
         backgroundColor: theme.chartOther,

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -8,7 +8,10 @@ import {AVG_COLOR} from 'sentry/views/starfish/colours';
 import Chart from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {isNearAverage} from 'sentry/views/starfish/components/samplesTable/common';
-import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
+import {
+  SpanSummaryQueryFilters,
+  useSpanMetrics,
+} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import {SpanSample, useSpanSamples} from 'sentry/views/starfish/queries/useSpanSamples';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
@@ -27,6 +30,7 @@ type Props = {
   onClickSample?: (sample: SpanSample) => void;
   onMouseLeaveSample?: () => void;
   onMouseOverSample?: (sample: SpanSample) => void;
+  release?: string;
   spanDescription?: string;
   transactionMethod?: string;
 };
@@ -62,17 +66,22 @@ function DurationChart({
   onMouseOverSample,
   highlightedSpanId,
   transactionMethod,
+  release,
 }: Props) {
   const theme = useTheme();
   const {setPageError} = usePageError();
   const pageFilter = usePageFilters();
 
-  const filters = {
+  const filters: SpanSummaryQueryFilters = {
     transactionName,
   };
 
   if (transactionMethod) {
     filters['transaction.method'] = transactionMethod;
+  }
+
+  if (release) {
+    filters.release = release;
   }
 
   const {
@@ -88,7 +97,7 @@ function DurationChart({
 
   const {data: spanMetrics, error: spanMetricsError} = useSpanMetrics(
     groupId,
-    {transactionName, 'transaction.method': transactionMethod},
+    filters,
     [`avg(${SPAN_SELF_TIME})`, SPAN_OP],
     'api.starfish.span-summary-panel-samples-table-avg'
   );
@@ -103,6 +112,7 @@ function DurationChart({
     groupId,
     transactionName,
     transactionMethod,
+    release,
   });
 
   const baselineAvgSeries: Series = {

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -9,8 +9,14 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import useOrganization from 'sentry/utils/useOrganization';
-import {SpanSamplesTable} from 'sentry/views/starfish/components/samplesTable/spanSamplesTable';
-import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
+import {
+  SamplesTableColumnHeader,
+  SpanSamplesTable,
+} from 'sentry/views/starfish/components/samplesTable/spanSamplesTable';
+import {
+  SpanSummaryQueryFilters,
+  useSpanMetrics,
+} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {SpanSample, useSpanSamples} from 'sentry/views/starfish/queries/useSpanSamples';
 import {useTransactions} from 'sentry/views/starfish/queries/useTransactions';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
@@ -24,9 +30,11 @@ const SpanSamplesTableContainer = styled('div')`
 type Props = {
   groupId: string;
   transactionName: string;
+  columnOrder?: SamplesTableColumnHeader[];
   highlightedSpanId?: string;
   onMouseLeaveSample?: () => void;
   onMouseOverSample?: (sample: SpanSample) => void;
+  release?: string;
   transactionMethod?: string;
 };
 
@@ -37,13 +45,19 @@ function SampleTable({
   onMouseLeaveSample,
   onMouseOverSample,
   transactionMethod,
+  columnOrder,
+  release,
 }: Props) {
-  const filters = {
+  const filters: SpanSummaryQueryFilters = {
     transactionName,
   };
 
   if (transactionMethod) {
     filters['transaction.method'] = transactionMethod;
+  }
+
+  if (release) {
+    filters.release = release;
   }
 
   const {data: spanMetrics, isFetching: isFetchingSpanMetrics} = useSpanMetrics(
@@ -66,6 +80,7 @@ function SampleTable({
     groupId,
     transactionName,
     transactionMethod,
+    release,
   });
 
   const {
@@ -126,6 +141,7 @@ function SampleTable({
           onMouseLeaveSample={onMouseLeaveSample}
           onMouseOverSample={onMouseOverSample}
           highlightedSpanId={highlightedSpanId}
+          columnOrder={columnOrder}
           data={spans.map(sample => {
             return {
               ...sample,


### PR DESCRIPTION
Sample slide out panel for screen load flow needs to support
differentiating samples for the two releases that are being
compared.

- Have a chart & table for each sample
- Add profile id as a column in samples (these should start working after https://github.com/getsentry/sentry/pull/59170 and https://github.com/getsentry/sentry/pull/59168 are deployed)

![Screenshot 2023-11-01 at 11 15 43 AM](https://github.com/getsentry/sentry/assets/63818634/1d2116d8-5e04-47b7-95d1-5b36c23abdf8)
