### PR TITLE
ref(ddm): Improve implementation and support MQB parser

### DIFF
--- a/src/sentry/sentry_metrics/querying/api.py
+++ b/src/sentry/sentry_metrics/querying/api.py
@@ -81,6 +81,8 @@ class QueryMeta:
         self._transform_meta_type()
 
     def _transform_meta_type(self):
+        # Since we don't support the array aggregate value, and we return the first element, we just return the type of
+        # the values of the array.
         if self.type.startswith("Array("):
             self.type = self.type[6 : len(self.type) - 1]
 

--- a/src/sentry/sentry_metrics/querying/api.py
+++ b/src/sentry/sentry_metrics/querying/api.py
@@ -187,6 +187,11 @@ class QueryParser:
         return [Column(group_by) for group_by in self._group_bys]
 
     def _transform_timeseries(self, timeseries: Timeseries) -> Timeseries:
+        """
+        Transforms a timeseries to a variant which is supported by the metrics layer.
+
+        For now, the only transformation that is being performed is the conversion of percentiles.
+        """
         # In case we have a percentile in the form `px` where `x` is in the range [0-100], we want to convert it to
         # the quantiles operation which generalizes any percentile.
         if (match := self.PERCENTILE_REGEX.match(timeseries.aggregate)) is not None:
@@ -196,6 +201,9 @@ class QueryParser:
         return timeseries
 
     def _parse_mql(self, field: str) -> Timeseries:
+        """
+        Parses the field with the MQL grammar.
+        """
         parsed_query = parse_mql(field)
         return self._transform_timeseries(parsed_query.query)
 

--- a/src/sentry/sentry_metrics/querying/api.py
+++ b/src/sentry/sentry_metrics/querying/api.py
@@ -200,8 +200,8 @@ class QueryExecutor:
         # By default we want to execute totals.
         self._scheduled_queries.append((query, with_totals))
 
-    def execute(self, in_batch: bool = False) -> Generator[ExecutionResult, None, None]:
-        if in_batch:
+    def execute(self, batch: bool = False) -> Generator[ExecutionResult, None, None]:
+        if batch:
             # TODO: implement batching.
             # Run batch query and flatten results.
             pass

--- a/src/sentry/sentry_metrics/querying/api.py
+++ b/src/sentry/sentry_metrics/querying/api.py
@@ -166,9 +166,8 @@ class QueryExecutor:
     def __init__(self, organization: Organization, referrer: str):
         self._organization = organization
         self._referrer = referrer
-        self._next_id = 0
         # List of queries scheduled for execution.
-        self._scheduled_queries: Dict[int, Tuple[MetricsQuery, bool]] = {}
+        self._scheduled_queries: List[Tuple[MetricsQuery, bool]] = []
 
     def _build_request(self, query: MetricsQuery) -> Request:
         return Request(
@@ -199,8 +198,7 @@ class QueryExecutor:
 
     def schedule(self, query: MetricsQuery, with_totals: bool = True):
         # By default we want to execute totals.
-        self._scheduled_queries[self._next_id] = (query, with_totals)
-        self._next_id += 1
+        self._scheduled_queries.append((query, with_totals))
 
     def execute(self, in_batch: bool = False) -> Generator[ExecutionResult, None, None]:
         if in_batch:
@@ -208,7 +206,7 @@ class QueryExecutor:
             # Run batch query and flatten results.
             pass
         else:
-            for query_id, (query, with_totals) in self._scheduled_queries.items():
+            for query, with_totals in self._scheduled_queries:
                 result = self._execute(query, with_totals)
                 yield ExecutionResult(query=query, result=result, with_totals=with_totals)
 

--- a/src/sentry/sentry_metrics/querying/api.py
+++ b/src/sentry/sentry_metrics/querying/api.py
@@ -342,7 +342,7 @@ def _is_nan(value: ResultValue) -> bool:
     if value is None:
         return False
     elif isinstance(value, list):
-        return any(map(lambda e: math.isnan(e), value))
+        return any(map(lambda e: e is not None and math.isnan(e), value))
 
     return math.isnan(value)
 

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -74,7 +74,7 @@ class OrganizationMetricsDataWithNewLayerTest(MetricsAPIBaseTestCase):
         )
         run_metrics_query.assert_called_once()
 
