### PR TITLE
ref(slug): Remove option, change mixin to custom slug serializer field

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -11,9 +11,8 @@ import sentry_sdk
 from django.conf import settings
 from django.http import HttpResponse
 from django.http.request import HttpRequest
-from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
-from rest_framework import serializers, status
+from rest_framework import status
 from rest_framework.authentication import BaseAuthentication, SessionAuthentication
 from rest_framework.exceptions import ParseError
 from rest_framework.permissions import BasePermission
@@ -87,13 +86,6 @@ DEFAULT_AUTHENTICATION = (
 logger = logging.getLogger(__name__)
 audit_logger = logging.getLogger("sentry.audit.api")
 api_access_logger = logging.getLogger("sentry.access.api")
-
-DEFAULT_SLUG_PATTERN = r"^[a-z0-9_\-]+$"
-NON_NUMERIC_SLUG_PATTERN = r"^(?![0-9]+$)[a-z0-9_\-]+$"
-DEFAULT_SLUG_ERROR_MESSAGE = _(
-    "Enter a valid slug consisting of lowercase letters, numbers, underscores or hyphens. "
-    "It cannot be entirely numeric."
-)
 
 
 def allow_cors_options(func):
@@ -575,17 +567,6 @@ class ReleaseAnalyticsMixin:
             project_ids=project_ids,
             user_agent=request.META.get("HTTP_USER_AGENT", ""),
         )
-
-
-class PreventNumericSlugMixin:
-    def validate_slug(self, slug: str) -> str:
-        """
-        Validates that the slug is not entirely numeric. Requires a feature flag
-        to be turned on.
-        """
-        if options.get("api.prevent-numeric-slugs") and slug.isdecimal():
-            raise serializers.ValidationError(DEFAULT_SLUG_ERROR_MESSAGE)
-        return slug
 
 
 def resolve_region(request: HttpRequest) -> Optional[str]:

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
@@ -1,4 +1,3 @@
-from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -6,6 +5,7 @@ from rest_framework.response import Response
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppInstallationsBaseEndpoint
+from sentry.api.fields.sentry_slug import SentrySlugField
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.constants import SENTRY_APP_SLUG_MAX_LENGTH
@@ -14,21 +14,10 @@ from sentry.sentry_apps.installations import SentryAppInstallationCreator
 
 
 class SentryAppInstallationsSerializer(serializers.Serializer):
