### PR TITLE
ref(replays): add wrapping to feedback item header actions

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -58,7 +58,7 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
   return (
     <Fragment>
       <HeaderPanelItem>
-        <Flex gap={space(2)} justify="space-between">
+        <Flex gap={space(2)} justify="space-between" wrap="wrap">
           <Flex column>
             <Flex align="center" gap={space(0.5)}>
               <FeedbackItemUsername feedbackIssue={feedbackItem} detailDisplay />
@@ -70,18 +70,16 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
                 />
               ) : null}
             </Flex>
-            <Flex gap={space(1)}>
-              <Flex align="center" gap={space(0.5)}>
-                <ProjectAvatar
-                  project={feedbackItem.project}
-                  size={12}
-                  title={feedbackItem.project.slug}
-                />
-                {feedbackItem.project.slug}
-              </Flex>
+            <Flex gap={space(0.5)} align="center">
+              <ProjectAvatar
+                project={feedbackItem.project}
+                size={12}
+                title={feedbackItem.project.slug}
+              />
+              {feedbackItem.project.slug}
             </Flex>
           </Flex>
-          <Flex gap={space(1)} align="center">
+          <Flex gap={space(1)} align="center" wrap="wrap">
             <ErrorBoundary mini>
               <FeedbackAssignedTo
                 feedbackIssue={feedbackItem}

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -8,7 +8,6 @@ import {
 } from 'sentry/actionCreators/indicator';
 import Button from 'sentry/components/actions/button';
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
-import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackAssignedTo from 'sentry/components/feedback/feedbackItem/feedbackAssignedTo';
 import Section from 'sentry/components/feedback/feedbackItem/feedbackItemSection';
@@ -62,13 +61,6 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
           <Flex column>
             <Flex align="center" gap={space(0.5)}>
               <FeedbackItemUsername feedbackIssue={feedbackItem} detailDisplay />
-              {feedbackItem.metadata.contact_email ? (
-                <CopyToClipboardButton
-                  size="xs"
-                  iconSize="xs"
-                  text={feedbackItem.metadata.contact_email}
-                />
-              ) : null}
             </Flex>
             <Flex gap={space(0.5)} align="center">
               <ProjectAvatar

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -20,7 +20,7 @@ export default function FeedbackItemUsername({feedbackIssue, detailDisplay}: Pro
 
   if (detailDisplay) {
     return (
-      <Flex wrap="wrap" align="center" padding-bottom="3px">
+      <Flex wrap="wrap" align="center">
         <strong>
           {name ?? t('No Name')}
           <Purple>•</Purple>

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Flex} from 'sentry/components/profiling/flex';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -25,7 +26,10 @@ export default function FeedbackItemUsername({feedbackIssue, detailDisplay}: Pro
           {name ?? t('No Name')}
           <Purple>•</Purple>
         </strong>
-        <strong>{email ?? t('No Email')}</strong>
+        <Flex align="center" gap={space(1)}>
+          <strong>{email ?? t('No Email')}</strong>
+          {email ? <CopyToClipboardButton size="xs" iconSize="xs" text={email} /> : null}
+        </Flex>
       </Flex>
     );
   }

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {Flex} from 'sentry/components/profiling/flex';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
@@ -19,11 +20,13 @@ export default function FeedbackItemUsername({feedbackIssue, detailDisplay}: Pro
 
   if (detailDisplay) {
     return (
-      <strong>
-        {name ?? t('No Name')}
-        <Purple>•</Purple>
-        {email ?? t('No Email')}
-      </strong>
+      <Flex wrap="wrap" align="center" padding-bottom="3px">
+        <strong>
+          {name ?? t('No Name')}
+          <Purple>•</Purple>
+        </strong>
+        <strong>{email ?? t('No Email')}</strong>
+      </Flex>
     );
   }
 


### PR DESCRIPTION

sometimes the header gets crowded (e.g. email is too long or screen size is narrow etc) so let's wrap the actions to the next line when it becomes too long

https://github.com/getsentry/sentry/assets/56095982/24c87500-0f5c-4b46-b593-b6a7c6637b6b

