### PR TITLE
feat(starfish): Update release selector to use txn counts

### DIFF
--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -35,7 +35,7 @@ export function ReleaseSelector({selectorName, selectorKey, selectorValue}: Prop
     let selectedReleaseSessionCount: number | undefined = undefined;
     let selectedReleaseDateCreated: string | undefined = undefined;
     if (defined(selectedRelease)) {
-      selectedReleaseSessionCount = selectedRelease['sum(session)'];
+      selectedReleaseSessionCount = selectedRelease.count;
       selectedReleaseDateCreated = selectedRelease.dateCreated;
     }
 
@@ -44,7 +44,7 @@ export function ReleaseSelector({selectorName, selectorKey, selectorValue}: Prop
       label: selectorValue,
       details: (
         <LabelDetails
-          sessionCount={selectedReleaseSessionCount}
+          screenCount={selectedReleaseSessionCount}
           dateCreated={selectedReleaseDateCreated}
         />
       ),
@@ -53,18 +53,18 @@ export function ReleaseSelector({selectorName, selectorKey, selectorValue}: Prop
   data
     ?.filter(({version}) => selectorValue !== version)
     .forEach(release => {
-      const option = {
-        value: release.version,
-        label: release.version,
-        details: (
-          <LabelDetails
-            sessionCount={release['sum(session)']}
-            dateCreated={release.dateCreated}
-          />
-        ),
-      };
+      const screenCount = release.count;
+      if (screenCount) {
+        const option = {
+          value: release.version,
+          label: release.version,
+          details: (
+            <LabelDetails screenCount={screenCount} dateCreated={release.dateCreated} />
+          ),
+        };
 
-      options.push(option);
+        options.push(option);
+      }
     });
 
   return (
@@ -81,7 +81,7 @@ export function ReleaseSelector({selectorName, selectorKey, selectorValue}: Prop
       options={[
         {
           value: '_releases',
-          label: t('Sorted by session count'),
+          label: t('Sorted by date created'),
           options,
         },
       ]}
@@ -106,16 +106,16 @@ export function ReleaseSelector({selectorName, selectorKey, selectorValue}: Prop
 
 type LabelDetailsProps = {
   dateCreated?: string;
-  sessionCount?: number;
+  screenCount?: number;
 };
 
 function LabelDetails(props: LabelDetailsProps) {
   return (
     <DetailsContainer>
       <div>
-        {defined(props.sessionCount)
-          ? tn('%s session', '%s sessions', props.sessionCount)
-          : t('No sessions')}
+        {defined(props.screenCount)
+          ? tn('%s event', '%s events', props.screenCount)
+          : t('No screens')}
       </div>
       <div>
         {defined(props.dateCreated)

--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -53,18 +53,14 @@ export function ReleaseSelector({selectorName, selectorKey, selectorValue}: Prop
   data
     ?.filter(({version}) => selectorValue !== version)
     .forEach(release => {
-      const screenCount = release.count;
-      if (screenCount) {
-        const option = {
-          value: release.version,
-          label: release.version,
-          details: (
-            <LabelDetails screenCount={screenCount} dateCreated={release.dateCreated} />
-          ),
-        };
-
-        options.push(option);
-      }
+      const option = {
+        value: release.version,
+        label: release.version,
+        details: (
+          <LabelDetails screenCount={release.count} dateCreated={release.dateCreated} />
+        ),
+      };
+      options.push(option);
     });
 
   return (

--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -1,61 +1,75 @@
-import {Release} from 'sentry/types';
+import {NewQuery, Release} from 'sentry/types';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
 export function useReleases(searchTerm?: string) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const {environments, projects} = selection;
 
-  const result = useApiQuery<Release[]>(
+  const releaseResults = useApiQuery<Release[]>(
     [
       `/organizations/${organization.slug}/releases/`,
       {
         query: {
           project: projects,
-          per_page: 50,
+          per_page: 100,
           environment: environments,
           query: searchTerm,
-          health: 1,
-          sort: 'sessions',
-          flatten: 1,
+          sort: 'date',
         },
       },
     ],
     {staleTime: Infinity}
   );
 
+  const newQuery: NewQuery = {
+    name: '',
+    fields: ['release', 'count()'],
+    query: `transaction.op:ui.load ${searchTerm ? `release:*${searchTerm}*` : ''}`,
+    dataset: DiscoverDatasets.METRICS,
+    version: 2,
+    projects: selection.projects,
+  };
+  const eventView = EventView.fromNewQueryWithPageFilters(newQuery, selection);
+  const {data: metricsResult, isLoading: isMetricsStatsLoading} = useTableQuery({
+    eventView,
+    limit: 100,
+  });
+
+  const metricsStats: {[version: string]: {count: number}} = {};
+  metricsResult?.data?.forEach(release => {
+    metricsStats[release.release] = {count: release['count()'] as number};
+  });
+
   const releaseStats: {
     dateCreated: string;
-    platform: string;
-    projectSlug: string;
-    'sum(session)': number | undefined;
     version: string;
+    count?: number;
   }[] =
-    result.data && result.data.length
-      ? result.data.map(release => {
+    releaseResults.data && releaseResults.data.length && !isMetricsStatsLoading
+      ? releaseResults.data.flatMap(release => {
           const releaseVersion = release.version;
-          const releaseProject = release.projects[0];
           const dateCreated = release.dateCreated;
-
-          const projectSlug = releaseProject.slug;
-          const platform = releaseProject.platform;
-          const sessionCount = releaseProject.healthData?.totalSessions;
-          return {
-            projectSlug,
-            'sum(session)': sessionCount,
-            platform,
-            dateCreated,
-            version: releaseVersion,
-          };
+          if (metricsStats[releaseVersion]?.count) {
+            return {
+              dateCreated,
+              version: releaseVersion,
+              count: metricsStats[releaseVersion]?.count,
+            };
+          }
+          return [];
         })
       : [];
 
   return {
-    ...result,
+    ...releaseResults,
     data: releaseStats,
   };
 }


### PR DESCRIPTION
Release selector now only shows release that have screens ordered by date created.