### PR TITLE
chore(hybrid-cloud): Activate DiscordRequestParser

### DIFF
--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -63,6 +63,7 @@ class IntegrationClassification(BaseClassification):
         from .parsers import (
             BitbucketRequestParser,
             BitbucketServerRequestParser,
+            DiscordRequestParser,
             GithubEnterpriseRequestParser,
             GithubRequestParser,
             GitlabRequestParser,
@@ -76,6 +77,7 @@ class IntegrationClassification(BaseClassification):
         active_parsers: List[Type[BaseRequestParser]] = [
             BitbucketRequestParser,
             BitbucketServerRequestParser,
+            DiscordRequestParser,
             GithubEnterpriseRequestParser,
             GithubRequestParser,
             GitlabRequestParser,

--- a/src/sentry/middleware/integrations/parsers/__init__.py
+++ b/src/sentry/middleware/integrations/parsers/__init__.py
@@ -1,5 +1,6 @@
 from .bitbucket import BitbucketRequestParser
 from .bitbucket_server import BitbucketServerRequestParser
+from .discord import DiscordRequestParser
 from .github import GithubRequestParser
 from .github_enterprise import GithubEnterpriseRequestParser
 from .gitlab import GitlabRequestParser
@@ -13,6 +14,7 @@ from .vsts import VstsRequestParser
 __all__ = (
     "BitbucketRequestParser",
     "BitbucketServerRequestParser",
+    "DiscordRequestParser",
     "GithubEnterpriseRequestParser",
     "GithubRequestParser",
     "GitlabRequestParser",


### PR DESCRIPTION
I forgot to activate the `DiscordRequestParser` parser in https://github.com/getsentry/sentry/pull/59374; so I'm activating it in this pull request.

Fixes https://sentry-st.sentry.io/discover/hc-test-control:0240aefb425e49469d28a531fb6c0fee/