### PR TITLE
feat(ddm): Add support for custom metrics in the query builders

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -807,6 +807,9 @@ class MetricsQueryBuilder(QueryBuilder):
 
         This function could be moved entirely in the `MetricsQuery` object but the metrics layer wasn't designed to
         infer the use case id but rather it expects to have it specified from the outside.
+
+        Note that this is an alternative way to compute the use case id, which overrides the `use_case_id()` method
+        which is used for non metrics layer queries.
         """
         use_case_ids = set()
 
@@ -824,14 +827,7 @@ class MetricsQueryBuilder(QueryBuilder):
                 "You can only query metrics belonging to the same use case id."
             )
 
-        use_case_id = use_case_ids.pop()
-        # TODO: remove this hack, since it's just there to avoid touching spans tests which are right now using the
-        #  transactions use case id. From what I have been able to see, the spans have not been properly implemented
-        #  in the metrics layer, thus right now we case to TRANSACTIONS but this HAS to change.
-        if use_case_id == UseCaseID.SPANS:
-            use_case_id = UseCaseID.TRANSACTIONS
-
-        return use_case_id
+        return use_case_ids.pop()
 
     def run_query(self, referrer: str, use_cache: bool = False) -> Any:
         groupby_aliases = [

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -805,8 +805,8 @@ class MetricsQueryBuilder(QueryBuilder):
         """
         Extracts the use case from the `MetricsQuery` which has to be executed in the metrics layer.
 
