### PR TITLE
feat(feedback): hide feedback issues by default if not filtered on

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -424,6 +424,8 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                 if gc != GroupCategory.PROFILE.value
                 or features.has("organizations:issue-platform", organization, actor=actor)
             }
+            # if we're not searching for feedbacks, then hide them by default
+            group_categories.discard(GroupCategory.FEEDBACK.value)
 
         if not features.has("organizations:performance-issues-search", organization):
             group_categories.discard(GroupCategory.PERFORMANCE.value)
@@ -1228,7 +1230,6 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         actor: Optional[Any] = None,
         aggregate_kwargs: Optional[PrioritySortWeights] = None,
     ) -> CursorResult[Group]:
-
         if not validate_cdc_search_filters(search_filters):
             raise InvalidQueryForExecutor("Search filters invalid for this query executor")
 


### PR DESCRIPTION
Previously: https://github.com/getsentry/sentry/pull/57528

Instead of trying to control the display of feedbacks, lets just hide them by default unless they are filtered on.

Aspirationally, we'd like to eventually have our own feedbacks endpoint that only displays feedbacks, and have feedbacks hidden from issues search entirely, but I do not see a good way of doing this without it being either extremely hacky, or a lot of work.