### PR TITLE
chore(starfish): Screen load module UI clean up

### DIFF
--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -15,6 +15,7 @@ import {
   useReleases,
   useReleaseSelection,
 } from 'sentry/views/starfish/queries/useReleases';
+import {centerTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 
 type Props = {
   selectorKey: string;
@@ -72,6 +73,7 @@ export function ReleaseSelector({selectorName, selectorKey, selectorValue}: Prop
         prefix: selectorName,
         title: selectorValue,
       }}
+      triggerLabel={selectorValue ? centerTruncate(selectorValue, 25) : selectorValue}
       menuTitle={t('Filter Release')}
       loading={isLoading}
       searchable

--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -72,6 +72,7 @@ export function ReleaseSelector({selectorName, selectorKey, selectorValue}: Prop
         prefix: selectorName,
         title: selectorValue,
       }}
+      menuTitle={t('Filter Release')}
       loading={isLoading}
       searchable
       value={selectorValue}

--- a/static/app/views/starfish/utils/centerTruncate.ts
+++ b/static/app/views/starfish/utils/centerTruncate.ts
@@ -1,0 +1,7 @@
+export function centerTruncate(value: string, maxLength: number = 20) {
+  const divider = Math.floor(maxLength / 2);
+  if (value.length > maxLength) {
+    return `${value.slice(0, divider)}\u2026${value.slice(value.length - divider)}`;
+  }
+  return value;
+}

--- a/static/app/views/starfish/views/screens/index.tsx
+++ b/static/app/views/starfish/views/screens/index.tsx
@@ -258,7 +258,7 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
             color: isPrimary
               ? theme.charts.getColorPalette(TOP_SCREENS - 2)[index]
               : Color(theme.charts.getColorPalette(TOP_SCREENS - 2)[index])
-                  .lighten(0.5)
+                  .lighten(0.3)
                   .string(),
           },
         } as SeriesDataUnit;
@@ -279,17 +279,17 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
 
           case 'medium':
             return Color(theme.charts.getColorPalette(TOP_SCREENS - 2)[index])
-              .lighten(0.2)
+              .lighten(0.1)
               .string();
 
           case 'low':
             return Color(theme.charts.getColorPalette(TOP_SCREENS - 2)[index])
-              .lighten(0.4)
+              .lighten(0.2)
               .string();
 
           default:
             return Color(theme.charts.getColorPalette(TOP_SCREENS - 2)[index])
-              .lighten(0.6)
+              .lighten(0.3)
               .string();
         }
       }

--- a/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
@@ -106,12 +106,8 @@ export function ScreenLoadSpansTable({
     [SPAN_DESCRIPTION]: t('Span Description'),
     'count()': DataTitles.count,
     'time_spent_percentage()': DataTitles.timeSpent,
-    [`avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`]: t(
-      'Avg Duration (Release 1)'
-    ),
-    [`avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`]: t(
-      'Avg Duration  (Release 2)'
-    ),
+    [`avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`]: t('Duration (Release 1)'),
+    [`avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`]: t('Duration  (Release 2)'),
   };
 
   function renderBodyCell(column, row): React.ReactNode {

--- a/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
@@ -6,7 +6,6 @@ import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
 import SortLink from 'sentry/components/gridEditable/sortLink';
 import Link from 'sentry/components/links/link';
 import Pagination from 'sentry/components/pagination';
-import Truncate from 'sentry/components/truncate';
 import {t} from 'sentry/locale';
 import {NewQuery} from 'sentry/types';
 import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
@@ -25,6 +24,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 import {TableColumn} from 'sentry/views/discover/table/types';
+import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
@@ -140,7 +140,7 @@ export function ScreenLoadSpansTable({
             });
           }}
         >
-          <Truncate value={label} maxLength={75} />
+          <OverflowEllipsisTextContainer>{label}</OverflowEllipsisTextContainer>
         </Link>
       );
     }


### PR DESCRIPTION
A couple small things:
- Updates chart colours a bit, some of them were too light
- Center truncates release names
- Uses text overflow for span descriptions
- Shows a loading indicator on release selector

<img width="591" alt="Screenshot 2023-11-01 at 11 04 53 PM" src="https://github.com/getsentry/sentry/assets/63818634/3743e15b-6b28-4607-93dc-1a21858105fd">
