### PR TITLE
feat(starfish): Add a min-width so the event count and date don't wrap

### DIFF
--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -153,4 +153,5 @@ const DetailsContainer = styled('div')`
   flex-direction: row;
   justify-content: space-between;
   gap: ${space(1)};
+  min-width: 200px;
 `;


### PR DESCRIPTION
<img width="303" alt="Screenshot 2023-11-03 at 2 28 42 PM" src="https://github.com/getsentry/sentry/assets/63818634/d1f15b1f-ae36-4ccd-8588-36da3015b8f9">
