### PR TITLE
feat(backup): Create standalone encryption command

### DIFF
--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -46,7 +46,7 @@ def cli(ctx, config):
 for cmd in map(
     import_string,
     (
-        "sentry.runner.commands.backup.compare",
+        "sentry.runner.commands.backup.backup",
         "sentry.runner.commands.backup.export",
         "sentry.runner.commands.backup.import_",
         "sentry.runner.commands.cleanup.cleanup",

--- a/src/sentry/utils/relocation.py
+++ b/src/sentry/utils/relocation.py
@@ -235,6 +235,7 @@ COMPARE_VALIDATION_STEP_TEMPLATE = Template(
       - "-v"
       - "/workspace/findings:/findings"
       - "web"
+      - "backup"
       - "compare"
       - "/in/$tarfile"
       - "/out/$jsonfile"

--- a/tests/sentry/tasks/snapshots/PreprocessingCompleteTest/test_success.pysnap
+++ b/tests/sentry/tasks/snapshots/PreprocessingCompleteTest/test_success.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-10-31T20:53:56.260180Z'
+created: '2023-11-08T16:54:13.403961Z'
 creator: sentry
 source: tests/sentry/tasks/test_relocation.py
 ---
@@ -295,6 +295,7 @@ steps:
   - -v
   - /workspace/findings:/findings
   - web
+  - backup
   - compare
   - /in/baseline-config.tar
   - /out/baseline-config.json
@@ -324,6 +325,7 @@ steps:
   - -v
   - /workspace/findings:/findings
   - web
+  - backup
   - compare
   - /in/colliding-users.tar
   - /out/colliding-users.json


### PR DESCRIPTION
This also moves general backup tools into the `sentry backup` command, so `sentry compare` is now spelled `sentry backup compare`.

Issue: getsentry/team-ospo#214