### PR TITLE
feat(dashboards): Bump up retries to 5

### DIFF
--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -485,11 +485,11 @@ function getEventsRequest(
       ...eventView.generateQueryStringObject(),
       ...params,
     },
-    // Tries events request up to 3 times on rate limit
+    // Tries events request up to 5 times on rate limit
     {
       retry: {
         statusCodes: [429],
-        tries: 3,
+        tries: 5,
       },
     }
   );


### PR DESCRIPTION
Even with 3 retries on error 429 we still run into rate limiting. Bumping up retry count to 5.