### PR TITLE
ref(feedback): don't show 'url not found' when loading

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -120,11 +120,13 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
           </Blockquote>
         </Section>
 
-        <Section icon={<IconLink size="xs" />} title={t('Url')}>
-          <ErrorBoundary mini>
-            <TextCopyInput size="sm">{url?.value ?? t('URL not found')}</TextCopyInput>
-          </ErrorBoundary>
-        </Section>
+        {url && (
+          <Section icon={<IconLink size="xs" />} title={t('Url')}>
+            <ErrorBoundary mini>
+              <TextCopyInput size="sm">{url.value ?? t('URL not found')}</TextCopyInput>
+            </ErrorBoundary>
+          </Section>
+        )}
 
         {hasReplayId && replayId ? (
           <ReplaySection

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -120,13 +120,13 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
           </Blockquote>
         </Section>
 
-        {url && (
-          <Section icon={<IconLink size="xs" />} title={t('Url')}>
-            <ErrorBoundary mini>
-              <TextCopyInput size="sm">{url.value ?? t('URL not found')}</TextCopyInput>
-            </ErrorBoundary>
-          </Section>
-        )}
+        <Section icon={<IconLink size="xs" />} title={t('Url')}>
+          <ErrorBoundary mini>
+            <TextCopyInput size="sm">
+              {eventData?.tags ? (url ? url.value : t('URL not found')) : ''}
+            </TextCopyInput>
+          </ErrorBoundary>
+        </Section>
 
         {hasReplayId && replayId ? (
           <ReplaySection


### PR DESCRIPTION
don't show the feedback URL until it's done loading (show empty string instead)


https://github.com/getsentry/sentry/assets/56095982/ef42080e-5583-4100-b933-8d2e9d8a5b3b

if no URL: same as before

<img width="769" alt="SCR-20231106-mxem" src="https://github.com/getsentry/sentry/assets/56095982/1fa78973-8ca6-4596-84bb-df4138c41680">
