### PR TITLE
ref(discord): Remove feature flag from logic

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule_trigger_action.py
+++ b/src/sentry/incidents/serializers/alert_rule_trigger_action.py
@@ -1,7 +1,7 @@
 from django.utils.encoding import force_str
 from rest_framework import serializers
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.incidents.logic import (
     InvalidTriggerActionError,
@@ -118,9 +118,7 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                     {"integration": "Integration must be provided for slack"}
                 )
         elif attrs.get("type") == AlertRuleTriggerAction.Type.DISCORD:
-            if not attrs.get("integration_id") or not features.has(
-                "organizations:integrations-discord-metric-alerts", self.context["organization"]
-            ):
+            if not attrs.get("integration_id"):
                 raise serializers.ValidationError(
                     {"integration": "Integration must be provided for discord"}
                 )

--- a/src/sentry/integrations/discord/actions/issue_alert/notification.py
+++ b/src/sentry/integrations/discord/actions/issue_alert/notification.py
@@ -1,6 +1,5 @@
 from typing import Any, Generator, Optional, Sequence
 
-from sentry import features
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.discord.actions.issue_alert.form import DiscordNotifyServiceForm
 from sentry.integrations.discord.client import DiscordClient
@@ -43,11 +42,6 @@ class DiscordNotifyServiceAction(IntegrationEventAction):
             return
 
         def send_notification(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
-            if not features.has(
-                "organizations:integrations-discord-notifications", event.organization
-            ):
-                return
-
             rules = [f.rule for f in futures]
             message = DiscordIssuesMessageBuilder(event.group, event=event, tags=tags, rules=rules)
 

--- a/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
@@ -60,14 +60,13 @@ class AlertRuleTriggerActionSerializerTest(TestCase):
             },
         )
         trigger = create_alert_rule_trigger(alert_rule, "hi", 1000)
-        with self.feature("organizations:integrations-discord-metric-alerts"):
-            action = create_alert_rule_trigger_action(
-                trigger,
-                AlertRuleTriggerAction.Type.DISCORD,
-                AlertRuleTriggerAction.TargetType.SPECIFIC,
-                target_identifier="channel-id",
-                integration_id=integration.id,
-            )
+        action = create_alert_rule_trigger_action(
+            trigger,
+            AlertRuleTriggerAction.Type.DISCORD,
+            AlertRuleTriggerAction.TargetType.SPECIFIC,
+            target_identifier="channel-id",
+            integration_id=integration.id,
+        )
 
         result = serialize(action)
         self.assert_action_serialized(action, result)
@@ -97,14 +96,13 @@ class AlertRuleTriggerActionSerializerTest(TestCase):
             },
         )
         trigger = create_alert_rule_trigger(alert_rule, "hi", 1000)
-        with self.feature("organizations:integrations-discord-metric-alerts"):
-            action = create_alert_rule_trigger_action(
-                trigger,
-                AlertRuleTriggerAction.Type.DISCORD,
-                AlertRuleTriggerAction.TargetType.SPECIFIC,
-                target_identifier=None,
-                integration_id=integration.id,
-            )
+        action = create_alert_rule_trigger_action(
+            trigger,
+            AlertRuleTriggerAction.Type.DISCORD,
+            AlertRuleTriggerAction.TargetType.SPECIFIC,
+            target_identifier=None,
+            integration_id=integration.id,
+        )
 
         result = serialize(action)
         self.assert_action_serialized(action, result)

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -884,6 +884,20 @@ class TestAlertRuleTriggerActionSerializer(TestAlertRuleSerializerBase):
             {"nonFieldErrors": ["User does not belong to this organization"]},
         )
 
