### PR TITLE
fix(hybrid-cloud): Add DiscordNonProxyClient

### DIFF
--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -6,32 +6,64 @@ import logging
 from requests import PreparedRequest
 
 from sentry import options
+from sentry.integrations.client import ApiClient
 from sentry.integrations.discord.message_builder.base.base import DiscordMessageBuilder
 from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient, infer_org_integration
+from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.utils.json import JSONData
 
 logger = logging.getLogger("sentry.integrations.discord")
+
+DISCORD_BASE_URL = "https://discord.com/api/v10"
+
+# https://discord.com/developers/docs/resources/guild#get-guild
+GUILD_URL = "/guilds/{guild_id}"
+
+# https://discord.com/developers/docs/resources/user#leave-guild
+USERS_GUILD_URL = "/users/@me/guilds/{guild_id}"
+
+# https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
+APPLICATION_COMMANDS_URL = "/applications/{application_id}/commands"
+
+# https://discord.com/developers/docs/resources/channel#get-channel
+CHANNEL_URL = "/channels/{channel_id}"
+
+# https://discord.com/developers/docs/resources/channel#create-message
+MESSAGE_URL = "/channels/{channel_id}/messages"
+
+
+class DiscordNonProxyClient(ApiClient):
+    integration_name: str = "discord"
+    base_url: str = DISCORD_BASE_URL
+
+    def __init__(self):
+        super().__init__()
+        self.application_id = options.get("discord.application-id")
+        self.bot_token = options.get("discord.bot-token")
+
+    def with_base_url(self, url: str) -> str:
+        return f"{DISCORD_BASE_URL}{url}"
+
+    def overwrite_application_commands(self, commands: list[object]) -> None:
+        self.put(
+            self.with_base_url(APPLICATION_COMMANDS_URL.format(application_id=self.application_id)),
+            data=commands,
+        )
+
+    def get_guild_name(self, guild_id: str) -> str:
+        url = GUILD_URL.format(guild_id=guild_id)
+        headers = {"Authorization": f"Bot {self.bot_token}"}
+        try:
+            response = self.get(url, headers=headers)
+            return response["name"]  # type: ignore
+        except (ApiError, AttributeError):
+            return guild_id
 
 
 class DiscordClient(IntegrationProxyClient):
     integration_name: str = "discord"
     base_url: str = "https://discord.com/api/v10"
