### PR TITLE
perf(discover): Disable resize observer on cell dropdown

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -473,7 +473,11 @@ export function Control({
     setTriggerWidth(triggerRef.current?.offsetWidth ?? 0);
   }, [menuWiderThanTrigger, triggerRef]);
 
-  useResizeObserver({ref: triggerRef, onResize: updateTriggerWidth});
+  useResizeObserver({
+    // Passing undefined disables ResizeObserver
+    ref: menuWiderThanTrigger ? triggerRef : undefined,
+    onResize: updateTriggerWidth,
+  });
   // If ResizeObserver is not available, manually update the width
   // when any of [trigger, triggerLabel, triggerProps] changes.
   useEffect(() => {

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -209,7 +209,11 @@ function DropdownMenu({
     setTriggerWidth(triggerRef.current?.offsetWidth ?? 0);
   }, [menuWiderThanTrigger, triggerRef]);
 
-  useResizeObserver({ref: triggerRef, onResize: updateTriggerWidth});
+  useResizeObserver({
+    // Passing undefined disables ResizeObserver
+    ref: menuWiderThanTrigger ? triggerRef : undefined,
+    onResize: updateTriggerWidth,
+  });
   // If ResizeObserver is not available, manually update the width
   // when any of [trigger, triggerLabel, triggerProps] changes.
   useEffect(() => {

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -272,6 +272,7 @@ class CellAction extends Component<Props, State> {
                 'left-end',
               ],
             }}
+            menuWiderThanTrigger={false}
             trigger={triggerProps => (
               <ActionMenuTrigger
                 {...triggerProps}


### PR DESCRIPTION
Disables the dropdown in each discover table cell from measuring the width of the trigger. Skips a setState inside each dropdown.

![image](https://github.com/getsentry/sentry/assets/1400464/dc302e3c-1472-47e0-9d86-4593a6073261)


https://sentry.slack.com/archives/C8V02RHC7/p1698842611607529