### PR TITLE
feat(eventuser): Migrate search util function away from EventUser model

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -26,8 +26,10 @@ from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
 if TYPE_CHECKING:
     from sentry.api.event_search import SearchFilter
 
+from sentry import features
 from sentry.models.environment import Environment
 from sentry.models.eventuser import KEYWORD_MAP
+from sentry.models.eventuser import EventUser as EventUser_model
 from sentry.models.group import STATUS_QUERY_CHOICES
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
@@ -48,7 +50,13 @@ class InvalidQuery(Exception):
 def get_user_tag(projects: Sequence[Project], key: str, value: str) -> str:
     # TODO(dcramer): do something with case of multiple matches
     try:
-        euser = EventUser.for_projects(projects, {key: value})[0]
+        if features.has("organizations:eventuser-from-snuba", projects[0].organization):
+            euser = EventUser.for_projects(projects, {key: value})[0]
+        else:
+            lookup = EventUser_model.attr_from_keyword(key)
+            euser = EventUser_model.objects.filter(
+                project_id__in=[p.id for p in projects], **{lookup: value}
+            )[0]
     except (KeyError, IndexError):
         return f"{key}:{value}"
     except DataError:

--- a/src/sentry/utils/eventuser.py
+++ b/src/sentry/utils/eventuser.py
@@ -35,7 +35,7 @@ class EventUser:
     username: Optional[str]
     name: Optional[str]
     ip_address: Optional[str]
-    user_id: Optional[int]
+    user_ident: Optional[int]
     id: Optional[int] = None  # EventUser model id
 
     @staticmethod
@@ -47,7 +47,7 @@ class EventUser:
             username=event.data.get("user", {}).get("username") if event else None,
             name=event.data.get("user", {}).get("name") if event else None,
             ip_address=event.data.get("user", {}).get("ip_address") if event else None,
-            user_id=event.data.get("user", {}).get("id") if event else None,
+            user_ident=event.data.get("user", {}).get("id") if event else None,
         )
 
     def get_display_name(self):
@@ -116,13 +116,13 @@ class EventUser:
         Converts the object from the Snuba query into an EventUser instance
         """
         return EventUser(
-            id=result.get("user_id"),
+            id=None,
             project_id=result.get("project_id"),
             email=result.get("user_email"),
             username=result.get("user_name"),
             name=result.get("user_name"),
             ip_address=result.get("ip_address_4") or result.get("ip_address_6"),
-            user_id=result.get("user_id"),
+            user_ident=result.get("user_id"),
         )
 
     @property
@@ -130,7 +130,7 @@ class EventUser:
         """
         Return the identifier to link this user.
         """
-        return f"id:{self.user_id}"
+        return f"id:{self.user_ident}"
 
     def serialize(self):
         return {

--- a/src/sentry/utils/eventuser.py
+++ b/src/sentry/utils/eventuser.py
@@ -39,7 +39,7 @@ class EventUser:
     id: Optional[int] = None  # EventUser model id
 
     @staticmethod
-    def from_event(event: Event):
+    def from_event(event: Event) -> EventUser:
         return EventUser(
             id=None,
             project_id=event.project_id if event else None,
@@ -58,7 +58,13 @@ class EventUser:
         return KEYWORD_MAP.get_key(keyword)
 
     @classmethod
-    def for_projects(self, projects: List[Project], keyword_filters: Mapping[str, Any]):
+    def for_projects(
+        self, projects: List[Project], keyword_filters: Mapping[str, Any]
+    ) -> Mapping[str, Any]:
+        """
+        Fetch the EventUsers for a list of projects with a Snuba query.
+        Valid `keyword_filters` keys are in KEYWORD_MAP.
+        """
         oldest_project = min(projects, key=lambda item: item.date_added)
 
         where_conditions = [
@@ -103,7 +109,10 @@ class EventUser:
         return results
 
     @staticmethod
-    def from_snuba(result: Mapping[str, Any]):
+    def from_snuba(result: Mapping[str, Any]) -> EventUser:
+        """
+        Converts the object from the Snuba query into an EventUser instance
+        """
         return EventUser(
             id=result.get("user_id"),
             project_id=result.get("project_id"),
@@ -115,9 +124,9 @@ class EventUser:
         )
 
     @property
-    def tag_value(self):
+    def tag_value(self) -> str:
         """
