### PR TITLE
fix(issue-details): Move default analytics values to prevent them from overriding correct values

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -613,15 +613,20 @@ function useTrackView({
     alert_type: typeof alert_type === 'string' ? alert_type : undefined,
     ref_fallback,
     group_event_type: groupEventType,
+  });
+  // Set default values for properties that may be updated in subcomponents.
+  // Must be separate from the above values, otherwise the actual values filled in
+  // by subcomponents may be overwritten when the above values change.
+  useRouteAnalyticsParams({
     // Will be updated by StacktraceLink if there is a stacktrace link
     stacktrace_link_viewed: false,
     // Will be updated by IssueQuickTrace if there is a trace
     trace_status: 'none',
     // Will be updated in GroupDetailsHeader if there are replays
     group_has_replay: false,
-    // Will be updated in EventCause if there are suspect commits
-    num_suspect_commits: -1,
-    suspect_commit_calculation: 'none',
+    // Will be updated in SuspectCommits if there are suspect commits
+    num_suspect_commits: 0,
+    suspect_commit_calculation: 'no suspect commit',
   });
   useDisableRouteAnalytics(!group || !event || !project);
 }


### PR DESCRIPTION
We set a lot of properties on the `issue_details.viewed` event, some of which have default values on init, but get filled in later by subcomponents that make another request (like stacktrace linking and suspect commits). I noticed that sometimes the values don't seem right. I found that there is a race condition where, if  a value changes in the initial `useRouteAnalyticsParams` after the values were populated by subcomponents, those values would be reset back to the initial values. By separating the initializers into their own call, they will only be called once and not override the actual values.