### PR TITLE
ref(orgStats): Replace `PageTimeRangeSelector` component

### DIFF
--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -18,8 +18,8 @@ import PageFiltersContainer from 'sentry/components/organizations/pageFilters/co
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
 import {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
-import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
 import {
   DATA_CATEGORY_INFO,
   DEFAULT_RELATIVE_PERIODS,
@@ -44,6 +44,8 @@ import UsageStatsOrg from './usageStatsOrg';
 import UsageStatsProjects from './usageStatsProjects';
 
 const HookHeader = HookOrDefault({hookName: 'component:org-stats-banner'});
+
+const relativeOptions = omit(DEFAULT_RELATIVE_PERIODS, ['1h']);
 
 export const PAGE_QUERY_PARAMS = [
   // From DatePageFilter
@@ -336,13 +338,15 @@ export class OrganizationStats extends Component<OrganizationStatsProps> {
           onChange={opt => this.setStateOnUrl({dataCategory: String(opt.value)})}
         />
 
-        <StyledPageTimeRangeSelector
+        <StyledTimeRangeSelector
           relative={period ?? ''}
           start={start ?? null}
           end={end ?? null}
           utc={utc ?? null}
           onChange={this.handleUpdateDatetime}
-          relativeOptions={omit(DEFAULT_RELATIVE_PERIODS, ['1h'])}
+          relativeOptions={relativeOptions}
+          triggerLabel={period && relativeOptions[period]}
+          triggerProps={{prefix: t('Date Range')}}
         />
       </SelectorGrid>
     );
@@ -473,7 +477,7 @@ const DropdownDataCategory = styled(CompactSelect)`
   }
 `;
 
-const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`
+const StyledTimeRangeSelector = styled(TimeRangeSelector)`
   grid-column: auto / span 1;
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     grid-column: auto / span 2;

--- a/static/app/views/organizationStats/teamInsights/controls.tsx
+++ b/static/app/views/organizationStats/teamInsights/controls.tsx
@@ -8,8 +8,8 @@ import moment from 'moment';
 
 import SelectControl from 'sentry/components/forms/controls/selectControl';
 import {ChangeData} from 'sentry/components/organizations/timeRangeSelector';
-import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
 import TeamSelector from 'sentry/components/teamSelector';
+import {TimeRangeSelector} from 'sentry/components/timeRangeSelector';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DateString, TeamWithProjects} from 'sentry/types';
@@ -21,6 +21,13 @@ import useProjects from 'sentry/utils/useProjects';
 import {dataDatetime} from './utils';
 
 const INSIGHTS_DEFAULT_STATS_PERIOD = '8w';
+
+const relativeOptions = {
+  '14d': t('Last 2 weeks'),
+  '4w': t('Last 4 weeks'),
+  [INSIGHTS_DEFAULT_STATS_PERIOD]: t('Last 8 weeks'),
+  '12w': t('Last 12 weeks'),
+};
 
 const PAGE_QUERY_PARAMS = [
   'pageStatsPeriod',
@@ -208,19 +215,16 @@ function TeamStatsControls({
           inFieldLabel={t('Environment:')}
         />
       )}
-      <StyledPageTimeRangeSelector
+      <StyledTimeRangeSelector
         relative={period ?? ''}
         start={start ?? null}
         end={end ?? null}
         utc={utc ?? null}
         onChange={handleUpdateDatetime}
         showAbsolute={false}
-        relativeOptions={{
-          '14d': t('Last 2 weeks'),
-          '4w': t('Last 4 weeks'),
-          [INSIGHTS_DEFAULT_STATS_PERIOD]: t('Last 8 weeks'),
-          '12w': t('Last 12 weeks'),
-        }}
+        relativeOptions={relativeOptions}
+        triggerLabel={period && relativeOptions[period]}
+        triggerProps={{prefix: t('Date Range')}}
       />
     </ControlsWrapper>
   );
@@ -245,7 +249,7 @@ const StyledTeamSelector = styled(TeamSelector)`
   }
 `;
 
-const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`
+const StyledTimeRangeSelector = styled(TimeRangeSelector)`
   div {
     min-height: unset;
   }


### PR DESCRIPTION
`PageTimeRangeSelector` will be removed soon. We can use `TimeRangeSelector` instead.

**Before ——**
<img width="1475" alt="Screenshot 2023-11-06 at 4 05 01 PM" src="https://github.com/getsentry/sentry/assets/44172267/ff253836-aee0-4048-8508-054d056eadca">

**After ——**
<img width="1475" alt="Screenshot 2023-11-06 at 4 05 35 PM" src="https://github.com/getsentry/sentry/assets/44172267/e10c14d6-f6a1-4ee2-823f-cfe2398cdf8e">
