### PR TITLE
fix(codeowners-sync): Correctly update `date_updated` when codeowners is autosynced

### DIFF
--- a/src/sentry/models/projectcodeowners.py
+++ b/src/sentry/models/projectcodeowners.py
@@ -117,6 +117,8 @@ class ProjectCodeOwners(Model):
             code_mapping=self.repository_project_path_config,
         )
 
+        self.date_updated = timezone.now()
+
         # Convert IssueOwner syntax into schema syntax
         try:
             schema = create_schema_from_issue_owners(

--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -51,14 +51,15 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         assert response.status_code == 204
         assert not ProjectCodeOwners.objects.filter(id=str(self.codeowners.id)).exists()
 
-    def test_basic_update(self):
+    @patch("django.utils.timezone.now")
+    def test_basic_update(self, mock_timezone_now):
         self.create_external_team(external_name="@getsentry/frontend", integration=self.integration)
         self.create_external_team(external_name="@getsentry/docs", integration=self.integration)
         date = datetime(2023, 10, 3, tzinfo=timezone.utc)
+        mock_timezone_now.return_value = date
         raw = "\n# cool stuff comment\n*.js                    @getsentry/frontend @NisanthanNanthakumar\n# good comment\n\n\n  docs/*  @getsentry/docs @getsentry/ecosystem\n\n"
         data = {
             "raw": raw,
-            "date_updated": date,
         }
         with self.feature({"organizations:integrations-codeowners": True}):
             response = self.client.put(self.url, data)


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/59096

While investigating the above issue, I found that the sync was working for me locally, but the sync time was not updating correctly. This change ensure that `date_updated` doesn't get stale when the row is modified.