### PR TITLE
fix(starfish): Clicking span description shouldn't reload page

### DIFF
--- a/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
@@ -22,7 +22,6 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import useRouter from 'sentry/utils/useRouter';
 import {TableColumn} from 'sentry/views/discover/table/types';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
@@ -51,7 +50,6 @@ export function ScreenLoadSpansTable({
   const {selection} = usePageFilters();
   const organization = useOrganization();
   const routingContext = useRoutingContext();
-  const router = useRouter();
 
   const searchQuery = new MutableSearch([
     'transaction.op:ui.load',
@@ -118,7 +116,7 @@ export function ScreenLoadSpansTable({
     if (column.key === SPAN_DESCRIPTION) {
       const label = row[SpanMetricsField.SPAN_DESCRIPTION];
 
-      const pathname = `${routingContext.baseURL}/pageload/spans`;
+      const pathname = `${routingContext.baseURL}/pageload/spans/`;
       const query = {
         ...location.query,
         transaction,
@@ -127,15 +125,7 @@ export function ScreenLoadSpansTable({
       };
 
       return (
-        <Link
-          to={`${pathname}?${qs.stringify(query)}`}
-          onClick={() => {
-            router.replace({
-              pathname,
-              query,
-            });
-          }}
-        >
+        <Link to={`${pathname}?${qs.stringify(query)}`}>
           <OverflowEllipsisTextContainer>{label}</OverflowEllipsisTextContainer>
         </Link>
       );


### PR DESCRIPTION
Removing the onClick because I think it's messing with opening the sidebar and causing a page refresh. The sidebar seems to work fine without doing this.

I can revert if it doesn't look like it fixes the issue for other orgs or if it makes the experience worse in some way.