### PR TITLE
feat(suspect-commits): Retry commit_context task on unexpected API errors

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -43,10 +43,6 @@ logger = logging.getLogger("sentry.integrations.github")
 MINIMUM_REQUESTS = 200
 
 
-class GitHubApproachingRateLimit(Exception):
-    pass
-
-
 class GithubRateLimitInfo:
     def __init__(self, info: Dict[str, int]) -> None:
         self.limit = info["limit"]
@@ -701,7 +697,7 @@ class GitHubClientMixin(GithubProxyClient):
         metrics.incr("sentry.integrations.github.get_blame_for_files")
         rate_limit = self.get_rate_limit(specific_resource="graphql")
         if rate_limit.remaining < MINIMUM_REQUESTS:
-            metrics.incr("sentry.integrations.github.get_blame_for_files.rate_limit")
+            metrics.incr("integrations.github.get_blame_for_files.not_enough_requests_remaining")
             logger.error(
                 "sentry.integrations.github.get_blame_for_files.rate_limit",
                 extra={
@@ -712,7 +708,7 @@ class GitHubClientMixin(GithubProxyClient):
                     "organization_integration_id": self.org_integration_id,
                 },
             )
-            raise GitHubApproachingRateLimit()
+            raise ApiRateLimitedError("Not enough requests remaining for GitHub")
 
         file_path_mapping = generate_file_path_mapping(files)
         data = create_blame_query(file_path_mapping, extra=log_info)
@@ -739,14 +735,19 @@ class GitHubClientMixin(GithubProxyClient):
         if not isinstance(response, MappingApiResponse):
             raise ApiError("Response is not JSON")
 
-        if response.get("errors"):
-            err_message = ", ".join(
-                [error.get("message", "") for error in response.get("errors", [])]
-            )
-            logger.error(
-                "get_blame_for_files.graphql_error",
-                extra={**log_info, "error_message": err_message},
-            )
+        errors = response.get("errors", [])
+        if len(errors) > 0:
+            if any([error for error in errors if error.get("type") == "RATE_LIMITED"]):
+                raise ApiRateLimitedError("GitHub rate limit exceeded")
+
+            # When data is present, it means that the query was at least partially successful,
+            # usually a missing repo/branch/file which is expected with wrong configurations.
+            # If data is not present, the query may be formed incorrectly, so raise an error.
+            if not response.get("data"):
+                err_message = ", ".join(
+                    [error.get("message", "") for error in response.get("errors", [])]
+                )
+                raise ApiError(err_message)
 
         return extract_commits_from_blame_response(
             response=response,

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -129,8 +129,10 @@ def queue_comment_task_if_needed(
     retry_backoff_max=60 * 60 * 3,  # 3 hours
     retry_jitter=False,
     silo_mode=SiloMode.REGION,
+    bind=True,
 )
 def process_commit_context(
+    self,
     event_id,
     event_platform,
     event_frames,
@@ -266,13 +268,15 @@ def process_commit_context(
                         project_id=project_id,
                         extra=basic_logging_details,
                     )
-                except Exception as e:
-                    logger.exception(e, extra=basic_logging_details)
+                except ApiError:
+                    logger.info(
+                        "process_commit_context.retry",
+                        extra={**basic_logging_details, "retry_count": self.request.retries},
+                    )
+                    metrics.incr("tasks.process_commit_context.retry")
+                    self.retry()
 
                 if not blame or not installation:
-                    # Debounces the task for 1 day.
-                    # This is temporary to match the current behavior, but should be removed in https://github.com/getsentry/sentry/issues/57438
-                    cache.set(cache_key, True, timedelta(days=7).total_seconds())
                     # Fall back to the release logic if we can't find a commit for any of the frames
                     process_suspect_commits.delay(
                         event_id=event_id,
@@ -480,6 +484,7 @@ def process_commit_context(
     except UnableToAcquireLock:
         pass
     except MaxRetriesExceededError:
+        metrics.incr("tasks.process_commit_context.max_retries_exceeded")
         logger.info(
             "process_commit_context.max_retries_exceeded",
             extra={

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -13,7 +13,7 @@ from responses import matchers
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.blame import create_blame_query, generate_file_path_mapping
-from sentry.integrations.github.client import GitHubApproachingRateLimit, GitHubAppsClient
+from sentry.integrations.github.client import GitHubAppsClient
 from sentry.integrations.github.integration import GitHubIntegration
 from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo, SourceLineInfo
 from sentry.integrations.notify_disable import notify_disable
@@ -1612,7 +1612,7 @@ class GitHubClientFileBlameRateLimitTest(GitHubClientFileBlameBase):
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate
     def test_rate_limit_exceeded(self, get_jwt, mock_logger_error):
-        with pytest.raises(GitHubApproachingRateLimit):
+        with pytest.raises(ApiRateLimitedError):
             self.github_client.get_blame_for_files([self.file], extra={})
         mock_logger_error.assert_called_with(
             "sentry.integrations.github.get_blame_for_files.rate_limit",


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/59446

- Modify GitHub client to use detect when rate limits have been hit and raise `ApiRateLimitedError` when that happens
- Re-raise unexpected API errors (anything other than 401, 403, 404)  to process_commit_context
- Manually retry the task when one of these exceptions is re-raised
- Fall back to release-based suspect commits after hitting max_retries