### PR TITLE
ref: use daemon instead of deprecated setDaemon

### DIFF
--- a/src/sentry/bgtasks/api.py
+++ b/src/sentry/bgtasks/api.py
@@ -54,8 +54,7 @@ class BgTask:
         if self.running:
             return
         logger.info("bgtask.spawn", extra=dict(task_name=self.name))
-        t = threading.Thread(target=self.run)
-        t.setDaemon(True)
+        t = threading.Thread(target=self.run, daemon=True)
         t.start()
 
     def stop(self):

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -89,8 +89,7 @@ class InternalMetrics:
                 finally:
                     q.task_done()
 
-        t = Thread(target=worker)
-        t.setDaemon(True)
+        t = Thread(target=worker, daemon=True)
         t.start()
 
         self._started = True


### PR DESCRIPTION
this warns in python 3.10




<!-- Describe your PR here. -->