-
-    # https://discord.com/developers/docs/resources/guild#get-guild
-    GUILD_URL = "/guilds/{guild_id}"
-
-    # https://discord.com/developers/docs/resources/user#leave-guild
-    USERS_GUILD_URL = "/users/@me/guilds/{guild_id}"
-
-    # https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands
-    APPLICATION_COMMANDS_URL = "/applications/{application_id}/commands"
-
-    # https://discord.com/developers/docs/resources/channel#get-channel
-    CHANNEL_URL = "/channels/{channel_id}"
-
-    # https://discord.com/developers/docs/resources/channel#create-message
-    MESSAGE_URL = "/channels/{channel_id}/messages"
 
     def __init__(
         self,
@@ -58,25 +90,19 @@ class DiscordClient(IntegrationProxyClient):
         """
         Normal version of get_guild_name that uses the regular auth flow.
         """
-        return self.get(self.GUILD_URL.format(guild_id=guild_id))["name"]  # type:ignore
+        return self.get(GUILD_URL.format(guild_id=guild_id))["name"]  # type:ignore
 
     def leave_guild(self, guild_id: str) -> None:
         """
         Leave the given guild_id, if the bot is currently a member.
         """
-        self.delete(self.USERS_GUILD_URL.format(guild_id=guild_id))
-
-    def overwrite_application_commands(self, commands: list[object]) -> None:
-        self.put(
-            self.APPLICATION_COMMANDS_URL.format(application_id=self.application_id),
-            data=commands,
-        )
+        self.delete(USERS_GUILD_URL.format(guild_id=guild_id))
 
     def get_channel(self, channel_id: str) -> object | None:
         """
         Get a channel by id.
         """
-        return self.get(self.CHANNEL_URL.format(channel_id=channel_id))
+        return self.get(CHANNEL_URL.format(channel_id=channel_id))
 
     def send_message(
         self, channel_id: str, message: DiscordMessageBuilder, notification_uuid: str | None = None
@@ -85,7 +111,7 @@ class DiscordClient(IntegrationProxyClient):
         Send a message to the specified channel.
         """
         self.post(
-            self.MESSAGE_URL.format(channel_id=channel_id),
+            MESSAGE_URL.format(channel_id=channel_id),
             data=message.build(notification_uuid=notification_uuid),
             timeout=5,
         )

--- a/src/sentry/integrations/discord/commands.py
+++ b/src/sentry/integrations/discord/commands.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sentry.integrations.discord.client import DiscordClient
+from sentry.integrations.discord.client import DiscordNonProxyClient
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.utils.cache import cache
 
@@ -41,7 +41,7 @@ class DiscordCommandManager:
         if result is None:
             cache.set(cache_key, True, 3600)
             try:
-                DiscordClient().overwrite_application_commands(self.COMMANDS)
+                DiscordNonProxyClient().overwrite_application_commands(self.COMMANDS)
             except ApiError as e:
                 logger.error("discord.setup.update_bot_commands_failure", extra={"status": e.code})
                 cache.delete(cache_key)

--- a/tests/sentry/integrations/discord/test_client.py
+++ b/tests/sentry/integrations/discord/test_client.py
@@ -2,7 +2,7 @@ import responses
 from django.test import override_settings
 
 from sentry import options
-from sentry.integrations.discord.client import DiscordClient
+from sentry.integrations.discord.client import GUILD_URL, DiscordClient
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import TestCase
@@ -40,7 +40,7 @@ class DiscordClientTest(TestCase):
 
         responses.add(
             responses.GET,
-            url=f"{DiscordClient.base_url}{DiscordClient.GUILD_URL.format(guild_id=guild_id)}",
+            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=guild_id)}",
             json={
                 "id": guild_id,
                 "name": server_name,
@@ -86,14 +86,14 @@ class DiscordProxyClientTest(TestCase):
 
         responses.add(
             method=responses.GET,
-            url=f"{DiscordClient.base_url}{DiscordClient.GUILD_URL.format(guild_id=self.integration.external_id)}",
+            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=self.integration.external_id)}",
             json={"guild_id": "1234567890", "name": "Cool server"},
             status=200,
         )
 
         responses.add(
             method=responses.GET,
-            url=f"{control_address}{PROXY_BASE_PATH}{DiscordClient.GUILD_URL.format(guild_id=self.integration.external_id)}",
+            url=f"{control_address}{PROXY_BASE_PATH}{GUILD_URL.format(guild_id=self.integration.external_id)}",
             json={"guild_id": "1234567890", "name": "Cool server"},
             status=200,
         )
@@ -103,7 +103,7 @@ class DiscordProxyClientTest(TestCase):
             client.get_guild_name(self.integration.external_id)
             request = responses.calls[0].request
 
-            assert client.GUILD_URL.format(guild_id=self.integration.external_id) in request.url
+            assert GUILD_URL.format(guild_id=self.integration.external_id) in request.url
             assert client.base_url in request.url
             client.assert_proxy_request(request, is_proxy=False)
 
@@ -113,7 +113,7 @@ class DiscordProxyClientTest(TestCase):
             client.get_guild_name(self.integration.external_id)
             request = responses.calls[0].request
 
-            assert client.GUILD_URL.format(guild_id=self.integration.external_id) in request.url
+            assert GUILD_URL.format(guild_id=self.integration.external_id) in request.url
             assert client.base_url in request.url
             client.assert_proxy_request(request, is_proxy=False)
 
@@ -123,6 +123,6 @@ class DiscordProxyClientTest(TestCase):
             client.get_guild_name(self.integration.external_id)
             request = responses.calls[0].request
 
-            assert client.GUILD_URL.format(guild_id=self.integration.external_id) in request.url
+            assert GUILD_URL.format(guild_id=self.integration.external_id) in request.url
             assert client.base_url not in request.url
             client.assert_proxy_request(request, is_proxy=True)

--- a/tests/sentry/integrations/discord/test_integration.py
+++ b/tests/sentry/integrations/discord/test_integration.py
@@ -5,7 +5,7 @@ import pytest
 import responses
 
 from sentry import audit_log, options
-from sentry.integrations.discord.client import DiscordClient
+from sentry.integrations.discord.client import APPLICATION_COMMANDS_URL, GUILD_URL, DiscordClient
 from sentry.integrations.discord.integration import DiscordIntegrationProvider
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.integrations.integration import Integration
@@ -51,7 +51,7 @@ class DiscordIntegrationTest(IntegrationTestCase):
 
         responses.add(
             responses.GET,
-            url=f"{DiscordClient.base_url}{DiscordClient.GUILD_URL.format(guild_id=guild_id)}",
+            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=guild_id)}",
             json={
                 "id": guild_id,
                 "name": server_name,
@@ -121,7 +121,7 @@ class DiscordIntegrationTest(IntegrationTestCase):
 
         responses.add(
             responses.GET,
-            url=f"{DiscordClient.base_url}{DiscordClient.GUILD_URL.format(guild_id=guild_id)}",
+            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=guild_id)}",
             json={
                 "id": guild_id,
                 "name": guild_name,
@@ -140,7 +140,7 @@ class DiscordIntegrationTest(IntegrationTestCase):
 
         responses.add(
             responses.GET,
-            url=f"{DiscordClient.base_url}{DiscordClient.GUILD_URL.format(guild_id=guild_id)}",
+            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=guild_id)}",
             status=500,
         )
 
@@ -153,7 +153,7 @@ class DiscordIntegrationTest(IntegrationTestCase):
     def test_setup(self):
         provider = self.provider()
 
-        url = f"{DiscordClient.base_url}{DiscordClient.APPLICATION_COMMANDS_URL.format(application_id=self.application_id)}"
+        url = f"{DiscordClient.base_url}{APPLICATION_COMMANDS_URL.format(application_id=self.application_id)}"
         responses.add(
             responses.PUT,
             url=url,
@@ -170,7 +170,7 @@ class DiscordIntegrationTest(IntegrationTestCase):
         mock_log_error.return_value = None
         provider = self.provider()
 
-        url = f"{DiscordClient.base_url}{DiscordClient.APPLICATION_COMMANDS_URL.format(application_id=self.application_id)}"
+        url = f"{DiscordClient.base_url}{APPLICATION_COMMANDS_URL.format(application_id=self.application_id)}"
         responses.add(
             responses.PUT,
             url=url,
@@ -186,7 +186,7 @@ class DiscordIntegrationTest(IntegrationTestCase):
     def test_setup_cache(self):
         provider = self.provider()
 
-        url = f"{DiscordClient.base_url}{DiscordClient.APPLICATION_COMMANDS_URL.format(application_id=self.application_id)}"
+        url = f"{DiscordClient.base_url}{APPLICATION_COMMANDS_URL.format(application_id=self.application_id)}"
         responses.add(
             responses.PUT,
             url=url,

--- a/tests/sentry/integrations/discord/test_integration.py
+++ b/tests/sentry/integrations/discord/test_integration.py
@@ -128,7 +128,7 @@ class DiscordIntegrationTest(IntegrationTestCase):
             },
         )
 
-        resp = provider._get_guild_name(guild_id)
+        resp = provider.client.get_guild_name(guild_id)
         assert resp == "asdf"
         mock_request = responses.calls[0].request
         assert mock_request.headers["Authorization"] == f"Bot {self.bot_token}"
@@ -144,7 +144,7 @@ class DiscordIntegrationTest(IntegrationTestCase):
             status=500,
         )
 
-        resp = provider._get_guild_name(guild_id)
+        resp = provider.client.get_guild_name(guild_id)
         assert resp == "1234"
         mock_request = responses.calls[0].request
         assert mock_request.headers["Authorization"] == f"Bot {self.bot_token}"

--- a/tests/sentry/integrations/discord/test_issue_alert.py
+++ b/tests/sentry/integrations/discord/test_issue_alert.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 
 from sentry.integrations.discord.actions.issue_alert.form import DiscordNotifyServiceForm
 from sentry.integrations.discord.actions.issue_alert.notification import DiscordNotifyServiceAction
-from sentry.integrations.discord.client import DiscordClient
+from sentry.integrations.discord.client import MESSAGE_URL
 from sentry.integrations.discord.message_builder import LEVEL_TO_COLOR
 from sentry.integrations.discord.message_builder.base.component import DiscordComponentCustomIds
 from sentry.integrations.message_builder import build_attachment_title, build_footer, get_title_link
@@ -59,7 +59,7 @@ class DiscordIssueAlertTest(RuleTestCase):
 
         responses.add(
             method=responses.POST,
-            url=f"{DiscordClient.MESSAGE_URL.format(channel_id=self.channel_id)}",
+            url=f"{MESSAGE_URL.format(channel_id=self.channel_id)}",
             status=200,
         )
 
@@ -215,9 +215,7 @@ class DiscordIssueAlertTest(RuleTestCase):
         assert len(results) == 1
         results[0].callback(self.event, futures=[])
 
-        responses.assert_call_count(
-            f"{DiscordClient.MESSAGE_URL.format(channel_id=self.channel_id)}", 0
-        )
+        responses.assert_call_count(f"{MESSAGE_URL.format(channel_id=self.channel_id)}", 0)
 
     @responses.activate
     def test_integration_removed(self):

--- a/tests/sentry/integrations/discord/test_uninstall.py
+++ b/tests/sentry/integrations/discord/test_uninstall.py
@@ -4,7 +4,7 @@ from unittest import mock
 import responses
 
 from sentry.constants import ObjectStatus
-from sentry.integrations.discord.client import DiscordClient
+from sentry.integrations.discord.client import USERS_GUILD_URL, DiscordClient
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.organization import Organization
@@ -16,9 +16,7 @@ from sentry.testutils.factories import Factories
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 GUILD_ID = "guild-id"
-LEAVE_GUILD_URL = (
-    f"{DiscordClient.base_url}{DiscordClient.USERS_GUILD_URL.format(guild_id=GUILD_ID)}"
-)
+LEAVE_GUILD_URL = f"{DiscordClient.base_url}{USERS_GUILD_URL.format(guild_id=GUILD_ID)}"
 
 
 @control_silo_test(stable=True)
@@ -76,7 +74,7 @@ class DiscordUninstallTest(APITestCase):
     def mock_discord_guild_leave(self, status: int = 204):
         responses.add(
             responses.DELETE,
-            url=f"{DiscordClient.base_url}{DiscordClient.USERS_GUILD_URL.format(guild_id=GUILD_ID)}",
+            url=f"{DiscordClient.base_url}{USERS_GUILD_URL.format(guild_id=GUILD_ID)}",
             status=status,
         )
 


### PR DESCRIPTION
The `DiscordClient()` client is initialized with no given integration id. This breaks the integration proxy flow, as there's no value to populate the `X-Sentry-Subnet-Organization-Integration` header.

Instead of doing the integration proxy request dance, we perform the request to Discord's API directly with `DiscordNonProxyClient`.

Fixes https://sentry-st.sentry.io/discover/hc-test-control:268787f09ec3477b83e22bd4c53a81bd/ 