### PR TITLE
fix(discover): bailout of rerender if no tips

### DIFF
--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -1046,7 +1046,7 @@ describe('Results', function () {
     it('displays tip when events response contains a tip', async function () {
       renderMockRequests();
 
-      const eventsResultsMock = MockApiClient.addMockResponse({
+      MockApiClient.addMockResponse({
         url: '/organizations/org-slug/events/',
         body: {
           meta: {
@@ -1081,11 +1081,7 @@ describe('Results', function () {
         {context: initialData.routerContext, organization}
       );
 
-      await waitFor(() => {
-        expect(eventsResultsMock).toHaveBeenCalled();
-      });
-
-      expect(screen.getByText('this is a tip')).toBeInTheDocument();
+      expect(await screen.findByText('this is a tip')).toBeInTheDocument();
     });
 
     it('renders metric fallback alert', async function () {

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -560,6 +560,16 @@ export class Results extends Component<Props, State> {
     return null;
   }
 
+  setTips(tips: string[]) {
+    // If there are currently no tips set and the new tips are empty, do nothing
+    // and bail out of an expensive entire table rerender
+    if (!tips.length && !this.state.tips.length) {
+      return;
+    }
+
+    this.setState({tips});
+  }
+
   render() {
     const {organization, location, router, selection, api, setSavedQuery, isHomepage} =
       this.props;
@@ -654,7 +664,7 @@ export class Results extends Component<Props, State> {
                   confirmedQuery={confirmedQuery}
                   onCursor={this.handleCursor}
                   isHomepage={isHomepage}
-                  setTips={(tips: string[]) => this.setState({tips})}
+                  setTips={this.setTips}
                 />
               </Layout.Main>
               {showTags ? this.renderTagsTable() : null}

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -560,15 +560,14 @@ export class Results extends Component<Props, State> {
     return null;
   }
 
-  setTips(tips: string[]) {
+  setTips = (tips: string[]) => {
     // If there are currently no tips set and the new tips are empty, do nothing
     // and bail out of an expensive entire table rerender
     if (!tips.length && !this.state.tips.length) {
       return;
     }
-
     this.setState({tips});
-  }
+  };
 
   render() {
     const {organization, location, router, selection, api, setSavedQuery, isHomepage} =


### PR DESCRIPTION
setTips is expensive as it rerenders an entire table. The proper fix would be to optimize fetching so it doesn't impact the entire table rerender, but for now we can at least bailout of a rerender if no tips are available and none are set. We do this by avoiding a setState with empty array which would invalidate the previous reference. I also created a member method to proxy setTips so we can pass stable references as props

[Example profile](https://sentry.sentry.io/profiling/profile/javascript/ca7bb63a5c034c3493aba5d389c2a4f3/flamegraph/?colorCoding=by+system+vs+application+frame&frameName=%3Cobject%3E.%7Bchildren%235%7D.setTips&framePackage=app%2Fviews%2Fdiscover%2Fresults&query=&sorting=call+order&tid=0&view=top+down)

![CleanShot 2023-11-06 at 08 49 52@2x](https://github.com/getsentry/sentry/assets/9317857/528e18d0-5dfc-43cd-95f6-87902c2ad0b9)
