### PR TITLE
fix(ddm): mri parsing

### DIFF
--- a/static/app/utils/metrics.spec.tsx
+++ b/static/app/utils/metrics.spec.tsx
@@ -1,0 +1,70 @@
+import {formatMetricsUsingUnitAndOp, parseMRI} from 'sentry/utils/metrics';
+
+describe('parseMRI', () => {
+  it('should parse MRI with name, unit, and mri (custom use case)', () => {
+    const mri = 'd:custom/sentry.events.symbolicator.query_task@second';
+    const expectedResult = {
+      name: 'sentry.events.symbolicator.query_task',
+      unit: 'second',
+      mri: 'd:custom/sentry.events.symbolicator.query_task@second',
+      useCase: 'custom',
+    };
+    expect(parseMRI(mri)).toEqual(expectedResult);
+  });
+
+  it('should parse MRI with name, unit, and cleanMRI (transactions use case)', () => {
+    const mri = 'd:transactions/sentry.events.symbolicator.query_task@milisecond';
+    const expectedResult = {
+      name: 'sentry.events.symbolicator.query_task',
+      unit: 'milisecond',
+      mri: 'd:transactions/sentry.events.symbolicator.query_task@milisecond',
+      useCase: 'transactions',
+    };
+    expect(parseMRI(mri)).toEqual(expectedResult);
+  });
+
+  it('should parse MRI with name, unit, and cleanMRI (sessions use case)', () => {
+    const mri = 'd:sessions/sentry.events.symbolicator.query_task@week';
+    const expectedResult = {
+      name: 'sentry.events.symbolicator.query_task',
+      unit: 'week',
+      mri: 'd:sessions/sentry.events.symbolicator.query_task@week',
+      useCase: 'sessions',
+    };
+    expect(parseMRI(mri)).toEqual(expectedResult);
+  });
+
+  it('should extract MRI from nested operations', () => {
+    const mri = 'd:custom/sentry.events.symbolicator.query_task@second';
+
+    const expectedResult = {
+      name: 'sentry.events.symbolicator.query_task',
+      unit: 'second',
+      mri: 'd:custom/sentry.events.symbolicator.query_task@second',
+      useCase: 'custom',
+    };
+    expect(parseMRI(`sum(avg(${mri}))`)).toEqual(expectedResult);
+  });
+});
+
+describe('formatMetricsUsingUnitAndOp', () => {
+  it('should format the value according to the unit', () => {
+    // Test cases for different units
+    expect(formatMetricsUsingUnitAndOp(123456, 'millisecond')).toEqual('2.06min');
+    expect(formatMetricsUsingUnitAndOp(5000, 'second')).toEqual('1.39hr');
+    expect(formatMetricsUsingUnitAndOp(600, 'byte')).toEqual('600 B');
+    expect(formatMetricsUsingUnitAndOp(4096, 'kibibyte')).toEqual('4.0 MiB');
+    expect(formatMetricsUsingUnitAndOp(3145728, 'megabyte')).toEqual('3.15 TB');
+  });
+
+  it('should handle value as null', () => {
+    expect(formatMetricsUsingUnitAndOp(null, 'millisecond')).toEqual('—');
+    expect(formatMetricsUsingUnitAndOp(null, 'byte')).toEqual('—');
+    expect(formatMetricsUsingUnitAndOp(null, 'megabyte')).toEqual('—');
+  });
+
+  it('should format count operation as a number', () => {
+    expect(formatMetricsUsingUnitAndOp(99, 'none', 'count')).toEqual('99');
+    expect(formatMetricsUsingUnitAndOp(null, 'none', 'count')).toEqual('');
+  });
+});

--- a/static/app/views/ddm/chart.tsx
+++ b/static/app/views/ddm/chart.tsx
@@ -13,11 +13,7 @@ import {RELEASE_LINES_THRESHOLD} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
 import {DateString, PageFilters} from 'sentry/types';
 import {ReactEchartsRef} from 'sentry/types/echarts';
