### PR TITLE
ref(tsc): Convert `JsonViewer` to FC

### DIFF
--- a/static/app/components/events/attachmentViewers/jsonViewer.spec.tsx
+++ b/static/app/components/events/attachmentViewers/jsonViewer.spec.tsx
@@ -1,0 +1,53 @@
+import {Event} from 'sentry-fixture/event';
+import {EventAttachment} from 'sentry-fixture/eventAttachment';
+import {Organization} from 'sentry-fixture/organization';
+import {Project} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import JsonViewer from 'sentry/components/events/attachmentViewers/jsonViewer';
+
+describe('JsonViewer', () => {
+  const organization = Organization();
+  const project = Project({organization});
+  const event = Event({project});
+  const attachment = EventAttachment({event_id: event.id});
+
+  it('Renders error if fetch is not successful', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.id}/${project.slug}/events/${event.id}/attachments/${attachment.id}/?download`,
+      status: 500,
+      statusCode: 500,
+    });
+
+    render(
+      <JsonViewer
+        attachment={attachment}
+        eventId={event.id}
+        orgId={organization.id}
+        projectSlug={project.slug}
+      />
+    );
+
+    expect(await screen.findByText(/Failed to load attachment/)).toBeInTheDocument();
+  });
+
+  it('Renders JSON content if fetch is successful', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.id}/${project.slug}/events/${event.id}/attachments/${attachment.id}/?download`,
+      body: '{"key":"value"}',
+    });
+
+    render(
+      <JsonViewer
+        attachment={attachment}
+        eventId={event.id}
+        orgId={organization.id}
+        projectSlug={project.slug}
+      />
+    );
+
+    expect(await screen.findByText('"key"')).toBeInTheDocument();
+    expect(await screen.findByText('"value"')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/attachmentViewers/jsonViewer.tsx
+++ b/static/app/components/events/attachmentViewers/jsonViewer.tsx
@@ -12,10 +12,13 @@ import {t} from 'sentry/locale';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
 export default function NewJsonViewer(props: ViewerProps) {
-  const query = useApiQuery([getAttachmentUrl(props)], {
-    staleTime: Infinity,
-    retry: false,
-  });
+  const query = useApiQuery(
+    [getAttachmentUrl(props), {headers: {Accept: '*/*; charset=utf-8'}}],
+    {
+      staleTime: Infinity,
+      retry: false,
+    }
+  );
 
   if (query.isLoading) {
     return <LoadingIndicator mini />;

--- a/static/app/components/events/attachmentViewers/jsonViewer.tsx
+++ b/static/app/components/events/attachmentViewers/jsonViewer.tsx
@@ -9,6 +9,7 @@ import {
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
 export default function NewJsonViewer(props: ViewerProps) {
@@ -21,7 +22,11 @@ export default function NewJsonViewer(props: ViewerProps) {
   );
 
   if (query.isLoading) {
-    return <LoadingIndicator mini />;
+    return (
+      <LoadingContainer>
+        <LoadingIndicator mini />
+      </LoadingContainer>
+    );
   }
 
   if (query.isError) {
@@ -55,6 +60,12 @@ export default function NewJsonViewer(props: ViewerProps) {
     </PreviewPanelItem>
   );
 }
+
+const LoadingContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  padding: ${space(1)};
+`;
 
 const StyledContextData = styled(ContextData)`
   margin-bottom: 0;

--- a/static/app/components/events/attachmentViewers/jsonViewer.tsx
+++ b/static/app/components/events/attachmentViewers/jsonViewer.tsx
@@ -12,7 +12,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
-export default function NewJsonViewer(props: ViewerProps) {
+export default function JsonViewer(props: ViewerProps) {
   const query = useApiQuery(
     [getAttachmentUrl(props), {headers: {Accept: '*/*; charset=utf-8'}}],
     {


### PR DESCRIPTION
You get it, it's the thing we're doing. Out with the old, in with the new. Plus, adds a less gross error state and a nicer loading spinner while I'm at it.

It's this dude, on event details pages:
<img width="905" alt="Screenshot 2023-11-02 at 1 58 51 PM" src="https://github.com/getsentry/sentry/assets/989898/2eb84ecc-9740-4f4a-a590-dc0b153597b9">

https://github.com/getsentry/frontend-tsc/issues/2