### PR TITLE
Disable carryforward for "smart-tests" flag

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -64,9 +64,10 @@ flags:
 flag_management:
   individual_flags:
     - name: smart-tests
-      carryforward: true
+      # Prevents the upload with this flag from being copied accross commits
+      carryforward: false
       # https://docs.codecov.com/docs/getting-started-with-ats#step-2-configure-the-codecovyml-for-automated-test-selection
-      carryforward_mode: "labels"
+      # carryforward_mode: "labels"
       statuses:
         # https://github.com/codecov/shared/blob/main/shared/validation/user_schema.py#L310
         - type: "patch"


### PR DESCRIPTION
The smart-tests flag includes labels, and that is balooning the size of the report saved by Codecov to the point that Codecov can't handle such a large report.

While they deal with it it's best to disable the flag being carried forward.
