### PR TITLE
chore(stacktrace linking): Remove front end usage of flag

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -154,10 +154,16 @@ describe('Exception Content', function () {
   describe('exception groups', function () {
     const event = TestStubs.Event({entries: [TestStubs.EventEntryExceptionGroup()]});
     const project = TestStubs.Project();
-    const promptResponse = {
-      dismissed_ts: undefined,
-      snoozed_ts: undefined,
-    };
+    beforeEach(() => {
+      const promptResponse = {
+        dismissed_ts: undefined,
+        snoozed_ts: undefined,
+      };
+      MockApiClient.addMockResponse({
+        url: '/prompts-activity/',
+        body: promptResponse,
+      });
+    });
 
     const defaultProps = {
       type: StackType.ORIGINAL,
@@ -171,11 +177,6 @@ describe('Exception Content', function () {
     };
 
     it('displays exception group tree under first exception', function () {
-      MockApiClient.addMockResponse({
-        url: '/prompts-activity/',
-        body: promptResponse,
-      });
-
       render(<Content {...defaultProps} />);
 
       const exceptions = screen.getAllByTestId('exception-value');
@@ -188,11 +189,6 @@ describe('Exception Content', function () {
     });
 
     it('displays exception group tree in first frame when there is no other context', function () {
-      MockApiClient.addMockResponse({
-        url: '/prompts-activity/',
-        body: promptResponse,
-      });
-
       render(<Content {...defaultProps} />);
 
       const exceptions = screen.getAllByTestId('exception-value');
@@ -204,10 +200,6 @@ describe('Exception Content', function () {
     });
 
     it('collapses sub-groups by default', async function () {
-      MockApiClient.addMockResponse({
-        url: '/prompts-activity/',
-        body: promptResponse,
-      });
       render(<Content {...defaultProps} />);
 
       // There are 4 values, but 1 should be hidden
@@ -232,10 +224,6 @@ describe('Exception Content', function () {
     });
 
     it('auto-opens sub-groups when clicking link in tree', async function () {
-      MockApiClient.addMockResponse({
-        url: '/prompts-activity/',
-        body: promptResponse,
-      });
       render(<Content {...defaultProps} />);
 
       expect(screen.queryByRole('heading', {name: 'ValueError'})).not.toBeInTheDocument();

--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -154,6 +154,10 @@ describe('Exception Content', function () {
   describe('exception groups', function () {
     const event = TestStubs.Event({entries: [TestStubs.EventEntryExceptionGroup()]});
     const project = TestStubs.Project();
+    const promptResponse = {
+      dismissed_ts: undefined,
+      snoozed_ts: undefined,
+    };
 
     const defaultProps = {
       type: StackType.ORIGINAL,
@@ -167,6 +171,11 @@ describe('Exception Content', function () {
     };
 
     it('displays exception group tree under first exception', function () {
+      MockApiClient.addMockResponse({
+        url: '/prompts-activity/',
+        body: promptResponse,
+      });
+
       render(<Content {...defaultProps} />);
 
       const exceptions = screen.getAllByTestId('exception-value');
@@ -179,6 +188,11 @@ describe('Exception Content', function () {
     });
 
     it('displays exception group tree in first frame when there is no other context', function () {
+      MockApiClient.addMockResponse({
+        url: '/prompts-activity/',
+        body: promptResponse,
+      });
+
       render(<Content {...defaultProps} />);
 
       const exceptions = screen.getAllByTestId('exception-value');
@@ -190,6 +204,10 @@ describe('Exception Content', function () {
     });
 
     it('collapses sub-groups by default', async function () {
+      MockApiClient.addMockResponse({
+        url: '/prompts-activity/',
+        body: promptResponse,
+      });
       render(<Content {...defaultProps} />);
 
       // There are 4 values, but 1 should be hidden
@@ -214,6 +232,10 @@ describe('Exception Content', function () {
     });
 
     it('auto-opens sub-groups when clicking link in tree', async function () {
+      MockApiClient.addMockResponse({
+        url: '/prompts-activity/',
+        body: promptResponse,
+      });
       render(<Content {...defaultProps} />);
 
       expect(screen.queryByRole('heading', {name: 'ValueError'})).not.toBeInTheDocument();

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
@@ -31,6 +31,10 @@ function renderedComponent(
 }
 
 describe('StackTrace', function () {
+  const promptResponse = {
+    dismissed_ts: undefined,
+    snoozed_ts: undefined,
+  };
   it('renders', function () {
     renderedComponent({});
 
@@ -172,6 +176,10 @@ describe('StackTrace', function () {
   });
 
   it('displays a toggle button when there is more than one non-inapp frame', function () {
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      body: promptResponse,
+    });
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: true};
 
@@ -189,6 +197,10 @@ describe('StackTrace', function () {
   });
 
   it('shows/hides frames when toggle button clicked', async function () {
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      body: promptResponse,
+    });
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: true};
     dataFrames[1] = {...dataFrames[1], function: 'non-in-app-frame'};
@@ -212,6 +224,10 @@ describe('StackTrace', function () {
   });
 
   it('does not display a toggle button when there is only one non-inapp frame', function () {
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      body: promptResponse,
+    });
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: true};
     dataFrames[2] = {...dataFrames[2], inApp: true};
@@ -232,6 +248,10 @@ describe('StackTrace', function () {
 
   describe('if there is a frame with in_app equal to true, display only in_app frames', function () {
     it('displays crashed from only', function () {
+      MockApiClient.addMockResponse({
+        url: '/prompts-activity/',
+        body: promptResponse,
+      });
       const dataFrames = [...data.frames];
 
       const newData = {
@@ -262,6 +282,10 @@ describe('StackTrace', function () {
     });
 
     it('displays called from only', function () {
+      MockApiClient.addMockResponse({
+        url: '/prompts-activity/',
+        body: promptResponse,
+      });
       const dataFrames = [...data.frames];
 
       const newData = {
@@ -295,6 +319,10 @@ describe('StackTrace', function () {
     });
 
     it('displays crashed from and called from', function () {
+      MockApiClient.addMockResponse({
+        url: '/prompts-activity/',
+        body: promptResponse,
+      });
       const dataFrames = [...data.frames];
 
       const newData = {
@@ -329,6 +357,11 @@ describe('StackTrace', function () {
     });
 
     it('displays "occurred in" when event is not an error', function () {
+      MockApiClient.addMockResponse({
+        url: '/prompts-activity/',
+        body: promptResponse,
+      });
+
       const dataFrames = [...data.frames];
 
       const newData = {
@@ -363,6 +396,10 @@ describe('StackTrace', function () {
     });
 
     it('displays "occurred in" when event is an ANR error', function () {
+      MockApiClient.addMockResponse({
+        url: '/prompts-activity/',
+        body: promptResponse,
+      });
       const dataFrames = [...data.frames];
 
       const newData = {

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
@@ -31,10 +31,16 @@ function renderedComponent(
 }
 
 describe('StackTrace', function () {
-  const promptResponse = {
-    dismissed_ts: undefined,
-    snoozed_ts: undefined,
-  };
+  beforeEach(() => {
+    const promptResponse = {
+      dismissed_ts: undefined,
+      snoozed_ts: undefined,
+    };
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      body: promptResponse,
+    });
+  });
   it('renders', function () {
     renderedComponent({});
 
@@ -176,10 +182,6 @@ describe('StackTrace', function () {
   });
 
   it('displays a toggle button when there is more than one non-inapp frame', function () {
-    MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
-      body: promptResponse,
-    });
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: true};
 
@@ -197,10 +199,6 @@ describe('StackTrace', function () {
   });
 
   it('shows/hides frames when toggle button clicked', async function () {
-    MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
-      body: promptResponse,
-    });
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: true};
     dataFrames[1] = {...dataFrames[1], function: 'non-in-app-frame'};
@@ -224,10 +222,6 @@ describe('StackTrace', function () {
   });
 
   it('does not display a toggle button when there is only one non-inapp frame', function () {
-    MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
-      body: promptResponse,
-    });
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: true};
     dataFrames[2] = {...dataFrames[2], inApp: true};
@@ -248,10 +242,6 @@ describe('StackTrace', function () {
 
   describe('if there is a frame with in_app equal to true, display only in_app frames', function () {
     it('displays crashed from only', function () {
-      MockApiClient.addMockResponse({
-        url: '/prompts-activity/',
-        body: promptResponse,
-      });
       const dataFrames = [...data.frames];
 
       const newData = {
@@ -282,10 +272,6 @@ describe('StackTrace', function () {
     });
 
     it('displays called from only', function () {
-      MockApiClient.addMockResponse({
-        url: '/prompts-activity/',
-        body: promptResponse,
-      });
       const dataFrames = [...data.frames];
 
       const newData = {
@@ -319,10 +305,6 @@ describe('StackTrace', function () {
     });
 
     it('displays crashed from and called from', function () {
-      MockApiClient.addMockResponse({
-        url: '/prompts-activity/',
-        body: promptResponse,
-      });
       const dataFrames = [...data.frames];
 
       const newData = {
@@ -357,11 +339,6 @@ describe('StackTrace', function () {
     });
 
     it('displays "occurred in" when event is not an error', function () {
-      MockApiClient.addMockResponse({
-        url: '/prompts-activity/',
-        body: promptResponse,
-      });
-
       const dataFrames = [...data.frames];
 
       const newData = {
@@ -396,10 +373,6 @@ describe('StackTrace', function () {
     });
 
     it('displays "occurred in" when event is an ANR error', function () {
-      MockApiClient.addMockResponse({
-        url: '/prompts-activity/',
-        body: promptResponse,
-      });
       const dataFrames = [...data.frames];
 
       const newData = {

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
@@ -30,6 +30,10 @@ function renderedComponent(
   );
 }
 describe('Native StackTrace', function () {
+  const promptResponse = {
+    dismissed_ts: undefined,
+    snoozed_ts: undefined,
+  };
   it('does not render non in app tags', function () {
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: false};
@@ -47,6 +51,10 @@ describe('Native StackTrace', function () {
   });
 
   it('displays a toggle button when there is more than one non-inapp frame', function () {
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      body: promptResponse,
+    });
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: true};
 
@@ -64,6 +72,10 @@ describe('Native StackTrace', function () {
   });
 
   it('shows/hides frames when toggle button clicked', async function () {
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      body: promptResponse,
+    });
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: true};
     dataFrames[1] = {...dataFrames[1], function: 'non-in-app-frame'};
@@ -87,6 +99,10 @@ describe('Native StackTrace', function () {
   });
 
   it('does not display a toggle button when there is only one non-inapp frame', function () {
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      body: promptResponse,
+    });
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: true};
     dataFrames[2] = {...dataFrames[2], inApp: true};

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
@@ -30,10 +30,16 @@ function renderedComponent(
   );
 }
 describe('Native StackTrace', function () {
-  const promptResponse = {
-    dismissed_ts: undefined,
-    snoozed_ts: undefined,
-  };
+  beforeEach(() => {
+    const promptResponse = {
+      dismissed_ts: undefined,
+      snoozed_ts: undefined,
+    };
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      body: promptResponse,
+    });
+  });
   it('does not render non in app tags', function () {
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: false};
@@ -51,10 +57,6 @@ describe('Native StackTrace', function () {
   });
 
   it('displays a toggle button when there is more than one non-inapp frame', function () {
-    MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
-      body: promptResponse,
-    });
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: true};
 
@@ -72,10 +74,6 @@ describe('Native StackTrace', function () {
   });
 
   it('shows/hides frames when toggle button clicked', async function () {
-    MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
-      body: promptResponse,
-    });
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: true};
     dataFrames[1] = {...dataFrames[1], function: 'non-in-app-frame'};
@@ -99,10 +97,6 @@ describe('Native StackTrace', function () {
   });
 
   it('does not display a toggle button when there is only one non-inapp frame', function () {
-    MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
-      body: promptResponse,
-    });
     const dataFrames = [...data.frames];
     dataFrames[0] = {...dataFrames[0], inApp: true};
     dataFrames[2] = {...dataFrames[2], inApp: true};

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -139,12 +139,7 @@ function Context({
   }
 
   const startLineNo = hasContextSource ? frame.context[0][0] : 0;
-  const hasStacktraceLink =
-    frame.inApp &&
-    !!frame.filename &&
-    isExpanded &&
-    organization?.features.includes('integrations-stacktrace-link');
-
+  const hasStacktraceLink = frame.inApp && !!frame.filename && isExpanded;
   return (
     <Wrapper
       start={startLineNo}

--- a/static/app/components/events/interfaces/threads.spec.tsx
+++ b/static/app/components/events/interfaces/threads.spec.tsx
@@ -9,10 +9,16 @@ import {EventOrGroupType} from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
 
 describe('Threads', function () {
-  const promptResponse = {
-    dismissed_ts: undefined,
-    snoozed_ts: undefined,
-  };
+  beforeEach(() => {
+    const promptResponse = {
+      dismissed_ts: undefined,
+      snoozed_ts: undefined,
+    };
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      body: promptResponse,
+    });
+  });
   const {project, organization} = initializeOrg();
 
   describe('non native platform', function () {
@@ -210,10 +216,6 @@ describe('Threads', function () {
       };
 
       it('renders', function () {
-        MockApiClient.addMockResponse({
-          url: '/prompts-activity/',
-          body: promptResponse,
-        });
         render(<Threads {...props} />, {
           organization,
         });
@@ -237,10 +239,6 @@ describe('Threads', function () {
       });
 
       it('toggle full stack trace button', async function () {
-        MockApiClient.addMockResponse({
-          url: '/prompts-activity/',
-          body: promptResponse,
-        });
         render(<Threads {...props} />, {organization});
 
         expect(screen.queryAllByTestId('stack-trace-frame')).toHaveLength(3);
@@ -255,10 +253,6 @@ describe('Threads', function () {
       });
 
       it('toggle sort by display option', async function () {
-        MockApiClient.addMockResponse({
-          url: '/prompts-activity/',
-          body: promptResponse,
-        });
         render(<Threads {...props} />, {organization});
 
         expect(
@@ -299,10 +293,6 @@ describe('Threads', function () {
       });
 
       it('check display options', async function () {
-        MockApiClient.addMockResponse({
-          url: '/prompts-activity/',
-          body: promptResponse,
-        });
         render(<Threads {...props} />, {organization});
 
         await userEvent.click(screen.getByRole('button', {name: 'Options'}));
@@ -1071,10 +1061,6 @@ describe('Threads', function () {
       });
 
       it('toggle full stack trace button', async function () {
-        MockApiClient.addMockResponse({
-          url: '/prompts-activity/',
-          body: promptResponse,
-        });
         render(<Threads {...props} />, {organization});
 
         expect(screen.queryAllByTestId('stack-trace-frame')).toHaveLength(3);

--- a/static/app/components/events/interfaces/threads.spec.tsx
+++ b/static/app/components/events/interfaces/threads.spec.tsx
@@ -9,6 +9,10 @@ import {EventOrGroupType} from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
 
 describe('Threads', function () {
+  const promptResponse = {
+    dismissed_ts: undefined,
+    snoozed_ts: undefined,
+  };
   const {project, organization} = initializeOrg();
 
   describe('non native platform', function () {
@@ -206,6 +210,10 @@ describe('Threads', function () {
       };
 
       it('renders', function () {
+        MockApiClient.addMockResponse({
+          url: '/prompts-activity/',
+          body: promptResponse,
+        });
         render(<Threads {...props} />, {
           organization,
         });
@@ -229,6 +237,10 @@ describe('Threads', function () {
       });
 
       it('toggle full stack trace button', async function () {
+        MockApiClient.addMockResponse({
+          url: '/prompts-activity/',
+          body: promptResponse,
+        });
         render(<Threads {...props} />, {organization});
 
         expect(screen.queryAllByTestId('stack-trace-frame')).toHaveLength(3);
@@ -243,6 +255,10 @@ describe('Threads', function () {
       });
 
       it('toggle sort by display option', async function () {
+        MockApiClient.addMockResponse({
+          url: '/prompts-activity/',
+          body: promptResponse,
+        });
         render(<Threads {...props} />, {organization});
 
         expect(
@@ -283,6 +299,10 @@ describe('Threads', function () {
       });
 
       it('check display options', async function () {
+        MockApiClient.addMockResponse({
+          url: '/prompts-activity/',
+          body: promptResponse,
+        });
         render(<Threads {...props} />, {organization});
 
         await userEvent.click(screen.getByRole('button', {name: 'Options'}));
@@ -1051,6 +1071,10 @@ describe('Threads', function () {
       });
 
       it('toggle full stack trace button', async function () {
+        MockApiClient.addMockResponse({
+          url: '/prompts-activity/',
+          body: promptResponse,
+        });
         render(<Threads {...props} />, {organization});
 
         expect(screen.queryAllByTestId('stack-trace-frame')).toHaveLength(3);

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -119,10 +119,7 @@ class ConfigureIntegration extends DeprecatedAsyncView<Props, State> {
 
   hasStacktraceLinking(provider: IntegrationProvider) {
     // CodeOwners will only work if the provider has StackTrace Linking
-    return (
-      provider.features.includes('stacktrace-link') &&
-      this.props.organization.features.includes('integrations-stacktrace-link')
-    );
+    return provider.features.includes('stacktrace-link');
   }
 
   hasCodeOwners(provider: IntegrationProvider) {


### PR DESCRIPTION
Remove the front end checking of the stacktrace linking flag since it's available to all customers. Next I'll remove the references in getsentry, then remove the backend usage. 