### PR TITLE
chore(provisioning): require partnership flag in FE

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -130,9 +130,9 @@ export interface Member {
     'idp:provisioned': boolean;
     'idp:role-restricted': boolean;
     'member-limit:restricted': boolean;
+    'partnership:restricted': boolean;
     'sso:invalid': boolean;
     'sso:linked': boolean;
-    'partnership:restricted'?: boolean;
   };
   id: string;
   inviteStatus: 'approved' | 'requested_to_be_invited' | 'requested_to_join';


### PR DESCRIPTION
Requires https://github.com/getsentry/getsentry/pull/12004

The above PR updates the Owner fixture which was preventing the flag from being required in the first place.