### PR TITLE
ref: add backward compatibility for swapping django-stubs to a fork

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -92,7 +92,7 @@ install-py-dev() {
     echo "--> Installing Sentry (for development)"
 
     # pip doesn't do well with swapping drop-ins
-    pip uninstall -qqy uwsgi
+    pip uninstall -qqy sentry-forked-django-stubs sentry-forked-djangorestframework-stubs
 
     pip-install -r requirements-dev-frozen.txt
 


### PR DESCRIPTION
I also removed the `uwsgi` backward-compat since it has been over a year since we made the switch to pyuwsgi