### PR TITLE
feat(suspect-commits): Add suspect commit calculation type to frontend analytics

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -112,8 +112,13 @@ export type TeamInsightsEventParameters = {
   };
   'issue_details.suspect_commits.commit_clicked': IssueDetailsWithAlert & {
     has_pull_request: boolean;
+    suspect_commit_calculation: string;
+    suspect_commit_index: number;
   };
-  'issue_details.suspect_commits.pull_request_clicked': IssueDetailsWithAlert;
+  'issue_details.suspect_commits.pull_request_clicked': IssueDetailsWithAlert & {
+    suspect_commit_calculation: string;
+    suspect_commit_index: number;
+  };
   'issue_details.tab_changed': IssueDetailsWithAlert & {
     tab: Tab;
   };

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -621,6 +621,9 @@ function useTrackView({
     trace_status: 'none',
     // Will be updated in GroupDetailsHeader if there are replays
     group_has_replay: false,
+    // Will be updated in EventCause if there are suspect commits
+    num_suspect_commits: -1,
+    suspect_commit_calculation: 'none',
   });
   useDisableRouteAnalytics(!group || !event || !project);
 }


### PR DESCRIPTION
- Remove `loading` from the analytics, don't think it was necessary (and certainly not descriptive)
- Fixed `num_suspect_commits` to use the correct number (commits instead of committers)
- Added `suspect_commit_calculation` to distinguish between suspect commits created with the release method vs the SCM method