### PR TITLE
feat(perf): Add basic percentile selector to Query Details duration chart

### DIFF
--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -115,27 +115,28 @@ function SpanSummaryPage({params}: Props) {
     [SpanMetricsField.SPAN_GROUP]: string;
   };
 
-  const {isLoading: areSpanMetricsSeriesLoading, data: spanMetricsSeriesData} =
-    useSpanMetricsSeries(
-      groupId,
-      queryFilter,
-      [`${durationAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`, 'spm()'],
-      'api.starfish.span-summary-page-metrics-chart'
-    );
+  const {isLoading: isThroughputDataLoading, data: throughputData} = useSpanMetricsSeries(
+    groupId,
+    queryFilter,
+    ['spm()'],
+    'api.starfish.span-summary-page-metrics-chart'
+  );
+
+  const throughputSeries = throughputData['spm()'];
+
+  const {isLoading: isDurationDataLoading, data: durationData} = useSpanMetricsSeries(
+    groupId,
+    queryFilter,
+    [`${durationAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`],
+    'api.starfish.span-summary-page-metrics-chart'
+  );
+
+  const durationSeries =
+    durationData[`${durationAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`];
+
+  const areSpanMetricsSeriesLoading = isThroughputDataLoading || isDurationDataLoading;
 
   useSynchronizeCharts([!areSpanMetricsSeriesLoading]);
