### PR TITLE
ref(replays): move viewers section to next to description

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -88,11 +88,6 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
                 feedbackEvent={eventData}
               />
             </ErrorBoundary>
-
-            <ErrorBoundary mini>
-              <FeedbackViewers feedbackItem={feedbackItem} />
-            </ErrorBoundary>
-
             <ErrorBoundary mini>
               <Button
                 onClick={() => {
@@ -121,7 +116,10 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
         </Flex>
       </HeaderPanelItem>
       <OverflowPanelItem>
-        <Section title={t('Description')}>
+        <Section
+          title={t('Description')}
+          contentRight={<FeedbackViewers feedbackItem={feedbackItem} />}
+        >
           <Blockquote>
             <pre>{feedbackItem.metadata.message}</pre>
           </Blockquote>

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -118,7 +118,11 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
       <OverflowPanelItem>
         <Section
           title={t('Description')}
-          contentRight={<FeedbackViewers feedbackItem={feedbackItem} />}
+          contentRight={
+            <ErrorBoundary>
+              <FeedbackViewers feedbackItem={feedbackItem} />
+            </ErrorBoundary>
+          }
         >
           <Blockquote>
             <pre>{feedbackItem.metadata.message}</pre>

--- a/static/app/components/feedback/feedbackItem/feedbackItemSection.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemSection.tsx
@@ -18,22 +18,34 @@ const SectionTitle = styled('h3')`
   display: flex;
   gap: ${space(0.5)};
   align-items: center;
+  justify-content: space-between;
+`;
+
+const LeftAlignedContent = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
 `;
 
 export default function Section({
   children,
   icon,
   title,
+  contentRight,
 }: {
   children: ReactNode;
   title: string;
+  contentRight?: ReactNode;
   icon?: ReactNode;
 }) {
   return (
     <SectionWrapper>
       <SectionTitle>
-        {icon}
-        <span>{title}</span>
+        <LeftAlignedContent>
+          {icon}
+          {title}
+        </LeftAlignedContent>
+        {contentRight}
       </SectionTitle>
       {children}
     </SectionWrapper>

--- a/static/app/components/feedback/feedbackItem/feedbackViewers.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackViewers.tsx
@@ -18,7 +18,7 @@ export default function FeedbackViewers({feedbackItem}: Props) {
     <StyledAvatarList
       users={displayUsers}
       avatarSize={28}
-      maxVisibleAvatars={3}
+      maxVisibleAvatars={5}
       tooltipOptions={{position: 'top'}}
       renderTooltip={user => (
         <Fragment>


### PR DESCRIPTION
The header was getting too crowded, so I moved the viewers section to be in line with the description, but right aligned.

<img width="700" alt="SCR-20231101-nexm" src="https://github.com/getsentry/sentry/assets/56095982/ea260ed5-a854-413c-a2a6-c56cfcddf77e">
