### PR TITLE
perf(issues): Move annotated text useProjects into subcomponent

### DIFF
--- a/static/app/components/events/meta/annotatedText/index.tsx
+++ b/static/app/components/events/meta/annotatedText/index.tsx
@@ -1,7 +1,3 @@
-import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
-import useProjects from 'sentry/utils/useProjects';
-
 import {AnnotatedTextErrors} from './annotatedTextErrors';
 import {AnnotatedTextValue} from './annotatedTextValue';
 
@@ -12,20 +8,9 @@ type Props = {
 };
 
 export function AnnotatedText({value, meta, className, ...props}: Props) {
-  const organization = useOrganization();
-  const location = useLocation();
-  const projectId = location.query.project;
-  const {projects} = useProjects();
-  const currentProject = projects.find(project => project.id === projectId);
-
   return (
     <span className={className} {...props}>
-      <AnnotatedTextValue
-        value={value}
-        meta={meta}
-        project={currentProject}
-        organization={organization}
-      />
+      <AnnotatedTextValue value={value} meta={meta} />
       <AnnotatedTextErrors errors={meta?.err} />
     </span>
   );


### PR DESCRIPTION
We only use projects/organization when displaying "[Filtered]", the rest do not need it. By moving it lower we can reduce the number of useProjects on the page (assuming not all values are filtered).

An update to the store causes all the components listening to useProjects to update which on some issue details pages could be 300-500 of these AnnotatedText components

![image](https://github.com/getsentry/sentry/assets/1400464/6ea59026-3712-41dc-b231-ceb92222b65b)
