### PR TITLE
fix(ddm): Fix unit of view.duration metric

### DIFF
--- a/src/sentry/middleware/stats.py
+++ b/src/sentry/middleware/stats.py
@@ -88,4 +88,10 @@ class RequestTimingMiddleware(MiddlewareMixin):
             return
 
         ms = int((time.time() - start_time) * 1000)
-        metrics.timing("view.duration", ms, instance=view_path, tags={"method": request.method})
+        metrics.distribution(
+            "view.duration",
+            ms,
+            instance=view_path,
+            tags={"method": request.method},
+            unit="millisecond",
+        )


### PR DESCRIPTION
This PR fixes the unit of the `view.duration` metric that was reported as `second` instead of `millisecond`.

Closes https://github.com/getsentry/sentry/issues/58777