### PR TITLE
feat(provisioning): Disable partner integration modifications

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/details.py
@@ -22,6 +22,7 @@ from sentry.utils import json
 from sentry.utils.audit import create_audit_entry
 
 logger = logging.getLogger(__name__)
+PARTNERSHIP_RESTRICTED_ERROR_MESSAGE = "This integration is managed by an active partnership and cannot be modified until the end of the partnership."
 
 
 @control_silo_endpoint
@@ -39,9 +40,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
     def put(self, request: Request, sentry_app) -> Response:
         if sentry_app.metadata.get("partnership_restricted", False):
             return Response(
-                {
-                    "detail": "This integration is managed by an active partnership and cannot be modified until the end of the partnership."
-                },
+                {"detail": PARTNERSHIP_RESTRICTED_ERROR_MESSAGE},
                 status=403,
             )
         owner_context = organization_service.get_organization_by_id(
@@ -113,9 +112,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
     def delete(self, request: Request, sentry_app) -> Response:
         if sentry_app.metadata.get("partnership_restricted", False):
             return Response(
-                {
-                    "detail": "This integration is managed by an active partnership and cannot be modified until the end of the partnership."
-                },
+                {"detail": PARTNERSHIP_RESTRICTED_ERROR_MESSAGE},
                 status=403,
             )
         if sentry_app.is_unpublished or sentry_app.is_internal:

--- a/src/sentry/api/endpoints/integrations/sentry_apps/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/details.py
@@ -37,6 +37,13 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
 
     @catch_raised_errors
     def put(self, request: Request, sentry_app) -> Response:
+        if sentry_app.metadata.get("partnership_restricted", False):
+            return Response(
+                {
+                    "detail": "This integration is managed by an active partnership and cannot be modified until the end of the partnership."
+                },
+                status=403,
+            )
         owner_context = organization_service.get_organization_by_id(
             id=sentry_app.owner_id, user_id=None
         )
@@ -104,6 +111,13 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
         return Response(serializer.errors, status=400)
 
     def delete(self, request: Request, sentry_app) -> Response:
+        if sentry_app.metadata.get("partnership_restricted", False):
+            return Response(
+                {
+                    "detail": "This integration is managed by an active partnership and cannot be modified until the end of the partnership."
+                },
+                status=403,
+            )
         if sentry_app.is_unpublished or sentry_app.is_internal:
             if not sentry_app.is_internal:
                 for install in sentry_app.installations.all():

--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
@@ -41,6 +41,14 @@ class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
+        if sentry_app.metadata.get("partnership_restricted", False):
+            return Response(
+                {
+                    "detail": "This integration is managed by an active partnership and cannot be modified until the end of the partnership."
+                },
+                status=403,
+            )
+
         with transaction.atomic(using=router.db_for_write(SentryAppInstallationToken)):
             try:
                 install_token = SentryAppInstallationToken.objects.get(api_token=api_token)

--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
@@ -8,6 +8,9 @@ from sentry import analytics, deletions
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppBaseEndpoint, SentryInternalAppTokenPermission
+from sentry.api.endpoints.integrations.sentry_apps.details import (
+    PARTNERSHIP_RESTRICTED_ERROR_MESSAGE,
+)
 from sentry.models.apitoken import ApiToken
 from sentry.models.integrations.sentry_app_installation_token import SentryAppInstallationToken
 
@@ -43,9 +46,7 @@ class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
 
         if sentry_app.metadata.get("partnership_restricted", False):
             return Response(
-                {
-                    "detail": "This integration is managed by an active partnership and cannot be modified until the end of the partnership."
-                },
+                {"detail": PARTNERSHIP_RESTRICTED_ERROR_MESSAGE},
                 status=403,
             )
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/index.py
@@ -46,6 +46,13 @@ class SentryInternalAppTokensEndpoint(SentryAppBaseEndpoint):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
+        if sentry_app.metadata.get("partnership_restricted", False):
+            return Response(
+                {
+                    "detail": "This integration is managed by an active partnership and cannot be modified until the end of the partnership."
+                },
+                status=403,
+            )
         sentry_app_installation = SentryAppInstallation.objects.get(sentry_app_id=sentry_app.id)
         try:
             api_token = SentryAppInstallationTokenCreator(

--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/index.py
@@ -5,6 +5,9 @@ from rest_framework.response import Response
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppBaseEndpoint, SentryInternalAppTokenPermission
+from sentry.api.endpoints.integrations.sentry_apps.details import (
+    PARTNERSHIP_RESTRICTED_ERROR_MESSAGE,
+)
 from sentry.api.serializers.models.apitoken import ApiTokenSerializer
 from sentry.exceptions import ApiTokenLimitError
 from sentry.models.apitoken import ApiToken
@@ -48,9 +51,7 @@ class SentryInternalAppTokensEndpoint(SentryAppBaseEndpoint):
 
         if sentry_app.metadata.get("partnership_restricted", False):
             return Response(
-                {
-                    "detail": "This integration is managed by an active partnership and cannot be modified until the end of the partnership."
-                },
+                {"detail": PARTNERSHIP_RESTRICTED_ERROR_MESSAGE},
                 status=403,
             )
         sentry_app_installation = SentryAppInstallation.objects.get(sentry_app_id=sentry_app.id)

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -435,6 +435,22 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             ]
         }
 
+    def test_cannot_update_partner_apps(self):
+        self.login_as(user=self.user)
+        self.published_app.update(metadata={"partnership_restricted": True})
+        response = self.client.put(
+            self.url,
+            data={
+                "name": self.published_app.name,
+                "author": "A Company",
+                "webhookUrl": "https://newurl.com",
+                "redirectUrl": "https://newredirecturl.com",
+                "isAlertable": True,
+            },
+            format="json",
+        )
+        assert response.status_code == 403
+
 
 @control_silo_test(stable=True)
 class DeleteSentryAppDetailsTest(SentryAppDetailsTest):
@@ -460,3 +476,9 @@ class DeleteSentryAppDetailsTest(SentryAppDetailsTest):
         response = self.client.delete(url)
         assert response.status_code == 403
         assert response.data == {"detail": ["Published apps cannot be removed."]}
+
+    def test_cannot_delete_partner_apps(self):
+        self.login_as(user=self.user)
+        self.published_app.update(metadata={"partnership_restricted": True})
+        response = self.client.delete(self.url)
+        assert response.status_code == 403

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
@@ -83,3 +83,9 @@ class SentryInternalAppTokenCreationTest(APITestCase):
         response = self.client.delete(url, format="json")
 
         assert response.status_code == 404
+
+    def test_cannot_delete_partner_app_token(self):
+        self.login_as(user=self.user)
+        self.internal_sentry_app.update(metadata={"partnership_restricted": True})
+        response = self.client.delete(self.url)
+        assert response.status_code == 403

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
@@ -63,6 +63,12 @@ class PostSentryInternalAppTokenTest(SentryInternalAppTokenTest):
         assert response.status_code == 403
         assert response.data == "Cannot generate more than 20 tokens for a single integration"
 
+    def test_cannot_create_partner_app_token(self):
+        self.login_as(user=self.user)
+        self.internal_sentry_app.update(metadata={"partnership_restricted": True})
+        response = self.client.post(self.url, format="json")
+        assert response.status_code == 403
+
 
 @control_silo_test(stable=True)
 class GetSentryInternalAppTokenTest(SentryInternalAppTokenTest):


### PR DESCRIPTION
Disabling endpoints around integration. The plan here is that if sentry APP has metadata "partnership_restricted" it means that this app is created by a partner and cannot be modified.
