### PR TITLE
feat(ui): Invalidate entirely numeric org slugs

### DIFF
--- a/static/app/utils/isValidOrgSlug.spec.tsx
+++ b/static/app/utils/isValidOrgSlug.spec.tsx
@@ -11,6 +11,7 @@ describe('isValidOrgSlug', function () {
     expect(isValidOrgSlug('albertos_apples')).toBe(false);
     expect(isValidOrgSlug('sentry-')).toBe(false);
     expect(isValidOrgSlug('-sentry')).toBe(false);
+    expect(isValidOrgSlug('1234')).toBe(false);
     expect(isValidOrgSlug('-')).toBe(false);
     expect(isValidOrgSlug('_')).toBe(false);
     expect(isValidOrgSlug('')).toBe(false);

--- a/static/app/utils/isValidOrgSlug.tsx
+++ b/static/app/utils/isValidOrgSlug.tsx
@@ -1,8 +1,10 @@
-// The isValidOrgSlug function should match the behaviour of this regular expression: ^[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$
+// The isValidOrgSlug function should match the behaviour of this regular expression:
+// ^(?![0-9]+$)[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$
+
 // See: https://bugs.webkit.org/show_bug.cgi?id=174931
 //
-// The ^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$ regex should almost match the above regex.
-const ORG_SLUG_REGEX = new RegExp('^[a-zA-Z0-9][a-zA-Z0-9-]*$');
+// The ^(?![0-9]+$)[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$ regex should almost match the above regex.
+const ORG_SLUG_REGEX = new RegExp('^(?![0-9]+$)[a-zA-Z0-9][a-zA-Z0-9-]*$');
 
 function isValidOrgSlug(orgSlug: string): boolean {
   return (


### PR DESCRIPTION
Changing the regex in https://github.com/getsentry/sentry/pull/59487

Matching frontend to new regex. We used a mixin previously to prevent numeric slugs, but I'm changing it to use pure regex