### PR TITLE
feat(backup): GET /relocations/public-key endpoint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,17 +90,17 @@ Makefile                                                 @getsentry/owners-sentr
 /static/app/components/sidebar/index.tsx                 @getsentry/open-source
 
 ## Relocation - getsentry/team-ospo#153
-/src/sentry/api/endpoints/relocation.py                  @getsentry/open-source
+/src/sentry/api/endpoints/relocation/                    @getsentry/open-source
 /src/sentry/backup/                                      @getsentry/open-source
 /src/sentry/runner/commands/backup.py                    @getsentry/open-source
 /src/sentry/services/hybrid-cloud/import_export/         @getsentry/open-source
 /src/sentry/tasks/relocation.py                          @getsentry/open-source
 /src/sentry/testutils/helpers/backups.py                 @getsentry/open-source
 /src/sentry/utils/relocation.py                          @getsentry/open-source
-/tests/sentry/api/endpoints/test_relocation.py           @getsentry/open-source
+/tests/sentry/api/endpoints/relocation                   @getsentry/open-source
 /tests/sentry/tasks/test_relocation.py                   @getsentry/open-source
 /tests/sentry/utils/test_relocation.py                   @getsentry/open-source
-/tests/sentry/backup                                     @getsentry/open-source
+/tests/sentry/backup/                                    @getsentry/open-source
 /tests/sentry/runner/commands/test_backup.py             @getsentry/open-source
 
 ## Build & Releases

--- a/src/sentry/api/endpoints/relocations/__init__.py
+++ b/src/sentry/api/endpoints/relocations/__init__.py
@@ -1,0 +1,1 @@
+ERR_FEATURE_DISABLED = "This feature is not yet enabled"

