### PR TITLE
chore: Revert releases rows returned to 100

### DIFF
--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -40,7 +40,7 @@ export function useReleases(searchTerm?: string) {
   const eventView = EventView.fromNewQueryWithPageFilters(newQuery, selection);
   const {data: metricsResult, isLoading: isMetricsStatsLoading} = useTableQuery({
     eventView,
-    limit: 250,
+    limit: 100,
     staleTime: Infinity,
   });
 


### PR DESCRIPTION
100 is the default max, so this breaks.
Will increase if necessary, the 250 was
just me trying to be conservative.