### PR TITLE
feat(issue-platform): Add toggle to enable/disable escalation detection

### DIFF
--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -162,7 +162,7 @@ class GroupType:
         return features.has(cls.build_post_process_group_feature_name(), organization)
 
     @classmethod
-    def can_generate_escalating_forecasts(cls, organization: Organization) -> bool:
+    def should_generate_escalating_forecasts(cls, organization: Organization) -> bool:
         if not features.has("organizations:issue-platform-api-crons-sd", organization):
             return True
         return cls.generate_escalating_forecasts

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -123,7 +123,7 @@ class GroupType:
     # Allow automatic resolution of an issue type, using the project-level option.
     enable_auto_resolve: bool = True
     # Allow escalation forecasts and detection
-    generate_escalating_forecasts: bool = True
+    enable_escalation_detection: bool = True
     creation_quota: Quota = Quota(3600, 60, 5)  # default 5 per hour, sliding window of 60 seconds
 
     def __init_subclass__(cls: Type[GroupType], **kwargs: Any) -> None:
@@ -162,10 +162,10 @@ class GroupType:
         return features.has(cls.build_post_process_group_feature_name(), organization)
 
     @classmethod
-    def should_generate_escalating_forecasts(cls, organization: Organization) -> bool:
+    def should_detect_escalation(cls, organization: Organization) -> bool:
         if not features.has("organizations:issue-platform-api-crons-sd", organization):
             return True
-        return cls.generate_escalating_forecasts
+        return cls.enable_escalation_detection
 
     @classmethod
     def build_feature_name_slug(cls) -> str:
@@ -343,7 +343,7 @@ class PerformanceDurationRegressionGroupType(PerformanceGroupTypeDefaults, Group
     noise_config = NoiseConfig(ignore_limit=0)
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
-    generate_escalating_forecasts = False
+    enable_escalation_detection = False
 
 
 @dataclass(frozen=True)
@@ -354,7 +354,7 @@ class PerformanceP95DurationRegressionGroupType(PerformanceGroupTypeDefaults, Gr
     noise_config = NoiseConfig(ignore_limit=0)
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
-    generate_escalating_forecasts = False
+    enable_escalation_detection = False
 
 
 # 2000 was ProfileBlockingFunctionMainThreadType

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -122,6 +122,8 @@ class GroupType:
 
     # Allow automatic resolution of an issue type, using the project-level option.
     enable_auto_resolve: bool = True
+    # Allow escalation forecasts and detection
+    generate_escalating_forecasts = True
     creation_quota: Quota = Quota(3600, 60, 5)  # default 5 per hour, sliding window of 60 seconds
 
     def __init_subclass__(cls: Type[GroupType], **kwargs: Any) -> None:
@@ -335,6 +337,7 @@ class PerformanceDurationRegressionGroupType(PerformanceGroupTypeDefaults, Group
     noise_config = NoiseConfig(ignore_limit=0)
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
+    generate_escalating_forecasts = False
 
 
 @dataclass(frozen=True)
@@ -345,6 +348,7 @@ class PerformanceP95DurationRegressionGroupType(PerformanceGroupTypeDefaults, Gr
     noise_config = NoiseConfig(ignore_limit=0)
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
+    generate_escalating_forecasts = False
 
 
 # 2000 was ProfileBlockingFunctionMainThreadType

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -123,7 +123,7 @@ class GroupType:
     # Allow automatic resolution of an issue type, using the project-level option.
     enable_auto_resolve: bool = True
     # Allow escalation forecasts and detection
-    generate_escalating_forecasts = True
+    generate_escalating_forecasts: bool = True
     creation_quota: Quota = Quota(3600, 60, 5)  # default 5 per hour, sliding window of 60 seconds
 
     def __init_subclass__(cls: Type[GroupType], **kwargs: Any) -> None:
@@ -160,6 +160,12 @@ class GroupType:
             return True
 
         return features.has(cls.build_post_process_group_feature_name(), organization)
+
+    @classmethod
+    def can_generate_escalating_forecasts(cls, organization: Organization) -> bool:
+        if not features.has("organizations:issue-platform-api-crons-sd", organization):
+            return True
+        return cls.generate_escalating_forecasts
 
     @classmethod
     def build_feature_name_slug(cls) -> str:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -786,7 +786,7 @@ def process_snoozes(job: PostProcessJob) -> None:
     event = job["event"]
     group = event.group
 
-    if not group.issue_type.can_generate_escalating_forecasts(group.organization):
+    if not group.issue_type.should_generate_escalating_forecasts(group.organization):
         return
 
     # Check if group is escalating

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -786,7 +786,10 @@ def process_snoozes(job: PostProcessJob) -> None:
     event = job["event"]
     group = event.group
 
-    # Check is group is escalating
+    if not group.issue_type.can_generate_escalating_forecasts(group.organization):
+        return
+
+    # Check if group is escalating
     if (
         features.has("organizations:escalating-issues", group.organization)
         and group.status == GroupStatus.IGNORED

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -786,7 +786,7 @@ def process_snoozes(job: PostProcessJob) -> None:
     event = job["event"]
     group = event.group
 
-    if not group.issue_type.should_generate_escalating_forecasts(group.organization):
+    if not group.issue_type.should_detect_escalation(group.organization):
         return
 
     # Check if group is escalating

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1517,8 +1517,8 @@ class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
     ):
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
         group = event.group
-        should_generate_escalating_forecasts = (
-            group.issue_type.should_generate_escalating_forecasts(self.project.organization)
+        should_detect_escalation = group.issue_type.should_detect_escalation(
+            self.project.organization
         )
 
         # Check for has_reappeared=False if is_new=True
@@ -1551,7 +1551,7 @@ class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
         )
         mock_processor.assert_called_with(EventMatcher(event), False, False, True, True)
 
-        if should_generate_escalating_forecasts:
+        if should_detect_escalation:
             mock_send_escalating_robust.assert_called_once_with(
                 project=group.project,
                 group=group,
@@ -1565,7 +1565,7 @@ class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
             assert GroupSnooze.objects.filter(id=snooze.id).exists()
 
         group.refresh_from_db()
-        if should_generate_escalating_forecasts:
+        if should_detect_escalation:
             assert group.status == GroupStatus.UNRESOLVED
             assert group.substatus == GroupSubStatus.ESCALATING
             assert GroupInbox.objects.filter(


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/58045

Add toggle for enabling and disabling escalation detection. Used for aggregate issue types like statistical detectors.