### PR TITLE
feat(provisioning): return partnership flag in API

### DIFF
--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -144,6 +144,7 @@ class OrganizationMemberSerializer(Serializer):
                 "sso:linked": bool(getattr(obj.flags, "sso:linked")),
                 "sso:invalid": bool(getattr(obj.flags, "sso:invalid")),
                 "member-limit:restricted": bool(getattr(obj.flags, "member-limit:restricted")),
+                "partnership:restricted": bool(getattr(obj.flags, "partnership:restricted")),
             },
             "dateCreated": obj.date_added,
             "inviteStatus": obj.get_invite_status_name(),

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -56,6 +56,7 @@ _OrganizationMemberFlags = TypedDict(
         "sso:linked": bool,
         "sso:invalid": bool,
         "member-limit:restricted": bool,
+        "partnership:restricted": bool,
     },
 )
 

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -157,6 +157,7 @@ class OrganizationExamples:
                     "sso:linked": False,
                     "sso:invalid": False,
                     "member-limit:restricted": False,
+                    "partnership:restricted": False,
                 },
                 "dateCreated": "2021-07-06T21:13:01.120263Z",
                 "inviteStatus": "approved",


### PR DESCRIPTION
Return the partnership flag in the OrganizationMember API to be read on the frontend.

For ER-1962