### PR TITLE
fix(replays): document per_page and cursor parameters

### DIFF
--- a/src/sentry/replays/validators.py
+++ b/src/sentry/replays/validators.py
@@ -78,6 +78,10 @@ UTC ISO8601 or epoch seconds. Use along with `start` instead of `statsPeriod`.
     per_page = serializers.IntegerField(
         help_text="Limit the number of rows to return in the result.", required=False
     )
+    cursor = serializers.CharField(
+        help_text="The cursor parameter is used to paginate results. See [here](https://docs.sentry.io/api/pagination/) for how to use this query parameter",
+        required=False,
+    )
 
 
 class ReplaySelectorValidator(serializers.Serializer):

--- a/src/sentry/replays/validators.py
+++ b/src/sentry/replays/validators.py
@@ -75,6 +75,9 @@ UTC ISO8601 or epoch seconds. Use along with `start` instead of `statsPeriod`.
     query = serializers.CharField(
         help_text="A structured query string to filter the output by.", required=False
     )
+    per_page = serializers.IntegerField(
+        help_text="Limit the number of rows to return in the result.", required=False
+    )
 
 
 class ReplaySelectorValidator(serializers.Serializer):


### PR DESCRIPTION
Adds documentation for these missing parameters on our replay index endpoint.

See https://sentry.sentry.io/feedback/?alert_rule_id=14726826&alert_type=issue&feedbackSlug=docs%3A4593424691