### PR TITLE
fix(crons): Properly query for mark_failed_threshold

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -117,7 +117,9 @@ def mark_failed_threshold(failed_checkin: MonitorCheckIn, failure_issue_threshol
         # use .values() to speed up query
         previous_checkins = list(
             reversed(
-                MonitorCheckIn.objects.filter(monitor_environment=monitor_env)
+                MonitorCheckIn.objects.filter(
+                    monitor_environment=monitor_env, date_added__lte=failed_checkin.date_added
+                )
                 .order_by("-date_added")
                 .values("id", "date_added", "status")[:failure_issue_threshold]
             )

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -120,17 +120,13 @@ def mark_failed_threshold(failed_checkin: MonitorCheckIn, failure_issue_threshol
                 MonitorCheckIn.objects.filter(
                     monitor_environment=monitor_env, date_added__lte=failed_checkin.date_added
                 )
+                .exclude(status=CheckInStatus.IN_PROGRESS)
                 .order_by("-date_added")
                 .values("id", "date_added", "status")[:failure_issue_threshold]
             )
         )
         # check for successive failed previous check-ins
-        if not all(
-            [
-                checkin["status"] not in [CheckInStatus.IN_PROGRESS, CheckInStatus.OK]
-                for checkin in previous_checkins
-            ]
-        ):
+        if not all([checkin["status"] != CheckInStatus.OK for checkin in previous_checkins]):
             return False
 
         # change monitor status + update fingerprint timestamp

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -734,7 +734,7 @@ class MarkFailedTestCase(TestCase):
         # create in-progress check-ins
         first_checkin = None
         checkins = []
-        for _ in range(0, failure_issue_threshold):
+        for i in range(0, failure_issue_threshold):
             checkin = MonitorCheckIn.objects.create(
                 monitor=monitor,
                 monitor_environment=monitor_environment,
@@ -742,7 +742,7 @@ class MarkFailedTestCase(TestCase):
                 status=CheckInStatus.IN_PROGRESS,
             )
             checkins.append(checkin)
-            if _ == 0:
+            if i == 0:
                 first_checkin = checkin
 
         # mark check-ins as failed

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -731,16 +731,24 @@ class MarkFailedTestCase(TestCase):
             status=CheckInStatus.OK,
         )
 
-        failure_statuses = cycle([CheckInStatus.ERROR, CheckInStatus.TIMEOUT, CheckInStatus.MISSED])
-
-        for _ in range(0, failure_issue_threshold - 1):
-            status = next(failure_statuses)
+        # create in-progress check-ins
+        first_checkin = None
+        checkins = []
+        for _ in range(0, failure_issue_threshold):
             checkin = MonitorCheckIn.objects.create(
                 monitor=monitor,
                 monitor_environment=monitor_environment,
                 project_id=self.project.id,
-                status=status,
+                status=CheckInStatus.IN_PROGRESS,
             )
+            checkins.append(checkin)
+            if _ == 0:
+                first_checkin = checkin
+
+        # mark check-ins as failed
+        for _ in range(0, failure_issue_threshold - 1):
+            checkin = checkins.pop(0)
+            checkin.update(status=CheckInStatus.TIMEOUT)
             mark_failed(checkin, ts=checkin.date_added)
 
         # failure has not hit threshold, monitor should be in an OK status
@@ -749,32 +757,14 @@ class MarkFailedTestCase(TestCase):
         # check that timestamp has not updated
         assert monitor_environment.last_state_change is None
 
-        # create another OK check-in to break the chain
-        MonitorCheckIn.objects.create(
-            monitor=monitor,
-            monitor_environment=monitor_environment,
-            project_id=self.project.id,
-            status=CheckInStatus.OK,
-        )
-
-        first_checkin = None
-        for _ in range(0, failure_issue_threshold):
-            status = next(failure_statuses)
-            checkin = MonitorCheckIn.objects.create(
-                monitor=monitor,
-                monitor_environment=monitor_environment,
-                project_id=self.project.id,
-                status=status,
-            )
-            if _ == 0:
-                first_checkin = checkin
-            mark_failed(checkin, ts=checkin.date_added)
+        checkin = checkins.pop(0)
+        checkin.update(status=CheckInStatus.TIMEOUT)
+        mark_failed(checkin, ts=checkin.date_added)
 
         # failure has hit threshold, monitor should be in a failed state
         monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
         assert monitor_environment.status == MonitorStatus.ERROR
         assert monitor_environment.last_state_change == monitor_environment.last_checkin
-        prior_last_state_change = monitor_environment.last_state_change
 
         # check that an incident has been created correctly
         monitor_incidents = MonitorIncident.objects.filter(monitor_environment=monitor_environment)
@@ -786,31 +776,6 @@ class MarkFailedTestCase(TestCase):
 
         # assert correct number of occurrences was sent
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == failure_issue_threshold
-        # assert that the correct uuid fingerprint was sent
-        kwargs = mock_produce_occurrence_to_kafka.call_args.kwargs
-        occurrence = kwargs["occurrence"]
-        occurrence = occurrence.to_dict()
-        assert occurrence["fingerprint"][0] == monitor_incident.grouphash
-
-        # send another check-in to make sure we don't update last_state_change
-        status = next(failure_statuses)
-        checkin = MonitorCheckIn.objects.create(
-            monitor=monitor,
-            monitor_environment=monitor_environment,
-            project_id=self.project.id,
-            status=status,
-        )
-        mark_failed(checkin, ts=checkin.date_added)
-        monitor_environment = MonitorEnvironment.objects.get(id=monitor_environment.id)
-        assert monitor_environment.status == MonitorStatus.ERROR
-        assert monitor_environment.last_state_change == prior_last_state_change
-
-        # check that incident has not changed
-        monitor_incident = MonitorIncident.objects.get(id=monitor_incident.id)
-        assert monitor_incident.grouphash == monitor_environment.incident_grouphash
-
-        # assert correct number of occurrences was sent
-        assert len(mock_produce_occurrence_to_kafka.mock_calls) == failure_issue_threshold + 1
         # assert that the correct uuid fingerprint was sent
         kwargs = mock_produce_occurrence_to_kafka.call_args.kwargs
         occurrence = kwargs["occurrence"]

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -734,7 +734,7 @@ class MarkFailedTestCase(TestCase):
         # create in-progress check-ins
         first_checkin = None
         checkins = []
-        for i in range(0, failure_issue_threshold):
+        for i in range(0, failure_issue_threshold + 1):
             checkin = MonitorCheckIn.objects.create(
                 monitor=monitor,
                 monitor_environment=monitor_environment,

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -701,6 +701,8 @@ class MarkFailedTestCase(TestCase):
         occurrence = occurrence.to_dict()
         assert occurrence["fingerprint"][0] == monitor_incident.grouphash
 
+    # Test to make sure that timeout mark_failed (which occur in the past)
+    # correctly create issues once passing the failure_issue_threshold
     @patch("sentry.issues.producer.produce_occurrence_to_kafka")
     def test_mark_failed_issue_threshold_timeout(self, mock_produce_occurrence_to_kafka):
         failure_issue_threshold = 8


### PR DESCRIPTION
Uses the `check-in` time to query previous threshold timeouts

Closes https://github.com/getsentry/team-crons/issues/116
Closes https://github.com/getsentry/sentry/issues/59431