### PR TITLE
ref(alerts): Replace `PageTimeRangeSelector` component

### DIFF
--- a/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
@@ -21,8 +21,8 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
-import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCopy, IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -461,7 +461,7 @@ function AlertRuleDetails({params, location, router}: AlertRuleDetailsProps) {
                   )}
             </Alert>
           )}
-          <StyledPageTimeRangeSelector
+          <StyledTimeRangeSelector
             relative={period ?? ''}
             start={start ?? null}
             end={end ?? null}
@@ -499,7 +499,7 @@ function AlertRuleDetails({params, location, router}: AlertRuleDetailsProps) {
 
 export default AlertRuleDetails;
 
-const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`
+const StyledTimeRangeSelector = styled(TimeRangeSelector)`
   margin-bottom: ${space(2)};
 `;
 

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -10,10 +10,10 @@ import {LinkButton} from 'sentry/components/button';
 import {getInterval} from 'sentry/components/charts/utils';
 import * as Layout from 'sentry/components/layouts/thirds';
 import type {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
-import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import Placeholder from 'sentry/components/placeholder';
+import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
 import {IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -192,15 +192,15 @@ export default function MetricDetailsBody({
                   )}
             </Alert>
           )}
-          <StyledPageTimeRangeSelector
+          <StyledTimeRangeSelector
             relative={timePeriod.period ?? ''}
             start={(timePeriod.custom && timePeriod.start) || null}
             end={(timePeriod.custom && timePeriod.end) || null}
-            utc={null}
             onChange={handleTimePeriodChange}
             relativeOptions={relativeOptions}
             showAbsolute={false}
             disallowArbitraryRelativeRanges
+            triggerLabel={relativeOptions[timePeriod.period ?? '']}
           />
 
           {showMigrationWarning ? (
@@ -309,6 +309,6 @@ const ChartPanel = styled(Panel)`
   margin-top: ${space(2)};
 `;
 
-const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`
+const StyledTimeRangeSelector = styled(TimeRangeSelector)`
   margin-bottom: ${space(2)};
 `;


### PR DESCRIPTION
`PageTimeRangeSelector` will be removed soon. We can use `TimeRangeSelector` instead.

**Before ——**
<img width="1475" alt="Screenshot 2023-11-06 at 3 51 50 PM" src="https://github.com/getsentry/sentry/assets/44172267/112fb933-2bbc-4900-8814-fa01d468ba52">


**After ——**
<img width="1475" alt="Screenshot 2023-11-06 at 3 52 35 PM" src="https://github.com/getsentry/sentry/assets/44172267/2f57cba2-dbd5-40f9-a4eb-caa9e51ff833">
