### PR TITLE
chore(bug reports): Mark new User Feedback as beta!

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -365,7 +365,7 @@ function Sidebar({location, organization}: Props) {
         label={t('User Feedback')}
         to={`/organizations/${organization.slug}/feedback/`}
         id="feedback"
-        isAlpha
+        isBeta
         variant="short"
       />
     </Feature>

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -6,6 +6,7 @@ import {Location} from 'history';
 import {hideSidebar, showSidebar} from 'sentry/actionCreators/preferences';
 import Feature from 'sentry/components/acl/feature';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
+import FeatureBadge from 'sentry/components/featureBadge';
 import {OnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {getMergedTasks} from 'sentry/components/onboardingWizard/taskConfig';
 import PerformanceOnboardingSidebar from 'sentry/components/performanceOnboarding/sidebar';
@@ -362,11 +363,18 @@ function Sidebar({location, organization}: Props) {
       <SidebarItem
         {...sidebarItemProps}
         icon={<IconMegaphone />}
-        label={t('User Feedback')}
+        label={
+          <Fragment>
+            {t('User Feedback')}{' '}
+            <FeatureBadge
+              title={t('This feature is available for early adopters and may change')}
+              type="alpha"
+              variant="short"
+            />
+          </Fragment>
+        }
         to={`/organizations/${organization.slug}/feedback/`}
         id="feedback"
-        isBeta
-        variant="short"
       />
     </Feature>
   );


### PR DESCRIPTION
This is the only instance i found related to the new thing.

Our messaging says "alpha" but it's not just for internal qa purposes.

<img width="438" alt="SCR-20231102-jpex" src="https://github.com/getsentry/sentry/assets/187460/94d55bc1-6359-462f-ac88-064b1b2154f1">

