### PR TITLE
fix(clippedbox): fallback for contentbox

### DIFF
--- a/static/app/components/clippedBox.tsx
+++ b/static/app/components/clippedBox.tsx
@@ -139,9 +139,11 @@ function ClippedBox(props: ClippedBoxProps) {
           return;
         }
 
-        const contentBox = entry.contentBoxSize[0];
-        const height = contentBox.blockSize;
-        if (!contentBox || height === 0) {
+        const contentBox = entry.contentBoxSize?.[0];
+        const borderBox = entry.borderBoxSize?.[0];
+        const height = contentBox?.blockSize ?? borderBox?.blockSize ?? 0;
+
+        if (height === 0) {
           return;
         }
 


### PR DESCRIPTION
Fixes https://sentry.sentry.io/issues/4611741032/events/1908a9bcb12e49dc95baf0e35447432f/?project=11276&referrer=previous-event

Seems like some old ff versions do not have a contentBox (or it is empty) and we are not checking the index access here (ts noUncheckedIndexedAccess would have caught this error)