+    def test_discord(self):
+        self.run_fail_validation_test(
+            {
+                "type": AlertRuleTriggerAction.get_registered_type(
+                    AlertRuleTriggerAction.Type.DISCORD
+                ).slug,
+                "targetType": ACTION_TARGET_TYPE_TO_STRING[
+                    AlertRuleTriggerAction.TargetType.SPECIFIC
+                ],
+                "targetIdentifier": "123",
+            },
+            {"integration": ["Integration must be provided for discord"]},
+        )
+
     def test_slack(self):
         self.run_fail_validation_test(
             {

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1461,14 +1461,13 @@ class CreateAlertRuleTriggerActionTest(BaseAlertRuleTriggerActionTest, TestCase)
             url=f"https://discord.com/api/v10/channels/{channel_id}",
             json=metadata,
         )
-        with self.feature("organizations:integrations-discord-metric-alerts"):
-            action = create_alert_rule_trigger_action(
-                self.trigger,
-                type,
-                target_type,
-                target_identifier=channel_id,
-                integration_id=integration.id,
-            )
+        action = create_alert_rule_trigger_action(
+            self.trigger,
+            type,
+            target_type,
+            target_identifier=channel_id,
+            integration_id=integration.id,
+        )
         assert action.alert_rule_trigger == self.trigger
         assert action.type == type.value
         assert action.target_type == target_type.value
@@ -1832,14 +1831,13 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
             },
         )
 
-        with self.feature("organizations:integrations-discord-metric-alerts"):
-            action = update_alert_rule_trigger_action(
-                self.action,
-                type,
-                target_type,
-                target_identifier=channel_id,
-                integration_id=integration.id,
-            )
+        action = update_alert_rule_trigger_action(
+            self.action,
+            type,
+            target_type,
+            target_identifier=channel_id,
+            integration_id=integration.id,
+        )
         assert action.alert_rule_trigger == self.trigger
         assert action.type == type.value
         assert action.target_type == target_type.value
@@ -1870,15 +1868,14 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
         target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
         responses.add(method=responses.GET, url=f"{base_url}/channels/{channel_id}", status=404)
 
-        with self.feature("organizations:integrations-discord-metric-alerts"):
-            with pytest.raises(InvalidTriggerActionError):
-                update_alert_rule_trigger_action(
-                    self.action,
-                    type,
-                    target_type,
-                    target_identifier=channel_id,
-                    integration_id=integration.id,
-                )
+        with pytest.raises(InvalidTriggerActionError):
+            update_alert_rule_trigger_action(
+                self.action,
+                type,
+                target_type,
+                target_identifier=channel_id,
+                integration_id=integration.id,
+            )
 
     @responses.activate
     def test_discord_bad_response(self):
@@ -1905,30 +1902,28 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
             method=responses.GET, url=f"{base_url}/channels/{channel_id}", body="Error", status=500
         )
 
-        with self.feature("organizations:integrations-discord-metric-alerts"):
-            with pytest.raises(InvalidTriggerActionError):
-                update_alert_rule_trigger_action(
-                    self.action,
-                    type,
-                    target_type,
-                    target_identifier=channel_id,
-                    integration_id=integration.id,
-                )
+        with pytest.raises(InvalidTriggerActionError):
+            update_alert_rule_trigger_action(
+                self.action,
+                type,
+                target_type,
+                target_identifier=channel_id,
+                integration_id=integration.id,
+            )
 
     @responses.activate
     def test_discord_no_integration(self):
         channel_id = "channel-id"
         type = AlertRuleTriggerAction.Type.DISCORD
         target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
-        with self.feature("organizations:integrations-discord-metric-alerts"):
-            with pytest.raises(InvalidTriggerActionError):
-                update_alert_rule_trigger_action(
-                    self.action,
-                    type,
-                    target_type,
-                    target_identifier=channel_id,
-                    integration_id=None,
-                )
+        with pytest.raises(InvalidTriggerActionError):
+            update_alert_rule_trigger_action(
+                self.action,
+                type,
+                target_type,
+                target_identifier=channel_id,
+                integration_id=None,
+            )
 
     @responses.activate
     @mock.patch("sentry.integrations.discord.utils.channel.validate_channel_id")
@@ -1963,15 +1958,14 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
             },
         )
 
-        with self.feature("organizations:integrations-discord-metric-alerts"):
-            with pytest.raises(ChannelLookupTimeoutError):
-                update_alert_rule_trigger_action(
-                    self.action,
-                    type,
-                    target_type,
-                    target_identifier=channel_id,
-                    integration_id=integration.id,
-                )
+        with pytest.raises(ChannelLookupTimeoutError):
+            update_alert_rule_trigger_action(
+                self.action,
+                type,
+                target_type,
+                target_identifier=channel_id,
+                integration_id=integration.id,
+            )
 
     @responses.activate
     def test_discord_channel_not_in_guild(self):
@@ -2004,15 +1998,14 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
             },
         )
 
