### PR TITLE
ref(overlay): Add min width modifier

### DIFF
--- a/static/app/components/compactSelect/control.tsx
+++ b/static/app/components/compactSelect/control.tsx
@@ -12,7 +12,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
 import {useKeyboard} from '@react-aria/interactions';
-import {mergeProps, useResizeObserver} from '@react-aria/utils';
+import {mergeProps} from '@react-aria/utils';
 import {ListState} from '@react-stately/list';
 import {OverlayTriggerState} from '@react-stately/overlays';
 
@@ -149,11 +149,6 @@ export interface ControlProps
    * Title to display in the menu's header. Keep the title as short as possible.
    */
   menuTitle?: React.ReactNode;
-  /**
-   * Whether the menu should always be wider than the trigger. If true, then the menu
-   * will have a min width equal to the trigger's width. Defaults to false.
-   */
-  menuWiderThanTrigger?: boolean;
   menuWidth?: number | string;
   /**
    * Called when the clear button is clicked (applicable only when `clearable` is
@@ -219,7 +214,6 @@ export function Control({
   maxMenuHeight = '32rem',
   maxMenuWidth,
   menuWidth,
-  menuWiderThanTrigger = false,
   menuHeaderTrailingItems,
   menuBody,
   menuFooter,
@@ -458,35 +452,6 @@ export function Control({
     [registerListState, saveSelectedOptions, overlayState, overlayIsOpen, search]
   );
 
-  // Calculate the current trigger element's width. This will be used as
-  // the min width for the menu.
-  const [triggerWidth, setTriggerWidth] = useState<number>();
-  // Update triggerWidth when its size changes using useResizeObserver
-  const updateTriggerWidth = useCallback(async () => {
-    if (!menuWiderThanTrigger) {
-      return;
-    }
-
-    // Wait until the trigger element finishes rendering, otherwise
-    // ResizeObserver might throw an infinite loop error.
-    await new Promise(resolve => window.setTimeout(resolve));
-    setTriggerWidth(triggerRef.current?.offsetWidth ?? 0);
-  }, [menuWiderThanTrigger, triggerRef]);
-
-  useResizeObserver({
-    // Passing undefined disables ResizeObserver
-    ref: menuWiderThanTrigger ? triggerRef : undefined,
-    onResize: updateTriggerWidth,
-  });
-  // If ResizeObserver is not available, manually update the width
-  // when any of [trigger, triggerLabel, triggerProps] changes.
-  useEffect(() => {
-    if (typeof window.ResizeObserver !== 'undefined') {
-      return;
-    }
-    updateTriggerWidth();
-  }, [updateTriggerWidth]);
-
   const theme = useTheme();
   return (
     <SelectContext.Provider value={contextValue}>
@@ -510,7 +475,7 @@ export function Control({
         >
           <StyledOverlay
             width={menuWidth ?? menuFullWidth}
-            minWidth={triggerWidth}
+            minWidth={overlayProps.style.minWidth}
             maxWidth={maxMenuWidth}
             maxHeight={overlayProps.style.maxHeight}
             maxHeightProp={maxMenuHeight}

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -1,9 +1,8 @@
-import {useCallback, useContext, useEffect, useMemo, useState} from 'react';
+import {useContext, useMemo} from 'react';
 import {createPortal} from 'react-dom';
 import styled from '@emotion/styled';
 import {useButton} from '@react-aria/button';
 import {useMenuTrigger} from '@react-aria/menu';
-import {useResizeObserver} from '@react-aria/utils';
 import {Item, Section} from '@react-stately/collections';
 
 import DropdownButton, {DropdownButtonProps} from 'sentry/components/dropdownButton';
@@ -82,15 +81,6 @@ interface DropdownMenuProps
    */
   menuTitle?: React.ReactChild;
   /**
-   * Whether the menu should always be wider than the trigger. If true (default), then
-   * the menu will have a min width equal to the trigger's width.
-   */
-  menuWiderThanTrigger?: boolean;
-  /**
-   * Minimum menu width, in pixels
-   */
-  minMenuWidth?: number;
-  /**
    * Tag name for the outer wrap, defaults to `div`
    */
   renderWrapAs?: React.ElementType;