-    slug = serializers.RegexField(
-        r"^[a-z0-9_\-]+$",
+    slug = SentrySlugField(
+        required=True,
         max_length=SENTRY_APP_SLUG_MAX_LENGTH,
-        error_messages={
-            "invalid": _(
-                "Enter a valid slug consisting of lowercase letters, "
-                "numbers, underscores or hyphens."
-            )
-        },
     )
-
-    def validate(self, attrs):
-        if not attrs.get("slug"):
-            raise serializers.ValidationError("Sentry App slug is required")
-        return attrs
 
 
 @control_silo_endpoint

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -5,7 +6,6 @@ from rest_framework.response import Response
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppInstallationsBaseEndpoint
-from sentry.api.fields.sentry_slug import SentrySlugField
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.constants import SENTRY_APP_SLUG_MAX_LENGTH
@@ -14,10 +14,21 @@ from sentry.sentry_apps.installations import SentryAppInstallationCreator
 
 
 class SentryAppInstallationsSerializer(serializers.Serializer):
-    slug = SentrySlugField(
-        required=True,
+    slug = serializers.RegexField(
+        r"^[a-z0-9_\-]+$",
         max_length=SENTRY_APP_SLUG_MAX_LENGTH,
+        error_messages={
+            "invalid": _(
+                "Enter a valid slug consisting of lowercase letters, "
+                "numbers, underscores or hyphens."
+            )
+        },
     )
+
+    def validate(self, attrs):
+        if not attrs.get("slug"):
+            raise serializers.ValidationError("Sentry App slug is required")
+        return attrs
 
 
 @control_silo_endpoint

--- a/src/sentry/api/endpoints/organization_slugs.py
+++ b/src/sentry/api/endpoints/organization_slugs.py
@@ -1,10 +1,8 @@
 from django.core.exceptions import ValidationError
-from django.core.validators import validate_slug
 from django.db import IntegrityError, router, transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import options
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
@@ -36,10 +34,7 @@ class SlugsUpdateEndpoint(OrganizationEndpoint):
         for project_id, slug in slugs.items():
             slug = slug.lower()
             try:
-                if options.get("api.prevent-numeric-slugs"):
-                    validate_sentry_slug(slug)
-                else:
-                    validate_slug(slug)
+                validate_sentry_slug(slug)
             except ValidationError:
                 return Response({"detail": 'Invalid slug "%s".' % slug}, status=400)
             slugs[project_id] = slug

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -10,13 +10,9 @@ from rest_framework.response import Response
 
 from sentry import audit_log
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import (
-    DEFAULT_SLUG_ERROR_MESSAGE,
-    DEFAULT_SLUG_PATTERN,
-    PreventNumericSlugMixin,
-    region_silo_endpoint,
-)
+from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.fields.sentry_slug import SentrySlugField
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.team import TeamSerializer, TeamSerializerResponse
@@ -46,15 +42,13 @@ class OrganizationTeamsPermission(OrganizationPermission):
 
 
 @extend_schema_serializer(exclude_fields=["idp_provisioned"], deprecate_fields=["name"])
-class TeamPostSerializer(serializers.Serializer, PreventNumericSlugMixin):
-    slug = serializers.RegexField(
-        DEFAULT_SLUG_PATTERN,
+class TeamPostSerializer(serializers.Serializer):
+    slug = SentrySlugField(
         help_text="""Uniquely identifies a team and is used for the interface. If not
         provided, it is automatically generated from the name.""",
         max_length=50,
         required=False,
         allow_null=True,
-        error_messages={"invalid": DEFAULT_SLUG_ERROR_MESSAGE},
     )
     name = serializers.CharField(
         help_text="""**`[DEPRECATED]`** The name for the team. If not provided, it is

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -13,15 +13,11 @@ from rest_framework.serializers import ListField
 
 from sentry import audit_log, features
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import (
-    DEFAULT_SLUG_ERROR_MESSAGE,
-    DEFAULT_SLUG_PATTERN,
-    PreventNumericSlugMixin,
-    region_silo_endpoint,
-)
+from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.api.decorators import sudo_required
 from sentry.api.fields.empty_integer import EmptyIntegerField
+from sentry.api.fields.sentry_slug import SentrySlugField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import DetailedProjectSerializer
 from sentry.api.serializers.rest_framework.list import EmptyListField
@@ -138,17 +134,15 @@ class ProjectMemberSerializer(serializers.Serializer):
         "recapServerToken",
     ]
 )
-class ProjectAdminSerializer(ProjectMemberSerializer, PreventNumericSlugMixin):
+class ProjectAdminSerializer(ProjectMemberSerializer):
     name = serializers.CharField(
         help_text="The name for the project",
         max_length=200,
         required=False,
     )
-    slug = serializers.RegexField(
-        DEFAULT_SLUG_PATTERN,
-        max_length=50,
-        error_messages={"invalid": DEFAULT_SLUG_ERROR_MESSAGE},
+    slug = SentrySlugField(
         help_text="Uniquely identifies a project and is used for the interface.",
+        max_length=50,
         required=False,
     )
     platform = serializers.CharField(
@@ -270,7 +264,6 @@ class ProjectAdminSerializer(ProjectMemberSerializer, PreventNumericSlugMixin):
             raise serializers.ValidationError(
                 "Another project (%s) is already using that slug" % other.name
             )
-        slug = super().validate_slug(slug)
         return slug
 
     def validate_relayPiiConfig(self, value):

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -7,14 +7,10 @@ from rest_framework.response import Response
 
 from sentry import audit_log, features, roles
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import (
-    DEFAULT_SLUG_ERROR_MESSAGE,
-    DEFAULT_SLUG_PATTERN,
-    PreventNumericSlugMixin,
-    region_silo_endpoint,
-)
+from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.decorators import sudo_required
+from sentry.api.fields.sentry_slug import SentrySlugField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.team import TeamSerializer as ModelTeamSerializer
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
@@ -22,11 +18,9 @@ from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.models.team import Team, TeamStatus
 
 
-class TeamSerializer(CamelSnakeModelSerializer, PreventNumericSlugMixin):
-    slug = serializers.RegexField(
-        DEFAULT_SLUG_PATTERN,
+class TeamSerializer(CamelSnakeModelSerializer):
+    slug = SentrySlugField(
         max_length=50,
-        error_messages={"invalid": DEFAULT_SLUG_ERROR_MESSAGE},
     )
     org_role = serializers.ChoiceField(
         choices=tuple(list(roles.get_choices()) + [("")]),
@@ -43,7 +37,6 @@ class TeamSerializer(CamelSnakeModelSerializer, PreventNumericSlugMixin):
         )
         if qs.exists():
             raise serializers.ValidationError(f'The slug "{value}" is already in use.')
-        super().validate_slug(value)
         return value
 
     def validate_org_role(self, value):

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -8,14 +8,9 @@ from rest_framework.response import Response
 
 from sentry import audit_log
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import (
-    DEFAULT_SLUG_ERROR_MESSAGE,
-    DEFAULT_SLUG_PATTERN,
-    EnvironmentMixin,
-    PreventNumericSlugMixin,
-    region_silo_endpoint,
-)
+from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases.team import TeamEndpoint, TeamPermission
+from sentry.api.fields.sentry_slug import SentrySlugField
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import ProjectSummarySerializer, serialize
 from sentry.api.serializers.models.project import OrganizationProjectResponse, ProjectSerializer
@@ -32,18 +27,16 @@ from sentry.utils.snowflake import MaxSnowflakeRetryError
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '14d', and '30d'"
 
 
-class ProjectPostSerializer(serializers.Serializer, PreventNumericSlugMixin):
+class ProjectPostSerializer(serializers.Serializer):
     name = serializers.CharField(
         help_text="The name for the project.", max_length=50, required=True
     )
-    slug = serializers.RegexField(
-        DEFAULT_SLUG_PATTERN,
+    slug = SentrySlugField(
         help_text="""Uniquely identifies a project and is used for the interface.
         If not provided, it is automatically generated from the name.""",
         max_length=50,
         required=False,
         allow_null=True,
-        error_messages={"invalid": DEFAULT_SLUG_ERROR_MESSAGE},
     )
     platform = serializers.CharField(
         help_text="The platform for the project.", required=False, allow_blank=True, allow_null=True

--- a/src/sentry/api/fields/__init__.py
+++ b/src/sentry/api/fields/__init__.py
@@ -4,5 +4,6 @@ from .empty_decimal import *  # noqa: F401,F403
 from .empty_integer import *  # noqa: F401,F403
 from .multiplechoice import *  # noqa: F401,F403
 from .secret import *  # noqa: F401,F403
+from .sentry_slug import *  # noqa: F401,F403
 from .serializedfile import *  # noqa: F401,F403
 from .user import *  # noqa: F401,F403

--- a/src/sentry/api/fields/sentry_slug.py
+++ b/src/sentry/api/fields/sentry_slug.py
@@ -36,5 +36,5 @@ class SentrySlugField(serializers.RegexField):
         # Avoid using mutable dict for error_messages defaults b/c all calls to
         # the function reuse this one instance, persisting changes between them.
         if error_messages is None:
-            error_messages = self.default_error_messages
+            error_messages = self.default_error_messages.copy()
         super().__init__(regex=regex, error_messages=error_messages, *args, **kwargs)

--- a/src/sentry/api/fields/sentry_slug.py
+++ b/src/sentry/api/fields/sentry_slug.py
@@ -7,20 +7,24 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-# Standard slug pattern:
+r"""
+Standard slug pattern:
 # (?![0-9]+$) - Negative lookahead to ensure the slug is not entirely numeric
 # [a-z0-9_\-] - Matches lowercase letters, numbers, underscores, and hyphens
+"""
 MIXED_SLUG_PATTERN = r"^(?![0-9]+$)[a-z0-9_\-]+$"
 DEFAULT_SLUG_ERROR_MESSAGE = _(
     "Enter a valid slug consisting of lowercase letters, numbers, underscores or hyphens. "
     "It cannot be entirely numeric."
 )
 
-# Organization slug pattern:
-# (?![0-9]+$)   - Negative lookahead to ensure the slug cannot be entirely numeric
-# [a-zA-Z0-9]   - The slug must start with a letter or number
-# [a-zA-Z0-9-]* - The slug can contain letters, numbers, and dashes
-# (?<!-)        - Negative lookbehind to ensure the slug does not end with a dash
+"""
+Organization slug pattern:
+(?![0-9]+$)   - Negative lookahead to ensure the slug is not entirely numeric
+[a-zA-Z0-9]   - Must start with a lowercase letter or number
+[a-zA-Z0-9-]* - Matches lowercase letters, numbers, and hyphens
+(?<!-)        - Negative lookbehind to ensure the slug does not end with a hyphen
+"""
 ORG_SLUG_PATTERN = r"^(?![0-9]+$)[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$"
 
 

--- a/src/sentry/api/fields/sentry_slug.py
+++ b/src/sentry/api/fields/sentry_slug.py
@@ -28,7 +28,7 @@ class SentrySlugField(serializers.RegexField):
 
     def __init__(
         self,
-        regex=MIXED_SLUG_PATTERN,
+        pattern=MIXED_SLUG_PATTERN,
         error_messages=None,
         *args,
         **kwargs,
@@ -37,4 +37,4 @@ class SentrySlugField(serializers.RegexField):
         # the function reuse this one instance, persisting changes between them.
         if error_messages is None:
             error_messages = self.default_error_messages.copy()
-        super().__init__(regex=regex, error_messages=error_messages, *args, **kwargs)
+        super().__init__(pattern, error_messages=error_messages, *args, **kwargs)

--- a/src/sentry/api/fields/sentry_slug.py
+++ b/src/sentry/api/fields/sentry_slug.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from django.utils.translation import gettext_lazy as _
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -13,7 +14,7 @@ DEFAULT_SLUG_ERROR_MESSAGE = _(
 )
 
 
-@extend_schema_field(str)
+@extend_schema_field(field=OpenApiTypes.STR)
 class SentrySlugField(serializers.RegexField):
     """
     A regex field which validates that the input is a valid slug. Allowed

--- a/src/sentry/api/fields/sentry_slug.py
+++ b/src/sentry/api/fields/sentry_slug.py
@@ -28,7 +28,7 @@ class SentrySlugField(serializers.RegexField):
 
     def __init__(
         self,
-        pattern=MIXED_SLUG_PATTERN,
+        regex=MIXED_SLUG_PATTERN,
         error_messages=None,
         *args,
         **kwargs,
@@ -37,4 +37,4 @@ class SentrySlugField(serializers.RegexField):
         # the function reuse this one instance, persisting changes between them.
         if error_messages is None:
             error_messages = self.default_error_messages
-        super().__init__(pattern, error_messages=error_messages, *args, **kwargs)
+        super().__init__(regex=regex, error_messages=error_messages, *args, **kwargs)

--- a/src/sentry/api/fields/sentry_slug.py
+++ b/src/sentry/api/fields/sentry_slug.py
@@ -5,16 +5,17 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
+DEFAULT_SLUG_ERROR_MESSAGE = _(
+    "Enter a valid slug consisting of lowercase letters, numbers, underscores or hyphens. "
+    "It cannot be entirely numeric."
+)
+
 r"""
 Standard slug pattern:
     (?![0-9]+$) - Negative lookahead to ensure the slug is not entirely numeric
     [a-z0-9_\-] - Matches lowercase letters, numbers, underscores, and hyphens
 """
 MIXED_SLUG_PATTERN = r"^(?![0-9]+$)[a-z0-9_\-]+$"
-DEFAULT_SLUG_ERROR_MESSAGE = _(
-    "Enter a valid slug consisting of lowercase letters, numbers, underscores or hyphens. "
-    "It cannot be entirely numeric."
-)
 
 """
 Organization slug pattern:

--- a/src/sentry/api/fields/sentry_slug.py
+++ b/src/sentry/api/fields/sentry_slug.py
@@ -7,8 +7,8 @@ from rest_framework import serializers
 
 r"""
 Standard slug pattern:
-# (?![0-9]+$) - Negative lookahead to ensure the slug is not entirely numeric
-# [a-z0-9_\-] - Matches lowercase letters, numbers, underscores, and hyphens
+    (?![0-9]+$) - Negative lookahead to ensure the slug is not entirely numeric
+    [a-z0-9_\-] - Matches lowercase letters, numbers, underscores, and hyphens
 """
 MIXED_SLUG_PATTERN = r"^(?![0-9]+$)[a-z0-9_\-]+$"
 DEFAULT_SLUG_ERROR_MESSAGE = _(
@@ -18,10 +18,10 @@ DEFAULT_SLUG_ERROR_MESSAGE = _(
 
 """
 Organization slug pattern:
-(?![0-9]+$)   - Negative lookahead to ensure the slug is not entirely numeric
-[a-zA-Z0-9]   - Must start with a lowercase letter or number
-[a-zA-Z0-9-]* - Matches lowercase letters, numbers, and hyphens
-(?<!-)        - Negative lookbehind to ensure the slug does not end with a hyphen
+    (?![0-9]+$)   - Negative lookahead to ensure the slug is not entirely numeric
+    [a-zA-Z0-9]   - Must start with a lowercase letter or number
+    [a-zA-Z0-9-]* - Matches lowercase letters, numbers, and hyphens
+    (?<!-)        - Negative lookbehind to ensure the slug does not end with a hyphen
 """
 ORG_SLUG_PATTERN = r"^(?![0-9]+$)[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$"
 

--- a/src/sentry/api/fields/sentry_slug.py
+++ b/src/sentry/api/fields/sentry_slug.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from django.utils.translation import gettext_lazy as _
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+# (?![0-9]+$) - Negative lookahead to ensure the slug is not entirely numeric
+# [a-z0-9_\-] - Matches lowercase letters, numbers, underscores, and hyphens
+NON_NUMERIC_SLUG_PATTERN = r"^(?![0-9]+$)[a-z0-9_\-]+$"
+DEFAULT_SLUG_ERROR_MESSAGE = _(
+    "Enter a valid slug consisting of lowercase letters, numbers, underscores or hyphens. "
+    "It cannot be entirely numeric."
+)
+
+
+@extend_schema_field(str)
+class SentrySlugField(serializers.RegexField):
+    """
+    A regex field which validates that the input is a valid slug. We default to
+    preventing entirely numeric slugs.
+    """
+
+    default_error_messages = {
+        "invalid": DEFAULT_SLUG_ERROR_MESSAGE,
+    }
+
+    def __init__(
+        self,
+        pattern=NON_NUMERIC_SLUG_PATTERN,
+        error_messages=None,
+        *args,
+        **kwargs,
+    ):
+        # Avoid using mutable dict for error_messages defaults b/c all calls to
+        # the function reuse this one instance, persisting changes between them.
+        if error_messages is None:
+            error_messages = self.default_error_messages
+        super().__init__(pattern, error_messages=error_messages, *args, **kwargs)

--- a/src/sentry/api/fields/sentry_slug.py
+++ b/src/sentry/api/fields/sentry_slug.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 
 # (?![0-9]+$) - Negative lookahead to ensure the slug is not entirely numeric
 # [a-z0-9_\-] - Matches lowercase letters, numbers, underscores, and hyphens
-NON_NUMERIC_ONLY_SLUG_PATTERN = r"^(?![0-9]+$)[a-z0-9_\-]+$"
+MIXED_SLUG_PATTERN = r"^(?![0-9]+$)[a-z0-9_\-]+$"
 DEFAULT_SLUG_ERROR_MESSAGE = _(
     "Enter a valid slug consisting of lowercase letters, numbers, underscores or hyphens. "
     "It cannot be entirely numeric."
@@ -16,8 +16,9 @@ DEFAULT_SLUG_ERROR_MESSAGE = _(
 @extend_schema_field(str)
 class SentrySlugField(serializers.RegexField):
     """
-    A regex field which validates that the input is a valid slug. We default to
-    preventing entirely numeric slugs.
+    A regex field which validates that the input is a valid slug. Allowed
+    characters are lowercase letters, numbers, underscores, and hyphens. The
+    slug cannot be entirely numeric.
     """
 
     default_error_messages = {
@@ -26,7 +27,7 @@ class SentrySlugField(serializers.RegexField):
 
     def __init__(
         self,
-        pattern=NON_NUMERIC_ONLY_SLUG_PATTERN,
+        pattern=MIXED_SLUG_PATTERN,
         error_messages=None,
         *args,
         **kwargs,

--- a/src/sentry/api/fields/sentry_slug.py
+++ b/src/sentry/api/fields/sentry_slug.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Mapping
-
 from django.utils.translation import gettext_lazy as _
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
@@ -42,7 +40,7 @@ class SentrySlugField(serializers.RegexField):
 
     def __init__(
         self,
-        error_messages: Mapping[str, str] = None,
+        error_messages=None,
         org_slug: bool = False,
         *args,
         **kwargs,
@@ -56,4 +54,4 @@ class SentrySlugField(serializers.RegexField):
         if org_slug:
             pattern = ORG_SLUG_PATTERN
 
-        super().__init__(regex=pattern, error_messages=error_messages, *args, **kwargs)
+        super().__init__(pattern, error_messages=error_messages, *args, **kwargs)

--- a/src/sentry/api/fields/sentry_slug.py
+++ b/src/sentry/api/fields/sentry_slug.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 
 # (?![0-9]+$) - Negative lookahead to ensure the slug is not entirely numeric
 # [a-z0-9_\-] - Matches lowercase letters, numbers, underscores, and hyphens
-NON_NUMERIC_SLUG_PATTERN = r"^(?![0-9]+$)[a-z0-9_\-]+$"
+NON_NUMERIC_ONLY_SLUG_PATTERN = r"^(?![0-9]+$)[a-z0-9_\-]+$"
 DEFAULT_SLUG_ERROR_MESSAGE = _(
     "Enter a valid slug consisting of lowercase letters, numbers, underscores or hyphens. "
     "It cannot be entirely numeric."
@@ -26,7 +26,7 @@ class SentrySlugField(serializers.RegexField):
 
     def __init__(
         self,
-        pattern=NON_NUMERIC_SLUG_PATTERN,
+        pattern=NON_NUMERIC_ONLY_SLUG_PATTERN,
         error_messages=None,
         *args,
         **kwargs,

--- a/src/sentry/api/helpers/slugs.py
+++ b/src/sentry/api/helpers/slugs.py
@@ -1,15 +1,15 @@
 from django.core.validators import RegexValidator
 from django.utils.regex_helper import _lazy_re_compile
 
-from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE, NON_NUMERIC_SLUG_PATTERN
+from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE, NON_NUMERIC_ONLY_SLUG_PATTERN
 
 
 def validate_sentry_slug(slug: str) -> None:
     """
-    Validates a sentry slug matches DEFAULT_SLUG_PATTERN. Raises ValidationError if it does not.
+    Validates a sentry slug matches NON_NUMERIC_ONLY_SLUG_PATTERN. Raises ValidationError if it does not.
     """
     validator = RegexValidator(
-        _lazy_re_compile(NON_NUMERIC_SLUG_PATTERN),
+        _lazy_re_compile(NON_NUMERIC_ONLY_SLUG_PATTERN),
         DEFAULT_SLUG_ERROR_MESSAGE,
         "invalid",
     )

--- a/src/sentry/api/helpers/slugs.py
+++ b/src/sentry/api/helpers/slugs.py
@@ -1,15 +1,15 @@
 from django.core.validators import RegexValidator
 from django.utils.regex_helper import _lazy_re_compile
 
-from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE, NON_NUMERIC_ONLY_SLUG_PATTERN
+from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE, MIXED_SLUG_PATTERN
 
 
 def validate_sentry_slug(slug: str) -> None:
     """
-    Validates a sentry slug matches NON_NUMERIC_ONLY_SLUG_PATTERN. Raises ValidationError if it does not.
+    Validates a sentry slug matches MIXED_SLUG_PATTERN. Raises ValidationError if it does not.
     """
     validator = RegexValidator(
-        _lazy_re_compile(NON_NUMERIC_ONLY_SLUG_PATTERN),
+        _lazy_re_compile(MIXED_SLUG_PATTERN),
         DEFAULT_SLUG_ERROR_MESSAGE,
         "invalid",
     )

--- a/src/sentry/api/helpers/slugs.py
+++ b/src/sentry/api/helpers/slugs.py
@@ -1,7 +1,7 @@
 from django.core.validators import RegexValidator
 from django.utils.regex_helper import _lazy_re_compile
 
-from sentry.api.base import DEFAULT_SLUG_ERROR_MESSAGE, NON_NUMERIC_SLUG_PATTERN
+from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE, NON_NUMERIC_SLUG_PATTERN
 
 
 def validate_sentry_slug(slug: str) -> None:

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -23,7 +23,7 @@ from sentry_relay.exceptions import RelayError
 from typing_extensions import TypedDict
 
 from sentry import features, onboarding_tasks, quotas, roles
-from sentry.api.base import PreventNumericSlugMixin
+from sentry.api.fields.sentry_slug import SentrySlugField
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.project import ProjectSerializerResponse
 from sentry.api.serializers.models.role import (
@@ -96,15 +96,15 @@ ORGANIZATION_OPTIONS_AS_FEATURES: Mapping[str, List[OptionFeature]] = {
 }
 
 
-class BaseOrganizationSerializer(serializers.Serializer, PreventNumericSlugMixin):
+class BaseOrganizationSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=64)
 
     # The slug pattern consists of the following:
     # [a-zA-Z0-9]   - The slug must start with a letter or number
     # [a-zA-Z0-9-]* - The slug can contain letters, numbers, and dashes
     # (?<!-)        - Negative lookbehind to ensure the slug does not end with a dash
-    slug = serializers.RegexField(
-        r"^[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$",
+    slug = SentrySlugField(
+        pattern=r"^[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$",
         max_length=50,
         error_messages={
             "invalid": _(
@@ -136,7 +136,6 @@ class BaseOrganizationSerializer(serializers.Serializer, PreventNumericSlugMixin
             raise serializers.ValidationError(
                 f'The slug "{value}" should not contain any whitespace.'
             )
-        value = super().validate_slug(value)
         return value
 
 

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -100,11 +100,12 @@ class BaseOrganizationSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=64)
 
     # The slug pattern consists of the following:
+    # (?![0-9]+$)   - Negative lookahead to ensure the slug cannot be entirely numeric
     # [a-zA-Z0-9]   - The slug must start with a letter or number
     # [a-zA-Z0-9-]* - The slug can contain letters, numbers, and dashes
     # (?<!-)        - Negative lookbehind to ensure the slug does not end with a dash
     slug = SentrySlugField(
-        pattern=r"^[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$",
+        regex=r"^(?![0-9]+$)[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$",
         max_length=50,
         error_messages={
             "invalid": _(

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -95,19 +95,17 @@ ORGANIZATION_OPTIONS_AS_FEATURES: Mapping[str, List[OptionFeature]] = {
     ],
 }
 
-ORG_SLUG_PATTERN = r"^(?![0-9]+$)[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$"
-
 
 class BaseOrganizationSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=64)
 
-    # The slug pattern consists of the following:
-    # (?![0-9]+$)   - Negative lookahead to ensure the slug cannot be entirely numeric
-    # [a-zA-Z0-9]   - The slug must start with a letter or number
-    # [a-zA-Z0-9-]* - The slug can contain letters, numbers, and dashes
-    # (?<!-)        - Negative lookbehind to ensure the slug does not end with a dash
+    # XXX: Sentry org slugs are different from other resource slugs. See
+    # SentrySlugField for the full regex pattern. In short, they differ b/c
+    # 1. cannot contain hyphens
+    # 2. must start with a number or letter
+    # 3. cannot end with a dash
     slug = SentrySlugField(
-        pattern=ORG_SLUG_PATTERN,
+        org_slug=True,
         max_length=50,
         error_messages={
             "invalid": _(

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -107,7 +107,7 @@ class BaseOrganizationSerializer(serializers.Serializer):
     # [a-zA-Z0-9-]* - The slug can contain letters, numbers, and dashes
     # (?<!-)        - Negative lookbehind to ensure the slug does not end with a dash
     slug = SentrySlugField(
-        regex=ORG_SLUG_PATTERN,
+        pattern=ORG_SLUG_PATTERN,
         max_length=50,
         error_messages={
             "invalid": _(

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -101,7 +101,7 @@ class BaseOrganizationSerializer(serializers.Serializer):
 
     # XXX: Sentry org slugs are different from other resource slugs. See
     # SentrySlugField for the full regex pattern. In short, they differ b/c
-    # 1. cannot contain hyphens
+    # 1. cannot contain underscores
     # 2. must start with a number or letter
     # 3. cannot end with a dash
     slug = SentrySlugField(

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -95,6 +95,8 @@ ORGANIZATION_OPTIONS_AS_FEATURES: Mapping[str, List[OptionFeature]] = {
     ],
 }
 
+ORG_SLUG_PATTERN = r"^(?![0-9]+$)[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$"
+
 
 class BaseOrganizationSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=64)
@@ -105,7 +107,7 @@ class BaseOrganizationSerializer(serializers.Serializer):
     # [a-zA-Z0-9-]* - The slug can contain letters, numbers, and dashes
     # (?<!-)        - Negative lookbehind to ensure the slug does not end with a dash
     slug = SentrySlugField(
-        regex=r"^(?![0-9]+$)[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$",
+        regex=ORG_SLUG_PATTERN,
         max_length=50,
         error_messages={
             "invalid": _(

--- a/src/sentry/api/serializers/rest_framework/doc_integration.py
+++ b/src/sentry/api/serializers/rest_framework/doc_integration.py
@@ -8,7 +8,6 @@ from jsonschema.exceptions import ValidationError as SchemaValidationError
 from rest_framework import serializers
 from rest_framework.serializers import Serializer, ValidationError
 
-from sentry import options
 from sentry.api.fields.avatar import AvatarField
 from sentry.api.serializers.rest_framework.sentry_app import URLField
 from sentry.api.validators.doc_integration import validate_metadata_schema
@@ -69,7 +68,7 @@ class DocIntegrationSerializer(Serializer):
 
         # If option is set, add random 3 lowercase letter suffix to prevent numeric slug
         # eg: 123 -> 123-abc
-        if options.get("api.prevent-numeric-slugs") and slug.isdecimal():
+        if slug.isdecimal():
             slug = f"{slug}-{''.join(random.choice(string.ascii_lowercase) for _ in range(3))}"
 
         features = validated_data.pop("features") if validated_data.get("features") else []

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -9,7 +9,6 @@ from django.db.models.expressions import BaseExpression, CombinedExpression, Val
 from django.utils.crypto import get_random_string
 from django.utils.text import slugify
 
-from sentry import options
 from sentry.db.exceptions import CannotResolveExpression
 
 COMBINED_EXPRESSION_CALLBACKS = {
@@ -75,14 +74,12 @@ def unique_db_instance(
 
     setattr(inst, field_name, base_value)
 
-    # Don't further mutate if the value is unique
-    if not base_qs.filter(**{f"{field_name}__iexact": base_value}).exists():
-        if options.get("api.prevent-numeric-slugs"):
-            # if feature flag is on, we only return if the slug is not entirely numeric
-            if not base_value.isdecimal():
-                return
-        else:
-            return
+    # Don't further mutate if the value is unique and not entirely numeric
+    if (
+        not base_qs.filter(**{f"{field_name}__iexact": base_value}).exists()
+        and not base_value.isdecimal()
+    ):
+        return
 
     # We want to sanely generate the shortest unique slug possible, so
     # we try different length endings until we get one that works, or bail.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -270,13 +270,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register(
-    "api.prevent-numeric-slugs",
-    default=False,
-    type=Bool,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Beacon
 register("beacon.anonymous", type=Bool, flags=FLAG_REQUIRED)
 

--- a/src/sentry/sentry_apps/apps.py
+++ b/src/sentry/sentry_apps/apps.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 from sentry_sdk.api import push_scope
 
-from sentry import analytics, audit_log, options
+from sentry import analytics, audit_log
 from sentry.constants import SentryAppStatus
 from sentry.coreapi import APIError
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
@@ -301,7 +301,7 @@ class SentryAppCreator:
 
         # If option is set, add random 3 lowercase letter suffix to prevent numeric slug
         # eg: 123 -> 123-abc
-        if options.get("api.prevent-numeric-slugs") and slug.isdecimal():
+        if slug.isdecimal():
             slug = f"{slug}-{''.join(random.choice(string.ascii_lowercase) for _ in range(3))}"
 
         # validate globally unique slug

--- a/tests/sentry/api/endpoints/test_doc_integrations.py
+++ b/tests/sentry/api/endpoints/test_doc_integrations.py
@@ -9,7 +9,6 @@ from sentry.api.serializers.base import serialize
 from sentry.models.integrations.doc_integration import DocIntegration
 from sentry.models.integrations.integration_feature import IntegrationFeature, IntegrationTypes
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.json import JSONData
 
@@ -131,7 +130,6 @@ class PostDocIntegrationsTest(DocIntegrationsTest):
         response = self.get_error_response(status_code=status.HTTP_400_BAD_REQUEST, **payload)
         assert "name" in response.data.keys()
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_generated_slug_not_entirely_numeric(self):
         """
         Tests that generated slug based on name is not entirely numeric

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -34,7 +34,6 @@ from sentry.models.user import User
 from sentry.signals import project_created
 from sentry.silo import SiloMode, unguarded_write
 from sentry.testutils.cases import APITestCase, TwoFactorAPITestCase
-from sentry.testutils.helpers import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_snuba
@@ -375,8 +374,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         self.get_error_response(self.organization.slug, slug="canada-", status_code=400)
         self.get_error_response(self.organization.slug, slug="-canada", status_code=400)
         self.get_error_response(self.organization.slug, slug="----", status_code=400)
-        with override_options({"api.prevent-numeric-slugs": True}):
-            self.get_error_response(self.organization.slug, slug="1234", status_code=400)
+        self.get_error_response(self.organization.slug, slug="1234", status_code=400)
 
     def test_upload_avatar(self):
         data = {

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -361,7 +361,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         self.get_error_response(self.organization.slug, slug=illegal_slug, status_code=400)
 
     def test_valid_slugs(self):
-        valid_slugs = ["santry", "downtown-canada", "1234", "SaNtRy"]
+        valid_slugs = ["santry", "downtown-canada", "1234-foo", "SaNtRy"]
         for slug in valid_slugs:
             self.organization.refresh_from_db()
             self.get_success_response(self.organization.slug, slug=slug)

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -12,7 +12,6 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.team import Team
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase, TwoFactorAPITestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
@@ -180,8 +179,7 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
             self.get_error_response(name="name", slug="canada-", status_code=400)
             self.get_error_response(name="name", slug="-canada", status_code=400)
             self.get_error_response(name="name", slug="----", status_code=400)
-            with override_options({"api.prevent-numeric-slugs": True}):
-                self.get_error_response(name="name", slug="1234", status_code=400)
+            self.get_error_response(name="name", slug="1234", status_code=400)
 
     def test_without_slug(self):
         response = self.get_success_response(name="hello world")
@@ -190,7 +188,6 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
         org = Organization.objects.get(id=organization_id)
         assert org.slug == "hello-world"
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_generated_slug_not_entirely_numeric(self):
         response = self.get_success_response(name="1234")
 

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -4,6 +4,7 @@ import re
 from typing import Any
 from unittest.mock import patch
 
+from sentry.api.serializers.models.organization import ORG_SLUG_PATTERN
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.models.authenticator import Authenticator
 from sentry.models.organization import Organization, OrganizationStatus
@@ -163,7 +164,7 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
         OrganizationMemberTeam.objects.get(organizationmember_id=org_member.id, team_id=team.id)
 
     def test_slugs(self):
-        valid_slugs = ["santry", "downtown-canada", "1234", "CaNaDa"]
+        valid_slugs = ["santry", "downtown-canada", "1234-foo", "CaNaDa"]
         for input_slug in valid_slugs:
             self.organization.refresh_from_db()
             response = self.get_success_response(name=input_slug, slug=input_slug)
@@ -205,7 +206,7 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
         org = Organization.objects.get(id=response.data["id"])
         assert org.slug == "foo"
 
-        org_slug_pattern = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$")
+        org_slug_pattern = re.compile(ORG_SLUG_PATTERN)
 
         response = self.get_success_response(name="---foo---")
         org = Organization.objects.get(id=response.data["id"])
@@ -233,9 +234,9 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
         assert org.slug == "canada"
         assert org_slug_pattern.match(org.slug)
 
-        response = self.get_success_response(name="1234")
+        response = self.get_success_response(name="1234-foo")
         org = Organization.objects.get(id=response.data["id"])
-        assert org.slug == "1234"
+        assert org.slug == "1234-foo"
         assert org_slug_pattern.match(org.slug)
 
     def test_required_terms_with_terms_url(self):

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -4,7 +4,7 @@ import re
 from typing import Any
 from unittest.mock import patch
 
-from sentry.api.serializers.models.organization import ORG_SLUG_PATTERN
+from sentry.api.fields.sentry_slug import ORG_SLUG_PATTERN
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.models.authenticator import Authenticator
 from sentry.models.organization import Organization, OrganizationStatus

--- a/tests/sentry/api/endpoints/test_organization_project_slugs.py
+++ b/tests/sentry/api/endpoints/test_organization_project_slugs.py
@@ -1,6 +1,5 @@
 from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models.project import Project
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import region_silo_test
 
 
@@ -30,7 +29,6 @@ class OrganizationIndexDocs(APIDocsTestCase):
             str(project_two.id): "new-two",
         }
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_invalid_numeric_slug(self):
         invalid_slugs = {**self.slugs, self.project_two.id: "1234"}
         response = self.get_error_response(

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -2,13 +2,12 @@ from functools import cached_property
 
 from django.urls import reverse
 
-from sentry.api.base import DEFAULT_SLUG_ERROR_MESSAGE
+from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.team import Team
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import region_silo_test
 from sentry.types.integrations import get_provider_string
 
@@ -253,14 +252,12 @@ class OrganizationTeamsCreateTest(APITestCase):
             self.organization.slug, name="x" * 65, slug="xxxxxxx", status_code=400
         )
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_invalid_numeric_slug(self):
         response = self.get_error_response(
             self.organization.slug, name="hello word", slug="1234", status_code=400
         )
         assert response.data["slug"][0] == DEFAULT_SLUG_ERROR_MESSAGE
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_generated_slug_not_entirely_numeric(self):
         response = self.get_success_response(self.organization.slug, name="1234", status_code=201)
         team = Team.objects.get(id=response.data["id"])

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -10,7 +10,7 @@ from django.db import router
 from django.urls import reverse
 
 from sentry import audit_log
-from sentry.api.base import DEFAULT_SLUG_ERROR_MESSAGE
+from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE
 from sentry.constants import RESERVED_PROJECT_SLUGS, ObjectStatus
 from sentry.dynamic_sampling import DEFAULT_BIASES, RuleType
 from sentry.dynamic_sampling.rules.base import NEW_MODEL_THRESHOLD_IN_MINUTES
@@ -33,7 +33,6 @@ from sentry.notifications.types import NotificationSettingOptionValues, Notifica
 from sentry.silo import SiloMode, unguarded_write
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import Feature, with_feature
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.integrations import ExternalProviders
@@ -548,7 +547,6 @@ class ProjectUpdateTest(APITestCase):
         project = Project.objects.get(id=self.project.id)
         assert project.slug != new_project.slug
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_invalid_numeric_slug(self):
         response = self.get_error_response(
             self.org_slug,

--- a/tests/sentry/api/endpoints/test_scim_team_details.py
+++ b/tests/sentry/api/endpoints/test_scim_team_details.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.team import Team, TeamStatus
 from sentry.testutils.cases import SCIMTestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import region_silo_test
 
 
@@ -135,7 +134,6 @@ class SCIMDetailPatchTest(SCIMTestCase):
             "sentry.scim.team.update", tags={"organization": self.organization}
         )
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_scim_team_details_patch_rename_team_invalid_slug(self):
         self.base_data["Operations"] = [
             {

--- a/tests/sentry/api/endpoints/test_scim_team_index.py
+++ b/tests/sentry/api/endpoints/test_scim_team_index.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from sentry.models.team import Team
 from sentry.signals import receivers_raise_on_send
 from sentry.testutils.cases import SCIMTestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import region_silo_test
 
 
@@ -236,7 +235,6 @@ class SCIMIndexCreateTest(SCIMTestCase):
         )
         assert response.data["detail"] == "A team with this slug already exists."
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_scim_team_invalid_numeric_slug(self):
         invalid_post_data = {**self.post_data, "displayName": "1234"}
         response = self.get_error_response(

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -18,7 +18,6 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import Feature, with_feature
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.utils import json
 
@@ -541,7 +540,6 @@ class PostSentryAppsTest(SentryAppsTest):
     def test_allows_empty_schema(self):
         self.get_success_response(**self.get_data(shema={}))
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_generated_slug_not_entirely_numeric(self):
         response = self.get_success_response(**self.get_data(name="1234"), status_code=201)
         slug = response.data["slug"]

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -1,5 +1,5 @@
 from sentry import audit_log
-from sentry.api.base import DEFAULT_SLUG_ERROR_MESSAGE
+from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.deletedteam import DeletedTeam
 from sentry.models.scheduledeletion import RegionScheduledDeletion
@@ -9,7 +9,6 @@ from sentry.silo import SiloMode
 from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
@@ -89,7 +88,6 @@ class TeamUpdateTest(TeamDetailsTestBase):
         assert team.name == "hello world"
         assert team.slug == "foobar"
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_invalid_numeric_slug(self):
         response = self.get_error_response(self.organization.slug, self.team.slug, slug="1234")
         assert response.data["slug"][0] == DEFAULT_SLUG_ERROR_MESSAGE

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -1,10 +1,9 @@
-from sentry.api.base import DEFAULT_SLUG_ERROR_MESSAGE
+from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.notifications.types import FallthroughChoiceType
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import region_silo_test
 
 
@@ -64,7 +63,6 @@ class TeamProjectsCreateTest(APITestCase):
         assert project.platform == "python"
         assert project.teams.first() == self.team
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_invalid_numeric_slug(self):
         response = self.get_error_response(
             self.organization.slug,
@@ -76,7 +74,6 @@ class TeamProjectsCreateTest(APITestCase):
 
         assert response.data["slug"][0] == DEFAULT_SLUG_ERROR_MESSAGE
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_generated_slug_not_entirely_numeric(self):
         response = self.get_success_response(
             self.organization.slug,

--- a/tests/sentry/db/models/test_utils.py
+++ b/tests/sentry/db/models/test_utils.py
@@ -1,7 +1,6 @@
 from sentry.db.models.utils import slugify_instance
 from sentry.models.organization import Organization
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 
 
 class SlugifyInstanceTest(TestCase):
@@ -27,7 +26,6 @@ class SlugifyInstanceTest(TestCase):
         slugify_instance(org, org.name, max_length=2)
         assert org.slug == "ma"
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_appends_to_entirely_numeric(self):
         org = Organization(name="1234")
         slugify_instance(org, org.name)

--- a/tests/sentry/hybrid_cloud/rpc_services/test_control_organization_provisioning.py
+++ b/tests/sentry/hybrid_cloud/rpc_services/test_control_organization_provisioning.py
@@ -26,7 +26,6 @@ from sentry.services.organization import (
 )
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import override_options
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 from sentry.types.region import get_local_region
 
@@ -140,7 +139,6 @@ class TestControlOrganizationProvisioning(TestControlOrganizationProvisioningBas
         assert self.provisioning_args.provision_options.slug in new_org_slug_reservation.slug
         assert new_org_slug_reservation.slug != self.provisioning_args.provision_options.slug
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_rewrites_numeric_slug_if_prevent_numeric_option_enabled(self):
         numeric_slug = "123456"
         self.provisioning_args.provision_options.slug = numeric_slug

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 
-from sentry.api.base import DEFAULT_SLUG_ERROR_MESSAGE
+from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE
 from sentry.db.models import BoundedPositiveIntegerField
 from sentry.monitors.constants import TIMEOUT
 from sentry.monitors.models import (

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -1,12 +1,11 @@
 import pytest
 
-from sentry.api.base import DEFAULT_SLUG_ERROR_MESSAGE
+from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE
 from sentry.models.environment import Environment
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
 from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorObjectStatus, ScheduleType
 from sentry.testutils.cases import MonitorTestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import region_silo_test
 
 
@@ -99,7 +98,6 @@ class UpdateMonitorTest(MonitorTestCase):
             self.organization.slug, monitor.slug, method="PUT", status_code=400, **{"slug": None}
         )
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_invalid_numeric_slug(self):
         monitor = self._create_monitor()
         resp = self.get_error_response(

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from django.conf import settings
 from django.test.utils import override_settings
 
-from sentry.api.base import DEFAULT_SLUG_ERROR_MESSAGE
+from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE
 from sentry.models.rule import Rule, RuleSource
 from sentry.monitors.models import (
     Monitor,
@@ -16,7 +16,6 @@ from sentry.monitors.models import (
     ScheduleType,
 )
 from sentry.testutils.cases import MonitorTestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import region_silo_test
 
 
@@ -224,7 +223,6 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
 
         assert response.data["slug"] == "my-monitor"
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_invalid_numeric_slug(self):
         data = {
             "project": self.project.slug,
@@ -236,7 +234,6 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
         response = self.get_error_response(self.organization.slug, **data, status_code=400)
         assert response.data["slug"][0] == DEFAULT_SLUG_ERROR_MESSAGE
 
-    @override_options({"api.prevent-numeric-slugs": True})
     def test_generated_slug_not_entirely_numeric(self):
         data = {
             "project": self.project.slug,


### PR DESCRIPTION
Remove the previous option that we used to rollout this feature.

Also replace the `PreventNumericSlugMixin` with the custom serializer field `SentrySlugField` to prevent entirely numeric slugs.