-        with self.feature("organizations:integrations-discord-metric-alerts"):
-            with pytest.raises(InvalidTriggerActionError):
-                update_alert_rule_trigger_action(
-                    self.action,
-                    type,
-                    target_type,
-                    target_identifier=channel_id,
-                    integration_id=integration.id,
-                )
+        with pytest.raises(InvalidTriggerActionError):
+            update_alert_rule_trigger_action(
+                self.action,
+                type,
+                target_type,
+                target_identifier=channel_id,
+                integration_id=integration.id,
+            )
 
     @responses.activate
     def test_discord_unsupported_type(self):
@@ -2045,15 +2038,14 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
             },
         )
 
-        with self.feature("organizations:integrations-discord-metric-alerts"):
-            with pytest.raises(InvalidTriggerActionError):
-                update_alert_rule_trigger_action(
-                    self.action,
-                    type,
-                    target_type,
-                    target_identifier=channel_id,
-                    integration_id=integration.id,
-                )
+        with pytest.raises(InvalidTriggerActionError):
+            update_alert_rule_trigger_action(
+                self.action,
+                type,
+                target_type,
+                target_identifier=channel_id,
+                integration_id=integration.id,
+            )
 
 
 class DeleteAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):

--- a/tests/sentry/integrations/discord/test_issue_alert.py
+++ b/tests/sentry/integrations/discord/test_issue_alert.py
@@ -72,8 +72,7 @@ class DiscordIssueAlertTest(RuleTestCase):
         )
         assert len(results) == 1
 
-        with self.feature("organizations:integrations-discord-notifications"):
-            results[0].callback(self.event, futures=[])
+        results[0].callback(self.event, futures=[])
 
         body = responses.calls[0].request.body
         data = json.loads(bytes.decode(body, "utf-8"))
@@ -138,8 +137,7 @@ class DiscordIssueAlertTest(RuleTestCase):
         results = list(self.rule.after(self.event, self.get_state()))
         assert len(results) == 1
 
-        with self.feature("organizations:integrations-discord-notifications"):
-            results[0].callback(self.event, futures=[])
+        results[0].callback(self.event, futures=[])
 
         body = responses.calls[0].request.body
         data = json.loads(bytes.decode(body, "utf-8"))
@@ -166,8 +164,7 @@ class DiscordIssueAlertTest(RuleTestCase):
         results = list(self.rule.after(self.event, self.get_state()))
         assert len(results) == 1
 
-        with self.feature("organizations:integrations-discord-notifications"):
-            results[0].callback(self.event, futures=[])
+        results[0].callback(self.event, futures=[])
 
         body = responses.calls[0].request.body
         data = json.loads(bytes.decode(body, "utf-8"))
@@ -194,8 +191,7 @@ class DiscordIssueAlertTest(RuleTestCase):
         results = list(self.rule.after(self.event, self.get_state()))
         assert len(results) == 1
 
-        with self.feature("organizations:integrations-discord-notifications"):
-            results[0].callback(self.event, futures=[])
+        results[0].callback(self.event, futures=[])
 
         body = responses.calls[0].request.body
         data = json.loads(bytes.decode(body, "utf-8"))
@@ -217,8 +213,7 @@ class DiscordIssueAlertTest(RuleTestCase):
     def test_feature_flag_disabled(self):
         results = list(self.rule.after(self.event, self.get_state()))
         assert len(results) == 1
-        with self.feature("organizations:integrations-discord-notifications"):
-            results[0].callback(self.event, futures=[])
+        results[0].callback(self.event, futures=[])
 
         responses.assert_call_count(
             f"{DiscordClient.MESSAGE_URL.format(channel_id=self.channel_id)}", 0

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -20,7 +20,6 @@ from sentry.rules.filters.base import EventFilter
 from sentry.rules.processor import RuleProcessor
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import install_slack
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
@@ -741,7 +740,6 @@ class RuleProcessorTestFilters(TestCase):
             in mock_post.call_args[1]["data"]["attachments"][0]["content"]["body"][0]["text"]
         )
 
-    @with_feature("organizations:integrations-discord-notifications")
     @patch("sentry.integrations.discord.message_builder.base.DiscordMessageBuilder._build")
     def test_discord_title_link_notification_uuid(self, mock_build):
         integration = self.create_integration(


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/58911

Removes 
- organizations:integrations-discord-notifications
- organizations:integrations-discord-metric-alerts
- organizations:integrations-discord

From usage in python files.