### PR TITLE
Revert "debug(crons): Add kwargs to mark_checkin_timeout"

### DIFF
--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -338,15 +338,7 @@ def check_timeout(current_datetime: datetime):
     metrics.gauge("sentry.monitors.tasks.check_timeout.count", qs.count(), sample_rate=1)
     # check for any monitors which are still running and have exceeded their maximum runtime
     for checkin in qs:
-        # used for temporary debugging
-        kwargs = {
-            "monitor_id": checkin.monitor.id,
-            "monitor_environment_id": checkin.monitor_environment.id,
-            "status": checkin.status,
-            "date_added": checkin.date_added,
-            "timeout_at": checkin.timeout_at,
-        }
-        mark_checkin_timeout.delay(checkin.id, current_datetime, **kwargs)
+        mark_checkin_timeout.delay(checkin.id, current_datetime)
 
 
 @instrumented_task(

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -62,16 +62,6 @@ def make_ref_time(**kwargs):
     return task_run_ts, sub_task_run_ts, trimmed_ts
 
 
-def get_checkin_timeout_kwargs(checkin: MonitorCheckIn):
-    return {
-        "monitor_id": checkin.monitor.id,
-        "monitor_environment_id": checkin.monitor_environment.id,
-        "status": checkin.status,
-        "date_added": checkin.date_added,
-        "timeout_at": checkin.timeout_at,
-    }
-
-
 class MonitorTaskCheckMissingTest(TestCase):
     @mock.patch("sentry.monitors.tasks.mark_environment_missing")
     def test_missing_checkin(self, mark_environment_missing_mock):
@@ -662,18 +652,15 @@ class MonitorTaskCheckTimeoutTest(TestCase):
         assert mark_checkin_timeout_mock.delay.call_count == 0
 
         # Timout at 12:30
-        checkin_kwargs = get_checkin_timeout_kwargs(checkin)
         check_timeout(task_run_ts + timedelta(minutes=30))
         assert mark_checkin_timeout_mock.delay.call_count == 1
         assert mark_checkin_timeout_mock.delay.mock_calls[0] == mock.call(
             checkin.id,
             sub_task_run_ts + timedelta(minutes=30),
-            **checkin_kwargs,
         )
         mark_checkin_timeout(
             checkin.id,
             sub_task_run_ts + timedelta(minutes=30),
-            **checkin_kwargs,
         )
 
         # Check in is marked as timed out
@@ -757,19 +744,16 @@ class MonitorTaskCheckTimeoutTest(TestCase):
         assert mark_checkin_timeout_mock.delay.call_count == 0
 
         # First checkin timed out
-        checkin_kwargs = get_checkin_timeout_kwargs(checkin1)
         check_timeout(task_run_ts + timedelta(minutes=30))
         assert mark_checkin_timeout_mock.delay.call_count == 1
         assert mark_checkin_timeout_mock.delay.mock_calls[0] == mock.call(
             checkin1.id,
             sub_task_run_ts + timedelta(minutes=30),
-            **checkin_kwargs,
         )
 
         mark_checkin_timeout(
             checkin1.id,
             sub_task_run_ts + timedelta(minutes=30),
-            **checkin_kwargs,
         )
 
         # First checkin is marked as timed out
@@ -835,15 +819,13 @@ class MonitorTaskCheckTimeoutTest(TestCase):
         )
 
         # Check in was marked as timed out
-        checkin_kwargs = get_checkin_timeout_kwargs(checkin)
         check_timeout(task_run_ts)
         assert mark_checkin_timeout_mock.delay.call_count == 1
         assert mark_checkin_timeout_mock.delay.mock_calls[0] == mock.call(
             checkin.id,
             sub_task_run_ts,
-            **checkin_kwargs,
         )
-        mark_checkin_timeout(checkin.id, sub_task_run_ts, **checkin_kwargs)
+        mark_checkin_timeout(checkin.id, sub_task_run_ts)
 
         # First checkin is marked as timed out
         assert MonitorCheckIn.objects.filter(id=checkin.id, status=CheckInStatus.TIMEOUT).exists()
@@ -897,18 +879,15 @@ class MonitorTaskCheckTimeoutTest(TestCase):
         )
 
         # Timout at 12:05
-        checkin_kwargs = get_checkin_timeout_kwargs(checkin)
         check_timeout(task_run_ts + timedelta(minutes=5))
         assert mark_checkin_timeout_mock.delay.call_count == 1
         assert mark_checkin_timeout_mock.delay.mock_calls[0] == mock.call(
             checkin.id,
             sub_task_run_ts + timedelta(minutes=5),
-            **checkin_kwargs,
         )
         mark_checkin_timeout(
             checkin.id,
             sub_task_run_ts + timedelta(minutes=5),
-            **checkin_kwargs,
         )
 
         # Check in is marked as timed out
@@ -979,7 +958,6 @@ class MonitorTaskCheckTimeoutTest(TestCase):
 
         # Running check monitor will mark the first checkin as timed out. The
         # second checkin was already marked as OK.
-        checkin_kwargs = get_checkin_timeout_kwargs(checkin1)
         check_timeout(task_run_ts)
 
         # assert that task is called for the specific checkin
@@ -987,10 +965,9 @@ class MonitorTaskCheckTimeoutTest(TestCase):
         assert mark_checkin_timeout_mock.delay.mock_calls[0] == mock.call(
             checkin1.id,
             sub_task_run_ts,
-            **checkin_kwargs,
         )
 
-        mark_checkin_timeout(checkin1.id, sub_task_run_ts, **checkin_kwargs)
+        mark_checkin_timeout(checkin1.id, sub_task_run_ts)
 
         # The first checkin is marked as timed out
         assert MonitorCheckIn.objects.filter(id=checkin1.id, status=CheckInStatus.TIMEOUT).exists()


### PR DESCRIPTION
This reverts commit 0315c29bd42505a3ccd01abc8bdeba8639b89f70.

Not needed anymore as we have a handle on the bug.
