### PR TITLE
ref(sdk-crashes): Add path replacement names

### DIFF
--- a/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/cocoa_sdk_crash_detector.py
@@ -1,36 +1,33 @@
-from sentry.utils.sdk_crashes.sdk_crash_detector import SDKCrashDetector, SDKCrashDetectorConfig
+from sentry.utils.sdk_crashes.sdk_crash_detector import SDKCrashDetectorConfig
 
-
-class CocoaSDKCrashDetector(SDKCrashDetector):
-    def __init__(self):
-
-        config = SDKCrashDetectorConfig(
-            # Explicitly use an allow list to avoid detecting SDK crashes for SDK names we don't know.
-            sdk_names=[
-                "sentry.cocoa",
-                "sentry.cocoa.capacitor",
-                "sentry.cocoa.react-native",
-                "sentry.cocoa.dotnet",
-                "sentry.cocoa.flutter",
-                "sentry.cocoa.kmp",
-                "sentry.cocoa.unity",
-                "sentry.cocoa.unreal",
-            ],
-            # Since changing the debug image type to macho (https://github.com/getsentry/sentry-cocoa/pull/2701)
-            # released in sentry-cocoa 8.2.0 (https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#820),
-            # the frames contain the full paths required for detecting system frames in is_system_library_frame.
-            # Therefore, we require at least sentry-cocoa 8.2.0.
-            min_sdk_version="8.2.0",
-            system_library_paths={"/System/Library/", "/usr/lib/"},
-            sdk_frame_function_matchers={
-                r"*sentrycrash*",
-                r"*\[Sentry*",
-                r"*(Sentry*)*",  # Objective-C class extension categories
-                r"SentryMX*",  # MetricKit Swift classes
-            },
-            sdk_frame_filename_matchers={"Sentry**"},
-            # [SentrySDK crash] is a testing function causing a crash.
-            # Therefore, we don't want to mark it a as a SDK crash.
-            sdk_crash_ignore_functions_matchers={"**SentrySDK crash**"},
-        )
-        super().__init__(config)
+_cocoa_sdk_crash_detector_config = SDKCrashDetectorConfig(
+    # Explicitly use an allow list to avoid detecting SDK crashes for SDK names we don't know.
+    sdk_names=[
+        "sentry.cocoa",
+        "sentry.cocoa.capacitor",
+        "sentry.cocoa.react-native",
+        "sentry.cocoa.dotnet",
+        "sentry.cocoa.flutter",
+        "sentry.cocoa.kmp",
+        "sentry.cocoa.unity",
+        "sentry.cocoa.unreal",
+    ],
+    # Since changing the debug image type to macho (https://github.com/getsentry/sentry-cocoa/pull/2701)
+    # released in sentry-cocoa 8.2.0 (https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#820),
+    # the frames contain the full paths required for detecting system frames in is_system_library_frame.
+    # Therefore, we require at least sentry-cocoa 8.2.0.
+    min_sdk_version="8.2.0",
+    system_library_paths={"/System/Library/", "/usr/lib/"},
+    sdk_frame_function_matchers={
+        r"*sentrycrash*",
+        r"*\[Sentry*",
+        r"*(Sentry*)*",  # Objective-C class extension categories
+        r"SentryMX*",  # MetricKit Swift classes
+    },
+    sdk_frame_filename_matchers={"Sentry**"},
+    sdk_frame_path_replacement_names={},
+    sdk_frame_path_default_replacement_name="Sentry.framework",
+    # [SentrySDK crash] is a testing function causing a crash.
+    # Therefore, we don't want to mark it a as a SDK crash.
+    sdk_crash_ignore_functions_matchers={"**SentrySDK crash**"},
+)

