### PR TITLE
fix(note email): Fix user avatar in note emails

### DIFF
--- a/src/sentry/notifications/notifications/activity/note.py
+++ b/src/sentry/notifications/notifications/activity/note.py
@@ -46,6 +46,6 @@ class NoteActivityNotification(GroupActivityNotification):
         and want the avatar on it's own rather than bundled with the author's display name
         because the display name is already shown in the notification title."""
         fmt = '<span class="avatar-container">{}</span>'
-        author = format_html(fmt, avatar_as_html(self.user, 48))
-        context = {"author": author}
-        return context
+        if self.user:
+            return format_html(fmt, avatar_as_html(self.user, 48))
+        return format_html(description)

--- a/src/sentry/notifications/notifications/activity/note.py
+++ b/src/sentry/notifications/notifications/activity/note.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional
 
+from django.utils.html import format_html
+from django.utils.safestring import SafeString
+
+from sentry.notifications.utils.avatar import avatar_as_html
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.types.integrations import ExternalProviders
 
@@ -33,3 +37,15 @@ class NoteActivityNotification(GroupActivityNotification):
 
     def get_message_description(self, recipient: RpcActor, provider: ExternalProviders) -> Any:
         return self.get_context()["text_description"]
+
+    def description_as_html(self, description: str, params: Mapping[str, Any]) -> SafeString:
+        """Note emails are formatted differently from almost all other activity emails.
+        Rather than passing the `description` as a string to be formatted into HTML with
+        `author` and `an_issue` (see base definition and resolved.py's `get_description`
+        as an example) we are simply passed the comment as a string that needs no formatting,
+        and want the avatar on it's own rather than bundled with the author's display name
+        because the display name is already shown in the notification title."""
+        fmt = '<span class="avatar-container">{}</span>'
+        author = format_html(fmt, avatar_as_html(self.user, 48))
+        context = {"author": author}
+        return context

--- a/src/sentry/notifications/utils/avatar.py
+++ b/src/sentry/notifications/utils/avatar.py
@@ -38,15 +38,18 @@ def get_sentry_avatar_url() -> str:
     return str(absolute_uri(get_asset_url("sentry", url)))
 
 
-def avatar_as_html(user: User | RpcUser) -> SafeString:
+def avatar_as_html(user: User | RpcUser, size: int = 20) -> SafeString:
     if not user:
         return format_html(
-            '<img class="avatar" src="{}" width="20px" height="20px" />', get_sentry_avatar_url()
+            '<img class="avatar" src="{}" width={}"px" height="{}px" />',
+            get_sentry_avatar_url(),
+            size,
+            size,
         )
     avatar_type = user.get_avatar_type()
     if avatar_type == "upload":
         return format_html('<img class="avatar" src="{}" />', get_user_avatar_url(user))
     elif avatar_type == "letter_avatar":
-        return get_email_avatar(user.get_display_name(), user.get_label(), 20, False)
+        return get_email_avatar(user.get_display_name(), user.get_label(), size, False)
     else:
-        return get_email_avatar(user.get_display_name(), user.get_label(), 20, True)
+        return get_email_avatar(user.get_display_name(), user.get_label(), size, True)

--- a/src/sentry/notifications/utils/avatar.py
+++ b/src/sentry/notifications/utils/avatar.py
@@ -41,7 +41,7 @@ def get_sentry_avatar_url() -> str:
 def avatar_as_html(user: User | RpcUser, size: int = 20) -> SafeString:
     if not user:
         return format_html(
-            '<img class="avatar" src="{}" width={}"px" height="{}px" />',
+            '<img class="avatar" src="{}" width="{}px" height="{}px" />',
             get_sentry_avatar_url(),
             size,
             size,

--- a/src/sentry/templates/sentry/emails/activity/note.html
+++ b/src/sentry/templates/sentry/emails/activity/note.html
@@ -15,13 +15,7 @@
   <table class="note">
     <tr>
       <td class="avatar-column">
-        {% if author.get_avatar_type == 'upload' %}
-          <img class="avatar" src="{% profile_photo_url author.id 48 %}">
-        {% elif author.get_avatar_type == 'letter_avatar' %}
-          {% email_avatar author.get_display_name author.get_label 48 False %}
-        {% else %}
-          {% email_avatar author.get_display_name author.get_label 48 %}
-        {% endif %}
+          {{ html_description.author }}
       </td>
       <td class="notch-column">
         <img width="7" height="48" src="{% absolute_asset_url 'sentry' 'images/email/avatar-notch.png' %}">

--- a/src/sentry/templates/sentry/emails/activity/note.html
+++ b/src/sentry/templates/sentry/emails/activity/note.html
@@ -15,7 +15,7 @@
   <table class="note">
     <tr>
       <td class="avatar-column">
-          {{ html_description.author }}
+          {{ html_description }}
       </td>
       <td class="notch-column">
         <img width="7" height="48" src="{% absolute_asset_url 'sentry' 'images/email/avatar-notch.png' %}">


### PR DESCRIPTION
Fix broken user avatars in note emails - they currently always look like this with the question mark:

<img width="466" alt="note-activity-broken-avatar" src="https://github.com/getsentry/sentry/assets/29959063/6304d198-9d0a-4458-afdd-c2286d885ced">

But after the fix they look like this:
(with a letter avatar)
<img width="717" alt="note-activity-letter-avatar" src="https://github.com/getsentry/sentry/assets/29959063/b4ef54f1-24e0-4184-9050-48b9b156d8bc">
(with an uploaded image avatar)
<img width="725" alt="note-activity-uploaded-avatar" src="https://github.com/getsentry/sentry/assets/29959063/08d9ceaf-fe80-438b-9214-89a814257efb">


`description_as_html` works well for most other activity (aka workflow) notifications because it expects to be passed a template string that it fills in and formats as HTML, but for note activity notifications (aka comments) there is no template string, it just needs to render the comment that was left on the issue. Also because of a different design, I needed to rewrite building up the avatar HTML because other workflow notifications (like resolving an issue, for example) render the user avatar and email address on the same line as the text and that's added in the template like this:
![Screenshot 2023-11-06 at 1 09 52 PM](https://github.com/getsentry/sentry/assets/29959063/0d0c6412-8bf9-4d66-822f-dd82a83e3775)
but for note activity notifications, the title has the email address of the user who commented on the issue, and then the description needs to render _only_ the user avatar and then the comment. 


Fixes #58420 