### PR TITLE
fix(jira-server): Fetch project priorities using safe API

### DIFF
--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -153,7 +153,7 @@ class JiraServerClient(IntegrationProxyClient):
         fetch priorities for a project, so we instead fetch all priority schemes and find the one that
         applies to the project. Priority schemes only contain priority ids (not human-readable), so we also
         need to fetch the full list of priorities and find the overlap to get both ids and names.
-        XXX: Note that we can't use getAssignedPriorityScheme b/c it requires either global or proj administrator.
+        XXX: Note that we can't use getAssignedPriorityScheme b/c it requires global or proj admin permission.
         """
         priorities = self.get_cached(self.PRIORITIES_URL)
         all_schemes = self.get_cached(self.PRIORITY_SCHEMES_URL)["schemes"]

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -835,9 +835,15 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
 
         for field in fields:
             if field["name"] == "priority":
+                # The default project may be deleted and not in the list of
+                # available projects. In that case, set project_key to None and
+                # fetching priorities will fail silently, returning all priorities.
+                filtered_projects = [proj for proj in jira_projects if proj["id"] == project_id]
+                project_key = filtered_projects[0]["key"] if filtered_projects else None
+
                 # whenever priorities are available, put the available ones in the list.
                 # allowedValues for some reason doesn't pass enough info.
-                field["choices"] = self.make_choices(client.get_priorities(project_id))
+                field["choices"] = self.make_choices(client.get_priorities(project_key))
                 field["default"] = defaults.get("priority", "")
             elif field["name"] == "fixVersions":
                 field["choices"] = self.make_choices(client.get_versions(project_id))

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -382,8 +382,8 @@ class JiraServerIntegrationTest(APITestCase):
                         "expand": "projectKeys",
                         "self": "http://jira.example.org/rest/api/2/priorityschemes/2",
                         "id": 2,
-                        "name": "Missing Medium Priority",
-                        "description": "Excludes medium",
+                        "name": "Missing Low Priority",
+                        "description": "Excludes low",
                         "defaultOptionId": "2",
                         "optionIds": ["1"],
                         "defaultScheme": False,
@@ -451,9 +451,7 @@ class JiraServerIntegrationTest(APITestCase):
             }
 
     @responses.activate
-    def test_get_create_issue_config_failing_to_fetch_priorities_returns_all_priorities(
-        self, mock_logger
-    ):
+    def test_get_create_issue_config_failing_to_fetch_priorities_returns_all_priorities(self):
         """Test failing to fetch priorities fails silently and returns all priorities"""
         event = self.store_event(
             data={
@@ -535,7 +533,7 @@ class JiraServerIntegrationTest(APITestCase):
             assert priority_field == {
                 "default": "",
                 # When the project priorities cannot be fetched, we return all priorities
-                "choices": [("1", "High"), ("2", "Medium")],
+                "choices": [("1", "High"), ("2", "Low")],
                 "type": "select",
                 "name": "priority",
                 "label": "Priority",


### PR DESCRIPTION
‼️ Reverted b/c this runs into the same permission issue as https://github.com/getsentry/sentry/pull/58749 despite the Jira Server API docs not stating I needed global/admin permission. This is the relevant [Sentry Issue](https://sentry.sentry.io/issues/4593933722/events/6886ed5320694ad8a4925816ba9c254a/?project=1&referrer=issue-list&statsPeriod=10m)

Fixes https://github.com/getsentry/sentry/issues/58906

I changed the way we fetch Jira Server priorities to scope them per project in https://github.com/getsentry/sentry/pull/58749. However I used [getAssignedPriorityScheme](https://docs.atlassian.com/software/jira/docs/api/REST/9.11.0/#api/2/project/{projectKeyOrId}/priorityscheme-getAssignedPriorityScheme) which requires project/global admin permission.

This fix switches to using [getPrioritySchemes](https://docs.atlassian.com/software/jira/docs/api/REST/9.11.0/#api/2/priorityschemes-getPrioritySchemes) where we first fetch all priority schemes, then match the response with the project key to find the priority IDs.

### Auto-Ticket Creation

https://github.com/getsentry/sentry/assets/67301797/4dab6974-c8b9-4788-a683-af6c53f5e589

### Manual Ticket Creation

https://github.com/getsentry/sentry/assets/67301797/e31a7c6c-005e-4ed6-b5a4-099411c4e149
