### PR TITLE
fix(starfish): Split sidebar comparison styling evenly

### DIFF
--- a/static/app/views/starfish/views/screens/screenLoadSpans/sidebar.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/sidebar.tsx
@@ -89,6 +89,7 @@ export function ScreenLoadSpansSidebar({transaction}: Props) {
               organization={organization}
               version={primaryRelease}
               tooltipRawVersion
+              truncate
             />
           )}
           <SidebarMetricsValue>
@@ -111,6 +112,7 @@ export function ScreenLoadSpansSidebar({transaction}: Props) {
               organization={organization}
               version={secondaryRelease}
               tooltipRawVersion
+              truncate
             />
           )}
           <SidebarMetricsValue>
@@ -136,6 +138,7 @@ export function ScreenLoadSpansSidebar({transaction}: Props) {
               organization={organization}
               version={primaryRelease}
               tooltipRawVersion
+              truncate
             />
           )}
           <SidebarMetricsValue>
@@ -193,8 +196,8 @@ const SidebarMetricsValue = styled('div')`
 `;
 
 const Container = styled('div')`
-  display: flex;
-  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   align-items: center;
 `;
 


### PR DESCRIPTION
The styling wasn't consistently splitting the sidebar width by half, so the TTID and TTFD comparisons were uneven.

![Screenshot 2023-11-03 at 1 06 28 PM](https://github.com/getsentry/sentry/assets/22846452/e2fb1622-079c-43f5-8125-b513d238292f)

Swapped flexbox for grid and added the `truncate` flag for the `Version` component so it renders consistently on the same line

![Screenshot 2023-11-03 at 1 05 02 PM](https://github.com/getsentry/sentry/assets/22846452/f5a3cab4-5ffb-4141-9973-2ec32f2996e0)