-import {
-  formatMetricsUsingUnitAndOp,
-  getNameFromMRI,
-  MetricDisplayType,
-} from 'sentry/utils/metrics';
+import {formatMetricsUsingUnitAndOp, MetricDisplayType} from 'sentry/utils/metrics';
 import theme from 'sentry/utils/theme';
 import useRouter from 'sentry/utils/useRouter';
 import {DDM_CHART_GROUP} from 'sentry/views/ddm/constants';
@@ -77,7 +73,6 @@ export function MetricChart({
   const formatters = {
     valueFormatter: (value: number) =>
       formatMetricsUsingUnitAndOp(value, unit, operation),
-    nameFormatter: mri => getNameFromMRI(mri),
     isGroupedByDate: true,
     bucketSize,
     showTimeInTooltip: true,

--- a/static/app/views/ddm/queryBuilder.tsx
+++ b/static/app/views/ddm/queryBuilder.tsx
@@ -12,10 +12,10 @@ import {MetricsTag, SavedSearchType, TagCollection} from 'sentry/types';
 import {
   defaultMetricDisplayType,
   getReadableMetricType,
-  getUseCaseFromMri,
   isAllowedOp,
   MetricDisplayType,
   MetricsQuery,
+  parseMRI,
   useMetricsMeta,
   useMetricsTags,
 } from 'sentry/utils/metrics';
@@ -195,12 +195,13 @@ function MetricSearchBar({tags, mri, disabled, onChange, query}: MetricSearchBar
   // TODO(ddm): try to use useApiQuery here
   const getTagValues = useCallback(
     async tag => {
+      const {useCase} = parseMRI(mri);
       const tagsValues = await api.requestPromise(
         `/organizations/${org.slug}/metrics/tags/${tag.key}/`,
         {
           query: {
             metric: mri,
-            useCase: getUseCaseFromMri(mri),
+            useCase,
             project: selection.projects,
           },
         }

--- a/static/app/views/ddm/summaryTable.tsx
+++ b/static/app/views/ddm/summaryTable.tsx
@@ -9,7 +9,7 @@ import {IconArrow, IconLightning, IconReleases} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getUtcDateString} from 'sentry/utils/dates';
-import {formatMetricsUsingUnitAndOp, getNameFromMRI} from 'sentry/utils/metrics';
+import {formatMetricsUsingUnitAndOp, parseMRI} from 'sentry/utils/metrics';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
@@ -103,10 +103,11 @@ export function SummaryTable({
 
   const rows = series
     .map(s => {
+      const {name} = parseMRI(s.seriesName);
       return {
         ...s,
         ...getValues(s.data),
-        name: getNameFromMRI(s.seriesName),
+        name,
       };
     })
     .sort((a, b) => {

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -17,10 +17,10 @@ import {space} from 'sentry/styles/space';
 import {PageFilters} from 'sentry/types';
 import {
   defaultMetricDisplayType,
-  getUnitFromMRI,
   MetricDisplayType,
   MetricsData,
   MetricsQuery,
+  parseMRI,
   updateQuery,
   useMetricsDataZoom,
 } from 'sentry/utils/metrics';
@@ -249,7 +249,8 @@ function MetricWidgetBody({
 }
 
 function getChartSeries(data: MetricsData, {focusedSeries, groupBy, hoveredLegend}) {
-  const unit = getUnitFromMRI(Object.keys(data.groups[0]?.series ?? {})[0]); // this assumes that all series have the same unit
+  // this assumes that all series have the same unit
+  const {unit} = parseMRI(Object.keys(data.groups[0]?.series ?? {})[0]);
 
   const series = data.groups.map(g => {
     return {
@@ -289,7 +290,9 @@ function getSeriesName(
   groupBy: MetricsQuery['groupBy']
 ) {
   if (isOnlyGroup && !groupBy?.length) {
-    return Object.keys(group.series)?.[0] ?? '(none)';
+    const mri = Object.keys(group.series)?.[0] ?? '(none)';
+    const {name} = parseMRI(mri);
+    return name;
   }
 
   return Object.entries(group.by)


### PR DESCRIPTION
Fixes a case where mri was not parse correctly if there was an operation applied to it. Unifies parsing logic into one `parseMRI` function.

<img width="706" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/3097b3fa-4446-4cd2-95eb-27cbb8f13409">
