### PR TITLE
feat(provisioning): org member update rpc

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -39,6 +39,7 @@ from sentry.services.hybrid_cloud.organization import (
     RpcUserOrganizationContext,
 )
 from sentry.services.hybrid_cloud.organization.model import (
+    OrganizationMemberUpdateArgs,
     RpcAuditLogEntryActor,
     RpcOrganizationDeleteResponse,
     RpcOrganizationDeleteState,
@@ -350,6 +351,18 @@ class DatabaseBackedOrganizationService(OrganizationService):
                     invite_status=invite_status,
                 )
         return serialize_member(org_member)
+
+    def update_organization_member(
+        self, *, organization_id: int, member_id: int, attrs: OrganizationMemberUpdateArgs
+    ) -> Optional[RpcOrganizationMember]:
+        member = OrganizationMember.objects.get(id=member_id)
+        with outbox_context(transaction.atomic(router.db_for_write(OrganizationMember))):
+            if len(attrs):
+                for k, v in attrs.items():
+                    setattr(member, k, v)
+                member.save()
+
+        return serialize_member(member)
 
     def get_single_team(self, *, organization_id: int) -> Optional[RpcTeam]:
         teams = list(Team.objects.filter(organization_id=organization_id)[0:2])

--- a/src/sentry/services/hybrid_cloud/organization/model.py
+++ b/src/sentry/services/hybrid_cloud/organization/model.py
@@ -353,3 +353,9 @@ class RpcAuditLogEntryActor(RpcModel):
     actor_id: int
     actor_key: Optional[str]
     ip_address: Optional[str]
+
+
+class OrganizationMemberUpdateArgs(TypedDict, total=False):
+    flags: Optional[RpcOrganizationMemberFlags]
+    role: str
+    invite_status: int

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -10,6 +10,7 @@ from django.dispatch import Signal
 
 from sentry.services.hybrid_cloud import OptionValue, silo_mode_delegation
 from sentry.services.hybrid_cloud.organization.model import (
+    OrganizationMemberUpdateArgs,
     RpcAuditLogEntryActor,
     RpcOrganization,
     RpcOrganizationDeleteResponse,
@@ -212,6 +213,13 @@ class OrganizationService(RpcService):
         inviter_id: Optional[int] = None,
         invite_status: Optional[int] = None,
     ) -> RpcOrganizationMember:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def update_organization_member(
+        self, *, organization_id: int, member_id: int, attrs: OrganizationMemberUpdateArgs
+    ) -> Optional[RpcOrganizationMember]:
         pass
 
     @regional_rpc_method(resolve=ByOrganizationId())

--- a/tests/sentry/hybrid_cloud/test_organization.py
+++ b/tests/sentry/hybrid_cloud/test_organization.py
@@ -292,7 +292,6 @@ class RpcOrganizationMemberTest(TestCase):
 @region_silo_test(stable=True)
 def test_org_member():
     org = Factories.create_organization()
-    Factories.create_organization()
     user = Factories.create_user(email="test@sentry.io")
     rpc_member = organization_service.add_organization_member(
         organization_id=org.id,

--- a/tests/sentry/hybrid_cloud/test_organization.py
+++ b/tests/sentry/hybrid_cloud/test_organization.py
@@ -305,7 +305,7 @@ def test_org_member():
     assert member_query[0].role == "member"
     assert rpc_member.id == member_query[0].id
 
-    rpc_member = organization_service.update_organization_member(
+    organization_service.update_organization_member(
         organization_id=org.id, member_id=rpc_member.id, attrs=dict(role="manager")
     )
     member_query = OrganizationMember.objects.all()


### PR DESCRIPTION
Making provisioning API control silo safe by calling RPC for region silo objects.

Previous PRs:
Team member
Team
Project
PartnerAccount

This PR: org member