--- a/src/sentry/utils/sdk_crashes/event_stripper.py
+++ b/src/sentry/utils/sdk_crashes/event_stripper.py
@@ -159,22 +159,27 @@ def _strip_frames(
     frames: Sequence[MutableMapping[str, Any]], sdk_crash_detector: SDKCrashDetector
 ) -> Sequence[Mapping[str, Any]]:
     """
-    Only keep SDK frames or Apple system libraries.
-    We need to adapt this logic once we support other platforms.
+    Only keep SDK and system libraries frames.
+
+    This method sets in_app to True for SDK frames for grouping. The grouping config
+    will set in_app false for all SDK frames. To not change the grouping logic, we must
+    add a stacktrace rule for each path_replacement_name configured in
+    `SDKCrashDetectorConfig.sdk_frame_path_replacement_names` and
+    `SDKCrashDetectorConfig.sdk_frame_path_default_replacement_name` like
+    `stack.abs_path:{{abs_path_replacement}} +app` to the project configured for the
+    platform in the options.
+
+    For example, Cocoa only uses `Sentry.framework` as a replacement path, so we must add the rule `stack.abs_path:Sentry.framework +app` to it's project in Sentry.
     """
 
     def strip_frame(frame: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
-        # Set in_app to True for SDK frames for grouping. Anyways the grouping config will set in_app false
-        # for all Cocoa SDK frames. To not change the grouping logic, we must add the following stacktrace
-        # rule  `stack.abs_path:Sentry.framework +app` to the project with configured for Cocoa with the option
-        # `issues.sdk_crash_detection.cocoa.project_id`
         if sdk_crash_detector.is_sdk_frame(frame):
             frame["in_app"] = True
 
             # The path field usually contains the name of the application, which we can't keep.
             for field in sdk_crash_detector.fields_containing_paths:
                 if frame.get(field):
-                    frame[field] = "Sentry.framework"
+                    frame[field] = sdk_crash_detector.replace_sdk_frame_path(field)
         else:
             frame["in_app"] = False
 

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -8,7 +8,7 @@ import sentry_sdk
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import GroupCategory
 from sentry.utils.safe import get_path, set_path
-from sentry.utils.sdk_crashes.cocoa_sdk_crash_detector import CocoaSDKCrashDetector
+from sentry.utils.sdk_crashes.cocoa_sdk_crash_detector import _cocoa_sdk_crash_detector_config
 from sentry.utils.sdk_crashes.event_stripper import strip_event_data
 from sentry.utils.sdk_crashes.sdk_crash_detection_config import SDKCrashDetectionConfig, SdkName
 from sentry.utils.sdk_crashes.sdk_crash_detector import SDKCrashDetector
@@ -125,6 +125,6 @@ class SDKCrashDetection:
 
 
 _crash_reporter = SDKCrashReporter()
-_cocoa_sdk_crash_detector = CocoaSDKCrashDetector()
+_cocoa_sdk_crash_detector = SDKCrashDetector(config=_cocoa_sdk_crash_detector_config)
 
 sdk_crash_detection = SDKCrashDetection(_crash_reporter, {SdkName.Cocoa: _cocoa_sdk_crash_detector})

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 
 from fixtures.sdk_crash_detection.crash_event import (
@@ -7,8 +9,9 @@ from fixtures.sdk_crash_detection.crash_event import (
 )
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils.safe import get_path, set_path
-from sentry.utils.sdk_crashes.cocoa_sdk_crash_detector import CocoaSDKCrashDetector
+from sentry.utils.sdk_crashes.cocoa_sdk_crash_detector import _cocoa_sdk_crash_detector_config
 from sentry.utils.sdk_crashes.event_stripper import strip_event_data
+from sentry.utils.sdk_crashes.sdk_crash_detector import SDKCrashDetector
 
 
 @pytest.fixture
@@ -21,9 +24,9 @@ def store_event(default_project, factories):
 
 @pytest.fixture
 def store_and_strip_event(store_event):
-    def inner(data):
+    def inner(data, config=_cocoa_sdk_crash_detector_config):
         event = store_event(data=data)
-        return strip_event_data(event.data, CocoaSDKCrashDetector())
+        return strip_event_data(event.data, SDKCrashDetector(config=config))
 
     return inner
 
@@ -87,7 +90,9 @@ def test_strip_event_data_strips_value_if_not_simple_type(store_event):
     event = store_event(data=get_crash_event())
     event.data["type"] = {"foo": "bar"}
 
-    stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+    stripped_event_data = strip_event_data(
+        event.data, SDKCrashDetector(config=_cocoa_sdk_crash_detector_config)
+    )
 
     assert stripped_event_data.get("type") is None
 
@@ -101,7 +106,9 @@ def test_strip_event_data_keeps_simple_types(store_event):
     event.data["timestamp"] = 1
     event.data["platform"] = "cocoa"
 
-    stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+    stripped_event_data = strip_event_data(
+        event.data, SDKCrashDetector(config=_cocoa_sdk_crash_detector_config)
+    )
 
     assert stripped_event_data.get("type") is True
     assert stripped_event_data.get("datetime") == 0.1
@@ -140,7 +147,9 @@ def test_strip_event_data_keeps_exception_mechanism(store_event):
         value="bar",
     )
 
-    stripped_event_data = strip_event_data(event.data, CocoaSDKCrashDetector())
+    stripped_event_data = strip_event_data(
+        event.data, SDKCrashDetector(config=_cocoa_sdk_crash_detector_config)
+    )
 
     mechanism = get_path(stripped_event_data, "exception", "values", 0, "mechanism")
 
@@ -288,6 +297,40 @@ def test_strip_frames_sdk_frames(store_and_strip_event):
         "package": "Sentry.framework",
         "abs_path": "Sentry.framework",
         "module": "Sentry.framework",
+        "in_app": True,
+        "image_addr": "0x100304000",
+    }
+
+
+@django_db_all
+@pytest.mark.snuba
+def test_strip_frames_sdk_frames_multiple_replacement_names(store_and_strip_event):
+    frames = get_frames("SentryCrashMonitor_CPPException.cpp", sentry_frame_in_app=False)
+
+    sentry_sdk_frame = frames[-1]
+    sentry_sdk_frame["package"] = "abs/Package/SomeApp"
+    sentry_sdk_frame["module"] = "abs/Module/SomeApp"
+    sentry_sdk_frame["abs_path"] = "SomeApp/SentryDispatchQueueWrapper.m"
+
+    event_data = get_crash_event_with_frames(frames)
+
+    config = copy.deepcopy(_cocoa_sdk_crash_detector_config)
+    config.sdk_frame_path_replacement_names = {
+        r"*Package*": "SentryPackage",
+        r"*Module*": "SentryModule",
+    }
+    stripped_event_data = store_and_strip_event(data=event_data, config=config)
+
+    stripped_frames = get_path(
+        stripped_event_data, "exception", "values", -1, "stacktrace", "frames"
+    )
+
+    cocoa_sdk_frame = stripped_frames[-1]
+    assert cocoa_sdk_frame == {
+        "function": "SentryCrashMonitor_CPPException.cpp",
+        "package": "SentryPackage",
+        "abs_path": "Sentry.framework",
+        "module": "SentryModule",
         "in_app": True,
         "image_addr": "0x100304000",
     }

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -38,7 +38,6 @@ class BaseSDKCrashDetectionMixin(BaseTestCase, metaclass=abc.ABCMeta):
         pass
 
     def execute_test(self, event_data, should_be_reported, mock_sdk_crash_reporter):
-
         event = self.create_event(
             data=event_data,
             project_id=self.project.id,
@@ -712,7 +711,6 @@ class CococaSDKFramesTestMixin(BaseSDKCrashDetectionMixin):
 class SDKCrashReportTestMixin(BaseSDKCrashDetectionMixin, SnubaTestCase):
     @django_db_all
     def test_sdk_crash_event_stored_to_sdk_crash_project(self):
-
         cocoa_sdk_crashes_project = self.create_project(
             name="Cocoa SDK Crashes",
             slug="cocoa-sdk-crashes",


### PR DESCRIPTION
Remove the Cocoa SDK specific logic in the event stripper by adding properties to the SDKCrashDetectorConfig to configure how path fields on stack trace frames get replaced.

