### PR TITLE
fix(profile-summary): Charts used wrong units

### DIFF
--- a/static/app/views/profiling/profileSummary/profilingSparklineChart.tsx
+++ b/static/app/views/profiling/profileSummary/profilingSparklineChart.tsx
@@ -20,7 +20,7 @@ function asSeries(
   return {
     data: data.map(p => ({
       name: p.timestamp * 1e3,
-      value: p.value / 1e6 ?? 0,
+      value: p.value ?? 0,
     })),
     color,
     seriesName,
@@ -103,8 +103,8 @@ function makeSeriesBeforeAfterLines(
   beforeLine.markLine = {
     data: [
       [
-        {value: 'Past', coord: [start * 1e3, aggregate_range_1 / 1e6]},
-        {coord: [breakpoint * 1e3, aggregate_range_1 / 1e6]},
+        {value: 'Past', coord: [start * 1e3, aggregate_range_1]},
+        {coord: [breakpoint * 1e3, aggregate_range_1]},
       ],
     ],
     label: {
@@ -132,9 +132,9 @@ function makeSeriesBeforeAfterLines(
       [
         {
           value: 'Present',
-          coord: [breakpoint * 1e3, aggregate_range_2 / 1e6],
+          coord: [breakpoint * 1e3, aggregate_range_2],
         },
-        {coord: [end * 1e3, aggregate_range_2 / 1e6]},
+        {coord: [end * 1e3, aggregate_range_2]},
       ],
     ],
     label: {

--- a/static/app/views/profiling/profileSummary/regressedProfileFunctions.tsx
+++ b/static/app/views/profiling/profileSummary/regressedProfileFunctions.tsx
@@ -274,7 +274,7 @@ export function MostRegressedProfileFunctions(props: MostRegressedProfileFunctio
               </RegressedFunctionMetricsRow>
               <RegressedFunctionSparklineContainer>
                 <ProfilingSparklineChart
-                  name=""
+                  name="p95(function.duration)"
                   points={trendToPoints(fn)}
                   color={trendType === 'improvement' ? theme.green300 : theme.red300}
                   aggregate_range_1={fn.aggregate_range_1}


### PR DESCRIPTION
There was a mix of nanoseconds and milliseconds used on this chart. Make sure to pass everything as nanoseconds until it needs to be converted.