### PR TITLE
fix(github-invite): improve performance of missing members api

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -24,7 +24,6 @@ from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
-from sentry.search.utils import tokenize_query
 from sentry.services.hybrid_cloud.integration import integration_service
 
 if TYPE_CHECKING:
@@ -71,15 +70,27 @@ def _format_external_id(external_id: str | None) -> str | None:
 
 
 def _get_missing_organization_members(
-    organization: Organization, provider: str, integration_ids: Sequence[int]
+    organization: Organization,
+    provider: str,
+    integration_ids: Sequence[int],
+    shared_domain: str | None,
 ) -> QuerySet[CommitAuthor___commit__count]:
-    member_emails = set(
+    member_emails = list(
         organization.member_set.exclude(email=None).values_list("email", flat=True)
-    ) | set(organization.member_set.exclude(user_email=None).values_list("user_email", flat=True))
+    ) + list(organization.member_set.exclude(user_email=None).values_list("user_email", flat=True))
 
     nonmember_authors = CommitAuthor.objects.filter(organization_id=organization.id).exclude(
         Q(email__in=member_emails) | Q(external_id=None)
     )
+
+    if shared_domain:
+        nonmember_authors = nonmember_authors.filter(email__endswith=shared_domain)
+    else:
+        for filtered_email in FILTERED_EMAIL_DOMAINS:
+            nonmember_authors = nonmember_authors.exclude(email__endswith=filtered_email)
+
+    for filtered_character in FILTERED_CHARACTERS:
+        nonmember_authors = nonmember_authors.exclude(email__icontains=filtered_character)
 
     org_repos = Repository.objects.filter(
         provider="integrations:" + provider,
@@ -88,7 +99,7 @@ def _get_missing_organization_members(
     ).values_list("id", flat=True)
 
     recent_commits = Commit.objects.filter(
-        repository_id__in=set(org_repos), date_added__gte=timezone.now() - timedelta(days=30)
+        repository_id__in=org_repos, date_added__gte=timezone.now() - timedelta(days=30)
     ).values_list("id", flat=True)
 
     return (
@@ -161,27 +172,8 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
                 continue
 
             queryset = _get_missing_organization_members(
-                organization, integration_provider, integration_ids
+                organization, integration_provider, integration_ids, shared_domain
             )
-
-            if shared_domain:
-                queryset = queryset.filter(email__endswith=shared_domain)
-            else:
-                for filtered_email in FILTERED_EMAIL_DOMAINS:
-                    queryset = queryset.exclude(email__endswith=filtered_email)
-
-            for filtered_character in FILTERED_CHARACTERS:
-                queryset = queryset.exclude(email__icontains=filtered_character)
-
-            if queryset.exists():
-                query = request.GET.get("query")
-                if query:
-                    tokens = tokenize_query(query)
-                    if "query" in tokens:
-                        query_value = " ".join(tokens["query"])
-                        queryset = queryset.filter(
-                            Q(email__icontains=query_value) | Q(external_id__icontains=query_value)
-                        )
 
             missing_members_for_integration = {
                 "integration": integration_provider,

--- a/tests/sentry/api/endpoints/test_organization_missing_org_members.py
+++ b/tests/sentry/api/endpoints/test_organization_missing_org_members.py
@@ -205,25 +205,6 @@ class OrganizationMissingMembersTestCase(APITestCase):
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
         ]
 
-    def test_query_on_author_email_and_external_id(self):
-        # self.nonmember_commit_author1 matches on email
-        # the below matches on external id
-        nonmember_commit_author = self.create_commit_author(
-            project=self.project, email="c2@example.com"
-        )
-        nonmember_commit_author.external_id = "github:c@example.com"
-        nonmember_commit_author.save()
-
-        self.create_commit(repo=self.repo, author=nonmember_commit_author)
-
-        response = self.get_success_response(self.organization.slug, query="c@example.com")
-
-        assert response.data[0]["integration"] == "github"
-        assert response.data[0]["users"] == [
-            {"email": "c@example.com", "externalId": "c", "commitCount": 2},
-            {"email": "c2@example.com", "externalId": "c@example.com", "commitCount": 1},
-        ]
-
     def test_no_github_integration(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.delete()


### PR DESCRIPTION
Trying some things:
- Moved additional filtering to `CommitAuthor` query earlier on for invalid emails and characters
- Removed call to `queryset.exists()` which actually executes the entire query and fetches ALL missing commit authors -- now the queryset should be evaluated with `list(queryset[:50])` aka with `LIMIT 50` in SQL which speeds up the call
- Removed querying on commit author emails and usernames which was in the `if` block with `queryset.exists()` (and also because it's unused)

queryset[:50] is here https://github.com/getsentry/sentry/pull/59298/files#diff-cbd8ba8431e084917e094daa440e25fed428825687ae0c41a54a746bfa4ca8a8R181