### PR TITLE
fix(issue-platform): allowing extra fields in StackTrace/Frames

### DIFF
--- a/src/sentry/issues/event.schema.json
+++ b/src/sentry/issues/event.schema.json
@@ -1810,7 +1810,7 @@
               ]
             }
           },
-          "additionalProperties": false
+          "additionalProperties": true
         }
       ]
     },

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -260,9 +260,7 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
         message["event"]["timestamp"] = 0000
         self.run_test(message)
 
-    def test_frame_data_valid_with_new_schema(self) -> None:
-        # per https://develop.sentry.dev/sdk/event-payloads/ timestamp can be numeric
-
+    def test_frame_additional_fields_valid_with_new_schema(self) -> None:
         message = deepcopy(get_test_message(self.project.id))
         message["event"]["stacktrace"]["frames"][0]["data"] = {"foo": "bar"}
         self.run_test(message)

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -260,6 +260,13 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
         message["event"]["timestamp"] = 0000
         self.run_test(message)
 
+    def test_frame_data_valid_with_new_schema(self) -> None:
+        # per https://develop.sentry.dev/sdk/event-payloads/ timestamp can be numeric
+
+        message = deepcopy(get_test_message(self.project.id))
+        message["event"]["stacktrace"]["frames"][0]["data"] = {"foo": "bar"}
+        self.run_test(message)
+
     def test_tags_not_required_with_new_schema(self) -> None:
         # per https://develop.sentry.dev/sdk/event-payloads/ tags are optional
         message = deepcopy(get_test_message(self.project.id))


### PR DESCRIPTION
Performance occurrences stack frames are symbolicated add extra fields not expected in SDK. 
This change is making validation less strict, allowing these extra fields. 