### PR TITLE
fix(issue-stream): Change default query request

### DIFF
--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -996,7 +996,7 @@ describe('IssueList', function () {
       expect(fetchDataMock).toHaveBeenLastCalledWith(
         '/organizations/org-slug/issues/',
         expect.objectContaining({
-          data: 'collapse=stats&collapse=unhandled&defaultQuery=0&expand=owners&expand=inbox&limit=25&project=99&query=is%3Aunresolved&savedSearch=1&shortIdLookup=1&statsPeriod=14d',
+          data: 'collapse=stats&collapse=unhandled&expand=owners&expand=inbox&limit=25&project=99&query=is%3Aunresolved&savedSearch=1&shortIdLookup=1&statsPeriod=14d',
         })
       );
     });

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -996,7 +996,7 @@ describe('IssueList', function () {
       expect(fetchDataMock).toHaveBeenLastCalledWith(
         '/organizations/org-slug/issues/',
         expect.objectContaining({
-          data: 'collapse=stats&collapse=unhandled&expand=owners&expand=inbox&limit=25&project=99&query=is%3Aunresolved&savedSearch=1&shortIdLookup=1&statsPeriod=14d',
+          data: 'collapse=stats&collapse=unhandled&defaultQuery=0&expand=owners&expand=inbox&limit=25&project=99&query=is%3Aunresolved&savedSearch=1&shortIdLookup=1&statsPeriod=14d',
         })
       );
     });

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -552,7 +552,6 @@ class IssueListOverview extends Component<Props, State> {
           ? savedSearchLookupEnabled
           : savedSearchLookupDisabled
         : savedSearchLookupDisabled,
-      defaultQuery: this.props.location.query ? 0 : 1,
     };
 
     if (
@@ -560,6 +559,14 @@ class IssueListOverview extends Component<Props, State> {
       this.props.selectedSearchId
     ) {
       requestParams.searchId = this.props.selectedSearchId;
+    }
+
+    if (
+      this.props.organization.features.includes('issue-stream-performance') &&
+      this.props.savedSearchLoading &&
+      !this.props.location.query.query
+    ) {
+      delete requestParams.query;
     }
 
     const currentQuery = this.props.location.query || {};

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -24,7 +24,7 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import QueryCount from 'sentry/components/queryCount';
 import ProcessingIssueList from 'sentry/components/stream/processingIssueList';
-import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
+import {DEFAULT_QUERY, DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t, tct, tn} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import SelectedGroupStore from 'sentry/stores/selectedGroupStore';
@@ -297,7 +297,7 @@ class IssueListOverview extends Component<Props, State> {
       return decodeScalar(query, '');
     }
 
-    return '';
+    return DEFAULT_QUERY;
   }
 
   getSortFromSavedSearchOrLocation({
@@ -347,14 +347,9 @@ class IssueListOverview extends Component<Props, State> {
     const params: EndpointParams = {
       project: selection.projects,
       environment: selection.environments,
+      query: this.getQuery(),
       ...selection.datetime,
     };
-
-    const query = this.getQuery();
-
-    if (query) {
-      params.query = query;
-    }
 
     if (selection.datetime.period) {
       delete params.period;
@@ -557,6 +552,7 @@ class IssueListOverview extends Component<Props, State> {
           ? savedSearchLookupEnabled
           : savedSearchLookupDisabled
         : savedSearchLookupDisabled,
+      defaultQuery: this.props.location.query ? 0 : 1,
     };
 
     if (

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -24,7 +24,7 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import QueryCount from 'sentry/components/queryCount';
 import ProcessingIssueList from 'sentry/components/stream/processingIssueList';
-import {DEFAULT_QUERY, DEFAULT_STATS_PERIOD} from 'sentry/constants';
+import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t, tct, tn} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import SelectedGroupStore from 'sentry/stores/selectedGroupStore';
@@ -297,7 +297,7 @@ class IssueListOverview extends Component<Props, State> {
       return decodeScalar(query, '');
     }
 
-    return DEFAULT_QUERY;
+    return '';
   }
 
   getSortFromSavedSearchOrLocation({
@@ -347,9 +347,14 @@ class IssueListOverview extends Component<Props, State> {
     const params: EndpointParams = {
       project: selection.projects,
       environment: selection.environments,
-      query: this.getQuery(),
       ...selection.datetime,
     };
+
+    const query = this.getQuery();
+
+    if (query) {
+      params.query = query;
+    }
 
     if (selection.datetime.period) {
       delete params.period;


### PR DESCRIPTION
this pr makes a slight change to the params we send to the backend. Now, on the initial load where we are not waiting for saved searches, we will delete the `query` query param if there is no specified query. in the endpoint (https://github.com/getsentry/sentry/pull/59484) , it will check if a query is sent and use it if it is. If not, it will go through the process of checking the saves searches and use the default "is:unresolved" if needed.