### PR TITLE
ref(vscode) Set import without spaces by default on settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,6 +43,8 @@
   // Avoid relative imports
   "typescript.preferences.importModuleSpecifier": "non-relative",
 
+  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
+  
   "[typescriptreact]": {
     "editor.formatOnSave": true,
     "editor.tabSize": 2


### PR DESCRIPTION
I made this PR because I noticed all getting started script files were using the import files without spacing and the files that I was altering were inserting spaces inside the import files automatically , so I made this PR in order to fix it.

Basically it forces vscode to format TypeScript imports to not have spaces inside the braces
```
import { code, code2 } from '...'
```
to
```
import {code, code2} from '...'
```
Which is the default format  used by Sentry.