-        This function might be moved entirely to the `MetricsQuery` object but this is something that can be done
-        at a later point.
+        This function could be moved entirely in the `MetricsQuery` object but the metrics layer wasn't designed to
+        infer the use case id but rather it expects to have it specified from the outside.
         """
         use_case_ids = set()
 
@@ -824,7 +824,14 @@ class MetricsQueryBuilder(QueryBuilder):
                 "You can only query metrics belonging to the same use case id."
             )
 
-        return use_case_ids.pop()
+        use_case_id = use_case_ids.pop()
+        # TODO: remove this hack, since it's just there to avoid touching spans tests which are right now using the
+        #  transactions use case id. From what I have been able to see, the spans have not been properly implemented
+        #  in the metrics layer, thus right now we case to TRANSACTIONS but this HAS to change.
+        if use_case_id == UseCaseID.SPANS:
+            use_case_id = UseCaseID.TRANSACTIONS
+
+        return use_case_id
 
     def run_query(self, referrer: str, use_cache: bool = False) -> Any:
         groupby_aliases = [

--- a/src/sentry/search/events/datasets/metrics_layer.py
+++ b/src/sentry/search/events/datasets/metrics_layer.py
@@ -241,6 +241,20 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
                     result_type_fn=self.reflective_result_type(),
                 ),
                 fields.MetricsFunction(
+                    "last",
+                    required_args=[
+                        fields.MetricArg("column"),
+                    ],
+                    snql_metric_layer=lambda args, alias: Function(
+                        "last",
+                        [
+                            self.resolve_mri(args["column"]),
+                        ],
+                        alias,
+                    ),
+                    result_type_fn=self.reflective_result_type(),
+                ),
+                fields.MetricsFunction(
                     "sum",
                     required_args=[
                         fields.MetricArg("column"),
@@ -301,7 +315,7 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
                     snql_metric_layer=lambda args, alias: Function(
                         "count_unique",
                         [
-                            Column(TransactionMRI.USER.value),
+                            self.resolve_mri(args["column"]),
                         ],
                         alias,
                     ),
@@ -338,10 +352,13 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
                 ),
                 fields.MetricsFunction(
                     "count",
+                    optional_args=[
+                        fields.with_default("transaction.duration", fields.MetricArg("column")),
+                    ],
                     snql_metric_layer=lambda args, alias: Function(
                         "count",
                         [
-                            Column(TransactionMRI.DURATION.value),
+                            self.resolve_mri(args["column"]),
                         ],
                         alias,
                     ),

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2138,17 +2138,16 @@ class MetricArg(FunctionArg):
     def normalize(self, value: str, params: ParamsType, combinator: Optional[Combinator]) -> str:
         from sentry.snuba.metrics.naming_layer.mapping import is_mri
 
+        allowed_column = True
         if self.allowed_columns is not None and len(self.allowed_columns) > 0:
-            allowed_value = (
-                value in self.allowed_columns
-                or (self.allow_custom_measurements and CUSTOM_MEASUREMENT_PATTERN.match(value))
-                or (self.allow_mri and is_mri(value))
+            allowed_column = value in self.allowed_columns or (
+                self.allow_custom_measurements and CUSTOM_MEASUREMENT_PATTERN.match(value)
             )
 
-            if allowed_value:
-                return value
-            else:
-                raise IncompatibleMetricsQuery(f"{value} is not an allowed column")
+        allowed_mri = self.allow_mri and is_mri(value)
+
+        if not allowed_column and not allowed_mri:
+            raise IncompatibleMetricsQuery(f"{value} is not an allowed column")
 
         return value
 

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2140,7 +2140,7 @@ class MetricArg(FunctionArg):
 
         if self.allowed_columns is not None and len(self.allowed_columns) > 0:
             allowed_value = (
-                self.allowed_columns
+                value in self.allowed_columns
                 or (self.allow_custom_measurements and CUSTOM_MEASUREMENT_PATTERN.match(value))
                 or (self.allow_mri and is_mri(value))
             )

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -217,7 +217,7 @@ def _get_entity_of_metric_mri(
         raise InvalidParams
 
     entity_keys_set: frozenset[EntityKey]
-    if use_case_id in [UseCaseID.TRANSACTIONS]:
+    if use_case_id in [UseCaseID.TRANSACTIONS, UseCaseID.SPANS]:
         entity_keys_set = frozenset(
             {
                 EntityKey.GenericMetricsCounters,
@@ -448,7 +448,12 @@ class RawOp(MetricOperation):
         org_id: int,
         params: Optional[MetricOperationParams] = None,
     ) -> Function:
-        if use_case_id in [UseCaseID.TRANSACTIONS, UseCaseID.CUSTOM, UseCaseID.ESCALATING_ISSUES]:
+        if use_case_id in [
+            UseCaseID.TRANSACTIONS,
+            UseCaseID.SPANS,
+            UseCaseID.CUSTOM,
+            UseCaseID.ESCALATING_ISSUES,
+        ]:
             snuba_function = GENERIC_OP_TO_SNUBA_FUNCTION[entity][self.op]
         else:
             snuba_function = OP_TO_SNUBA_FUNCTION[entity][self.op]

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -1028,7 +1028,7 @@ class SnubaQueryBuilder:
         if self._metrics_query.include_series:
             series_limit = limit.limit * intervals_len
 
-            if self._use_case_id is UseCaseID.TRANSACTIONS:
+            if self._use_case_id in [UseCaseID.TRANSACTIONS, UseCaseID.SPANS, UseCaseID.CUSTOM]:
                 time_groupby_column = self.__generate_time_groupby_column_for_discover_queries(
                     self._metrics_query.interval
                 )

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1876,7 +1876,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
         tags: Optional[Dict[str, str]] = None,
         timestamp: Optional[datetime] = None,
         project: Optional[int] = None,
-        use_case_id: UseCaseID = UseCaseID.TRANSACTIONS,  # TODO(wmak): this needs to be the span id
+        use_case_id: UseCaseID = UseCaseID.SPANS,
     ):
         internal_metric = SPAN_METRICS_MAP[metric] if internal_metric is None else internal_metric
         entity = self.ENTITY_MAP[metric] if entity is None else entity
@@ -1904,7 +1904,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
                 tags,
                 int(metric_timestamp),
                 subvalue,
-                use_case_id=UseCaseID.TRANSACTIONS,
+                use_case_id=use_case_id,
             )
 
     def wait_for_metric_count(

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1782,6 +1782,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
         "metrics_distributions": "distribution",
         "metrics_sets": "set",
         "metrics_counters": "counter",
+        "metrics_gauges": "gauge",
     }
     ENTITY_MAP = {
         "transaction.duration": "metrics_distributions",

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1862,7 +1862,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
                 tags,
                 int(metric_timestamp),
                 subvalue,
-                use_case_id=UseCaseID.TRANSACTIONS,
+                use_case_id=use_case_id,
                 aggregation_option=aggregation_option,
             )
 

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -2907,7 +2907,7 @@ class CustomMetricsWithMetricsLayerTest(MetricBuilderBaseTest):
             self.params,
             granularity=3600,
             dataset=Dataset.PerformanceMetrics,
-            selected_columns=[f"sum({mri})"],
+            selected_columns=[f"count({mri})"],
             config=QueryBuilderConfig(
                 use_metrics_layer=True,
             ),
@@ -2915,13 +2915,11 @@ class CustomMetricsWithMetricsLayerTest(MetricBuilderBaseTest):
 
         result = query.run_query("test_query")
 
-        assert result["data"] == [
-            {"sum_d_custom_sentry_process_profile_track_outcome_second": 60.0}
-        ]
+        assert result["data"] == [{"count_d_custom_sentry_process_profile_track_outcome_second": 3}]
         meta = result["meta"]
 
         assert len(meta) == 1
-        assert meta[0]["name"] == "sum_d_custom_sentry_process_profile_track_outcome_second"
+        assert meta[0]["name"] == "count_d_custom_sentry_process_profile_track_outcome_second"
 
     def test_distribution_timeseries_metrics_query(self):
         mri = "d:custom/sentry.process_profile.track_outcome@second"

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -718,7 +718,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithMetricLay
         assert response.status_code == 200, response.content
         data = response.data["data"]
         for (_, value), expected_value in zip(data, [10, 20, 30, 40, 50, 60]):
-            assert value[0]["count"] == expected_value
+            assert value[0]["count"] == expected_value  # type:ignore
 
     def test_distribution_custom_metric(self):
         mri = "d:custom/sentry.process_profile.track_outcome@second"
@@ -748,15 +748,15 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithMetricLay
         data = response.data
         min = data[f"min({mri})"]["data"]
         for (_, value), expected_value in zip(min, [10.0, 20.0, 30.0, 40.0, 50.0, 60.0]):
-            assert value[0]["count"] == expected_value
+            assert value[0]["count"] == expected_value  # type:ignore
 
         max = data[f"max({mri})"]["data"]
         for (_, value), expected_value in zip(max, [30.0, 60.0, 90.0, 120.0, 150.0, 180.0]):
-            assert value[0]["count"] == expected_value
+            assert value[0]["count"] == expected_value  # type:ignore
 
         p90 = data[f"p90({mri})"]["data"]
         for (_, value), expected_value in zip(p90, [28.0, 56.0, 84.0, 112.0, 140.0, 168.0]):
-            assert value[0]["count"] == expected_value
+            assert value[0]["count"] == expected_value  # type:ignore
 
     def test_set_custom_metric(self):
         mri = "s:custom/sentry.process_profile.track_outcome@second"
@@ -786,7 +786,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithMetricLay
         assert response.status_code == 200, response.content
         data = response.data["data"]
         for (_, value), expected_value in zip(data, [1, 1, 1, 1, 1, 1]):
-            assert value[0]["count"] == expected_value
+            assert value[0]["count"] == expected_value  # type:ignore
 
     def test_gauge_custom_metric(self):
         mri = "g:custom/sentry.process_profile.track_outcome@second"
@@ -824,20 +824,20 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithMetricLay
         data = response.data
         min = data[f"min({mri})"]["data"]
         for (_, value), expected_value in zip(min, [10.0, 20.0, 30.0, 40.0, 50.0, 60.0]):
-            assert value[0]["count"] == expected_value
+            assert value[0]["count"] == expected_value  # type:ignore
 
         max = data[f"max({mri})"]["data"]
         for (_, value), expected_value in zip(max, [30.0, 60.0, 90.0, 120.0, 150.0, 180.0]):
-            assert value[0]["count"] == expected_value
+            assert value[0]["count"] == expected_value  # type:ignore
 
         last = data[f"last({mri})"]["data"]
         for (_, value), expected_value in zip(last, [30.0, 60.0, 90.0, 120.0, 150.0, 180.0]):
-            assert value[0]["count"] == expected_value
+            assert value[0]["count"] == expected_value  # type:ignore
 
         sum = data[f"sum({mri})"]["data"]
         for (_, value), expected_value in zip(sum, [40.0, 80.0, 120.0, 160.0, 200.0, 240.0]):
-            assert value[0]["count"] == expected_value
+            assert value[0]["count"] == expected_value  # type:ignore
 
         count = data[f"count({mri})"]["data"]
         for (_, value), expected_value in zip(count, [40, 80, 120, 160, 200, 240]):
-            assert value[0]["count"] == expected_value
+            assert value[0]["count"] == expected_value  # type:ignore

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
@@ -76,7 +76,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
         event_counts = [6, 0, 6, 3, 0, 3]
         for hour, count in enumerate(event_counts):
             for minute in range(count):
-                self.store_transaction_metric(
+                self.store_span_metric(
                     1,
                     internal_metric=constants.SELF_TIME_LIGHT,
                     timestamp=self.day_ago + timedelta(hours=hour, minutes=minute),
@@ -105,7 +105,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
         event_counts = [6, 0, 6, 3, 0, 3]
         for hour, count in enumerate(event_counts):
             for minute in range(count):
-                self.store_transaction_metric(
+                self.store_span_metric(
                     1,
                     internal_metric=constants.SELF_TIME_LIGHT,
                     timestamp=self.day_ago + timedelta(hours=hour, minutes=minute + 30),
@@ -220,6 +220,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
         assert data[1][1][0]["count"] == 4.0
 
     def test_resource_decoded_length(self):
+        self.features["organizations:use-metrics-layer"] = True
         self.store_span_metric(
             4,
             metric="http.decoded_response_content_length",

--- a/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_span_metrics.py
@@ -220,7 +220,6 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(MetricsEnhancedPerformance
         assert data[1][1][0]["count"] == 4.0
 
     def test_resource_decoded_length(self):
-        self.features["organizations:use-metrics-layer"] = True
         self.store_span_metric(
             4,
             metric="http.decoded_response_content_length",


### PR DESCRIPTION
This PR adds the support of custom metrics into the query builder and fixes the lack of support for `UseCaseID.Spans` in the metrics layer.

The fix for the metrics layer was done since the PR depends on it, since when we will turn on the `use-metrics-layer` flag, also spans will go through the metrics layer.

_Note that the support for spans in the metrics layer will also require a follow-up PR in case we want to use the metrics meta and tags endpoints for having autocomplete support for spans metrics. `datasource.py` is the file containing the remaining code that needs a change_.

Closes https://github.com/getsentry/sentry/issues/59613