### PR TITLE
feat(starfish-web-vitals-score-widget): Adding new performance score widget

### DIFF
--- a/static/app/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -98,14 +98,14 @@ function WebVitalLabel({
           webVital,
         },
       }}
+      onMouseEnter={() => onHover(webVital)}
+      onMouseLeave={() => onUnHover()}
       disabled={!inPerformanceWidget}
     >
       <ProgressRingText
         isLink={inPerformanceWidget}
         x={coordinates.x + xOffset}
         y={coordinates.y + yOffset}
-        onMouseEnter={() => onHover(webVital)}
-        onMouseLeave={() => onUnHover()}
       >
         {webVital}
       </ProgressRingText>

--- a/static/app/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -199,44 +199,44 @@ function PerformanceScoreRingWithTooltips({
         {!hideWebVitalLabels && (
           <Fragment>
             <WebVitalLabel
+              {...commonWebVitalLabelProps}
               webVital="lcp"
               coordinates={{
                 x: 160,
                 y: 30,
               }}
-              {...commonWebVitalLabelProps}
             />
             <WebVitalLabel
+              {...commonWebVitalLabelProps}
               webVital="fcp"
               coordinates={{
                 x: 175,
                 y: 140,
               }}
-              {...commonWebVitalLabelProps}
             />
             <WebVitalLabel
+              {...commonWebVitalLabelProps}
               webVital="fid"
               coordinates={{
                 x: 20,
                 y: 140,
               }}
-              {...commonWebVitalLabelProps}
             />
             <WebVitalLabel
+              {...commonWebVitalLabelProps}
               webVital="cls"
               coordinates={{
                 x: 10,
                 y: 60,
               }}
-              {...commonWebVitalLabelProps}
             />
             <WebVitalLabel
+              {...commonWebVitalLabelProps}
               webVital="ttfb"
               coordinates={{
                 x: 50,
                 y: 20,
               }}
-              {...commonWebVitalLabelProps}
             />
           </Fragment>
         )}

--- a/static/app/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips.tsx
@@ -1,10 +1,16 @@
 import {Fragment, useRef, useState} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import {Location} from '@sentry/react/types/types';
 
+import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {Organization} from 'sentry/types';
+import {TableData} from 'sentry/utils/discover/discoverQuery';
 import useMouseTracking from 'sentry/utils/replays/hooks/useMouseTracking';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import PerformanceScoreRing from 'sentry/views/performance/browser/webVitals/components/performanceScoreRing';
 import {
   PERFORMANCE_SCORE_WEIGHTS,
@@ -14,6 +20,8 @@ import {WebVitals} from 'sentry/views/performance/browser/webVitals/utils/types'
 
 import {ORDER} from '../performanceScoreChart';
 
+import {getFormattedDuration} from './webVitalMeters';
+
 const {
   lcp: LCP_WEIGHT,
   fcp: FCP_WEIGHT,
@@ -22,6 +30,15 @@ const {
   ttfb: TTFB_WEIGHT,
 } = PERFORMANCE_SCORE_WEIGHTS;
 
+type Coordinates = {
+  x: number;
+  y: number;
+};
+
+type WebVitalsLabelCoordinates = {
+  [p in WebVitals]?: Coordinates;
+};
+
 type Props = {
   height: number;
   projectScore: ProjectScore;
@@ -29,25 +46,100 @@ type Props = {
   ringSegmentColors: string[];
   text: React.ReactNode;
   width: number;
+  barWidth?: number;
   hideWebVitalLabels?: boolean;
+  inPerformanceWidget?: boolean;
+  projectData?: TableData;
   size?: number;
+  webVitalLabelCoordinates?: WebVitalsLabelCoordinates;
   x?: number;
   y?: number;
 };
 
+type WebVitalLabelProps = {
+  coordinates: Coordinates;
+  inPerformanceWidget: boolean;
+  location: Location;
+  onHover: (webVital: WebVitals) => void;
+  onUnHover: () => void;
+  organization: Organization;
+  webVital: WebVitals;
+  projectData?: TableData;
+  webVitalLabelCoordinates?: WebVitalsLabelCoordinates;
+};
+
+function WebVitalLabel({
+  organization,
+  location,
+  webVital,
+  coordinates,
+  onHover,
+  onUnHover,
+  webVitalLabelCoordinates,
+  inPerformanceWidget,
+  projectData,
+}: WebVitalLabelProps) {
+  const xOffset = webVitalLabelCoordinates?.[webVital]?.x ?? 0;
+  const yOffset = webVitalLabelCoordinates?.[webVital]?.y ?? 0;
+  const webvitalInfo =
+    webVital === 'cls'
+      ? Math.round((projectData?.data?.[0]?.['p75(measurements.cls)'] as number) * 100) /
+        100
+      : getFormattedDuration(
+          (projectData?.data?.[0]?.[`p75(measurements.${webVital})`] as number) / 1000
+        );
+
+  return (
+    <Link
+      to={{
+        pathname: `/organizations/${organization.slug}/performance/browser/pageloads/`,
+        query: {
+          ...location.query,
+          webVital,
+        },
+      }}
+      disabled={!inPerformanceWidget}
+    >
+      <ProgressRingText
+        isLink={inPerformanceWidget}
+        x={coordinates.x + xOffset}
+        y={coordinates.y + yOffset}
+        onMouseEnter={() => onHover(webVital)}
+        onMouseLeave={() => onUnHover()}
+      >
+        {webVital}
+      </ProgressRingText>
+      {inPerformanceWidget && (
+        <ProgressRingSubText
+          x={coordinates.x + xOffset + (webVital === 'cls' ? 2 : 0)}
+          y={coordinates.y + yOffset + 15}
+        >
+          {webvitalInfo}
+        </ProgressRingSubText>
+      )}
+    </Link>
+  );
+}
+
 function PerformanceScoreRingWithTooltips({
   projectScore,
+  projectData,
   ringBackgroundColors,
   ringSegmentColors,
   width,
   height,
   text,
+  webVitalLabelCoordinates,
+  barWidth = 16,
   hideWebVitalLabels = false,
+  inPerformanceWidget = false,
   size = 140,
   x = 40,
   y = 20,
 }: Props) {
   const theme = useTheme();
+  const organization = useOrganization();
+  const location = useLocation();
   const [mousePosition, setMousePosition] = useState({x: 0, y: 0});
   const elem = useRef<HTMLDivElement>(null);
   const mouseTrackingProps = useMouseTracking({
@@ -60,6 +152,27 @@ function PerformanceScoreRingWithTooltips({
     },
   });
   const [webVitalTooltip, setWebVitalTooltip] = useState<WebVitals | null>(null);
+  const [labelHovered, setLabelHovered] = useState<WebVitals | null>(null);
+
+  if (labelHovered && inPerformanceWidget) {
+    const index = ORDER.indexOf(labelHovered);
+    ringSegmentColors = ringSegmentColors.map((color, i) => {
+      return i === index ? color : theme.gray200;
+    });
+    ringBackgroundColors = ringBackgroundColors.map((color, i) => {
+      return i === index ? color : `${theme.gray200}33`;
+    });
+  }
+
+  const commonWebVitalLabelProps = {
+    organization,
+    location,
+    inPerformanceWidget,
+    webVitalLabelCoordinates,
+    projectData,
+    onHover: (webVital: WebVitals) => setLabelHovered(webVital),
+    onUnHover: () => setLabelHovered(null),
+  };
 
   return (
     <ProgressRingContainer ref={elem} {...mouseTrackingProps}>
@@ -85,21 +198,46 @@ function PerformanceScoreRingWithTooltips({
       <svg height={height} width={width}>
         {!hideWebVitalLabels && (
           <Fragment>
-            <ProgressRingText x={160} y={30}>
-              LCP
-            </ProgressRingText>
-            <ProgressRingText x={175} y={140}>
-              FCP
-            </ProgressRingText>
-            <ProgressRingText x={20} y={140}>
-              FID
-            </ProgressRingText>
-            <ProgressRingText x={10} y={60}>
-              CLS
-            </ProgressRingText>
-            <ProgressRingText x={50} y={20}>
-              TTFB
-            </ProgressRingText>
+            <WebVitalLabel
+              webVital="lcp"
+              coordinates={{
+                x: 160,
+                y: 30,
+              }}
+              {...commonWebVitalLabelProps}
+            />
+            <WebVitalLabel
+              webVital="fcp"
+              coordinates={{
+                x: 175,
+                y: 140,
+              }}
+              {...commonWebVitalLabelProps}
+            />
+            <WebVitalLabel
+              webVital="fid"
+              coordinates={{
+                x: 20,
+                y: 140,
+              }}
+              {...commonWebVitalLabelProps}
+            />
+            <WebVitalLabel
+              webVital="cls"
+              coordinates={{
+                x: 10,
+                y: 60,
+              }}
+              {...commonWebVitalLabelProps}
+            />
+            <WebVitalLabel
+              webVital="ttfb"
+              coordinates={{
+                x: 50,
+                y: 20,
+              }}
+              {...commonWebVitalLabelProps}
+            />
           </Fragment>
         )}
         <PerformanceScoreRing
@@ -113,7 +251,7 @@ function PerformanceScoreRingWithTooltips({
           maxValues={[LCP_WEIGHT, FCP_WEIGHT, FID_WEIGHT, CLS_WEIGHT, TTFB_WEIGHT]}
           text={text}
           size={size}
-          barWidth={14}
+          barWidth={barWidth}
           textCss={() => css`
             font-size: 32px;
             font-weight: bold;
@@ -139,10 +277,16 @@ function PerformanceScoreRingWithTooltips({
 
 const ProgressRingContainer = styled('div')``;
 
-const ProgressRingText = styled('text')`
+const ProgressRingText = styled('text')<{isLink?: boolean}>`
   font-size: ${p => p.theme.fontSizeMedium};
-  fill: ${p => p.theme.textColor};
+  fill: ${p => (p.isLink ? p.theme.blue300 : p.theme.textColor)};
   font-weight: bold;
+  text-transform: uppercase;
+`;
+
+const ProgressRingSubText = styled('text')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  fill: ${p => p.theme.subText};
 `;
 
 // Hover element on mouse

--- a/static/app/views/performance/browser/webVitals/components/webVitalMeters.tsx
+++ b/static/app/views/performance/browser/webVitals/components/webVitalMeters.tsx
@@ -93,7 +93,7 @@ export default function WebVitalMeters({onClick, projectData, projectScore}: Pro
   );
 }
 
-const getFormattedDuration = (value: number) => {
+export const getFormattedDuration = (value: number) => {
   return getDuration(value, value < 1 ? 0 : 2, true);
 };
 

--- a/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery.tsx
@@ -50,7 +50,7 @@ export const useProjectWebVitalsQuery = ({transaction, tag, dataset}: Props = {}
     cursor: '',
     options: {
       enabled: pageFilters.isReady,
-      refetchOnWindowFocus: false,
+      refetchOnWindowFocus: true,
     },
   });
 };

--- a/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery.tsx
@@ -50,7 +50,7 @@ export const useProjectWebVitalsQuery = ({transaction, tag, dataset}: Props = {}
     cursor: '',
     options: {
       enabled: pageFilters.isReady,
-      refetchOnWindowFocus: true,
+      refetchOnWindowFocus: false,
     },
   });
 };

--- a/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
@@ -179,7 +179,6 @@ export function WebVitalsDetailPanel({
                 webVital,
               },
             }}
-            onClick={onClose}
           >
             {row.transaction}
           </Link>

--- a/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsLandingPage.tsx
@@ -1,5 +1,6 @@
 import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
+import omit from 'lodash/omit';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
@@ -16,6 +17,7 @@ import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+import useRouter from 'sentry/utils/useRouter';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import WebVitalMeters from 'sentry/views/performance/browser/webVitals/components/webVitalMeters';
 import {PagePerformanceTable} from 'sentry/views/performance/browser/webVitals/pagePerformanceTable';
@@ -31,6 +33,7 @@ export default function WebVitalsLandingPage() {
   const organization = useOrganization();
   const location = useLocation();
   const {projects} = useProjects();
+  const router = useRouter();
   const transaction = location.query.transaction
     ? Array.isArray(location.query.transaction)
       ? location.query.transaction[0]
@@ -43,7 +46,7 @@ export default function WebVitalsLandingPage() {
   );
 
   const [state, setState] = useState<{webVital: WebVitals | null}>({
-    webVital: null,
+    webVital: (location.query.webVital as WebVitals) ?? null,
   });
 
   const {data: projectData, isLoading} = useProjectWebVitalsQuery({transaction});
@@ -124,6 +127,10 @@ export default function WebVitalsLandingPage() {
       <WebVitalsDetailPanel
         webVital={state.webVital}
         onClose={() => {
+          router.replace({
+            pathname: router.location.pathname,
+            query: omit(router.location.query, 'webVital'),
+          });
           setState({...state, webVital: null});
         }}
       />

--- a/static/app/views/performance/landing/views/allTransactionsView.tsx
+++ b/static/app/views/performance/landing/views/allTransactionsView.tsx
@@ -24,6 +24,12 @@ export function AllTransactionsView(props: BasePerformanceViewProps) {
       doubleChartRowCharts.unshift(PerformanceWidgetSetting.MOST_CHANGED);
       doubleChartRowCharts.unshift(PerformanceWidgetSetting.MOST_RELATED_ISSUES);
     }
+
+    if (
+      props.organization.features.includes('starfish-browser-webvitals-pageoverview-v2')
+    ) {
+      doubleChartRowCharts.unshift(PerformanceWidgetSetting.OVERALL_PERFORMANCE_SCORE);
+    }
   } else {
     doubleChartRowCharts.unshift(PerformanceWidgetSetting.MOST_REGRESSED);
     doubleChartRowCharts.push(PerformanceWidgetSetting.MOST_IMPROVED);

--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -123,7 +123,7 @@ export function DataDisplay<T extends WidgetDataConstraint>(
         hasData={hasData}
         errorComponent={<DefaultErrorComponent height={totalHeight} />}
         dataComponents={Visualizations.map((Visualization, index) => (
-          <ContentContainer
+          <ContentBodyContainer
             key={index}
             noPadding={Visualization.noPadding}
             bottomPadding={Visualization.bottomPadding}
@@ -143,7 +143,7 @@ export function DataDisplay<T extends WidgetDataConstraint>(
               ),
               fixed: <Placeholder height={`${chartHeight}px`} />,
             })}
-          </ContentContainer>
+          </ContentBodyContainer>
         ))}
         loadingComponent={
           <LoadingWrapper height={totalHeight}>
@@ -181,6 +181,10 @@ const ContentContainer = styled('div')<{bottomPadding?: boolean; noPadding?: boo
   padding-left: ${p => (p.noPadding ? space(0) : space(2))};
   padding-right: ${p => (p.noPadding ? space(0) : space(2))};
   padding-bottom: ${p => (p.bottomPadding ? space(1) : space(0))};
+`;
+
+const ContentBodyContainer = styled(ContentContainer)`
+  height: 100%;
 `;
 
 const PerformanceWidgetPlaceholder = styled(Placeholder)`

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -890,7 +890,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
   });
 
-  it('Highest opportunity pages widget', async function () {
+  it('Best Page Opportunities widget', async function () {
     const data = initializeData();
 
     wrapper = render(
@@ -903,7 +903,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
 
     expect(await screen.findByTestId('performance-widget-title')).toHaveTextContent(
-      'Highest Opportunity Pages'
+      'Best Page Opportunities'
     );
     expect(eventsMock).toHaveBeenCalledTimes(1);
     expect(eventsMock).toHaveBeenNthCalledWith(

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -31,6 +31,7 @@ import {
 } from '../widgetDefinitions';
 import {HistogramWidget} from '../widgets/histogramWidget';
 import {LineChartListWidget} from '../widgets/lineChartListWidget';
+import {PerformanceScoreWidget} from '../widgets/performanceScoreWidget';
 import {SingleFieldAreaWidget} from '../widgets/singleFieldAreaWidget';
 import {StackedAreaChartListWidget} from '../widgets/stackedAreaChartListWidget';
 import {TrendsWidget} from '../widgets/trendsWidget';
@@ -199,6 +200,8 @@ function _WidgetContainer(props: Props) {
       );
     case GenericPerformanceWidgetDataType.STACKED_AREA:
       return <StackedAreaChartListWidget {...passedProps} {...widgetProps} />;
+    case GenericPerformanceWidgetDataType.PERFORMANCE_SCORE:
+      return <PerformanceScoreWidget {...passedProps} {...widgetProps} />;
     default:
       throw new Error(`Widget type "${widgetProps.dataType}" has no implementation.`);
   }

--- a/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
@@ -19,8 +19,10 @@ export function WidgetHeader<T extends WidgetDataConstraint>(
 ) {
   const {title, titleTooltip, Subtitle, HeaderActions, InteractiveTitle, chartSetting} =
     props;
-  const isHighestOpportunityPagesWidget =
-    chartSetting === PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES;
+  const isWebVitalsWidget = [
+    PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES,
+    PerformanceWidgetSetting.OVERALL_PERFORMANCE_SCORE,
+  ].includes(chartSetting);
   return (
     <WidgetHeaderContainer>
       <TitleContainer>
@@ -30,7 +32,7 @@ export function WidgetHeader<T extends WidgetDataConstraint>(
           ) : (
             <TextOverflow>{title}</TextOverflow>
           )}
-          {isHighestOpportunityPagesWidget && <FeatureBadge type="alpha" />}
+          {isWebVitalsWidget && <FeatureBadge type="new" />}
           <MEPTag />
           {titleTooltip && (
             <QuestionTooltip position="top" size="sm" title={titleTooltip} />

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -23,6 +23,7 @@ export enum GenericPerformanceWidgetDataType {
   LINE_LIST = 'line_list',
   TRENDS = 'trends',
   STACKED_AREA = 'stacked_area',
+  PERFORMANCE_SCORE = 'performance_score',
 }
 
 export type PerformanceWidgetProps = {

--- a/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
+++ b/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
@@ -64,6 +64,7 @@ export enum PerformanceWidgetSetting {
   SPAN_OPERATIONS = 'span_operations',
   TIME_TO_INITIAL_DISPLAY = 'time_to_initial_display',
   TIME_TO_FULL_DISPLAY = 'time_to_full_display',
+  OVERALL_PERFORMANCE_SCORE = 'overall_performance_score',
 }
 
 const WIDGET_PALETTE = CHART_PALETTE[5];
@@ -271,11 +272,18 @@ export const WIDGET_DEFINITIONS: ({
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.HIGHEST_OPPORTUNITY_PAGES]: {
-    title: t('Highest Opportunity Pages'),
-    subTitle: t('Recommended pages to improve your performance score'),
+    title: t('Best Page Opportunities'),
+    subTitle: t('Pages to improve your performance score'),
     titleTooltip: '',
     fields: [`count()`],
     dataType: GenericPerformanceWidgetDataType.STACKED_AREA,
+  },
+  [PerformanceWidgetSetting.OVERALL_PERFORMANCE_SCORE]: {
+    title: t('Performance Score'),
+    subTitle: t('The overall performance score across selected projects'),
+    titleTooltip: '',
+    fields: [],
+    dataType: GenericPerformanceWidgetDataType.PERFORMANCE_SCORE,
   },
   [PerformanceWidgetSetting.SLOW_HTTP_OPS]: {
     title: t('Slow HTTP Ops'),

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreWidget.tsx
@@ -1,0 +1,115 @@
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {LinkButton} from 'sentry/components/button';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {useLocation} from 'sentry/utils/useLocation';
+import PerformanceScoreRingWithTooltips from 'sentry/views/performance/browser/webVitals/components/performanceScoreRingWithTooltips';
+import {calculatePerformanceScore} from 'sentry/views/performance/browser/webVitals/utils/calculatePerformanceScore';
+import {useProjectWebVitalsQuery} from 'sentry/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery';
+
+import {GenericPerformanceWidget} from '../components/performanceWidget';
+import {Subtitle, WidgetEmptyStateWarning} from '../components/selectableList';
+import {PerformanceWidgetProps} from '../types';
+
+export function PerformanceScoreWidget(props: PerformanceWidgetProps) {
+  const location = useLocation();
+  const {InteractiveTitle, organization} = props;
+  const theme = useTheme();
+  const {data: projectData, isLoading} = useProjectWebVitalsQuery();
+
+  const noTransactions = !isLoading && projectData?.data[0]['count()'] === 0;
+
+  const projectScore =
+    isLoading || noTransactions
+      ? undefined
+      : calculatePerformanceScore({
+          lcp: projectData?.data[0]['p75(measurements.lcp)'] as number,
+          fcp: projectData?.data[0]['p75(measurements.fcp)'] as number,
+          cls: projectData?.data[0]['p75(measurements.cls)'] as number,
+          ttfb: projectData?.data[0]['p75(measurements.ttfb)'] as number,
+          fid: projectData?.data[0]['p75(measurements.fid)'] as number,
+        });
+
+  const ringSegmentColors = theme.charts.getColorPalette(3);
+  const ringBackgroundColors = ringSegmentColors.map(color => `${color}50`);
+
+  return (
+    <GenericPerformanceWidget
+      {...props}
+      location={location}
+      Subtitle={() => (
+        <Subtitle>{props.subTitle ?? t('P75 in Top Transactions')}</Subtitle>
+      )}
+      HeaderActions={() => (
+        <div>
+          <LinkButton
+            to={`/organizations/${organization.slug}/performance/browser/pageloads/`}
+            size="sm"
+          >
+            {t('View All')}
+          </LinkButton>
+        </div>
+      )}
+      InteractiveTitle={
+        InteractiveTitle ? () => <InteractiveTitle isLoading={false} /> : null
+      }
+      EmptyComponent={WidgetEmptyStateWarning}
+      Queries={{}}
+      Visualizations={[
+        {
+          component: () => (
+            <Wrapper>
+              {projectScore && !noTransactions ? (
+                <PerformanceScoreRingWithTooltips
+                  inPerformanceWidget
+                  projectScore={projectScore}
+                  projectData={projectData}
+                  y={25}
+                  text={
+                    <span style={{fontSize: 'xxx-large'}}>{projectScore.totalScore}</span>
+                  }
+                  width={280}
+                  height={240}
+                  size={200}
+                  barWidth={20}
+                  webVitalLabelCoordinates={{
+                    lcp: {x: 80, y: 25},
+                    fcp: {x: 60, y: 55},
+                    fid: {x: 10, y: 65},
+                    cls: {x: -5, y: 15},
+                    ttfb: {x: 10, y: -10},
+                  }}
+                  ringBackgroundColors={ringBackgroundColors}
+                  ringSegmentColors={ringSegmentColors}
+                />
+              ) : isLoading ? (
+                <StyledLoadingIndicator size={40} />
+              ) : (
+                <WidgetEmptyStateWarning />
+              )}
+            </Wrapper>
+          ),
+          height: 124 + props.chartHeight,
+          noPadding: true,
+        },
+      ]}
+    />
+  );
+}
+
+const Wrapper = styled('div')`
+  padding-top: 10px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-top: 1px solid ${p => p.theme.gray200};
+  margin-top: ${space(1)};
+`;
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  margin: 0;
+`;

--- a/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
@@ -72,10 +72,13 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
   const {ContainerActions, organization, InteractiveTitle, fields} = props;
   const pageError = usePageError();
   const theme = useTheme();
-  const {data: projectData, isLoading: isProjectWebVitalDataLoading} =
-    useProjectWebVitalsQuery();
   const colors = [...theme.charts.getColorPalette(5)].reverse();
   const field = fields[0];
+
+  // TODO Abdullah Khan: Create a new widget type/file for Best Page Opportunity
+  // Web vitals widget. Code path is very different from generic stacked area chart widget.
+  const {data: projectData, isLoading: isProjectWebVitalDataLoading} =
+    useProjectWebVitalsQuery();
 
   const listQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
     () => ({

--- a/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/stackedAreaChartListWidget.tsx
@@ -336,7 +336,7 @@ export function StackedAreaChartListWidget(props: PerformanceWidgetProps) {
         return (
           <Chart
             stacked
-            height={150}
+            height={props.chartHeight}
             data={formatTimeSeriesResultsToChartData(
               formattedWebVitalsScoreBreakdown,
               segmentColors


### PR DESCRIPTION
The pr adds the new Performance score widget to the **Performance Landing > All transactions** tab under the feature flag `starfish-browser-webvitals-pageoverview-v2`.

![Screenshot 2023-11-06 at 4 07 15 PM](https://github.com/getsentry/sentry/assets/60121741/3d81722b-a066-4021-9017-50807623cc82)
