### PR TITLE
chore(vscode): Remove some deprecated settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,20 +70,11 @@
     "editor.formatOnSave": false
   },
 
-  "python.linting.pylintEnabled": false,
-  "python.linting.flake8Enabled": true,
   // test discovery is sluggish and the UI around running
   // tests is often in your way and misclicked
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
-  "python.testing.nosetestsEnabled": false,
   "editor.tabSize": 4,
-  "restructuredtext.confPath": "",
-  "python.linting.enabled": true,
-  "python.linting.flake8Path": "${workspaceFolder}/.venv/bin/flake8",
-  "python.linting.pycodestylePath": "${workspaceFolder}/.venv/bin/pep8",
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
-  "python.formatting.blackPath": "${workspaceFolder}/.venv/bin/black",
-  "python.formatting.provider": "none",
   "python.testing.pytestArgs": ["tests"]
 }


### PR DESCRIPTION
I had some warnings in my VS code about some of them.
When I loaded the file, it showed all of these settings as grayed out.