### PR TITLE
fix(issues): Filter out null/undefined headers when formatting request as curl

### DIFF
--- a/static/app/components/events/interfaces/utils.spec.tsx
+++ b/static/app/components/events/interfaces/utils.spec.tsx
@@ -74,7 +74,7 @@ describe('components/interfaces/utils', function () {
           ' "http://example.com/foo?foo=bar"'
       );
 
-      // Do not add data if data is empty
+      // Do not add `data` if `data` is missing
       expect(
         getCurlCommand({
           apiTarget: null,
@@ -89,7 +89,7 @@ describe('components/interfaces/utils', function () {
         })
       ).toEqual('curl \\\n "http://example.com/foo?foo=bar"');
 
-      // Do not add data if data is empty object
+      // Do not add `data` if `data` is empty object
       expect(
         getCurlCommand({
           apiTarget: null,
@@ -104,6 +104,48 @@ describe('components/interfaces/utils', function () {
           method: 'GET',
         })
       ).toEqual('curl \\\n "http://example.com/foo"');
+
+      // Filter out undefined headers
+      expect(
+        getCurlCommand({
+          apiTarget: null,
+          url: 'http://example.com/foo',
+          headers: [
+            ['Referer', 'http://example.com'],
+            ['Content-Type', 'application/json'],
+            undefined as any,
+          ],
+          data: '{"hello": "world"}',
+          method: 'GET',
+        })
+      ).toEqual(
+        'curl \\\n' +
+          ' -H "Content-Type: application/json" \\\n' +
+          ' -H "Referer: http://example.com" \\\n' +
+          ' --data "{\\"hello\\": \\"world\\"}" \\\n' +
+          ' "http://example.com/foo"'
+      );
+
+      // Filter out null headers
+      expect(
+        getCurlCommand({
+          apiTarget: null,
+          url: 'http://example.com/foo',
+          headers: [
+            ['Referer', 'http://example.com'],
+            ['Content-Type', 'application/json'],
+            null as any,
+          ],
+          data: '{"hello": "world"}',
+          method: 'GET',
+        })
+      ).toEqual(
+        'curl \\\n' +
+          ' -H "Content-Type: application/json" \\\n' +
+          ' -H "Referer: http://example.com" \\\n' +
+          ' --data "{\\"hello\\": \\"world\\"}" \\\n' +
+          ' "http://example.com/foo"'
+      );
 
       // Escape escaped strings.
       expect(

--- a/static/app/components/events/interfaces/utils.tsx
+++ b/static/app/components/events/interfaces/utils.tsx
@@ -125,6 +125,8 @@ export function getCurlCommand(data: EntryRequest['data']) {
     result += ' \\\n -X ' + data.method;
   }
 
+  data.headers = data.headers?.filter(defined);
+
   // TODO(benvinegar): just gzip? what about deflate?
   const compressed = data.headers?.find(
     h => h[0] === 'Accept-Encoding' && h[1].includes('gzip')


### PR DESCRIPTION
On the issue details page, there is a button to display data about the request in `curl` format, at which point we convert it and do the formatting on the fly. As part of this formatting, we sort the headers. But if any of the headers is `null` or `undefined`, that sorting crashes, because it expects every header to be of the form `[headerName, value]` and therefore assumes it's safe to index into it, which of course you can't do with `null` or `undefined`. As a result of this sorting crash, the entire formatting process fails and we don't produce any output.

This fixes that by filtering `null` and `undefined` out of the `request.headers` array before any other processing is done.

Fixes https://github.com/getsentry/sentry/issues/59034
Fixes JAVASCRIPT-2PBG