### PR TITLE
feat(feedback): add level to issues

### DIFF
--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -201,6 +201,7 @@ class ErrorPageEmbedView(View):
                         "email": report.email,
                         "comments": report.comments,
                         "event_id": report.event_id,
+                        "level": "error",  # assume error level from error page embed
                     },
                     event,
                     project,

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -428,6 +428,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
             mock_event_data["contexts"]["feedback"]["associated_event_id"]
             == event_with_replay.event_id
         )
+        assert mock_event_data["level"] == "error"
 
     @patch("sentry.feedback.usecases.create_feedback.produce_occurrence_to_kafka")
     def test_simple_shim_to_feedback_no_event(self, mock_produce_occurrence_to_kafka):
@@ -462,3 +463,4 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         assert mock_event_data["contexts"]["feedback"]["name"] == "Foo Bar"
         assert mock_event_data["platform"] == "other"
         assert mock_event_data["contexts"]["feedback"]["associated_event_id"] == event_id
+        assert mock_event_data["level"] == "info"

--- a/tests/sentry/feedback/test_feedback_ingest.py
+++ b/tests/sentry/feedback/test_feedback_ingest.py
@@ -76,6 +76,18 @@ class FeedbackIngestTest(MonitorIngestTestCase):
             assert feedback.data["platform"] == "javascript"
 
             assert len(mock_produce_occurrence_to_kafka.mock_calls) == 1
+            mock_event_data = mock_produce_occurrence_to_kafka.call_args_list[0][1]["event_data"]
+            assert (
+                mock_event_data["contexts"]["feedback"]["contact_email"] == "colton.allen@sentry.io"
+            )
+            assert (
+                mock_event_data["contexts"]["feedback"]["message"]
+                == "I really like this user-feedback feature!"
+            )
+            assert mock_event_data["contexts"]["feedback"]["name"] == "Colton Allen"
+            assert mock_event_data["platform"] == "javascript"
+            assert "associated_event_id" not in mock_event_data["contexts"]["feedback"]
+            assert mock_event_data["level"] == "info"
 
             self.project.refresh_from_db()
             assert self.project.flags.has_feedbacks

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -270,6 +270,7 @@ class ErrorPageEmbedEnvironmentTest(TestCase):
             assert mock_event_data["contexts"]["feedback"]["name"] == "Jane Bloggs"
             assert mock_event_data["platform"] == "other"
             assert mock_event_data["contexts"]["feedback"]["associated_event_id"] == self.event_id
+            assert mock_event_data["level"] == "error"
 
     @mock.patch("sentry.feedback.usecases.create_feedback.produce_occurrence_to_kafka")
     def test_calls_feedback_shim_no_event_if_ff_enabled(self, mock_produce_occurrence_to_kafka):
@@ -291,3 +292,4 @@ class ErrorPageEmbedEnvironmentTest(TestCase):
             assert mock_event_data["contexts"]["feedback"]["name"] == "Jane Bloggs"
             assert mock_event_data["platform"] == "other"
             assert mock_event_data["contexts"]["feedback"]["associated_event_id"] == self.event_id
+            assert mock_event_data["level"] == "error"


### PR DESCRIPTION
Adjust level based on input. 

- [x] If it's from crash report dialog, assume error
- [x] If there's an event associated and we have access to it, take that event's level
- [x] If no event, assume info.