### PR TITLE
perf(assigneeselector): lazy compute assignees

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -346,7 +346,7 @@ export class AssigneeSelectorDropdown extends Component<
       if (assignee.type !== 'user' && assignee.type !== 'team') {
         continue;
       }
-      if (assignee.type !== assignedTo?.type && assignee.id !== assignedTo?.id) {
+      if (!(assignee.type !== assignedTo?.type && assignee.id !== assignedTo?.id)) {
         continue;
       }
 

--- a/static/app/components/dropdownAutoComplete/index.tsx
+++ b/static/app/components/dropdownAutoComplete/index.tsx
@@ -1,33 +1,82 @@
+import React, {useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 
+import type {MenuProps} from './menu';
 import Menu from './menu';
 
-type MenuProps = React.ComponentProps<typeof Menu>;
+function makeActorProps(
+  renderProps,
+  options: {
+    lazy: boolean;
+    allowActorToggle?: boolean;
+    onLazyOpen?: (fn: (e: React.MouseEvent) => void) => void;
+  }
+) {
+  const {isOpen, actions, getActorProps} = renderProps;
+  // Don't pass `onClick` from `getActorProps`
+  const {onClick: _onClick, ...actorProps} = getActorProps();
+  const onOpen =
+    options.lazy && options.onLazyOpen ? options.onLazyOpen(actions.open) : actions.open;
 
-type Props = {
+  return {
+    role: 'button',
+    tabIndex: 0,
+    isOpen,
+    onClick: isOpen && options.allowActorToggle ? actions.close : onOpen,
+    ...actorProps,
+  };
+}
+
+interface BaseProps extends Omit<MenuProps, 'items'> {
   // Should clicking the actor toggle visibility
   allowActorToggle?: boolean;
-} & MenuProps;
+}
+interface LazyDropdownAutoCompleteProps extends BaseProps {
+  lazyItems: () => MenuProps['items'];
+  items?: never;
+}
 
-function DropdownAutoComplete({allowActorToggle = false, children, ...props}: Props) {
+export interface StaticDropdownAutoCompleteProps extends BaseProps {
+  items: MenuProps['items'];
+  lazyItems?: never;
+}
+
+export type DropdownAutoCompleteProps =
+  | LazyDropdownAutoCompleteProps
+  | StaticDropdownAutoCompleteProps;
+
+function DropdownAutoComplete(
+  props: LazyDropdownAutoCompleteProps | StaticDropdownAutoCompleteProps
+) {
+  const {allowActorToggle, children, items, lazyItems, ...rest} = props;
+  const [maybeLazyItems, setMaybeLazyItems] = useState<MenuProps['items']>(
+    items ? items : null
+  );
+
+  const onLazyOpen = useCallback(
+    (onActionOpen: (e: React.MouseEvent) => void) => {
+      return (e: React.MouseEvent) => {
+        if (typeof lazyItems !== 'function') {
+          onActionOpen(e);
+          return;
+        }
+        setMaybeLazyItems(lazyItems());
+        onActionOpen(e);
+      };
+    },
+    [lazyItems]
+  );
+
+  const isLazy = typeof props.lazyItems === 'function';
   return (
-    <Menu {...props}>
-      {renderProps => {
-        const {isOpen, actions, getActorProps} = renderProps;
-        // Don't pass `onClick` from `getActorProps`
-        const {onClick: _onClick, ...actorProps} = getActorProps<HTMLDivElement>();
-        return (
-          <Actor
-            isOpen={isOpen}
-            role="button"
-            tabIndex={0}
-            onClick={isOpen && allowActorToggle ? actions.close : actions.open}
-            {...actorProps}
-          >
-            {children(renderProps)}
-          </Actor>
-        );
-      }}
+    <Menu {...rest} items={isLazy ? maybeLazyItems : items === undefined ? null : items}>
+      {renderProps => (
+        <Actor
+          {...makeActorProps(renderProps, {lazy: isLazy, onLazyOpen, allowActorToggle})}
+        >
+          {children(renderProps)}
+        </Actor>
+      )}
     </Menu>
   );
 }

--- a/static/app/components/dropdownAutoComplete/index.tsx
+++ b/static/app/components/dropdownAutoComplete/index.tsx
@@ -68,6 +68,7 @@ function DropdownAutoComplete(
   );
 
   const isLazy = typeof props.lazyItems === 'function';
+
   return (
     <Menu {...rest} items={isLazy ? maybeLazyItems : items === undefined ? null : items}>
       {renderProps => (

--- a/static/app/components/dropdownAutoComplete/menu.tsx
+++ b/static/app/components/dropdownAutoComplete/menu.tsx
@@ -22,7 +22,11 @@ export type MenuFooterChildProps = {
 
 type ListProps = React.ComponentProps<typeof List>;
 
-type Props = {
+export interface MenuProps
+  extends Pick<
+    ListProps,
+    'virtualizedHeight' | 'virtualizedLabelHeight' | 'itemSize' | 'onScroll'
+  > {
   children: (
     args: Pick<
       AutoCompleteChildrenArgs,
@@ -200,10 +204,7 @@ type Props = {
    * Optional element to be rendered on the right side of the dropdown menu
    */
   subPanel?: React.ReactNode;
-} & Pick<
-  ListProps,
-  'virtualizedHeight' | 'virtualizedLabelHeight' | 'itemSize' | 'onScroll'
->;
+}
 
 function Menu({
   autoCompleteFilter = defaultAutoCompleteFilter,
@@ -245,7 +246,7 @@ function Menu({
   closeOnSelect,
   'data-test-id': dataTestId,
   ...props
-}: Props) {
+}: MenuProps) {
   // Can't search if there are no items
   const hasItems = !!items?.length;
 
@@ -493,7 +494,7 @@ const LabelWithPadding = styled('div')<{disableLabelPadding: boolean}>`
   padding: ${p => !p.disableLabelPadding && `${space(0.25)} ${space(1)}`};
 `;
 
-const ItemList = styled('div')<{maxHeight: NonNullable<Props['maxHeight']>}>`
+const ItemList = styled('div')<{maxHeight: NonNullable<MenuProps['maxHeight']>}>`
   max-height: ${p => `${p.maxHeight}px`};
   overflow-y: auto;
 `;

--- a/static/app/components/forms/fields/choiceMapperField.tsx
+++ b/static/app/components/forms/fields/choiceMapperField.tsx
@@ -2,7 +2,9 @@ import {Component, Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
-import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
+import DropdownAutoComplete, {
+  StaticDropdownAutoCompleteProps,
+} from 'sentry/components/dropdownAutoComplete';
 import {Item} from 'sentry/components/dropdownAutoComplete/types';
 import DropdownButton from 'sentry/components/dropdownButton';
 import SelectControl, {
@@ -45,7 +47,7 @@ export interface ChoiceMapperProps extends DefaultProps {
   /**
    * Props forwarded to the add mapping dropdown.
    */
-  addDropdown: React.ComponentProps<typeof DropdownAutoComplete>;
+  addDropdown: StaticDropdownAutoCompleteProps;
   /**
    * A list of column labels (headers) for the multichoice table. This should
    * have the same mapping keys as the mappedSelectors prop.


### PR DESCRIPTION
The Assignee selector precomputes the dropdown list before it needs it, meaning we are precomputing a very large list for large orgs which impacts loading UX. For example in sentry's use case, we are precomputing roughly 200*n where n is the number of assignee selectors the page is rendering.