### PR TITLE
fix(starfish): Use project param from row in profile URL

### DIFF
--- a/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
@@ -123,7 +123,7 @@ export function SpanSamplesTable({
       return row.profile_id ? (
         <Link
           {...commonProps}
-          to={`/profiling/profile/${row['project.name']}/${row.profile_id}/flamechart/`}
+          to={`/profiling/profile/${row.project}/${row.profile_id}/flamechart/`}
         >
           {row.profile_id.slice(0, 8)}
         </Link>


### PR DESCRIPTION
Project is returned from span samples as the project name, so we can just use that