### PR TITLE
ref(issues): Rename EventCause to SuspectCommits

### DIFF
--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -22,7 +22,6 @@ import {objectIsEmpty} from 'sentry/utils';
 import {EventContexts} from './contexts';
 import {EventDevice} from './device';
 import {EventAttachments} from './eventAttachments';
-import {EventCause} from './eventCause';
 import {EventDataSection} from './eventDataSection';
 import {EventEntry} from './eventEntry';
 import {EventErrors} from './eventErrors';
@@ -34,6 +33,7 @@ import {EventGroupingInfo} from './groupingInfo';
 import {EventPackageData} from './packageData';
 import {EventRRWebIntegration} from './rrwebIntegration';
 import {DataSection} from './styles';
+import {SuspectCommits} from './suspectCommits';
 import {EventUserFeedback} from './userFeedback';
 
 type Props = {
@@ -78,7 +78,7 @@ function EventEntries({
     <div className={className}>
       <EventErrors event={event} project={project} isShare={isShare} />
       {!isShare && isNotSharedOrganization(organization) && (
-        <EventCause
+        <SuspectCommits
           project={project}
           eventId={event.id}
           group={group}

--- a/static/app/components/events/styles.tsx
+++ b/static/app/components/events/styles.tsx
@@ -79,7 +79,7 @@ export const BannerSummary = styled('p')`
   }
 `;
 
-export const CauseHeader = styled('div')`
+export const SuspectCommitHeader = styled('div')`
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/static/app/components/events/suspectCommits.spec.tsx
+++ b/static/app/components/events/suspectCommits.spec.tsx
@@ -1,18 +1,22 @@
+import {Event} from 'sentry-fixture/event';
+import {Group} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
+import {Project} from 'sentry-fixture/project';
 import {Repository} from 'sentry-fixture/repository';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {EventCause} from 'sentry/components/events/eventCause';
+import {QuickContextCommitRow} from 'sentry/components/discover/quickContextCommitRow';
 
 import {CommitRow} from '../commitRow';
-import {QuickContextCommitRow} from '../discover/quickContextCommitRow';
 
-describe('EventCause', function () {
+import {SuspectCommits} from './suspectCommits';
+
+describe('SuspectCommits', function () {
   const organization = Organization();
-  const project = TestStubs.Project();
-  const event = TestStubs.Event();
-  const group = TestStubs.Group({firstRelease: {}});
+  const project = Project();
+  const event = Event();
+  const group = Group({firstRelease: {}} as any);
 
   const committers = [
     {
@@ -66,15 +70,12 @@ describe('EventCause', function () {
 
   it('Renders base commit row', async function () {
     render(
-      <EventCause
+      <SuspectCommits
         project={project}
         commitRow={CommitRow}
         eventId={event.id}
         group={group}
-      />,
-      {
-        organization,
-      }
+      />
     );
 
     expect(await screen.findByTestId('commit-row')).toBeInTheDocument();
@@ -84,15 +85,12 @@ describe('EventCause', function () {
 
   it('Renders quick context commit row', async function () {
     render(
-      <EventCause
+      <SuspectCommits
         project={project}
         commitRow={QuickContextCommitRow}
         eventId={event.id}
         group={group}
-      />,
-      {
-        organization,
-      }
+      />
     );
 
     expect(await screen.findByTestId('quick-context-commit-row')).toBeInTheDocument();
@@ -111,15 +109,12 @@ describe('EventCause', function () {
     });
 
     render(
-      <EventCause
+      <SuspectCommits
         project={project}
         commitRow={CommitRow}
         eventId={event.id}
         group={group}
-      />,
-      {
-        organization,
-      }
+      />
     );
 
     expect(await screen.findByText(/Suspect Commit/i)).toBeInTheDocument();
@@ -128,15 +123,12 @@ describe('EventCause', function () {
 
   it('renders correct heading for multiple commits (and filters to unique commits)', async () => {
     render(
-      <EventCause
+      <SuspectCommits
         project={project}
         commitRow={CommitRow}
         eventId={event.id}
         group={group}
-      />,
-      {
-        organization,
-      }
+      />
     );
 
     // There are two commits rather than three because two of the mock commits above are the same
@@ -145,15 +137,12 @@ describe('EventCause', function () {
 
   it('expands', async function () {
     render(
-      <EventCause
+      <SuspectCommits
         project={project}
         commitRow={CommitRow}
         eventId={event.id}
         group={group}
-      />,
-      {
-        organization,
-      }
+      />
     );
 
     await userEvent.click(await screen.findByText('Show more'));
@@ -187,15 +176,12 @@ describe('EventCause', function () {
     });
 
     render(
-      <EventCause
+      <SuspectCommits
         project={project}
         commitRow={CommitRow}
         eventId={event.id}
         group={group}
-      />,
-      {
-        organization,
-      }
+      />
     );
 
     expect(await screen.findByTestId('commit-row')).toBeInTheDocument();

--- a/static/app/components/events/suspectCommits.tsx
+++ b/static/app/components/events/suspectCommits.tsx
@@ -1,15 +1,15 @@
-import {Fragment, JSXElementConstructor, useState} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 import flatMap from 'lodash/flatMap';
 import uniqBy from 'lodash/uniqBy';
 
-import {CommitRowProps} from 'sentry/components/commitRow';
-import {CauseHeader, DataSection} from 'sentry/components/events/styles';
+import type {CommitRowProps} from 'sentry/components/commitRow';
+import {DataSection, SuspectCommitHeader} from 'sentry/components/events/styles';
 import Panel from 'sentry/components/panels/panel';
 import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {AvatarProject, Commit, Group} from 'sentry/types';
+import type {AvatarProject, Commit, Group} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -17,13 +17,13 @@ import useCommitters from 'sentry/utils/useCommitters';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
-  commitRow: JSXElementConstructor<CommitRowProps>;
+  commitRow: React.ComponentType<CommitRowProps>;
   eventId: string;
   project: AvatarProject;
   group?: Group;
 }
 
-export function EventCause({group, eventId, project, commitRow: CommitRow}: Props) {
+export function SuspectCommits({group, eventId, project, commitRow: CommitRow}: Props) {
   const organization = useOrganization();
   const [isExpanded, setIsExpanded] = useState(false);
   const {data} = useCommitters({
@@ -81,8 +81,8 @@ export function EventCause({group, eventId, project, commitRow: CommitRow}: Prop
 
   return (
     <DataSection>
-      <CauseHeader>
-        <h3 data-test-id="event-cause">{commitHeading}</h3>
+      <SuspectCommitHeader>
+        <h3 data-test-id="suspect-commit">{commitHeading}</h3>
         {commits.length > 1 && (
           <ExpandButton
             onClick={() => setIsExpanded(!isExpanded)}
@@ -99,7 +99,7 @@ export function EventCause({group, eventId, project, commitRow: CommitRow}: Prop
             )}
           </ExpandButton>
         )}
-      </CauseHeader>
+      </SuspectCommitHeader>
       <StyledPanel>
         {commits.slice(0, isExpanded ? 100 : 1).map((commit, commitIndex) => (
           <CommitRow

--- a/static/app/views/discover/table/quickContext/issueContext.tsx
+++ b/static/app/views/discover/table/quickContext/issueContext.tsx
@@ -4,8 +4,8 @@ import styled from '@emotion/styled';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import Count from 'sentry/components/count';
 import {QuickContextCommitRow} from 'sentry/components/discover/quickContextCommitRow';
-import {EventCause, StyledPanel} from 'sentry/components/events/eventCause';
-import {CauseHeader, DataSection} from 'sentry/components/events/styles';
+import {DataSection, SuspectCommitHeader} from 'sentry/components/events/styles';
+import {StyledPanel, SuspectCommits} from 'sentry/components/events/suspectCommits';
 import {getAssignedToDisplayName} from 'sentry/components/group/assignedTo';
 import Panel from 'sentry/components/panels/panel';
 import {IconWrapper} from 'sentry/components/sidebarSection';
@@ -157,7 +157,7 @@ function IssueContext(props: BaseContextProps) {
     event.eventID &&
     issue && (
       <SuspectCommitsContainer data-test-id="quick-context-suspect-commits-container">
-        <EventCause
+        <SuspectCommits
           project={issue.project}
           eventId={event.eventID}
           commitRow={QuickContextCommitRow}
@@ -195,7 +195,7 @@ const SuspectCommitsContainer = styled(ContextContainer)`
     padding: 0;
   }
 
-  ${CauseHeader} {
+  ${SuspectCommitHeader} {
     margin: ${space(2)} 0 ${space(0.75)};
   }
 `;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -494,8 +494,7 @@ describe('EventCause', () => {
 
     render(<TestComponent project={props.project} />, {organization: props.organization});
 
-    expect(await screen.findByTestId(/event-cause/)).toBeInTheDocument();
-    expect(screen.queryByTestId(/loaded-event-cause-empty/)).not.toBeInTheDocument();
+    expect(await screen.findByTestId(/suspect-commit/)).toBeInTheDocument();
   });
 });
 

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -7,7 +7,6 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import {EventContexts} from 'sentry/components/events/contexts';
 import {EventDevice} from 'sentry/components/events/device';
 import {EventAttachments} from 'sentry/components/events/eventAttachments';
-import {EventCause} from 'sentry/components/events/eventCause';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {EventEntry} from 'sentry/components/events/eventEntry';
 import {EventEvidence} from 'sentry/components/events/eventEvidence';
@@ -32,6 +31,7 @@ import {AnrRootCause} from 'sentry/components/events/interfaces/performance/anrR
 import {SpanEvidenceSection} from 'sentry/components/events/interfaces/performance/spanEvidence';
 import {EventPackageData} from 'sentry/components/events/packageData';
 import {EventRRWebIntegration} from 'sentry/components/events/rrwebIntegration';
+import {SuspectCommits} from 'sentry/components/events/suspectCommits';
 import {EventUserFeedback} from 'sentry/components/events/userFeedback';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -98,7 +98,7 @@ function DefaultGroupEventDetailsContent({
       {hasActionableItems && (
         <ActionableItems event={event} project={project} isShare={false} />
       )}
-      <EventCause
+      <SuspectCommits
         project={project}
         eventId={event.id}
         group={group}


### PR DESCRIPTION
I think at some point we pictured there being different event causes. It is only suspect commits

