### PR TITLE
fix(issue-stream): Fix default search behavior

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -227,6 +227,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         :qparam bool savedSearch:  if this is set to False, then we are making the request without
                                    a saved search and will look for the default search from this endpoint.
         :qparam string searchId:   if passed in, this is the selected search
+        :qparam bool defaultQuery:  if this is set to true, then we are using the default query for search
         :pparam string organization_slug: the slug of the organization the
                                           issues belong to.
         :auth: required

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -227,7 +227,6 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         :qparam bool savedSearch:  if this is set to False, then we are making the request without
                                    a saved search and will look for the default search from this endpoint.
         :qparam string searchId:   if passed in, this is the selected search
-        :qparam bool defaultQuery:  if this is set to true, then we are using the default query for search
         :pparam string organization_slug: the slug of the organization the
                                           issues belong to.
         :auth: required

--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -78,9 +78,9 @@ def build_query_params_from_request(
             query_kwargs["cursor"] = Cursor.from_string(request.GET.get("cursor"))
         except ValueError:
             raise ParseError(detail="Invalid cursor parameter.")
+    has_query = request.GET.get("query")
     query = request.GET.get("query", "is:unresolved").strip()
-    default_query = request.GET.get("defaultQuery")
-    if request.GET.get("savedSearch") == "0" and request.user and default_query == "1":
+    if request.GET.get("savedSearch") == "0" and request.user and not has_query:
         saved_searches = (
             SavedSearch.objects
             # Do not include pinned or personal searches from other users in

--- a/src/sentry/api/helpers/group_index/index.py
+++ b/src/sentry/api/helpers/group_index/index.py
@@ -79,7 +79,8 @@ def build_query_params_from_request(
         except ValueError:
             raise ParseError(detail="Invalid cursor parameter.")
     query = request.GET.get("query", "is:unresolved").strip()
-    if request.GET.get("savedSearch") == "0" and request.user:
+    default_query = request.GET.get("defaultQuery")
+    if request.GET.get("savedSearch") == "0" and request.user and default_query == "1":
         saved_searches = (
             SavedSearch.objects
             # Do not include pinned or personal searches from other users in


### PR DESCRIPTION
follow up to https://github.com/getsentry/sentry/pull/59452. we need to know if the query being sent from the frontend is the default or not, to know if we need to look for a pinned or selected search. in the past, if there was a query being passed, on load, it would still look for your pinned search. now, we will know if a query is being passed in, and if it is, then we will always use that query on the initial load