### PR TITLE
fix(stat-detectors): Align change markers in table

### DIFF
--- a/static/app/utils/performance/regression/table.tsx
+++ b/static/app/utils/performance/regression/table.tsx
@@ -93,6 +93,7 @@ const Change = styled('span')`
   display: grid;
   grid-template-columns: 1fr 12px 1fr 1fr;
   gap: ${space(1)};
+  align-items: center;
 `;
 
 const ChangeDescription = styled('span')`


### PR DESCRIPTION
before
![Screenshot 2023-11-03 at 1 15 27 PM](https://github.com/getsentry/sentry/assets/22846452/f039fdec-54a2-4092-9c18-fa8cd70d4d9a)


after
![Screenshot 2023-11-03 at 1 15 33 PM](https://github.com/getsentry/sentry/assets/22846452/d501ef8f-6546-4f82-9ffb-a773b198fc7d)