--- a/src/sentry/api/endpoints/relocations/public_key.py
+++ b/src/sentry/api/endpoints/relocations/public_key.py
@@ -1,0 +1,43 @@
+import logging
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.endpoints.relocations import ERR_FEATURE_DISABLED
+from sentry.backup.helpers import DEFAULT_CRYPTO_KEY_VERSION, get_public_key_using_gcp_kms
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class RelocationPublicKeyEndpoint(Endpoint):
+    owner = ApiOwner.RELOCATION
+    publish_status = {
+        # TODO(getsentry/team-ospo#214): Stabilize before GA.
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request: Request) -> Response:
+        """
+        Get your public key for relocation encryption.
+        ``````````````````````````````````````````````
+
+        Returns a public key which can be used to create an encrypted export tarball.
+
+        :auth: required
+        """
+
+        logger.info("get.start", extra={"caller": request.user.id})
+        if not features.has("relocation:enabled"):
+            return Response({"detail": ERR_FEATURE_DISABLED}, status=400)
+
+        # TODO(getsentry/team-ospo#190): We should support per-user keys in the future.
+        public_key = get_public_key_using_gcp_kms(DEFAULT_CRYPTO_KEY_VERSION)
+
+        return Response({"public_key": public_key.decode("utf-8")}, status=200)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -37,7 +37,8 @@ from sentry.api.endpoints.release_thresholds.release_threshold_index import (
 from sentry.api.endpoints.release_thresholds.release_threshold_status_index import (
     ReleaseThresholdStatusIndexEndpoint,
 )
-from sentry.api.endpoints.relocation import RelocationEndpoint
+from sentry.api.endpoints.relocations.index import RelocationIndexEndpoint
+from sentry.api.endpoints.relocations.public_key import RelocationPublicKeyEndpoint
 from sentry.api.endpoints.source_map_debug_blue_thunder_edition import (
     SourceMapDebugBlueThunderEditionEndpoint,
 )
@@ -737,6 +738,19 @@ BROADCAST_URLS = [
     re_path(
         r"^(?P<broadcast_id>[^\/]+)/$",
         BroadcastDetailsEndpoint.as_view(),
+    ),
+]
+
+RELOCATION_URLS = [
+    re_path(
+        r"^$",
+        RelocationIndexEndpoint.as_view(),
+        name="sentry-api-0-relocations-index",
+    ),
+    re_path(
+        r"^public-key/$",
+        RelocationPublicKeyEndpoint.as_view(),
+        name="sentry-api-0-relocations-public-key",
     ),
 ]
 
@@ -3022,12 +3036,10 @@ urlpatterns = [
         r"^internal/",
         include(INTERNAL_URLS),
     ),
-    # Relocation
-    # TODO(getsentry/team-ospo#169): Add URL endpoint to pull encryption public key.
+    # Relocations
     re_path(
-        r"^relocation/$",
-        RelocationEndpoint.as_view(),
-        name="sentry-api-0-relocation",
+        r"^relocations/",
+        include(RELOCATION_URLS),
     ),
     # Catch all
     re_path(

--- a/src/sentry/backup/helpers.py
+++ b/src/sentry/backup/helpers.py
@@ -181,6 +181,7 @@ class CryptoKeyVersion(NamedTuple):
     version: str
 
 
+# TODO(getsentry/team-ospo#215): These should be options, instead of hard coding.
 DEFAULT_CRYPTO_KEY_VERSION = CryptoKeyVersion(
     project_id=gcp_project_id(),
     location="global",

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
+from sentry.api.endpoints.relocations import ERR_FEATURE_DISABLED
 from sentry.backup.helpers import create_encrypted_export_tarball
 from sentry.models.relocation import Relocation, RelocationFile
 from sentry.testutils.cases import APITestCase
@@ -19,7 +20,7 @@ FRESH_INSTALL_PATH = get_fixture_path("backup", "fresh-install.json")
 
 @region_silo_test
 class RelocationCreateTest(APITestCase):
-    endpoint = "sentry-api-0-relocation"
+    endpoint = "sentry-api-0-relocations-index"
 
     def setUp(self):
         super().setUp()
@@ -53,9 +54,8 @@ class RelocationCreateTest(APITestCase):
             with self.feature("relocation:enabled"), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
-                    url = reverse("sentry-api-0-relocation")
                     response = self.client.post(
-                        url,
+                        reverse(self.endpoint),
                         {
                             "owner": self.owner.username,
                             "file": SimpleUploadedFile(
@@ -71,7 +71,7 @@ class RelocationCreateTest(APITestCase):
         assert response.status_code == 201
         assert Relocation.objects.count() == relocation_count + 1
         assert RelocationFile.objects.count() == relocation_file_count + 1
-        assert uploading_complete_mock.called == 1
+        assert uploading_complete_mock.call_count == 1
 
     def test_success_relocation_for_same_owner_already_completed(self):
         Relocation.objects.create(
@@ -96,9 +96,8 @@ class RelocationCreateTest(APITestCase):
             with self.feature("relocation:enabled"), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
-                    url = reverse("sentry-api-0-relocation")
                     response = self.client.post(
-                        url,
+                        reverse(self.endpoint),
                         {
                             "owner": self.owner.username,
                             "file": SimpleUploadedFile(
@@ -121,9 +120,8 @@ class RelocationCreateTest(APITestCase):
             with open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
-                    url = reverse("sentry-api-0-relocation")
                     response = self.client.post(
-                        url,
+                        reverse(self.endpoint),
                         {
                             "owner": self.owner.username,
                             "file": SimpleUploadedFile(
@@ -137,14 +135,15 @@ class RelocationCreateTest(APITestCase):
                     )
 
         assert response.status_code == 400
+        assert response.data.get("detail") is not None
+        assert response.data.get("detail") == ERR_FEATURE_DISABLED
 
     def test_fail_missing_file(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
             with self.feature("relocation:enabled"):
-                url = reverse("sentry-api-0-relocation")
                 response = self.client.post(
-                    url,
+                    reverse(self.endpoint),
                     {
                         "owner": self.owner.username,
                         "orgs": ["testing", "foo"],
@@ -162,9 +161,8 @@ class RelocationCreateTest(APITestCase):
             with self.feature("relocation:enabled"), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
-                    url = reverse("sentry-api-0-relocation")
                     response = self.client.post(
-                        url,
+                        reverse(self.endpoint),
                         {
                             "owner": self.owner.username,
                             "file": SimpleUploadedFile(
@@ -186,9 +184,8 @@ class RelocationCreateTest(APITestCase):
             with self.feature("relocation:enabled"), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
-                    url = reverse("sentry-api-0-relocation")
                     response = self.client.post(
-                        url,
+                        reverse(self.endpoint),
                         {
                             "file": SimpleUploadedFile(
                                 "export.tar",
@@ -210,9 +207,8 @@ class RelocationCreateTest(APITestCase):
             with self.feature("relocation:enabled"), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
-                    url = reverse("sentry-api-0-relocation")
                     response = self.client.post(
-                        url,
+                        reverse(self.endpoint),
                         {
                             "owner": "doesnotexist",
                             "file": SimpleUploadedFile(
@@ -242,7 +238,6 @@ class RelocationCreateTest(APITestCase):
             with self.feature("relocation:enabled"), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
-                    url = reverse("sentry-api-0-relocation")
                     simple_file = SimpleUploadedFile(
                         "export.tar",
                         create_encrypted_export_tarball(data, p).getvalue(),
@@ -250,7 +245,7 @@ class RelocationCreateTest(APITestCase):
                     )
                     simple_file.name = None
                     response = self.client.post(
-                        url,
+                        reverse(self.endpoint),
                         {
                             "owner": self.owner.username,
                             "file": simple_file,

--- a/tests/sentry/api/endpoints/relocations/test_public_key.py
+++ b/tests/sentry/api/endpoints/relocations/test_public_key.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.urls import reverse
+from google.api_core.exceptions import GoogleAPIError
+
+from sentry.api.endpoints.relocations import ERR_FEATURE_DISABLED
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.backups import FakeKeyManagementServiceClient, generate_rsa_key_pair
+from sentry.testutils.silo import region_silo_test
+
+
+@patch(
+    "sentry.backup.helpers.KeyManagementServiceClient",
+    new_callable=lambda: FakeKeyManagementServiceClient,
+)
+@region_silo_test
+class RelocationPublicKeyTest(APITestCase):
+    endpoint = "sentry-api-0-relocations-public-key"
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user("user", is_superuser=False, is_staff=True, is_active=True)
+        self.login_as(user=self.user, superuser=True)
+
+        (_, pub_key_pem) = generate_rsa_key_pair()
+        self.pub_key_pem = pub_key_pem
+
+    def mock_kms_client(self, fake_kms_client: FakeKeyManagementServiceClient):
+        fake_kms_client.get_public_key.call_count = 0
+        fake_kms_client.get_public_key.return_value = SimpleNamespace(
+            pem=self.pub_key_pem.decode("utf-8")
+        )
+        fake_kms_client.get_public_key.side_effect = None
+
+    def test_success_simple(self, fake_kms_client: FakeKeyManagementServiceClient):
+        self.mock_kms_client(fake_kms_client)
+
+        with self.feature("relocation:enabled"):
+            response = self.client.get(reverse(self.endpoint), {})
+
+        assert response.status_code == 200
+        assert fake_kms_client.get_public_key.call_count == 1
+
+    def test_fail_feature_disabled(self, fake_kms_client: FakeKeyManagementServiceClient):
+        self.mock_kms_client(fake_kms_client)
+
+        response = self.client.get(reverse(self.endpoint), {})
+
+        assert response.status_code == 400
+        assert fake_kms_client.get_public_key.call_count == 0
+        assert response.data.get("detail") is not None
+        assert response.data.get("detail") == ERR_FEATURE_DISABLED
+
+    def test_fail_network_error(self, fake_kms_client: FakeKeyManagementServiceClient):
+        self.mock_kms_client(fake_kms_client)
+        fake_kms_client.get_public_key.return_value = None
+        fake_kms_client.get_public_key.side_effect = GoogleAPIError("Test")
+
+        with self.feature("relocation:enabled"):
+            response = self.client.get(reverse(self.endpoint), {})
+
+        assert response.status_code == 500
+        assert fake_kms_client.get_public_key.call_count == 1


### PR DESCRIPTION
This allows would-be relocating users to pull down a public key to encrypt their exports into a secure tarball with.

Issue: getsentry/team-ospo#215