### PR TITLE
feat(starfish-webvitals-opportunity-widget): Adding widget functionality

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -572,6 +572,7 @@ const ControlWrap = styled('div')`
 const TriggerLabel = styled('span')`
   ${p => p.theme.overflowEllipsis}
   text-align: left;
+  line-height: normal;
 `;
 
 const StyledBadge = styled(Badge)`

--- a/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
@@ -4,9 +4,13 @@ import styled from '@emotion/styled';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {Series} from 'sentry/types/echarts';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {PERFORMANCE_SCORE_WEIGHTS} from 'sentry/views/performance/browser/webVitals/utils/calculatePerformanceScore';
-import {useProjectWebVitalsTimeseriesQuery} from 'sentry/views/performance/browser/webVitals/utils/useProjectWebVitalsTimeseriesQuery';
+import {
+  useProjectWebVitalsTimeseriesQuery,
+  WebVitalsScoreBreakdown,
+} from 'sentry/views/performance/browser/webVitals/utils/useProjectWebVitalsTimeseriesQuery';
 import Chart from 'sentry/views/starfish/components/chart';
 
 const {
@@ -19,6 +23,66 @@ const {
 
 type Props = {
   transaction?: string;
+};
+
+export const formatTimeSeriesResultsToChartData = (
+  data: WebVitalsScoreBreakdown,
+  segmentColors: string[]
+): Series[] => {
+  return [
+    {
+      data: data?.lcp.map(({name, value}) => ({
+        name,
+        value: value * LCP_WEIGHT * 0.01,
+      })),
+      seriesName: 'LCP',
+      color: segmentColors[0],
+    },
+    {
+      data: data?.fcp.map(
+        ({name, value}) => ({
+          name,
+          value: value * FCP_WEIGHT * 0.01,
+        }),
+        []
+      ),
+      seriesName: 'FCP',
+      color: segmentColors[1],
+    },
+    {
+      data: data?.fid.map(
+        ({name, value}) => ({
+          name,
+          value: value * FID_WEIGHT * 0.01,
+        }),
+        []
+      ),
+      seriesName: 'FID',
+      color: segmentColors[2],
+    },
+    {
+      data: data?.cls.map(
+        ({name, value}) => ({
+          name,
+          value: value * CLS_WEIGHT * 0.01,
+        }),
+        []
+      ),
+      seriesName: 'CLS',
+      color: segmentColors[3],
+    },
+    {
+      data: data?.ttfb.map(
+        ({name, value}) => ({
+          name,
+          value: value * TTFB_WEIGHT * 0.01,
+        }),
+        []
+      ),
+      seriesName: 'TTFB',
+      color: segmentColors[4],
+    },
+  ];
 };
 
 export function PerformanceScoreBreakdownChart({transaction}: Props) {
@@ -39,60 +103,7 @@ export function PerformanceScoreBreakdownChart({transaction}: Props) {
       <Chart
         stacked
         height={180}
-        data={[
-          {
-            data: data?.lcp.map(({name, value}) => ({
-              name,
-              value: value * LCP_WEIGHT * 0.01,
-            })),
-            seriesName: 'LCP',
-            color: segmentColors[0],
-          },
-          {
-            data: data?.fcp.map(
-              ({name, value}) => ({
-                name,
-                value: value * FCP_WEIGHT * 0.01,
-              }),
-              []
-            ),
-            seriesName: 'FCP',
-            color: segmentColors[1],
-          },
-          {
-            data: data?.fid.map(
-              ({name, value}) => ({
-                name,
-                value: value * FID_WEIGHT * 0.01,
-              }),
-              []
-            ),
-            seriesName: 'FID',
-            color: segmentColors[2],
-          },
-          {
-            data: data?.cls.map(
-              ({name, value}) => ({
-                name,
-                value: value * CLS_WEIGHT * 0.01,
-              }),
-              []
-            ),
-            seriesName: 'CLS',
-            color: segmentColors[3],
-          },
-          {
-            data: data?.ttfb.map(
-              ({name, value}) => ({
-                name,
-                value: value * TTFB_WEIGHT * 0.01,
-              }),
-              []
-            ),
-            seriesName: 'TTFB',
-            color: segmentColors[4],
-          },
-        ]}
+        data={formatTimeSeriesResultsToChartData(data, segmentColors)}
         disableXAxis
         loading={isLoading}
         utc={false}

--- a/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsTimeseriesQuery.tsx
@@ -17,6 +17,15 @@ type Props = {
   transaction?: string;
 };
 
+export type WebVitalsScoreBreakdown = {
+  cls: SeriesDataUnit[];
+  fcp: SeriesDataUnit[];
+  fid: SeriesDataUnit[];
+  lcp: SeriesDataUnit[];
+  total: SeriesDataUnit[];
+  ttfb: SeriesDataUnit[];
+};
+
 export const useProjectWebVitalsTimeseriesQuery = ({transaction, tag}: Props) => {
   const pageFilters = usePageFilters();
   const location = useLocation();
@@ -70,14 +79,7 @@ export const useProjectWebVitalsTimeseriesQuery = ({transaction, tag}: Props) =>
     },
   });
 
-  const data: {
-    cls: SeriesDataUnit[];
-    fcp: SeriesDataUnit[];
-    fid: SeriesDataUnit[];
-    lcp: SeriesDataUnit[];
-    total: SeriesDataUnit[];
-    ttfb: SeriesDataUnit[];
-  } = {
+  const data: WebVitalsScoreBreakdown = {
     lcp: [],
     fcp: [],
     cls: [],

--- a/static/app/views/performance/landing/views/frontendOtherView.tsx
+++ b/static/app/views/performance/landing/views/frontendOtherView.tsx
@@ -38,6 +38,12 @@ export function FrontendOtherView(props: BasePerformanceViewProps) {
     PerformanceWidgetSetting.SLOW_RESOURCE_OPS,
   ];
 
+  if (
+    props.organization.features.includes('starfish-browser-webvitals-pageoverview-v2')
+  ) {
+    doubleChartRowCharts.unshift(PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES);
+  }
+
   return (
     <PerformanceDisplayProvider
       value={{performanceType: ProjectPerformanceType.FRONTEND_OTHER}}

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -890,6 +890,50 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
   });
 
+  it('Highest opportunity pages widget', async function () {
+    const data = initializeData();
+
+    wrapper = render(
+      <MEPSettingProvider forceTransactions>
+        <WrappedComponent
+          data={data}
+          defaultChartSetting={PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES}
+        />
+      </MEPSettingProvider>
+    );
+
+    expect(await screen.findByTestId('performance-widget-title')).toHaveTextContent(
+      'Highest Opportunity Pages'
+    );
+    expect(eventsMock).toHaveBeenCalledTimes(1);
+    expect(eventsMock).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          dataset: 'metrics',
+          environment: ['prod'],
+          field: [
+            'transaction',
+            'transaction.op',
+            'project.id',
+            'p75(measurements.lcp)',
+            'p75(measurements.fcp)',
+            'p75(measurements.cls)',
+            'p75(measurements.ttfb)',
+            'p75(measurements.fid)',
+            'count()',
+          ],
+          per_page: QUERY_LIMIT_PARAM,
+          project: ['-42'],
+          query: 'transaction.op:pageload',
+          sort: '-count()',
+          statsPeriod: '7d',
+        }),
+      })
+    );
+  });
+
   it('Most regressed trends widget', async function () {
     const data = initializeData();
 

--- a/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
@@ -12,11 +12,15 @@ import {
   WidgetDataConstraint,
   WidgetDataProps,
 } from '../types';
+import {PerformanceWidgetSetting} from '../widgetDefinitions';
 
 export function WidgetHeader<T extends WidgetDataConstraint>(
   props: GenericPerformanceWidgetProps<T> & WidgetDataProps<T>
 ) {
-  const {title, titleTooltip, Subtitle, HeaderActions, InteractiveTitle} = props;
+  const {title, titleTooltip, Subtitle, HeaderActions, InteractiveTitle, chartSetting} =
+    props;
+  const isHighestOpportunityPagesWidget =
+    chartSetting === PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES;
   return (
     <WidgetHeaderContainer>
       <TitleContainer>
@@ -26,6 +30,7 @@ export function WidgetHeader<T extends WidgetDataConstraint>(
           ) : (
             <TextOverflow>{title}</TextOverflow>
           )}
+          {isHighestOpportunityPagesWidget && <FeatureBadge type="alpha" />}
           <MEPTag />
           {titleTooltip && (
             <QuestionTooltip position="top" size="sm" title={titleTooltip} />
@@ -48,6 +53,7 @@ const StyledHeaderTitleLegend = styled(HeaderTitleLegend)`
   ${FeatureBadge} {
     position: relative;
     top: -${space(0.25)};
+    margin-left: ${space(0.25)};
   }
 `;
 

--- a/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
+++ b/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
@@ -50,6 +50,7 @@ export enum PerformanceWidgetSetting {
   MOST_RELATED_ERRORS = 'most_related_errors',
   MOST_RELATED_ISSUES = 'most_related_issues',
   MOST_TIME_SPENT_DB_QUERIES = 'most_time_spent_db_queries',
+  HIGHEST_OPPORTUNITY_PAGES = 'highest_opportunity_pages',
   SLOW_HTTP_OPS = 'slow_http_ops',
   SLOW_DB_OPS = 'slow_db_ops',
   SLOW_RESOURCE_OPS = 'slow_resource_ops',
@@ -268,6 +269,13 @@ export const WIDGET_DEFINITIONS: ({
     fields: [`time_spent_percentage()`],
     dataType: GenericPerformanceWidgetDataType.LINE_LIST,
     chartColor: WIDGET_PALETTE[0],
+  },
+  [PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES]: {
+    title: t('Highest Opportunity Pages'),
+    subTitle: t('Recommended pages to improve your performance score'),
+    titleTooltip: '',
+    fields: [`count()`],
+    dataType: GenericPerformanceWidgetDataType.STACKED_AREA,
   },
   [PerformanceWidgetSetting.SLOW_HTTP_OPS]: {
     title: t('Slow HTTP Ops'),

--- a/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
@@ -1,12 +1,15 @@
 import {Fragment, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 
 import Accordion from 'sentry/components/accordion/accordion';
+import {LinkButton} from 'sentry/components/button';
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import StackedAreaChart from 'sentry/components/charts/stackedAreaChart';
 import {getInterval} from 'sentry/components/charts/utils';
 import Count from 'sentry/components/count';
+import {Tooltip} from 'sentry/components/tooltip';
 import Truncate from 'sentry/components/truncate';
 import {t} from 'sentry/locale';
 import {
@@ -16,6 +19,7 @@ import {
 } from 'sentry/utils/discover/charts';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {
   canUseMetricsData,
   useMEPSettingContext,
@@ -24,11 +28,19 @@ import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import withApi from 'sentry/utils/withApi';
+import {PerformanceBadge} from 'sentry/views/performance/browser/webVitals/components/performanceBadge';
+import {formatTimeSeriesResultsToChartData} from 'sentry/views/performance/browser/webVitals/components/performanceScoreBreakdownChart';
+import {calculateOpportunity} from 'sentry/views/performance/browser/webVitals/utils/calculateOpportunity';
+import {calculatePerformanceScore} from 'sentry/views/performance/browser/webVitals/utils/calculatePerformanceScore';
+import {WebVitals} from 'sentry/views/performance/browser/webVitals/utils/types';
+import {useProjectWebVitalsQuery} from 'sentry/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery';
+import {WebVitalsScoreBreakdown} from 'sentry/views/performance/browser/webVitals/utils/useProjectWebVitalsTimeseriesQuery';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {
   createUnnamedTransactionsDiscoverTarget,
   UNPARAMETERIZED_TRANSACTION,
 } from 'sentry/views/performance/utils';
+import Chart from 'sentry/views/starfish/components/chart';
 
 import {GenericPerformanceWidget} from '../components/performanceWidget';
 import {
@@ -45,6 +57,7 @@ import {
   getMEPParamsIfApplicable,
   QUERY_LIMIT_PARAM,
 } from '../utils';
+import {PerformanceWidgetSetting} from '../widgetDefinitions';
 
 type DataType = {
   chart: WidgetDataResult & ReturnType<typeof transformEventsRequestToStackedArea>;
@@ -58,41 +71,75 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
   const {ContainerActions, organization, InteractiveTitle, fields} = props;
   const pageError = usePageError();
   const theme = useTheme();
-
+  const {data: projectData} = useProjectWebVitalsQuery();
   const colors = [...theme.charts.getColorPalette(5)].reverse();
+  const field = fields[0];
 
   const listQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
     () => ({
       fields,
       component: provided => {
         const eventView = provided.eventView.clone();
+        let extraQueryParams = getMEPParamsIfApplicable(mepSetting, props.chartSetting);
 
-        eventView.fields = [
-          {field: 'transaction'},
-          {field: 'team_key_transaction'},
-          {field: 'count()'},
-          {field: 'project.id'},
-          ...fields.map(f => ({field: f})),
-        ];
+        if (props.chartSetting === PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES) {
+          // Set fields
+          eventView.fields = [
+            {field: 'transaction'},
+            {field: 'transaction.op'},
+            {field: 'project.id'},
+            {field: 'p75(measurements.lcp)'},
+            {field: 'p75(measurements.fcp)'},
+            {field: 'p75(measurements.cls)'},
+            {field: 'p75(measurements.ttfb)'},
+            {field: 'p75(measurements.fid)'},
+            {field},
+          ];
 
-        eventView.sorts = [
-          {kind: 'desc', field: 'team_key_transaction'},
-          {kind: 'desc', field: 'count()'},
-        ];
+          // Set Metrics
+          eventView.dataset = DiscoverDatasets.METRICS;
+          extraQueryParams = {
+            ...extraQueryParams,
+            dataset: DiscoverDatasets.METRICS,
+          };
 
-        if (canUseMetricsData(organization)) {
-          eventView.additionalConditions.setFilterValues('!transaction', [
-            UNPARAMETERIZED_TRANSACTION,
-          ]);
+          eventView.sorts = [{kind: 'desc', field}];
+
+          // Update query
+          const mutableSearch = new MutableSearch(eventView.query);
+          mutableSearch.removeFilter('event.type');
+          eventView.additionalConditions.removeFilter('event.type');
+          mutableSearch.addFilterValue('transaction.op', 'pageload');
+          eventView.query = mutableSearch.formatString();
+        } else {
+          eventView.fields = [
+            {field: 'transaction'},
+            {field: 'team_key_transaction'},
+            {field: 'count()'},
+            {field: 'project.id'},
+            ...fields.map(f => ({field: f})),
+          ];
+
+          eventView.sorts = [
+            {kind: 'desc', field: 'team_key_transaction'},
+            {kind: 'desc', field: 'count()'},
+          ];
+
+          if (canUseMetricsData(organization)) {
+            eventView.additionalConditions.setFilterValues('!transaction', [
+              UNPARAMETERIZED_TRANSACTION,
+            ]);
+          }
+          const mutableSearch = new MutableSearch(eventView.query);
+          mutableSearch.removeFilter('transaction.duration');
+
+          eventView.query = mutableSearch.formatString();
+
+          // Don't retrieve list items with 0 in the field.
+          eventView.additionalConditions.setFilterValues('count()', ['>0']);
+          eventView.additionalConditions.setFilterValues('!transaction.op', ['']);
         }
-        const mutableSearch = new MutableSearch(eventView.query);
-        mutableSearch.removeFilter('transaction.duration');
 
-        eventView.query = mutableSearch.formatString();
-
-        // Don't retrieve list items with 0 in the field.
-        eventView.additionalConditions.setFilterValues('count()', ['>0']);
-        eventView.additionalConditions.setFilterValues('!transaction.op', ['']);
         return (
           <DiscoverQuery
             {...provided}
@@ -101,7 +148,7 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
             limit={QUERY_LIMIT_PARAM}
             cursor="0:0:1"
             noPagination
-            queryExtras={getMEPParamsIfApplicable(mepSetting, props.chartSetting)}
+            queryExtras={extraQueryParams}
           />
         );
       },
@@ -120,49 +167,88 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
         fields,
         component: provided => {
           const eventView = props.eventView.clone();
+          let extraQueryParams = getMEPParamsIfApplicable(mepSetting, props.chartSetting);
+          const pageFilterDatetime = {
+            start: provided.start,
+            end: provided.end,
+            period: provided.period,
+          };
+
+          // Chart options
+          let currentSeriesNames = [field];
+          let yAxis = provided.yAxis;
+          const interval = getInterval(pageFilterDatetime, 'low');
+
           if (!provided.widgetData.list.data[selectedListIndex]?.transaction) {
             return null;
           }
 
-          // Skip character escaping because generating the query for EventsRequest
-          // downstream will already handle escaping
-          eventView.additionalConditions.setFilterValues(
-            'transaction',
-            [provided.widgetData.list.data[selectedListIndex].transaction as string],
-            false
-          );
+          if (props.chartSetting === PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES) {
+            // Update request params
+            eventView.dataset = DiscoverDatasets.METRICS;
+            extraQueryParams = {
+              ...extraQueryParams,
+              dataset: DiscoverDatasets.METRICS,
+              excludeOther: false,
+              per_page: 50,
+            };
+            eventView.fields = [];
 
-          if (canUseMetricsData(organization)) {
-            eventView.additionalConditions.setFilterValues('!transaction', [
-              UNPARAMETERIZED_TRANSACTION,
-            ]);
+            // Update chart options
+            yAxis = [
+              'p75(measurements.lcp)',
+              'p75(measurements.fcp)',
+              'p75(measurements.cls)',
+              'p75(measurements.ttfb)',
+              'p75(measurements.fid)',
+              'count()',
+            ];
+
+            // Update search query
+            eventView.additionalConditions.removeFilter('event.type');
+            eventView.additionalConditions.addFilterValue('transaction.op', 'pageload');
+            const mutableSearch = new MutableSearch(eventView.query);
+            mutableSearch.addFilterValue(
+              'transaction',
+              provided.widgetData.list.data[selectedListIndex].transaction.toString()
+            );
+            eventView.query = mutableSearch.formatString();
+          } else {
+            // Skip character escaping because generating the query for EventsRequest
+            // downstream will already handle escaping
+            eventView.additionalConditions.setFilterValues(
+              'transaction',
+              [provided.widgetData.list.data[selectedListIndex].transaction as string],
+              false
+            );
+
+            if (canUseMetricsData(organization)) {
+              eventView.additionalConditions.setFilterValues('!transaction', [
+                UNPARAMETERIZED_TRANSACTION,
+              ]);
+            }
+            const listResult = provided.widgetData.list.data[selectedListIndex];
+            const nonEmptySpanOpFields = Object.entries(listResult)
+              .filter(result => fields.includes(result[0]) && result[1] !== 0)
+              .map(result => result[0]);
+            currentSeriesNames = nonEmptySpanOpFields;
+            yAxis = nonEmptySpanOpFields;
           }
-          const listResult = provided.widgetData.list.data[selectedListIndex];
-          const nonEmptySpanOpFields = Object.entries(listResult)
-            .filter(result => fields.includes(result[0]) && result[1] !== 0)
-            .map(result => result[0]);
-          const prunedProvided = {...provided, yAxis: nonEmptySpanOpFields};
 
           return (
             <EventsRequest
-              {...pick(prunedProvided, eventsRequestQueryProps)}
+              {...pick(provided, eventsRequestQueryProps)}
               limit={5}
+              yAxis={yAxis}
               includePrevious={false}
               includeTransformedData
               partial
-              currentSeriesNames={nonEmptySpanOpFields}
+              currentSeriesNames={currentSeriesNames}
               query={eventView.getQueryWithAdditionalConditions()}
-              interval={getInterval(
-                {
-                  start: prunedProvided.start,
-                  end: prunedProvided.end,
-                  period: prunedProvided.period,
-                },
-                'low'
-              )}
+              interval={interval}
               hideError
               onError={pageError.setPageError}
-              queryExtras={getMEPParamsIfApplicable(mepSetting, props.chartSetting)}
+              queryExtras={extraQueryParams}
             />
           );
         },
@@ -183,6 +269,91 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
 
   const getAreaChart = provided =>
     function () {
+      if (props.chartSetting === PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES) {
+        const segmentColors = theme.charts.getColorPalette(3);
+
+        const formattedWebVitalsScoreBreakdown: WebVitalsScoreBreakdown = {
+          lcp: [],
+          fcp: [],
+          cls: [],
+          ttfb: [],
+          fid: [],
+          total: [],
+        };
+
+        const getWebVitalValue = (webVital: WebVitals, rowIndex: number): number =>
+          provided.widgetData.chart.data?.find(
+            series => series.seriesName === `p75(measurements.${webVital})`
+          ).data[rowIndex].value;
+
+        provided.widgetData.chart.data
+          ?.find(series => series.seriesName === 'p75(measurements.lcp)')
+          ?.data.forEach((dataRow, index) => {
+            const lcp: number = getWebVitalValue('lcp', index);
+            const fcp: number = getWebVitalValue('fcp', index);
+            const cls: number = getWebVitalValue('cls', index);
+            const ttfb: number = getWebVitalValue('ttfb', index);
+            const fid: number = getWebVitalValue('fid', index);
+
+            // // This is kinda jank, but since events-stats zero fills, we need to assume that 0 values mean no data.
+            // // 0 value for a webvital is low frequency, but not impossible. We may need to figure out a better way to handle this in the future.
+            const {totalScore, lcpScore, fcpScore, fidScore, clsScore, ttfbScore} =
+              calculatePerformanceScore({
+                lcp: lcp === 0 ? Infinity : lcp,
+                fcp: fcp === 0 ? Infinity : fcp,
+                cls: cls === 0 ? Infinity : cls,
+                ttfb: ttfb === 0 ? Infinity : ttfb,
+                fid: fid === 0 ? Infinity : fid,
+              });
+
+            formattedWebVitalsScoreBreakdown.total.push({
+              value: totalScore,
+              name: dataRow.name,
+            });
+            formattedWebVitalsScoreBreakdown.cls.push({
+              value: clsScore,
+              name: dataRow.name,
+            });
+            formattedWebVitalsScoreBreakdown.lcp.push({
+              value: lcpScore,
+              name: dataRow.name,
+            });
+            formattedWebVitalsScoreBreakdown.fcp.push({
+              value: fcpScore,
+              name: dataRow.name,
+            });
+            formattedWebVitalsScoreBreakdown.ttfb.push({
+              value: ttfbScore,
+              name: dataRow.name,
+            });
+            formattedWebVitalsScoreBreakdown.fid.push({
+              value: fidScore,
+              name: dataRow.name,
+            });
+          });
+        return (
+          <Chart
+            stacked
+            height={150}
+            data={formatTimeSeriesResultsToChartData(
+              formattedWebVitalsScoreBreakdown,
+              segmentColors
+            )}
+            disableXAxis
+            loading={false}
+            utc={false}
+            grid={{
+              left: 5,
+              right: 5,
+              top: 5,
+              bottom: 0,
+            }}
+            dataMax={100}
+            chartColors={segmentColors}
+          />
+        );
+      }
+
       const durationUnit = getDurationUnit(provided.widgetData.chart.data);
       return (
         <StackedAreaChart
@@ -223,6 +394,62 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
       listItem =>
         function () {
           const transaction = (listItem.transaction as string | undefined) ?? '';
+          const count = projectData?.data[0]['count()'] as number;
+          if (props.chartSetting === PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES) {
+            const projectScore = calculatePerformanceScore({
+              lcp: projectData?.data[0]['p75(measurements.lcp)'] as number,
+              fcp: projectData?.data[0]['p75(measurements.fcp)'] as number,
+              cls: projectData?.data[0]['p75(measurements.cls)'] as number,
+              ttfb: projectData?.data[0]['p75(measurements.ttfb)'] as number,
+              fid: projectData?.data[0]['p75(measurements.fid)'] as number,
+            });
+            const rowScore = calculatePerformanceScore({
+              lcp: listItem['p75(measurements.lcp)'] as number,
+              fcp: listItem['p75(measurements.fcp)'] as number,
+              cls: listItem['p75(measurements.cls)'] as number,
+              ttfb: listItem['p75(measurements.ttfb)'] as number,
+              fid: listItem['p75(measurements.fid)'] as number,
+            });
+            const opportunity = calculateOpportunity(
+              projectScore.totalScore,
+              count,
+              rowScore.totalScore,
+              listItem['count()']
+            );
+            return (
+              <Fragment>
+                <GrowLink
+                  to={{
+                    pathname: '/performance/browser/pageloads/overview/',
+                    query: {...location.query, transaction},
+                  }}
+                >
+                  <Truncate value={transaction} maxLength={40} />
+                </GrowLink>
+                <StyledRightAlignedCell>
+                  <Tooltip
+                    title={t(
+                      'The opportunity to improve your cumulative performance score.'
+                    )}
+                    isHoverable
+                    showUnderline
+                  >
+                    <PerformanceBadge score={rowScore.totalScore} />
+                  </Tooltip>
+                  <Tooltip
+                    title={t(
+                      'The opportunity to improve your cumulative performance score.'
+                    )}
+                    isHoverable
+                    showUnderline
+                    skipWrapper
+                  >
+                    {opportunity}
+                  </Tooltip>
+                </StyledRightAlignedCell>
+              </Fragment>
+            );
+          }
 
           const isUnparameterizedRow = transaction === UNPARAMETERIZED_TRANSACTION;
           const transactionTarget = isUnparameterizedRow
@@ -254,16 +481,36 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
         }
     );
 
+  const getContainerActions = provided => {
+    return props.chartSetting === PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES ? (
+      <Fragment>
+        <div>
+          <LinkButton
+            to={`/organizations/${organization.slug}/performance/browser/pageloads/`}
+            size="sm"
+          >
+            {t('View All')}
+          </LinkButton>
+        </div>
+        {ContainerActions && (
+          <ContainerActions isLoading={provided.widgetData.list?.isLoading} />
+        )}
+      </Fragment>
+    ) : (
+      ContainerActions && (
+        <ContainerActions isLoading={provided.widgetData.list?.isLoading} />
+      )
+    );
+  };
+
   return (
     <GenericPerformanceWidget<DataType>
       {...props}
       location={location}
-      Subtitle={() => <Subtitle>{t('P75 in Top Transactions')}</Subtitle>}
-      HeaderActions={provided =>
-        ContainerActions && (
-          <ContainerActions isLoading={provided.widgetData.list?.isLoading} />
-        )
-      }
+      Subtitle={() => (
+        <Subtitle>{props.subTitle ?? t('P75 in Top Transactions')}</Subtitle>
+      )}
+      HeaderActions={provided => getContainerActions(provided)}
       InteractiveTitle={
         InteractiveTitle
           ? provided => <InteractiveTitle {...provided.widgetData.chart} />
@@ -288,4 +535,8 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
   );
 }
 
+const StyledRightAlignedCell = styled(RightAlignedCell)`
+  justify-content: space-between;
+  width: 115px;
+`;
 const EventsRequest = withApi(_EventsRequest);

--- a/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
@@ -9,6 +9,7 @@ import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import StackedAreaChart from 'sentry/components/charts/stackedAreaChart';
 import {getInterval} from 'sentry/components/charts/utils';
 import Count from 'sentry/components/count';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Tooltip} from 'sentry/components/tooltip';
 import Truncate from 'sentry/components/truncate';
 import {t} from 'sentry/locale';
@@ -71,7 +72,8 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
   const {ContainerActions, organization, InteractiveTitle, fields} = props;
   const pageError = usePageError();
   const theme = useTheme();
-  const {data: projectData} = useProjectWebVitalsQuery();
+  const {data: projectData, isLoading: isProjectWebVitalDataLoading} =
+    useProjectWebVitalsQuery();
   const colors = [...theme.charts.getColorPalette(5)].reverse();
   const field = fields[0];
 
@@ -427,25 +429,21 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
                   <Truncate value={transaction} maxLength={40} />
                 </GrowLink>
                 <StyledRightAlignedCell>
-                  <Tooltip
-                    title={t(
-                      'The opportunity to improve your cumulative performance score.'
-                    )}
-                    isHoverable
-                    showUnderline
-                  >
-                    <PerformanceBadge score={rowScore.totalScore} />
-                  </Tooltip>
-                  <Tooltip
-                    title={t(
-                      'The opportunity to improve your cumulative performance score.'
-                    )}
-                    isHoverable
-                    showUnderline
-                    skipWrapper
-                  >
-                    {opportunity}
-                  </Tooltip>
+                  <PerformanceBadge score={rowScore.totalScore} />
+                  {isProjectWebVitalDataLoading ? (
+                    <StyledLoadingIndicator size={20} />
+                  ) : (
+                    <Tooltip
+                      title={t(
+                        'The opportunity to improve your cumulative performance score.'
+                      )}
+                      isHoverable
+                      showUnderline
+                      skipWrapper
+                    >
+                      {opportunity}
+                    </Tooltip>
+                  )}
                 </StyledRightAlignedCell>
               </Fragment>
             );
@@ -538,5 +536,12 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
 const StyledRightAlignedCell = styled(RightAlignedCell)`
   justify-content: space-between;
   width: 115px;
+`;
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  &,
+  .loading-message {
+    margin: 0;
+  }
 `;
 const EventsRequest = withApi(_EventsRequest);


### PR DESCRIPTION
This pr adds the new widget under the feature flag `organizations:starfish-browser-webvital` to the performance landing page > frontend tab.

Widget States: 
<img width="400" alt="Screenshot 2023-11-02 at 3 03 28 PM" src="https://github.com/getsentry/sentry/assets/60121741/257c9282-a7e7-4966-b106-dcb6ad4d22c4">

<img width="400" alt="Screenshot 2023-11-02 at 3 03 01 PM" src="https://github.com/getsentry/sentry/assets/60121741/a1673874-69e7-4e8a-bb3a-34e3e612bc42">