### PR TITLE
feat(feedbacks): add associated_event_id to feedback context

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -137,6 +137,7 @@ class UserReportShimDict(TypedDict):
     name: str
     email: str
     comments: str
+    event_id: str
 
 
 def shim_to_feedback(report: UserReportShimDict, event: Event, project: Project):
@@ -159,7 +160,7 @@ def shim_to_feedback(report: UserReportShimDict, event: Event, project: Project)
         }
 
         if event:
-            feedback_event["contexts"]["feedback"]["crash_report_event_id"] = event.event_id
+            feedback_event["contexts"]["feedback"]["associated_event_id"] = event.event_id
 
             if get_path(event.data, "contexts", "replay", "replay_id"):
                 feedback_event["contexts"]["replay"] = event.data["contexts"]["replay"]
@@ -169,10 +170,12 @@ def shim_to_feedback(report: UserReportShimDict, event: Event, project: Project)
             feedback_event["timestamp"] = event.datetime.timestamp()
 
             feedback_event["platform"] = event.platform
-
         else:
             feedback_event["timestamp"] = datetime.utcnow().timestamp()
             feedback_event["platform"] = "other"
+
+            if report.get("event_id"):
+                feedback_event["contexts"]["feedback"]["associated_event_id"] = report["event_id"]
 
         create_feedback_issue(feedback_event, project.id)
     except Exception:

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -200,6 +200,7 @@ class ErrorPageEmbedView(View):
                         "name": report.name,
                         "email": report.email,
                         "comments": report.comments,
+                        "event_id": report.event_id,
                     },
                     event,
                     project,

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -424,19 +424,22 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         assert mock_event_data["contexts"]["feedback"]["replay_id"] == replay_id
         assert mock_event_data["contexts"]["replay"]["replay_id"] == replay_id
         assert mock_event_data["platform"] == "other"
-        assert mock_event_data["contexts"]["feedback"]["crash_report_event_id"]
+        assert (
+            mock_event_data["contexts"]["feedback"]["associated_event_id"]
+            == event_with_replay.event_id
+        )
 
     @patch("sentry.feedback.usecases.create_feedback.produce_occurrence_to_kafka")
     def test_simple_shim_to_feedback_no_event(self, mock_produce_occurrence_to_kafka):
         self.login_as(user=self.user)
 
         url = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/user-feedback/"
-
+        event_id = uuid4().hex
         with self.feature("organizations:user-feedback-ingest"):
             response = self.client.post(
                 url,
                 data={
-                    "event_id": uuid4().hex,
+                    "event_id": event_id,
                     "email": "foo@example.com",
                     "name": "Foo Bar",
                     "comments": "It broke!",
@@ -458,4 +461,4 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         assert mock_event_data["contexts"]["feedback"]["message"] == "It broke!"
         assert mock_event_data["contexts"]["feedback"]["name"] == "Foo Bar"
         assert mock_event_data["platform"] == "other"
-        assert not mock_event_data["contexts"]["feedback"].get("crash_report_event_id")
+        assert mock_event_data["contexts"]["feedback"]["associated_event_id"] == event_id

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -269,4 +269,25 @@ class ErrorPageEmbedEnvironmentTest(TestCase):
             assert mock_event_data["contexts"]["feedback"]["message"] == "This is an example!"
             assert mock_event_data["contexts"]["feedback"]["name"] == "Jane Bloggs"
             assert mock_event_data["platform"] == "other"
-            assert mock_event_data["contexts"]["feedback"]["crash_report_event_id"]
+            assert mock_event_data["contexts"]["feedback"]["associated_event_id"] == self.event_id
+
+    @mock.patch("sentry.feedback.usecases.create_feedback.produce_occurrence_to_kafka")
+    def test_calls_feedback_shim_no_event_if_ff_enabled(self, mock_produce_occurrence_to_kafka):
+        with self.feature({"organizations:user-feedback-ingest": True}):
+            self.client.post(
+                self.path,
+                {
+                    "name": "Jane Bloggs",
+                    "email": "jane@example.com",
+                    "comments": "This is an example!",
+                },
+                HTTP_REFERER="http://example.com",
+                HTTP_ACCEPT="application/json",
+            )
+            assert len(mock_produce_occurrence_to_kafka.mock_calls) == 1
+            mock_event_data = mock_produce_occurrence_to_kafka.call_args_list[0][1]["event_data"]
+            assert mock_event_data["contexts"]["feedback"]["contact_email"] == "jane@example.com"
+            assert mock_event_data["contexts"]["feedback"]["message"] == "This is an example!"
+            assert mock_event_data["contexts"]["feedback"]["name"] == "Jane Bloggs"
+            assert mock_event_data["platform"] == "other"
+            assert mock_event_data["contexts"]["feedback"]["associated_event_id"] == self.event_id


### PR DESCRIPTION
- [x] change `crash_report_event_id` to `associated_event_id` to make more general.
- [x] add the event_id to the feedback context even if the event does not exist yet, as because of processing they can come out of order.