### PR TITLE
fix(ui): Correctly show new values when updating issue form

### DIFF
--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -311,6 +311,11 @@ export default class AbstractExternalIssueForm<
     };
   };
 
+  /**
+   * Populate all async fields with their choices, then return the full list of fields.
+   * We pull from the fetchedFieldOptionsCache which contains the most recent response
+   * for each async field.
+   */
   getCleanedFields = (): IssueConfigField[] => {
     const {fetchedFieldOptionsCache, integrationDetails} = this.state;
 

--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -297,7 +297,7 @@ export default class AbstractExternalIssueForm<
 
   hasErrorInFields = (): boolean => {
     // check if we have any form fields with name error and type blank
-    const fields = this.getCleanedFields();
+    const fields = this.loadAsyncThenFetchAllFields();
     return fields.some(field => field.name === 'error' && field.type === 'blank');
   };
 
@@ -313,10 +313,10 @@ export default class AbstractExternalIssueForm<
 
   /**
    * Populate all async fields with their choices, then return the full list of fields.
-   * We pull from the fetchedFieldOptionsCache which contains the most recent response
+   * We pull from the fetchedFieldOptionsCache which contains the most recent choices
    * for each async field.
    */
-  getCleanedFields = (): IssueConfigField[] => {
+  loadAsyncThenFetchAllFields = (): IssueConfigField[] => {
     const {fetchedFieldOptionsCache, integrationDetails} = this.state;
 
     const configsFromAPI = (integrationDetails || {})[this.getConfigName()];

--- a/static/app/components/group/externalIssueForm.tsx
+++ b/static/app/components/group/externalIssueForm.tsx
@@ -154,6 +154,6 @@ export default class ExternalIssueForm extends AbstractExternalIssueForm<Props, 
   };
 
   renderBody() {
-    return this.renderForm(this.getCleanedFields());
+    return this.renderForm(this.loadAsyncThenFetchAllFields());
   }
 }

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
@@ -195,8 +195,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
     });
 
     it('should not persist value when unavailable in new choices', async function () {
-      renderComponent();
-      await selectEvent.select(screen.getByRole('textbox', {name: 'Reporter'}), 'a');
+      renderComponent({data: {reporter: 'a'}});
 
       addMockConfigsAPICall({
         label: 'Reporter',

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.spec.tsx
@@ -194,7 +194,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
       await submitSuccess();
     });
 
-    it('should not persist value when not available in new choices', async function () {
+    it('should not persist value when unavailable in new choices', async function () {
       renderComponent();
       await selectEvent.select(screen.getByRole('textbox', {name: 'Reporter'}), 'a');
 
@@ -207,6 +207,7 @@ describe('ProjectAlerts -> TicketRuleModal', function () {
         ignorePriorChoices: true,
       });
 
+      // Switch Issue Type so we refetch the config and update Reporter choices
       await selectEvent.select(screen.getByRole('textbox', {name: 'Issue Type'}), 'Epic');
       await expect(
         selectEvent.select(screen.getByRole('textbox', {name: 'Reporter'}), 'a')

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -168,7 +168,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
 
     const cleanedFields = this.getCleanedFields();
     const newFields = cleanedFields
-      // Skip fields if they already exist.
+      // Don't overwrite the default values for title and description.
       .filter(field => !fields.map(f => f.name).includes(field.name))
       .map(field => {
         // Overwrite defaults with previously selected values if they exist.

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -39,8 +39,12 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
     const issueConfigFieldsCache = Object.values(instance?.dynamic_form_fields || {});
     return {
       ...super.getDefaultState(),
+      // fetchedFieldOptionsCache should contain async fields, so we
+      // need to filter beforehand. Only async fields have a `url` property.
       fetchedFieldOptionsCache: Object.fromEntries(
-        issueConfigFieldsCache.map(field => [field.name, field.choices as Choices])
+        issueConfigFieldsCache
+          .filter(field => field.url)
+          .map(field => [field.name, field.choices as Choices])
       ),
       issueConfigFieldsCache,
     };
@@ -162,18 +166,31 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
       } as IssueConfigField,
     ];
 
-    return fields.concat(
-      this.getCleanedFields()
-        // Skip fields if they already exist.
-        .filter(field => !fields.map(f => f.name).includes(field.name))
-        .map(field => {
-          // Overwrite defaults from cache.
-          if (instance.hasOwnProperty(field.name)) {
-            field.default = instance[field.name] || field.default;
-          }
-          return field;
-        })
-    );
+    const cleanedFields = this.getCleanedFields();
+    const newFields = cleanedFields
+      // Skip fields if they already exist.
+      .filter(field => !fields.map(f => f.name).includes(field.name))
+      .map(field => {
+        // Overwrite defaults with previously selected values if they exist.
+        // Certain fields have their options change depending on other fields
+        // such as project or issue type (Jira eg), so we need to check if the
+        // last selected value is in the list of field choices.
+
+        const prevChoice = instance?.[field.name];
+        // Note that field.choices is an array of tuples, where each tuple is
+        // ("id", "label") such as ("1", "Bug")
+        if (
+          prevChoice && field.choices && Array.isArray(prevChoice)
+            ? // Multi-select fields have an array of values, eg: ['a', 'b']
+              prevChoice.every(value => field.choices?.some(tuple => tuple[0] === value))
+            : // Single-select fields have a single value, eg: 'a'
+              field.choices?.some(item => item[0] === prevChoice)
+        ) {
+          field.default = prevChoice;
+        }
+        return field;
+      });
+    return [...fields, ...newFields];
   };
 
   getErrors() {

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -39,7 +39,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
     const issueConfigFieldsCache = Object.values(instance?.dynamic_form_fields || {});
     return {
       ...super.getDefaultState(),
-      // fetchedFieldOptionsCache should contain async fields, so we
+      // fetchedFieldOptionsCache should contain async fields so we
       // need to filter beforehand. Only async fields have a `url` property.
       fetchedFieldOptionsCache: Object.fromEntries(
         issueConfigFieldsCache
@@ -166,22 +166,21 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
       } as IssueConfigField,
     ];
 
-    const cleanedFields = this.getCleanedFields();
-    const newFields = cleanedFields
+    const cleanedFields = this.loadAsyncThenFetchAllFields()
       // Don't overwrite the default values for title and description.
       .filter(field => !fields.map(f => f.name).includes(field.name))
       .map(field => {
         // Overwrite defaults with previously selected values if they exist.
-        // Certain fields have their options change depending on other fields
-        // such as project or issue type (Jira eg), so we need to check if the
-        // last selected value is in the list of field choices.
-
+        // Certain fields such as priority (for Jira) have their options change
+        // because they depend on another field such as Project, so we need to
+        // check if the last selected value is in the list of available field choices.
         const prevChoice = instance?.[field.name];
-        // Note that field.choices is an array of tuples, where each tuple is
-        // ("id", "label") such as ("1", "Bug")
+        // Note that field.choices is an array of tuples, where each tuple
+        // contains a numeric id and string label, eg. ("10000", "EX") or ("1", "Bug")
         if (
           prevChoice && field.choices && Array.isArray(prevChoice)
-            ? // Multi-select fields have an array of values, eg: ['a', 'b']
+            ? // Multi-select fields have an array of values, eg: ['a', 'b'] so we
+              // check that every value exists in choices
               prevChoice.every(value => field.choices?.some(tuple => tuple[0] === value))
             : // Single-select fields have a single value, eg: 'a'
               field.choices?.some(item => item[0] === prevChoice)
@@ -190,7 +189,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
         }
         return field;
       });
-    return [...fields, ...newFields];
+    return [...fields, ...cleanedFields];
   };
 
   getErrors() {


### PR DESCRIPTION
There was a previous frontend bug in the external issue modal. Basically when switching a field value that fetches a new field configurations, we would carry over the last selected value + options even if they didn't exist in the fetched configuration.
This only affects Alert Rule ticket actions, because it's not possible to save values when manually creating an issue, because we don't store the selected fields and create the external issue immediately.

### Bug in Action
In this example below, before saving the `IS` project has several `Component/s` + `fixVersions`, but `SEIJI` has none. After we save, the fields carry over when we switch to `SEIJI` even though they don't exist in the project.

https://github.com/getsentry/sentry/assets/67301797/2dbd5596-e08d-43ff-a201-e93b141b16d6

### After Fix
`Component/s` + `fixVersions` correctly resets after switching projects.

https://github.com/getsentry/sentry/assets/67301797/2ee8f4ce-5c20-46e0-bb1e-c8d97e7005f1