### PR TITLE
feat(starfish): Page Overview Table Columns

### DIFF
--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -104,10 +104,11 @@ type GridEditableProps<DataRow, ColumnKey> = {
   height?: string | number;
 
   isLoading?: boolean;
+  minimumColWidth?: number;
+
   scrollable?: boolean;
 
   stickyHeader?: boolean;
-
   /**
    * GridEditable (mostly) do not maintain any internal state and relies on the
    * parent component to tell it how/what to render and will mutate the view
@@ -282,22 +283,23 @@ class GridEditable<
       return;
     }
 
+    const minimumColWidth = this.props.minimumColWidth ?? COL_WIDTH_MINIMUM;
     const prependColumns = this.props.grid.prependColumnWidths || [];
     const prepend = prependColumns.join(' ');
     const widths = columnOrder.map((item, index) => {
       if (item.width === COL_WIDTH_UNDEFINED) {
-        return `minmax(${COL_WIDTH_MINIMUM}px, auto)`;
+        return `minmax(${minimumColWidth}px, auto)`;
       }
-      if (typeof item.width === 'number' && item.width > COL_WIDTH_MINIMUM) {
+      if (typeof item.width === 'number' && item.width > minimumColWidth) {
         if (index === columnOrder.length - 1) {
           return `minmax(${item.width}px, auto)`;
         }
         return `${item.width}px`;
       }
       if (index === columnOrder.length - 1) {
-        return `minmax(${COL_WIDTH_MINIMUM}px, auto)`;
+        return `minmax(${minimumColWidth}px, auto)`;
       }
-      return `${COL_WIDTH_MINIMUM}px`;
+      return `${minimumColWidth}px`;
     });
 
     // The last column has no resizer and should always be a flexible column

--- a/static/app/views/performance/browser/webVitals/pageOverview.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverview.tsx
@@ -59,14 +59,16 @@ const LANDING_DISPLAYS = [
 const SAMPLES_COLUMN_ORDER: GridColumnOrder<
   keyof TransactionSampleRowWithScoreAndExtra
 >[] = [
+  {key: 'id', width: COL_WIDTH_UNDEFINED, name: 'Event ID'},
   {key: 'user.display', width: COL_WIDTH_UNDEFINED, name: 'User'},
-  {key: 'measurements.lcp', width: 60, name: 'LCP'},
-  {key: 'measurements.fcp', width: 60, name: 'FCP'},
-  {key: 'measurements.fid', width: 60, name: 'FID'},
-  {key: 'measurements.cls', width: 60, name: 'CLS'},
-  {key: 'measurements.ttfb', width: 60, name: 'TTFB'},
-  {key: 'score', width: 60, name: 'Score'},
-  {key: 'view', width: 110, name: 'View'},
+  {key: 'measurements.lcp', width: COL_WIDTH_UNDEFINED, name: 'LCP'},
+  {key: 'measurements.fcp', width: COL_WIDTH_UNDEFINED, name: 'FCP'},
+  {key: 'measurements.fid', width: COL_WIDTH_UNDEFINED, name: 'FID'},
+  {key: 'measurements.cls', width: COL_WIDTH_UNDEFINED, name: 'CLS'},
+  {key: 'measurements.ttfb', width: COL_WIDTH_UNDEFINED, name: 'TTFB'},
+  {key: 'profile.id', width: COL_WIDTH_UNDEFINED, name: 'Profile'},
+  {key: 'replayId', width: COL_WIDTH_UNDEFINED, name: 'Replay'},
+  {key: 'score', width: COL_WIDTH_UNDEFINED, name: 'Score'},
 ];
 
 function getCurrentTabSelection(selectedTab) {


### PR DESCRIPTION
Reorders and restyles page overview samples table. also makes some changes to gridEditable to allow squishing more content into smaller sized tables
![image](https://github.com/getsentry/sentry/assets/83961295/70ae3485-6bc2-45ec-bbae-bb351a843f1b)
