### PR TITLE
fix(issues-platform): get stack traces for when we fail to validate with the new schema

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -173,6 +173,9 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                         sample_rate=1.0,
                         tags={"occurrence_type": occurrence_data["type"]},
                     )
+                    logger.exception(
+                        "Error validating event payloa, falling back to legacy validation"
+                    )
                     try:
                         jsonschema.validate(event_data, LEGACY_EVENT_PAYLOAD_SCHEMA)
                     except jsonschema.exceptions.ValidationError:

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -174,7 +174,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                         tags={"occurrence_type": occurrence_data["type"]},
                     )
                     logger.exception(
-                        "Error validating event payloa, falling back to legacy validation"
+                        "Error validating event payload, falling back to legacy validation"
                     )
                     try:
                         jsonschema.validate(event_data, LEGACY_EVENT_PAYLOAD_SCHEMA)

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -279,7 +279,7 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
             )
 
     def test_valid_nan_exception_log(self) -> None:
-        # NaN is invalid in new event schema, but valid in legacy schema, so it emits only one of the metrics
+        # NaN is invalid in new event schema, but valid in legacy schema, so it emits logging, but doesn't raise
         message = deepcopy(get_test_message(self.project.id))
         message["event"]["tags"]["nan-tag"] = float("nan")
         with self.assertLogs("sentry.issues.occurrence_consumer", logging.ERROR) as cm:

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -278,6 +278,18 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
                 tags={"occurrence_type": mock.ANY},
             )
 
+    def test_valid_nan_exception_log(self) -> None:
+        # NaN is invalid in new event schema, but valid in legacy schema, so it emits only one of the metrics
+        message = deepcopy(get_test_message(self.project.id))
+        message["event"]["tags"]["nan-tag"] = float("nan")
+        with self.assertLogs("sentry.issues.occurrence_consumer", logging.ERROR) as cm:
+            self.run_test(message)
+
+        assert (
+            "Error validating event payload, falling back to legacy validation" in cm.records[0].msg
+        )
+        assert cm.records[0].exc_info is not None
+
     def test_invalid_payload_emits_both_metrics(self) -> None:
         with mock.patch("sentry.issues.occurrence_consumer.metrics") as metrics:
             self.run_invalid_payload_test(


### PR DESCRIPTION

Get a stack trace when new JSON Schema validation fails, while still falling back to legacy validation. 

Followup to #58743
Related to #57649