### PR TITLE
fix(starfish): Fix issue where web vitals landing page links forward search query to page overview

### DIFF
--- a/static/app/views/performance/browser/webVitals/pagePerformanceTable.tsx
+++ b/static/app/views/performance/browser/webVitals/pagePerformanceTable.tsx
@@ -206,7 +206,7 @@ export function PagePerformanceTable() {
               )
                 ? {pathname: `${location.pathname}overview/`}
                 : {}),
-              query: {...location.query, transaction: row.transaction},
+              query: {...location.query, transaction: row.transaction, query: undefined},
             }}
           >
             {row.transaction}


### PR DESCRIPTION
Fix page links from webvitals landing to not include query in query string. This prevents an issue where the search from the landing page also propagates to the page overview, which shouldn't happen.