### PR TITLE
feat(browser-starfish): add time spent to resource module page

### DIFF
--- a/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
@@ -16,6 +16,7 @@ import {DurationCell} from 'sentry/views/starfish/components/tableCells/duration
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import {SpanDescriptionCell} from 'sentry/views/starfish/components/tableCells/spanDescriptionCell';
 import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
+import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 import {ModuleName, SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 
@@ -27,6 +28,8 @@ const {
   PROJECT_ID,
   SPAN_GROUP,
 } = SpanMetricsField;
+
+const {TIME_SPENT_PERCENTAGE} = SpanFunction;
 
 const {SPM} = SpanFunction;
 
@@ -41,6 +44,8 @@ type Row = {
   'span.group': string;
   'span.op': `resource.${'script' | 'img' | 'css' | 'iframe' | string}`;
   'spm()': number;
+  'sum(span.self_time)': number;
+  'time_spent_percentage()': number;
 };
 
 type Column = GridColumnHeader<keyof Row>;
@@ -60,11 +65,16 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
   const columnOrder: GridColumnOrder<keyof Row>[] = [
     {key: SPAN_DESCRIPTION, width: COL_WIDTH_UNDEFINED, name: t('Resource Description')},
     {key: SPAN_OP, width: COL_WIDTH_UNDEFINED, name: t('Type')},
-    {key: `avg(${SPAN_SELF_TIME})`, width: COL_WIDTH_UNDEFINED, name: DataTitles.avg},
     {
       key: `${SPM}()`,
       width: COL_WIDTH_UNDEFINED,
       name: getThroughputTitle('http'),
+    },
+    {key: `avg(${SPAN_SELF_TIME})`, width: COL_WIDTH_UNDEFINED, name: DataTitles.avg},
+    {
+      key: `${TIME_SPENT_PERCENTAGE}()`,
+      width: COL_WIDTH_UNDEFINED,
+      name: DataTitles.timeSpent,
     },
     {
       key: `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
@@ -119,6 +129,11 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
         row['http.response_content_length'] ===
         row['http.decoded_response_content_length'];
       return <span>{isUncompressed ? t('true') : t('false')}</span>;
+    }
+    if (key === 'time_spent_percentage()') {
+      return (
+        <TimeSpentCell percentage={row[key]} total={row[`sum(${SPAN_SELF_TIME})`]} />
+      );
     }
     return <span>{row[key]}</span>;
   };

--- a/static/app/views/performance/browser/resources/utils/useResourceSort.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceSort.ts
@@ -1,10 +1,11 @@
 import {fromSorts} from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 
 const {SPAN_SELF_TIME, SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH} = SpanMetricsField;
+const {TIME_SPENT_PERCENTAGE} = SpanFunction;
 
 type Query = {
   sort?: string;
@@ -15,6 +16,7 @@ const SORTABLE_FIELDS = [
   SPAN_DESCRIPTION,
   'spm()',
   `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
+  `${TIME_SPENT_PERCENTAGE}()`,
 ] as const;
 
 export type ValidSort = Sort & {
@@ -36,7 +38,7 @@ export function useResourceSort(
 
 const DEFAULT_SORT: Sort = {
   kind: 'desc',
-  field: SORTABLE_FIELDS[2],
+  field: SORTABLE_FIELDS[4],
 };
 
 function isAValidSort(sort: Sort): sort is ValidSort {

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -6,7 +6,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {ValidSort} from 'sentry/views/performance/browser/resources/utils/useResourceSort';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {EMPTY_OPTION_VALUE} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
 const {
@@ -19,6 +19,8 @@ const {
   HTTP_RESPONSE_CONTENT_LENGTH,
   PROJECT_ID,
 } = SpanMetricsField;
+
+const {TIME_SPENT_PERCENTAGE} = SpanFunction;
 
 type Props = {
   sort: ValidSort;
@@ -67,6 +69,8 @@ export const useResourcesQuery = ({sort, defaultResourceTypes, query, limit}: Pr
         SPAN_DOMAIN,
         `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
         'project.id',
+        `${TIME_SPENT_PERCENTAGE}()`,
+        `sum(${SPAN_SELF_TIME})`,
       ],
       name: 'Resource module - resource table',
       query: queryConditions.join(' '),
@@ -107,7 +111,9 @@ export const useResourcesQuery = ({sort, defaultResourceTypes, query, limit}: Pr
     [`avg(http.response_content_length)`]: row[
       `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`
     ] as number,
+    [`time_spent_percentage()`]: row[`${TIME_SPENT_PERCENTAGE}()`] as number,
     ['count_unique(transaction)']: row['count_unique(transaction)'] as number,
+    [`sum(span.self_time)`]: row[`sum(${SPAN_SELF_TIME})`] as number,
   }));
 
   return {...result, data: data || []};

--- a/static/app/views/starfish/views/spans/types.tsx
+++ b/static/app/views/starfish/views/spans/types.tsx
@@ -43,7 +43,7 @@ export const getThroughputTitle = (spanOp?: string) => {
     return t('Queries Per Min');
   }
   if (defined(spanOp)) {
-    return t('Requests');
+    return t('Requests Per Sec');
   }
   return '--';
 };


### PR DESCRIPTION
Updates to resource module main table
<img width="1255" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/a4d4e3fa-af16-48a4-a4c3-ec3afa94bf9c">


1. Move some columns around to match the column order of mocks/queries module
2. Change requests column header to `requests per sec` to match queries module
3. Add time spent column
4. Make time spent column the default sort.