### PR TITLE
feat(metric-alerts): Explicitly add entity to columns for error alerts

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1565,6 +1565,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:transaction-metrics-extraction": False,
     # True if Relay should drop raw session payloads after extracting metrics from them.
     "organizations:release-health-drop-sessions": False,
+    # Enable ignoring archived issues in metric alerts
+    "organizations:metric-alert-ignore-archived": False,
     # Enable threshold period in metric alert rule builder
     "organizations:metric-alert-threshold-period": False,
     # Enable integration functionality to create and link groups to issues on

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -108,6 +108,7 @@ default_manager.add("organizations:issue-stream-performance-cache", Organization
 default_manager.add("organizations:large-debug-files", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:mep-rollout-flag", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:metric-alert-chartcuterie", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:metric-alert-ignore-archived", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:metric-alert-rate-limiting", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:metric-alert-threshold-period", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:metrics-extraction", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/search/events/builder/__init__.py
+++ b/src/sentry/search/events/builder/__init__.py
@@ -6,6 +6,7 @@ from .discover import (  # NOQA
     TopEventsQueryBuilder,
     UnresolvedQuery,
 )
+from .errors import ErrorsQueryBuilder  # NOQA
 from .issue_platform import IssuePlatformTimeseriesQueryBuilder  # NOQA
 from .metrics import (  # NOQA
     AlertMetricsQueryBuilder,

--- a/src/sentry/search/events/builder/__init__.py
+++ b/src/sentry/search/events/builder/__init__.py
@@ -46,6 +46,7 @@ __all__ = [
     "TopEventsQueryBuilder",
     "UnresolvedQuery",
     "AlertMetricsQueryBuilder",
+    "ErrorsQueryBuilder",
     "HistogramMetricQueryBuilder",
     "MetricsQueryBuilder",
     "TimeseriesMetricQueryBuilder",

--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -1109,7 +1109,7 @@ class BaseQueryBuilder:
         return AliasedExpression(column, self.tag_to_prefixed_map.get(name, name))
 
     def column(self, name: str) -> Column:
-        """Given an unresolved sentry name and return a snql column.
+        """Given an unresolved sentry column name and return a snql column.
 
         :param name: The unresolved sentry name.
         """

--- a/src/sentry/search/events/builder/errors.py
+++ b/src/sentry/search/events/builder/errors.py
@@ -52,7 +52,5 @@ class ErrorsQueryBuilder(QueryBuilder):
 
         :param name: The unresolved sentry name.
         """
-        # Probably need to handle the entity here somehow. Either include it in the name, have an optional entity param,
-        # and if no entity included, maybe have a default entity on the QueryBuilder to default to?
         resolved_column = self.resolve_column_name(name)
         return Column(resolved_column, entity=Entity(self.dataset.value, alias=self.dataset.value))

--- a/src/sentry/search/events/builder/errors.py
+++ b/src/sentry/search/events/builder/errors.py
@@ -30,7 +30,7 @@ class ErrorsQueryBuilder(QueryBuilder):
         self.validate_having_clause()
         return Request(
             dataset=self.dataset.value,
-            app_id="default",
+            app_id="errors",
             query=Query(
                 match=self.match,
                 select=self.columns,
@@ -48,7 +48,7 @@ class ErrorsQueryBuilder(QueryBuilder):
         )
 
     def column(self, name: str) -> Column:
-        """Given an unresolved sentry name and return a snql column.
+        """Given an unresolved sentry column name and return a snql column.
 
         :param name: The unresolved sentry name.
         """

--- a/src/sentry/search/events/builder/errors.py
+++ b/src/sentry/search/events/builder/errors.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from snuba_sdk import Column, Entity, Flags, Query, Request
+
+from sentry.search.events.builder import QueryBuilder
+
+
+class ErrorsQueryBuilder(QueryBuilder):
+    def __init__(self, *args, **kwargs):
+        self.match = None
+        super().__init__(*args, **kwargs)
+
+    def resolve_match(self):
+        self.match = Entity(self.dataset.value, alias=self.dataset.value, sample=self.sample_rate)
+
+    def resolve_query(
+        self,
+        query: Optional[str] = None,
+        selected_columns: Optional[List[str]] = None,
+        groupby_columns: Optional[List[str]] = None,
+        equations: Optional[List[str]] = None,
+        orderby: list[str] | str | None = None,
+    ) -> None:
+        super().resolve_query(query, selected_columns, groupby_columns, equations, orderby)
+        self.resolve_match()
+
+    def get_snql_query(self) -> Request:
+        self.validate_having_clause()
+        return Request(
+            dataset=self.dataset.value,
+            app_id="default",
+            query=Query(
+                match=self.match,
+                select=self.columns,
+                array_join=self.array_join,
+                where=self.where,
+                having=self.having,
+                groupby=self.groupby,
+                orderby=self.orderby,
+                limit=self.limit,
+                offset=self.offset,
+                limitby=self.limitby,
+            ),
+            flags=Flags(turbo=self.turbo),
+            tenant_ids=self.tenant_ids,
+        )
+
+    def column(self, name: str) -> Column:
+        """Given an unresolved sentry name and return a snql column.
+
+        :param name: The unresolved sentry name.
+        """
+        # Probably need to handle the entity here somehow. Either include it in the name, have an optional entity param,
+        # and if no entity included, maybe have a default entity on the QueryBuilder to default to?
+        resolved_column = self.resolve_column_name(name)
+        return Column(resolved_column, entity=Entity(self.dataset.value, alias=self.dataset.value))

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -178,7 +178,7 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
         params: Optional[MutableMapping[str, Any]] = None,
         skip_field_validation_for_entity_subscription_deletion: bool = False,
     ) -> QueryBuilder:
-        from sentry.search.events.builder import QueryBuilder
+        from sentry.search.events.builder import ErrorsQueryBuilder, QueryBuilder
 
         if params is None:
             params = {}
@@ -189,7 +189,11 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
         if environment:
             params["environment"] = environment.name
 
-        return QueryBuilder(
+        query_builder_cls = QueryBuilder
+        if self.dataset == Dataset.Events:
+            query_builder_cls = ErrorsQueryBuilder
+
+        return query_builder_cls(
             dataset=Dataset(self.dataset.value),
             query=query,
             selected_columns=[self.aggregate],

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -190,7 +190,11 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
             params["environment"] = environment.name
 
         query_builder_cls = QueryBuilder
-        if self.dataset == Dataset.Events:
+        # TODO: Remove this query when we remove the feature check
+        organization = Organization.objects.filter(project__id__in=project_ids)[0]
+        if self.dataset == Dataset.Events and features.has(
+            "organizations:metric-alert-ignore-archived", organization
+        ):
             query_builder_cls = ErrorsQueryBuilder
 
         return query_builder_cls(

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -653,9 +653,10 @@ class EntitySubscriptionTestCase(TestCase):
 
         entity = Entity(Dataset.Events.value, alias=Dataset.Events.value)
 
-        snql_query = entity_subscription.build_query_builder(
-            "release:latest", [self.project.id], None
-        ).get_snql_query()
+        with self.feature("organizations:metric-alert-ignore-archived"):
+            snql_query = entity_subscription.build_query_builder(
+                "release:latest", [self.project.id], None
+            ).get_snql_query()
         assert snql_query.query.select == [
             Function(
                 function="uniq",

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from snuba_sdk import And, Column, Condition, Function, Op
+from snuba_sdk import And, Column, Condition, Entity, Function, Op
 
 from sentry.exceptions import (
     IncompatibleMetricsQuery,
@@ -651,30 +651,33 @@ class EntitySubscriptionTestCase(TestCase):
         assert entity_subscription.get_entity_extra_params() == {}
         assert entity_subscription.dataset == Dataset.Events
 
+        entity = Entity(Dataset.Events.value, alias=Dataset.Events.value)
+
         snql_query = entity_subscription.build_query_builder(
             "release:latest", [self.project.id], None
         ).get_snql_query()
         assert snql_query.query.select == [
             Function(
                 function="uniq",
-                parameters=[Column(name="tags[sentry:user]")],
+                parameters=[Column(name="tags[sentry:user]", entity=entity)],
                 alias="count_unique_user",
             )
         ]
         assert snql_query.query.where == [
             And(
                 [
-                    Condition(Column("type"), Op.EQ, "error"),
+                    Condition(Column("type", entity=entity), Op.EQ, "error"),
                     Condition(
                         Function(
-                            function="ifNull", parameters=[Column(name="tags[sentry:release]"), ""]
+                            function="ifNull",
+                            parameters=[Column(name="tags[sentry:release]", entity=entity), ""],
                         ),
                         Op.IN,
                         [""],
                     ),
                 ]
             ),
-            Condition(Column("project_id"), Op.IN, [self.project.id]),
+            Condition(Column("project_id", entity=entity), Op.IN, [self.project.id]),
         ]
 
 


### PR DESCRIPTION
We want to allow error metric alerts to be filtered by status. To do this, we need to be able to join to the issue level table that has been replicated to Snuba. Snql supports this, but when defining our query we'll need to specify which entity each column belongs to.

This pr does the preliminary work of adding an errors specific `QueryBuilder` that handles adding entities onto all existing columns, and uses it in `BaseEventsAndTransactionEntitySubscription`. Actual work to filter on the status column will be in a follow up.
