### PR TITLE
fix(on_demand): skip spec generation for error widgets

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -498,18 +498,13 @@ def _is_on_demand_supported_search_filter(token: QueryToken) -> bool:
 
 
 def _is_excluding_transactions(token: SearchFilter) -> bool:
-    is_not_transaction = (
-        token.key.name == "event.type"
-        and token.operator == "!="
-        and token.value.raw_value == "transaction"
-    )
-    is_error = (
-        token.key.name == "event.type"
-        and token.operator == "="
-        and token.value.raw_value == "error"
-    )
+    if token.key.name != "event.type":
+        return False
 
-    return is_not_transaction or is_error
+    is_not_transaction = token.operator == "!=" and token.value.raw_value == "transaction"
+    is_error_or_default = token.operator == "=" and token.value.raw_value in ["error", "default"]
+
+    return is_not_transaction or is_error_or_default
 
 
 def _is_standard_metrics_field(field: str) -> bool:

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -558,6 +558,7 @@ def to_standard_metrics_query(query: str) -> str:
         tokens = event_search.parse_search_query(query)
     except InvalidSearchQuery:
         logger.error(f"Failed to parse search query: {query}", exc_info=True)
+        raise
 
     cleaned_query = to_standard_metrics_tokens(tokens)
     return query_tokens_to_string(cleaned_query)

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -44,6 +44,8 @@ from sentry.testutils.pytest.fixtures import django_db_all
             True,
         ),  # transaction.duration query is on-demand
         ("count[)", "", False),  # Malformed aggregate should return false
+        ("count()", "event.type:error", False),  # event.type:error not supported by metrics
+        ("count()", "error.handled:true", False),  # error.handled is an error search term
     ],
 )
 def test_should_use_on_demand(agg, query, result):

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -44,8 +44,21 @@ from sentry.testutils.pytest.fixtures import django_db_all
             True,
         ),  # transaction.duration query is on-demand
         ("count[)", "", False),  # Malformed aggregate should return false
-        ("count()", "event.type:error", False),  # event.type:error not supported by metrics
-        ("count()", "error.handled:true", False),  # error.handled is an error search term
+        (
+            "count()",
+            "event.type:error transaction.duration:>0",
+            False,
+        ),  # event.type:error not supported by metrics
+        (
+            "count()",
+            "event.type:default transaction.duration:>0",
+            False,
+        ),  # event.type:error not supported by metrics
+        (
+            "count()",
+            "error.handled:true transaction.duration:>0",
+            False,
+        ),  # error.handled is an error search term
     ],
 )
 def test_should_use_on_demand(agg, query, result):


### PR DESCRIPTION
Enhances on demand metrics check. 
- Fixes a case where queries containing `error.*` search terms were identified as custom tags.
- Filters out queries containing `event.type:error` or `event.type:default`
- Part of #58983