### PR TITLE
ref(analytics): Add actor type to Slack notification analytics

### DIFF
--- a/src/sentry/integrations/slack/analytics.py
+++ b/src/sentry/integrations/slack/analytics.py
@@ -18,7 +18,6 @@ class SlackIntegrationStatus(analytics.Event):
     )
 
 
-# TODO: add field for whether target is user or team
 class SlackIntegrationNotificationSent(analytics.Event):
     type = "integrations.slack.notification_sent"
 
@@ -31,6 +30,7 @@ class SlackIntegrationNotificationSent(analytics.Event):
         analytics.Attribute("group_id", required=False),
         analytics.Attribute("notification_uuid"),
         analytics.Attribute("alert_id", required=False),
+        analytics.Attribute("actor_type", required=False),
     )
 
 

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -263,6 +263,7 @@ class ActivityNotificationTest(APITestCase):
             organization_id=self.organization.id,
             group_id=self.group.id,
             notification_uuid=notification_uuid,
+            actor_type="User",
         )
 
     @responses.activate
@@ -326,6 +327,7 @@ class ActivityNotificationTest(APITestCase):
             organization_id=self.organization.id,
             group_id=None,
             notification_uuid=notification_uuid,
+            actor_type="User",
         )
 
     @responses.activate
@@ -389,6 +391,7 @@ class ActivityNotificationTest(APITestCase):
             organization_id=self.organization.id,
             group_id=group.id,
             notification_uuid=notification_uuid,
+            actor_type="User",
         )
 
     @responses.activate
@@ -446,6 +449,7 @@ class ActivityNotificationTest(APITestCase):
             organization_id=self.organization.id,
             group_id=self.group.id,
             notification_uuid=notification_uuid,
+            actor_type="User",
         )
 
     @responses.activate
@@ -527,6 +531,7 @@ class ActivityNotificationTest(APITestCase):
             organization_id=self.organization.id,
             group_id=event.group_id,
             notification_uuid=notification_uuid,
+            actor_type="User",
         )
 
 


### PR DESCRIPTION
Add actor type to Slack notification analytics so we can see how many notifications we're sending to teams

closes https://github.com/getsentry/sentry/issues/58551