### PR TITLE
fix(pageFilters): Check ability to select multiple projects in mapping function

### DIFF
--- a/static/app/components/organizations/projectPageFilter/index.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.tsx
@@ -158,12 +158,14 @@ export function ProjectPageFilter({
 
       // "My Projects"
       if (!val.length) {
-        return memberProjects.map(p => parseInt(p.id, 10));
+        return allowMultiple
+          ? memberProjects.map(p => parseInt(p.id, 10))
+          : [parseInt(memberProjects[0]?.id, 10)];
       }
 
-      return val;
+      return allowMultiple ? val : [val[0]];
     },
-    [memberProjects]
+    [memberProjects, allowMultiple]
   );
 
   const value = useMemo<number[]>(

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -234,6 +234,7 @@ describe('OrganizationStats', function () {
 
     render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
       context: newOrg.routerContext,
+      organization: newOrg.organization,
     });
 
     expect(screen.queryByText('My Projects')).not.toBeInTheDocument();
@@ -249,8 +250,10 @@ describe('OrganizationStats', function () {
       // TODO(Leander): Remove the following check once the project-stats flag is GA
       'project-stats',
     ];
+    OrganizationStore.onUpdate(newOrg.organization, {replace: true});
     render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
       context: newOrg.routerContext,
+      organization: newOrg.organization,
     });
 
     expect(screen.getByText('All Projects')).toBeInTheDocument();
@@ -288,7 +291,10 @@ describe('OrganizationStats', function () {
         organization={newOrg.organization}
         selection={newSelection}
       />,
-      {context: newOrg.routerContext}
+      {
+        context: newOrg.routerContext,
+        organization: newOrg.organization,
+      }
     );
     act(() => PageFiltersStore.updateProjects(selectedProjects, []));
 
@@ -330,7 +336,10 @@ describe('OrganizationStats', function () {
         organization={newOrg.organization}
         selection={newSelection}
       />,
-      {context: newOrg.routerContext}
+      {
+        context: newOrg.routerContext,
+        organization: newOrg.organization,
+      }
     );
     act(() => PageFiltersStore.updateProjects(selectedProject, []));
 
@@ -363,6 +372,7 @@ describe('OrganizationStats', function () {
     ];
     render(<OrganizationStats {...defaultProps} organization={newOrg.organization} />, {
       context: newOrg.routerContext,
+      organization: newOrg.organization,
     });
     await userEvent.click(screen.getByTestId('proj-1'));
     expect(screen.queryByText('My Projects')).not.toBeInTheDocument();
@@ -387,7 +397,10 @@ describe('OrganizationStats', function () {
           organization={newOrg.organization}
           selection={newSelection}
         />,
-        {context: newOrg.routerContext}
+        {
+          context: newOrg.routerContext,
+          organization: newOrg.organization,
+        }
       );
       act(() => PageFiltersStore.updateProjects(selectedProject, []));
       expect(screen.queryByText('My Projects')).not.toBeInTheDocument();


### PR DESCRIPTION
**Before**: in organizations without multiple project selection enabled, clicking "Reset" switches the selection value to "My Projects"/"All Projects", which is invalid:
<img width="613" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/353f4660-154c-458e-aa70-da60f0ee9728">

**After**: clicking "Reset" switches to the default value (the first project in the projects list):
<img width="349" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/0cd6cf07-f3da-46fc-a13d-d34661023721">
