### PR TITLE
feat(hybrid-cloud): Implement Discord request parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -475,7 +475,6 @@ module = [
     "sentry.middleware.auth",
     "sentry.middleware.health",
     "sentry.middleware.integrations.parsers.base",
-    "sentry.middleware.integrations.parsers.slack",
     "sentry.middleware.ratelimit",
     "sentry.middleware.subdomain",
     "sentry.middleware.superuser",

--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging
+
+from rest_framework.request import Request
+
+from sentry.integrations.discord.requests.base import DiscordRequest
+from sentry.integrations.discord.views.link_identity import DiscordLinkIdentityView
+from sentry.integrations.discord.views.unlink_identity import DiscordUnlinkIdentityView
+from sentry.integrations.discord.webhooks.base import DiscordInteractionsEndpoint
+from sentry.middleware.integrations.parsers.base import BaseRequestParser
+from sentry.models.integrations import Integration
+from sentry.models.outbox import WebhookProviderIdentifier
+from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
+
+logger = logging.getLogger(__name__)
+
+
+class DiscordRequestParser(BaseRequestParser):
+    provider = EXTERNAL_PROVIDERS[ExternalProviders.DISCORD]
+    webhook_identifier = WebhookProviderIdentifier.DISCORD
+
+    control_classes = [
+        DiscordLinkIdentityView,
+        DiscordUnlinkIdentityView,
+    ]
+
+    def get_integration_from_request(self) -> Integration | None:
+        if self.view_class in self.control_classes:
+            return None
+
+        drf_request: Request = DiscordInteractionsEndpoint().initialize_request(self.request)
+        discord_request: DiscordRequest = self.view_class.discord_request_class(drf_request)
+
+        return Integration.objects.filter(
+            provider=self.provider,
+            external_id=discord_request.guild_id,
+        ).first()
+
+    def get_response(self):
+        if self.view_class in self.control_classes:
+            return self.get_response_from_control_silo()
+
+        regions = self.get_regions_from_organizations()
+        if len(regions) == 0:
+            logger.info(f"{self.provider}.no_regions", extra={"path": self.request.path})
+            return self.get_response_from_control_silo()
+
+        if self.view_class == DiscordInteractionsEndpoint:
+            drf_request: Request = DiscordInteractionsEndpoint().initialize_request(self.request)
+            discord_request: DiscordRequest = self.view_class.discord_request_class(drf_request)
+
+            if discord_request.is_command():
+                return self.get_response_from_first_region()
+            if discord_request.is_message_component():
+                return self.get_response_from_all_regions()
+
+        return self.get_response_from_control_silo()

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import List
 
-from django.http import HttpResponse
 from rest_framework.request import Request
 
 from sentry.integrations.slack.requests.base import SlackRequestError
@@ -21,9 +19,7 @@ from sentry.integrations.slack.webhooks.command import SlackCommandsEndpoint
 from sentry.integrations.slack.webhooks.event import SlackEventEndpoint
 from sentry.models.integrations.integration import Integration
 from sentry.models.outbox import WebhookProviderIdentifier
-from sentry.silo.client import SiloClientError
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
-from sentry.types.region import Region
 from sentry.utils.signing import unsign
 
 from .base import BaseRequestParser
@@ -66,23 +62,6 @@ class SlackRequestParser(BaseRequestParser):
     See: `src/sentry/integrations/slack/views`
     """
 
-    def handle_action_endpoint(self, regions: List[Region]) -> HttpResponse:
-        drf_request: Request = SlackDMEndpoint().initialize_request(self.request)
-        slack_request = self.view_class.slack_request_class(drf_request)
-        action_option = SlackActionEndpoint.get_action_option(slack_request=slack_request)
-
-        if action_option in ACTIONS_ENDPOINT_ALL_SILOS_ACTIONS:
-            return self.get_response_from_control_silo()
-        else:
-            response_map = self.get_responses_from_region_silos(regions=regions)
-            successful_responses = [
-                result for result in response_map.values() if result.response is not None
-            ]
-            if len(successful_responses) == 0:
-                error_map = {region: result.error for region, result in response_map.items()}
-                raise SiloClientError("No successful region responses", error_map)
-            return successful_responses[0].response
-
     def get_integration_from_request(self) -> Integration | None:
         if self.view_class in self.webhook_endpoints:
             # We need convert the raw Django request to a Django Rest Framework request
@@ -105,28 +84,6 @@ class SlackRequestParser(BaseRequestParser):
             return Integration.objects.filter(id=params.get("integration_id")).first()
 
         return None
-
-    def get_response_from_first_region(self):
-        regions = self.get_regions_from_organizations()
-        first_region = regions[0]
-        response_map = self.get_responses_from_region_silos(regions=[first_region])
-        region_result = response_map[first_region.name]
-        if region_result.error is not None:
-            # We want to fail loudly so that devs know this error happened on the region silo (for now)
-            error = SiloClientError(region_result.error)
-            raise SiloClientError(error)
-        return region_result.response
-
-    def get_response_from_all_regions(self):
-        regions = self.get_regions_from_organizations()
-        response_map = self.get_responses_from_region_silos(regions=regions)
-        successful_responses = [
-            result for result in response_map.values() if result.response is not None
-        ]
-        if len(successful_responses) == 0:
-            error_map = {region: result.error for region, result in response_map.items()}
-            raise SiloClientError("No successful region responses", error_map)
-        return successful_responses[0].response
 
     def get_response(self):
         """

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -407,6 +407,7 @@ class WebhookProviderIdentifier(IntEnum):
     BITBUCKET_SERVER = 9
     LEGACY_PLUGIN = 10
     GETSENTRY = 11
+    DISCORD = 12
 
 
 def _ensure_not_null(k: str, v: Any) -> Any:

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import RequestFactory
+from django.urls import reverse
+
+from sentry.integrations.discord.requests.base import DiscordRequestTypes
+from sentry.middleware.integrations.parsers.discord import DiscordRequestParser
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+from sentry.types.region import Region, RegionCategory
+from sentry.utils.signing import sign
+
+
+@control_silo_test(stable=True)
+class DiscordRequestParserTest(TestCase):
+    get_response = MagicMock()
+    factory = RequestFactory()
+    region = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
+    discord_id = "808"
+
+    @pytest.fixture(autouse=True)
+    def patch_get_region(self):
+        with patch.object(
+            DiscordRequestParser, "get_regions_from_organizations", return_value=[self.region]
+        ):
+            yield
+
+    def setUp(self):
+        super().setUp()
+        self.integration = self.create_integration(
+            organization=self.organization,
+            external_id="discord:123",
+            provider="discord",
+        )
+
+    def get_parser(self, path: str, data: Mapping[str, Any] | None = None):
+        if not data:
+            data = {}
+        self.request = self.factory.post(path, data=data, content_type="application/json")
+        return DiscordRequestParser(self.request, self.get_response)
+
+    def test_interactions_endpoint_routing_ping(self):
+        data = {"guild_id": self.integration.external_id, "type": DiscordRequestTypes.PING}
+        parser = self.get_parser(reverse("sentry-integration-discord-interactions"), data=data)
+        integration = parser.get_integration_from_request()
+        assert integration == self.integration
+        with patch.object(
+            parser, "get_response_from_control_silo"
+        ) as mock_response_from_control, assume_test_silo_mode(
+            SiloMode.CONTROL, can_be_monolith=False
+        ):
+            parser.get_response()
+            assert mock_response_from_control.called
+
+    def test_interactions_endpoint_routing_command(self):
+        data = {"guild_id": self.integration.external_id, "type": int(DiscordRequestTypes.COMMAND)}
+        parser = self.get_parser(reverse("sentry-integration-discord-interactions"), data=data)
+        integration = parser.get_integration_from_request()
+        assert integration == self.integration
+        with patch.object(
+            parser, "get_response_from_first_region"
+        ) as mock_respond_from_first, assume_test_silo_mode(
+            SiloMode.CONTROL, can_be_monolith=False
+        ):
+            parser.get_response()
+            assert mock_respond_from_first.called
+
+    def test_interactions_endpoint_routing_message_component(self):
+        data = {
+            "guild_id": self.integration.external_id,
+            "type": int(DiscordRequestTypes.MESSAGE_COMPONENT),
+        }
+        parser = self.get_parser(reverse("sentry-integration-discord-interactions"), data=data)
+        integration = parser.get_integration_from_request()
+        assert integration == self.integration
+        with patch.object(
+            parser, "get_response_from_all_regions"
+        ) as mock_response_from_all, assume_test_silo_mode(SiloMode.CONTROL, can_be_monolith=False):
+            parser.get_response()
+            assert mock_response_from_all.called
+
+    def test_control_classes(self):
+        params = sign(integration_id=self.integration.id, discord_id=self.discord_id)
+        link_path = reverse(
+            "sentry-integration-discord-link-identity",
+            kwargs={"signed_params": params},
+        )
+        unlink_path = reverse(
+            "sentry-integration-discord-unlink-identity",
+            kwargs={"signed_params": params},
+        )
+        for path in [link_path, unlink_path]:
+            parser = self.get_parser(path)
+            parser_integration = parser.get_integration_from_request()
+            assert parser_integration.id == self.integration.id
+
+            # Forwards to control silo
+            with patch.object(
+                parser, "get_response_from_outbox_creation"
+            ) as get_response_from_outbox_creation, patch.object(
+                parser, "get_response_from_control_silo"
+            ) as mock_response_from_control, assume_test_silo_mode(
+                SiloMode.CONTROL, can_be_monolith=False
+            ):
+                parser.get_response()
+                assert mock_response_from_control.called
+                assert not get_response_from_outbox_creation.called


### PR DESCRIPTION
Handles routing discord requests to region silos. Similar to the slack webhooks, it can only respond to slash commands from a single silo, but must fan out issue operations to all regions.