### PR TITLE
chore(vscode): Remove deprecated python settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,20 +70,9 @@
     "editor.formatOnSave": false
   },
 
-  "python.linting.pylintEnabled": false,
-  "python.linting.flake8Enabled": true,
-  // test discovery is sluggish and the UI around running
-  // tests is often in your way and misclicked
+  "editor.tabSize": 4,
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
-  "python.testing.nosetestsEnabled": false,
-  "editor.tabSize": 4,
-  "restructuredtext.confPath": "",
-  "python.linting.enabled": true,
-  "python.linting.flake8Path": "${workspaceFolder}/.venv/bin/flake8",
-  "python.linting.pycodestylePath": "${workspaceFolder}/.venv/bin/pep8",
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
-  "python.formatting.blackPath": "${workspaceFolder}/.venv/bin/black",
-  "python.formatting.provider": "none",
   "python.testing.pytestArgs": ["tests"]
 }


### PR DESCRIPTION
The newer versions of the python extension has had linting in other packages for a while and have been doing nothing. This just cleans them up

docs https://code.visualstudio.com/docs/python/linting
