### PR TITLE
ref(feedback): initial onboarding flow

### DIFF
--- a/fixtures/js-stubs/project.tsx
+++ b/fixtures/js-stubs/project.tsx
@@ -28,6 +28,7 @@ export function Project(params: Partial<TProject> = {}): TProject {
     firstTransactionEvent: false,
     groupingAutoUpdate: false,
     groupingConfig: '',
+    hasFeedbacks: false,
     hasMinifiedStackTrace: false,
     hasProfiles: false,
     hasReplays: false,

--- a/static/app/components/feedback/feedbackSetupBanner.tsx
+++ b/static/app/components/feedback/feedbackSetupBanner.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import replaysDeadRageBackground from 'sentry-images/spot/replay-dead-rage-changelog.svg';
 
 import {LinkButton} from 'sentry/components/button';
-import {useHasOrganizationSetupFeedback} from 'sentry/components/feedback/useFeedbackOnboarding';
 import PageBanner from 'sentry/components/replays/pageBanner';
 import {IconBroadcast} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -18,7 +17,6 @@ const LOCAL_STORAGE_KEY = 'feedback-set-up-alert-dismissed';
 
 export default function FeedbackSetupBanner({style}: Props) {
   const {dismiss, isDismissed} = useDismissAlert({key: LOCAL_STORAGE_KEY});
-  const {hasOrgSetupFeedback} = useHasOrganizationSetupFeedback();
 
   const docsButton = (
     <LinkButton
@@ -30,7 +28,7 @@ export default function FeedbackSetupBanner({style}: Props) {
     </LinkButton>
   );
 
-  return isDismissed || hasOrgSetupFeedback ? null : (
+  return isDismissed ? null : (
     <PageBanner
       style={style}
       button={docsButton}

--- a/static/app/components/feedback/feedbackSetupBanner.tsx
+++ b/static/app/components/feedback/feedbackSetupBanner.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import replaysDeadRageBackground from 'sentry-images/spot/replay-dead-rage-changelog.svg';
 
 import {LinkButton} from 'sentry/components/button';
+import {useHasOrganizationSetupFeedback} from 'sentry/components/feedback/useFeedbackOnboarding';
 import PageBanner from 'sentry/components/replays/pageBanner';
 import {IconBroadcast} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -17,6 +18,7 @@ const LOCAL_STORAGE_KEY = 'feedback-set-up-alert-dismissed';
 
 export default function FeedbackSetupBanner({style}: Props) {
   const {dismiss, isDismissed} = useDismissAlert({key: LOCAL_STORAGE_KEY});
+  const {hasOrgSetupFeedback} = useHasOrganizationSetupFeedback();
 
   const docsButton = (
     <LinkButton
@@ -28,7 +30,7 @@ export default function FeedbackSetupBanner({style}: Props) {
     </LinkButton>
   );
 
-  return isDismissed ? null : (
+  return isDismissed || hasOrgSetupFeedback ? null : (
     <PageBanner
       style={style}
       button={docsButton}

--- a/static/app/components/feedback/list/feedbackList.tsx
+++ b/static/app/components/feedback/list/feedbackList.tsx
@@ -11,6 +11,7 @@ import styled from '@emotion/styled';
 import FeedbackListHeader from 'sentry/components/feedback/list/feedbackListHeader';
 import FeedbackListItem from 'sentry/components/feedback/list/feedbackListItem';
 import useListItemCheckboxState from 'sentry/components/feedback/list/useListItemCheckboxState';
+import {useHaveSelectedProjectsSetupFeedback} from 'sentry/components/feedback/useFeedbackOnboarding';
 import useFetchFeedbackInfiniteListData from 'sentry/components/feedback/useFetchFeedbackInfiniteListData';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import PanelItem from 'sentry/components/panels/panelItem';
@@ -48,6 +49,8 @@ export default function FeedbackList() {
     hits,
     knownIds: issues.map(issue => issue.id),
   });
+
+  const {hasSetupOneFeedback} = useHaveSelectedProjectsSetupFeedback();
 
   const listRef = useRef<ReactVirtualizedList>(null);
 
@@ -112,7 +115,9 @@ export default function FeedbackList() {
                         unfilteredItems={issues}
                         clearSearchTerm={clearSearchTerm}
                       >
-                        {t('No feedback received')}
+                        {hasSetupOneFeedback
+                          ? t('No feedback found')
+                          : t('No feedback received yet')}
                       </NoRowRenderer>
                     )
                   }

--- a/static/app/components/feedback/useFeedbackOnboarding.tsx
+++ b/static/app/components/feedback/useFeedbackOnboarding.tsx
@@ -1,0 +1,47 @@
+import {useMemo} from 'react';
+
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
+import {Project} from 'sentry/types';
+import {PageFilters} from 'sentry/types/core';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
+
+function getSelectedProjectList(
+  selectedProjects: PageFilters['projects'],
+  projects: Project[]
+) {
+  if (selectedProjects[0] === ALL_ACCESS_PROJECTS || selectedProjects.length === 0) {
+    return projects;
+  }
+
+  const projectsByProjectId = projects.reduce<Record<string, Project>>((acc, project) => {
+    acc[project.id] = project;
+    return acc;
+  }, {});
+  return selectedProjects.map(id => projectsByProjectId[id]).filter(Boolean);
+}
+
+export function useHasOrganizationSetupFeedback() {
+  const {projects, fetching} = useProjects();
+  const hasOrgSetupFeedback = useMemo(
+    () => projects.some(p => p.hasFeedbacks),
+    [projects]
+  );
+  return {hasOrgSetupFeedback, fetching};
+}
+
+export function useHaveSelectedProjectsSetupFeedback() {
+  const {projects, fetching} = useProjects();
+  const {selection} = usePageFilters();
+
+  const orgSetupOneOrMoreFeedback = useMemo(() => {
+    const selectedProjects = getSelectedProjectList(selection.projects, projects);
+    const hasSetupOneFeedback = selectedProjects.some(project => project.hasFeedbacks);
+    return hasSetupOneFeedback;
+  }, [selection.projects, projects]);
+
+  return {
+    hasSetupOneFeedback: orgSetupOneOrMoreFeedback,
+    fetching,
+  };
+}

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -28,6 +28,7 @@ export type Project = {
   groupingAutoUpdate: boolean;
   groupingConfig: string;
   hasAccess: boolean;
+  hasFeedbacks: boolean;
   hasMinifiedStackTrace: boolean;
   hasProfiles: boolean;
   hasReplays: boolean;


### PR DESCRIPTION
This PR updates a couple empty states using the new `project.hasFeedbacks` flag:

If none of the selected project(s) has setup feedbacks, then we display "no feedback received yet":
<img width="416" alt="SCR-20231107-lzwj" src="https://github.com/getsentry/sentry/assets/56095982/b14874c3-c8ce-481a-b6eb-1aa4bb5b445a">
Once we get designs for this, we'll update this message with some sort of CTA button linking to the docs.

If at least one of the selected project(s) has set up feedbacks but the search filters are just returning nothing, display "no feedbacks found":
<img width="430" alt="SCR-20231107-mabs" src="https://github.com/getsentry/sentry/assets/56095982/537d89a9-e3b0-4e1b-aa13-70409772b5b8">