### PR TITLE
ref: match the debian release in the self-hosted builder/runtime

### DIFF
--- a/self-hosted/builder.dockerfile
+++ b/self-hosted/builder.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.16-slim-buster as sdist
+FROM python:3.8.16-slim-bullseye as sdist
 
 LABEL maintainer="oss@sentry.io"
 LABEL org.opencontainers.image.title="Sentry Wheel Builder"


### PR DESCRIPTION
buster is getting pretty close to eol

upgrading getsentry here: https://github.com/getsentry/getsentry/pull/12017