### PR TITLE
feat(backup): Remove some options from exports

### DIFF
--- a/fixtures/backup/duplicate-username-and-organization-slug.json
+++ b/fixtures/backup/duplicate-username-and-organization-slug.json
@@ -1,26 +1,6 @@
 [
 {
   "model": "sentry.option",
-  "pk": 1,
-  "fields": {
-    "key": "sentry:last_worker_ping",
-    "last_updated": "2023-06-27T21:40:01.305Z",
-    "last_updated_by": "unknown",
-    "value": 1687902001.2623305
-  }
-},
-{
-  "model": "sentry.option",
-  "pk": 2,
-  "fields": {
-    "key": "sentry:last_worker_version",
-    "last_updated": "2023-06-27T21:40:01.312Z",
-    "last_updated_by": "unknown",
-    "value": "\"23.7.0.dev0\""
-  }
-},
-{
-  "model": "sentry.option",
   "pk": 3,
   "fields": {
     "key": "sentry:install-id",

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -137,7 +137,13 @@ class BaseModel(models.Model):
 
     @classmethod
     def query_for_relocation_export(cls, q: models.Q, pk_map: PrimaryKeyMap) -> models.Q:
-        """ """
+        """
+        Create a custom query for performing exports. This is useful when we can't use the usual
+        method of filtering by foreign keys of already-seen models, and allows us to export a
+        smaller subset of data than "all models of this kind".
+
+        The `q` argument represents the exist query. This method should modify that query, then return it.
+        """
 
         model_name = get_model_name(cls)
         model_relations = dependencies()[model_name]

--- a/src/sentry/models/options/option.py
+++ b/src/sentry/models/options/option.py
@@ -5,6 +5,7 @@ import abc
 from django.db import models
 from django.utils import timezone
 
+from sentry.backup.dependencies import PrimaryKeyMap
 from sentry.backup.mixins import OverwritableConfigMixin
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
@@ -44,6 +45,11 @@ class BaseOption(OverwritableConfigMixin, Model):
     value = PickledObjectField()
 
     __repr__ = sane_repr("key", "value")
+
+    @classmethod
+    def query_for_relocation_export(cls, q: models.Q, pk_map: PrimaryKeyMap) -> models.Q:
+        # These ping options change too frequently to be useful in exports.
+        return q & ~models.Q(key__in={"sentry:last_worker_ping", "sentry:last_worker_version"})
 
 
 @region_silo_only_model

--- a/tests/sentry/backup/test_snapshots.py
+++ b/tests/sentry/backup/test_snapshots.py
@@ -14,6 +14,8 @@ from sentry.testutils.silo import region_silo_test
 @region_silo_test
 @django_db_all(transaction=True, reset_sequences=True)
 def test_good_fresh_install(tmp_path):
+    # TODO(getsentry/team-ospo#190): Once we release 23.12.0, we have fulfilled our "two versions
+    # back" promise, and we can remove `sentry:latest*` options from `fresh_install.json`.
     import_export_from_fixture_then_validate(
         tmp_path, "fresh-install.json", get_default_comparators()
     )

--- a/tests/sentry/backup/test_validate.py
+++ b/tests/sentry/backup/test_validate.py
@@ -18,7 +18,7 @@ def test_good_ignore_differing_pks(tmp_path):
                 "model": "sentry.option",
                 "pk": 2,
                 "fields": {
-                "key": "sentry:last_worker_version",
+                "key": "sentry:latest_version",
                 "last_updated": "2023-06-23T00:00:00.000Z",
                 "last_updated_by": "unknown",
                 "value": "\\"23.7.1\\""
@@ -34,7 +34,7 @@ def test_good_ignore_differing_pks(tmp_path):
                 "model": "sentry.option",
                 "pk": 3,
                 "fields": {
-                "key": "sentry:last_worker_version",
+                "key": "sentry:latest_version",
                 "last_updated": "2023-06-23T00:00:00.000Z",
                 "last_updated_by": "unknown",
                 "value": "\\"23.7.1\\""
@@ -94,7 +94,7 @@ def test_bad_out_of_order_entry(tmp_path):
                 "model": "sentry.option",
                 "pk": 3,
                 "fields": {
-                "key": "sentry:last_worker_version",
+                "key": "sentry:latest_version",
                 "last_updated": "2023-06-23T00:00:00.000Z",
                 "last_updated_by": "unknown",
                 "value": "\\"23.7.1\\""
@@ -141,7 +141,7 @@ def test_bad_extra_left_entry(tmp_path):
                 "model": "sentry.option",
                 "pk": 2,
                 "fields": {
-                "key": "sentry:last_worker_version",
+                "key": "sentry:latest_version",
                 "last_updated": "2023-06-23T00:00:00.000Z",
                 "last_updated_by": "unknown",
                 "value": "\\"23.7.1\\""
@@ -172,7 +172,7 @@ def test_bad_extra_right_entry(tmp_path):
                 "model": "sentry.option",
                 "pk": 2,
                 "fields": {
-                "key": "sentry:last_worker_version",
+                "key": "sentry:latest_version",
                 "last_updated": "2023-06-23T00:00:00.000Z",
                 "last_updated_by": "unknown",
                 "value": "\\"23.7.1\\""


### PR DESCRIPTION
Most options we can export fine. But the ping options aren't useful verify, and are just noise that will be immediately overwritten at the next ping.

Issue: getsentry/team-ospo#203