### PR TITLE
feat(starfish): tooltips, page loads side chart, and landing page table improvements

### DIFF
--- a/static/app/views/performance/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/performance/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -6,7 +6,6 @@ import ChartZoom from 'sentry/components/charts/chartZoom';
 import {LineChart, LineChartSeries} from 'sentry/components/charts/lineChart';
 import ExternalLink from 'sentry/components/links/externalLink';
 import QuestionTooltip from 'sentry/components/questionTooltip';
-import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {PageFilters} from 'sentry/types';
@@ -100,7 +99,6 @@ export function PageOverviewSidebar({projectScore, transaction}: Props) {
 
   const ringSegmentColors = theme.charts.getColorPalette(3);
   const ringBackgroundColors = ringSegmentColors.map(color => `${color}50`);
-  const performanceScoreSubtext = (period && DEFAULT_RELATIVE_PERIODS[period]) ?? '';
 
   return (
     <Fragment>
@@ -120,7 +118,6 @@ export function PageOverviewSidebar({projectScore, transaction}: Props) {
           }
         />
       </SectionHeading>
-      <PerformanceScoreSubText>{performanceScoreSubtext}</PerformanceScoreSubText>
       <SidebarPerformanceScoreRingContainer>
         {projectScore && (
           <PerformanceScoreRingWithTooltips
@@ -237,12 +234,5 @@ const SectionHeading = styled('h4')`
 
 const MiniAggregateWaterfallContainer = styled('div')`
   margin-top: ${space(1)};
-  margin-bottom: ${space(1)};
-`;
-
-const PerformanceScoreSubText = styled('div')`
-  width: 100%;
-  font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
   margin-bottom: ${space(1)};
 `;

--- a/static/app/views/performance/browser/webVitals/components/pageOverviewSidebar.tsx
+++ b/static/app/views/performance/browser/webVitals/components/pageOverviewSidebar.tsx
@@ -4,10 +4,14 @@ import styled from '@emotion/styled';
 
 import ChartZoom from 'sentry/components/charts/chartZoom';
 import {LineChart, LineChartSeries} from 'sentry/components/charts/lineChart';
+import ExternalLink from 'sentry/components/links/externalLink';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {PageFilters} from 'sentry/types';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import {getPeriod} from 'sentry/utils/getPeriod';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 import {MiniAggregateWaterfall} from 'sentry/views/performance/browser/webVitals/components/miniAggregateWaterfall';
@@ -29,13 +33,21 @@ export function PageOverviewSidebar({projectScore, transaction}: Props) {
   const router = useRouter();
   const pageFilters = usePageFilters();
   const {period, start, end, utc} = pageFilters.selection.datetime;
+  const doubledPeriod = getPeriod({period, start, end}, {shouldDoublePeriod: true});
+  const doubledDatetime: PageFilters['datetime'] = {
+    period: doubledPeriod.statsPeriod ?? null,
+    start: doubledPeriod.start ?? null,
+    end: doubledPeriod.end ?? null,
+    utc,
+  };
 
   const {data, isLoading: isLoading} = useProjectWebVitalsValuesTimeseriesQuery({
     transaction,
+    datetime: doubledDatetime,
   });
 
   let seriesData = !isLoading
-    ? data?.eps.map(({name, value}) => ({
+    ? data?.count.map(({name, value}) => ({
         name,
         value,
       }))
@@ -45,23 +57,27 @@ export function PageOverviewSidebar({projectScore, transaction}: Props) {
   if (seriesData.length > 0 && period && !start && !end) {
     seriesData = seriesData.slice(0, -1);
   }
+  const dataMiddleIndex = Math.floor(seriesData.length / 2);
+  const currentSeries = seriesData.slice(dataMiddleIndex);
+  const previousSeries = seriesData.slice(0, dataMiddleIndex);
+
+  const initialCount = !isLoading
+    ? previousSeries.reduce((acc, {value}) => acc + value, 0)
+    : undefined;
+  const currentCount = !isLoading
+    ? currentSeries.reduce((acc, {value}) => acc + value, 0)
+    : undefined;
+  const countDiff =
+    !isLoading && currentCount !== undefined && initialCount !== undefined
+      ? currentCount / initialCount
+      : undefined;
 
   const throughtputData: LineChartSeries[] = [
     {
-      data: seriesData,
+      data: currentSeries,
       seriesName: t('Page Loads'),
     },
   ];
-
-  const epsDiff = !isLoading
-    ? seriesData[seriesData.length - 1].value / seriesData[0].value
-    : undefined;
-  const initialEps = !isLoading
-    ? `${Math.round(seriesData[0].value * 100) / 100}/s`
-    : undefined;
-  const currentEps = !isLoading
-    ? `${Math.round(seriesData[seriesData.length - 1].value * 100) / 100}/s`
-    : undefined;
 
   const diffToColor = (diff?: number, reverse?: boolean) => {
     if (diff === undefined) {
@@ -91,8 +107,17 @@ export function PageOverviewSidebar({projectScore, transaction}: Props) {
       <SectionHeading>
         {t('Performance Score')}
         <QuestionTooltip
+          isHoverable
           size="sm"
-          title={t('Overall performance rating of your application')}
+          title={
+            <span>
+              {t('The overall performance rating of this page.')}
+              <br />
+              <ExternalLink href="https://docs.sentry.io/product/performance/web-vitals/#performance-score">
+                {t('How is this calculated?')}
+              </ExternalLink>
+            </span>
+          }
         />
       </SectionHeading>
       <PerformanceScoreSubText>{performanceScoreSubtext}</PerformanceScoreSubText>
@@ -113,13 +138,21 @@ export function PageOverviewSidebar({projectScore, transaction}: Props) {
         {t('Page Loads')}
         <QuestionTooltip
           size="sm"
-          title={t('The number of transactions per unit time')}
+          title={t('The total number of times that users have loaded this page.')}
         />
       </SectionHeading>
-      <ChartValue>{currentEps}</ChartValue>
-      <ChartSubText color={diffToColor(epsDiff)}>
-        {getChartSubText(epsDiff, initialEps, currentEps)}
-      </ChartSubText>
+      <ChartValue>
+        {currentCount ? formatAbbreviatedNumber(currentCount) : null}
+      </ChartValue>
+      {initialCount && currentCount && countDiff && (
+        <ChartSubText color={diffToColor(countDiff)}>
+          {getChartSubText(
+            countDiff,
+            formatAbbreviatedNumber(initialCount),
+            formatAbbreviatedNumber(currentCount)
+          )}
+        </ChartSubText>
+      )}
       <ChartZoom router={router} period={period} start={start} end={end} utc={utc}>
         {zoomRenderProps => (
           <LineChart
@@ -133,8 +166,8 @@ export function PageOverviewSidebar({projectScore, transaction}: Props) {
               top: 10,
               bottom: -10,
             }}
-            yAxis={{axisLabel: {formatter: value => `${value}/s`}}}
-            tooltip={{valueFormatter: value => `${Math.round(value * 100) / 100}/s`}}
+            yAxis={{axisLabel: {formatter: number => formatAbbreviatedNumber(number)}}}
+            tooltip={{valueFormatter: number => formatAbbreviatedNumber(number)}}
           />
         )}
       </ChartZoom>
@@ -143,7 +176,7 @@ export function PageOverviewSidebar({projectScore, transaction}: Props) {
         {t('Aggregate Spans')}
         <QuestionTooltip
           size="sm"
-          title={t('Waterfall view displaying common span paths that the page may take')}
+          title={t('A synthesized span waterfall for this page.')}
         />
       </SectionHeading>
       <MiniAggregateWaterfallContainer>

--- a/static/app/views/performance/browser/webVitals/pagePerformanceTable.tsx
+++ b/static/app/views/performance/browser/webVitals/pagePerformanceTable.tsx
@@ -132,28 +132,43 @@ export function PagePerformanceTable() {
     if (col.key === 'score') {
       return (
         <AlignCenter>
-          <span>{col.name}</span>
+          <StyledTooltip
+            isHoverable
+            title={
+              <span>
+                {t('The overall performance rating of this page.')}
+                <br />
+                <ExternalLink href="https://docs.sentry.io/product/performance/web-vitals/#performance-score">
+                  {t('How is this calculated?')}
+                </ExternalLink>
+              </span>
+            }
+          >
+            <TooltipHeader>{t('Perf Score')}</TooltipHeader>
+          </StyledTooltip>
         </AlignCenter>
       );
     }
     if (col.key === 'opportunity') {
       return (
-        <Tooltip
-          isHoverable
-          title={
-            <span>
-              {t(
-                "A number rating how impactful a performance improvement on this page would be to your application's overall Performance Score."
-              )}
-              <br />
-              <ExternalLink href="https://docs.sentry.io/product/performance/web-vitals/#opportunity">
-                {t('How is this calculated?')}
-              </ExternalLink>
-            </span>
-          }
-        >
-          <OpportunityHeader>{col.name}</OpportunityHeader>
-        </Tooltip>
+        <AlignRight>
+          <StyledTooltip
+            isHoverable
+            title={
+              <span>
+                {t(
+                  "A number rating how impactful a performance improvement on this page would be to your application's overall Performance Score."
+                )}
+                <br />
+                <ExternalLink href="https://docs.sentry.io/product/performance/web-vitals/#opportunity">
+                  {t('How is this calculated?')}
+                </ExternalLink>
+              </span>
+            }
+          >
+            <TooltipHeader>{col.name}</TooltipHeader>
+          </StyledTooltip>
+        </AlignRight>
       );
     }
     return <span>{col.name}</span>;
@@ -310,7 +325,7 @@ const GridContainer = styled('div')`
   margin-bottom: ${space(1)};
 `;
 
-const OpportunityHeader = styled('span')`
+const TooltipHeader = styled('span')`
   ${p => p.theme.tooltipUnderline()};
 `;
 
@@ -327,4 +342,9 @@ const Wrapper = styled('div')`
   align-items: center;
   justify-content: flex-end;
   margin: 0;
+`;
+
+const StyledTooltip = styled(Tooltip)`
+  top: 1px;
+  position: relative;
 `;

--- a/static/app/views/performance/browser/webVitals/pageSamplePerformanceTable.tsx
+++ b/static/app/views/performance/browser/webVitals/pageSamplePerformanceTable.tsx
@@ -12,6 +12,7 @@ import GridEditable, {
   GridColumnOrder,
 } from 'sentry/components/gridEditable';
 import SortLink from 'sentry/components/gridEditable/sortLink';
+import ExternalLink from 'sentry/components/links/externalLink';
 import Pagination from 'sentry/components/pagination';
 import {Tooltip} from 'sentry/components/tooltip';
 import {IconChevron, IconPlay, IconProfiling} from 'sentry/icons';
@@ -156,7 +157,20 @@ export function PageSamplePerformanceTable({
     if (col.key === 'score') {
       return (
         <AlignCenter>
-          <span>{t('Perf Score')}</span>
+          <StyledTooltip
+            isHoverable
+            title={
+              <span>
+                {t('The overall performance rating of this page.')}
+                <br />
+                <ExternalLink href="https://docs.sentry.io/product/performance/web-vitals/#performance-score">
+                  {t('How is this calculated?')}
+                </ExternalLink>
+              </span>
+            }
+          >
+            <TooltipHeader>{t('Perf Score')}</TooltipHeader>
+          </StyledTooltip>
         </AlignCenter>
       );
     }
@@ -410,4 +424,13 @@ const Wrapper = styled('div')`
   align-items: center;
   justify-content: flex-end;
   margin: 0;
+`;
+
+const TooltipHeader = styled('span')`
+  ${p => p.theme.tooltipUnderline()};
+`;
+
+const StyledTooltip = styled(Tooltip)`
+  top: 1px;
+  position: relative;
 `;

--- a/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
+++ b/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
@@ -2,6 +2,8 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import ExternalLink from 'sentry/components/links/externalLink';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -55,7 +57,22 @@ export function PerformanceScoreChart({
   return (
     <Flex>
       <PerformanceScoreLabelContainer>
-        <PerformanceScoreLabel>{t('Performance Score')}</PerformanceScoreLabel>
+        <PerformanceScoreLabel>
+          {t('Performance Score')}
+          <StyledQuestionTooltip
+            isHoverable
+            size="sm"
+            title={
+              <span>
+                {t('The overall performance rating of this page.')}
+                <br />
+                <ExternalLink href="https://docs.sentry.io/product/performance/web-vitals/#performance-score">
+                  {t('How is this calculated?')}
+                </ExternalLink>
+              </span>
+            }
+          />
+        </PerformanceScoreLabel>
         <PerformanceScoreSubtext>{performanceScoreSubtext}</PerformanceScoreSubtext>
         {!isProjectScoreLoading && projectScore && (
           <PerformanceScoreRingWithTooltips
@@ -109,4 +126,10 @@ const PerformanceScoreSubtext = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.gray300};
   margin-bottom: ${space(1)};
+`;
+
+const StyledQuestionTooltip = styled(QuestionTooltip)`
+  position: relative;
+  margin-left: ${space(0.5)};
+  top: ${space(0.25)};
 `;

--- a/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsValuesTimeseriesQuery.tsx
@@ -1,4 +1,5 @@
 import {getInterval} from 'sentry/components/charts/utils';
+import {PageFilters} from 'sentry/types';
 import {SeriesDataUnit} from 'sentry/types/echarts';
 import EventView, {MetaType} from 'sentry/utils/discover/eventView';
 import {
@@ -11,10 +12,14 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
 type Props = {
+  datetime?: PageFilters['datetime'];
   transaction?: string | null;
 };
 
-export const useProjectWebVitalsValuesTimeseriesQuery = ({transaction}: Props) => {
+export const useProjectWebVitalsValuesTimeseriesQuery = ({
+  transaction,
+  datetime,
+}: Props) => {
   const pageFilters = usePageFilters();
   const location = useLocation();
   const organization = useOrganization();
@@ -39,7 +44,10 @@ export const useProjectWebVitalsValuesTimeseriesQuery = ({transaction}: Props) =
       interval: getInterval(pageFilters.selection.datetime, 'low'),
       dataset: DiscoverDatasets.METRICS,
     },
-    pageFilters.selection
+    {
+      ...pageFilters.selection,
+      datetime: datetime ?? pageFilters.selection.datetime,
+    }
   );
 
   const result = useGenericDiscoverQuery<

--- a/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 import {Link} from 'react-router';
 import styled from '@emotion/styled';
+import toUpper from 'lodash/toUpper';
 
 import {LineChartSeries} from 'sentry/components/charts/lineChart';
 import GridEditable, {
@@ -9,8 +10,9 @@ import GridEditable, {
   GridColumnOrder,
   GridColumnSortBy,
 } from 'sentry/components/gridEditable';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {Tooltip} from 'sentry/components/tooltip';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {getDuration} from 'sentry/utils/formatters';
 import {
   PageErrorAlert,
@@ -126,9 +128,19 @@ export function WebVitalsDetailPanel({
     if (col.key === 'opportunity') {
       return (
         <Tooltip
-          title={t(
-            'The biggest opportunities to improve your cumulative performance score.'
-          )}
+          isHoverable
+          title={
+            <span>
+              {tct(
+                "A number rating how impactful a performance improvement on this page would be to your application's [webVital] Performance Score.",
+                {webVital: webVital ? toUpper(webVital) : ''}
+              )}
+              <br />
+              <ExternalLink href="https://docs.sentry.io/product/performance/web-vitals/#opportunity">
+                {t('How is this calculated?')}
+              </ExternalLink>
+            </span>
+          }
         >
           <OpportunityHeader>{col.name}</OpportunityHeader>
         </Tooltip>


### PR DESCRIPTION
Updates tooltips and adds links to performance score and opportunity score docs.
Updates landing page table to have more rows and moves pagination next to search bar.
Updates page overview "Page Loads" chart data to be just raw page load count instead of rate.