### PR TITLE
ref: Remove post process forwarder command

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -7,18 +7,15 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Collection,
-    Literal,
     Mapping,
     MutableMapping,
     Optional,
     Sequence,
     TypedDict,
-    Union,
     cast,
 )
 
 from sentry.issues.issue_occurrence import IssueOccurrence
-from sentry.post_process_forwarder import PostProcessForwarderType
 from sentry.tasks.post_process import post_process_group
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.services import Service
@@ -72,7 +69,6 @@ class EventStream(Service):
         "replace_group_unsafe",
         "exclude_groups",
         "requires_post_process_forwarder",
-        "run_post_process_forwarder",
         "_get_event_type",
     )
 
@@ -203,20 +199,6 @@ class EventStream(Service):
 
     def requires_post_process_forwarder(self) -> bool:
         return False
-
-    def run_post_process_forwarder(
-        self,
-        entity: PostProcessForwarderType,
-        consumer_group: str,
-        topic: Optional[str],
-        commit_log_topic: str,
-        synchronize_commit_group: str,
-        concurrency: int,
-        initial_offset_reset: Union[Literal["latest"], Literal["earliest"]],
-        strict_offset_reset: bool,
-    ) -> None:
-        assert not self.requires_post_process_forwarder()
-        raise ForwarderNotRequired
 
     @staticmethod
     def _get_event_type(event: Event | GroupEvent) -> EventStreamEventType:

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -1,17 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    Mapping,
-    MutableMapping,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
 
 from confluent_kafka import KafkaError
 from confluent_kafka import Message as KafkaMessage
@@ -22,7 +12,6 @@ from sentry import options
 from sentry.eventstream.base import EventStreamEventType, GroupStates
 from sentry.eventstream.snuba import KW_SKIP_SEMANTIC_PARTITIONING, SnubaProtocolEventStream
 from sentry.killswitches import killswitch_matches_context
-from sentry.post_process_forwarder import PostProcessForwarder, PostProcessForwarderType
 from sentry.utils import json
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
@@ -65,7 +54,6 @@ class KafkaEventStream(SnubaProtocolEventStream):
         skip_consume: bool,
         group_states: Optional[GroupStates] = None,
     ) -> MutableMapping[str, str]:
-
         # HACK: We are putting all this extra information that is required by the
         # post process forwarder into the headers so we can skip parsing entire json
         # messages. The post process forwarder is currently bound to a single core.
@@ -231,25 +219,3 @@ class KafkaEventStream(SnubaProtocolEventStream):
 
     def requires_post_process_forwarder(self) -> bool:
         return True
-
-    def run_post_process_forwarder(
-        self,
-        entity: PostProcessForwarderType,
-        consumer_group: str,
-        topic: Optional[str],
-        commit_log_topic: str,
-        synchronize_commit_group: str,
-        concurrency: int,
-        initial_offset_reset: Union[Literal["latest"], Literal["earliest"]],
-        strict_offset_reset: bool,
-    ) -> None:
-        PostProcessForwarder().run(
-            entity,
-            consumer_group,
-            topic,
-            commit_log_topic,
-            synchronize_commit_group,
-            concurrency,
-            initial_offset_reset,
-            strict_offset_reset,
-        )

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -75,7 +75,6 @@ def kafka_options(
     default_max_batch_size: Optional[int] = None,
     default_max_batch_time_ms: Optional[int] = 1000,
 ):
-
     """
     Basic set of Kafka options for a consumer.
     """
@@ -359,61 +358,6 @@ def cron(**options):
             # without_heartbeat=True,
             **options
         ).run()
-
-
-@run.command("post-process-forwarder")
-@kafka_options("snuba-post-processor", allow_force_cluster=False)
-@strict_offset_reset_option()
-@click.option(
-    "--topic",
-    type=str,
-    help="Main topic with messages for post processing",
-)
-@click.option(
-    "--commit-log-topic",
-    default="snuba-commit-log",
-    help="Topic that the Snuba writer is publishing its committed offsets to.",
-)
-@click.option(
-    "--synchronize-commit-group",
-    default="snuba-consumers",
-    help="Consumer group that the Snuba writer is committing its offset as.",
-)
-@click.option(
-    "--concurrency",
-    default=5,
-    type=int,
-    help="Thread pool size for post process worker.",
-)
-@click.option(
-    "--entity",
-    type=click.Choice(["errors", "transactions", "search_issues"]),
-    help="The type of entity to process (errors, transactions, search_issues).",
-)
-@log_options()
-@configuration
-def post_process_forwarder(**options):
-    from sentry import eventstream
-    from sentry.eventstream.base import ForwarderNotRequired
-
-    try:
-        # TODO(markus): convert to use run_processor_with_signals -- can't yet because there's a custom shutdown handler
-        eventstream.backend.run_post_process_forwarder(
-            entity=options["entity"],
-            consumer_group=options["group_id"],
-            topic=options["topic"],
-            commit_log_topic=options["commit_log_topic"],
-            synchronize_commit_group=options["synchronize_commit_group"],
-            concurrency=options["concurrency"],
-            initial_offset_reset=options["auto_offset_reset"],
-            strict_offset_reset=options["strict_offset_reset"],
-        )
-    except ForwarderNotRequired:
-        sys.stdout.write(
-            "The configured event stream backend does not need a forwarder "
-            "process to enqueue post-process tasks. Exiting...\n"
-        )
-        return
 
 
 @run.command("query-subscription-consumer")


### PR DESCRIPTION
It's been migrated onto the unified consumer in all environments now

