### PR TITLE
fix(ui): Ignore project selector trigger width

### DIFF
--- a/static/app/components/organizations/environmentPageFilter/index.tsx
+++ b/static/app/components/organizations/environmentPageFilter/index.tsx
@@ -203,6 +203,7 @@ export function EnvironmentPageFilter({
       menuWidth={menuWidth ?? defaultMenuWidth}
       menuBody={desynced && <DesyncedFilterMessage />}
       menuFooterMessage={footerMessage}
+      menuWiderThanTrigger
       trigger={
         trigger ??
         ((triggerProps, isOpen) => (

--- a/static/app/components/organizations/projectPageFilter/index.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.tsx
@@ -392,6 +392,7 @@ export function ProjectPageFilter({
         )
       }
       menuFooterMessage={menuFooterMessage}
+      menuWiderThanTrigger
       trigger={
         trigger ??
         ((triggerProps, isOpen) => (


### PR DESCRIPTION
Skips the setState from resizeObserver. There's more work we can do to fix performance impact of the trigger width but this just ignores it for the project selector.

https://sentry.slack.com/archives/C8V02RHC7/p1698842611607529
