### PR TITLE
feat(stats-detectors): Overlay throughput on chart for regression issues

### DIFF
--- a/static/app/components/events/eventStatisticalDetector/functionBreakpointChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/functionBreakpointChart.tsx
@@ -87,10 +87,7 @@ function EventFunctionBreakpointChartInner({
 
   const throughputSeries = useMemo(() => {
     const rawData = functionStats?.data?.data?.find(({axis}) => axis === 'count()');
-    const timestamps = functionStats?.data?.timestamps;
-    if (!timestamps) {
-      return undefined;
-    }
+    const timestamps = functionStats?.data?.timestamps ?? [];
 
     const bucketSize = 12 * 60 * 60;
 

--- a/static/app/components/events/eventStatisticalDetector/lineChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/lineChart.tsx
@@ -22,7 +22,7 @@ interface ChartProps {
   evidenceData: NormalizedTrendsTransaction;
   percentileSeries: Series[];
   start: string;
-  throughputSeries?: Series;
+  throughputSeries: Series;
 }
 
 function LineChart({
@@ -51,12 +51,7 @@ function LineChart({
     ];
   }, [percentileSeries, evidenceData, theme]);
 
-  const rightSeries = useMemo(() => {
-    if (!throughputSeries) {
-      return [];
-    }
-    return [throughputSeries];
-  }, [throughputSeries]);
+  const rightSeries = useMemo(() => [throughputSeries], [throughputSeries]);
 
   const series = useMemo(() => {
     return [
@@ -98,11 +93,8 @@ function LineChart({
     const legend = {
       right: 16,
       top: 12,
-      data: percentileSeries.map(s => s.seriesName),
+      data: [...percentileSeries.map(s => s.seriesName), throughputSeries.seriesName],
     };
-    if (throughputSeries) {
-      legend.data.push(throughputSeries.seriesName);
-    }
 
     const durationUnit = getDurationUnit(leftSeries);
 
@@ -126,8 +118,9 @@ function LineChart({
         },
       });
     }
+
     return {
-      colors: throughputSeries ? [theme.gray200, theme.gray500] : [theme.gray500],
+      colors: [theme.gray200, theme.gray500],
       grid: {
         left: '10px',
         right: '10px',

--- a/static/app/components/events/eventStatisticalDetector/lineChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/lineChart.tsx
@@ -114,7 +114,7 @@ function LineChart({
         axisLabel: {
           color: theme.chartLabel,
           formatter: (value: number) =>
-            axisLabelFormatter(value, 'rate', true, undefined, RateUnits.PER_MINUTE),
+            axisLabelFormatter(value, 'rate', true, undefined, RateUnits.PER_SECOND),
         },
       });
     }

--- a/static/app/components/events/eventStatisticalDetector/lineChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/lineChart.tsx
@@ -1,113 +1,156 @@
+import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 
+import BaseChart from 'sentry/components/charts/baseChart';
 import ChartZoom from 'sentry/components/charts/chartZoom';
-import VisualMap from 'sentry/components/charts/components/visualMap';
-import {
-  LineChart as EchartsLineChart,
-  LineChartProps,
-} from 'sentry/components/charts/lineChart';
-import {EventsStatsData} from 'sentry/types';
+import BarSeries from 'sentry/components/charts/series/barSeries';
+import LineSeries from 'sentry/components/charts/series/lineSeries';
+import {Series} from 'sentry/types/echarts';
 import {getUserTimezone} from 'sentry/utils/dates';
 import {
   axisLabelFormatter,
   getDurationUnit,
   tooltipFormatter,
 } from 'sentry/utils/discover/charts';
-import {aggregateOutputType} from 'sentry/utils/discover/fields';
+import {aggregateOutputType, RateUnits} from 'sentry/utils/discover/fields';
 import useRouter from 'sentry/utils/useRouter';
-import {transformEventStats} from 'sentry/views/performance/trends/chart';
 import {NormalizedTrendsTransaction} from 'sentry/views/performance/trends/types';
 import {getIntervalLine} from 'sentry/views/performance/utils';
 
 interface ChartProps {
-  chartLabel: string;
   end: string;
   evidenceData: NormalizedTrendsTransaction;
+  percentileSeries: Series[];
   start: string;
-  statsData: EventsStatsData;
+  throughputSeries?: Series;
 }
 
-function LineChart({statsData, evidenceData, start, end, chartLabel}: ChartProps) {
+function LineChart({
+  percentileSeries,
+  throughputSeries,
+  evidenceData,
+  start,
+  end,
+}: ChartProps) {
   const theme = useTheme();
   const router = useRouter();
 
-  const resultSeries = transformEventStats(statsData, chartLabel);
+  const leftSeries = useMemo(() => {
+    const needsLabel = true;
+    const intervalSeries = getIntervalLine(
+      theme,
+      percentileSeries || [],
+      0.5,
+      needsLabel,
+      evidenceData,
+      true
+    );
+    return [
+      ...percentileSeries,
+      ...intervalSeries.filter(s => !s.markArea), // get rid of the shading
+    ];
+  }, [percentileSeries, evidenceData, theme]);
 
-  const needsLabel = true;
-  const intervalSeries = getIntervalLine(
-    theme,
-    resultSeries || [],
-    0.5,
-    needsLabel,
-    evidenceData,
-    true
-  );
+  const rightSeries = useMemo(() => {
+    if (!throughputSeries) {
+      return [];
+    }
+    return [throughputSeries];
+  }, [throughputSeries]);
 
-  const series = [...resultSeries, ...intervalSeries];
+  const series = useMemo(() => {
+    return [
+      ...rightSeries.map(({seriesName, data, ...options}) =>
+        BarSeries({
+          ...options,
+          name: seriesName,
+          data: data?.map(({value, name, itemStyle}) => {
+            if (itemStyle === undefined) {
+              return [name, value];
+            }
+            return {value: [name, value], itemStyle};
+          }),
+          animation: false,
+          animationThreshold: 1,
+          animationDuration: 0,
+          yAxisIndex: 1,
+        })
+      ),
+      ...leftSeries.map(({seriesName, data, ...options}) =>
+        LineSeries({
+          ...options,
+          name: seriesName,
+          data: data?.map(({value, name}) => [name, value]),
+          animation: false,
+          animationThreshold: 1,
+          animationDuration: 0,
+          showSymbol: false,
+          yAxisIndex: 0,
+        })
+      ),
+    ];
+  }, [leftSeries, rightSeries]);
 
-  const durationUnit = getDurationUnit(series);
+  const chartOptions: Omit<
+    React.ComponentProps<typeof BaseChart>,
+    'series'
+  > = useMemo(() => {
+    const legend = {
+      right: 16,
+      top: 12,
+      data: percentileSeries.map(s => s.seriesName),
+    };
+    if (throughputSeries) {
+      legend.data.push(throughputSeries.seriesName);
+    }
 
-  const chartOptions: Omit<LineChartProps, 'series'> = {
-    tooltip: {
-      valueFormatter: (value, seriesName) => {
-        return tooltipFormatter(value, aggregateOutputType(seriesName));
+    const durationUnit = getDurationUnit(leftSeries);
+
+    const yAxes: React.ComponentProps<typeof BaseChart>['yAxes'] = [
+      {
+        minInterval: durationUnit,
+        axisLabel: {
+          color: theme.chartLabel,
+          formatter: (value: number) =>
+            axisLabelFormatter(value, 'duration', undefined, durationUnit),
+        },
       },
-    },
-    yAxis: {
-      minInterval: durationUnit,
-      axisLabel: {
-        color: theme.chartLabel,
-        formatter: (value: number) =>
-          axisLabelFormatter(value, 'duration', undefined, durationUnit),
+    ];
+
+    if (rightSeries.length) {
+      yAxes.push({
+        axisLabel: {
+          color: theme.chartLabel,
+          formatter: (value: number) =>
+            axisLabelFormatter(value, 'rate', true, undefined, RateUnits.PER_MINUTE),
+        },
+      });
+    }
+    return {
+      colors: throughputSeries ? [theme.gray200, theme.gray500] : [theme.gray500],
+      grid: {
+        left: '10px',
+        right: '10px',
+        top: '40px',
+        bottom: '0px',
       },
-    },
-  };
+      legend,
+      toolBox: {show: false},
+      tooltip: {
+        valueFormatter: (value, seriesName) => {
+          return tooltipFormatter(value, aggregateOutputType(seriesName));
+        },
+      },
+      xAxis: {type: 'time'},
+      yAxes,
+    };
+  }, [theme, leftSeries, rightSeries, percentileSeries, throughputSeries]);
 
   return (
     <ChartZoom router={router} start={start} end={end} utc={getUserTimezone() === 'UTC'}>
-      {zoomRenderProps => {
-        return (
-          <EchartsLineChart
-            {...zoomRenderProps}
-            {...chartOptions}
-            series={series}
-            seriesOptions={{
-              showSymbol: false,
-            }}
-            toolBox={{
-              show: false,
-            }}
-            grid={{
-              left: '10px',
-              right: '10px',
-              top: '20px',
-              bottom: '0px',
-            }}
-            options={{
-              visualMap: VisualMap({
-                show: false,
-                type: 'piecewise',
-                selectedMode: false,
-                dimension: 0,
-                pieces: [
-                  {
-                    gte: 0,
-                    lt: evidenceData?.breakpoint ? evidenceData.breakpoint * 1000 : 0,
-                    color: theme.gray500,
-                  },
-                  {
-                    gte: evidenceData?.breakpoint ? evidenceData.breakpoint * 1000 : 0,
-                    color: theme.red300,
-                  },
-                ],
-              }),
-            }}
-            xAxis={{
-              type: 'time',
-            }}
-          />
-        );
-      }}
+      {zoomRenderProps => (
+        <BaseChart {...zoomRenderProps} {...chartOptions} series={series} />
+      )}
     </ChartZoom>
   );
 }

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -23,7 +23,6 @@ import {EventFunctionRegressionEvidence} from 'sentry/components/events/eventSta
 import {EventFunctionBreakpointChart} from 'sentry/components/events/eventStatisticalDetector/functionBreakpointChart';
 import RegressionMessage from 'sentry/components/events/eventStatisticalDetector/regressionMessage';
 import EventSpanOpBreakdown from 'sentry/components/events/eventStatisticalDetector/spanOpBreakdown';
-import TransactionFrequencyChart from 'sentry/components/events/eventStatisticalDetector/transactionFrequencyChart';
 import {EventTagsAndScreenshot} from 'sentry/components/events/eventTagsAndScreenshot';
 import {EventViewHierarchy} from 'sentry/components/events/eventViewHierarchy';
 import {EventGroupingInfo} from 'sentry/components/events/groupingInfo';
@@ -200,9 +199,6 @@ function PerformanceDurationRegressionIssueDetailsContent({
         <RegressionMessage event={event} group={group} />
         <ErrorBoundary mini>
           <EventBreakpointChart event={event} />
-        </ErrorBoundary>
-        <ErrorBoundary mini>
-          <TransactionFrequencyChart event={event} />
         </ErrorBoundary>
         <ErrorBoundary mini>
           <EventSpanOpBreakdown event={event} />


### PR DESCRIPTION
Instead of having 2 separate charts taking up 2x the vertical space, overlay the throughput chart as with a lighter colour to make it less prominent but still usable to identify if increase in throughput is the cause.
