### PR TITLE
Bumped platformicons to version 5.7.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "papaparse": "^5.3.2",
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.6",
-    "platformicons": "^5.7.7",
+    "platformicons": "^5.7.8",
     "po-catalog-loader": "2.0.0",
     "prettier": "3.0.3",
     "prismjs": "^1.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9205,10 +9205,10 @@ platform@^1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-platformicons@^5.7.7:
-  version "5.7.7"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.7.7.tgz#037b3e42d60ee1c6d878d4c61919656f7569f5e5"
-  integrity sha512-Le6JzheZgFG2spvK+fIZcDmcAMf5vNxQV26mAbOeE+X6SEmAA7VuxHF/lxDZBzj10A5ecBJy995CSHDwBrsPXQ==
+platformicons@^5.7.8:
+  version "5.7.8"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.7.8.tgz#35022adf6b41341baa2634afb221abb088b05e63"
+  integrity sha512-5K5JZN8OumYThc2LSHstqUfW3n3jFA1jq5bvRVLR8dkUr2rY3IocEtAYClCFIidXXEG2XJYuzxCYG9TErXO47A==
   dependencies:
     "@types/node" "*"
     "@types/react" "*"


### PR DESCRIPTION
This concludes the redesign of the icons. now all of them look better and work in dark mode.