### PR TITLE
feat(alerts): Create GitHub Enterprise alert rule action

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -452,6 +452,25 @@ A list of actions that take place when all required conditions and filters for t
 }
 ```
 
+**Create a GitHub Enterprise Issue**
+- `integration` - The integration ID associated with GitHub Enterprise.
+- `repo` - The name of the repository to create the issue in.
+- `title` - The title of the issue.
+- `body` (optional) - The contents of the issue.
+- `assignee` (optional) - The GitHub user to assign the issue to.
+- `labels` (optional) - A list of labels to assign to the issue.
+```json
+{
+    "id": "sentry.integrations.github_enterprise.notify_action.GitHubEnterpriseCreateTicketAction",
+    "integration": 93749,
+    "repo": default,
+    "title": "My Test Issue",
+    "assignee": "Baxter the Hacker",
+    "labels": ["bug", "p1"]
+    ""
+}
+```
+
 **Create an Azure DevOps work item**
 - `integration` - The integration ID.
 - `project` - The ID of the Azure DevOps project.

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -298,6 +298,7 @@ TICKET_ACTIONS = frozenset(
         "sentry.integrations.jira_server.notify_action.JiraServerCreateTicketAction",
         "sentry.integrations.vsts.notify_action.AzureDevopsCreateTicketAction",
         "sentry.integrations.github.notify_action.GitHubCreateTicketAction",
+        "sentry.integrations.github_enterprise.notify_action.GitHubEnterpriseCreateTicketAction",
     ]
 )
 

--- a/src/sentry/integrations/github/actions/__init__.py
+++ b/src/sentry/integrations/github/actions/__init__.py
@@ -1,0 +1,3 @@
+from .create_ticket import GitHubCreateTicketAction
+
+__all__ = ("GitHubCreateTicketAction",)

--- a/src/sentry/integrations/github_enterprise/__init__.py
+++ b/src/sentry/integrations/github_enterprise/__init__.py
@@ -1,5 +1,11 @@
+from sentry.rules import rules
+
+from .actions.create_ticket import *  # noqa: F401,F403
+from .actions.create_ticket import GitHubEnterpriseCreateTicketAction
 from .client import *  # noqa: F401,F403
 from .integration import *  # noqa: F401,F403
 from .repository import *  # noqa: F401,F403
 from .urls import *  # noqa: F401,F403
 from .webhook import *  # noqa: F401,F403
+
+rules.add(GitHubEnterpriseCreateTicketAction)

--- a/src/sentry/integrations/github_enterprise/__init__.py
+++ b/src/sentry/integrations/github_enterprise/__init__.py
@@ -1,3 +1,4 @@
+from sentry import options
 from sentry.rules import rules
 
 from .actions.create_ticket import *  # noqa: F401,F403
@@ -8,4 +9,5 @@ from .repository import *  # noqa: F401,F403
 from .urls import *  # noqa: F401,F403
 from .webhook import *  # noqa: F401,F403
 
-rules.add(GitHubEnterpriseCreateTicketAction)
+if options.get("github-enterprise-app.alert-rule-action"):
+    rules.add(GitHubEnterpriseCreateTicketAction)

--- a/src/sentry/integrations/github_enterprise/actions/__init__.py
+++ b/src/sentry/integrations/github_enterprise/actions/__init__.py
@@ -1,0 +1,3 @@
+from .create_ticket import GitHubEnterpriseCreateTicketAction
+
+__all__ = ("GitHubEnterpriseCreateTicketAction",)

--- a/src/sentry/integrations/github_enterprise/actions/create_ticket.py
+++ b/src/sentry/integrations/github_enterprise/actions/create_ticket.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from sentry.rules.actions import TicketEventAction
+from sentry.utils.http import absolute_uri
+
+
+class GitHubEnterpriseCreateTicketAction(TicketEventAction):
+    id = "sentry.integrations.github_enterprise.notify_action.GitHubEnterpriseCreateTicketAction"
+    label = "Create a GitHub Enterprise issue in {integration} with these "
+    ticket_type = "a GitHub Enterprise issue"
+    # TODO(schew2381): Add link to docs once GitHub issue sync is available
+    link = None
+    provider = "github_enterprise"
+
+    def generate_footer(self, rule_url: str) -> str:
+        return "\nThis issue was automatically created by Sentry via [{}]({})".format(
+            self.rule.label,
+            absolute_uri(rule_url),
+        )

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -73,6 +73,12 @@ FEATURES = [
         """,
         IntegrationFeatures.CODEOWNERS,
     ),
+    FeatureDescription(
+        """
+        Automatically create GitHub issues based on Issue Alert conditions.
+        """,
+        IntegrationFeatures.TICKET_RULES,
+    ),
 ]
 
 

--- a/src/sentry/rules/registry.py
+++ b/src/sentry/rules/registry.py
@@ -11,7 +11,7 @@ class RuleRegistry:
         self._rules: dict[str, list[type[RuleBase]]] = defaultdict(list)
         self._map: dict[str, type[RuleBase]] = {}
 
-    def __contains__(self, rule_id: int) -> bool:
+    def __contains__(self, rule_id: str) -> bool:
         return rule_id in self._map
 
     def __iter__(self) -> Generator[tuple[str, type[RuleBase]], None, None]:

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -1,6 +1,8 @@
 from unittest.mock import Mock, patch
 
 from sentry.constants import TICKET_ACTIONS
+from sentry.integrations.github_enterprise import GitHubEnterpriseCreateTicketAction
+from sentry.rules import rules as default_rules
 from sentry.rules.filters.issue_category import IssueCategoryFilter
 from sentry.rules.registry import RuleRegistry
 from sentry.testutils.cases import APITestCase
@@ -8,6 +10,11 @@ from sentry.testutils.cases import APITestCase
 EMAIL_ACTION = "sentry.mail.actions.NotifyEmailAction"
 APP_ACTION = "sentry.rules.actions.notify_event_service.NotifyEventServiceAction"
 SENTRY_APP_ALERT_ACTION = "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"
+
+# Adding GitHub Enterprise ticket action is protected by an option, and we
+# cannot override the option before importing it in the test so we need to
+# manually add it here.
+default_rules.add(GitHubEnterpriseCreateTicketAction)
 
 
 class ProjectRuleConfigurationTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -23,7 +23,7 @@ class ProjectRuleConfigurationTest(APITestCase):
         self.create_project(teams=[team], name="baz")
 
         response = self.get_success_response(self.organization.slug, project1.slug)
-        assert len(response.data["actions"]) == 11
+        assert len(response.data["actions"]) == 12
         assert len(response.data["conditions"]) == 7
         assert len(response.data["filters"]) == 8
 
@@ -129,7 +129,7 @@ class ProjectRuleConfigurationTest(APITestCase):
 
         response = self.get_success_response(self.organization.slug, project1.slug)
 
-        assert len(response.data["actions"]) == 12
+        assert len(response.data["actions"]) == 13
         assert {
             "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
             "label": "Send a notification via {service}",
@@ -159,7 +159,7 @@ class ProjectRuleConfigurationTest(APITestCase):
         )
         response = self.get_success_response(self.organization.slug, project1.slug)
 
-        assert len(response.data["actions"]) == 12
+        assert len(response.data["actions"]) == 13
         assert {
             "id": SENTRY_APP_ALERT_ACTION,
             "service": sentry_app.slug,
@@ -175,7 +175,7 @@ class ProjectRuleConfigurationTest(APITestCase):
 
     def test_issue_type_and_category_filter_feature(self):
         response = self.get_success_response(self.organization.slug, self.project.slug)
-        assert len(response.data["actions"]) == 11
+        assert len(response.data["actions"]) == 12
         assert len(response.data["conditions"]) == 7
         assert len(response.data["filters"]) == 8
 

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -14,7 +14,8 @@ SENTRY_APP_ALERT_ACTION = "sentry.rules.actions.notify_event_sentry_app.NotifyEv
 # Adding GitHub Enterprise ticket action is protected by an option, and we
 # cannot override the option before importing it in the test so we need to
 # manually add it here.
-default_rules.add(GitHubEnterpriseCreateTicketAction)
+if GitHubEnterpriseCreateTicketAction not in default_rules:
+    default_rules.add(GitHubEnterpriseCreateTicketAction)
 
 
 class ProjectRuleConfigurationTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -14,7 +14,7 @@ SENTRY_APP_ALERT_ACTION = "sentry.rules.actions.notify_event_sentry_app.NotifyEv
 # Adding GitHub Enterprise ticket action is protected by an option, and we
 # cannot override the option before importing it in the test so we need to
 # manually add it here.
-if GitHubEnterpriseCreateTicketAction not in default_rules:
+if GitHubEnterpriseCreateTicketAction.id not in default_rules:
     default_rules.add(GitHubEnterpriseCreateTicketAction)
 
 

--- a/tests/sentry/integrations/github_enterprise/test_ticket_action.py
+++ b/tests/sentry/integrations/github_enterprise/test_ticket_action.py
@@ -1,0 +1,193 @@
+from unittest.mock import patch
+
+import pytest
+import responses
+from django.urls import reverse
+from rest_framework.test import APITestCase as BaseAPITestCase
+
+from sentry.eventstore.models import Event
+from sentry.integrations.github.integration import GitHubIntegration
+from sentry.integrations.github_enterprise import GitHubEnterpriseCreateTicketAction, client
+from sentry.models.integrations.external_issue import ExternalIssue
+from sentry.models.rule import Rule
+from sentry.testutils.cases import RuleTestCase
+from sentry.testutils.skips import requires_snuba
+from sentry.types.rules import RuleFuture
+
+pytestmark = [requires_snuba]
+
+
+class GitHubEnterpriseEnterpriseTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
+    rule_cls = GitHubEnterpriseCreateTicketAction
+    repo = "foo/bar"
+    assignee = "sentry_user"
+    labels = ["bug", "invalid"]
+    issue_num = 1
+
+    def setUp(self):
+        super().setUp()
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github_enterprise",
+            name="Github Enterprise",
+            external_id="1",
+            metadata={
+                "domain_name": "github.example.com",
+                "installation": {
+                    "private_key": "fake key",
+                    "id": 1,
+                    "verify_ssl": True,
+                },
+                "installation_id": 1234,
+            },
+        )
+
+        self.installation: GitHubIntegration = self.integration.get_installation(self.organization.id)  # type: ignore[assignment]
+
+        self.login_as(user=self.user)
+        responses.add(
+            method=responses.POST,
+            url="https://github.example.com/api/v3/app/installations/1234/access_tokens",
+            body='{"token": "12345token", "expires_at": "2099-01-01T00:00:00Z"}',
+            status=200,
+            content_type="application/json",
+        )
+
+    @pytest.fixture(autouse=True)
+    def stub_get_jwt(self):
+        with patch.object(client, "get_jwt", return_value="jwt_token_1"):
+            yield
+
+    def trigger(self, event, rule_object):
+        action = rule_object.data.get("actions", ())[0]
+        action_inst = self.get_rule(data=action, rule=rule_object)
+        results = list(action_inst.after(event=event, state=self.get_state()))
+        assert len(results) == 1
+
+        rule_future = RuleFuture(rule=rule_object, kwargs=results[0].kwargs)
+        return results[0].callback(event, futures=[rule_future])
+
+    def get_key(self, event: Event):
+        return ExternalIssue.objects.get_linked_issues(event, self.integration).values_list(
+            "key", flat=True
+        )[0]
+
+    @responses.activate()
+    def test_ticket_rules(self):
+        title = "sample title"
+        sample_description = "sample bug report"
+        html_url = f"https://github.example.com/api/v3/foo/bar/issues/{self.issue_num}"
+
+        responses.add(
+            method=responses.POST,
+            url="https://github.example.com/api/v3/repos/foo/bar/issues",
+            json={
+                "number": self.issue_num,
+                "title": title,
+                "body": sample_description,
+                "html_url": html_url,
+            },
+            status=200,
+        )
+        responses.add(
+            method=responses.GET,
+            url=f"https://github.example.com/api/v3/repos/foo/bar/issues/{self.issue_num}",
+            json={
+                "number": "1",
+                "title": title,
+                "body": sample_description,
+                "html_url": html_url,
+            },
+            status=200,
+        )
+
+        # Create a new Rule
+        response = self.client.post(
+            reverse(
+                "sentry-api-0-project-rules",
+                kwargs={
+                    "organization_slug": self.organization.slug,
+                    "project_slug": self.project.slug,
+                },
+            ),
+            format="json",
+            data={
+                "name": "hello world",
+                "owner": self.user.id,
+                "environment": None,
+                "actionMatch": "any",
+                "frequency": 5,
+                "actions": [
+                    {
+                        "id": "sentry.integrations.github_enterprise.notify_action.GitHubEnterpriseCreateTicketAction",
+                        "integration": self.integration.id,
+                        "dynamic_form_fields": [{"random": "garbage"}],
+                        "repo": self.repo,
+                        "assignee": self.assignee,
+                        "labels": self.labels,
+                    }
+                ],
+                "conditions": [],
+            },
+        )
+        assert response.status_code == 200
+
+        # Get the rule from DB
+        rule_object = Rule.objects.get(id=response.data["id"])
+        event = self.get_event()
+
+        # Trigger its `after`
+        self.trigger(event, rule_object)
+
+        # assert ticket created in DB
+        key = self.get_key(event)
+        external_issue_count = len(ExternalIssue.objects.filter(key=key))
+        assert external_issue_count == 1
+
+        # assert ticket created in GitHub Enterprise
+        data = self.installation.get_issue(
+            key, data={"repo": self.repo, "externalIssue": self.issue_num}
+        )
+        assert sample_description in data["description"]
+
+        # Trigger its `after` _again_
+        self.trigger(event, rule_object)
+
+        # assert new ticket NOT created in DB
+        assert ExternalIssue.objects.count() == external_issue_count
+
+    @responses.activate()
+    def test_fails_validation(self):
+        """
+        Test that the absence of dynamic_form_fields in the action fails validation
+        """
+        # Create a new Rule
+        response = self.client.post(
+            reverse(
+                "sentry-api-0-project-rules",
+                kwargs={
+                    "organization_slug": self.organization.slug,
+                    "project_slug": self.project.slug,
+                },
+            ),
+            format="json",
+            data={
+                "name": "hello world",
+                "owner": self.user.id,
+                "environment": None,
+                "actionMatch": "any",
+                "frequency": 5,
+                "actions": [
+                    {
+                        "id": "sentry.integrations.github_enterprise.notify_action.GitHubEnterpriseCreateTicketAction",
+                        "integration": self.integration.id,
+                        "repo": self.repo,
+                        "assignee": self.assignee,
+                        "labels": self.labels,
+                    }
+                ],
+                "conditions": [],
+            },
+        )
+        assert response.status_code == 400
+        assert response.data["actions"][0] == "Must configure issue link settings."

--- a/tests/sentry/integrations/github_enterprise/test_ticket_action.py
+++ b/tests/sentry/integrations/github_enterprise/test_ticket_action.py
@@ -10,11 +10,17 @@ from sentry.integrations.github.integration import GitHubIntegration
 from sentry.integrations.github_enterprise import GitHubEnterpriseCreateTicketAction, client
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.rule import Rule
+from sentry.rules import rules
 from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.skips import requires_snuba
 from sentry.types.rules import RuleFuture
 
 pytestmark = [requires_snuba]
+
+# Adding GitHub Enterprise ticket action is protected by an option, and we
+# cannot override the option before importing it in the test so we need to
+# manually add it here.
+rules.add(GitHubEnterpriseCreateTicketAction)
 
 
 class GitHubEnterpriseEnterpriseTicketRulesTestCase(RuleTestCase, BaseAPITestCase):

--- a/tests/sentry/integrations/github_enterprise/test_ticket_action.py
+++ b/tests/sentry/integrations/github_enterprise/test_ticket_action.py
@@ -20,7 +20,8 @@ pytestmark = [requires_snuba]
 # Adding GitHub Enterprise ticket action is protected by an option, and we
 # cannot override the option before importing it in the test so we need to
 # manually add it here.
-rules.add(GitHubEnterpriseCreateTicketAction)
+if GitHubEnterpriseCreateTicketAction not in rules:
+    rules.add(GitHubEnterpriseCreateTicketAction)
 
 
 class GitHubEnterpriseEnterpriseTicketRulesTestCase(RuleTestCase, BaseAPITestCase):

--- a/tests/sentry/integrations/github_enterprise/test_ticket_action.py
+++ b/tests/sentry/integrations/github_enterprise/test_ticket_action.py
@@ -20,7 +20,7 @@ pytestmark = [requires_snuba]
 # Adding GitHub Enterprise ticket action is protected by an option, and we
 # cannot override the option before importing it in the test so we need to
 # manually add it here.
-if GitHubEnterpriseCreateTicketAction not in rules:
+if GitHubEnterpriseCreateTicketAction.id not in rules:
     rules.add(GitHubEnterpriseCreateTicketAction)
 
 


### PR DESCRIPTION
Followup to https://github.com/getsentry/sentry/pull/58175

Create an alert rule action to create an Issue on GitHub Enterprise, matching the GitHub alert rule action