-
-  const spanMetricsThroughputSeries = {
-    seriesName: 'spm()',
-    data: spanMetricsSeriesData?.['spm()'].data,
-  };
-
-  const spanMetricsDurationSeries = {
-    seriesName: `${durationAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`,
-    data: spanMetricsSeriesData?.[
-      `${durationAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`
-    ].data,
-  };
 
   return (
     <ModulePageProviders
@@ -200,8 +201,8 @@ function SpanSummaryPage({params}: Props) {
               >
                 <Chart
                   height={CHART_HEIGHT}
-                  data={[spanMetricsThroughputSeries]}
-                  loading={areSpanMetricsSeriesLoading}
+                  data={[throughputSeries]}
+                  loading={isThroughputDataLoading}
                   utc={false}
                   chartColors={[THROUGHPUT_COLOR]}
                   isLineChart
@@ -227,8 +228,8 @@ function SpanSummaryPage({params}: Props) {
               >
                 <Chart
                   height={CHART_HEIGHT}
-                  data={[spanMetricsDurationSeries]}
-                  loading={areSpanMetricsSeriesLoading}
+                  data={[durationSeries]}
+                  loading={isDurationDataLoading}
                   utc={false}
                   chartColors={[AVG_COLOR]}
                   isLineChart

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -106,9 +106,7 @@ function SpanSummaryPage({params}: Props) {
   useSynchronizeCharts([!areSpanMetricsSeriesLoading]);
 
   const spanMetricsThroughputSeries = {
-    seriesName: span?.[SpanMetricsField.SPAN_OP]?.startsWith('db')
-      ? 'Queries'
-      : 'Requests',
+    seriesName: t('Queries'),
     data: spanMetricsSeriesData?.['spm()'].data,
   };
 

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -1,9 +1,8 @@
-import {browserHistory, RouteComponentProps} from 'react-router';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import Breadcrumbs from 'sentry/components/breadcrumbs';
-import {CompactSelect} from 'sentry/components/compactSelect';
 import FeedbackWidget from 'sentry/components/feedback/widget/feedbackWidget';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
@@ -18,6 +17,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {DurationAggregateSelector} from 'sentry/views/performance/database/durationAggregateSelector';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
 import {
   AVAILABLE_DURATION_AGGREGATE_OPTIONS,
@@ -75,16 +75,6 @@ function SpanSummaryPage({params}: Props) {
   ) {
     durationAggregate = DEFAULT_DURATION_AGGREGATE;
   }
-
-  const handleDurationFunctionChange = option => {
-    browserHistory.push({
-      ...location,
-      query: {
-        ...location.query,
-        aggregate: option.value,
-      },
-    });
-  };
 
   const {groupId} = params;
   const {transaction, transactionMethod, endpoint, endpointMethod} = location.query;
@@ -230,13 +220,7 @@ function SpanSummaryPage({params}: Props) {
               <ChartPanel
                 title={
                   arePercentilesEnabled ? (
-                    <StyledCompactSelect
-                      size="md"
-                      options={AVAILABLE_DURATION_AGGREGATE_OPTIONS}
-                      value={durationAggregate}
-                      onChange={handleDurationFunctionChange}
-                      triggerProps={{borderless: true, size: 'zero'}}
-                    />
+                    <DurationAggregateSelector aggregate={durationAggregate} />
                   ) : (
                     t('Average Duration')
                   )
@@ -297,20 +281,6 @@ const DescriptionContainer = styled('div')`
   margin-bottom: ${space(2)};
   font-size: 1rem;
   line-height: 1.2;
-`;
-
-// TODO: Talk to UI folks about making this a built-in dropdown size if we end
-// up using this element
-const StyledCompactSelect = styled(CompactSelect)`
-  text-align: left;
-  font-weight: normal;
-  margin: -${space(0.5)} -${space(1)} -${space(0.25)};
-  min-width: 0;
-
-  button {
-    padding: ${space(0.5)} ${space(1)};
-    font-size: ${p => p.theme.fontSizeLarge};
-  }
 `;
 
 export default SpanSummaryPage;

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -122,8 +122,6 @@ function SpanSummaryPage({params}: Props) {
     'api.starfish.span-summary-page-metrics-chart'
   );
 
-  const throughputSeries = throughputData['spm()'];
-
   const {isLoading: isDurationDataLoading, data: durationData} = useSpanMetricsSeries(
     groupId,
     queryFilter,
@@ -131,12 +129,7 @@ function SpanSummaryPage({params}: Props) {
     'api.starfish.span-summary-page-metrics-chart'
   );
 
-  const durationSeries =
-    durationData[`${durationAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`];
-
-  const areSpanMetricsSeriesLoading = isThroughputDataLoading || isDurationDataLoading;
-
-  useSynchronizeCharts([!areSpanMetricsSeriesLoading]);
+  useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);
 
   return (
     <ModulePageProviders
@@ -201,7 +194,7 @@ function SpanSummaryPage({params}: Props) {
               >
                 <Chart
                   height={CHART_HEIGHT}
-                  data={[throughputSeries]}
+                  data={[throughputData['spm()']]}
                   loading={isThroughputDataLoading}
                   utc={false}
                   chartColors={[THROUGHPUT_COLOR]}
@@ -228,7 +221,11 @@ function SpanSummaryPage({params}: Props) {
               >
                 <Chart
                   height={CHART_HEIGHT}
-                  data={[durationSeries]}
+                  data={[
+                    durationData[
+                      `${durationAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`
+                    ],
+                  ]}
                   loading={isDurationDataLoading}
                   utc={false}
                   chartColors={[AVG_COLOR]}

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -22,7 +22,6 @@ import {ModulePageProviders} from 'sentry/views/performance/database/modulePageP
 import {
   AVAILABLE_DURATION_AGGREGATE_OPTIONS,
   DEFAULT_DURATION_AGGREGATE,
-  DURATION_AGGREGATE_LABELS,
 } from 'sentry/views/performance/database/settings';
 import {AVG_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
 import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
@@ -127,12 +126,12 @@ function SpanSummaryPage({params}: Props) {
   useSynchronizeCharts([!areSpanMetricsSeriesLoading]);
 
   const spanMetricsThroughputSeries = {
-    seriesName: t('Queries'),
+    seriesName: 'spm()',
     data: spanMetricsSeriesData?.['spm()'].data,
   };
 
   const spanMetricsDurationSeries = {
-    seriesName: DURATION_AGGREGATE_LABELS[durationAggregate],
+    seriesName: `${durationAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`,
     data: spanMetricsSeriesData?.[
       `${durationAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`
     ].data,

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -99,7 +99,7 @@ function SpanSummaryPage({params}: Props) {
     useSpanMetricsSeries(
       groupId,
       queryFilter,
-      [`avg(${SpanMetricsField.SPAN_SELF_TIME})`, 'spm()', 'http_error_count()'],
+      [`avg(${SpanMetricsField.SPAN_SELF_TIME})`, 'spm()'],
       'api.starfish.span-summary-page-metrics-chart'
     );
 

--- a/static/app/views/performance/database/durationAggregateSelector.tsx
+++ b/static/app/views/performance/database/durationAggregateSelector.tsx
@@ -1,0 +1,49 @@
+import {browserHistory} from 'react-router';
+import styled from '@emotion/styled';
+
+import {CompactSelect} from 'sentry/components/compactSelect';
+import {space} from 'sentry/styles/space';
+import {useLocation} from 'sentry/utils/useLocation';
+import {AVAILABLE_DURATION_AGGREGATE_OPTIONS} from 'sentry/views/performance/database/settings';
+
+interface Props {
+  aggregate: string;
+}
+
+export function DurationAggregateSelector({aggregate}: Props) {
+  const location = useLocation();
+
+  const handleDurationFunctionChange = option => {
+    browserHistory.push({
+      ...location,
+      query: {
+        ...location.query,
+        aggregate: option.value,
+      },
+    });
+  };
+
+  return (
+    <StyledCompactSelect
+      size="md"
+      options={AVAILABLE_DURATION_AGGREGATE_OPTIONS}
+      value={aggregate}
+      onChange={handleDurationFunctionChange}
+      triggerProps={{borderless: true, size: 'zero'}}
+    />
+  );
+}
+
+// TODO: Talk to UI folks about making this a built-in dropdown size if we end
+// up using this element
+const StyledCompactSelect = styled(CompactSelect)`
+  text-align: left;
+  font-weight: normal;
+  margin: -${space(0.5)} -${space(1)} -${space(0.25)};
+  min-width: 0;
+
+  button {
+    padding: ${space(0.5)} ${space(1)};
+    font-size: ${p => p.theme.fontSizeLarge};
+  }
+`;

--- a/static/app/views/performance/database/settings.ts
+++ b/static/app/views/performance/database/settings.ts
@@ -1,3 +1,5 @@
+import {t} from 'sentry/locale';
+
 export const MIN_SDK_VERSION_BY_PLATFORM: {[platform: string]: string} = {
   'sentry.python': '1.29.2',
   'sentry.javascript': '7.63.0',
@@ -9,3 +11,22 @@ export const MIN_SDK_VERSION_BY_PLATFORM: {[platform: string]: string} = {
   'sentry.symfony': '4.11.0',
   'sentry.android': '6.30.0',
 };
+
+export const DEFAULT_DURATION_AGGREGATE = 'avg';
+
+export const AVAILABLE_DURATION_AGGREGATES = ['avg', 'p50', 'p75', 'p95', 'p99'];
+
+export const DURATION_AGGREGATE_LABELS = {
+  avg: t('Average Duration'),
+  p50: t('Duration p50'),
+  p75: t('Duration p75'),
+  p95: t('Duration p95'),
+  p99: t('Duration p99'),
+};
+
+export const AVAILABLE_DURATION_AGGREGATE_OPTIONS = AVAILABLE_DURATION_AGGREGATES.map(
+  aggregate => ({
+    value: aggregate,
+    label: DURATION_AGGREGATE_LABELS[aggregate],
+  })
+);

--- a/static/app/views/performance/database/settings.ts
+++ b/static/app/views/performance/database/settings.ts
@@ -16,7 +16,7 @@ export const DEFAULT_DURATION_AGGREGATE = 'avg';
 
 export const AVAILABLE_DURATION_AGGREGATES = ['avg', 'p50', 'p75', 'p95', 'p99']; // TODO: `max` is not a supported aggregate for this dataset on the backend. Why?
 
-export const DURATION_AGGREGATE_LABELS = {
+const DURATION_AGGREGATE_LABELS = {
   avg: t('Average Duration'),
   p50: t('Duration p50'),
   p75: t('Duration p75'),

--- a/static/app/views/performance/database/settings.ts
+++ b/static/app/views/performance/database/settings.ts
@@ -14,7 +14,7 @@ export const MIN_SDK_VERSION_BY_PLATFORM: {[platform: string]: string} = {
 
 export const DEFAULT_DURATION_AGGREGATE = 'avg';
 
-export const AVAILABLE_DURATION_AGGREGATES = ['avg', 'p50', 'p75', 'p95', 'p99'];
+export const AVAILABLE_DURATION_AGGREGATES = ['avg', 'p50', 'p75', 'p95', 'p99']; // TODO: `max` is not a supported aggregate for this dataset on the backend. Why?
 
 export const DURATION_AGGREGATE_LABELS = {
   avg: t('Average Duration'),

--- a/static/app/views/starfish/components/chartPanel.tsx
+++ b/static/app/views/starfish/components/chartPanel.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
 import Panel from 'sentry/components/panels/panel';
-import PanelBody from 'sentry/components/panels/panelBody';
 import {space} from 'sentry/styles/space';
 import {Subtitle} from 'sentry/views/performance/landing/widgets/widgets/singleFieldAreaWidget';
 
@@ -15,7 +14,7 @@ type Props = {
 export default function ChartPanel({title, children, button, subtitle}: Props) {
   return (
     <Panel>
-      <PanelBody withPadding>
+      <PanelBody>
         {title && (
           <Header>
             {title && <ChartLabel>{title}</ChartLabel>}
@@ -39,6 +38,10 @@ const SubtitleContainer = styled('div')`
 
 const ChartLabel = styled('div')`
   ${p => p.theme.text.cardTitle}
+`;
+
+const PanelBody = styled('div')`
+  padding: ${space(2)};
 `;
 
 const Header = styled('div')`

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -36,7 +36,6 @@ export const useSpanMetricsSeries = (
   const enabled =
     Boolean(group) && Object.values(queryFilters).every(value => Boolean(value));
 
-  // TODO: Add referrer
   const result = useSpansQuery<SpanMetrics[]>({
     eventView,
     initialData: [],
@@ -44,7 +43,6 @@ export const useSpanMetricsSeries = (
     enabled,
   });
 
-  // TODO: The series name is very often discarded by the caller. Maybe it shouldn't return a `Series`, and return raw data instead
   const parsedData = keyBy(
     yAxis.map(seriesName => {
       const series: Series = {

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -44,6 +44,7 @@ export const useSpanMetricsSeries = (
     enabled,
   });
 
+  // TODO: The series name is very often discarded by the caller. Maybe it shouldn't return a `Series`, and return raw data instead
   const parsedData = keyBy(
     yAxis.map(seriesName => {
       const series: Series = {


### PR DESCRIPTION
First steps. This is a tentative UI, to explore  how this performs with real data.

- Add a percentile selector to "Duration" chart on Query Details page
- Fetch `spm()` and `span.self_time` separately. Fetching durations takes _much_ longer, no point delaying showing the Throughput graph. This also prevents the Throughput chart from re-fetching when the duration aggregate changes
- Don't fetch `http_error_rate()`, we don't need it on this page. That was a copy error

**e.g.,**

https://github.com/getsentry/sentry/assets/989898/d718e478-9b5d-4d36-8466-4b5355a2f08d

