### PR TITLE
fix(starfish): Allow genericDiscoverQuery and api to opt out of forced cancellation via api.clear

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -275,6 +275,13 @@ export type RequestOptions = RequestCallbacks & {
    * Query parameters to add to the requested URL.
    */
   query?: Record<string, any>;
+  /**
+   * By default, requests will be aborted anytime api.clear() is called,
+   * which is commonly used on unmounts. When skipAbort is true, the
+   * request is opted out of this behavior. Useful for when you still
+   * want to cache a request on unmount.
+   */
+  skipAbort?: boolean;
 };
 
 type ClientOptions = {
@@ -483,7 +490,9 @@ export class Client {
 
     // AbortController is optional, though most browser should support it.
     const aborter =
-      typeof AbortController !== 'undefined' ? new AbortController() : undefined;
+      typeof AbortController !== 'undefined' && !options.skipAbort
+        ? new AbortController()
+        : undefined;
 
     // GET requests may not have a body
     const body = method !== 'GET' ? data : undefined;

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -414,7 +414,7 @@ export function useGenericDiscoverQuery<T, P>(props: Props<T, P>) {
 
   const res = useQuery<[T, string | undefined, ResponseMeta<T> | undefined], QueryError>(
     [route, apiPayload],
-    () =>
+    ({signal: _signal}) =>
       doDiscoverQuery<T>(api, url, apiPayload, {
         queryBatching: props.queryBatching,
         skipAbort: props.skipAbort,

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -95,6 +95,11 @@ type BaseDiscoverQueryProps = {
    * A callback to set an error so that the error can be rendered in parent components
    */
   setError?: (errObject: QueryError | undefined) => void;
+  /**
+   * A flag to skip aborting the request when api.clear() is called, which happens
+   * frequently on component unmounts.
+   */
+  skipAbort?: boolean;
 };
 
 export type DiscoverQueryPropsWithContext = BaseDiscoverQueryProps & OptionalContextProps;
@@ -326,9 +331,10 @@ export async function doDiscoverQuery<T>(
   options: {
     queryBatching?: QueryBatching;
     retry?: RetryOptions;
+    skipAbort?: boolean;
   } = {}
 ): Promise<[T, string | undefined, ResponseMeta<T> | undefined]> {
-  const {queryBatching, retry} = options;
+  const {queryBatching, retry, skipAbort} = options;
   if (queryBatching?.batchRequest) {
     return queryBatching.batchRequest(api, url, {
       query: params,
@@ -357,6 +363,7 @@ export async function doDiscoverQuery<T>(
           // marking params as any so as to not cause typescript errors
           ...(params as any),
         },
+        skipAbort,
       });
     } catch (err) {
       error = err;
@@ -410,6 +417,7 @@ export function useGenericDiscoverQuery<T, P>(props: Props<T, P>) {
     () =>
       doDiscoverQuery<T>(api, url, apiPayload, {
         queryBatching: props.queryBatching,
+        skipAbort: props.skipAbort,
       }),
     options
   );

--- a/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/useProjectWebVitalsQuery.tsx
@@ -52,5 +52,6 @@ export const useProjectWebVitalsQuery = ({transaction, tag, dataset}: Props = {}
       enabled: pageFilters.isReady,
       refetchOnWindowFocus: false,
     },
+    skipAbort: true,
   });
 };


### PR DESCRIPTION
Adds an option to genericDiscoverQuery and api to opt out of cancelling inflight requests when api.clear is called. Using this to fix an issue with infinite load because useQuery expects a resolution