### PR TITLE
feat(sdk-crashes): Path Replacers

### DIFF
--- a/src/sentry/utils/sdk_crashes/configs.py
+++ b/src/sentry/utils/sdk_crashes/configs.py
@@ -1,4 +1,8 @@
-from sentry.utils.sdk_crashes.sdk_crash_detector import SDKCrashDetectorConfig
+from sentry.utils.sdk_crashes.path_replacer import (
+    FixedPathReplacer,
+    KeepAfterPatternMatchPathReplacer,
+)
+from sentry.utils.sdk_crashes.sdk_crash_detector import SDKCrashDetectorConfig, SDKFrameConfig
 
 cocoa_sdk_crash_detector_config = SDKCrashDetectorConfig(
     # Explicitly use an allow list to avoid detecting SDK crashes for SDK names we don't know.
@@ -18,16 +22,39 @@ cocoa_sdk_crash_detector_config = SDKCrashDetectorConfig(
     # Therefore, we require at least sentry-cocoa 8.2.0.
     min_sdk_version="8.2.0",
     system_library_paths={"/System/Library/", "/usr/lib/"},
-    sdk_frame_function_matchers={
-        r"*sentrycrash*",
-        r"*\[Sentry*",
-        r"*(Sentry*)*",  # Objective-C class extension categories
-        r"SentryMX*",  # MetricKit Swift classes
-    },
-    sdk_frame_filename_matchers={"Sentry**"},
-    sdk_frame_path_replacement_names={},
-    sdk_frame_path_default_replacement_name="Sentry.framework",
+    sdk_frame_config=SDKFrameConfig(
+        function_patterns={
+            r"*sentrycrash*",
+            r"*\[Sentry*",
+            r"*(Sentry*)*",  # Objective-C class extension categories
+            r"SentryMX*",  # MetricKit Swift classes
+        },
+        filename_patterns={"Sentry**"},
+        path_replacer=FixedPathReplacer(path="Sentry.framework"),
+    ),
     # [SentrySDK crash] is a testing function causing a crash.
     # Therefore, we don't want to mark it a as a SDK crash.
     sdk_crash_ignore_functions_matchers={"**SentrySDK crash**"},
+)
+
+react_native_sdk_crash_detector_config = SDKCrashDetectorConfig(
+    sdk_names=[
+        "sentry.javascript.react-native",
+    ],
+    # 4.0.0 was released in June 2022, see https://github.com/getsentry/sentry-react-native/releases/tag/4.0.0.
+    # We require at least sentry-react-native 4.0.0 to only detect SDK crashes for not too old versions.
+    min_sdk_version="4.0.0",
+    system_library_paths={
+        "react-native/Libraries/",
+        "react-native-community/",
+    },
+    sdk_frame_config=SDKFrameConfig(
+        function_patterns=set(),
+        filename_patterns={r"**/sentry-react-native/**"},
+        path_replacer=KeepAfterPatternMatchPathReplacer(
+            patterns={r"\/sentry-react-native\/.*", r"\/@sentry.*"},
+            fallback_path="sentry-react-native",
+        ),
+    ),
+    sdk_crash_ignore_functions_matchers=set(),
 )

--- a/src/sentry/utils/sdk_crashes/event_stripper.py
+++ b/src/sentry/utils/sdk_crashes/event_stripper.py
@@ -163,11 +163,9 @@ def _strip_frames(
 
     This method sets in_app to True for SDK frames for grouping. The grouping config
     will set in_app false for all SDK frames. To not change the grouping logic, we must
-    add a stacktrace rule for each path_replacement_name configured in
-    `SDKCrashDetectorConfig.sdk_frame_path_replacement_names` and
-    `SDKCrashDetectorConfig.sdk_frame_path_default_replacement_name` like
-    `stack.abs_path:{{abs_path_replacement}} +app` to the project configured for the
-    platform in the options.
+    add a stacktrace rule for each path configured in
+    `SDKCrashDetectorConfig.sdk_frame_config.path_replacer` and
+    `SDKCrashDetectorConfig.sdk_frame_path_default_replacement_name`.
 
     For example, Cocoa only uses `Sentry.framework` as a replacement path, so we must add the rule `stack.abs_path:Sentry.framework +app` to it's project in Sentry.
     """
@@ -177,9 +175,12 @@ def _strip_frames(
             frame["in_app"] = True
 
             # The path field usually contains the name of the application, which we can't keep.
-            for field in sdk_crash_detector.fields_containing_paths:
-                if frame.get(field):
-                    frame[field] = sdk_crash_detector.replace_sdk_frame_path(field)
+            for path_field_key in sdk_crash_detector.fields_containing_paths:
+                path_field_value: str = frame.get(path_field_key, "")
+                if path_field_value:
+                    frame[path_field_key] = sdk_crash_detector.replace_sdk_frame_path(
+                        path_field_value
+                    )
         else:
             frame["in_app"] = False
 

--- a/src/sentry/utils/sdk_crashes/path_replacer.py
+++ b/src/sentry/utils/sdk_crashes/path_replacer.py
@@ -1,0 +1,46 @@
+import re
+from abc import ABC, abstractmethod
+from typing import Set
+
+
+class PathReplacer(ABC):
+    @abstractmethod
+    def replace_path(self, path: str) -> str:
+        pass
+
+
+class FixedPathReplacer(PathReplacer):
+    def __init__(
+        self,
+        path: str,
+    ):
+        self.path = path
+
+    def replace_path(self, path: str) -> str:
+        return self.path
+
+
+class KeepAfterPatternMatchPathReplacer(PathReplacer):
+    """
+    Replaces the path with the part of the path after the first pattern match.
+
+    For example, if the pattern is `/sentry/.*` and the path is `/Users/sentry/myfile.js` then the path will be replaced with `/sentry/myfile.js`.
+
+    :param patterns: A set of regular expressions.
+    :param fallback_path: The path to use if no pattern matches.
+    """
+
+    def __init__(
+        self,
+        patterns: Set[str],
+        fallback_path: str,
+    ):
+        self.patterns = {re.compile(element, re.IGNORECASE) for element in patterns}
+        self.fallback_path = fallback_path
+
+    def replace_path(self, path: str) -> str:
+        for pattern in self.patterns:
+            match = pattern.search(path)
+            if match:
+                return path[match.start() :]
+        return self.fallback_path

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detector.py
@@ -6,6 +6,16 @@ from packaging.version import InvalidVersion, Version
 from sentry.db.models import NodeData
 from sentry.utils.glob import glob_match
 from sentry.utils.safe import get_path
+from sentry.utils.sdk_crashes.path_replacer import PathReplacer
+
+
+@dataclass
+class SDKFrameConfig:
+    function_patterns: Set[str]
+
+    filename_patterns: Set[str]
+
+    path_replacer: PathReplacer
 
 
 @dataclass
@@ -16,29 +26,7 @@ class SDKCrashDetectorConfig:
 
     system_library_paths: Set[str]
 
-    sdk_frame_function_matchers: Set[str]
-
-    sdk_frame_filename_matchers: Set[str]
-
-    """
-    When stripping the frames of the original event, we have to replace the original
-    abs_path, module, and package field with something cause these fields could contain
-    the application name or other unwanted private data. This property contains the
-    replacements string for these fields. The first str of the mapping is a regex
-    pattern, the second str is the replacement name. If the regex pattern matches the
-    field, the field is replaced with the replacement name. If no regex pattern matches
-    the field, the `sdk_frame_path_default_replacement_name` is used.
-
-    str: regex pattern
-    str: replacement name
-    """
-    sdk_frame_path_replacement_names: Mapping[str, str]
-
-    """
-    If `sdk_frame_path_replacement_names` doesn't contain a replacement name for the
-    path field, this is the default replacement name.
-    """
-    sdk_frame_path_default_replacement_name: str
+    sdk_frame_config: SDKFrameConfig
 
     sdk_crash_ignore_functions_matchers: Set[str]
 
@@ -61,12 +49,8 @@ class SDKCrashDetector:
     def fields_containing_paths(self) -> Set[str]:
         return {"package", "module", "abs_path", "filename"}
 
-    def replace_sdk_frame_path(self, field: str) -> str:
-        for matcher, replacement_name in self.config.sdk_frame_path_replacement_names.items():
-            if glob_match(field, matcher, ignorecase=True):
-                return replacement_name
-
-        return self.config.sdk_frame_path_default_replacement_name
+    def replace_sdk_frame_path(self, path: str) -> str:
+        return self.config.sdk_frame_config.path_replacer.replace_path(path)
 
     def should_detect_sdk_crash(self, event_data: NodeData) -> bool:
         sdk_name = get_path(event_data, "sdk", "name")
@@ -136,14 +120,14 @@ class SDKCrashDetector:
 
         function = frame.get("function")
         if function:
-            for matcher in self.config.sdk_frame_function_matchers:
-                if glob_match(function, matcher, ignorecase=True):
+            for patterns in self.config.sdk_frame_config.function_patterns:
+                if glob_match(function, patterns, ignorecase=True):
                     return True
 
         filename = frame.get("filename")
         if filename:
-            for matcher in self.config.sdk_frame_filename_matchers:
-                if glob_match(filename, matcher, ignorecase=True):
+            for patterns in self.config.sdk_frame_config.filename_patterns:
+                if glob_match(filename, patterns, ignorecase=True):
                     return True
 
         return False

--- a/tests/sentry/utils/sdk_crashes/test_path_replacer.py
+++ b/tests/sentry/utils/sdk_crashes/test_path_replacer.py
@@ -1,0 +1,46 @@
+import pytest
+
+from sentry.utils.sdk_crashes.path_replacer import (
+    FixedPathReplacer,
+    KeepAfterPatternMatchPathReplacer,
+)
+
+
+@pytest.mark.parametrize("path", ["path", "another"])
+def test_fixed_path_replacer(path):
+    fixed_path_replacer = FixedPathReplacer(path="fixed_path")
+
+    assert fixed_path_replacer.replace_path(path=path) == "fixed_path"
+
+
+@pytest.mark.parametrize(
+    "patterns,path,expected_path",
+    [
+        (
+            {r"\/sentry-react-native\/.*"},
+            "Users/sentry/git-repos/sentry-react-native/dist/js/integrations/reactnative",
+            "/sentry-react-native/dist/js/integrations/reactnative",
+        ),
+        (
+            {r"\/sentry-react-native\/.*"},
+            "Users/sentry/git-repos/sentry-react-natives/dist/js/integrations/reactnative",
+            "fallback_path",
+        ),
+        (
+            {r"\/sentry-react-native\/.*", r"\/gitrepos\/.*"},
+            "Users/sentry/git-repos/sentry-react-native/dist/js/integrations/reactnative",
+            "/sentry-react-native/dist/js/integrations/reactnative",
+        ),
+    ],
+    ids=[
+        "pattern_matches_path",
+        "no_match_returns_fallback_path",
+        "multiple_patterns_one_matches_path",
+    ],
+)
+def test_keep_after_pattern(patterns, path, expected_path):
+    path_replacer = KeepAfterPatternMatchPathReplacer(
+        patterns=patterns, fallback_path="fallback_path"
+    )
+
+    assert path_replacer.replace_path(path=path) == expected_path


### PR DESCRIPTION
Add different path replacers for replacing the path in fields of SDK frames. The code replaces the path fields for frames of the Cocoa SDK simply with "Sentry.framework". For React-Native, we need to keep the path after the occurrence of sentry-react-native, because the path contains in which file a function is located. More than the function name is required to understand the stack trace. Furthermore, this PR adds a config for React-Native, which is only used by tests. Further changes are necessary so the SDK crash detection reports crashes for React-Native.