### PR TITLE
fix(starfish): Replace Pageload header with Screens

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -327,7 +327,7 @@ function Sidebar({location, organization}: Props) {
         />
         <SidebarItem
           {...sidebarItemProps}
-          label={<GuideAnchor target="starfish">{t('Screen Load')}</GuideAnchor>}
+          label={<GuideAnchor target="starfish">{t('Screens')}</GuideAnchor>}
           to={`/organizations/${organization.slug}/starfish/pageload/`}
           id="starfish-mobile-screen-loads"
           icon={<SubitemDot collapsed={collapsed} />}

--- a/static/app/views/starfish/utils/routeNames.tsx
+++ b/static/app/views/starfish/utils/routeNames.tsx
@@ -7,6 +7,6 @@ export const ROUTE_NAMES = {
   'span-summary': t('Span Summary'),
   'web-service': t('Web Service'),
   initialization: t('App Initialization'),
-  pageload: t('Pageload'),
+  pageload: t('Screens'),
   responsiveness: t('Responsiveness'),
 };

--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
@@ -13,6 +13,7 @@ import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
@@ -54,12 +55,12 @@ function ScreenLoadSpans() {
   const crumbs: Crumb[] = [
     {
       to: screenLoadModule,
-      label: t('Module View'),
+      label: t('Screens'),
       preservePageFilters: true,
     },
     {
       to: '',
-      label: t('Screen Load'),
+      label: decodeScalar(location.query.transaction),
     },
   ];
 


### PR DESCRIPTION
Replaces just the header for now. There are components and URLs that use 'pageload' but we can consider replacing them in another PR if that needs to happen

![Screenshot 2023-11-02 at 2 47 11 PM](https://github.com/getsentry/sentry/assets/22846452/862d6427-741c-456d-ac70-2172af7a2e86)