@@ -140,8 +130,6 @@ function DropdownMenu({
   triggerProps = {},
   isDisabled: disabledProp,
   isOpen: isOpenProp,
-  minMenuWidth,
-  menuWiderThanTrigger = true,
   renderWrapAs = 'div',
   size = 'md',
   className,
@@ -194,35 +182,6 @@ function DropdownMenu({
     triggerRef
   );
 
-  // Calculate the current trigger element's width. This will be used as
-  // the min width for the menu.
-  const [triggerWidth, setTriggerWidth] = useState<number>();
-  // Update triggerWidth when its size changes using useResizeObserver
-  const updateTriggerWidth = useCallback(async () => {
-    if (!menuWiderThanTrigger) {
-      return;
-    }
-
-    // Wait until the trigger element finishes rendering, otherwise
-    // ResizeObserver might throw an infinite loop error.
-    await new Promise(resolve => window.setTimeout(resolve));
-    setTriggerWidth(triggerRef.current?.offsetWidth ?? 0);
-  }, [menuWiderThanTrigger, triggerRef]);
-
-  useResizeObserver({
-    // Passing undefined disables ResizeObserver
-    ref: menuWiderThanTrigger ? triggerRef : undefined,
-    onResize: updateTriggerWidth,
-  });
-  // If ResizeObserver is not available, manually update the width
-  // when any of [trigger, triggerLabel, triggerProps] changes.
-  useEffect(() => {
-    if (typeof window.ResizeObserver !== 'undefined') {
-      return;
-    }
-    updateTriggerWidth();
-  }, [updateTriggerWidth]);
-
   function renderTrigger() {
     if (trigger) {
       return trigger({...overlayTriggerProps, ...buttonProps}, isOpen);
@@ -253,7 +212,6 @@ function DropdownMenu({
         {...props}
         {...menuProps}
         size={size}
-        minWidth={Math.max(minMenuWidth ?? 0, triggerWidth ?? 0)}
         disabledKeys={disabledKeys ?? defaultDisabledKeys}
         overlayPositionProps={overlayProps}
         overlayState={overlayState}

--- a/static/app/components/dropdownMenu/list.tsx
+++ b/static/app/components/dropdownMenu/list.tsx
@@ -61,14 +61,14 @@ export interface DropdownMenuListProps
   /**
    * Minimum menu width
    */
-  minWidth?: number;
+  minMenuWidth?: number;
   size?: MenuItemProps['size'];
 }
 
 function DropdownMenuList({
   closeOnSelect = true,
   onClose,
-  minWidth,
+  minMenuWidth,
   size,
   menuTitle,
   overlayState,
@@ -180,7 +180,6 @@ function DropdownMenuList({
         onClose={onClose}
         closeOnSelect={closeOnSelect}
         menuTitle={node.value.submenuTitle}
-        menuWiderThanTrigger={false}
         isDismissable={false}
         shouldCloseOnBlur={false}
         shouldCloseOnInteractOutside={() => false}
@@ -242,7 +241,7 @@ function DropdownMenuList({
               {...mergeProps(modifiedMenuProps, keyboardProps)}
               style={{
                 maxHeight: overlayPositionProps.style?.maxHeight,
-                minWidth,
+                minWidth: minMenuWidth ?? overlayPositionProps.style?.minWidth,
               }}
             >
               {renderCollection(stateCollection)}

--- a/static/app/components/pageTimeRangeSelector.tsx
+++ b/static/app/components/pageTimeRangeSelector.tsx
@@ -16,7 +16,6 @@ function PageTimeRangeSelector(props: PageTimeRangeSelectorProps) {
           ? props.relativeOptions[props.relative]
           : null
       }
-      menuWiderThanTrigger
       {...props}
     />
   );

--- a/static/app/utils/useOverlay.tsx
+++ b/static/app/utils/useOverlay.tsx
@@ -74,6 +74,16 @@ const applyMaxSize: Modifier<'applyMaxSize', {}> = {
   },
 };
 
+const applyMinWidth: Modifier<'applyMinWidth', {}> = {
+  name: 'applyMinWidth',
+  phase: 'beforeWrite',
+  enabled: false, // will be enabled when overlay is open
+  fn({state}) {
+    const {reference} = state.rects;
+    state.styles.popper.minWidth = `${reference.width}px`;
+  },
+};
+
 export interface UseOverlayProps
   extends Partial<AriaOverlayProps>,
     Partial<OverlayTriggerProps>,
@@ -201,6 +211,10 @@ function useOverlay({
           padding: 16,
           ...preventOverflowOptions,
         },
+      },
+      {
+        ...applyMinWidth,
+        enabled: openState.isOpen,
       },
       {
         ...applyMaxSize,

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -272,7 +272,6 @@ class CellAction extends Component<Props, State> {
                 'left-end',
               ],
             }}
-            menuWiderThanTrigger={false}
             trigger={triggerProps => (
               <ActionMenuTrigger
                 {...triggerProps}


### PR DESCRIPTION
Add an `applyMinWidth` PopperJS modifier to `useOverlay()` to set the overlay element's minimum width equal to the trigger element's width:
<img width="446" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/7ac44027-f63f-4d65-95e5-7b0b27be0350">

This replaces the manual width computations in `CompactSelect` and `DropdownMenu` (see `updateTriggerWidth()`), which cause expensive computations on mount:
<img width="1074" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/e95f028f-97d2-41b5-a1c7-d9ba759fc3df">
This is a notable problem in pages with a lot of dropdown menus or selectors, e.g. Discover Home.

With the new modifier, the min width is set _when the overlay opens_ (not when the component mounts) as part of the [PopperJS modifier lifecycle](https://popper.js.org/docs/v2/modifiers/#phase). PopperJS modifiers have access to cached versions of the trigger and overlay element's widths, so there's no extra size computation:
<img width="1351" alt="image" src="https://github.com/getsentry/sentry/assets/44172267/a2ae22d5-ec8f-418c-b755-bb8d891fb66a">

