### PR TITLE
style(feedback): don't invert colors if checkbox is disabled

### DIFF
--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -78,20 +78,11 @@ function Checkbox({
         color={checkboxColor}
         invertColors={invertColors}
       >
-        {checked === true && !props.disabled && (
+        {checked === true && (
           <VariableWeightIcon
             viewBox="0 0 16 16"
             size={checkboxSizeMap[size].icon}
-            invertColors={invertColors}
-          >
-            <path d="M2.86 9.14C4.42 10.7 6.9 13.14 6.86 13.14L12.57 3.43" />
-          </VariableWeightIcon>
-        )}
-        {checked === true && props.disabled && (
-          <VariableWeightIcon
-            viewBox="0 0 16 16"
-            size={checkboxSizeMap[size].icon}
-            invertColors={false}
+            invertColors={props.disabled ? false : invertColors}
           >
             <path d="M2.86 9.14C4.42 10.7 6.9 13.14 6.86 13.14L12.57 3.43" />
           </VariableWeightIcon>

--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -78,11 +78,20 @@ function Checkbox({
         color={checkboxColor}
         invertColors={invertColors}
       >
-        {checked === true && (
+        {checked === true && !props.disabled && (
           <VariableWeightIcon
             viewBox="0 0 16 16"
             size={checkboxSizeMap[size].icon}
             invertColors={invertColors}
+          >
+            <path d="M2.86 9.14C4.42 10.7 6.9 13.14 6.86 13.14L12.57 3.43" />
+          </VariableWeightIcon>
+        )}
+        {checked === true && props.disabled && (
+          <VariableWeightIcon
+            viewBox="0 0 16 16"
+            size={checkboxSizeMap[size].icon}
+            invertColors={false}
           >
             <path d="M2.86 9.14C4.42 10.7 6.9 13.14 6.86 13.14L12.57 3.43" />
           </VariableWeightIcon>


### PR DESCRIPTION
disabled + selected:
<img width="400" alt="SCR-20231106-metl" src="https://github.com/getsentry/sentry/assets/56095982/b373ca3c-340a-417e-a6ec-07fbac98fec0">
disabled + not selected:
<img width="386" alt="SCR-20231106-meza" src="https://github.com/getsentry/sentry/assets/56095982/0cd5e08d-53d4-4063-96ce-8b063549986a">
checked + not selected:
<img width="401" alt="SCR-20231106-mewm" src="https://github.com/getsentry/sentry/assets/56095982/eac00637-1970-44a7-a64e-fa22a742c598">
checked + selected:
<img width="392" alt="SCR-20231106-meuw" src="https://github.com/getsentry/sentry/assets/56095982/8e856d8a-93b0-4906-b3f1-3f9f13714753">

 fixes https://github.com/getsentry/sentry/issues/59338