### PR TITLE
chore(rules): Deprecate project combined rule index endpoint

### DIFF
--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -7,6 +9,7 @@ from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.paginator import CombinedQuerysetIntermediary, CombinedQuerysetPaginator
 from sentry.api.serializers import CombinedRuleSerializer, serialize
 from sentry.constants import ObjectStatus
@@ -18,10 +21,12 @@ from sentry.snuba.dataset import Dataset
 
 @region_silo_endpoint
 class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
+    DEPRECATION_DATE = datetime.fromisoformat("2024-02-07T00:00:00+00:00:00")
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
 
+    @deprecated(DEPRECATION_DATE, "sentry-api-0-organization-combined-rules")
     def get(self, request: Request, project) -> Response:
         """
         Fetches alert rules and legacy rules for a project. @deprecated. Use OrganizationCombinedRuleIndexEndpoint instead.

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -24,7 +24,7 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
 
     def get(self, request: Request, project) -> Response:
         """
-        Fetches alert rules and legacy rules for a project
+        Fetches alert rules and legacy rules for a project. @deprecated. Use OrganizationCombinedRuleIndexEndpoint instead.
         """
         alert_rules = AlertRule.objects.fetch_for_project(project)
         if not features.has("organizations:performance-view", project.organization):


### PR DESCRIPTION
We don't use this endpoint in the app at all, and it's only being used by 2 customers (who we need to email around the same time this is merged). The `OrganizationCombinedRuleIndexEndpoint` serves the same purpose and can be passed a project.

Closes #55830 