-        Return the identifier used with tags to link this user.
+        Return the identifier to link this user.
         """
         return f"id:{self.user_id}"
 

--- a/src/sentry/utils/eventuser.py
+++ b/src/sentry/utils/eventuser.py
@@ -20,7 +20,7 @@ REFERRER = "sentry.utils.eventuser"
 
 KEYWORD_MAP = BidirectionalMapping(
     {
-        ("user_id"): "id",
+        ("user_ident"): "id",
         ("user_name"): "username",
         ("email"): "email",
         ("ip_address_4", "ip_address_6"): "ip",
@@ -126,11 +126,20 @@ class EventUser:
         )
 
     @property
-    def tag_value(self) -> str:
+    def tag_value(self):
         """
-        Return the identifier to link this user.
+        Return the identifier used with tags to link this user.
         """
-        return f"id:{self.user_ident}"
+        for key, value in self.iter_attributes():
+            if value:
+                return f"{KEYWORD_MAP[key]}:{value}"
+
+    def iter_attributes(self):
+        """
+        Iterate over key/value pairs for this EventUser in priority order.
+        """
+        for key in KEYWORD_MAP.keys():
+            yield key, getattr(self, key)
 
     def serialize(self):
         return {

--- a/src/sentry/utils/eventuser.py
+++ b/src/sentry/utils/eventuser.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, List, Mapping, Optional, Tuple
 
-from snuba_sdk import Column, Condition, Entity, Op, Query, Request
+from snuba_sdk import Column, Condition, Direction, Entity, Limit, Op, OrderBy, Query, Request
 
 from sentry.eventstore.models import Event
 from sentry.models.project import Project
@@ -62,8 +62,8 @@ class EventUser:
         self, projects: List[Project], keyword_filters: Mapping[str, Any]
     ) -> Mapping[str, Any]:
         """
-        Fetch the EventUsers for a list of projects with a Snuba query.
-        Valid `keyword_filters` keys are in KEYWORD_MAP.
+        Fetch the EventUser with a Snuba query that exists within a list of projects
+        and valid `keyword_filters`. The `keyword_filter` keys are in `KEYWORD_MAP`.
         """
         oldest_project = min(projects, key=lambda item: item.date_added)
 
@@ -95,6 +95,8 @@ class EventUser:
                 Column("user_email"),
             ],
             where=where_conditions,
+            limit=Limit(1),
+            orderby=[OrderBy(Column("timestamp"), Direction.DESC)],
         )
 
         request = Request(

--- a/src/sentry/utils/eventuser.py
+++ b/src/sentry/utils/eventuser.py
@@ -31,11 +31,11 @@ KEYWORD_MAP = BidirectionalMapping(
 @dataclass
 class EventUser:
     project_id: Optional[int]
-    email: str
-    username: str
-    name: str
-    ip_address: str
-    user_id: int
+    email: Optional[str]
+    username: Optional[str]
+    name: Optional[str]
+    ip_address: Optional[str]
+    user_id: Optional[int]
     id: Optional[int] = None  # EventUser model id
 
     @staticmethod
@@ -60,7 +60,7 @@ class EventUser:
     @classmethod
     def for_projects(
         self, projects: List[Project], keyword_filters: Mapping[str, Any]
-    ) -> Mapping[str, Any]:
+    ) -> List[EventUser]:
         """
         Fetch the EventUser with a Snuba query that exists within a list of projects
         and valid `keyword_filters`. The `keyword_filter` keys are in `KEYWORD_MAP`.

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -22,6 +22,7 @@ from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test, region_silo_test
 
 
@@ -449,6 +450,7 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
         result = self.parse_query("user.xxxxxx:example")
         assert result["tags"]["sentry:user"] == "xxxxxx:example"
 
+    @with_feature("organizations:eventuser-from-snuba")
     def test_user_lookup_with_dot_query(self):
         self.project.date_added = timezone.now() - timedelta(minutes=10)
         self.project.save()
