### PR TITLE
feat(backup): Generate validation run cloudbuild.yaml

### DIFF
--- a/src/sentry/models/relocation.py
+++ b/src/sentry/models/relocation.py
@@ -161,17 +161,20 @@ class RelocationFile(DefaultFieldsModel):
         def get_choices(cls) -> list[tuple[int, str]]:
             return [(key.value, key.name) for key in cls]
 
-        def to_filename(self, suffix: str):
+        def __str__(self):
             if self.name == "RAW_USER_DATA":
-                return f"raw-relocation-data.{suffix}"
+                return "raw-relocation-data"
             elif self.name == "NORMALIZED_USER_DATA":
-                return f"normalized-relocation-data.{suffix}"
+                return "normalized-relocation-data"
             elif self.name == "BASELINE_CONFIG_VALIDATION_DATA":
-                return f"baseline-config.{suffix}"
+                return "baseline-config"
             elif self.name == "COLLIDING_USERS_VALIDATION_DATA":
-                return f"colliding-users.{suffix}"
+                return "colliding-users"
             else:
                 raise ValueError("Cannot extract a filename from `RelocationFile.Kind.UNKNOWN`.")
+
+        def to_filename(self, ext: str):
+            return str(self) + "." + ext
 
     relocation = FlexibleForeignKey("sentry.Relocation")
     file = FlexibleForeignKey("sentry.File")

--- a/src/sentry/utils/relocation.py
+++ b/src/sentry/utils/relocation.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 import logging
 from contextlib import contextmanager
 from enum import Enum, unique
+from functools import lru_cache
+from string import Template
 from typing import Generator, Optional, Tuple
 
-from sentry.models.relocation import Relocation
+from sentry.backup.dependencies import dependencies, get_model_name, sorted_dependencies
+from sentry.backup.scopes import RelocationScope
+from sentry.models.files.utils import get_storage
+from sentry.models.relocation import Relocation, RelocationFile
+from sentry.models.user import User
 
 logger = logging.getLogger("sentry.relocation.tasks")
 
@@ -37,6 +43,205 @@ RELOCATION_FILE_TYPE = "relocation.file"
 # Note that the actual production file size limit, set by uwsgi, is currently 209715200 bytes, or
 # ~200MB, so we should never see more than ~4 blobs in
 RELOCATION_BLOB_SIZE = int((2**31) / 32)
