### PR TITLE
Do not inherit source context from raw_stacktrace

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -278,7 +278,7 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
             merged_context_frame = _merge_frame_context(sinfo_frame, raw_frame)
             new_raw_frames.append(merged_context_frame)
 
-            merged_frame = _merge_frame(merged_context_frame, complete_frame)
+            merged_frame = _merge_frame(sinfo_frame, complete_frame)
             new_frames.append(merged_frame)
 
         sinfo.stacktrace["frames"] = new_frames


### PR DESCRIPTION
Symbolicator makes sure to correctly copy over all the necessary fields from the `raw_frame`. Doing so again in Sentry could inherit a wrong `post_context` from the `raw_frame` in case the correctly symbolicated frame does not have any `post_context` at all.