### PR TITLE
fix(stacktrace): Allow text selection for absolute path tooltip

### DIFF
--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -302,6 +302,7 @@ function NativeFrame({
                 title={frame.absPath}
                 disabled={!(defined(frame.absPath) && frame.absPath !== frame.filename)}
                 delay={tooltipDelay}
+                isHoverable
               >
                 <FileName>
                   {'('}


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/59058

This part of the frame is only seen in native stack traces. You can use this issue for testing: https://sentry-sdks.sentry.io/issues/4587997850/

https://github.com/getsentry/sentry/assets/10888943/2b515b4f-e4f8-4957-9310-7f2a3f4a7873

