### PR TITLE
ref(monitors): Remove method for monitor seats

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -220,7 +220,6 @@ class Quota(Service):
         "get_transaction_sampling_tier_for_volume",
         "assign_monitor_seat",
         "check_accept_monitor_checkin",
-        "remove_monitor_seat",
         "update_monitor_slug",
     )
 
@@ -511,19 +510,11 @@ class Quota(Service):
 
     def check_accept_monitor_checkin(self, project_id: int, monitor_slug: str):
         """
-        Will return an `AcceptedCheckInStatus`.
+        Will return a `PermitCheckInStatus`.
         """
         from sentry.monitors.constants import PermitCheckInStatus
 
         return PermitCheckInStatus.ACCEPT
-
-    def remove_monitor_seat(
-        self,
-        monitor: Monitor,
-    ):
-        """
-        Removes a monitor seat assignment when a Monitor is deleted.
-        """
 
     def update_monitor_slug(self, previous_slug: str, new_slug: str, project_id: int):
         """

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -121,17 +121,6 @@ class QuotaTest(TestCase):
             == PermitCheckInStatus.ACCEPT
         )
 
-    def test_remove_monitor_seat(self):
-        monitor = Monitor.objects.create(
-            slug="test-monitor",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            name="test monitor",
-            status=MonitorObjectStatus.ACTIVE,
-            type=MonitorType.CRON_JOB,
-        )
-        assert self.backend.remove_monitor_seat(monitor) is None
-
 
 @pytest.mark.parametrize(
     "obj,json",


### PR DESCRIPTION
Removes the `remove_monitor_seat()` method for monitors as it is no longer required here.
