### PR TITLE
fix(hybrid-cloud): Fix email message builder for region silo

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -229,7 +229,7 @@ class DatabaseBackedUserService(UserService):
 
     def verify_user_emails(
         self, *, user_id_emails: List[Tuple[int, str]]
-    ) -> Dict[str, Dict[str, Any]]:
+    ) -> Dict[int, Dict[str, Any]]:
         results = {}
         for user_id, email in user_id_emails:
             exists = UserEmail.objects.filter(user_id=user_id, email__iexact=email).exists()

--- a/src/sentry/services/hybrid_cloud/user/model.py
+++ b/src/sentry/services/hybrid_cloud/user/model.py
@@ -141,3 +141,13 @@ class UserUpdateArgs(TypedDict, total=False):
     avatar_type: int
     actor_id: int  # TODO(hybrid-cloud): Remove this after the actor migration is complete
     is_active: bool
+
+
+class UserIdEmailArgs(TypedDict):
+    user_id: int
+    email: str
+
+
+class RpcVerifyUserEmail(RpcModel):
+    exists: bool = False
+    email: str = ""

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -4,7 +4,7 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from sentry.hybridcloud.rpc.services.caching import back_with_silo_cache
 from sentry.services.hybrid_cloud.auth import AuthenticationContext
@@ -158,6 +158,13 @@ class UserService(RpcService):
     @rpc_method
     @abstractmethod
     def trigger_user_consent_email_if_applicable(self, *, user_id: int) -> None:
+        pass
+
+    @rpc_method
+    @abstractmethod
+    def verify_user_emails(
+        self, *, user_id_emails: List[Tuple[int, str]]
+    ) -> Dict[str, Dict[str, Any]]:
         pass
 
 

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -164,7 +164,7 @@ class UserService(RpcService):
     @abstractmethod
     def verify_user_emails(
         self, *, user_id_emails: List[Tuple[int, str]]
-    ) -> Dict[str, Dict[str, Any]]:
+    ) -> Dict[int, Dict[str, Any]]:
         pass
 
 

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -4,7 +4,7 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from sentry.hybridcloud.rpc.services.caching import back_with_silo_cache
 from sentry.services.hybrid_cloud.auth import AuthenticationContext
@@ -17,6 +17,7 @@ from sentry.services.hybrid_cloud.user import (
     UserSerializeType,
     UserUpdateArgs,
 )
+from sentry.services.hybrid_cloud.user.model import RpcVerifyUserEmail, UserIdEmailArgs
 from sentry.silo import SiloMode
 
 
@@ -163,8 +164,8 @@ class UserService(RpcService):
     @rpc_method
     @abstractmethod
     def verify_user_emails(
-        self, *, user_id_emails: List[Tuple[int, str]]
-    ) -> Dict[int, Dict[str, Any]]:
+        self, *, user_id_emails: List[UserIdEmailArgs]
+    ) -> Dict[int, RpcVerifyUserEmail]:
         pass
 
 

--- a/src/sentry/utils/email/manager.py
+++ b/src/sentry/utils/email/manager.py
@@ -4,7 +4,6 @@ import logging
 from typing import Iterable, List, Mapping
 
 from sentry.models.project import Project
-from sentry.models.useremail import UserEmail
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.services.hybrid_cloud.user_option import RpcUserOption, user_option_service
 
