### PR TITLE
fix(suspect-commits): Prioritize code mappings which have more defined stack roots

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_links.py
+++ b/src/sentry/api/endpoints/project_stacktrace_links.py
@@ -10,13 +10,12 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.mixins import RepositoryMixin
+from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.project import Project
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.sdk import set_measurement
-
-from .project_stacktrace_link import get_code_mapping_configs
 
 MAX_CODE_MAPPINGS_USED = 3
 
@@ -64,7 +63,7 @@ class ProjectStacktraceLinksEndpoint(ProjectEndpoint):
         mappings_used = 0
         mappings_attempted = 0
 
-        configs = get_code_mapping_configs(project)
+        configs = get_sorted_code_mapping_configs(project)
 
         default_error = "stack_root_mismatch" if configs else "no_code_mappings"
 

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -423,6 +423,52 @@ def create_code_mapping(
     return new_code_mapping
 
 
+def get_sorted_code_mapping_configs(project: Project) -> List[RepositoryProjectPathConfig]:
+    """
+    Returns the code mapping config list for a project sorted based on precedence.
+    User generated code mappings are evaluated before Sentry generated code mappings.
+    Code mappings with more defined stack trace roots are evaluated before less defined stack trace
+    roots.
+
+    `project`: The project to get the list of sorted code mapping configs for
+    """
+
+    # xxx(meredith): if there are ever any changes to this query, make
+    # sure that we are still ordering by `id` because we want to make sure
+    # the ordering is deterministic
+    # codepath mappings must have an associated integration for stacktrace linking.
+    configs = RepositoryProjectPathConfig.objects.filter(
+        project=project, organization_integration_id__isnull=False
+    )
+
+    sorted_configs: list[RepositoryProjectPathConfig] = []
+
+    try:
+        for config in configs:
+            inserted = False
+            for index, sorted_config in enumerate(sorted_configs):
+                # This check will ensure that all user defined code mappings will come before Sentry generated ones
+                if (
+                    sorted_config.automatically_generated and not config.automatically_generated
+                ) or (  # Insert more defined stack roots before less defined ones
+                    (sorted_config.automatically_generated == config.automatically_generated)
+                    and config.stack_root.startswith(sorted_config.stack_root)
+                ):
+                    sorted_configs.insert(index, config)
+                    inserted = True
+                    break
+            if not inserted:
+                # Insert the code mapping at the back if it's Sentry generated or at the front if it is user defined
+                if config.automatically_generated:
+                    sorted_configs.insert(len(sorted_configs), config)
+                else:
+                    sorted_configs.insert(0, config)
+    except Exception:
+        logger.exception("There was a failure sorting the code mappings")
+
+    return sorted_configs
+
+
 def _get_code_mapping_source_path(src_file: str, frame_filename: FrameFilename) -> str:
     """Generate the source code root for a code mapping. It always includes a last backslash"""
     source_code_root = None

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Dict, List, NamedTuple, Tuple, Union
 

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -9,6 +9,7 @@ from sentry_sdk import set_tag
 from sentry import analytics, features
 from sentry.api.serializers.models.release import get_users_for_authors
 from sentry.integrations.base import IntegrationInstallation
+from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
 from sentry.integrations.utils.commit_context import (
     find_commit_context_for_event,
     find_commit_context_for_event_all_frames,
@@ -18,7 +19,6 @@ from sentry.locks import locks
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
-from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.project import Project
 from sentry.models.pullrequest import PullRequest, PullRequestCommit
@@ -204,7 +204,7 @@ def process_commit_context(
                 )
                 return
 
-            code_mappings = RepositoryProjectPathConfig.objects.filter(project=project)
+            code_mappings = get_sorted_code_mapping_configs(project)
 
             frames = event_frames or []
             munged = munged_filename_and_frames(event_platform, frames, "munged_filename", sdk_name)

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -6,7 +6,6 @@ import pytest
 import responses
 
 from sentry import options
-from sentry.api.endpoints.project_stacktrace_link import get_code_mapping_configs
 from sentry.integrations.example.integration import ExampleIntegration
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
@@ -527,19 +526,6 @@ class ProjectStacktraceLinkTestMultipleMatches(BaseProjectStacktraceLink):
         ]
 
         self.filepath = "usr/src/getsentry/src/sentry/src/sentry/utils/safe.py"
-
-    def test_multiple_code_mapping_matches_order(self):
-        # Expected configs: stack_root, automatically_generated
-        expected_config_order = [
-            self.code_mapping3,  # "usr/src/getsentry/", False
-            self.code_mapping4,  # "usr/src/", False
-            self.code_mapping1,  # "", False
-            self.code_mapping5,  # "usr/src/getsentry/src/sentry/", True
-            self.code_mapping2,  # "usr/src/getsentry/src/", True
-        ]
-
-        sorted_configs = get_code_mapping_configs(self.project)
-        assert sorted_configs == expected_config_order
 
     def test_multiple_code_mapping_matches(self):
         with patch.object(

--- a/tests/sentry/api/endpoints/test_project_stacktrace_links.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_links.py
@@ -2,8 +2,8 @@ from unittest.mock import patch
 
 from rest_framework.exceptions import ErrorDetail
 
-from sentry.api.endpoints.project_stacktrace_link import get_code_mapping_configs
 from sentry.integrations.example.integration import ExampleIntegration
+from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.shared_integrations.exceptions import ApiError
@@ -203,7 +203,7 @@ class ProjectStacktraceLinksTest(APITestCase):
         code_mapping2 = self.setup_code_mapping("foo/bar", "bar")
 
         # this is the code mapping order that will be tried
-        assert get_code_mapping_configs(self.project) == [code_mapping2, code_mapping1]
+        assert get_sorted_code_mapping_configs(self.project) == [code_mapping2, code_mapping1]
 
         with patch.object(
             ExampleIntegration, "get_stacktrace_link", side_effect=[None, "https://sourceurl.com"]
@@ -288,7 +288,7 @@ class ProjectStacktraceLinksTest(APITestCase):
         code_mapping6 = self.setup_code_mapping("baz", "")
 
         # this is the code mapping order that will be tried
-        assert get_code_mapping_configs(self.project) == [
+        assert get_sorted_code_mapping_configs(self.project) == [
             code_mapping6,
             code_mapping5,
             code_mapping4,


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/59351

This fixes a problem where empty stack roots are applied before more defined ones which were added later.  This also further aligns suspect commits with stacktrace linking by sharing logic between them. By applying code mappings in a similar way we can make the results of suspect commits less surprising.

- Moves `get_code_mapping_configs` to a util file and rename to `get_sorted_code_mapping_configs`
- Use the util function in the `commit_context` task as well as the stacktrace linking endpoint

Because the old suspect commit logic used all matching code mappings, the order shouldn't affect the results.