+
+
+# Create the relevant directories: a `/workspace/in` directory containing the inputs that will
+# be imported, a `/workspace/out` directory for exports that will be generated, and
+# `/workspace/findings` for findings.
+#
+# TODO(getsentry/team-ospo#203): Make `get-self-hosted-repo` pull a pinned version, not
+# mainline.
+#
+# TODO(getsentry/team-ospo#203): Use script in self-hosted to completely flush db instead of
+# using truncation tables.
+CLOUDBUILD_YAML_TEMPLATE = Template(
+    """
+steps:
+
+  ##############################
+  ### Setup steps
+  ##############################
+
+  - name: "gcr.io/cloud-builders/gsutil"
+    id: copy-inputs-being-validated
+    waitFor: ["-"]
+    args: ["cp", "-r", "$bucket_root/relocations/runs/$uuid/in", "."]
+    timeout: 600s
+
+
+  - name: "gcr.io/cloud-builders/docker"
+    id: create-working-dirs
+    waitFor: ["-"]
+    entrypoint: "bash"
+    args:
+      - "-e"
+      - "-c"
+      - |
+        mkdir /workspace/out && chmod 777 /workspace/out
+        mkdir /workspace/findings && chmod 777 /workspace/findings
+        echo '[]' > /workspace/findings/null.json
+    timeout: 15s
+
+
+  - name: "gcr.io/cloud-builders/docker"
+    id: get-self-hosted-repo
+    waitFor: ["-"]
+    entrypoint: "bash"
+    args:
+      - "-e"
+      - "-c"
+      - |
+        mkdir self-hosted && cd self-hosted
+        curl -L "https://github.com/getsentry/self-hosted/archive/$self_hosted_version.tar.gz" | tar xzf - --strip-components=1
+        echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
+    timeout: 120s
+
+
+  - name: "gcr.io/cloud-builders/docker"
+    id: run-install-script
+    waitFor:
+      - get-self-hosted-repo
+    entrypoint: "bash"
+    dir_: self-hosted
+    args:
+      - "-e"
+      - "-c"
+      - |
+        ./install.sh --skip-commit-check --skip-user-creation
+    timeout: 600s
+
+
+  - name: "gcr.io/cloud-builders/docker"
+    id: instance-ready
+    waitFor:
+      - run-install-script
+    args:
+      $docker_compose_cmd
+      - "up"
+      - "-d"
+    timeout: 900s
+
+
+  - name: "gcr.io/cloud-builders/docker"
+    id: clear-database
+    waitFor:
+      - instance-ready
+    args:
+      $docker_compose_cmd
+      - "exec"
+      - "-T"
+      - "postgres"
+      - "psql"
+      - "-U"
+      - "postgres"
+      - "-c"
+      - "TRUNCATE $truncate_tables RESTART IDENTITY CASCADE;"
+    timeout: 30s
+
+  ##############################
+  ### Validation steps
+  ##############################
+  $validation_steps
+
+artifacts:
+  objects:
+    location: "$bucket_root/relocations/runs/$uuid/findings/"
+    paths: ["/workspace/findings/**"]
+timeout: 2400s
+options:
+  machineType: "N1_HIGHCPU_32"
+  env:
+    - "REPORT_SELF_HOSTED_ISSUES=0"
+tags: ["cloud-builders-community"]
+"""
+)
+
+IMPORT_VALIDATION_STEP_TEMPLATE = Template(
+    """
+  - name: "gcr.io/cloud-builders/docker"
+    id: import-$kind
+    waitFor:
+      - copy-inputs-being-validated
+      - create-working-dirs
+      - clear-database
+      $wait_for
+    args:
+      $docker_compose_cmd
+      $docker_compose_run
+      - "-v"
+      - "/workspace/in:/in"
+      - "-v"
+      - "/workspace/findings:/findings"
+      - "web"
+      - "import"
+      - "$scope"
+      - "/in/$tarfile"
+      - "--findings-file"
+      - "/findings/import-$jsonfile"
+      - "--decrypt-with-gcp-kms"
+      - "/in/kms-config.json"
+      $args
+    timeout: 30s
+    """
+)
+
+# TODO(getsentry/team-ospo#203): Encrypt outgoing as well.
+EXPORT_VALIDATION_STEP_TEMPLATE = Template(
+    """
+  - name: "gcr.io/cloud-builders/docker"
+    id: export-$kind
+    waitFor:
+      - import-$kind
+      $wait_for
+    args:
+      $docker_compose_cmd
+      $docker_compose_run
+      - "-v"
+      - "/workspace/out:/out"
+      - "-v"
+      - "/workspace/findings:/findings"
+      - "-e"
+      - "SENTRY_LOG_LEVEL=CRITICAL"
+      - "web"
+      - "export"
+      - "$scope"
+      - "/out/$jsonfile"
+      - "--findings-file"
+      - "/findings/export-$jsonfile"
+      $args
+    timeout: 30s
+    """
+)
+
+# TODO(getsentry/team-ospo#203): Encrypt right side as well.
+COMPARE_VALIDATION_STEP_TEMPLATE = Template(
+    """
+  - name: "gcr.io/cloud-builders/docker"
+    id: compare-$kind
+    waitFor:
+      - export-$kind
+      $wait_for
+    args:
+      $docker_compose_cmd
+      $docker_compose_run
+      - "-v"
+      - "/workspace/in:/in"
+      - "-v"
+      - "/workspace/out:/out"
+      - "-v"
+      - "/workspace/findings:/findings"
+      - "web"
+      - "compare"
+      - "/in/$tarfile"
+      - "/out/$jsonfile"
+      - "--findings-file"
+      - "/findings/compare-$jsonfile"
+      - "--decrypt-left-with-gcp-kms"
+      - "/in/kms-config.json"
+      $args
+    timeout: 30s
+    """
+)
 
 
 def start_relocation_task(
@@ -146,3 +351,158 @@ def retry_task_or_fail_relocation(
         raise e
     else:
         logger.info("Task finished", extra=logger_data)
+
+
+def make_cloudbuild_step_args(indent: int, args: list[str]) -> str:
+    return f"\n{'  ' * indent}".join([f'- "{arg}"' for arg in args])
+
+
+# The set of arguments to invoke a "docker compose" in a cloudbuild step is tedious and repetitive -
+# better to just handle it here.
+@lru_cache(maxsize=1)
+def get_docker_compose_cmd():
+    return make_cloudbuild_step_args(
+        3,
+        [
+            "compose",
+            "-f",
+            "/workspace/self-hosted/docker-compose.yml",
+            "-f",
+            "/workspace/self-hosted/docker-compose.override.yml",
+        ],
+    )
+
+
+# The set of arguments to invoke a "docker compose run" in a cloudbuild step is tedious and
+# repetitive - better to just handle it here.
+@lru_cache(maxsize=1)
+def get_docker_compose_run():
+    return make_cloudbuild_step_args(
+        3,
+        [
+            "run",
+            "--rm",
+            "-T",
+        ],
+    )
+
+
+def create_cloudbuild_yaml(relocation: Relocation) -> bytes:
+    # Only test existing users for collision and mutation.
+    existing_usernames = User.objects.filter(username__in=relocation.want_usernames).values_list(
+        "username", flat=True
+    )
+    filter_usernames_args = [
+        "--filter-usernames",
+        ",".join(existing_usernames) if existing_usernames else ",",
+    ]
+    filter_org_slugs_args = ["--filter-org-slugs", ",".join(relocation.want_org_slugs)]
+    storage = get_storage()
+    bucket_root = (
+        "gs://default"
+        if getattr(storage, "bucket_name", None) is None
+        else (f"gs://{storage.bucket_name}")
+    )
+
+    validation_steps = [
+        create_cloudbuild_validation_step(
+            id="import-baseline-config",
+            step=IMPORT_VALIDATION_STEP_TEMPLATE,
+            scope="config",
+            wait_for=[],
+            kind=RelocationFile.Kind.BASELINE_CONFIG_VALIDATION_DATA,
+            args=["--overwrite-configs"],
+        ),
+        create_cloudbuild_validation_step(
+            id="import-colliding-users",
+            step=IMPORT_VALIDATION_STEP_TEMPLATE,
+            scope="users",
+            wait_for=["import-baseline-config"],
+            kind=RelocationFile.Kind.COLLIDING_USERS_VALIDATION_DATA,
+            args=filter_usernames_args,
+        ),
+        create_cloudbuild_validation_step(
+            id="import-raw-relocation-data",
+            step=IMPORT_VALIDATION_STEP_TEMPLATE,
+            scope="organizations",
+            wait_for=["import-colliding-users"],
+            kind=RelocationFile.Kind.RAW_USER_DATA,
+            args=filter_org_slugs_args,
+        ),
+        create_cloudbuild_validation_step(
+            id="export-baseline-config",
+            step=EXPORT_VALIDATION_STEP_TEMPLATE,
+            scope="config",
+            wait_for=["import-raw-relocation-data"],
+            kind=RelocationFile.Kind.BASELINE_CONFIG_VALIDATION_DATA,
+            args=[],
+        ),
+        create_cloudbuild_validation_step(
+            id="export-colliding-users",
+            step=EXPORT_VALIDATION_STEP_TEMPLATE,
+            scope="users",
+            wait_for=["export-baseline-config"],
+            kind=RelocationFile.Kind.COLLIDING_USERS_VALIDATION_DATA,
+            args=filter_usernames_args,
+        ),
+        create_cloudbuild_validation_step(
+            id="export-raw-relocation-data",
+            step=EXPORT_VALIDATION_STEP_TEMPLATE,
+            scope="organizations",
+            wait_for=["export-colliding-users"],
+            kind=RelocationFile.Kind.RAW_USER_DATA,
+            args=filter_org_slugs_args,
+        ),
+        create_cloudbuild_validation_step(
+            id="compare-baseline-config",
+            step=COMPARE_VALIDATION_STEP_TEMPLATE,
+            scope="config",
+            wait_for=["export-raw-relocation-data"],
+            kind=RelocationFile.Kind.BASELINE_CONFIG_VALIDATION_DATA,
+            args=[],
+        ),
+        create_cloudbuild_validation_step(
+            id="compare-colliding-users",
+            step=COMPARE_VALIDATION_STEP_TEMPLATE,
+            scope="users",
+            wait_for=["compare-baseline-config"],
+            kind=RelocationFile.Kind.COLLIDING_USERS_VALIDATION_DATA,
+            args=[],
+        ),
+        # TODO(getsentry/team-ospo#203): Add compare-raw-relocation-data as well.
+    ]
+
+    deps = dependencies()
+    truncate_tables = [
+        deps[get_model_name(m)].table_name
+        for m in sorted_dependencies()
+        if deps[get_model_name(m)].relocation_scope != RelocationScope.Excluded
+    ]
+    return CLOUDBUILD_YAML_TEMPLATE.substitute(
+        docker_compose_cmd=get_docker_compose_cmd(),
+        bucket_root=bucket_root,
+        self_hosted_version="master",
+        truncate_tables=",".join(truncate_tables),
+        uuid=relocation.uuid,
+        validation_steps="".join(validation_steps),
+    ).encode("utf-8")
+
+
+def create_cloudbuild_validation_step(
+    id: str,
+    step: Template,
+    scope: str,
+    wait_for: list[str],
+    kind: RelocationFile.Kind,
+    args: list[str],
+) -> str:
+    return step.substitute(
+        args=make_cloudbuild_step_args(3, args),
+        docker_compose_cmd=get_docker_compose_cmd(),
+        docker_compose_run=get_docker_compose_run(),
+        jsonfile=kind.to_filename("json"),
+        kind=str(kind),
+        scope=scope,
+        tarfile=kind.to_filename("tar"),
+        wait_for=make_cloudbuild_step_args(3, wait_for),
+    )

--- a/tests/sentry/tasks/snapshots/PreprocessingCompleteTest/test_success.pysnap
+++ b/tests/sentry/tasks/snapshots/PreprocessingCompleteTest/test_success.pysnap
@@ -1,0 +1,342 @@
+---
+created: '2023-10-31T20:53:56.260180Z'
+creator: sentry
+source: tests/sentry/tasks/test_relocation.py
+---
+artifacts:
+  objects:
+    location: gs://<BUCKET>/runs/<UUID>/findings/
+    paths:
+    - /workspace/findings/**
+options:
+  env:
+  - REPORT_SELF_HOSTED_ISSUES=0
+  machineType: N1_HIGHCPU_32
+steps:
+- args:
+  - cp
+  - -r
+  - gs://<BUCKET>/runs/<UUID>/in
+  - .
+  id: copy-inputs-being-validated
+  name: gcr.io/cloud-builders/gsutil
+  timeout: 600s
+  waitFor:
+  - '-'
+- args:
+  - -e
+  - -c
+  - 'mkdir /workspace/out && chmod 777 /workspace/out
+
+    mkdir /workspace/findings && chmod 777 /workspace/findings
+
+    echo ''[]'' > /workspace/findings/null.json
+
+    '
+  entrypoint: bash
+  id: create-working-dirs
+  name: gcr.io/cloud-builders/docker
+  timeout: 15s
+  waitFor:
+  - '-'
+- args:
+  - -e
+  - -c
+  - 'mkdir self-hosted && cd self-hosted
+
+    curl -L "https://github.com/getsentry/self-hosted/archive/master.tar.gz" | tar
+    xzf - --strip-components=1
+
+    echo ''{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}''
+    > docker-compose.override.yml
+
+    '
+  entrypoint: bash
+  id: get-self-hosted-repo
+  name: gcr.io/cloud-builders/docker
+  timeout: 120s
+  waitFor:
+  - '-'
+- args:
+  - -e
+  - -c
+  - './install.sh --skip-commit-check --skip-user-creation
+
+    '
+  dir_: self-hosted
+  entrypoint: bash
+  id: run-install-script
+  name: gcr.io/cloud-builders/docker
+  timeout: 600s
+  waitFor:
+  - get-self-hosted-repo
+- args:
+  - compose
+  - -f
+  - /workspace/self-hosted/docker-compose.yml
+  - -f
+  - /workspace/self-hosted/docker-compose.override.yml
+  - up
+  - -d
+  id: instance-ready
+  name: gcr.io/cloud-builders/docker
+  timeout: 900s
+  waitFor:
+  - run-install-script
+- args:
+  - compose
+  - -f
+  - /workspace/self-hosted/docker-compose.yml
+  - -f
+  - /workspace/self-hosted/docker-compose.override.yml
+  - exec
+  - -T
+  - postgres
+  - psql
+  - -U
+  - postgres
+  - -c
+  - TRUNCATE sentry_controloption,sentry_integration,sentry_option,sentry_organization,sentry_organizationintegration,sentry_organizationoptions,sentry_project,sentry_projectintegration,sentry_projectkey,sentry_projectoptions,sentry_projectownership,sentry_projectredirect,sentry_relay,sentry_relayusage,sentry_repository,sentry_team,auth_user,sentry_userip,sentry_useroption,sentry_userpermission,sentry_userrole,sentry_userrole_users,sentry_savedsearch,sentry_recentsearch,sentry_projectteam,sentry_projectbookmark,sentry_orgauthtoken,sentry_organizationmember,sentry_organizationaccessrequest,sentry_monitor,sentry_environment,sentry_email,sentry_dashboardtombstone,sentry_dashboard,sentry_customdynamicsamplingrule,sentry_projectcounter,sentry_authprovider,sentry_authidentity,auth_authenticator,sentry_apikey,sentry_apiapplication,sentry_actor,sentry_useremail,sentry_snubaquery,sentry_sentryapp,sentry_rule,sentry_querysubscription,sentry_organizationmember_teams,sentry_notificationaction,sentry_neglectedrule,sentry_environmentproject,sentry_dashboardwidget,sentry_customdynamicsamplingruleproject,sentry_apitoken,sentry_apigrant,sentry_apiauthorization,sentry_alertrule,sentry_snubaqueryeventtype,sentry_sentryappinstallation,sentry_sentryappcomponent,sentry_rulesnooze,sentry_ruleactivity,sentry_notificationactionproject,sentry_incident,sentry_dashboardwidgetquery,sentry_alertruletrigger,sentry_alertruleexcludedprojects,sentry_alertruleactivity,sentry_timeseriessnapshot,sentry_servicehook,sentry_pendingincidentsnapshot,sentry_incidenttrigger,sentry_incidentsubscription,sentry_incidentsnapshot,sentry_incidentactivity,sentry_alertruletriggerexclusion,sentry_alertruletriggeraction
+    RESTART IDENTITY CASCADE;
+  id: clear-database
+  name: gcr.io/cloud-builders/docker
+  timeout: 30s
+  waitFor:
+  - instance-ready
+- args:
+  - compose
+  - -f
+  - /workspace/self-hosted/docker-compose.yml
+  - -f
+  - /workspace/self-hosted/docker-compose.override.yml
+  - run
+  - --rm
+  - -T
+  - -v
+  - /workspace/in:/in
+  - -v
+  - /workspace/findings:/findings
+  - web
+  - import
+  - config
+  - /in/baseline-config.tar
+  - --findings-file
+  - /findings/import-baseline-config.json
+  - --decrypt-with-gcp-kms
+  - /in/kms-config.json
+  - --overwrite-configs
+  id: import-baseline-config
+  name: gcr.io/cloud-builders/docker
+  timeout: 30s
+  waitFor:
+  - copy-inputs-being-validated
+  - create-working-dirs
+  - clear-database
+- args:
+  - compose
+  - -f
+  - /workspace/self-hosted/docker-compose.yml
+  - -f
+  - /workspace/self-hosted/docker-compose.override.yml
+  - run
+  - --rm
+  - -T
+  - -v
+  - /workspace/in:/in
+  - -v
+  - /workspace/findings:/findings
+  - web
+  - import
+  - users
+  - /in/colliding-users.tar
+  - --findings-file
+  - /findings/import-colliding-users.json
+  - --decrypt-with-gcp-kms
+  - /in/kms-config.json
+  - --filter-usernames
+  - importing
+  id: import-colliding-users
+  name: gcr.io/cloud-builders/docker
+  timeout: 30s
+  waitFor:
+  - copy-inputs-being-validated
+  - create-working-dirs
+  - clear-database
+  - import-baseline-config
+- args:
+  - compose
+  - -f
+  - /workspace/self-hosted/docker-compose.yml
+  - -f
+  - /workspace/self-hosted/docker-compose.override.yml
+  - run
+  - --rm
+  - -T
+  - -v
+  - /workspace/in:/in
+  - -v
+  - /workspace/findings:/findings
+  - web
+  - import
+  - organizations
+  - /in/raw-relocation-data.tar
+  - --findings-file
+  - /findings/import-raw-relocation-data.json
+  - --decrypt-with-gcp-kms
+  - /in/kms-config.json
+  - --filter-org-slugs
+  - testing
+  id: import-raw-relocation-data
+  name: gcr.io/cloud-builders/docker
+  timeout: 30s
+  waitFor:
+  - copy-inputs-being-validated
+  - create-working-dirs
+  - clear-database
+  - import-colliding-users
+- args:
+  - compose
+  - -f
+  - /workspace/self-hosted/docker-compose.yml
+  - -f
+  - /workspace/self-hosted/docker-compose.override.yml
+  - run
+  - --rm
+  - -T
+  - -v
+  - /workspace/out:/out
+  - -v
+  - /workspace/findings:/findings
+  - -e
+  - SENTRY_LOG_LEVEL=CRITICAL
+  - web
+  - export
+  - config
+  - /out/baseline-config.json
+  - --findings-file
+  - /findings/export-baseline-config.json
+  id: export-baseline-config
+  name: gcr.io/cloud-builders/docker
+  timeout: 30s
+  waitFor:
+  - import-baseline-config
+  - import-raw-relocation-data
+- args:
+  - compose
+  - -f
+  - /workspace/self-hosted/docker-compose.yml
+  - -f
+  - /workspace/self-hosted/docker-compose.override.yml
+  - run
+  - --rm
+  - -T
+  - -v
+  - /workspace/out:/out
+  - -v
+  - /workspace/findings:/findings
+  - -e
+  - SENTRY_LOG_LEVEL=CRITICAL
+  - web
+  - export
+  - users
+  - /out/colliding-users.json
+  - --findings-file
+  - /findings/export-colliding-users.json
+  - --filter-usernames
+  - importing
+  id: export-colliding-users
+  name: gcr.io/cloud-builders/docker
+  timeout: 30s
+  waitFor:
+  - import-colliding-users
+  - export-baseline-config
+- args:
+  - compose
+  - -f
+  - /workspace/self-hosted/docker-compose.yml
+  - -f
+  - /workspace/self-hosted/docker-compose.override.yml
+  - run
+  - --rm
+  - -T
+  - -v
+  - /workspace/out:/out
+  - -v
+  - /workspace/findings:/findings
+  - -e
+  - SENTRY_LOG_LEVEL=CRITICAL
+  - web
+  - export
+  - organizations
+  - /out/raw-relocation-data.json
+  - --findings-file
+  - /findings/export-raw-relocation-data.json
+  - --filter-org-slugs
+  - testing
+  id: export-raw-relocation-data
+  name: gcr.io/cloud-builders/docker
+  timeout: 30s
+  waitFor:
+  - import-raw-relocation-data
+  - export-colliding-users
+- args:
+  - compose
+  - -f
+  - /workspace/self-hosted/docker-compose.yml
+  - -f
+  - /workspace/self-hosted/docker-compose.override.yml
+  - run
+  - --rm
+  - -T
+  - -v
+  - /workspace/in:/in
+  - -v
+  - /workspace/out:/out
+  - -v
+  - /workspace/findings:/findings
+  - web
+  - compare
+  - /in/baseline-config.tar
+  - /out/baseline-config.json
+  - --findings-file
+  - /findings/compare-baseline-config.json
+  - --decrypt-left-with-gcp-kms
+  - /in/kms-config.json
+  id: compare-baseline-config
+  name: gcr.io/cloud-builders/docker
+  timeout: 30s
+  waitFor:
+  - export-baseline-config
+  - export-raw-relocation-data
+- args:
+  - compose
+  - -f
+  - /workspace/self-hosted/docker-compose.yml
+  - -f
+  - /workspace/self-hosted/docker-compose.override.yml
+  - run
+  - --rm
+  - -T
+  - -v
+  - /workspace/in:/in
+  - -v
+  - /workspace/out:/out
+  - -v
+  - /workspace/findings:/findings
+  - web
+  - compare
+  - /in/colliding-users.tar
+  - /out/colliding-users.json
+  - --findings-file
+  - /findings/compare-colliding-users.json
+  - --decrypt-left-with-gcp-kms
+  - /in/kms-config.json
+  id: compare-colliding-users
+  name: gcr.io/cloud-builders/docker
+  timeout: 30s
+  waitFor:
+  - export-colliding-users
+  - compare-baseline-config
+tags:
+- cloud-builders-community
+timeout: 2400s


### PR DESCRIPTION
This file instruments the validation run we need to perform before we can kick off the actual relocation. We build a bespoke YAML for each such run, rather than using substitutions, as there is enough variability that this ends up a bit easier to read, and some variables could grow longer than the substitution API is willing to accept.

Issue: getsentry/team-ospo#203