### PR TITLE
fix(browser-starfish): filtering resources modules inconsistent

### DIFF
--- a/static/app/views/performance/browser/resources/jsCssView/index.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/index.tsx
@@ -23,6 +23,8 @@ const {
   RESOURCE_RENDER_BLOCKING_STATUS,
 } = BrowserStarfishFields;
 
+const DEFAULT_RESOURCE_TYPES = ['resource.script', 'resource.css'];
+
 type Option = {
   label: string;
   value: string;
@@ -48,9 +50,15 @@ function JSCSSView() {
   return (
     <Fragment>
       <FilterOptionsContainer>
-        <DomainSelector value={filters[SPAN_DOMAIN] || ''} />
+        <DomainSelector
+          value={filters[SPAN_DOMAIN] || ''}
+          defaultResourceTypes={DEFAULT_RESOURCE_TYPES}
+        />
         <ResourceTypeSelector value={filters[RESOURCE_TYPE] || ''} />
-        <PageSelector value={filters[TRANSACTION] || ''} />
+        <PageSelector
+          value={filters[TRANSACTION] || ''}
+          defaultResourceTypes={DEFAULT_RESOURCE_TYPES}
+        />
         <SwitchContainer>
           <SwitchButton
             isActive={filters[RESOURCE_RENDER_BLOCKING_STATUS] === 'blocking'}
@@ -59,7 +67,7 @@ function JSCSSView() {
           {t('Render Blocking')}
         </SwitchContainer>
       </FilterOptionsContainer>
-      <ResourceTable sort={sort} />
+      <ResourceTable sort={sort} defaultResourceTypes={DEFAULT_RESOURCE_TYPES} />
     </Fragment>
   );
 }
@@ -90,9 +98,15 @@ function ResourceTypeSelector({value}: {value?: string}) {
   );
 }
 
-function PageSelector({value}: {value?: string}) {
+function PageSelector({
+  value,
+  defaultResourceTypes,
+}: {
+  defaultResourceTypes?: string[];
+  value?: string;
+}) {
   const location = useLocation();
-  const {data: pages} = useResourcePagesQuery();
+  const {data: pages} = useResourcePagesQuery(defaultResourceTypes);
 
   const options: Option[] = [
     {value: '', label: 'All'},

--- a/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
@@ -47,13 +47,14 @@ type Column = GridColumnHeader<keyof Row>;
 
 type Props = {
   sort: ValidSort;
+  defaultResourceTypes?: string[];
 };
 
-function ResourceTable({sort}: Props) {
+function ResourceTable({sort, defaultResourceTypes}: Props) {
   const location = useLocation();
   const {data, isLoading, pageLinks} = useResourcesQuery({
     sort,
-    defaultResourceTypes: ['resource.script', 'resource.css'],
+    defaultResourceTypes,
   });
 
   const columnOrder: GridColumnOrder<keyof Row>[] = [

--- a/static/app/views/performance/browser/resources/shared/domainSelector.tsx
+++ b/static/app/views/performance/browser/resources/shared/domainSelector.tsx
@@ -7,15 +7,29 @@ import SelectControlWithProps, {
 } from 'sentry/views/performance/browser/resources/shared/selectControlWithProps';
 import {useResourceDomainsQuery} from 'sentry/views/performance/browser/resources/utils/useResourceDomansQuery';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {
+  EMPTY_OPTION_VALUE,
+  EmptyContainer,
+} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
 const {SPAN_DOMAIN} = SpanMetricsField;
 
-export function DomainSelector({value}: {value?: string}) {
+export function DomainSelector({
+  value,
+  defaultResourceTypes,
+}: {
+  defaultResourceTypes?: string[];
+  value?: string;
+}) {
   const location = useLocation();
-  const {data} = useResourceDomainsQuery();
+  const {data} = useResourceDomainsQuery(defaultResourceTypes);
 
   const options: Option[] = [
     {value: '', label: 'All'},
+    {
+      value: EMPTY_OPTION_VALUE,
+      label: <EmptyContainer>{t('No domain')}</EmptyContainer>,
+    },
     ...data.map(domain => ({
       value: domain,
       label: domain,

--- a/static/app/views/performance/browser/resources/shared/selectControlWithProps.tsx
+++ b/static/app/views/performance/browser/resources/shared/selectControlWithProps.tsx
@@ -1,9 +1,11 @@
+import {ReactElement} from 'react';
+
 import SelectControl, {
   ControlProps,
 } from 'sentry/components/forms/controls/selectControl';
 
 export type Option = {
-  label: string;
+  label: string | ReactElement;
   value: string;
 };
 

--- a/static/app/views/performance/browser/resources/utils/useResourceDomansQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceDomansQuery.ts
@@ -7,7 +7,10 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
-import {DEFAULT_RESOURCE_FILTERS} from 'sentry/views/performance/browser/resources/utils/useResourcesQuery';
+import {
+  DEFAULT_RESOURCE_FILTERS,
+  getResourceTypeFilter,
+} from 'sentry/views/performance/browser/resources/utils/useResourcesQuery';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 
 const {SPAN_DOMAIN, SPAN_OP, TRANSACTION} = SpanMetricsField;
@@ -15,7 +18,7 @@ const {SPAN_DOMAIN, SPAN_OP, TRANSACTION} = SpanMetricsField;
 /**
  * Gets a list of pages that have a resource.
  */
-export const useResourceDomainsQuery = () => {
+export const useResourceDomainsQuery = (defaultResourceTypes?: string[]) => {
   const location = useLocation();
   const pageFilters = usePageFilters();
   const {slug: orgSlug} = useOrganization();
@@ -25,8 +28,8 @@ export const useResourceDomainsQuery = () => {
 
   const queryConditions = [
     ...DEFAULT_RESOURCE_FILTERS,
-    `${SPAN_OP}:${resourceFilters[SPAN_OP] || '[resource.script,resource.css]'}`,
     `has:${SPAN_DOMAIN}`,
+    ...getResourceTypeFilter(resourceFilters[SPAN_OP], defaultResourceTypes),
     ...(resourceFilters[TRANSACTION]
       ? [`transaction:${resourceFilters[TRANSACTION]}`]
       : []),
@@ -59,6 +62,7 @@ export const useResourceDomainsQuery = () => {
         }
         return domains[0].toString();
       })
+      .filter(domain => domain !== '*')
       .sort() || [];
 
   return {...result, data};

--- a/static/app/views/performance/browser/resources/utils/useResourcePagesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcePagesQuery.ts
@@ -5,7 +5,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
-import {DEFAULT_RESOURCE_FILTERS} from 'sentry/views/performance/browser/resources/utils/useResourcesQuery';
+import {
+  DEFAULT_RESOURCE_FILTERS,
+  getDomainFilter,
+  getResourceTypeFilter,
+} from 'sentry/views/performance/browser/resources/utils/useResourcesQuery';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 
 const {SPAN_DOMAIN, SPAN_OP} = SpanMetricsField;
@@ -13,7 +17,7 @@ const {SPAN_DOMAIN, SPAN_OP} = SpanMetricsField;
 /**
  * Gets a list of pages that have a resource.
  */
-export const useResourcePagesQuery = () => {
+export const useResourcePagesQuery = (defaultResourceTypes?: string[]) => {
   const location = useLocation();
   const pageFilters = usePageFilters();
   const {slug: orgSlug} = useOrganization();
@@ -24,8 +28,8 @@ export const useResourcePagesQuery = () => {
 
   const queryConditions = [
     ...DEFAULT_RESOURCE_FILTERS,
-    `${SPAN_OP}:${resourceFilters[SPAN_OP] || 'resource.*'}`,
-    ...(spanDomain ? [`${SPAN_DOMAIN}:${spanDomain}`] : []),
+    ...getResourceTypeFilter(resourceFilters[SPAN_OP], defaultResourceTypes),
+    ...getDomainFilter(spanDomain),
   ]; // TODO: We will need to consider other ops
 
   const eventView = EventView.fromNewQueryWithPageFilters(

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -117,11 +117,11 @@ export const getDomainFilter = (selectedDomain: string | undefined) => {
   if (!selectedDomain) {
     return [];
   }
- 
+
   if (selectedDomain === EMPTY_OPTION_VALUE) {
     return [`!has:${SPAN_DOMAIN}`];
   }
-  
+
   return [`${SPAN_DOMAIN}:${selectedDomain}`];
 };
 

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -114,15 +114,15 @@ export const useResourcesQuery = ({sort, defaultResourceTypes, query, limit}: Pr
 };
 
 export const getDomainFilter = (selectedDomain: string | undefined) => {
-  let domainFilter: string[] = [];
-  if (selectedDomain) {
-    if (selectedDomain === EMPTY_OPTION_VALUE) {
-      domainFilter = [`!has:${SPAN_DOMAIN}`];
-    } else {
-      domainFilter = [`${SPAN_DOMAIN}:${selectedDomain}`];
-    }
+  if (!selectedDomain) {
+    return [];
   }
-  return domainFilter;
+ 
+  if (selectedDomain === EMPTY_OPTION_VALUE) {
+    return [`!has:${SPAN_DOMAIN}`];
+  }
+  
+  return [`${SPAN_DOMAIN}:${selectedDomain}`];
 };
 
 export const getResourceTypeFilter = (

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -7,6 +7,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {ValidSort} from 'sentry/views/performance/browser/resources/utils/useResourceSort';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {EMPTY_OPTION_VALUE} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
 const {
   SPAN_DOMAIN,
@@ -35,18 +36,14 @@ export const useResourcesQuery = ({sort, defaultResourceTypes, query, limit}: Pr
   const {slug: orgSlug} = useOrganization();
 
   const queryConditions = [
-    `${SPAN_OP}:${
-      resourceFilters[SPAN_OP] || `[${defaultResourceTypes?.join(',')}]` || 'resource.*'
-    }`,
     ...(!query
       ? [
           ...DEFAULT_RESOURCE_FILTERS,
           ...(resourceFilters.transaction
             ? [`transaction:"${resourceFilters.transaction}"`]
             : []),
-          ...(resourceFilters[SPAN_DOMAIN]
-            ? [`${SPAN_DOMAIN}:${resourceFilters[SPAN_DOMAIN]}`]
-            : []),
+          ...getResourceTypeFilter(resourceFilters[SPAN_OP], defaultResourceTypes),
+          ...getDomainFilter(resourceFilters[SPAN_DOMAIN]),
           ...(resourceFilters['resource.render_blocking_status']
             ? [
                 `resource.render_blocking_status:${resourceFilters['resource.render_blocking_status']}`,
@@ -114,4 +111,29 @@ export const useResourcesQuery = ({sort, defaultResourceTypes, query, limit}: Pr
   }));
 
   return {...result, data: data || []};
+};
+
+export const getDomainFilter = (selectedDomain: string | undefined) => {
+  let domainFilter: string[] = [];
+  if (selectedDomain) {
+    if (selectedDomain === EMPTY_OPTION_VALUE) {
+      domainFilter = [`!has:${SPAN_DOMAIN}`];
+    } else {
+      domainFilter = [`${SPAN_DOMAIN}:${selectedDomain}`];
+    }
+  }
+  return domainFilter;
+};
+
+export const getResourceTypeFilter = (
+  selectedSpanOp: string | undefined,
+  defaultResourceTypes: string[] | undefined
+) => {
+  let resourceFilter: string[] = [`${SPAN_OP}:resource.*`];
+  if (selectedSpanOp) {
+    resourceFilter = [`${SPAN_OP}:${selectedSpanOp}`];
+  } else if (defaultResourceTypes) {
+    resourceFilter = [`${SPAN_OP}:[${defaultResourceTypes.join(',')}]`];
+  }
+  return resourceFilter;
 };


### PR DESCRIPTION
1. Remove '*' from the domains filter, this would just search of all domains.
2. Add a 'no domain' filter option, useful when you have relative resources ex. '/main.js'
3. Fix filtering on pageSelector showing pages that have non supported resources types.
4. Add some shared filtering functionality.