### PR TITLE
fix(starfish): Screenload charts are always 2 columns with full width

### DIFF
--- a/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
@@ -6,7 +6,6 @@ import Color from 'color';
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {getInterval} from 'sentry/components/charts/utils';
 import LoadingContainer from 'sentry/components/loading/loadingContainer';
-import {PerformanceLayoutBodyRow} from 'sentry/components/performance/layouts';
 import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {space} from 'sentry/styles/space';
 import {Series, SeriesDataUnit} from 'sentry/types/echarts';
@@ -236,14 +235,17 @@ export function ScreenCharts({yAxes, additionalFilters, chartHeight}: Props) {
 
   return (
     <div data-test-id="starfish-mobile-view">
-      <StyledRow minSize={200}>{renderCharts()}</StyledRow>
+      <StyledRow>{renderCharts()}</StyledRow>
     </div>
   );
 }
 
-const StyledRow = styled(PerformanceLayoutBodyRow)`
-  margin-bottom: ${space(2)};
+const StyledRow = styled('div')`
+  display: grid;
   grid-template-columns: repeat(2, 1fr);
+  grid-column-gap: ${space(2)};
+
+  margin-bottom: ${space(2)};
 `;
 
 const ChartsContainerItem = styled('div')`

--- a/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
@@ -236,22 +236,14 @@ export function ScreenCharts({yAxes, additionalFilters, chartHeight}: Props) {
 
   return (
     <div data-test-id="starfish-mobile-view">
-      <StyledRow minSize={200}>
-        <ChartsContainer>{renderCharts()}</ChartsContainer>
-      </StyledRow>
+      <StyledRow minSize={200}>{renderCharts()}</StyledRow>
     </div>
   );
 }
 
 const StyledRow = styled(PerformanceLayoutBodyRow)`
   margin-bottom: ${space(2)};
-`;
-
-const ChartsContainer = styled('div')`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  gap: ${space(2)};
+  grid-template-columns: repeat(2, 1fr);
 `;
 
 const ChartsContainerItem = styled('div')`


### PR DESCRIPTION
When the window is made smaller horizontally, then the smallest breakpoint of PerformanceLayoutBodyRow is to force its children into 2 columns. Since there was a ChartsContainer wrapping the charts, both charts would render squished in the first column.

before:
![Screenshot 2023-11-02 at 2 34 19 PM](https://github.com/getsentry/sentry/assets/22846452/6d181dd9-9d58-4976-868a-91d85e1b7452)


after:
https://github.com/getsentry/sentry/assets/22846452/16e85cd9-b4e7-40cf-b9a6-840e14217821

