### PR TITLE
Move `EventAttachment.mimetype` property into Serializer

### DIFF
--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -1,10 +1,7 @@
-import mimetypes
-
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.utils import timezone
-from django.utils.functional import cached_property
 
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model, region_silo_only_model, sane_repr
@@ -50,16 +47,6 @@ class EventAttachment(Model):
         unique_together = (("project_id", "event_id", "file_id"),)
 
     __repr__ = sane_repr("event_id", "name", "file_id")
-
-    @cached_property
-    def mimetype(self):
-        from sentry.models.files.file import File
-
-        file = File.objects.get(id=self.file_id)
-        rv = file.headers.get("Content-Type")
-        if rv:
-            return rv.split(";")[0].strip()
-        return mimetypes.guess_type(self.name)[0] or "application/octet-stream"
 
     def delete(self, *args, **kwargs):
         from sentry.models.files.file import File

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -35,7 +35,6 @@ class CreateAttachmentMixin:
             type=self.file.type,
             name="hello.png",
         )
-        assert self.attachment.mimetype == "image/png"
 
         return self.attachment
 
@@ -53,7 +52,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
 
         assert response.status_code == 200, response.content
         assert response.data["id"] == str(self.attachment.id)
-        assert response.data["mimetype"] == self.attachment.mimetype
+        assert response.data["mimetype"] == "image/png"
         assert response.data["event_id"] == self.event.event_id
 
     def test_download(self):

--- a/tests/sentry/api/endpoints/test_event_attachments.py
+++ b/tests/sentry/api/endpoints/test_event_attachments.py
@@ -44,7 +44,7 @@ class EventAttachmentsTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(attachment1.id)
-        assert response.data[0]["mimetype"] == attachment1.mimetype
+        assert response.data[0]["mimetype"] == "image/png"
         assert response.data[0]["event_id"] == attachment1.event_id
 
     def test_is_screenshot(self):
@@ -78,5 +78,5 @@ class EventAttachmentsTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(attachment1.id)
-        assert response.data[0]["mimetype"] == attachment1.mimetype
+        assert response.data[0]["mimetype"] == "image/png"
         assert response.data[0]["event_id"] == attachment1.event_id


### PR DESCRIPTION
The `EventAttachmentSerializer` was careful to batch-fetch the associated `File`, just for the `EventAttachment.mimetype` property to fetch the associated `File` one by one once again.

Move the `mimetype` property to the serializer code directly and thus avoid this N+1 query.