-    def test_query_with_transactions_metric(self):
+    def test_compare_query_with_transactions_metric(self):
         self.store_performance_metric(
             name=TransactionMRI.DURATION.value,
             tags={"transaction": "/hello", "platform": "ios"},
@@ -83,16 +83,15 @@ class OrganizationMetricsDataWithNewLayerTest(MetricsAPIBaseTestCase):
 
         responses = []
         for flag_value in False, True:
-            with self.feature({"organizations:metrics-api-new-metrics-layer": flag_value}):
-                response = self.get_response(
-                    self.project.organization.slug,
-                    field=f"sum({TransactionMRI.DURATION.value})",
-                    useCase="transactions",
-                    useNewMetricsLayer="true" if flag_value else "false",
-                    statsPeriod="1h",
-                    interval="1h",
-                )
-                responses.append(response)
+            response = self.get_response(
+                self.project.organization.slug,
+                field=f"sum({TransactionMRI.DURATION.value})",
+                useCase="transactions",
+                useNewMetricsLayer="true" if flag_value else "false",
+                statsPeriod="1h",
+                interval="1h",
+            )
+            responses.append(response)
 
         response_old = responses[0].data
         response_new = responses[1].data

--- a/tests/sentry/sentry_metrics/querying/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/test_api.py
@@ -93,7 +93,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert groups[0]["series"] == {field: [0.0, 9.0, 8.0]}
         assert groups[0]["totals"] == {field: 17.0}
 
-    @pytest.mark.skip(reason="missing: percentiles are not properly parsed")
     def test_query_with_percentile(self) -> None:
         field = f"p90({TransactionMRI.DURATION.value})"
         results = run_metrics_query(
@@ -110,8 +109,8 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         groups = results["groups"]
         assert len(groups) == 1
         assert groups[0]["by"] == {}
-        assert groups[0]["series"] == {field: [0.0, 9.0, 8.0]}
-        assert groups[0]["totals"] == {field: 17.0}
+        assert groups[0]["series"] == {field: [0.0, 4.6, 3.0]}
+        assert groups[0]["totals"] == {field: 4.0}
 
     def test_query_with_group_by(self) -> None:
         # Query with one aggregation and two group by.

--- a/tests/sentry/sentry_metrics/querying/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/test_api.py
@@ -46,6 +46,33 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
     def ts(self, dt: datetime) -> int:
         return int(dt.timestamp())
 
+    def test_query_with_empty_results(self) -> None:
+        for aggregate, expected_identity in (
+            ("count", 0.0),
+            ("avg", None),
+            ("sum", 0.0),
+            ("min", 0.0),
+        ):
+            field = f"{aggregate}({TransactionMRI.DURATION.value})"
+            results = run_metrics_query(
+                fields=[field],
+                query="transaction:/bar",
+                group_bys=None,
+                start=self.now() - timedelta(minutes=30),
+                end=self.now() + timedelta(hours=1, minutes=30),
+                interval=3600,
+                organization=self.project.organization,
+                projects=[self.project],
+                referrer="metrics.data.api",
+            )
+            groups = results["groups"]
+            assert len(groups) == 1
+            assert groups[0]["by"] == {}
+            assert groups[0]["series"] == {
+                field: [expected_identity, expected_identity, expected_identity]
+            }
+            assert groups[0]["totals"] == {field: expected_identity}
+
     def test_query_with_one_aggregation(self) -> None:
         # Query with just one aggregation.
         field = f"sum({TransactionMRI.DURATION.value})"
@@ -63,7 +90,27 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         groups = results["groups"]
         assert len(groups) == 1
         assert groups[0]["by"] == {}
-        assert groups[0]["series"] == {field: [None, 9.0, 8.0]}
+        assert groups[0]["series"] == {field: [0.0, 9.0, 8.0]}
+        assert groups[0]["totals"] == {field: 17.0}
+
+    @pytest.mark.skip(reason="missing: percentiles are not properly parsed")
+    def test_query_with_percentile(self) -> None:
+        field = f"p90({TransactionMRI.DURATION.value})"
+        results = run_metrics_query(
+            fields=[field],
+            query=None,
+            group_bys=None,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            referrer="metrics.data.api",
+        )
+        groups = results["groups"]
+        assert len(groups) == 1
+        assert groups[0]["by"] == {}
+        assert groups[0]["series"] == {field: [0.0, 9.0, 8.0]}
         assert groups[0]["totals"] == {field: 17.0}
 
     def test_query_with_group_by(self) -> None:
@@ -83,13 +130,13 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         groups = results["groups"]
         assert len(groups) == 3
         assert groups[0]["by"] == {"platform": "android", "transaction": "/hello"}
-        assert groups[0]["series"] == {field: [None, 1.0, 2.0]}
+        assert groups[0]["series"] == {field: [0.0, 1.0, 2.0]}
         assert groups[0]["totals"] == {field: 3.0}
         assert groups[1]["by"] == {"platform": "ios", "transaction": "/hello"}
-        assert groups[1]["series"] == {field: [None, 3.0, 3.0]}
+        assert groups[1]["series"] == {field: [0.0, 3.0, 3.0]}
         assert groups[1]["totals"] == {field: 6.0}
         assert groups[2]["by"] == {"platform": "windows", "transaction": "/world"}
-        assert groups[2]["series"] == {field: [None, 5.0, 3.0]}
+        assert groups[2]["series"] == {field: [0.0, 5.0, 3.0]}
         assert groups[2]["totals"] == {field: 8.0}
 
     def test_query_with_filters(self) -> None:
@@ -109,7 +156,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         groups = results["groups"]
         assert len(groups) == 1
         assert groups[0]["by"] == {"platform": "ios"}
-        assert groups[0]["series"] == {field: [None, 3.0, 3.0]}
+        assert groups[0]["series"] == {field: [0.0, 3.0, 3.0]}
         assert groups[0]["totals"] == {field: 6.0}
 
     def test_query_with_multiple_aggregations(self) -> None:
@@ -130,7 +177,7 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         groups = results["groups"]
         assert len(groups) == 1
         assert groups[0]["by"] == {}
-        assert groups[0]["series"] == {field_2: [None, 5.0, 3.0], field_1: [None, 1.0, 2.0]}
+        assert groups[0]["series"] == {field_2: [0.0, 5.0, 3.0], field_1: [0.0, 1.0, 2.0]}
         assert groups[0]["totals"] == {field_2: 5.0, field_1: 1.0}
 
     @pytest.mark.skip(reason="sessions are not supported in the new metrics layer")


### PR DESCRIPTION
This PR fixes some errors with the data type conversion, implements a first integration of the `mql` language and refactors the code.

The refactor aims at simplifying the handling of queries and wants to improve typing across the board, in the following way:
* `QueryParser` now abstracts the parsing of the queries and lazily returns timeseries to execute.
* `QueryExecutor` executes queries by correctly handling totals and series queries. In addition, it prepares facilities to implement batch query execution. The execution is also lazy.
* `ExecutionResult` abstracts away the concept of an execution result, which encapsulates the query (that can be split into two queries if totals are requested). This abstraction simplifies the access to all the important fields of the result which are using during results translation.

The code also implements support for percentiles, which are converted from `px` to `quantiles(x)` in the timeseries query. This requires some transformation work across multiple levels of the query execution.