### PR TITLE
style(replays): increase z-index of network tab close buton

### DIFF
--- a/static/app/views/replays/detail/network/details/index.tsx
+++ b/static/app/views/replays/detail/network/details/index.tsx
@@ -114,7 +114,7 @@ const CloseButtonWrapper = styled('div')`
   right: 0;
   height: 100%;
   padding: ${space(1)};
-  z-index: 2;
+  z-index: ${p => p.theme.zIndex.initial + 1};
   display: flex;
   align-items: center;
 `;

--- a/static/app/views/replays/detail/network/details/index.tsx
+++ b/static/app/views/replays/detail/network/details/index.tsx
@@ -114,7 +114,7 @@ const CloseButtonWrapper = styled('div')`
   right: 0;
   height: 100%;
   padding: ${space(1)};
-  z-index: ${p => p.theme.zIndex.initial};
+  z-index: 2;
   display: flex;
   align-items: center;
 `;


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry/issues/59566. the z-index of the close button is now higher, so it'll always be visible, even if the split divider is hovered

new behavior:

https://github.com/getsentry/sentry/assets/56095982/fd127d45-0978-4ae3-9a07-2c21f8f89a44


(old behavior for reference):


https://github.com/getsentry/sentry/assets/56095982/4c94d017-ef19-4604-b51d-353ed1c96665

