### PR TITLE
feat: apitoken last characters option

### DIFF
--- a/src/sentry/backup/comparators.py
+++ b/src/sentry/backup/comparators.py
@@ -666,9 +666,7 @@ def get_default_comparators():
     default_comparators: ComparatorMap = defaultdict(
         list,
         {
-            "sentry.apitoken": [
-                HashObfuscatingComparator("refresh_token", "token", "token_last_characters")
-            ],
+            "sentry.apitoken": [HashObfuscatingComparator("refresh_token", "token")],
             "sentry.apiapplication": [HashObfuscatingComparator("client_id", "client_secret")],
             "sentry.authidentity": [HashObfuscatingComparator("ident", "token")],
             "sentry.alertrule": [DateUpdatedComparator("date_modified")],

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -59,9 +59,6 @@ class ApiToken(ReplicatedControlModel, HasApiScopes):
         return force_str(self.token)
 
     def save(self, *args: Any, **kwargs: Any) -> None:
-        # when a new ApiToken is created we take the last four characters of the token
-        # and save them in the `token_last_characters` field so users can identify
-        # tokens in the UI where they're mostly obfuscated
         if options.get("apitoken.auto-add-last-chars"):
             token_last_characters = self.token[-4:]
             self.token_last_characters = token_last_characters

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import secrets
 from datetime import timedelta
-from typing import ClassVar, Collection, Optional, Tuple
+from typing import Any, ClassVar, Collection, Optional, Tuple
 
 from django.db import models, router, transaction
 from django.utils import timezone
 from django.utils.encoding import force_str
 
+from sentry import options
 from sentry.backup.dependencies import ImportKind
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.scopes import ImportScope, RelocationScope
@@ -57,15 +58,15 @@ class ApiToken(ReplicatedControlModel, HasApiScopes):
     def __str__(self):
         return force_str(self.token)
 
-    # TODO(mdtro): uncomment this function after 0583_apitoken_add_name_and_last_chars migration has been applied
-    # def save(self, *args: Any, **kwargs: Any) -> None:
-    #     # when a new ApiToken is created we take the last four characters of the token
-    #     # and save them in the `token_last_characters` field so users can identify
-    #     # tokens in the UI where they're mostly obfuscated
-    #     token_last_characters = self.token[-4:]
-    #     self.token_last_characters = token_last_characters
+    def save(self, *args: Any, **kwargs: Any) -> None:
+        # when a new ApiToken is created we take the last four characters of the token
+        # and save them in the `token_last_characters` field so users can identify
+        # tokens in the UI where they're mostly obfuscated
+        if options.get("apitoken.auto-add-last-chars"):
+            token_last_characters = self.token[-4:]
+            self.token_last_characters = token_last_characters
 
-    #     return super().save(**kwargs)
+        return super().save(**kwargs)
 
     def outbox_region_names(self) -> Collection[str]:
         return list(find_all_region_names())

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -263,6 +263,13 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_REQUIRED,
 )
 
+# API Tokens
+register(
+    "apitoken.auto-add-last-chars",
+    default=True,
+    type=Bool,
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "api.rate-limit.org-create",

--- a/tests/sentry/backup/snapshots/ReleaseTests/test_at_head.pysnap
+++ b/tests/sentry/backup/snapshots/ReleaseTests/test_at_head.pysnap
@@ -1,18 +1,18 @@
 ---
-created: '2023-11-09T18:52:25.540028Z'
+created: '2023-11-15T22:32:21.442670Z'
 creator: sentry
 source: tests/sentry/backup/test_releases.py
 ---
 - fields:
     key: bar
-    last_updated: '2023-11-09T18:52:25.146Z'
+    last_updated: '2023-11-15T22:32:21.141Z'
     last_updated_by: unknown
     value: '"b"'
   model: sentry.controloption
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:24.413Z'
-    date_updated: '2023-11-09T18:52:24.413Z'
+    date_added: '2023-11-15T22:32:20.645Z'
+    date_updated: '2023-11-15T22:32:20.646Z'
     external_id: slack:test-org
     metadata: {}
     name: Slack for test-org
@@ -22,13 +22,13 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     key: foo
-    last_updated: '2023-11-09T18:52:25.145Z'
+    last_updated: '2023-11-15T22:32:21.140Z'
     last_updated_by: unknown
     value: '"a"'
   model: sentry.option
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:23.926Z'
+    date_added: '2023-11-15T22:32:20.347Z'
     default_role: member
     flags: '1'
     is_test: false
@@ -36,92 +36,92 @@ source: tests/sentry/backup/test_releases.py
     slug: test-org
     status: 0
   model: sentry.organization
-  pk: 4552945452908560
+  pk: 4552980291649552
 - fields:
-    date_added: '2023-11-09T18:52:24.645Z'
+    date_added: '2023-11-15T22:32:20.836Z'
     default_role: member
     flags: '1'
     is_test: false
-    name: Set Stinkbug
-    slug: set-stinkbug
+    name: Aware Dolphin
+    slug: aware-dolphin
     status: 0
   model: sentry.organization
-  pk: 4552945452974099
+  pk: 4552980291649556
 - fields:
     config:
       hello: hello
-    date_added: '2023-11-09T18:52:24.415Z'
-    date_updated: '2023-11-09T18:52:24.415Z'
+    date_added: '2023-11-15T22:32:20.647Z'
+    date_updated: '2023-11-15T22:32:20.647Z'
     default_auth_id: null
     grace_period_end: null
     integration: 6
-    organization_id: 4552945452908560
+    organization_id: 4552980291649552
     status: 0
   model: sentry.organizationintegration
   pk: 6
 - fields:
     key: sentry:account-rate-limit
-    organization: 4552945452908560
+    organization: 4552980291649552
     value: 0
   model: sentry.organizationoption
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:24.207Z'
+    date_added: '2023-11-15T22:32:20.488Z'
     first_event: null
     flags: '10'
     forced_color: null
     name: project-test-org
-    organization: 4552945452908560
+    organization: 4552980291649552
     platform: null
     public: false
     slug: project-test-org
     status: 0
   model: sentry.project
-  pk: 4552945452974097
+  pk: 4552980291649554
 - fields:
-    date_added: '2023-11-09T18:52:24.448Z'
+    date_added: '2023-11-15T22:32:20.673Z'
     first_event: null
     flags: '10'
     forced_color: null
     name: other-project-test-org
-    organization: 4552945452908560
+    organization: 4552980291649552
     platform: null
     public: false
     slug: other-project-test-org
     status: 0
   model: sentry.project
-  pk: 4552945452974098
+  pk: 4552980291649555
 - fields:
-    date_added: '2023-11-09T18:52:24.760Z'
+    date_added: '2023-11-15T22:32:20.897Z'
     first_event: null
     flags: '10'
     forced_color: null
-    name: Joint Pup
-    organization: 4552945452908560
+    name: Chief Trout
+    organization: 4552980291649552
     platform: null
     public: false
-    slug: joint-pup
+    slug: chief-trout
     status: 0
   model: sentry.project
-  pk: 4552945452974100
+  pk: 4552980291649557
 - fields:
-    date_added: '2023-11-09T18:52:25.075Z'
+    date_added: '2023-11-15T22:32:21.094Z'
     first_event: null
     flags: '10'
     forced_color: null
-    name: Summary Aphid
-    organization: 4552945452908560
+    name: Saved Leopard
+    organization: 4552980291649552
     platform: null
     public: false
-    slug: summary-aphid
+    slug: saved-leopard
     status: 0
   model: sentry.project
-  pk: 4552945453039632
+  pk: 4552980291715088
 - fields:
     config:
       hello: hello
     integration_id: 6
-    project: 4552945452974097
+    project: 4552980291649554
   model: sentry.projectintegration
   pk: 6
 - fields:
@@ -129,14 +129,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2023-11-09T18:52:24.254Z'
+    date_added: '2023-11-15T22:32:20.504Z'
     label: Default
-    project: 4552945452974097
-    public_key: 7f6828dc2559ec75e837a921508ec9bf
+    project: 4552980291649554
+    public_key: 6f7a092fcb34db896df7282204af0799
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: d5454e7970276564ae93b28617846829
+    secret_key: 8757b145c120990475bbbdb21be3e66a
     status: 0
   model: sentry.projectkey
   pk: 21
@@ -145,14 +145,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2023-11-09T18:52:24.476Z'
+    date_added: '2023-11-15T22:32:20.693Z'
     label: Default
-    project: 4552945452974098
-    public_key: 699a2ac0c9020db7528fa19789e8c470
+    project: 4552980291649555
+    public_key: 8313a71c77b700b7534095abe6f2014a
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 135622368236a746ace6c71aaedf2d29
+    secret_key: 8a4604b90c32e56a53fa39f58a34c0bc
     status: 0
   model: sentry.projectkey
   pk: 22
@@ -161,14 +161,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2023-11-09T18:52:24.801Z'
+    date_added: '2023-11-15T22:32:20.914Z'
     label: Default
-    project: 4552945452974100
-    public_key: f27f04ac4ab068011e8e940fa5302dc8
+    project: 4552980291649557
+    public_key: fd15b01a3b96e5ed058756382b38f8c3
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 0b4c1d0d3bbccb2d803b22d7f0d4c58e
+    secret_key: 78ce5129eb94d127c6b0cd5996486738
     status: 0
   model: sentry.projectkey
   pk: 23
@@ -177,97 +177,97 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2023-11-09T18:52:25.101Z'
+    date_added: '2023-11-15T22:32:21.110Z'
     label: Default
-    project: 4552945453039632
-    public_key: 7f1ce70db7d6513acb1715323b04e199
+    project: 4552980291715088
+    public_key: d609cb8f90d04eca2c7ea5b525bf0413
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 40547c704b4929c95d30bf8543cd204c
+    secret_key: c9a44b60560a82e128e0e903b601447d
     status: 0
   model: sentry.projectkey
   pk: 24
 - fields:
     key: sentry:relay-rev
-    project: 4552945452974097
-    value: '"8cad9bdaeb2946d1ba5955be61d80b2c"'
+    project: 4552980291649554
+    value: '"ee3d4558e5db4f88aac4bb744b8f8310"'
   model: sentry.projectoption
   pk: 61
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4552945452974097
-    value: '"2023-11-09T18:52:24.261463Z"'
+    project: 4552980291649554
+    value: '"2023-11-15T22:32:20.509019Z"'
   model: sentry.projectoption
   pk: 62
 - fields:
     key: sentry:option-epoch
-    project: 4552945452974097
+    project: 4552980291649554
     value: 11
   model: sentry.projectoption
   pk: 63
 - fields:
     key: sentry:relay-rev
-    project: 4552945452974098
-    value: '"028fa421716c49eca619c7a92a629faf"'
+    project: 4552980291649555
+    value: '"84ae06a2c7fa4499bf512f2634b5fd6d"'
   model: sentry.projectoption
   pk: 64
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4552945452974098
-    value: '"2023-11-09T18:52:24.484071Z"'
+    project: 4552980291649555
+    value: '"2023-11-15T22:32:20.698969Z"'
   model: sentry.projectoption
   pk: 65
 - fields:
     key: sentry:option-epoch
-    project: 4552945452974098
+    project: 4552980291649555
     value: 11
   model: sentry.projectoption
   pk: 66
 - fields:
     key: sentry:relay-rev
-    project: 4552945452974100
-    value: '"1a57087a5d324ed58a94efe5582b1feb"'
+    project: 4552980291649557
+    value: '"8a75642dddec4710af6bfe6dbb044a3c"'
   model: sentry.projectoption
   pk: 67
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4552945452974100
-    value: '"2023-11-09T18:52:24.812348Z"'
+    project: 4552980291649557
+    value: '"2023-11-15T22:32:20.917761Z"'
   model: sentry.projectoption
   pk: 68
 - fields:
     key: sentry:option-epoch
-    project: 4552945452974100
+    project: 4552980291649557
     value: 11
   model: sentry.projectoption
   pk: 69
 - fields:
     key: sentry:relay-rev
-    project: 4552945453039632
-    value: '"fa04be9c4f3546a398c7d7c59604c290"'
+    project: 4552980291715088
+    value: '"638a3ccb9d7042969b12e68a94bf1b37"'
   model: sentry.projectoption
   pk: 70
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4552945453039632
-    value: '"2023-11-09T18:52:25.107906Z"'
+    project: 4552980291715088
+    value: '"2023-11-15T22:32:21.113867Z"'
   model: sentry.projectoption
   pk: 71
 - fields:
     key: sentry:option-epoch
-    project: 4552945453039632
+    project: 4552980291715088
     value: 11
   model: sentry.projectoption
   pk: 72
 - fields:
     auto_assignment: true
     codeowners_auto_sync: true
-    date_created: '2023-11-09T18:52:24.295Z'
+    date_created: '2023-11-15T22:32:20.526Z'
     fallthrough: true
     is_active: true
-    last_updated: '2023-11-09T18:52:24.295Z'
-    project: 4552945452974097
+    last_updated: '2023-11-15T22:32:20.526Z'
+    project: 4552980291649554
     raw: '{"hello":"hello"}'
     schema:
       hello: hello
@@ -275,9 +275,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.projectownership
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:24.301Z'
-    organization: 4552945452908560
-    project: 4552945452974097
+    date_added: '2023-11-15T22:32:20.531Z'
+    organization: 4552980291649552
+    project: 4552980291649554
     redirect_slug: project_slug_in_test-org
   model: sentry.projectredirect
   pk: 6
@@ -285,26 +285,26 @@ source: tests/sentry/backup/test_releases.py
     first_seen: null
     is_internal: true
     last_seen: null
-    public_key: cvCjahSYrg3JU2Klf6Ln-QX2S_GFciSXOdjeCpicLSg
-    relay_id: a46b3413-4a6f-4c9d-a5a0-39107bb768a8
+    public_key: B8-ccOfOEqsN_kfksdHESdoiBcLK_MtEk-eNZwNFSmE
+    relay_id: 8efe8117-ae1e-4a9e-a7cf-fc62676bf94e
   model: sentry.relay
   pk: 6
 - fields:
-    first_seen: '2023-11-09T18:52:25.143Z'
-    last_seen: '2023-11-09T18:52:25.143Z'
-    public_key: cvCjahSYrg3JU2Klf6Ln-QX2S_GFciSXOdjeCpicLSg
-    relay_id: a46b3413-4a6f-4c9d-a5a0-39107bb768a8
+    first_seen: '2023-11-15T22:32:21.139Z'
+    last_seen: '2023-11-15T22:32:21.139Z'
+    public_key: B8-ccOfOEqsN_kfksdHESdoiBcLK_MtEk-eNZwNFSmE
+    relay_id: 8efe8117-ae1e-4a9e-a7cf-fc62676bf94e
     version: 0.0.1
   model: sentry.relayusage
   pk: 6
 - fields:
     config: {}
-    date_added: '2023-11-09T18:52:24.611Z'
+    date_added: '2023-11-15T22:32:20.810Z'
     external_id: null
     integration_id: 6
     languages: '[]'
     name: getsentry/getsentry
-    organization_id: 4552945452908560
+    organization_id: 4552980291649552
     provider: integrations:github
     status: 0
     url: https://github.com/getsentry/getsentry
@@ -312,19 +312,19 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     actor: 6
-    date_added: '2023-11-09T18:52:24.119Z'
+    date_added: '2023-11-15T22:32:20.443Z'
     idp_provisioned: false
     name: test_team_in_test-org
     org_role: null
-    organization: 4552945452908560
+    organization: 4552980291649552
     slug: test_team_in_test-org
     status: 0
   model: sentry.team
-  pk: 4552945452974096
+  pk: 4552980291649553
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-09T18:52:23.719Z'
+    date_joined: '2023-11-15T22:32:20.211Z'
     email: owner
     flags: '0'
     is_active: true
@@ -334,11 +334,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: true
     is_unclaimed: false
-    last_active: '2023-11-09T18:52:23.719Z'
+    last_active: '2023-11-15T22:32:20.211Z'
     last_login: null
-    last_password_change: '2023-11-09T18:52:23.720Z'
+    last_password_change: '2023-11-15T22:32:20.211Z'
     name: ''
-    password: md5$DFDPBRotUqdEoAJawkngCa$5751f437360069f62db4a07b821250b1
+    password: md5$A530NO0y6sCd8Ic0L0o8ez$9ef501dfa8ddbad1ef9f7087af4176fb
     session_nonce: null
     username: owner
   model: sentry.user
@@ -346,7 +346,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-09T18:52:23.870Z'
+    date_joined: '2023-11-15T22:32:20.311Z'
     email: invitee
     flags: '0'
     is_active: true
@@ -356,11 +356,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2023-11-09T18:52:23.870Z'
+    last_active: '2023-11-15T22:32:20.311Z'
     last_login: null
-    last_password_change: '2023-11-09T18:52:23.870Z'
+    last_password_change: '2023-11-15T22:32:20.311Z'
     name: ''
-    password: md5$LB9TKVQQiHDXsAcPsfbDNf$d9108486761bde76914f4778d185966a
+    password: md5$phEsdsBm2OZr1PxLrNfZdP$98a934101ef2acc8bc46bfd0f8b03393
     session_nonce: null
     username: invitee
   model: sentry.user
@@ -368,7 +368,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-09T18:52:24.533Z'
+    date_joined: '2023-11-15T22:32:20.733Z'
     email: admin@localhost
     flags: '0'
     is_active: true
@@ -378,11 +378,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: true
     is_unclaimed: false
-    last_active: '2023-11-09T18:52:24.533Z'
+    last_active: '2023-11-15T22:32:20.733Z'
     last_login: null
-    last_password_change: '2023-11-09T18:52:24.533Z'
+    last_password_change: '2023-11-15T22:32:20.734Z'
     name: ''
-    password: md5$aZFRG0i2fYT6DMRsTCZQfP$06215495d615abe6b2333c415cf6808d
+    password: md5$xK5SXH6Qvt1Zx6depY04Hd$46d3713f1b1e30073e25bf040ace79d0
     session_nonce: null
     username: admin@localhost
   model: sentry.user
@@ -390,8 +390,8 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-09T18:52:24.613Z'
-    email: 8f25fd7280c0416db7f12447622a8777@example.com
+    date_joined: '2023-11-15T22:32:20.812Z'
+    email: 78010d98140841648f1a2d1b4a709699@example.com
     flags: '0'
     is_active: true
     is_managed: false
@@ -400,19 +400,19 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: false
     is_unclaimed: false
-    last_active: '2023-11-09T18:52:24.613Z'
+    last_active: '2023-11-15T22:32:20.812Z'
     last_login: null
-    last_password_change: '2023-11-09T18:52:24.613Z'
+    last_password_change: '2023-11-15T22:32:20.812Z'
     name: ''
-    password: md5$XuFFesJdLsMQIhFrERCaMU$0ed27f89ee31ef5d4a49ef373b46dc46
+    password: md5$gBygL9dbt2rtEa0nkmwcIz$249fbf75b4281f2add1316aaae5b30be
     session_nonce: null
-    username: 8f25fd7280c0416db7f12447622a8777@example.com
+    username: 78010d98140841648f1a2d1b4a709699@example.com
   model: sentry.user
   pk: 34
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-09T18:52:24.711Z'
+    date_joined: '2023-11-15T22:32:20.871Z'
     email: ''
     flags: '0'
     is_active: true
@@ -422,20 +422,20 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2023-11-09T18:52:24.711Z'
+    last_active: '2023-11-15T22:32:20.871Z'
     last_login: null
     last_password_change: null
     name: ''
     password: ''
     session_nonce: null
-    username: test-app-8d6d9fb6-c7b1-4326-a418-491007dbc9c3
+    username: test-app-74b44ab2-6d62-4c68-a26f-f858c4e8fad5
   model: sentry.user
   pk: 35
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-09T18:52:25.038Z'
-    email: 887172daf50746a28ffb0845cd5ba315@example.com
+    date_joined: '2023-11-15T22:32:21.071Z'
+    email: 1e3b38e01d14459cbbd85012c62d7b53@example.com
     flags: '0'
     is_active: true
     is_managed: false
@@ -444,13 +444,13 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: false
     is_unclaimed: false
-    last_active: '2023-11-09T18:52:25.038Z'
+    last_active: '2023-11-15T22:32:21.071Z'
     last_login: null
-    last_password_change: '2023-11-09T18:52:25.038Z'
+    last_password_change: '2023-11-15T22:32:21.071Z'
     name: ''
-    password: md5$h7gt5TSMeyyRQmqUkWyN2K$40bd761899e3931087eba8b4375dc6ab
+    password: md5$NyJci9RVeL5bNDeN3QW8xe$3d85bc33e64c023e934039cab33b54b9
     session_nonce: null
-    username: 887172daf50746a28ffb0845cd5ba315@example.com
+    username: 1e3b38e01d14459cbbd85012c62d7b53@example.com
   model: sentry.user
   pk: 36
 - fields:
@@ -493,24 +493,24 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.userpermission
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:23.817Z'
-    date_updated: '2023-11-09T18:52:23.817Z'
+    date_added: '2023-11-15T22:32:20.273Z'
+    date_updated: '2023-11-15T22:32:20.273Z'
     name: test-admin-role
     permissions: '[]'
   model: sentry.userrole
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:23.822Z'
-    date_updated: '2023-11-09T18:52:23.822Z'
+    date_added: '2023-11-15T22:32:20.277Z'
+    date_updated: '2023-11-15T22:32:20.277Z'
     role: 6
     user: 31
   model: sentry.userroleuser
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:24.593Z'
+    date_added: '2023-11-15T22:32:20.805Z'
     is_global: false
     name: Saved query for test-org
-    organization: 4552945452908560
+    organization: 4552980291649552
     owner_id: null
     query: saved query for test-org
     sort: date
@@ -519,9 +519,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.savedsearch
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:24.592Z'
-    last_seen: '2023-11-09T18:52:24.592Z'
-    organization: 4552945452908560
+    date_added: '2023-11-15T22:32:20.804Z'
+    last_seen: '2023-11-15T22:32:20.804Z'
+    organization: 4552980291649552
     query: some query for test-org
     query_hash: 7c69362cd42207b83f80087bc15ebccb
     type: 0
@@ -529,42 +529,42 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.recentsearch
   pk: 6
 - fields:
-    project: 4552945452974097
-    team: 4552945452974096
+    project: 4552980291649554
+    team: 4552980291649553
   model: sentry.projectteam
   pk: 11
 - fields:
-    project: 4552945452974098
-    team: 4552945452974096
+    project: 4552980291649555
+    team: 4552980291649553
   model: sentry.projectteam
   pk: 12
 - fields:
-    date_added: '2023-11-09T18:52:24.292Z'
-    project: 4552945452974097
+    date_added: '2023-11-15T22:32:20.524Z'
+    project: 4552980291649554
     user_id: 31
   model: sentry.projectbookmark
   pk: 6
 - fields:
     created_by: null
-    date_added: '2023-11-09T18:52:24.387Z'
+    date_added: '2023-11-15T22:32:20.626Z'
     date_deactivated: null
     date_last_used: null
     name: token 1 for test-org
-    organization_id: 4552945452908560
-    project_last_used_id: 4552945452974097
+    organization_id: 4552980291649552
+    project_last_used_id: 4552980291649554
     scope_list: '[''org:ci'']'
     token_hashed: ABCDEFtest-org
     token_last_characters: xyz1
   model: sentry.orgauthtoken
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:23.986Z'
+    date_added: '2023-11-15T22:32:20.381Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: null
-    organization: 4552945452908560
+    organization: 4552980291649552
     role: owner
     token: null
     token_expires_at: null
@@ -575,13 +575,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 11
 - fields:
-    date_added: '2023-11-09T18:52:24.037Z'
+    date_added: '2023-11-15T22:32:20.407Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: null
-    organization: 4552945452908560
+    organization: 4552980291649552
     role: member
     token: null
     token_expires_at: null
@@ -594,104 +594,104 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     member: 12
     requester_id: null
-    team: 4552945452974096
+    team: 4552980291649553
   model: sentry.organizationaccessrequest
   pk: 6
 - fields:
     config:
       schedule: '* * * * *'
       schedule_type: 1
-    date_added: '2023-11-09T18:52:24.443Z'
-    guid: a0f5fb79-6a79-4f4c-a437-c3f5a6586423
+    date_added: '2023-11-15T22:32:20.668Z'
+    guid: 5ca5880c-8f2e-40ab-a19d-be18f37d9f9e
     name: ''
-    organization_id: 4552945452908560
-    project_id: 4552945452974097
-    slug: 3ff94ea6f2a1
+    organization_id: 4552980291649552
+    project_id: 4552980291649554
+    slug: 08fd9d95a228
     status: 0
     type: 3
   model: sentry.monitor
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:24.440Z'
-    name: visually prepared shrew
-    organization_id: 4552945452908560
+    date_added: '2023-11-15T22:32:20.664Z'
+    name: painfully crucial lacewing
+    organization_id: 4552980291649552
   model: sentry.environment
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:23.731Z'
+    date_added: '2023-11-15T22:32:20.216Z'
     email: owner
   model: sentry.email
   pk: 43
 - fields:
-    date_added: '2023-11-09T18:52:23.875Z'
+    date_added: '2023-11-15T22:32:20.314Z'
     email: invitee
   model: sentry.email
   pk: 44
 - fields:
-    date_added: '2023-11-09T18:52:24.538Z'
+    date_added: '2023-11-15T22:32:20.738Z'
     email: admin@localhost
   model: sentry.email
   pk: 45
 - fields:
-    date_added: '2023-11-09T18:52:24.617Z'
-    email: 8f25fd7280c0416db7f12447622a8777@example.com
+    date_added: '2023-11-15T22:32:20.816Z'
+    email: 78010d98140841648f1a2d1b4a709699@example.com
   model: sentry.email
   pk: 46
 - fields:
-    date_added: '2023-11-09T18:52:24.718Z'
+    date_added: '2023-11-15T22:32:20.875Z'
     email: ''
   model: sentry.email
   pk: 47
 - fields:
-    date_added: '2023-11-09T18:52:25.048Z'
-    email: 887172daf50746a28ffb0845cd5ba315@example.com
+    date_added: '2023-11-15T22:32:21.074Z'
+    email: 1e3b38e01d14459cbbd85012c62d7b53@example.com
   model: sentry.email
   pk: 48
 - fields:
-    date_added: '2023-11-09T18:52:24.591Z'
-    organization: 4552945452908560
+    date_added: '2023-11-15T22:32:20.803Z'
+    organization: 4552980291649552
     slug: test-tombstone-in-test-org
   model: sentry.dashboardtombstone
   pk: 6
 - fields:
     created_by_id: 31
-    date_added: '2023-11-09T18:52:24.587Z'
+    date_added: '2023-11-15T22:32:20.799Z'
     filters: null
-    last_visited: '2023-11-09T18:52:24.587Z'
-    organization: 4552945452908560
+    last_visited: '2023-11-15T22:32:20.799Z'
+    organization: 4552980291649552
     title: Dashboard 1 for test-org
     visits: 1
   model: sentry.dashboard
   pk: 6
 - fields:
     condition: '{"op":"equals","name":"environment","value":"prod"}'
-    condition_hash: 36443c14bbe061da559bcfd90e9c12f533107b98
+    condition_hash: 90dcce273a6f3e0a9568531c92d7f4193e8934a9
     created_by_id: null
-    date_added: '2023-11-09T18:52:24.431Z'
-    end_date: '2023-11-09T19:52:24.429Z'
+    date_added: '2023-11-15T22:32:20.658Z'
+    end_date: '2023-11-15T23:32:20.656Z'
     is_active: true
     is_org_level: false
     num_samples: 100
-    organization: 4552945452908560
+    organization: 4552980291649552
     query: environment:prod event.type:transaction
     rule_id: 1
     sample_rate: 0.5
-    start_date: '2023-11-09T18:52:24.429Z'
+    start_date: '2023-11-15T22:32:20.656Z'
   model: sentry.customdynamicsamplingrule
   pk: 4
 - fields:
-    project: 4552945452974097
+    project: 4552980291649554
     value: 1
   model: sentry.counter
   pk: 6
 - fields:
     config: {}
-    date_added: '2023-11-09T18:52:24.330Z'
+    date_added: '2023-11-15T22:32:20.560Z'
     default_global_access: true
     default_role: 50
     flags: '0'
     last_sync: null
-    organization_id: 4552945452908560
+    organization_id: 4552980291649552
     provider: sentry
     sync_time: null
   model: sentry.authprovider
@@ -707,16 +707,16 @@ source: tests/sentry/backup/test_releases.py
       - 3
       key4:
         nested_key: nested_value
-    date_added: '2023-11-09T18:52:24.365Z'
+    date_added: '2023-11-15T22:32:20.582Z'
     ident: 123456789test-org
-    last_synced: '2023-11-09T18:52:24.365Z'
-    last_verified: '2023-11-09T18:52:24.365Z'
+    last_synced: '2023-11-15T22:32:20.582Z'
+    last_verified: '2023-11-15T22:32:20.582Z'
     user: 31
   model: sentry.authidentity
   pk: 6
 - fields:
     config: '""'
-    created_at: '2023-11-09T18:52:23.778Z'
+    created_at: '2023-11-15T22:32:20.240Z'
     last_used_at: null
     type: 1
     user: 31
@@ -724,7 +724,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 11
 - fields:
     config: '""'
-    created_at: '2023-11-09T18:52:23.902Z'
+    created_at: '2023-11-15T22:32:20.334Z'
     last_used_at: null
     type: 1
     user: 32
@@ -732,10 +732,10 @@ source: tests/sentry/backup/test_releases.py
   pk: 12
 - fields:
     allowed_origins: null
-    date_added: '2023-11-09T18:52:24.310Z'
-    key: 7983664d39dd43a7a6138a399d43ffaa
+    date_added: '2023-11-15T22:32:20.541Z'
+    key: 47c3ebd814ed4405a785d0a988ecdfee
     label: Default
-    organization_id: 4552945452908560
+    organization_id: 4552980291649552
     scope_list: '[]'
     scopes: '0'
     status: 0
@@ -743,11 +743,11 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     allowed_origins: ''
-    client_id: 9f0ef968c57ce824843be87f2f077f6116af967202f79676483cf977131078c3
-    client_secret: c73eb3930c59df321419caf57f3064c9b71c9e893ceb85e51ab8006d0bc2daa0
-    date_added: '2023-11-09T18:52:24.733Z'
+    client_id: 4610d43d85641cf0f6b41e275ec68ac8147d3098e1baa5e235bb3af6a9e9789b
+    client_secret: 1e5830d2725f553db83467065f2cd98972731f50156d39719c94de2ee5bd6b83
+    date_added: '2023-11-15T22:32:20.880Z'
     homepage_url: null
-    name: Maximum Unicorn
+    name: Equal Oarfish
     owner: 35
     privacy_url: null
     redirect_uris: ''
@@ -756,63 +756,63 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.apiapplication
   pk: 6
 - fields:
-    team: 4552945452974096
+    team: 4552980291649553
     type: 0
     user_id: null
   model: sentry.actor
   pk: 6
 - fields:
-    date_hash_added: '2023-11-09T18:52:23.727Z'
+    date_hash_added: '2023-11-15T22:32:20.214Z'
     email: owner
     is_verified: true
     user: 31
-    validation_hash: hzbOdy9PVTuHyfsKeqlS8o8B5Su5fNYE
+    validation_hash: R7OI98OW7TqSHLFSHijbJMKB5am0fK6c
   model: sentry.useremail
   pk: 31
 - fields:
-    date_hash_added: '2023-11-09T18:52:23.873Z'
+    date_hash_added: '2023-11-15T22:32:20.312Z'
     email: invitee
     is_verified: true
     user: 32
-    validation_hash: JKapgwfdj0rDqypDl5ucRipXB5QZuetP
+    validation_hash: R7LnZl0Dll9I6GB2XnzOuwqkDMFgBwH2
   model: sentry.useremail
   pk: 32
 - fields:
-    date_hash_added: '2023-11-09T18:52:24.536Z'
+    date_hash_added: '2023-11-15T22:32:20.736Z'
     email: admin@localhost
     is_verified: true
     user: 33
-    validation_hash: Sexp36PELm3nBZsTIUJATpKyeyScxOdR
+    validation_hash: uBdSyXhZhLjTYIIpK5ZI5nugdLhSO0wU
   model: sentry.useremail
   pk: 33
 - fields:
-    date_hash_added: '2023-11-09T18:52:24.616Z'
-    email: 8f25fd7280c0416db7f12447622a8777@example.com
+    date_hash_added: '2023-11-15T22:32:20.814Z'
+    email: 78010d98140841648f1a2d1b4a709699@example.com
     is_verified: true
     user: 34
-    validation_hash: WiaWtoh3enfeTfG85b4nu4X3PYUrnBrR
+    validation_hash: 8RJWxOULDqmW3ZQ4d1DlA91bQ662U0cq
   model: sentry.useremail
   pk: 34
 - fields:
-    date_hash_added: '2023-11-09T18:52:24.715Z'
+    date_hash_added: '2023-11-15T22:32:20.873Z'
     email: ''
     is_verified: false
     user: 35
-    validation_hash: Inp0YrIUyCSWOgfW5iV9IJE6JP0TyTDa
+    validation_hash: 93CWQ2Ode5v2CqrHy9ItVu811fGehWCO
   model: sentry.useremail
   pk: 35
 - fields:
-    date_hash_added: '2023-11-09T18:52:25.045Z'
-    email: 887172daf50746a28ffb0845cd5ba315@example.com
+    date_hash_added: '2023-11-15T22:32:21.072Z'
+    email: 1e3b38e01d14459cbbd85012c62d7b53@example.com
     is_verified: true
     user: 36
-    validation_hash: aVtiu2L5yJbUv87NVdqNwd5gdoGJVmRm
+    validation_hash: G896RmyqoGNuMCyu0iinuirtd0H8iy5L
   model: sentry.useremail
   pk: 36
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2023-11-09T18:52:24.509Z'
+    date_added: '2023-11-15T22:32:20.715Z'
     environment: null
     query: level:error
     resolution: 60
@@ -823,7 +823,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2023-11-09T18:52:24.567Z'
+    date_added: '2023-11-15T22:32:20.775Z'
     environment: null
     query: test query
     resolution: 60
@@ -834,17 +834,17 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     application: 6
     author: A Company
-    creator_label: 8f25fd7280c0416db7f12447622a8777@example.com
+    creator_label: 78010d98140841648f1a2d1b4a709699@example.com
     creator_user: 34
-    date_added: '2023-11-09T18:52:24.735Z'
+    date_added: '2023-11-15T22:32:20.881Z'
     date_deleted: null
     date_published: null
-    date_updated: '2023-11-09T18:52:24.960Z'
+    date_updated: '2023-11-15T22:32:21.025Z'
     events: '[]'
     is_alertable: false
     name: test app
     overview: null
-    owner_id: 4552945452908560
+    owner_id: 4552980291649552
     popularity: 1
     proxy_user: 35
     redirect_url: null
@@ -885,26 +885,26 @@ source: tests/sentry/backup/test_releases.py
     scopes: '0'
     slug: test-app
     status: 0
-    uuid: a1215f2b-312d-4ab9-89a8-ada444d94084
+    uuid: 2c76b31a-c04b-4108-8295-b36168c9785c
     verify_install: true
     webhook_url: https://example.com/webhook
   model: sentry.sentryapp
   pk: 6
 - fields:
     data: '{"conditions":[{"id":"sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},{"id":"sentry.rules.conditions.every_event.EveryEventCondition"}],"action_match":"all","filter_match":"all","actions":[{"id":"sentry.rules.actions.notify_event.NotifyEventAction"},{"id":"sentry.rules.actions.notify_event_service.NotifyEventServiceAction","service":"mail"}]}'
-    date_added: '2023-11-09T18:52:24.422Z'
+    date_added: '2023-11-15T22:32:20.652Z'
     environment_id: null
     label: ''
     owner: null
-    project: 4552945452974097
+    project: 4552980291649554
     source: 0
     status: 0
   model: sentry.rule
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:24.519Z'
-    date_updated: '2023-11-09T18:52:24.519Z'
-    project: 4552945452974097
+    date_added: '2023-11-15T22:32:20.722Z'
+    date_updated: '2023-11-15T22:32:20.722Z'
+    project: 4552980291649554
     snuba_query: 11
     status: 1
     subscription_id: null
@@ -912,9 +912,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 21
 - fields:
-    date_added: '2023-11-09T18:52:24.571Z'
-    date_updated: '2023-11-09T18:52:24.571Z'
-    project: 4552945452974097
+    date_added: '2023-11-15T22:32:20.779Z'
+    date_updated: '2023-11-15T22:32:20.779Z'
+    project: 4552980291649554
     snuba_query: 12
     status: 1
     subscription_id: null
@@ -922,9 +922,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 22
 - fields:
-    date_added: '2023-11-09T18:52:24.765Z'
-    date_updated: '2023-11-09T18:52:24.765Z'
-    project: 4552945452974100
+    date_added: '2023-11-15T22:32:20.900Z'
+    date_updated: '2023-11-15T22:32:20.900Z'
+    project: 4552980291649557
     snuba_query: 11
     status: 1
     subscription_id: null
@@ -932,9 +932,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 23
 - fields:
-    date_added: '2023-11-09T18:52:25.080Z'
-    date_updated: '2023-11-09T18:52:25.080Z'
-    project: 4552945453039632
+    date_added: '2023-11-15T22:32:21.098Z'
+    date_updated: '2023-11-15T22:32:21.098Z'
+    project: 4552980291715088
     snuba_query: 11
     status: 1
     subscription_id: null
@@ -945,12 +945,12 @@ source: tests/sentry/backup/test_releases.py
     is_active: true
     organizationmember: 11
     role: null
-    team: 4552945452974096
+    team: 4552980291649553
   model: sentry.organizationmemberteam
   pk: 6
 - fields:
     integration_id: null
-    organization: 4552945452908560
+    organization: 4552980291649552
     sentry_app_id: null
     target_display: Sentry User
     target_identifier: '1'
@@ -961,7 +961,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 9
 - fields:
     integration_id: null
-    organization: 4552945452908560
+    organization: 4552980291649552
     sentry_app_id: 6
     target_display: Sentry User
     target_identifier: '1'
@@ -971,23 +971,23 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.notificationaction
   pk: 10
 - fields:
-    disable_date: '2023-11-09T18:52:24.428Z'
+    disable_date: '2023-11-15T22:32:20.655Z'
     opted_out: false
-    organization: 4552945452908560
+    organization: 4552980291649552
     rule: 6
-    sent_final_email_date: '2023-11-09T18:52:24.428Z'
-    sent_initial_email_date: '2023-11-09T18:52:24.428Z'
+    sent_final_email_date: '2023-11-15T22:32:20.655Z'
+    sent_initial_email_date: '2023-11-15T22:32:20.655Z'
   model: sentry.neglectedrule
   pk: 6
 - fields:
     environment: 6
     is_hidden: null
-    project: 4552945452974097
+    project: 4552980291649554
   model: sentry.environmentproject
   pk: 6
 - fields:
     dashboard: 6
-    date_added: '2023-11-09T18:52:24.588Z'
+    date_added: '2023-11-15T22:32:20.800Z'
     description: null
     detail: null
     display_type: 0
@@ -1001,51 +1001,51 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     custom_dynamic_sampling_rule: 4
-    project: 4552945452974097
+    project: 4552980291649554
   model: sentry.customdynamicsamplingruleproject
   pk: 4
 - fields:
     application: 6
-    date_added: '2023-11-09T18:52:24.870Z'
-    expires_at: '2023-11-10T02:52:24.870Z'
+    date_added: '2023-11-15T22:32:20.966Z'
+    expires_at: '2023-11-16T06:32:20.966Z'
     name: null
-    refresh_token: 703f2797e01420084bbc59bb1a0be0c9029b118d4372069f1f46992cce2c3890
+    refresh_token: 820af875ad962142320a7e51020df3debc03f1ff30876014988c07664c8e3505
     scope_list: '[]'
     scopes: '0'
-    token: db2e8cc7d472ba57c47990a63e91a07d783435f9816dd77edc73027197510638
-    token_last_characters: 0638
+    token: 7e016d6b0efb8072aa0a827e30286670b7831cccb51ba5545dce8a59df2f535a
+    token_last_characters: 535a
     user: 35
   model: sentry.apitoken
   pk: 14
 - fields:
     application: 6
-    date_added: '2023-11-09T18:52:24.968Z'
+    date_added: '2023-11-15T22:32:21.031Z'
     expires_at: null
     name: create_exhaustive_sentry_app
-    refresh_token: a1f2d94949599d00fda6dec7623c04152434b59473a400c8b5f114bb120a1bc8
+    refresh_token: dc45310ff00da876b87339d3f166f58fb3765eded41b22e1e49ae1f0f89e758a
     scope_list: '[]'
     scopes: '0'
-    token: 0fa15ae9f7e87ccd3436b02ded2e0f5b48642e410890289c928cb23d1142aeb5
-    token_last_characters: aeb5
+    token: 0635932b6fea781327eed01c842b3f49025735d62c459c2031c3d076e9e7e4ae
+    token_last_characters: e4ae
     user: 31
   model: sentry.apitoken
   pk: 15
 - fields:
     application: null
-    date_added: '2023-11-09T18:52:25.149Z'
+    date_added: '2023-11-15T22:32:21.143Z'
     expires_at: null
     name: create_exhaustive_global_configs
-    refresh_token: 19de8386887fab5b6c42301a57a9760733a478214c95b601357ddcc215525623
+    refresh_token: a1de5eb026a5c02e33ab43725ee5fba984758765142ba14680b6bd7437550036
     scope_list: '[]'
     scopes: '0'
-    token: 6416b02dfee3bf74904da47d354df54e828be494f35301850e1010503995a0f3
-    token_last_characters: a0f3
+    token: 6fff7f274ee0da637ff52397ec0aa4256f0ec650c2be6f0b5c7b5387f5a51458
+    token_last_characters: '1458'
     user: 31
   model: sentry.apitoken
   pk: 16
 - fields:
     application: 6
-    code: 898e984709df56670e75974af02a47504214d7490d9179dea8558e1462292d53
+    code: fff771ddf49365e3fc057f1bd1fa965fb6e3325f2ba87c8cd7057aec09347689
     expires_at: '2022-01-01T11:11:00.000Z'
     redirect_uri: https://example.com
     scope_list: '[''openid'', ''profile'', ''email'']'
@@ -1055,7 +1055,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 8
 - fields:
     application: 6
-    date_added: '2023-11-09T18:52:24.966Z'
+    date_added: '2023-11-15T22:32:21.030Z'
     scope_list: '[]'
     scopes: '0'
     user: 31
@@ -1063,7 +1063,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 9
 - fields:
     application: null
-    date_added: '2023-11-09T18:52:25.148Z'
+    date_added: '2023-11-15T22:32:21.142Z'
     scope_list: '[]'
     scopes: '0'
     user: 31
@@ -1071,11 +1071,11 @@ source: tests/sentry/backup/test_releases.py
   pk: 10
 - fields:
     comparison_delta: null
-    date_added: '2023-11-09T18:52:24.513Z'
-    date_modified: '2023-11-09T18:52:24.513Z'
+    date_added: '2023-11-15T22:32:20.717Z'
+    date_modified: '2023-11-15T22:32:20.717Z'
     include_all_projects: true
-    name: Enhanced Chigger
-    organization: 4552945452908560
+    name: Fancy Eel
+    organization: 4552980291649552
     owner: null
     resolve_threshold: null
     snuba_query: 11
@@ -1088,11 +1088,11 @@ source: tests/sentry/backup/test_releases.py
   pk: 11
 - fields:
     comparison_delta: null
-    date_added: '2023-11-09T18:52:24.569Z'
-    date_modified: '2023-11-09T18:52:24.569Z'
+    date_added: '2023-11-15T22:32:20.777Z'
+    date_modified: '2023-11-15T22:32:20.777Z'
     include_all_projects: false
-    name: Touching Mullet
-    organization: 4552945452908560
+    name: Above Stag
+    organization: 4552980291649552
     owner: null
     resolve_threshold: null
     snuba_query: 12
@@ -1116,13 +1116,13 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     api_grant: null
     api_token: 14
-    date_added: '2023-11-09T18:52:24.836Z'
+    date_added: '2023-11-15T22:32:20.932Z'
     date_deleted: null
-    date_updated: '2023-11-09T18:52:24.852Z'
-    organization_id: 4552945452908560
+    date_updated: '2023-11-15T22:32:20.947Z'
+    organization_id: 4552980291649552
     sentry_app: 6
     status: 1
-    uuid: 6d4883d5-06cb-49ee-85ea-cf2e9f1383e9
+    uuid: d522758d-adef-464d-ba0f-6843d27b36e4
   model: sentry.sentryappinstallation
   pk: 6
 - fields:
@@ -1160,12 +1160,12 @@ source: tests/sentry/backup/test_releases.py
       type: alert-rule-action
     sentry_app: 6
     type: alert-rule-action
-    uuid: 2ac2db5e-8801-46bf-8d7c-f2f6bed41a60
+    uuid: 67e80ea0-23c6-407f-84e4-7c6abe7430d0
   model: sentry.sentryappcomponent
   pk: 6
 - fields:
     alert_rule: null
-    date_added: '2023-11-09T18:52:24.426Z'
+    date_added: '2023-11-15T22:32:20.654Z'
     owner_id: 31
     rule: 6
     until: null
@@ -1173,7 +1173,7 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.rulesnooze
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:24.424Z'
+    date_added: '2023-11-15T22:32:20.653Z'
     rule: 6
     type: 1
     user_id: null
@@ -1181,26 +1181,26 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     action: 9
-    project: 4552945452974097
+    project: 4552980291649554
   model: sentry.notificationactionproject
   pk: 9
 - fields:
     action: 10
-    project: 4552945452974097
+    project: 4552980291649554
   model: sentry.notificationactionproject
   pk: 10
 - fields:
     alert_rule: 12
-    date_added: '2023-11-09T18:52:24.575Z'
+    date_added: '2023-11-15T22:32:20.784Z'
     date_closed: null
-    date_detected: '2023-11-09T18:52:24.574Z'
-    date_started: '2023-11-09T18:52:24.574Z'
+    date_detected: '2023-11-15T22:32:20.782Z'
+    date_started: '2023-11-15T22:32:20.782Z'
     detection_uuid: null
     identifier: 1
-    organization: 4552945452908560
+    organization: 4552980291649552
     status: 1
     status_method: 3
-    title: Singular Moose
+    title: Clever Cattle
     type: 2
   model: sentry.incident
   pk: 6
@@ -1208,7 +1208,7 @@ source: tests/sentry/backup/test_releases.py
     aggregates: null
     columns: null
     conditions: ''
-    date_added: '2023-11-09T18:52:24.589Z'
+    date_added: '2023-11-15T22:32:20.802Z'
     field_aliases: null
     fields: '[]'
     name: Test Query for test-org
@@ -1220,21 +1220,21 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     alert_rule: 11
     alert_threshold: 100.0
-    date_added: '2023-11-09T18:52:24.529Z'
-    label: Massive Egret
+    date_added: '2023-11-15T22:32:20.729Z'
+    label: United Wasp
     resolve_threshold: null
     threshold_type: null
   model: sentry.alertruletrigger
   pk: 6
 - fields:
     alert_rule: 11
-    date_added: '2023-11-09T18:52:24.516Z'
-    project: 4552945452974098
+    date_added: '2023-11-15T22:32:20.720Z'
+    project: 4552980291649555
   model: sentry.alertruleexcludedprojects
   pk: 6
 - fields:
     alert_rule: 11
-    date_added: '2023-11-09T18:52:24.521Z'
+    date_added: '2023-11-15T22:32:20.724Z'
     previous_alert_rule: null
     type: 1
     user_id: null
@@ -1242,30 +1242,30 @@ source: tests/sentry/backup/test_releases.py
   pk: 11
 - fields:
     alert_rule: 12
-    date_added: '2023-11-09T18:52:24.572Z'
+    date_added: '2023-11-15T22:32:20.780Z'
     previous_alert_rule: null
     type: 1
     user_id: null
   model: sentry.alertruleactivity
   pk: 12
 - fields:
-    date_added: '2023-11-09T18:52:24.581Z'
-    end: '2023-11-09T18:52:24.581Z'
+    date_added: '2023-11-15T22:32:20.789Z'
+    end: '2023-11-15T22:32:20.789Z'
     period: 1
-    start: '2023-11-08T18:52:24.581Z'
+    start: '2023-11-14T22:32:20.789Z'
     values: '[[1.0, 2.0, 3.0], [1.5, 2.5, 3.5]]'
   model: sentry.timeseriessnapshot
   pk: 6
 - fields:
     actor_id: 6
     application_id: 6
-    date_added: '2023-11-09T18:52:24.850Z'
+    date_added: '2023-11-15T22:32:20.945Z'
     events: '[]'
-    guid: 4ea5dd42d2504501a7d2adb26955f401
+    guid: 54bc7f111f034e46a4f04d111d132c28
     installation_id: 6
-    organization_id: 4552945452908560
+    organization_id: 4552980291649552
     project_id: null
-    secret: ccd7bad86ea44a8d98abbe2ce02dcfedc5c0bd5ee9978c9d394ba67354198bd6
+    secret: ca7ae41877433ddf63516d03ad373343689699214fc71693b432ef72971a8962
     status: 0
     url: https://example.com/webhook
     version: 0
@@ -1274,40 +1274,40 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     actor_id: 36
     application_id: 6
-    date_added: '2023-11-09T18:52:25.128Z'
+    date_added: '2023-11-15T22:32:21.128Z'
     events: '[''event.created'']'
-    guid: bb97c6d971654aceb9fe64a8fbb348ce
+    guid: 1011ff3a9eeb4ffdaa89f12919775be7
     installation_id: 6
-    organization_id: 4552945452908560
-    project_id: 4552945453039632
-    secret: c17748931bbef37b88ba0cc2f8c2d6d8efa317092ddc03b26704a0c04248cac1
+    organization_id: 4552980291649552
+    project_id: 4552980291715088
+    secret: 72a70b509f5fd7237e001071c57143123b28979a62560846d12c53d3eba41180
     status: 0
     url: https://example.com/sentry/webhook
     version: 0
   model: sentry.servicehook
   pk: 12
 - fields:
-    date_added: '2023-11-09T18:52:24.586Z'
+    date_added: '2023-11-15T22:32:20.797Z'
     incident: 6
-    target_run_date: '2023-11-09T22:52:24.586Z'
+    target_run_date: '2023-11-16T02:32:20.797Z'
   model: sentry.pendingincidentsnapshot
   pk: 6
 - fields:
     alert_rule_trigger: 6
-    date_added: '2023-11-09T18:52:24.585Z'
-    date_modified: '2023-11-09T18:52:24.585Z'
+    date_added: '2023-11-15T22:32:20.794Z'
+    date_modified: '2023-11-15T22:32:20.794Z'
     incident: 6
     status: 1
   model: sentry.incidenttrigger
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:24.583Z'
+    date_added: '2023-11-15T22:32:20.791Z'
     incident: 6
     user_id: 31
   model: sentry.incidentsubscription
   pk: 6
 - fields:
-    date_added: '2023-11-09T18:52:24.582Z'
+    date_added: '2023-11-15T22:32:20.790Z'
     event_stats_snapshot: 6
     incident: 6
     total_events: 1
@@ -1316,7 +1316,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     comment: hello test-org
-    date_added: '2023-11-09T18:52:24.580Z'
+    date_added: '2023-11-15T22:32:20.788Z'
     incident: 6
     notification_uuid: null
     previous_value: null
@@ -1327,13 +1327,13 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     alert_rule_trigger: 6
-    date_added: '2023-11-09T18:52:24.530Z'
+    date_added: '2023-11-15T22:32:20.730Z'
     query_subscription: 21
   model: sentry.alertruletriggerexclusion
   pk: 6
 - fields:
     alert_rule_trigger: 6
-    date_added: '2023-11-09T18:52:24.565Z'
+    date_added: '2023-11-15T22:32:20.773Z'
     integration_id: null
     sentry_app_config: null
     sentry_app_id: null

--- a/tests/sentry/backup/snapshots/ReleaseTests/test_at_head.pysnap
+++ b/tests/sentry/backup/snapshots/ReleaseTests/test_at_head.pysnap
@@ -1,18 +1,18 @@
 ---
-created: '2023-11-10T11:44:08.687106Z'
+created: '2023-11-07T21:45:37.794566Z'
 creator: sentry
 source: tests/sentry/backup/test_releases.py
 ---
 - fields:
     key: bar
-    last_updated: '2023-11-10T11:44:08.265Z'
+    last_updated: '2023-11-07T21:45:37.376Z'
     last_updated_by: unknown
     value: '"b"'
   model: sentry.controloption
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.833Z'
-    date_updated: '2023-11-10T11:44:07.833Z'
+    date_added: '2023-11-07T21:45:36.942Z'
+    date_updated: '2023-11-07T21:45:36.942Z'
     external_id: slack:test-org
     metadata: {}
     name: Slack for test-org
@@ -22,13 +22,13 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     key: foo
-    last_updated: '2023-11-10T11:44:08.264Z'
+    last_updated: '2023-11-07T21:45:37.375Z'
     last_updated_by: unknown
     value: '"a"'
   model: sentry.option
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.611Z'
+    date_added: '2023-11-07T21:45:36.711Z'
     default_role: member
     flags: '1'
     is_test: false
@@ -36,92 +36,92 @@ source: tests/sentry/backup/test_releases.py
     slug: test-org
     status: 0
   model: sentry.organization
-  pk: 4552949431205904
+  pk: 4552934809403408
 - fields:
-    date_added: '2023-11-10T11:44:07.976Z'
+    date_added: '2023-11-07T21:45:37.080Z'
     default_role: member
     flags: '1'
     is_test: false
-    name: Unbiased Woodcock
-    slug: unbiased-woodcock
+    name: Heroic Pegasus
+    slug: heroic-pegasus
     status: 0
   model: sentry.organization
-  pk: 4552949431205908
+  pk: 4552934809468944
 - fields:
     config:
       hello: hello
-    date_added: '2023-11-10T11:44:07.834Z'
-    date_updated: '2023-11-10T11:44:07.834Z'
+    date_added: '2023-11-07T21:45:36.944Z'
+    date_updated: '2023-11-07T21:45:36.944Z'
     default_auth_id: null
     grace_period_end: null
     integration: 6
-    organization_id: 4552949431205904
+    organization_id: 4552934809403408
     status: 0
   model: sentry.organizationintegration
   pk: 6
 - fields:
     key: sentry:account-rate-limit
-    organization: 4552949431205904
+    organization: 4552934809403408
     value: 0
   model: sentry.organizationoption
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.738Z'
+    date_added: '2023-11-07T21:45:36.843Z'
     first_event: null
     flags: '10'
     forced_color: null
     name: project-test-org
-    organization: 4552949431205904
+    organization: 4552934809403408
     platform: null
     public: false
     slug: project-test-org
     status: 0
   model: sentry.project
-  pk: 4552949431205906
+  pk: 4552934809403410
 - fields:
-    date_added: '2023-11-10T11:44:07.861Z'
+    date_added: '2023-11-07T21:45:36.967Z'
     first_event: null
     flags: '10'
     forced_color: null
     name: other-project-test-org
-    organization: 4552949431205904
+    organization: 4552934809403408
     platform: null
     public: false
     slug: other-project-test-org
     status: 0
   model: sentry.project
-  pk: 4552949431205907
+  pk: 4552934809403411
 - fields:
-    date_added: '2023-11-10T11:44:08.032Z'
+    date_added: '2023-11-07T21:45:37.148Z'
     first_event: null
     flags: '10'
     forced_color: null
-    name: Engaging Woodcock
-    organization: 4552949431205904
+    name: Cuddly Crawfish
+    organization: 4552934809403408
     platform: null
     public: false
-    slug: engaging-woodcock
+    slug: cuddly-crawfish
     status: 0
   model: sentry.project
-  pk: 4552949431271440
+  pk: 4552934809468945
 - fields:
-    date_added: '2023-11-10T11:44:08.221Z'
+    date_added: '2023-11-07T21:45:37.335Z'
     first_event: null
     flags: '10'
     forced_color: null
-    name: Amazed Albacore
-    organization: 4552949431205904
+    name: Communal Chicken
+    organization: 4552934809403408
     platform: null
     public: false
-    slug: amazed-albacore
+    slug: communal-chicken
     status: 0
   model: sentry.project
-  pk: 4552949431271441
+  pk: 4552934809468946
 - fields:
     config:
       hello: hello
     integration_id: 6
-    project: 4552949431205906
+    project: 4552934809403410
   model: sentry.projectintegration
   pk: 6
 - fields:
@@ -129,14 +129,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2023-11-10T11:44:07.752Z'
+    date_added: '2023-11-07T21:45:36.859Z'
     label: Default
-    project: 4552949431205906
-    public_key: acb24d1975908c2b417b30b9a428403a
+    project: 4552934809403410
+    public_key: b837c7e1fd557d6bc8261dc4c2d4eb0a
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: b735e5ef3499cd83a586bd8811cd0859
+    secret_key: 8c6e144b7b42b50f6b62145b7252ef2b
     status: 0
   model: sentry.projectkey
   pk: 21
@@ -145,14 +145,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2023-11-10T11:44:07.875Z'
+    date_added: '2023-11-07T21:45:36.981Z'
     label: Default
-    project: 4552949431205907
-    public_key: 517998b7a9ad683e164cc726418e6235
+    project: 4552934809403411
+    public_key: d0e867fb0cf12691fca4e65cb6b61651
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 47f596cea4b5bbb20aa850be4934f8c2
+    secret_key: 20c9fc0838189a03b495248436d6af88
     status: 0
   model: sentry.projectkey
   pk: 22
@@ -161,14 +161,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2023-11-10T11:44:08.049Z'
+    date_added: '2023-11-07T21:45:37.164Z'
     label: Default
-    project: 4552949431271440
-    public_key: a8ee9d0b5a2a5bafd2ea355d67de058d
+    project: 4552934809468945
+    public_key: 08659ec34232b1ed383d24858233c6d5
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 141a9127178f8c823846d44400ea751a
+    secret_key: 3d8188bcafd0dd26943b4282a36137e2
     status: 0
   model: sentry.projectkey
   pk: 23
@@ -177,97 +177,97 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2023-11-10T11:44:08.238Z'
+    date_added: '2023-11-07T21:45:37.351Z'
     label: Default
-    project: 4552949431271441
-    public_key: 54148b7ae26a14feb044a31a2a92b393
+    project: 4552934809468946
+    public_key: e54a0d0c3d1b91f6193124d44ea7b554
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 2ef1935d978fecb672adb95406a8b16e
+    secret_key: 4f4f3b9466d54b80f080c023714678e6
     status: 0
   model: sentry.projectkey
   pk: 24
 - fields:
     key: sentry:relay-rev
-    project: 4552949431205906
-    value: '"ecf8023b446e46b58266c9a233dae5a0"'
+    project: 4552934809403410
+    value: '"c4b7b4b05bb54a8b872c2c5317ba6527"'
   model: sentry.projectoption
   pk: 61
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4552949431205906
-    value: '"2023-11-10T11:44:07.756470Z"'
+    project: 4552934809403410
+    value: '"2023-11-07T21:45:36.863528Z"'
   model: sentry.projectoption
   pk: 62
 - fields:
     key: sentry:option-epoch
-    project: 4552949431205906
+    project: 4552934809403410
     value: 11
   model: sentry.projectoption
   pk: 63
 - fields:
     key: sentry:relay-rev
-    project: 4552949431205907
-    value: '"b2645092e7984424a36853308b9c6013"'
+    project: 4552934809403411
+    value: '"0f2753d342654c9482131e94e6adb6d8"'
   model: sentry.projectoption
   pk: 64
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4552949431205907
-    value: '"2023-11-10T11:44:07.879597Z"'
+    project: 4552934809403411
+    value: '"2023-11-07T21:45:36.984915Z"'
   model: sentry.projectoption
   pk: 65
 - fields:
     key: sentry:option-epoch
-    project: 4552949431205907
+    project: 4552934809403411
     value: 11
   model: sentry.projectoption
   pk: 66
 - fields:
     key: sentry:relay-rev
-    project: 4552949431271440
-    value: '"d60e27c9a5be421182ea638d569ff730"'
+    project: 4552934809468945
+    value: '"da7a1304bd454253a8ccb02dbf59df47"'
   model: sentry.projectoption
   pk: 67
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4552949431271440
-    value: '"2023-11-10T11:44:08.053688Z"'
+    project: 4552934809468945
+    value: '"2023-11-07T21:45:37.167732Z"'
   model: sentry.projectoption
   pk: 68
 - fields:
     key: sentry:option-epoch
-    project: 4552949431271440
+    project: 4552934809468945
     value: 11
   model: sentry.projectoption
   pk: 69
 - fields:
     key: sentry:relay-rev
-    project: 4552949431271441
-    value: '"62dbe4dd34ef492cbebcfd8427054fcb"'
+    project: 4552934809468946
+    value: '"8413ea3af65845318ca99711883b1dfa"'
   model: sentry.projectoption
   pk: 70
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4552949431271441
-    value: '"2023-11-10T11:44:08.242163Z"'
+    project: 4552934809468946
+    value: '"2023-11-07T21:45:37.355273Z"'
   model: sentry.projectoption
   pk: 71
 - fields:
     key: sentry:option-epoch
-    project: 4552949431271441
+    project: 4552934809468946
     value: 11
   model: sentry.projectoption
   pk: 72
 - fields:
     auto_assignment: true
     codeowners_auto_sync: true
-    date_created: '2023-11-10T11:44:07.769Z'
+    date_created: '2023-11-07T21:45:36.877Z'
     fallthrough: true
     is_active: true
-    last_updated: '2023-11-10T11:44:07.769Z'
-    project: 4552949431205906
+    last_updated: '2023-11-07T21:45:36.877Z'
+    project: 4552934809403410
     raw: '{"hello":"hello"}'
     schema:
       hello: hello
@@ -275,9 +275,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.projectownership
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.772Z'
-    organization: 4552949431205904
-    project: 4552949431205906
+    date_added: '2023-11-07T21:45:36.881Z'
+    organization: 4552934809403408
+    project: 4552934809403410
     redirect_slug: project_slug_in_test-org
   model: sentry.projectredirect
   pk: 6
@@ -285,26 +285,26 @@ source: tests/sentry/backup/test_releases.py
     first_seen: null
     is_internal: true
     last_seen: null
-    public_key: 8WuGtLFvXJ9qNQ5bdxyE_sbKvFzfT9oyNVmERb_Fqp0
-    relay_id: fcffed14-3da2-4627-be7b-8c4e166b5fbb
+    public_key: bz-F98dr4lNFY0S1Kl9FUaNs2TLnv7f_OVBSlo1v2ac
+    relay_id: 937e54df-ca12-4741-81b8-eef5e43d9053
   model: sentry.relay
   pk: 6
 - fields:
-    first_seen: '2023-11-10T11:44:08.263Z'
-    last_seen: '2023-11-10T11:44:08.263Z'
-    public_key: 8WuGtLFvXJ9qNQ5bdxyE_sbKvFzfT9oyNVmERb_Fqp0
-    relay_id: fcffed14-3da2-4627-be7b-8c4e166b5fbb
+    first_seen: '2023-11-07T21:45:37.374Z'
+    last_seen: '2023-11-07T21:45:37.374Z'
+    public_key: bz-F98dr4lNFY0S1Kl9FUaNs2TLnv7f_OVBSlo1v2ac
+    relay_id: 937e54df-ca12-4741-81b8-eef5e43d9053
     version: 0.0.1
   model: sentry.relayusage
   pk: 6
 - fields:
     config: {}
-    date_added: '2023-11-10T11:44:07.952Z'
+    date_added: '2023-11-07T21:45:37.057Z'
     external_id: null
     integration_id: 6
     languages: '[]'
     name: getsentry/getsentry
-    organization_id: 4552949431205904
+    organization_id: 4552934809403408
     provider: integrations:github
     status: 0
     url: https://github.com/getsentry/getsentry
@@ -312,19 +312,19 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     actor: 6
-    date_added: '2023-11-10T11:44:07.695Z'
+    date_added: '2023-11-07T21:45:36.801Z'
     idp_provisioned: false
     name: test_team_in_test-org
     org_role: null
-    organization: 4552949431205904
+    organization: 4552934809403408
     slug: test_team_in_test-org
     status: 0
   model: sentry.team
-  pk: 4552949431205905
+  pk: 4552934809403409
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-10T11:44:07.466Z'
+    date_joined: '2023-11-07T21:45:36.581Z'
     email: owner
     flags: '0'
     is_active: true
@@ -334,11 +334,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: true
     is_unclaimed: false
-    last_active: '2023-11-10T11:44:07.466Z'
+    last_active: '2023-11-07T21:45:36.581Z'
     last_login: null
-    last_password_change: '2023-11-10T11:44:07.466Z'
+    last_password_change: '2023-11-07T21:45:36.581Z'
     name: ''
-    password: md5$8mWTITJG0pa6wN65VjaqUg$5ea04bc0b6c41389b285bf9d22894beb
+    password: md5$LpMOMS4B2uIw0E6jMmhrSZ$8f4b882bd08d58e1b8a668d027b502a6
     session_nonce: null
     username: owner
   model: sentry.user
@@ -346,7 +346,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-10T11:44:07.565Z'
+    date_joined: '2023-11-07T21:45:36.673Z'
     email: invitee
     flags: '0'
     is_active: true
@@ -356,11 +356,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2023-11-10T11:44:07.565Z'
+    last_active: '2023-11-07T21:45:36.673Z'
     last_login: null
-    last_password_change: '2023-11-10T11:44:07.565Z'
+    last_password_change: '2023-11-07T21:45:36.674Z'
     name: ''
-    password: md5$MotNV3tiw9BGoA6nDCINQz$bc64da97c260e497279ba7f42ff8eb6b
+    password: md5$h2xcXxmmPO8cBkJJTkBF4H$ae365c3ee888e0946ed28f68b432e4c1
     session_nonce: null
     username: invitee
   model: sentry.user
@@ -368,7 +368,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-10T11:44:07.903Z'
+    date_joined: '2023-11-07T21:45:37.010Z'
     email: admin@localhost
     flags: '0'
     is_active: true
@@ -378,11 +378,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: true
     is_unclaimed: false
-    last_active: '2023-11-10T11:44:07.903Z'
+    last_active: '2023-11-07T21:45:37.010Z'
     last_login: null
-    last_password_change: '2023-11-10T11:44:07.903Z'
+    last_password_change: '2023-11-07T21:45:37.010Z'
     name: ''
-    password: md5$O1qA3EdR3WNvNa6K7I98Gr$1b865e6159aad2e9e80d42d58d6e12a5
+    password: md5$RoRhINXn7HUAUE45ttLluU$9ab6655a185c035e8e9fd41bff6ddcf9
     session_nonce: null
     username: admin@localhost
   model: sentry.user
@@ -390,8 +390,8 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-10T11:44:07.953Z'
-    email: 0c797f56590f4ff99a86b920b4baaea3@example.com
+    date_joined: '2023-11-07T21:45:37.059Z'
+    email: 3ef6105756254b1988fdabb9045fc5b8@example.com
     flags: '0'
     is_active: true
     is_managed: false
@@ -400,19 +400,19 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: false
     is_unclaimed: false
-    last_active: '2023-11-10T11:44:07.953Z'
+    last_active: '2023-11-07T21:45:37.059Z'
     last_login: null
-    last_password_change: '2023-11-10T11:44:07.954Z'
+    last_password_change: '2023-11-07T21:45:37.059Z'
     name: ''
-    password: md5$Cm6pDIq5Xsm0oNe2vRW1bt$cef5f141109330d1d56a05e5e60494ce
+    password: md5$UAPUTu90KjoPfQfjsmaaln$db1ed070a13cd0c33d40cd031a222174
     session_nonce: null
-    username: 0c797f56590f4ff99a86b920b4baaea3@example.com
+    username: 3ef6105756254b1988fdabb9045fc5b8@example.com
   model: sentry.user
   pk: 34
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-10T11:44:08.008Z'
+    date_joined: '2023-11-07T21:45:37.125Z'
     email: ''
     flags: '0'
     is_active: true
@@ -422,20 +422,20 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2023-11-10T11:44:08.008Z'
+    last_active: '2023-11-07T21:45:37.125Z'
     last_login: null
     last_password_change: null
     name: ''
     password: ''
     session_nonce: null
-    username: test-app-cd4f2013-3ea0-4b9c-96d7-5421a864e617
+    username: test-app-abe6651b-d7bd-4885-81ba-ee3cba606850
   model: sentry.user
   pk: 35
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-10T11:44:08.200Z'
-    email: c2799776b72a48a19b1c6abfa33d9994@example.com
+    date_joined: '2023-11-07T21:45:37.314Z'
+    email: 10a26991c46a4d45b04d869b3a613154@example.com
     flags: '0'
     is_active: true
     is_managed: false
@@ -444,13 +444,13 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: false
     is_unclaimed: false
-    last_active: '2023-11-10T11:44:08.200Z'
+    last_active: '2023-11-07T21:45:37.314Z'
     last_login: null
-    last_password_change: '2023-11-10T11:44:08.201Z'
+    last_password_change: '2023-11-07T21:45:37.314Z'
     name: ''
-    password: md5$2SlADsXm48yF42Fy5R44xH$3ca589adf87b681743a2bc6c52a179bf
+    password: md5$wogCxmK2mpv2KJ3Nsw3wdy$580e7b4cdf41ce4f9437f591968f4acf
     session_nonce: null
-    username: c2799776b72a48a19b1c6abfa33d9994@example.com
+    username: 10a26991c46a4d45b04d869b3a613154@example.com
   model: sentry.user
   pk: 36
 - fields:
@@ -493,24 +493,24 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.userpermission
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.520Z'
-    date_updated: '2023-11-10T11:44:07.520Z'
+    date_added: '2023-11-07T21:45:36.637Z'
+    date_updated: '2023-11-07T21:45:36.637Z'
     name: test-admin-role
     permissions: '[]'
   model: sentry.userrole
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.524Z'
-    date_updated: '2023-11-10T11:44:07.524Z'
+    date_added: '2023-11-07T21:45:36.640Z'
+    date_updated: '2023-11-07T21:45:36.640Z'
     role: 6
     user: 31
   model: sentry.userroleuser
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.947Z'
+    date_added: '2023-11-07T21:45:37.053Z'
     is_global: false
     name: Saved query for test-org
-    organization: 4552949431205904
+    organization: 4552934809403408
     owner_id: null
     query: saved query for test-org
     sort: date
@@ -519,9 +519,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.savedsearch
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.946Z'
-    last_seen: '2023-11-10T11:44:07.946Z'
-    organization: 4552949431205904
+    date_added: '2023-11-07T21:45:37.052Z'
+    last_seen: '2023-11-07T21:45:37.052Z'
+    organization: 4552934809403408
     query: some query for test-org
     query_hash: 7c69362cd42207b83f80087bc15ebccb
     type: 0
@@ -529,42 +529,42 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.recentsearch
   pk: 6
 - fields:
-    project: 4552949431205906
-    team: 4552949431205905
+    project: 4552934809403410
+    team: 4552934809403409
   model: sentry.projectteam
   pk: 11
 - fields:
-    project: 4552949431205907
-    team: 4552949431205905
+    project: 4552934809403411
+    team: 4552934809403409
   model: sentry.projectteam
   pk: 12
 - fields:
-    date_added: '2023-11-10T11:44:07.768Z'
-    project: 4552949431205906
+    date_added: '2023-11-07T21:45:36.876Z'
+    project: 4552934809403410
     user_id: 31
   model: sentry.projectbookmark
   pk: 6
 - fields:
     created_by: null
-    date_added: '2023-11-10T11:44:07.821Z'
+    date_added: '2023-11-07T21:45:36.929Z'
     date_deactivated: null
     date_last_used: null
     name: token 1 for test-org
-    organization_id: 4552949431205904
-    project_last_used_id: 4552949431205906
+    organization_id: 4552934809403408
+    project_last_used_id: 4552934809403410
     scope_list: '[''org:ci'']'
     token_hashed: ABCDEFtest-org
     token_last_characters: xyz1
   model: sentry.orgauthtoken
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.643Z'
+    date_added: '2023-11-07T21:45:36.745Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: null
-    organization: 4552949431205904
+    organization: 4552934809403408
     role: owner
     token: null
     token_expires_at: null
@@ -575,13 +575,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 11
 - fields:
-    date_added: '2023-11-10T11:44:07.668Z'
+    date_added: '2023-11-07T21:45:36.771Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: null
-    organization: 4552949431205904
+    organization: 4552934809403408
     role: member
     token: null
     token_expires_at: null
@@ -594,105 +594,104 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     member: 12
     requester_id: null
-    team: 4552949431205905
+    team: 4552934809403409
   model: sentry.organizationaccessrequest
   pk: 6
 - fields:
     config:
       schedule: '* * * * *'
       schedule_type: 1
-    date_added: '2023-11-10T11:44:07.858Z'
-    guid: 12c8c2a0-d28c-413b-9475-c1a2021c4234
+    date_added: '2023-11-07T21:45:36.963Z'
+    guid: 58718ea1-4645-4114-8b61-458cb6d3f18e
     name: ''
-    organization_id: 4552949431205904
-    project_id: 4552949431205906
-    slug: 985a8be628f8
+    organization_id: 4552934809403408
+    project_id: 4552934809403410
+    slug: c7437cf6bd54
     status: 0
     type: 3
   model: sentry.monitor
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.856Z'
-    name: apparently possible walrus
-    organization_id: 4552949431205904
+    date_added: '2023-11-07T21:45:36.960Z'
+    name: slowly exotic prawn
+    organization_id: 4552934809403408
   model: sentry.environment
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.471Z'
+    date_added: '2023-11-07T21:45:36.585Z'
     email: owner
   model: sentry.email
   pk: 43
 - fields:
-    date_added: '2023-11-10T11:44:07.569Z'
+    date_added: '2023-11-07T21:45:36.677Z'
     email: invitee
   model: sentry.email
   pk: 44
 - fields:
-    date_added: '2023-11-10T11:44:07.906Z'
+    date_added: '2023-11-07T21:45:37.013Z'
     email: admin@localhost
   model: sentry.email
   pk: 45
 - fields:
-    date_added: '2023-11-10T11:44:07.957Z'
-    email: 0c797f56590f4ff99a86b920b4baaea3@example.com
+    date_added: '2023-11-07T21:45:37.061Z'
+    email: 3ef6105756254b1988fdabb9045fc5b8@example.com
   model: sentry.email
   pk: 46
 - fields:
-    date_added: '2023-11-10T11:44:08.011Z'
+    date_added: '2023-11-07T21:45:37.128Z'
     email: ''
   model: sentry.email
   pk: 47
 - fields:
-    date_added: '2023-11-10T11:44:08.204Z'
-    email: c2799776b72a48a19b1c6abfa33d9994@example.com
+    date_added: '2023-11-07T21:45:37.318Z'
+    email: 10a26991c46a4d45b04d869b3a613154@example.com
   model: sentry.email
   pk: 48
 - fields:
-    date_added: '2023-11-10T11:44:07.945Z'
-    organization: 4552949431205904
+    date_added: '2023-11-07T21:45:37.051Z'
+    organization: 4552934809403408
     slug: test-tombstone-in-test-org
   model: sentry.dashboardtombstone
   pk: 6
 - fields:
     created_by_id: 31
-    date_added: '2023-11-10T11:44:07.942Z'
+    date_added: '2023-11-07T21:45:37.048Z'
     filters: null
-    last_visited: '2023-11-10T11:44:07.942Z'
-    organization: 4552949431205904
+    last_visited: '2023-11-07T21:45:37.048Z'
+    organization: 4552934809403408
     title: Dashboard 1 for test-org
     visits: 1
   model: sentry.dashboard
   pk: 6
 - fields:
     condition: '{"op":"equals","name":"environment","value":"prod"}'
-    condition_hash: 446f9403d95bd9f51d18be47287659d9c3669663
+    condition_hash: 3e93349739d441effcc053f756d09b55de3e41db
     created_by_id: null
-    date_added: '2023-11-10T11:44:07.850Z'
-    end_date: '2023-11-10T12:44:07.849Z'
+    date_added: '2023-11-07T21:45:36.955Z'
+    end_date: '2023-11-07T22:45:36.953Z'
     is_active: true
     is_org_level: false
-    notification_sent: false
     num_samples: 100
-    organization: 4552949431205904
+    organization: 4552934809403408
     query: environment:prod event.type:transaction
     rule_id: 1
     sample_rate: 0.5
-    start_date: '2023-11-10T11:44:07.849Z'
+    start_date: '2023-11-07T21:45:36.953Z'
   model: sentry.customdynamicsamplingrule
   pk: 4
 - fields:
-    project: 4552949431205906
+    project: 4552934809403410
     value: 1
   model: sentry.counter
   pk: 6
 - fields:
     config: {}
-    date_added: '2023-11-10T11:44:07.792Z'
+    date_added: '2023-11-07T21:45:36.901Z'
     default_global_access: true
     default_role: 50
     flags: '0'
     last_sync: null
-    organization_id: 4552949431205904
+    organization_id: 4552934809403408
     provider: sentry
     sync_time: null
   model: sentry.authprovider
@@ -708,16 +707,16 @@ source: tests/sentry/backup/test_releases.py
       - 3
       key4:
         nested_key: nested_value
-    date_added: '2023-11-10T11:44:07.806Z'
+    date_added: '2023-11-07T21:45:36.916Z'
     ident: 123456789test-org
-    last_synced: '2023-11-10T11:44:07.806Z'
-    last_verified: '2023-11-10T11:44:07.806Z'
+    last_synced: '2023-11-07T21:45:36.916Z'
+    last_verified: '2023-11-07T21:45:36.916Z'
     user: 31
   model: sentry.authidentity
   pk: 6
 - fields:
     config: '""'
-    created_at: '2023-11-10T11:44:07.494Z'
+    created_at: '2023-11-07T21:45:36.611Z'
     last_used_at: null
     type: 1
     user: 31
@@ -725,7 +724,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 11
 - fields:
     config: '""'
-    created_at: '2023-11-10T11:44:07.595Z'
+    created_at: '2023-11-07T21:45:36.697Z'
     last_used_at: null
     type: 1
     user: 32
@@ -733,10 +732,10 @@ source: tests/sentry/backup/test_releases.py
   pk: 12
 - fields:
     allowed_origins: null
-    date_added: '2023-11-10T11:44:07.779Z'
-    key: 80636ae77ec24ff7bf147338eac18ee8
+    date_added: '2023-11-07T21:45:36.887Z'
+    key: 77e1864e387d43358ab09450eed11d21
     label: Default
-    organization_id: 4552949431205904
+    organization_id: 4552934809403408
     scope_list: '[]'
     scopes: '0'
     status: 0
@@ -744,11 +743,11 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     allowed_origins: ''
-    client_id: a964af0c98a568f91b3caaaae6dc62eb5aee47b754f344dbd9613a09006a9211
-    client_secret: 33bdf3c6314c7862ff8bec84ff62e4a6d4d7858728f6dcb7be3d13255ab90540
-    date_added: '2023-11-10T11:44:08.015Z'
+    client_id: 195dfe4bb098e7f21782caaba00a7c2211d3a09a0af8d6337b3f56823bc9dcb3
+    client_secret: 3ddb8abc1cae40df2b06ae3ca28e9e8c1ab0b0f42a941983353419482627152c
+    date_added: '2023-11-07T21:45:37.133Z'
     homepage_url: null
-    name: Ethical Lacewing
+    name: Champion Sole
     owner: 35
     privacy_url: null
     redirect_uris: ''
@@ -757,63 +756,63 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.apiapplication
   pk: 6
 - fields:
-    team: 4552949431205905
+    team: 4552934809403409
     type: 0
     user_id: null
   model: sentry.actor
   pk: 6
 - fields:
-    date_hash_added: '2023-11-10T11:44:07.469Z'
+    date_hash_added: '2023-11-07T21:45:36.583Z'
     email: owner
     is_verified: true
     user: 31
-    validation_hash: nAE72N1J3fRP5HvC1jwK5fRyS1jcsYY1
+    validation_hash: 0KHfs7fQBvga2kJnhAE0jjqt2aez1tjb
   model: sentry.useremail
   pk: 31
 - fields:
-    date_hash_added: '2023-11-10T11:44:07.567Z'
+    date_hash_added: '2023-11-07T21:45:36.675Z'
     email: invitee
     is_verified: true
     user: 32
-    validation_hash: Garu3gIeMiJF2GTfWOHLPbCln86w4aAw
+    validation_hash: nvO0UFG81tKAI5KXZHmMDCEL7JlLRRZp
   model: sentry.useremail
   pk: 32
 - fields:
-    date_hash_added: '2023-11-10T11:44:07.905Z'
+    date_hash_added: '2023-11-07T21:45:37.011Z'
     email: admin@localhost
     is_verified: true
     user: 33
-    validation_hash: ONZgeG6jv5CbpwvKCaivZaLLywcD6deU
+    validation_hash: 7Oxko8ui7tw6idZoat62j9jiXquFcROL
   model: sentry.useremail
   pk: 33
 - fields:
-    date_hash_added: '2023-11-10T11:44:07.955Z'
-    email: 0c797f56590f4ff99a86b920b4baaea3@example.com
+    date_hash_added: '2023-11-07T21:45:37.060Z'
+    email: 3ef6105756254b1988fdabb9045fc5b8@example.com
     is_verified: true
     user: 34
-    validation_hash: 0KTkaIBU1vw1gabxMWAAh61MQnXPpMyL
+    validation_hash: 1cV9KXbKGpkl5jNe5pZ15aXhsChp5bZB
   model: sentry.useremail
   pk: 34
 - fields:
-    date_hash_added: '2023-11-10T11:44:08.009Z'
+    date_hash_added: '2023-11-07T21:45:37.127Z'
     email: ''
     is_verified: false
     user: 35
-    validation_hash: Vi8bcalx9Kl40p3Vwi27EZM1ta0T5bS6
+    validation_hash: kUiAcoRWvV9qpVUTVWvidxNzQMvuPgu3
   model: sentry.useremail
   pk: 35
 - fields:
-    date_hash_added: '2023-11-10T11:44:08.202Z'
-    email: c2799776b72a48a19b1c6abfa33d9994@example.com
+    date_hash_added: '2023-11-07T21:45:37.316Z'
+    email: 10a26991c46a4d45b04d869b3a613154@example.com
     is_verified: true
     user: 36
-    validation_hash: v6XSGnHW09NdNIEZkXfdWlaA9cmEjLms
+    validation_hash: 2JOYMUUYJgc861ZkUrbJMOaNGrL872N2
   model: sentry.useremail
   pk: 36
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2023-11-10T11:44:07.890Z'
+    date_added: '2023-11-07T21:45:36.996Z'
     environment: null
     query: level:error
     resolution: 60
@@ -824,7 +823,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2023-11-10T11:44:07.926Z'
+    date_added: '2023-11-07T21:45:37.032Z'
     environment: null
     query: test query
     resolution: 60
@@ -835,18 +834,17 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     application: 6
     author: A Company
-    creator_label: 0c797f56590f4ff99a86b920b4baaea3@example.com
+    creator_label: 3ef6105756254b1988fdabb9045fc5b8@example.com
     creator_user: 34
-    date_added: '2023-11-10T11:44:08.016Z'
+    date_added: '2023-11-07T21:45:37.134Z'
     date_deleted: null
     date_published: null
-    date_updated: '2023-11-10T11:44:08.157Z'
+    date_updated: '2023-11-07T21:45:37.271Z'
     events: '[]'
     is_alertable: false
-    metadata: {}
     name: test app
     overview: null
-    owner_id: 4552949431205904
+    owner_id: 4552934809403408
     popularity: 1
     proxy_user: 35
     redirect_url: null
@@ -887,26 +885,26 @@ source: tests/sentry/backup/test_releases.py
     scopes: '0'
     slug: test-app
     status: 0
-    uuid: 44a7bc23-5a4a-4570-8d74-02533cc19ac8
+    uuid: 58ef785e-40ba-48d8-be7c-a49be651c065
     verify_install: true
     webhook_url: https://example.com/webhook
   model: sentry.sentryapp
   pk: 6
 - fields:
     data: '{"conditions":[{"id":"sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},{"id":"sentry.rules.conditions.every_event.EveryEventCondition"}],"action_match":"all","filter_match":"all","actions":[{"id":"sentry.rules.actions.notify_event.NotifyEventAction"},{"id":"sentry.rules.actions.notify_event_service.NotifyEventServiceAction","service":"mail"}]}'
-    date_added: '2023-11-10T11:44:07.839Z'
+    date_added: '2023-11-07T21:45:36.949Z'
     environment_id: null
     label: ''
     owner: null
-    project: 4552949431205906
+    project: 4552934809403410
     source: 0
     status: 0
   model: sentry.rule
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.896Z'
-    date_updated: '2023-11-10T11:44:07.896Z'
-    project: 4552949431205906
+    date_added: '2023-11-07T21:45:37.002Z'
+    date_updated: '2023-11-07T21:45:37.002Z'
+    project: 4552934809403410
     snuba_query: 11
     status: 1
     subscription_id: null
@@ -914,9 +912,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 21
 - fields:
-    date_added: '2023-11-10T11:44:07.928Z'
-    date_updated: '2023-11-10T11:44:07.928Z'
-    project: 4552949431205906
+    date_added: '2023-11-07T21:45:37.035Z'
+    date_updated: '2023-11-07T21:45:37.035Z'
+    project: 4552934809403410
     snuba_query: 12
     status: 1
     subscription_id: null
@@ -924,9 +922,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 22
 - fields:
-    date_added: '2023-11-10T11:44:08.036Z'
-    date_updated: '2023-11-10T11:44:08.036Z'
-    project: 4552949431271440
+    date_added: '2023-11-07T21:45:37.151Z'
+    date_updated: '2023-11-07T21:45:37.151Z'
+    project: 4552934809468945
     snuba_query: 11
     status: 1
     subscription_id: null
@@ -934,9 +932,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 23
 - fields:
-    date_added: '2023-11-10T11:44:08.225Z'
-    date_updated: '2023-11-10T11:44:08.225Z'
-    project: 4552949431271441
+    date_added: '2023-11-07T21:45:37.338Z'
+    date_updated: '2023-11-07T21:45:37.338Z'
+    project: 4552934809468946
     snuba_query: 11
     status: 1
     subscription_id: null
@@ -947,12 +945,12 @@ source: tests/sentry/backup/test_releases.py
     is_active: true
     organizationmember: 11
     role: null
-    team: 4552949431205905
+    team: 4552934809403409
   model: sentry.organizationmemberteam
   pk: 6
 - fields:
     integration_id: null
-    organization: 4552949431205904
+    organization: 4552934809403408
     sentry_app_id: null
     target_display: Sentry User
     target_identifier: '1'
@@ -963,7 +961,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 9
 - fields:
     integration_id: null
-    organization: 4552949431205904
+    organization: 4552934809403408
     sentry_app_id: 6
     target_display: Sentry User
     target_identifier: '1'
@@ -973,23 +971,23 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.notificationaction
   pk: 10
 - fields:
-    disable_date: '2023-11-10T11:44:07.842Z'
+    disable_date: '2023-11-07T21:45:36.952Z'
     opted_out: false
-    organization: 4552949431205904
+    organization: 4552934809403408
     rule: 6
-    sent_final_email_date: '2023-11-10T11:44:07.842Z'
-    sent_initial_email_date: '2023-11-10T11:44:07.842Z'
+    sent_final_email_date: '2023-11-07T21:45:36.952Z'
+    sent_initial_email_date: '2023-11-07T21:45:36.952Z'
   model: sentry.neglectedrule
   pk: 6
 - fields:
     environment: 6
     is_hidden: null
-    project: 4552949431205906
+    project: 4552934809403410
   model: sentry.environmentproject
   pk: 6
 - fields:
     dashboard: 6
-    date_added: '2023-11-10T11:44:07.943Z'
+    date_added: '2023-11-07T21:45:37.049Z'
     description: null
     detail: null
     display_type: 0
@@ -1003,51 +1001,51 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     custom_dynamic_sampling_rule: 4
-    project: 4552949431205906
+    project: 4552934809403410
   model: sentry.customdynamicsamplingruleproject
   pk: 4
 - fields:
     application: 6
-    date_added: '2023-11-10T11:44:08.100Z'
-    expires_at: '2023-11-10T19:44:08.100Z'
+    date_added: '2023-11-07T21:45:37.214Z'
+    expires_at: '2023-11-08T05:45:37.214Z'
     name: null
-    refresh_token: 7087a0a077daa675532d1bc963dddd085310bb06867aaa01e49bec8ee7e6eda6
+    refresh_token: 2c8cef577889f63d425f9a110ae38c44b2ab8c818a140ea5285d7286acd84b00
     scope_list: '[]'
     scopes: '0'
-    token: f230f77255063b46385793dfc9fe0fcd7cc36bec0253f5a829ac7ac43a32f711
-    token_last_characters: null
+    token: 1890cdc43c5c6342d01b44196821e922c59e64960ff6b7c281defb33614453df
+    token_last_characters: 53df
     user: 35
   model: sentry.apitoken
   pk: 14
 - fields:
     application: 6
-    date_added: '2023-11-10T11:44:08.162Z'
+    date_added: '2023-11-07T21:45:37.276Z'
     expires_at: null
     name: create_exhaustive_sentry_app
-    refresh_token: 2926997de7c6886cd1b65d8de68aaf407210ef3b91a8873aad64d0386c783cd9
+    refresh_token: 1512ff76cb43ae9b841fb03710e1f1bc87cf671e879eed4ca6ef9800448e06a9
     scope_list: '[]'
     scopes: '0'
-    token: 5211cafeffba3520ca041f24060a9306486995dc3f8a255eebbdcd490ababc6e
-    token_last_characters: null
+    token: bf566cb7adb75326ca8d197f227f3e1792cc1aeb9ead6fb7159a1aa52618cd73
+    token_last_characters: cd73
     user: 31
   model: sentry.apitoken
   pk: 15
 - fields:
     application: null
-    date_added: '2023-11-10T11:44:08.267Z'
+    date_added: '2023-11-07T21:45:37.377Z'
     expires_at: null
     name: create_exhaustive_global_configs
-    refresh_token: 66b6e075b1ca90bcc10cb6d00db28ff43569c30fe1eced1a8dfca60711462652
+    refresh_token: c5ae4d0c643d743b97e5e9ab40c1db880e05b6b55bccbd618f0e0ba5c44c46f9
     scope_list: '[]'
     scopes: '0'
-    token: 32d2b32b413478d713317bfcb91b9d221f1ec93336b511afdd170645842c9cf8
-    token_last_characters: null
+    token: bbaaf08b19bd5f2df7696f45c0a83525e3dab044d993ad7185738f9b67468611
+    token_last_characters: '8611'
     user: 31
   model: sentry.apitoken
   pk: 16
 - fields:
     application: 6
-    code: 6d5e6bafc7213544aa5640774ed9410fbb8251a7e01f3af2f7a48420c472e695
+    code: 12160967f53b065c6e415858e51b6833bba026e4d842df7b66fe46e60ca0ae7a
     expires_at: '2022-01-01T11:11:00.000Z'
     redirect_uri: https://example.com
     scope_list: '[''openid'', ''profile'', ''email'']'
@@ -1057,7 +1055,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 8
 - fields:
     application: 6
-    date_added: '2023-11-10T11:44:08.161Z'
+    date_added: '2023-11-07T21:45:37.275Z'
     scope_list: '[]'
     scopes: '0'
     user: 31
@@ -1065,7 +1063,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 9
 - fields:
     application: null
-    date_added: '2023-11-10T11:44:08.266Z'
+    date_added: '2023-11-07T21:45:37.377Z'
     scope_list: '[]'
     scopes: '0'
     user: 31
@@ -1073,11 +1071,11 @@ source: tests/sentry/backup/test_releases.py
   pk: 10
 - fields:
     comparison_delta: null
-    date_added: '2023-11-10T11:44:07.892Z'
-    date_modified: '2023-11-10T11:44:07.892Z'
+    date_added: '2023-11-07T21:45:36.998Z'
+    date_modified: '2023-11-07T21:45:36.998Z'
     include_all_projects: true
-    name: Fine Crawdad
-    organization: 4552949431205904
+    name: Creative Moccasin
+    organization: 4552934809403408
     owner: null
     resolve_threshold: null
     snuba_query: 11
@@ -1090,11 +1088,11 @@ source: tests/sentry/backup/test_releases.py
   pk: 11
 - fields:
     comparison_delta: null
-    date_added: '2023-11-10T11:44:07.927Z'
-    date_modified: '2023-11-10T11:44:07.927Z'
+    date_added: '2023-11-07T21:45:37.034Z'
+    date_modified: '2023-11-07T21:45:37.034Z'
     include_all_projects: false
-    name: Glowing Stallion
-    organization: 4552949431205904
+    name: Magnetic Midge
+    organization: 4552934809403408
     owner: null
     resolve_threshold: null
     snuba_query: 12
@@ -1118,13 +1116,13 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     api_grant: null
     api_token: 14
-    date_added: '2023-11-10T11:44:08.068Z'
+    date_added: '2023-11-07T21:45:37.181Z'
     date_deleted: null
-    date_updated: '2023-11-10T11:44:08.083Z'
-    organization_id: 4552949431205904
+    date_updated: '2023-11-07T21:45:37.197Z'
+    organization_id: 4552934809403408
     sentry_app: 6
     status: 1
-    uuid: 9287dbd1-7dd8-4551-8eb7-9b56a781473c
+    uuid: 468e3d74-a8b3-4ae7-b900-6148da0d9ebc
   model: sentry.sentryappinstallation
   pk: 6
 - fields:
@@ -1162,12 +1160,12 @@ source: tests/sentry/backup/test_releases.py
       type: alert-rule-action
     sentry_app: 6
     type: alert-rule-action
-    uuid: 88ea1e17-a674-4b14-9216-001e8d4e1d79
+    uuid: 7886b9c5-11ba-4df4-a5ee-9822788abcc5
   model: sentry.sentryappcomponent
   pk: 6
 - fields:
     alert_rule: null
-    date_added: '2023-11-10T11:44:07.841Z'
+    date_added: '2023-11-07T21:45:36.951Z'
     owner_id: 31
     rule: 6
     until: null
@@ -1175,7 +1173,7 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.rulesnooze
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.840Z'
+    date_added: '2023-11-07T21:45:36.950Z'
     rule: 6
     type: 1
     user_id: null
@@ -1183,26 +1181,26 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     action: 9
-    project: 4552949431205906
+    project: 4552934809403410
   model: sentry.notificationactionproject
   pk: 9
 - fields:
     action: 10
-    project: 4552949431205906
+    project: 4552934809403410
   model: sentry.notificationactionproject
   pk: 10
 - fields:
     alert_rule: 12
-    date_added: '2023-11-10T11:44:07.932Z'
+    date_added: '2023-11-07T21:45:37.039Z'
     date_closed: null
-    date_detected: '2023-11-10T11:44:07.931Z'
-    date_started: '2023-11-10T11:44:07.931Z'
+    date_detected: '2023-11-07T21:45:37.038Z'
+    date_started: '2023-11-07T21:45:37.038Z'
     detection_uuid: null
     identifier: 1
-    organization: 4552949431205904
+    organization: 4552934809403408
     status: 1
     status_method: 3
-    title: Skilled Cricket
+    title: Major Eft
     type: 2
   model: sentry.incident
   pk: 6
@@ -1210,7 +1208,7 @@ source: tests/sentry/backup/test_releases.py
     aggregates: null
     columns: null
     conditions: ''
-    date_added: '2023-11-10T11:44:07.944Z'
+    date_added: '2023-11-07T21:45:37.050Z'
     field_aliases: null
     fields: '[]'
     name: Test Query for test-org
@@ -1222,21 +1220,21 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     alert_rule: 11
     alert_threshold: 100.0
-    date_added: '2023-11-10T11:44:07.900Z'
-    label: Vocal Gnu
+    date_added: '2023-11-07T21:45:37.007Z'
+    label: Mature Turkey
     resolve_threshold: null
     threshold_type: null
   model: sentry.alertruletrigger
   pk: 6
 - fields:
     alert_rule: 11
-    date_added: '2023-11-10T11:44:07.894Z'
-    project: 4552949431205907
+    date_added: '2023-11-07T21:45:37.000Z'
+    project: 4552934809403411
   model: sentry.alertruleexcludedprojects
   pk: 6
 - fields:
     alert_rule: 11
-    date_added: '2023-11-10T11:44:07.897Z'
+    date_added: '2023-11-07T21:45:37.003Z'
     previous_alert_rule: null
     type: 1
     user_id: null
@@ -1244,30 +1242,30 @@ source: tests/sentry/backup/test_releases.py
   pk: 11
 - fields:
     alert_rule: 12
-    date_added: '2023-11-10T11:44:07.929Z'
+    date_added: '2023-11-07T21:45:37.036Z'
     previous_alert_rule: null
     type: 1
     user_id: null
   model: sentry.alertruleactivity
   pk: 12
 - fields:
-    date_added: '2023-11-10T11:44:07.936Z'
-    end: '2023-11-10T11:44:07.936Z'
+    date_added: '2023-11-07T21:45:37.043Z'
+    end: '2023-11-07T21:45:37.043Z'
     period: 1
-    start: '2023-11-09T11:44:07.936Z'
+    start: '2023-11-06T21:45:37.043Z'
     values: '[[1.0, 2.0, 3.0], [1.5, 2.5, 3.5]]'
   model: sentry.timeseriessnapshot
   pk: 6
 - fields:
     actor_id: 6
     application_id: 6
-    date_added: '2023-11-10T11:44:08.081Z'
+    date_added: '2023-11-07T21:45:37.195Z'
     events: '[]'
-    guid: 794ef968b06d4247b55ead4789ae7779
+    guid: 65d6c03742b746cfa50419d7f2d28c9b
     installation_id: 6
-    organization_id: 4552949431205904
+    organization_id: 4552934809403408
     project_id: null
-    secret: 7cec3304dcb09acb3bc6af3a272ec0e9df7118c6470ef1d8c3953d6123a3f53e
+    secret: 4884cf392a764bd90f6798aa298f12c8599804cef593a559b105e718bdd919af
     status: 0
     url: https://example.com/webhook
     version: 0
@@ -1276,40 +1274,40 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     actor_id: 36
     application_id: 6
-    date_added: '2023-11-10T11:44:08.251Z'
+    date_added: '2023-11-07T21:45:37.363Z'
     events: '[''event.created'']'
-    guid: bb72e8a431c94c91abad9df1b19cb487
+    guid: 61ba0199d21943599e023ceb5416433b
     installation_id: 6
-    organization_id: 4552949431205904
-    project_id: 4552949431271441
-    secret: fd221c149ccc3e6c222a03e26cc5a8bf22f610d4cd2d6bd0fc0351a2cdd04f6c
+    organization_id: 4552934809403408
+    project_id: 4552934809468946
+    secret: 58c0340d72cdb87016d3e9cb6634fb3a3462ed90dccd841b9d8c0b78d61eeabe
     status: 0
     url: https://example.com/sentry/webhook
     version: 0
   model: sentry.servicehook
   pk: 12
 - fields:
-    date_added: '2023-11-10T11:44:07.941Z'
+    date_added: '2023-11-07T21:45:37.047Z'
     incident: 6
-    target_run_date: '2023-11-10T15:44:07.940Z'
+    target_run_date: '2023-11-08T01:45:37.047Z'
   model: sentry.pendingincidentsnapshot
   pk: 6
 - fields:
     alert_rule_trigger: 6
-    date_added: '2023-11-10T11:44:07.939Z'
-    date_modified: '2023-11-10T11:44:07.939Z'
+    date_added: '2023-11-07T21:45:37.046Z'
+    date_modified: '2023-11-07T21:45:37.046Z'
     incident: 6
     status: 1
   model: sentry.incidenttrigger
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.938Z'
+    date_added: '2023-11-07T21:45:37.045Z'
     incident: 6
     user_id: 31
   model: sentry.incidentsubscription
   pk: 6
 - fields:
-    date_added: '2023-11-10T11:44:07.937Z'
+    date_added: '2023-11-07T21:45:37.044Z'
     event_stats_snapshot: 6
     incident: 6
     total_events: 1
@@ -1318,7 +1316,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     comment: hello test-org
-    date_added: '2023-11-10T11:44:07.935Z'
+    date_added: '2023-11-07T21:45:37.042Z'
     incident: 6
     notification_uuid: null
     previous_value: null
@@ -1329,13 +1327,13 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     alert_rule_trigger: 6
-    date_added: '2023-11-10T11:44:07.901Z'
+    date_added: '2023-11-07T21:45:37.008Z'
     query_subscription: 21
   model: sentry.alertruletriggerexclusion
   pk: 6
 - fields:
     alert_rule_trigger: 6
-    date_added: '2023-11-10T11:44:07.925Z'
+    date_added: '2023-11-07T21:45:37.031Z'
     integration_id: null
     sentry_app_config: null
     sentry_app_id: null

--- a/tests/sentry/backup/snapshots/ReleaseTests/test_at_head.pysnap
+++ b/tests/sentry/backup/snapshots/ReleaseTests/test_at_head.pysnap
@@ -1,18 +1,18 @@
 ---
-created: '2023-11-07T21:45:37.794566Z'
+created: '2023-11-09T18:52:25.540028Z'
 creator: sentry
 source: tests/sentry/backup/test_releases.py
 ---
 - fields:
     key: bar
-    last_updated: '2023-11-07T21:45:37.376Z'
+    last_updated: '2023-11-09T18:52:25.146Z'
     last_updated_by: unknown
     value: '"b"'
   model: sentry.controloption
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:36.942Z'
-    date_updated: '2023-11-07T21:45:36.942Z'
+    date_added: '2023-11-09T18:52:24.413Z'
+    date_updated: '2023-11-09T18:52:24.413Z'
     external_id: slack:test-org
     metadata: {}
     name: Slack for test-org
@@ -22,13 +22,13 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     key: foo
-    last_updated: '2023-11-07T21:45:37.375Z'
+    last_updated: '2023-11-09T18:52:25.145Z'
     last_updated_by: unknown
     value: '"a"'
   model: sentry.option
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:36.711Z'
+    date_added: '2023-11-09T18:52:23.926Z'
     default_role: member
     flags: '1'
     is_test: false
@@ -36,92 +36,92 @@ source: tests/sentry/backup/test_releases.py
     slug: test-org
     status: 0
   model: sentry.organization
-  pk: 4552934809403408
+  pk: 4552945452908560
 - fields:
-    date_added: '2023-11-07T21:45:37.080Z'
+    date_added: '2023-11-09T18:52:24.645Z'
     default_role: member
     flags: '1'
     is_test: false
-    name: Heroic Pegasus
-    slug: heroic-pegasus
+    name: Set Stinkbug
+    slug: set-stinkbug
     status: 0
   model: sentry.organization
-  pk: 4552934809468944
+  pk: 4552945452974099
 - fields:
     config:
       hello: hello
-    date_added: '2023-11-07T21:45:36.944Z'
-    date_updated: '2023-11-07T21:45:36.944Z'
+    date_added: '2023-11-09T18:52:24.415Z'
+    date_updated: '2023-11-09T18:52:24.415Z'
     default_auth_id: null
     grace_period_end: null
     integration: 6
-    organization_id: 4552934809403408
+    organization_id: 4552945452908560
     status: 0
   model: sentry.organizationintegration
   pk: 6
 - fields:
     key: sentry:account-rate-limit
-    organization: 4552934809403408
+    organization: 4552945452908560
     value: 0
   model: sentry.organizationoption
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:36.843Z'
+    date_added: '2023-11-09T18:52:24.207Z'
     first_event: null
     flags: '10'
     forced_color: null
     name: project-test-org
-    organization: 4552934809403408
+    organization: 4552945452908560
     platform: null
     public: false
     slug: project-test-org
     status: 0
   model: sentry.project
-  pk: 4552934809403410
+  pk: 4552945452974097
 - fields:
-    date_added: '2023-11-07T21:45:36.967Z'
+    date_added: '2023-11-09T18:52:24.448Z'
     first_event: null
     flags: '10'
     forced_color: null
     name: other-project-test-org
-    organization: 4552934809403408
+    organization: 4552945452908560
     platform: null
     public: false
     slug: other-project-test-org
     status: 0
   model: sentry.project
-  pk: 4552934809403411
+  pk: 4552945452974098
 - fields:
-    date_added: '2023-11-07T21:45:37.148Z'
+    date_added: '2023-11-09T18:52:24.760Z'
     first_event: null
     flags: '10'
     forced_color: null
-    name: Cuddly Crawfish
-    organization: 4552934809403408
+    name: Joint Pup
+    organization: 4552945452908560
     platform: null
     public: false
-    slug: cuddly-crawfish
+    slug: joint-pup
     status: 0
   model: sentry.project
-  pk: 4552934809468945
+  pk: 4552945452974100
 - fields:
-    date_added: '2023-11-07T21:45:37.335Z'
+    date_added: '2023-11-09T18:52:25.075Z'
     first_event: null
     flags: '10'
     forced_color: null
-    name: Communal Chicken
-    organization: 4552934809403408
+    name: Summary Aphid
+    organization: 4552945452908560
     platform: null
     public: false
-    slug: communal-chicken
+    slug: summary-aphid
     status: 0
   model: sentry.project
-  pk: 4552934809468946
+  pk: 4552945453039632
 - fields:
     config:
       hello: hello
     integration_id: 6
-    project: 4552934809403410
+    project: 4552945452974097
   model: sentry.projectintegration
   pk: 6
 - fields:
@@ -129,14 +129,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2023-11-07T21:45:36.859Z'
+    date_added: '2023-11-09T18:52:24.254Z'
     label: Default
-    project: 4552934809403410
-    public_key: b837c7e1fd557d6bc8261dc4c2d4eb0a
+    project: 4552945452974097
+    public_key: 7f6828dc2559ec75e837a921508ec9bf
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 8c6e144b7b42b50f6b62145b7252ef2b
+    secret_key: d5454e7970276564ae93b28617846829
     status: 0
   model: sentry.projectkey
   pk: 21
@@ -145,14 +145,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2023-11-07T21:45:36.981Z'
+    date_added: '2023-11-09T18:52:24.476Z'
     label: Default
-    project: 4552934809403411
-    public_key: d0e867fb0cf12691fca4e65cb6b61651
+    project: 4552945452974098
+    public_key: 699a2ac0c9020db7528fa19789e8c470
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 20c9fc0838189a03b495248436d6af88
+    secret_key: 135622368236a746ace6c71aaedf2d29
     status: 0
   model: sentry.projectkey
   pk: 22
@@ -161,14 +161,14 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2023-11-07T21:45:37.164Z'
+    date_added: '2023-11-09T18:52:24.801Z'
     label: Default
-    project: 4552934809468945
-    public_key: 08659ec34232b1ed383d24858233c6d5
+    project: 4552945452974100
+    public_key: f27f04ac4ab068011e8e940fa5302dc8
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 3d8188bcafd0dd26943b4282a36137e2
+    secret_key: 0b4c1d0d3bbccb2d803b22d7f0d4c58e
     status: 0
   model: sentry.projectkey
   pk: 23
@@ -177,97 +177,97 @@ source: tests/sentry/backup/test_releases.py
       dynamicSdkLoaderOptions:
         hasPerformance: true
         hasReplay: true
-    date_added: '2023-11-07T21:45:37.351Z'
+    date_added: '2023-11-09T18:52:25.101Z'
     label: Default
-    project: 4552934809468946
-    public_key: e54a0d0c3d1b91f6193124d44ea7b554
+    project: 4552945453039632
+    public_key: 7f1ce70db7d6513acb1715323b04e199
     rate_limit_count: null
     rate_limit_window: null
     roles: '1'
-    secret_key: 4f4f3b9466d54b80f080c023714678e6
+    secret_key: 40547c704b4929c95d30bf8543cd204c
     status: 0
   model: sentry.projectkey
   pk: 24
 - fields:
     key: sentry:relay-rev
-    project: 4552934809403410
-    value: '"c4b7b4b05bb54a8b872c2c5317ba6527"'
+    project: 4552945452974097
+    value: '"8cad9bdaeb2946d1ba5955be61d80b2c"'
   model: sentry.projectoption
   pk: 61
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4552934809403410
-    value: '"2023-11-07T21:45:36.863528Z"'
+    project: 4552945452974097
+    value: '"2023-11-09T18:52:24.261463Z"'
   model: sentry.projectoption
   pk: 62
 - fields:
     key: sentry:option-epoch
-    project: 4552934809403410
+    project: 4552945452974097
     value: 11
   model: sentry.projectoption
   pk: 63
 - fields:
     key: sentry:relay-rev
-    project: 4552934809403411
-    value: '"0f2753d342654c9482131e94e6adb6d8"'
+    project: 4552945452974098
+    value: '"028fa421716c49eca619c7a92a629faf"'
   model: sentry.projectoption
   pk: 64
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4552934809403411
-    value: '"2023-11-07T21:45:36.984915Z"'
+    project: 4552945452974098
+    value: '"2023-11-09T18:52:24.484071Z"'
   model: sentry.projectoption
   pk: 65
 - fields:
     key: sentry:option-epoch
-    project: 4552934809403411
+    project: 4552945452974098
     value: 11
   model: sentry.projectoption
   pk: 66
 - fields:
     key: sentry:relay-rev
-    project: 4552934809468945
-    value: '"da7a1304bd454253a8ccb02dbf59df47"'
+    project: 4552945452974100
+    value: '"1a57087a5d324ed58a94efe5582b1feb"'
   model: sentry.projectoption
   pk: 67
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4552934809468945
-    value: '"2023-11-07T21:45:37.167732Z"'
+    project: 4552945452974100
+    value: '"2023-11-09T18:52:24.812348Z"'
   model: sentry.projectoption
   pk: 68
 - fields:
     key: sentry:option-epoch
-    project: 4552934809468945
+    project: 4552945452974100
     value: 11
   model: sentry.projectoption
   pk: 69
 - fields:
     key: sentry:relay-rev
-    project: 4552934809468946
-    value: '"8413ea3af65845318ca99711883b1dfa"'
+    project: 4552945453039632
+    value: '"fa04be9c4f3546a398c7d7c59604c290"'
   model: sentry.projectoption
   pk: 70
 - fields:
     key: sentry:relay-rev-lastchange
-    project: 4552934809468946
-    value: '"2023-11-07T21:45:37.355273Z"'
+    project: 4552945453039632
+    value: '"2023-11-09T18:52:25.107906Z"'
   model: sentry.projectoption
   pk: 71
 - fields:
     key: sentry:option-epoch
-    project: 4552934809468946
+    project: 4552945453039632
     value: 11
   model: sentry.projectoption
   pk: 72
 - fields:
     auto_assignment: true
     codeowners_auto_sync: true
-    date_created: '2023-11-07T21:45:36.877Z'
+    date_created: '2023-11-09T18:52:24.295Z'
     fallthrough: true
     is_active: true
-    last_updated: '2023-11-07T21:45:36.877Z'
-    project: 4552934809403410
+    last_updated: '2023-11-09T18:52:24.295Z'
+    project: 4552945452974097
     raw: '{"hello":"hello"}'
     schema:
       hello: hello
@@ -275,9 +275,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.projectownership
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:36.881Z'
-    organization: 4552934809403408
-    project: 4552934809403410
+    date_added: '2023-11-09T18:52:24.301Z'
+    organization: 4552945452908560
+    project: 4552945452974097
     redirect_slug: project_slug_in_test-org
   model: sentry.projectredirect
   pk: 6
@@ -285,26 +285,26 @@ source: tests/sentry/backup/test_releases.py
     first_seen: null
     is_internal: true
     last_seen: null
-    public_key: bz-F98dr4lNFY0S1Kl9FUaNs2TLnv7f_OVBSlo1v2ac
-    relay_id: 937e54df-ca12-4741-81b8-eef5e43d9053
+    public_key: cvCjahSYrg3JU2Klf6Ln-QX2S_GFciSXOdjeCpicLSg
+    relay_id: a46b3413-4a6f-4c9d-a5a0-39107bb768a8
   model: sentry.relay
   pk: 6
 - fields:
-    first_seen: '2023-11-07T21:45:37.374Z'
-    last_seen: '2023-11-07T21:45:37.374Z'
-    public_key: bz-F98dr4lNFY0S1Kl9FUaNs2TLnv7f_OVBSlo1v2ac
-    relay_id: 937e54df-ca12-4741-81b8-eef5e43d9053
+    first_seen: '2023-11-09T18:52:25.143Z'
+    last_seen: '2023-11-09T18:52:25.143Z'
+    public_key: cvCjahSYrg3JU2Klf6Ln-QX2S_GFciSXOdjeCpicLSg
+    relay_id: a46b3413-4a6f-4c9d-a5a0-39107bb768a8
     version: 0.0.1
   model: sentry.relayusage
   pk: 6
 - fields:
     config: {}
-    date_added: '2023-11-07T21:45:37.057Z'
+    date_added: '2023-11-09T18:52:24.611Z'
     external_id: null
     integration_id: 6
     languages: '[]'
     name: getsentry/getsentry
-    organization_id: 4552934809403408
+    organization_id: 4552945452908560
     provider: integrations:github
     status: 0
     url: https://github.com/getsentry/getsentry
@@ -312,19 +312,19 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     actor: 6
-    date_added: '2023-11-07T21:45:36.801Z'
+    date_added: '2023-11-09T18:52:24.119Z'
     idp_provisioned: false
     name: test_team_in_test-org
     org_role: null
-    organization: 4552934809403408
+    organization: 4552945452908560
     slug: test_team_in_test-org
     status: 0
   model: sentry.team
-  pk: 4552934809403409
+  pk: 4552945452974096
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-07T21:45:36.581Z'
+    date_joined: '2023-11-09T18:52:23.719Z'
     email: owner
     flags: '0'
     is_active: true
@@ -334,11 +334,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: true
     is_unclaimed: false
-    last_active: '2023-11-07T21:45:36.581Z'
+    last_active: '2023-11-09T18:52:23.719Z'
     last_login: null
-    last_password_change: '2023-11-07T21:45:36.581Z'
+    last_password_change: '2023-11-09T18:52:23.720Z'
     name: ''
-    password: md5$LpMOMS4B2uIw0E6jMmhrSZ$8f4b882bd08d58e1b8a668d027b502a6
+    password: md5$DFDPBRotUqdEoAJawkngCa$5751f437360069f62db4a07b821250b1
     session_nonce: null
     username: owner
   model: sentry.user
@@ -346,7 +346,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-07T21:45:36.673Z'
+    date_joined: '2023-11-09T18:52:23.870Z'
     email: invitee
     flags: '0'
     is_active: true
@@ -356,11 +356,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2023-11-07T21:45:36.673Z'
+    last_active: '2023-11-09T18:52:23.870Z'
     last_login: null
-    last_password_change: '2023-11-07T21:45:36.674Z'
+    last_password_change: '2023-11-09T18:52:23.870Z'
     name: ''
-    password: md5$h2xcXxmmPO8cBkJJTkBF4H$ae365c3ee888e0946ed28f68b432e4c1
+    password: md5$LB9TKVQQiHDXsAcPsfbDNf$d9108486761bde76914f4778d185966a
     session_nonce: null
     username: invitee
   model: sentry.user
@@ -368,7 +368,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-07T21:45:37.010Z'
+    date_joined: '2023-11-09T18:52:24.533Z'
     email: admin@localhost
     flags: '0'
     is_active: true
@@ -378,11 +378,11 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: true
     is_unclaimed: false
-    last_active: '2023-11-07T21:45:37.010Z'
+    last_active: '2023-11-09T18:52:24.533Z'
     last_login: null
-    last_password_change: '2023-11-07T21:45:37.010Z'
+    last_password_change: '2023-11-09T18:52:24.533Z'
     name: ''
-    password: md5$RoRhINXn7HUAUE45ttLluU$9ab6655a185c035e8e9fd41bff6ddcf9
+    password: md5$aZFRG0i2fYT6DMRsTCZQfP$06215495d615abe6b2333c415cf6808d
     session_nonce: null
     username: admin@localhost
   model: sentry.user
@@ -390,8 +390,8 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-07T21:45:37.059Z'
-    email: 3ef6105756254b1988fdabb9045fc5b8@example.com
+    date_joined: '2023-11-09T18:52:24.613Z'
+    email: 8f25fd7280c0416db7f12447622a8777@example.com
     flags: '0'
     is_active: true
     is_managed: false
@@ -400,19 +400,19 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: false
     is_unclaimed: false
-    last_active: '2023-11-07T21:45:37.059Z'
+    last_active: '2023-11-09T18:52:24.613Z'
     last_login: null
-    last_password_change: '2023-11-07T21:45:37.059Z'
+    last_password_change: '2023-11-09T18:52:24.613Z'
     name: ''
-    password: md5$UAPUTu90KjoPfQfjsmaaln$db1ed070a13cd0c33d40cd031a222174
+    password: md5$XuFFesJdLsMQIhFrERCaMU$0ed27f89ee31ef5d4a49ef373b46dc46
     session_nonce: null
-    username: 3ef6105756254b1988fdabb9045fc5b8@example.com
+    username: 8f25fd7280c0416db7f12447622a8777@example.com
   model: sentry.user
   pk: 34
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-07T21:45:37.125Z'
+    date_joined: '2023-11-09T18:52:24.711Z'
     email: ''
     flags: '0'
     is_active: true
@@ -422,20 +422,20 @@ source: tests/sentry/backup/test_releases.py
     is_staff: false
     is_superuser: false
     is_unclaimed: false
-    last_active: '2023-11-07T21:45:37.125Z'
+    last_active: '2023-11-09T18:52:24.711Z'
     last_login: null
     last_password_change: null
     name: ''
     password: ''
     session_nonce: null
-    username: test-app-abe6651b-d7bd-4885-81ba-ee3cba606850
+    username: test-app-8d6d9fb6-c7b1-4326-a418-491007dbc9c3
   model: sentry.user
   pk: 35
 - fields:
     avatar_type: 0
     avatar_url: null
-    date_joined: '2023-11-07T21:45:37.314Z'
-    email: 10a26991c46a4d45b04d869b3a613154@example.com
+    date_joined: '2023-11-09T18:52:25.038Z'
+    email: 887172daf50746a28ffb0845cd5ba315@example.com
     flags: '0'
     is_active: true
     is_managed: false
@@ -444,13 +444,13 @@ source: tests/sentry/backup/test_releases.py
     is_staff: true
     is_superuser: false
     is_unclaimed: false
-    last_active: '2023-11-07T21:45:37.314Z'
+    last_active: '2023-11-09T18:52:25.038Z'
     last_login: null
-    last_password_change: '2023-11-07T21:45:37.314Z'
+    last_password_change: '2023-11-09T18:52:25.038Z'
     name: ''
-    password: md5$wogCxmK2mpv2KJ3Nsw3wdy$580e7b4cdf41ce4f9437f591968f4acf
+    password: md5$h7gt5TSMeyyRQmqUkWyN2K$40bd761899e3931087eba8b4375dc6ab
     session_nonce: null
-    username: 10a26991c46a4d45b04d869b3a613154@example.com
+    username: 887172daf50746a28ffb0845cd5ba315@example.com
   model: sentry.user
   pk: 36
 - fields:
@@ -493,24 +493,24 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.userpermission
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:36.637Z'
-    date_updated: '2023-11-07T21:45:36.637Z'
+    date_added: '2023-11-09T18:52:23.817Z'
+    date_updated: '2023-11-09T18:52:23.817Z'
     name: test-admin-role
     permissions: '[]'
   model: sentry.userrole
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:36.640Z'
-    date_updated: '2023-11-07T21:45:36.640Z'
+    date_added: '2023-11-09T18:52:23.822Z'
+    date_updated: '2023-11-09T18:52:23.822Z'
     role: 6
     user: 31
   model: sentry.userroleuser
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:37.053Z'
+    date_added: '2023-11-09T18:52:24.593Z'
     is_global: false
     name: Saved query for test-org
-    organization: 4552934809403408
+    organization: 4552945452908560
     owner_id: null
     query: saved query for test-org
     sort: date
@@ -519,9 +519,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.savedsearch
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:37.052Z'
-    last_seen: '2023-11-07T21:45:37.052Z'
-    organization: 4552934809403408
+    date_added: '2023-11-09T18:52:24.592Z'
+    last_seen: '2023-11-09T18:52:24.592Z'
+    organization: 4552945452908560
     query: some query for test-org
     query_hash: 7c69362cd42207b83f80087bc15ebccb
     type: 0
@@ -529,42 +529,42 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.recentsearch
   pk: 6
 - fields:
-    project: 4552934809403410
-    team: 4552934809403409
+    project: 4552945452974097
+    team: 4552945452974096
   model: sentry.projectteam
   pk: 11
 - fields:
-    project: 4552934809403411
-    team: 4552934809403409
+    project: 4552945452974098
+    team: 4552945452974096
   model: sentry.projectteam
   pk: 12
 - fields:
-    date_added: '2023-11-07T21:45:36.876Z'
-    project: 4552934809403410
+    date_added: '2023-11-09T18:52:24.292Z'
+    project: 4552945452974097
     user_id: 31
   model: sentry.projectbookmark
   pk: 6
 - fields:
     created_by: null
-    date_added: '2023-11-07T21:45:36.929Z'
+    date_added: '2023-11-09T18:52:24.387Z'
     date_deactivated: null
     date_last_used: null
     name: token 1 for test-org
-    organization_id: 4552934809403408
-    project_last_used_id: 4552934809403410
+    organization_id: 4552945452908560
+    project_last_used_id: 4552945452974097
     scope_list: '[''org:ci'']'
     token_hashed: ABCDEFtest-org
     token_last_characters: xyz1
   model: sentry.orgauthtoken
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:36.745Z'
+    date_added: '2023-11-09T18:52:23.986Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: null
-    organization: 4552934809403408
+    organization: 4552945452908560
     role: owner
     token: null
     token_expires_at: null
@@ -575,13 +575,13 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.organizationmember
   pk: 11
 - fields:
-    date_added: '2023-11-07T21:45:36.771Z'
+    date_added: '2023-11-09T18:52:24.037Z'
     email: null
     flags: '0'
     has_global_access: true
     invite_status: 0
     inviter_id: null
-    organization: 4552934809403408
+    organization: 4552945452908560
     role: member
     token: null
     token_expires_at: null
@@ -594,104 +594,104 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     member: 12
     requester_id: null
-    team: 4552934809403409
+    team: 4552945452974096
   model: sentry.organizationaccessrequest
   pk: 6
 - fields:
     config:
       schedule: '* * * * *'
       schedule_type: 1
-    date_added: '2023-11-07T21:45:36.963Z'
-    guid: 58718ea1-4645-4114-8b61-458cb6d3f18e
+    date_added: '2023-11-09T18:52:24.443Z'
+    guid: a0f5fb79-6a79-4f4c-a437-c3f5a6586423
     name: ''
-    organization_id: 4552934809403408
-    project_id: 4552934809403410
-    slug: c7437cf6bd54
+    organization_id: 4552945452908560
+    project_id: 4552945452974097
+    slug: 3ff94ea6f2a1
     status: 0
     type: 3
   model: sentry.monitor
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:36.960Z'
-    name: slowly exotic prawn
-    organization_id: 4552934809403408
+    date_added: '2023-11-09T18:52:24.440Z'
+    name: visually prepared shrew
+    organization_id: 4552945452908560
   model: sentry.environment
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:36.585Z'
+    date_added: '2023-11-09T18:52:23.731Z'
     email: owner
   model: sentry.email
   pk: 43
 - fields:
-    date_added: '2023-11-07T21:45:36.677Z'
+    date_added: '2023-11-09T18:52:23.875Z'
     email: invitee
   model: sentry.email
   pk: 44
 - fields:
-    date_added: '2023-11-07T21:45:37.013Z'
+    date_added: '2023-11-09T18:52:24.538Z'
     email: admin@localhost
   model: sentry.email
   pk: 45
 - fields:
-    date_added: '2023-11-07T21:45:37.061Z'
-    email: 3ef6105756254b1988fdabb9045fc5b8@example.com
+    date_added: '2023-11-09T18:52:24.617Z'
+    email: 8f25fd7280c0416db7f12447622a8777@example.com
   model: sentry.email
   pk: 46
 - fields:
-    date_added: '2023-11-07T21:45:37.128Z'
+    date_added: '2023-11-09T18:52:24.718Z'
     email: ''
   model: sentry.email
   pk: 47
 - fields:
-    date_added: '2023-11-07T21:45:37.318Z'
-    email: 10a26991c46a4d45b04d869b3a613154@example.com
+    date_added: '2023-11-09T18:52:25.048Z'
+    email: 887172daf50746a28ffb0845cd5ba315@example.com
   model: sentry.email
   pk: 48
 - fields:
-    date_added: '2023-11-07T21:45:37.051Z'
-    organization: 4552934809403408
+    date_added: '2023-11-09T18:52:24.591Z'
+    organization: 4552945452908560
     slug: test-tombstone-in-test-org
   model: sentry.dashboardtombstone
   pk: 6
 - fields:
     created_by_id: 31
-    date_added: '2023-11-07T21:45:37.048Z'
+    date_added: '2023-11-09T18:52:24.587Z'
     filters: null
-    last_visited: '2023-11-07T21:45:37.048Z'
-    organization: 4552934809403408
+    last_visited: '2023-11-09T18:52:24.587Z'
+    organization: 4552945452908560
     title: Dashboard 1 for test-org
     visits: 1
   model: sentry.dashboard
   pk: 6
 - fields:
     condition: '{"op":"equals","name":"environment","value":"prod"}'
-    condition_hash: 3e93349739d441effcc053f756d09b55de3e41db
+    condition_hash: 36443c14bbe061da559bcfd90e9c12f533107b98
     created_by_id: null
-    date_added: '2023-11-07T21:45:36.955Z'
-    end_date: '2023-11-07T22:45:36.953Z'
+    date_added: '2023-11-09T18:52:24.431Z'
+    end_date: '2023-11-09T19:52:24.429Z'
     is_active: true
     is_org_level: false
     num_samples: 100
-    organization: 4552934809403408
+    organization: 4552945452908560
     query: environment:prod event.type:transaction
     rule_id: 1
     sample_rate: 0.5
-    start_date: '2023-11-07T21:45:36.953Z'
+    start_date: '2023-11-09T18:52:24.429Z'
   model: sentry.customdynamicsamplingrule
   pk: 4
 - fields:
-    project: 4552934809403410
+    project: 4552945452974097
     value: 1
   model: sentry.counter
   pk: 6
 - fields:
     config: {}
-    date_added: '2023-11-07T21:45:36.901Z'
+    date_added: '2023-11-09T18:52:24.330Z'
     default_global_access: true
     default_role: 50
     flags: '0'
     last_sync: null
-    organization_id: 4552934809403408
+    organization_id: 4552945452908560
     provider: sentry
     sync_time: null
   model: sentry.authprovider
@@ -707,16 +707,16 @@ source: tests/sentry/backup/test_releases.py
       - 3
       key4:
         nested_key: nested_value
-    date_added: '2023-11-07T21:45:36.916Z'
+    date_added: '2023-11-09T18:52:24.365Z'
     ident: 123456789test-org
-    last_synced: '2023-11-07T21:45:36.916Z'
-    last_verified: '2023-11-07T21:45:36.916Z'
+    last_synced: '2023-11-09T18:52:24.365Z'
+    last_verified: '2023-11-09T18:52:24.365Z'
     user: 31
   model: sentry.authidentity
   pk: 6
 - fields:
     config: '""'
-    created_at: '2023-11-07T21:45:36.611Z'
+    created_at: '2023-11-09T18:52:23.778Z'
     last_used_at: null
     type: 1
     user: 31
@@ -724,7 +724,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 11
 - fields:
     config: '""'
-    created_at: '2023-11-07T21:45:36.697Z'
+    created_at: '2023-11-09T18:52:23.902Z'
     last_used_at: null
     type: 1
     user: 32
@@ -732,10 +732,10 @@ source: tests/sentry/backup/test_releases.py
   pk: 12
 - fields:
     allowed_origins: null
-    date_added: '2023-11-07T21:45:36.887Z'
-    key: 77e1864e387d43358ab09450eed11d21
+    date_added: '2023-11-09T18:52:24.310Z'
+    key: 7983664d39dd43a7a6138a399d43ffaa
     label: Default
-    organization_id: 4552934809403408
+    organization_id: 4552945452908560
     scope_list: '[]'
     scopes: '0'
     status: 0
@@ -743,11 +743,11 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     allowed_origins: ''
-    client_id: 195dfe4bb098e7f21782caaba00a7c2211d3a09a0af8d6337b3f56823bc9dcb3
-    client_secret: 3ddb8abc1cae40df2b06ae3ca28e9e8c1ab0b0f42a941983353419482627152c
-    date_added: '2023-11-07T21:45:37.133Z'
+    client_id: 9f0ef968c57ce824843be87f2f077f6116af967202f79676483cf977131078c3
+    client_secret: c73eb3930c59df321419caf57f3064c9b71c9e893ceb85e51ab8006d0bc2daa0
+    date_added: '2023-11-09T18:52:24.733Z'
     homepage_url: null
-    name: Champion Sole
+    name: Maximum Unicorn
     owner: 35
     privacy_url: null
     redirect_uris: ''
@@ -756,63 +756,63 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.apiapplication
   pk: 6
 - fields:
-    team: 4552934809403409
+    team: 4552945452974096
     type: 0
     user_id: null
   model: sentry.actor
   pk: 6
 - fields:
-    date_hash_added: '2023-11-07T21:45:36.583Z'
+    date_hash_added: '2023-11-09T18:52:23.727Z'
     email: owner
     is_verified: true
     user: 31
-    validation_hash: 0KHfs7fQBvga2kJnhAE0jjqt2aez1tjb
+    validation_hash: hzbOdy9PVTuHyfsKeqlS8o8B5Su5fNYE
   model: sentry.useremail
   pk: 31
 - fields:
-    date_hash_added: '2023-11-07T21:45:36.675Z'
+    date_hash_added: '2023-11-09T18:52:23.873Z'
     email: invitee
     is_verified: true
     user: 32
-    validation_hash: nvO0UFG81tKAI5KXZHmMDCEL7JlLRRZp
+    validation_hash: JKapgwfdj0rDqypDl5ucRipXB5QZuetP
   model: sentry.useremail
   pk: 32
 - fields:
-    date_hash_added: '2023-11-07T21:45:37.011Z'
+    date_hash_added: '2023-11-09T18:52:24.536Z'
     email: admin@localhost
     is_verified: true
     user: 33
-    validation_hash: 7Oxko8ui7tw6idZoat62j9jiXquFcROL
+    validation_hash: Sexp36PELm3nBZsTIUJATpKyeyScxOdR
   model: sentry.useremail
   pk: 33
 - fields:
-    date_hash_added: '2023-11-07T21:45:37.060Z'
-    email: 3ef6105756254b1988fdabb9045fc5b8@example.com
+    date_hash_added: '2023-11-09T18:52:24.616Z'
+    email: 8f25fd7280c0416db7f12447622a8777@example.com
     is_verified: true
     user: 34
-    validation_hash: 1cV9KXbKGpkl5jNe5pZ15aXhsChp5bZB
+    validation_hash: WiaWtoh3enfeTfG85b4nu4X3PYUrnBrR
   model: sentry.useremail
   pk: 34
 - fields:
-    date_hash_added: '2023-11-07T21:45:37.127Z'
+    date_hash_added: '2023-11-09T18:52:24.715Z'
     email: ''
     is_verified: false
     user: 35
-    validation_hash: kUiAcoRWvV9qpVUTVWvidxNzQMvuPgu3
+    validation_hash: Inp0YrIUyCSWOgfW5iV9IJE6JP0TyTDa
   model: sentry.useremail
   pk: 35
 - fields:
-    date_hash_added: '2023-11-07T21:45:37.316Z'
-    email: 10a26991c46a4d45b04d869b3a613154@example.com
+    date_hash_added: '2023-11-09T18:52:25.045Z'
+    email: 887172daf50746a28ffb0845cd5ba315@example.com
     is_verified: true
     user: 36
-    validation_hash: 2JOYMUUYJgc861ZkUrbJMOaNGrL872N2
+    validation_hash: aVtiu2L5yJbUv87NVdqNwd5gdoGJVmRm
   model: sentry.useremail
   pk: 36
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2023-11-07T21:45:36.996Z'
+    date_added: '2023-11-09T18:52:24.509Z'
     environment: null
     query: level:error
     resolution: 60
@@ -823,7 +823,7 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     aggregate: count()
     dataset: events
-    date_added: '2023-11-07T21:45:37.032Z'
+    date_added: '2023-11-09T18:52:24.567Z'
     environment: null
     query: test query
     resolution: 60
@@ -834,17 +834,17 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     application: 6
     author: A Company
-    creator_label: 3ef6105756254b1988fdabb9045fc5b8@example.com
+    creator_label: 8f25fd7280c0416db7f12447622a8777@example.com
     creator_user: 34
-    date_added: '2023-11-07T21:45:37.134Z'
+    date_added: '2023-11-09T18:52:24.735Z'
     date_deleted: null
     date_published: null
-    date_updated: '2023-11-07T21:45:37.271Z'
+    date_updated: '2023-11-09T18:52:24.960Z'
     events: '[]'
     is_alertable: false
     name: test app
     overview: null
-    owner_id: 4552934809403408
+    owner_id: 4552945452908560
     popularity: 1
     proxy_user: 35
     redirect_url: null
@@ -885,26 +885,26 @@ source: tests/sentry/backup/test_releases.py
     scopes: '0'
     slug: test-app
     status: 0
-    uuid: 58ef785e-40ba-48d8-be7c-a49be651c065
+    uuid: a1215f2b-312d-4ab9-89a8-ada444d94084
     verify_install: true
     webhook_url: https://example.com/webhook
   model: sentry.sentryapp
   pk: 6
 - fields:
     data: '{"conditions":[{"id":"sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},{"id":"sentry.rules.conditions.every_event.EveryEventCondition"}],"action_match":"all","filter_match":"all","actions":[{"id":"sentry.rules.actions.notify_event.NotifyEventAction"},{"id":"sentry.rules.actions.notify_event_service.NotifyEventServiceAction","service":"mail"}]}'
-    date_added: '2023-11-07T21:45:36.949Z'
+    date_added: '2023-11-09T18:52:24.422Z'
     environment_id: null
     label: ''
     owner: null
-    project: 4552934809403410
+    project: 4552945452974097
     source: 0
     status: 0
   model: sentry.rule
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:37.002Z'
-    date_updated: '2023-11-07T21:45:37.002Z'
-    project: 4552934809403410
+    date_added: '2023-11-09T18:52:24.519Z'
+    date_updated: '2023-11-09T18:52:24.519Z'
+    project: 4552945452974097
     snuba_query: 11
     status: 1
     subscription_id: null
@@ -912,9 +912,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 21
 - fields:
-    date_added: '2023-11-07T21:45:37.035Z'
-    date_updated: '2023-11-07T21:45:37.035Z'
-    project: 4552934809403410
+    date_added: '2023-11-09T18:52:24.571Z'
+    date_updated: '2023-11-09T18:52:24.571Z'
+    project: 4552945452974097
     snuba_query: 12
     status: 1
     subscription_id: null
@@ -922,9 +922,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 22
 - fields:
-    date_added: '2023-11-07T21:45:37.151Z'
-    date_updated: '2023-11-07T21:45:37.151Z'
-    project: 4552934809468945
+    date_added: '2023-11-09T18:52:24.765Z'
+    date_updated: '2023-11-09T18:52:24.765Z'
+    project: 4552945452974100
     snuba_query: 11
     status: 1
     subscription_id: null
@@ -932,9 +932,9 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.querysubscription
   pk: 23
 - fields:
-    date_added: '2023-11-07T21:45:37.338Z'
-    date_updated: '2023-11-07T21:45:37.338Z'
-    project: 4552934809468946
+    date_added: '2023-11-09T18:52:25.080Z'
+    date_updated: '2023-11-09T18:52:25.080Z'
+    project: 4552945453039632
     snuba_query: 11
     status: 1
     subscription_id: null
@@ -945,12 +945,12 @@ source: tests/sentry/backup/test_releases.py
     is_active: true
     organizationmember: 11
     role: null
-    team: 4552934809403409
+    team: 4552945452974096
   model: sentry.organizationmemberteam
   pk: 6
 - fields:
     integration_id: null
-    organization: 4552934809403408
+    organization: 4552945452908560
     sentry_app_id: null
     target_display: Sentry User
     target_identifier: '1'
@@ -961,7 +961,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 9
 - fields:
     integration_id: null
-    organization: 4552934809403408
+    organization: 4552945452908560
     sentry_app_id: 6
     target_display: Sentry User
     target_identifier: '1'
@@ -971,23 +971,23 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.notificationaction
   pk: 10
 - fields:
-    disable_date: '2023-11-07T21:45:36.952Z'
+    disable_date: '2023-11-09T18:52:24.428Z'
     opted_out: false
-    organization: 4552934809403408
+    organization: 4552945452908560
     rule: 6
-    sent_final_email_date: '2023-11-07T21:45:36.952Z'
-    sent_initial_email_date: '2023-11-07T21:45:36.952Z'
+    sent_final_email_date: '2023-11-09T18:52:24.428Z'
+    sent_initial_email_date: '2023-11-09T18:52:24.428Z'
   model: sentry.neglectedrule
   pk: 6
 - fields:
     environment: 6
     is_hidden: null
-    project: 4552934809403410
+    project: 4552945452974097
   model: sentry.environmentproject
   pk: 6
 - fields:
     dashboard: 6
-    date_added: '2023-11-07T21:45:37.049Z'
+    date_added: '2023-11-09T18:52:24.588Z'
     description: null
     detail: null
     display_type: 0
@@ -1001,51 +1001,51 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     custom_dynamic_sampling_rule: 4
-    project: 4552934809403410
+    project: 4552945452974097
   model: sentry.customdynamicsamplingruleproject
   pk: 4
 - fields:
     application: 6
-    date_added: '2023-11-07T21:45:37.214Z'
-    expires_at: '2023-11-08T05:45:37.214Z'
+    date_added: '2023-11-09T18:52:24.870Z'
+    expires_at: '2023-11-10T02:52:24.870Z'
     name: null
-    refresh_token: 2c8cef577889f63d425f9a110ae38c44b2ab8c818a140ea5285d7286acd84b00
+    refresh_token: 703f2797e01420084bbc59bb1a0be0c9029b118d4372069f1f46992cce2c3890
     scope_list: '[]'
     scopes: '0'
-    token: 1890cdc43c5c6342d01b44196821e922c59e64960ff6b7c281defb33614453df
-    token_last_characters: 53df
+    token: db2e8cc7d472ba57c47990a63e91a07d783435f9816dd77edc73027197510638
+    token_last_characters: 0638
     user: 35
   model: sentry.apitoken
   pk: 14
 - fields:
     application: 6
-    date_added: '2023-11-07T21:45:37.276Z'
+    date_added: '2023-11-09T18:52:24.968Z'
     expires_at: null
     name: create_exhaustive_sentry_app
-    refresh_token: 1512ff76cb43ae9b841fb03710e1f1bc87cf671e879eed4ca6ef9800448e06a9
+    refresh_token: a1f2d94949599d00fda6dec7623c04152434b59473a400c8b5f114bb120a1bc8
     scope_list: '[]'
     scopes: '0'
-    token: bf566cb7adb75326ca8d197f227f3e1792cc1aeb9ead6fb7159a1aa52618cd73
-    token_last_characters: cd73
+    token: 0fa15ae9f7e87ccd3436b02ded2e0f5b48642e410890289c928cb23d1142aeb5
+    token_last_characters: aeb5
     user: 31
   model: sentry.apitoken
   pk: 15
 - fields:
     application: null
-    date_added: '2023-11-07T21:45:37.377Z'
+    date_added: '2023-11-09T18:52:25.149Z'
     expires_at: null
     name: create_exhaustive_global_configs
-    refresh_token: c5ae4d0c643d743b97e5e9ab40c1db880e05b6b55bccbd618f0e0ba5c44c46f9
+    refresh_token: 19de8386887fab5b6c42301a57a9760733a478214c95b601357ddcc215525623
     scope_list: '[]'
     scopes: '0'
-    token: bbaaf08b19bd5f2df7696f45c0a83525e3dab044d993ad7185738f9b67468611
-    token_last_characters: '8611'
+    token: 6416b02dfee3bf74904da47d354df54e828be494f35301850e1010503995a0f3
+    token_last_characters: a0f3
     user: 31
   model: sentry.apitoken
   pk: 16
 - fields:
     application: 6
-    code: 12160967f53b065c6e415858e51b6833bba026e4d842df7b66fe46e60ca0ae7a
+    code: 898e984709df56670e75974af02a47504214d7490d9179dea8558e1462292d53
     expires_at: '2022-01-01T11:11:00.000Z'
     redirect_uri: https://example.com
     scope_list: '[''openid'', ''profile'', ''email'']'
@@ -1055,7 +1055,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 8
 - fields:
     application: 6
-    date_added: '2023-11-07T21:45:37.275Z'
+    date_added: '2023-11-09T18:52:24.966Z'
     scope_list: '[]'
     scopes: '0'
     user: 31
@@ -1063,7 +1063,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 9
 - fields:
     application: null
-    date_added: '2023-11-07T21:45:37.377Z'
+    date_added: '2023-11-09T18:52:25.148Z'
     scope_list: '[]'
     scopes: '0'
     user: 31
@@ -1071,11 +1071,11 @@ source: tests/sentry/backup/test_releases.py
   pk: 10
 - fields:
     comparison_delta: null
-    date_added: '2023-11-07T21:45:36.998Z'
-    date_modified: '2023-11-07T21:45:36.998Z'
+    date_added: '2023-11-09T18:52:24.513Z'
+    date_modified: '2023-11-09T18:52:24.513Z'
     include_all_projects: true
-    name: Creative Moccasin
-    organization: 4552934809403408
+    name: Enhanced Chigger
+    organization: 4552945452908560
     owner: null
     resolve_threshold: null
     snuba_query: 11
@@ -1088,11 +1088,11 @@ source: tests/sentry/backup/test_releases.py
   pk: 11
 - fields:
     comparison_delta: null
-    date_added: '2023-11-07T21:45:37.034Z'
-    date_modified: '2023-11-07T21:45:37.034Z'
+    date_added: '2023-11-09T18:52:24.569Z'
+    date_modified: '2023-11-09T18:52:24.569Z'
     include_all_projects: false
-    name: Magnetic Midge
-    organization: 4552934809403408
+    name: Touching Mullet
+    organization: 4552945452908560
     owner: null
     resolve_threshold: null
     snuba_query: 12
@@ -1116,13 +1116,13 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     api_grant: null
     api_token: 14
-    date_added: '2023-11-07T21:45:37.181Z'
+    date_added: '2023-11-09T18:52:24.836Z'
     date_deleted: null
-    date_updated: '2023-11-07T21:45:37.197Z'
-    organization_id: 4552934809403408
+    date_updated: '2023-11-09T18:52:24.852Z'
+    organization_id: 4552945452908560
     sentry_app: 6
     status: 1
-    uuid: 468e3d74-a8b3-4ae7-b900-6148da0d9ebc
+    uuid: 6d4883d5-06cb-49ee-85ea-cf2e9f1383e9
   model: sentry.sentryappinstallation
   pk: 6
 - fields:
@@ -1160,12 +1160,12 @@ source: tests/sentry/backup/test_releases.py
       type: alert-rule-action
     sentry_app: 6
     type: alert-rule-action
-    uuid: 7886b9c5-11ba-4df4-a5ee-9822788abcc5
+    uuid: 2ac2db5e-8801-46bf-8d7c-f2f6bed41a60
   model: sentry.sentryappcomponent
   pk: 6
 - fields:
     alert_rule: null
-    date_added: '2023-11-07T21:45:36.951Z'
+    date_added: '2023-11-09T18:52:24.426Z'
     owner_id: 31
     rule: 6
     until: null
@@ -1173,7 +1173,7 @@ source: tests/sentry/backup/test_releases.py
   model: sentry.rulesnooze
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:36.950Z'
+    date_added: '2023-11-09T18:52:24.424Z'
     rule: 6
     type: 1
     user_id: null
@@ -1181,26 +1181,26 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     action: 9
-    project: 4552934809403410
+    project: 4552945452974097
   model: sentry.notificationactionproject
   pk: 9
 - fields:
     action: 10
-    project: 4552934809403410
+    project: 4552945452974097
   model: sentry.notificationactionproject
   pk: 10
 - fields:
     alert_rule: 12
-    date_added: '2023-11-07T21:45:37.039Z'
+    date_added: '2023-11-09T18:52:24.575Z'
     date_closed: null
-    date_detected: '2023-11-07T21:45:37.038Z'
-    date_started: '2023-11-07T21:45:37.038Z'
+    date_detected: '2023-11-09T18:52:24.574Z'
+    date_started: '2023-11-09T18:52:24.574Z'
     detection_uuid: null
     identifier: 1
-    organization: 4552934809403408
+    organization: 4552945452908560
     status: 1
     status_method: 3
-    title: Major Eft
+    title: Singular Moose
     type: 2
   model: sentry.incident
   pk: 6
@@ -1208,7 +1208,7 @@ source: tests/sentry/backup/test_releases.py
     aggregates: null
     columns: null
     conditions: ''
-    date_added: '2023-11-07T21:45:37.050Z'
+    date_added: '2023-11-09T18:52:24.589Z'
     field_aliases: null
     fields: '[]'
     name: Test Query for test-org
@@ -1220,21 +1220,21 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     alert_rule: 11
     alert_threshold: 100.0
-    date_added: '2023-11-07T21:45:37.007Z'
-    label: Mature Turkey
+    date_added: '2023-11-09T18:52:24.529Z'
+    label: Massive Egret
     resolve_threshold: null
     threshold_type: null
   model: sentry.alertruletrigger
   pk: 6
 - fields:
     alert_rule: 11
-    date_added: '2023-11-07T21:45:37.000Z'
-    project: 4552934809403411
+    date_added: '2023-11-09T18:52:24.516Z'
+    project: 4552945452974098
   model: sentry.alertruleexcludedprojects
   pk: 6
 - fields:
     alert_rule: 11
-    date_added: '2023-11-07T21:45:37.003Z'
+    date_added: '2023-11-09T18:52:24.521Z'
     previous_alert_rule: null
     type: 1
     user_id: null
@@ -1242,30 +1242,30 @@ source: tests/sentry/backup/test_releases.py
   pk: 11
 - fields:
     alert_rule: 12
-    date_added: '2023-11-07T21:45:37.036Z'
+    date_added: '2023-11-09T18:52:24.572Z'
     previous_alert_rule: null
     type: 1
     user_id: null
   model: sentry.alertruleactivity
   pk: 12
 - fields:
-    date_added: '2023-11-07T21:45:37.043Z'
-    end: '2023-11-07T21:45:37.043Z'
+    date_added: '2023-11-09T18:52:24.581Z'
+    end: '2023-11-09T18:52:24.581Z'
     period: 1
-    start: '2023-11-06T21:45:37.043Z'
+    start: '2023-11-08T18:52:24.581Z'
     values: '[[1.0, 2.0, 3.0], [1.5, 2.5, 3.5]]'
   model: sentry.timeseriessnapshot
   pk: 6
 - fields:
     actor_id: 6
     application_id: 6
-    date_added: '2023-11-07T21:45:37.195Z'
+    date_added: '2023-11-09T18:52:24.850Z'
     events: '[]'
-    guid: 65d6c03742b746cfa50419d7f2d28c9b
+    guid: 4ea5dd42d2504501a7d2adb26955f401
     installation_id: 6
-    organization_id: 4552934809403408
+    organization_id: 4552945452908560
     project_id: null
-    secret: 4884cf392a764bd90f6798aa298f12c8599804cef593a559b105e718bdd919af
+    secret: ccd7bad86ea44a8d98abbe2ce02dcfedc5c0bd5ee9978c9d394ba67354198bd6
     status: 0
     url: https://example.com/webhook
     version: 0
@@ -1274,40 +1274,40 @@ source: tests/sentry/backup/test_releases.py
 - fields:
     actor_id: 36
     application_id: 6
-    date_added: '2023-11-07T21:45:37.363Z'
+    date_added: '2023-11-09T18:52:25.128Z'
     events: '[''event.created'']'
-    guid: 61ba0199d21943599e023ceb5416433b
+    guid: bb97c6d971654aceb9fe64a8fbb348ce
     installation_id: 6
-    organization_id: 4552934809403408
-    project_id: 4552934809468946
-    secret: 58c0340d72cdb87016d3e9cb6634fb3a3462ed90dccd841b9d8c0b78d61eeabe
+    organization_id: 4552945452908560
+    project_id: 4552945453039632
+    secret: c17748931bbef37b88ba0cc2f8c2d6d8efa317092ddc03b26704a0c04248cac1
     status: 0
     url: https://example.com/sentry/webhook
     version: 0
   model: sentry.servicehook
   pk: 12
 - fields:
-    date_added: '2023-11-07T21:45:37.047Z'
+    date_added: '2023-11-09T18:52:24.586Z'
     incident: 6
-    target_run_date: '2023-11-08T01:45:37.047Z'
+    target_run_date: '2023-11-09T22:52:24.586Z'
   model: sentry.pendingincidentsnapshot
   pk: 6
 - fields:
     alert_rule_trigger: 6
-    date_added: '2023-11-07T21:45:37.046Z'
-    date_modified: '2023-11-07T21:45:37.046Z'
+    date_added: '2023-11-09T18:52:24.585Z'
+    date_modified: '2023-11-09T18:52:24.585Z'
     incident: 6
     status: 1
   model: sentry.incidenttrigger
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:37.045Z'
+    date_added: '2023-11-09T18:52:24.583Z'
     incident: 6
     user_id: 31
   model: sentry.incidentsubscription
   pk: 6
 - fields:
-    date_added: '2023-11-07T21:45:37.044Z'
+    date_added: '2023-11-09T18:52:24.582Z'
     event_stats_snapshot: 6
     incident: 6
     total_events: 1
@@ -1316,7 +1316,7 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     comment: hello test-org
-    date_added: '2023-11-07T21:45:37.042Z'
+    date_added: '2023-11-09T18:52:24.580Z'
     incident: 6
     notification_uuid: null
     previous_value: null
@@ -1327,13 +1327,13 @@ source: tests/sentry/backup/test_releases.py
   pk: 6
 - fields:
     alert_rule_trigger: 6
-    date_added: '2023-11-07T21:45:37.008Z'
+    date_added: '2023-11-09T18:52:24.530Z'
     query_subscription: 21
   model: sentry.alertruletriggerexclusion
   pk: 6
 - fields:
     alert_rule_trigger: 6
-    date_added: '2023-11-07T21:45:37.031Z'
+    date_added: '2023-11-09T18:52:24.565Z'
     integration_id: null
     sentry_app_config: null
     sentry_app_id: null

--- a/tests/sentry/models/test_apitoken.py
+++ b/tests/sentry/models/test_apitoken.py
@@ -9,6 +9,7 @@ from sentry.models.integrations.sentry_app_installation import SentryAppInstalla
 from sentry.models.integrations.sentry_app_installation_token import SentryAppInstallationToken
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
@@ -60,6 +61,18 @@ class ApiTokenTest(TestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             assert ApiTokenReplica.objects.get(apitoken_id=token.id).organization_id is None
         assert token.organization_id is None
+
+    @override_options({"apitoken.auto-add-last-chars": True})
+    def test_last_chars_are_set(self):
+        user = self.create_user()
+        token = ApiToken.objects.create(user_id=user.id)
+        assert token.token_last_characters == token.token[-4:]
+
+    @override_options({"apitoken.auto-add-last-chars": False})
+    def test_last_chars_are_not_set(self):
+        user = self.create_user()
+        token = ApiToken.objects.create(user_id=user.id)
+        assert token.token_last_characters is None
 
 
 class ApiTokenInternalIntegrationTest(TestCase):


### PR DESCRIPTION
- Add an option to toggle on/off automatically populating the `token_last_characters` for the `ApiToken` model.

This option will ensure tokens created from here on have the field populated. It will also allow me to thoroughly test the backfill migration needed for existing tokens that will be coming in a future PR by disabling the option in tests, creating a bunch of API tokens, and then running the backfill migration test.

Tracking Issue: https://github.com/getsentry/sentry/issues/58918
RFC: https://github.com/getsentry/rfcs/pull/32