@@ -468,10 +470,12 @@ class ParseQueryTest(APITestCase, SnubaTestCase):
         result = self.parse_query("user.username:foobar")
         assert result["tags"]["sentry:user"] == "id:1"
 
+    @with_feature("organizations:eventuser-from-snuba")
     def test_unknown_user_legacy_syntax(self):
         result = self.parse_query("user:email:fake@example.com")
         assert result["tags"]["sentry:user"] == "email:fake@example.com"
 
+    @with_feature("organizations:eventuser-from-snuba")
     def test_user_lookup_legacy_syntax(self):
         self.project.date_added = timezone.now() - timedelta(minutes=10)
         self.project.save()

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 import pytest
 from django.utils import timezone
 
-from sentry.models.eventuser import EventUser
 from sentry.models.group import GroupStatus
 from sentry.models.release import Release
 from sentry.models.team import Team
@@ -21,8 +20,8 @@ from sentry.search.utils import (
 from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.services.hybrid_cloud.user.serial import serialize_rpc_user
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase
+from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
 from sentry.testutils.silo import control_silo_test, region_silo_test
 
 
@@ -138,7 +137,7 @@ def test_get_numeric_field_value_invalid():
 
 
 @region_silo_test(stable=True)
-class ParseQueryTest(TestCase):
+class ParseQueryTest(APITestCase, SnubaTestCase):
     @property
     def rpc_user(self):
         return user_service.get_user(user_id=self.user.id)
@@ -451,18 +450,46 @@ class ParseQueryTest(TestCase):
         assert result["tags"]["sentry:user"] == "xxxxxx:example"
 
     def test_user_lookup_with_dot_query(self):
-        euser = EventUser.objects.create(project_id=self.project.id, ident="1", username="foobar")
+        self.project.date_added = timezone.now() - timedelta(minutes=10)
+        self.project.save()
+
+        self.store_event(
+            data={
+                "user": {
+                    "id": 1,
+                    "email": "foo@example.com",
+                    "username": "foobar",
+                    "ip_address": "127.0.0.1",
+                },
+                "timestamp": iso_format(before_now(seconds=10)),
+            },
+            project_id=self.project.id,
+        )
         result = self.parse_query("user.username:foobar")
-        assert result["tags"]["sentry:user"] == euser.tag_value
+        assert result["tags"]["sentry:user"] == "id:1"
 
     def test_unknown_user_legacy_syntax(self):
         result = self.parse_query("user:email:fake@example.com")
         assert result["tags"]["sentry:user"] == "email:fake@example.com"
 
     def test_user_lookup_legacy_syntax(self):
-        euser = EventUser.objects.create(project_id=self.project.id, ident="1", username="foobar")
+        self.project.date_added = timezone.now() - timedelta(minutes=10)
+        self.project.save()
+
+        self.store_event(
+            data={
+                "user": {
+                    "id": 1,
+                    "email": "foo@example.com",
+                    "username": "foobar",
+                    "ip_address": "127.0.0.1",
+                },
+                "timestamp": iso_format(before_now(seconds=10)),
+            },
+            project_id=self.project.id,
+        )
         result = self.parse_query("user:username:foobar")
-        assert result["tags"]["sentry:user"] == euser.tag_value
+        assert result["tags"]["sentry:user"] == "id:1"
 
     def test_is_unassigned(self):
         result = self.parse_query("is:unassigned")

--- a/tests/sentry/utils/test_eventuser.py
+++ b/tests/sentry/utils/test_eventuser.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.silo import region_silo_test
+from sentry.utils.eventuser import EventUser
+
+
+@region_silo_test(stable=True)
+class EventUserTestCase(APITestCase, SnubaTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.project = self.create_project(date_added=(timezone.now() - timedelta(hours=2)))
+
+        self.store_event(
+            data={
+                "user": {
+                    "id": 1,
+                    "email": "foo@example.com",
+                    "username": "foobar",
+                    "ip_address": "127.0.0.1",
+                },
+                "timestamp": iso_format(before_now(seconds=10)),
+            },
+            project_id=self.project.id,
+        )
+
+        self.store_event(
+            data={
+                "user": {
+                    "id": 2,
+                    "email": "nisanthan@sentry.io",
+                    "username": "nisanthan",
+                    "ip_address": "1.1.1.1",
+                },
+                "timestamp": iso_format(before_now(seconds=20)),
+            },
+            project_id=self.project.id,
+        )
+
+        self.store_event(
+            data={
+                "user": {
+                    "id": 3,
+                    "email": "minion@universal.com",
+                    "username": "minion",
+                    "ip_address": "8.8.8.8",
+                },
+                "timestamp": iso_format(before_now(seconds=30)),
+            },
+            project_id=self.project.id,
+        )
+
+    def test_for_projects_query_filter_id(self):
+        euser = EventUser.for_projects([self.project], {"id": "2"})
+        assert len(euser) == 1
+        assert euser[0].user_ident == "2"
+        assert euser[0].email == "nisanthan@sentry.io"
+
+    def test_for_projects_query_filter_username(self):
+        euser = EventUser.for_projects([self.project], {"username": "minion"})
+        assert len(euser) == 1
+        assert euser[0].user_ident == "3"
+        assert euser[0].email == "minion@universal.com"
+
+    def test_for_projects_query_filter_email(self):
+        euser = EventUser.for_projects([self.project], {"email": "foo@example.com"})
+        assert len(euser) == 1
+        assert euser[0].user_ident == "1"
+        assert euser[0].email == "foo@example.com"
+
+    def test_for_projects_query_filter_ip(self):
+        euser = EventUser.for_projects([self.project], {"ip": "8.8.8.8"})
+        assert len(euser) == 1
+        assert euser[0].user_ident == "3"
+        assert euser[0].email == "minion@universal.com"
+
+    def test_tag_value_primary_is_user_ident(self):
+        euser = EventUser.for_projects([self.project], {"id": "2"})
+        assert len(euser) == 1
+        assert euser[0].user_ident == "2"
+        assert euser[0].tag_value == "id:2"
+
+    def test_tag_value_primary_is_username(self):
+        self.store_event(
+            data={
+                "user": {
+                    "id": None,
+                    "email": "cocoa@universal.com",
+                    "username": "cocoa",
+                    "ip_address": "8.8.8.8",
+                },
+                "timestamp": iso_format(before_now(seconds=30)),
+            },
+            project_id=self.project.id,
+        )
+        euser = EventUser.for_projects([self.project], {"username": "cocoa"})
+        assert len(euser) == 1
+        assert euser[0].user_ident is None
+        assert euser[0].tag_value == "username:cocoa"
+
+    def test_tag_value_primary_is_email(self):
+        self.store_event(
+            data={
+                "user": {
+                    "id": None,
+                    "email": "cocoa@universal.com",
+                    "username": None,
+                    "ip_address": "8.8.8.8",
+                },
+                "timestamp": iso_format(before_now(seconds=30)),
+            },
+            project_id=self.project.id,
+        )
+        euser = EventUser.for_projects([self.project], {"email": "cocoa@universal.com"})
+        assert len(euser) == 1
+        assert euser[0].user_ident is None
+        assert euser[0].username is None
+        assert euser[0].tag_value == "email:cocoa@universal.com"
+
+    def test_tag_value_primary_is_ip(self):
+        self.store_event(
+            data={
+                "user": {
+                    "id": None,
+                    "email": None,
+                    "username": None,
+                    "ip_address": "8.8.8.8",
+                },
+                "timestamp": iso_format(before_now(seconds=30)),
+            },
+            project_id=self.project.id,
+        )
+        euser = EventUser.for_projects([self.project], {"ip": "8.8.8.8"})
+        assert len(euser) == 1
+        assert euser[0].user_ident is None
+        assert euser[0].username is None
+        assert euser[0].email is None
+        assert euser[0].tag_value == "ip:8.8.8.8"


### PR DESCRIPTION
## Objective:

Migrates the `get_user_tag` search utility away from the EventUser model. Also creates the methods `for_projects`, `from_snuba` and the property `tag_value` on the EventUser dataclass