### PR TITLE
fix(dynamic-sampling): Emit sample rate as gauge metric

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -311,7 +311,7 @@ def adjust_sample_rates_of_projects(
             if rebalanced_project.id in PROJECTS_WITH_METRICS:
                 metrics.gauge(
                     "dynamic_sampling.project_sample_rate",
-                    rebalanced_project.new_sample_rate,
+                    rebalanced_project.new_sample_rate * 100,
                     tags={"project_id": rebalanced_project.id},
                     unit="percent",
                 )

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -309,10 +309,11 @@ def adjust_sample_rates_of_projects(
             )
 
             if rebalanced_project.id in PROJECTS_WITH_METRICS:
-                metrics.timing(
+                metrics.gauge(
                     "dynamic_sampling.project_sample_rate",
                     rebalanced_project.new_sample_rate,
                     tags={"project_id": rebalanced_project.id},
+                    unit="percent",
                 )
 
             # We want to store the new sample rate as a string.


### PR DESCRIPTION
This PR emits a new metrics for tracking the dynamic sampling sample rate.

Closes https://github.com/getsentry/sentry/issues/58567