### PR TITLE
ref(fields): Use drf-spec types over native python types for serializer fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,7 +315,6 @@ module = [
     "sentry.api.serializers.rest_framework.doc_integration",
     "sentry.api.serializers.rest_framework.mentions",
     "sentry.api.serializers.rest_framework.notification_action",
-    "sentry.api.serializers.rest_framework.project",
     "sentry.api.serializers.rest_framework.release",
     "sentry.api.serializers.rest_framework.rule",
     "sentry.api.serializers.rest_framework.sentry_app_request",

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
     from sentry.services.hybrid_cloud.user import RpcUser
 
 
-@extend_schema_field(str)
+@extend_schema_field(field=OpenApiTypes.STR)
 class ActorField(serializers.Field):
     def __init__(self, *args, **kwds):
         self.as_actor = kwds.pop("as_actor", False)

--- a/src/sentry/api/serializers/rest_framework/project.py
+++ b/src/sentry/api/serializers/rest_framework/project.py
@@ -1,3 +1,4 @@
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -6,7 +7,7 @@ from sentry.models.project import Project
 ValidationError = serializers.ValidationError
 
 
-@extend_schema_field(str)
+@extend_schema_field(field=OpenApiTypes.STR)
 class ProjectField(serializers.Field):
     def __init__(self, scope="project:write"):
         self.scope = scope

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -1,3 +1,4 @@
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -11,7 +12,7 @@ from sentry.utils import json
 ValidationError = serializers.ValidationError
 
 
-@extend_schema_field(dict)
+@extend_schema_field(field=OpenApiTypes.OBJECT)
 class RuleNodeField(serializers.Field):
     def __init__(self, type):
         super().__init__()


### PR DESCRIPTION
mypy complained in a recent PR when doing something like `@extend_schema_field(str)`, so I'm switching over the existing ones to use drf-spec types