### PR TITLE
fix(feedback): allow feedback in project config

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -60,6 +60,7 @@ EXPOSABLE_FEATURES = [
     "organizations:transaction-name-normalize",
     "organizations:profiling",
     "organizations:session-replay",
+    "organizations:user-feedback-ingest",
     "organizations:session-replay-recording-scrubbing",
     "organizations:device-class-synthesis",
     "organizations:custom-metrics",
@@ -467,7 +468,7 @@ class _ConfigBase:
     def __init__(self, **kwargs: Any) -> None:
         data: MutableMapping[str, Any] = {}
         object.__setattr__(self, "data", data)
-        for (key, val) in kwargs.items():
+        for key, val in kwargs.items():
             if val is not None:
                 data[key] = val
 


### PR DESCRIPTION
allow the `"organizations:user-feedback-ingest"` flag to be exposed in project configs that are used by relay.

Used here in relay https://github.com/getsentry/relay/blob/efe98703b8191df057a20da32294c91163e877fa/relay-dynamic-config/src/feature.rs#L17