@@ -28,18 +27,26 @@ def get_email_addresses(
         options = user_option_service.get_many(
             filter={"user_ids": pending, "project_id": project.id, "keys": ["mail:email"]}
         )
+
+        user_id_emails = []
         for option in (o for o in options if o.value and not is_fake_email(o.value)):
-            if UserEmail.objects.filter(user_id=option.user_id, email=option.value).exists():
-                results[option.user_id] = option.value
-                pending.discard(option.user_id)
+            user_id_emails.append((int(option.user_id), option.value))
+
+        user_id_emails_exists = user_service.verify_user_emails(user_id_emails=user_id_emails)
+
+        for user_id_key in user_id_emails_exists.keys():
+            user_id = int(user_id_key)
+            if user_id_emails_exists[user_id_key]["exists"]:
+                results[user_id] = user_id_emails_exists[user_id_key]["email"]
+                pending.discard(user_id)
             else:
-                pending.discard(option.user_id)
+                pending.discard(user_id)
                 to_delete.append(option)
         user_option_service.delete_options(option_ids=[o.id for o in to_delete])
 
     if pending:
         users = user_service.get_many(filter={"user_ids": list(pending)})
-        for (user_id, email) in [(user.id, user.email) for user in users]:
+        for user_id, email in [(user.id, user.email) for user in users]:
             if email and not is_fake_email(email):
                 results[user_id] = email
                 pending.discard(user_id)

--- a/src/sentry/utils/email/manager.py
+++ b/src/sentry/utils/email/manager.py
@@ -4,6 +4,7 @@ import logging
 from typing import Iterable, List, Mapping
 
 from sentry.models.project import Project
+from sentry.services.hybrid_cloud.user.model import UserIdEmailArgs
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.services.hybrid_cloud.user_option import RpcUserOption, user_option_service
 
@@ -30,14 +31,14 @@ def get_email_addresses(
 
         user_id_emails = []
         for option in (o for o in options if o.value and not is_fake_email(o.value)):
-            user_id_emails.append((int(option.user_id), option.value))
+            user_id_emails.append(UserIdEmailArgs(user_id=int(option.user_id), email=option.value))
 
         user_id_emails_exists = user_service.verify_user_emails(user_id_emails=user_id_emails)
 
         for user_id_key in user_id_emails_exists.keys():
             user_id = int(user_id_key)
-            if user_id_emails_exists[user_id_key]["exists"]:
-                results[user_id] = user_id_emails_exists[user_id_key]["email"]
+            if user_id_emails_exists[user_id_key].exists:
+                results[user_id] = user_id_emails_exists[user_id_key].email
                 pending.discard(user_id)
             else:
                 pending.discard(user_id)

--- a/tests/sentry/utils/email/test_message_builder.py
+++ b/tests/sentry/utils/email/test_message_builder.py
@@ -9,12 +9,15 @@ from sentry.models.groupemailthread import GroupEmailThread
 from sentry.models.options.user_option import UserOption
 from sentry.models.user import User
 from sentry.models.useremail import UserEmail
+from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.utils import json
 from sentry.utils.email import MessageBuilder
 from sentry.utils.email.faker import create_fake_email
 
 
+@region_silo_test(stable=True)
 class MessageBuilderTest(TestCase):
     def test_raw_content(self):
         msg = MessageBuilder(
@@ -88,15 +91,18 @@ class MessageBuilderTest(TestCase):
     def test_with_users(self):
         project = self.project
 
-        user_a = User.objects.create(email="foo@example.com")
-        user_b = User.objects.create(email="bar@example.com")
-        user_c = User.objects.create(email="baz@example.com")
+        assert len(mail.outbox) == 0
 
-        alternate_email = "bazzer@example.com"
-        UserEmail.objects.create(user=user_c, email=alternate_email)
-        UserOption.objects.create(
-            user=user_c, project_id=project.id, key="mail:email", value=alternate_email
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            user_a = User.objects.create(email="foo@example.com")
+            user_b = User.objects.create(email="bar@example.com")
+            user_c = User.objects.create(email="baz@example.com")
+
+            alternate_email = "bazzer@example.com"
+            UserEmail.objects.create(user=user_c, email=alternate_email)
+            UserOption.objects.create(
+                user=user_c, project_id=project.id, key="mail:email", value=alternate_email
+            )
 
         msg = MessageBuilder(
             subject="Test", body="hello world", html_body="<!DOCTYPE html>\n<b>hello world</b>"
@@ -115,16 +121,17 @@ class MessageBuilderTest(TestCase):
     def test_fake_dont_send(self):
         project = self.project
 
-        user_a = User.objects.create(email=create_fake_email("foo", "fake"))
-        user_b = User.objects.create(email=create_fake_email("bar", "fake"))
-        user_c = User.objects.create(email=create_fake_email("baz", "fake"))
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            user_a = User.objects.create(email=create_fake_email("foo", "fake"))
+            user_b = User.objects.create(email=create_fake_email("bar", "fake"))
+            user_c = User.objects.create(email=create_fake_email("baz", "fake"))
 
-        UserOption.objects.create(
-            user=user_c,
-            project_id=project.id,
-            key="mail:email",
-            value=create_fake_email("bazzer", "fake"),
-        )
+            UserOption.objects.create(
+                user=user_c,
+                project_id=project.id,
+                key="mail:email",
+                value=create_fake_email("bazzer", "fake"),
+            )
 
         msg = MessageBuilder(
             subject="Test", body="hello world", html_body="<!DOCTYPE html>\n<b>hello world</b>"


### PR DESCRIPTION
Fixes https://sentry-st.sentry.io/issues/4611108791/.

The `UserEmail` model is only available on the control silo. This pull request attempts to make the email message builder utility functions operate in the region silo.