### PR TITLE
ref(on-demand): Emit gauges in minimetrics

### DIFF
--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -162,8 +162,7 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         unit: Optional[str] = None,
     ) -> None:
         if self._keep_metric(sample_rate):
-            # XXX: make this into a gauge later
-            sentry_sdk.metrics.incr(
+            sentry_sdk.metrics.gauge(
                 key=self._get_key(key),
                 value=value,
                 tags=tags,

--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -162,12 +162,20 @@ class MiniMetricsMetricsBackend(MetricsBackend):
         unit: Optional[str] = None,
     ) -> None:
         if self._keep_metric(sample_rate):
-            sentry_sdk.metrics.gauge(
-                key=self._get_key(key),
-                value=value,
-                tags=tags,
-                unit=self._to_minimetrics_unit(unit=unit),
-            )
+            if options.get("delightful_metrics.emit_gauges"):
+                sentry_sdk.metrics.gauge(
+                    key=self._get_key(key),
+                    value=value,
+                    tags=tags,
+                    unit=self._to_minimetrics_unit(unit=unit),
+                )
+            else:
+                sentry_sdk.metrics.incr(
+                    key=self._get_key(key),
+                    value=value,
+                    tags=tags,
+                    unit=self._to_minimetrics_unit(unit=unit),
+                )
 
     def distribution(
         self,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1657,6 +1657,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "delightful_metrics.emit_gauges",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+
 register("metric_alerts.rate_limit", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # SDK Crash Detection

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -174,7 +174,7 @@ def test_incr_called_with_tag_value_as_list(backend, hub):
         "delightful_metrics.enable_common_tags": True,
     }
 )
-def test_gauge_as_counter(backend, hub):
+def test_gauge(backend, hub):
     # The minimetrics backend supports the list type.
     backend.gauge(key="foo", value=42.0)
     full_flush(hub)
@@ -183,8 +183,8 @@ def test_gauge_as_counter(backend, hub):
 
     assert len(metrics) == 1
     assert metrics[0][1] == "sentrytest.foo@none"
-    assert metrics[0][2] == "c"
-    assert metrics[0][3] == ["42.0"]
+    assert metrics[0][2] == "g"
+    assert metrics[0][3] == ["42.0", "42.0", "42.0", "42.0", "1"]
 
     assert len(hub.client.metrics_aggregator.buckets) == 0
 
@@ -283,7 +283,7 @@ def test_unit_is_correctly_propagated_for_gauge(sentry_sdk, unit, expected_unit)
     params = {"key": "sentrytest.unit", "value": 10.0, "tags": {"x": "bar"}, "unit": unit}
 
     backend.gauge(**params)
-    assert sentry_sdk.metrics.incr.call_args.kwargs == {**params, "unit": expected_unit}
+    assert sentry_sdk.metrics.gauge.call_args.kwargs == {**params, "unit": expected_unit}
 
 
 @pytest.mark.skipif(not have_minimetrics, reason="no minimetrics")

--- a/tests/sentry/metrics/test_minimetrics.py
+++ b/tests/sentry/metrics/test_minimetrics.py
@@ -172,6 +172,30 @@ def test_incr_called_with_tag_value_as_list(backend, hub):
     {
         "delightful_metrics.enable_capture_envelope": True,
         "delightful_metrics.enable_common_tags": True,
+        "delightful_metrics.emit_gauges": False,
+    }
+)
+def test_gauge_as_count(backend, hub):
+    # The minimetrics backend supports the list type.
+    backend.gauge(key="foo", value=42.0)
+    full_flush(hub)
+
+    metrics = hub.client.transport.get_metrics()
+
+    assert len(metrics) == 1
+    assert metrics[0][1] == "sentrytest.foo@none"
+    assert metrics[0][2] == "c"
+    assert metrics[0][3] == ["42.0"]
+
+    assert len(hub.client.metrics_aggregator.buckets) == 0
+
+
+@pytest.mark.skipif(not have_minimetrics, reason="no minimetrics")
+@override_options(
+    {
+        "delightful_metrics.enable_capture_envelope": True,
+        "delightful_metrics.enable_common_tags": True,
+        "delightful_metrics.emit_gauges": True,
     }
 )
 def test_gauge(backend, hub):
@@ -271,9 +295,7 @@ def test_unit_is_correctly_propagated_for_timing(sentry_sdk, unit, expected_unit
 
 @pytest.mark.skipif(not have_minimetrics, reason="no minimetrics")
 @override_options(
-    {
-        "delightful_metrics.minimetrics_sample_rate": 1.0,
-    }
+    {"delightful_metrics.minimetrics_sample_rate": 1.0, "delightful_metrics.emit_gauges": True}
 )
 @patch("sentry.metrics.minimetrics.sentry_sdk")
 @pytest.mark.parametrize("unit,expected_unit", [(None, "none"), ("second", "second")])


### PR DESCRIPTION
This PR switches the implementation of gauges that were previously being emitted as counters and now as proper gauges.

Closes https://github.com/getsentry/sentry/issues/59093