### PR TITLE
feat(backup): Add `--encrypt-with-gcp-kms` flag

### DIFF
--- a/src/sentry/api/endpoints/relocations/public_key.py
+++ b/src/sentry/api/endpoints/relocations/public_key.py
@@ -9,7 +9,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.endpoints.relocations import ERR_FEATURE_DISABLED
-from sentry.backup.helpers import DEFAULT_CRYPTO_KEY_VERSION, get_public_key_using_gcp_kms
+from sentry.backup.helpers import DEFAULT_CRYPTO_KEY_VERSION, GCPKMSEncryptor
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +38,8 @@ class RelocationPublicKeyEndpoint(Endpoint):
             return Response({"detail": ERR_FEATURE_DISABLED}, status=400)
 
         # TODO(getsentry/team-ospo#190): We should support per-user keys in the future.
-        public_key = get_public_key_using_gcp_kms(DEFAULT_CRYPTO_KEY_VERSION)
+        public_key_pem = GCPKMSEncryptor.from_crypto_key_version(
+            DEFAULT_CRYPTO_KEY_VERSION
+        ).get_public_key_pem()
 
-        return Response({"public_key": public_key.decode("utf-8")}, status=200)
+        return Response({"public_key": public_key_pem.decode("utf-8")}, status=200)

--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -20,8 +20,8 @@ from sentry.backup.exports import export_in_config_scope, export_in_user_scope
 from sentry.backup.helpers import (
     DEFAULT_CRYPTO_KEY_VERSION,
     GCPKMSDecryptor,
+    GCPKMSEncryptor,
     ImportFlags,
-    get_public_key_using_gcp_kms,
     unwrap_encrypted_export_tarball,
 )
 from sentry.backup.imports import import_in_organization_scope
@@ -348,7 +348,7 @@ def preprocessing_baseline_config(uuid: str) -> None:
         fp = BytesIO()
         export_in_config_scope(
             fp,
-            encrypt_with=BytesIO(get_public_key_using_gcp_kms(DEFAULT_CRYPTO_KEY_VERSION)),
+            encryptor=GCPKMSEncryptor.from_crypto_key_version(DEFAULT_CRYPTO_KEY_VERSION),
         )
         fp.seek(0)
         kind = RelocationFile.Kind.BASELINE_CONFIG_VALIDATION_DATA
@@ -400,7 +400,7 @@ def preprocessing_colliding_users(uuid: str) -> None:
         fp = BytesIO()
         export_in_user_scope(
             fp,
-            encrypt_with=BytesIO(get_public_key_using_gcp_kms(DEFAULT_CRYPTO_KEY_VERSION)),
+            encryptor=GCPKMSEncryptor.from_crypto_key_version(DEFAULT_CRYPTO_KEY_VERSION),
             user_filter=set(relocation.want_usernames),
         )
         fp.seek(0)

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -30,6 +30,7 @@ from sentry.backup.findings import ComparatorFindings
 from sentry.backup.helpers import (
     KeyManagementServiceClient,
     LocalFileDecryptor,
+    LocalFileEncryptor,
     decrypt_encrypted_tarball,
 )
 from sentry.backup.imports import import_in_global_scope
@@ -185,16 +186,26 @@ def export_to_encrypted_tarball(
         # These functions are just thin wrappers, but its best to exercise them directly anyway in
         # case that ever changes.
         if scope == ExportScope.Global:
-            export_in_global_scope(tmp_file, encrypt_with=public_key_fp, printer=NOOP_PRINTER)
+            export_in_global_scope(
+                tmp_file, encryptor=LocalFileEncryptor(public_key_fp), printer=NOOP_PRINTER
+            )
         elif scope == ExportScope.Config:
-            export_in_config_scope(tmp_file, encrypt_with=public_key_fp, printer=NOOP_PRINTER)
+            export_in_config_scope(
+                tmp_file, encryptor=LocalFileEncryptor(public_key_fp), printer=NOOP_PRINTER
+            )
         elif scope == ExportScope.Organization:
             export_in_organization_scope(
-                tmp_file, encrypt_with=public_key_fp, org_filter=filter_by, printer=NOOP_PRINTER
+                tmp_file,
+                encryptor=LocalFileEncryptor(public_key_fp),
+                org_filter=filter_by,
+                printer=NOOP_PRINTER,
             )
         elif scope == ExportScope.User:
             export_in_user_scope(
-                tmp_file, encrypt_with=public_key_fp, user_filter=filter_by, printer=NOOP_PRINTER
+                tmp_file,
+                encryptor=LocalFileEncryptor(public_key_fp),
+                user_filter=filter_by,
+                printer=NOOP_PRINTER,
             )
         else:
             raise AssertionError(f"Unknown `ExportScope`: `{scope.name}`")

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -7,7 +7,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
 from sentry.api.endpoints.relocations import ERR_FEATURE_DISABLED
-from sentry.backup.helpers import create_encrypted_export_tarball
+from sentry.backup.helpers import LocalFileEncryptor, create_encrypted_export_tarball
 from sentry.models.relocation import Relocation, RelocationFile
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.factories import get_fixture_path
@@ -60,7 +60,9 @@ class RelocationCreateTest(APITestCase):
                             "owner": self.owner.username,
                             "file": SimpleUploadedFile(
                                 "export.tar",
-                                create_encrypted_export_tarball(data, p).getvalue(),
+                                create_encrypted_export_tarball(
+                                    data, LocalFileEncryptor(p)
+                                ).getvalue(),
                                 content_type="application/tar",
                             ),
                             "orgs": ["testing", "foo"],
@@ -102,7 +104,9 @@ class RelocationCreateTest(APITestCase):
                             "owner": self.owner.username,
                             "file": SimpleUploadedFile(
                                 "export.tar",
-                                create_encrypted_export_tarball(data, p).getvalue(),
+                                create_encrypted_export_tarball(
+                                    data, LocalFileEncryptor(p)
+                                ).getvalue(),
                                 content_type="application/tar",
                             ),
                             "orgs": ["testing", "foo"],
@@ -126,7 +130,9 @@ class RelocationCreateTest(APITestCase):
                             "owner": self.owner.username,
                             "file": SimpleUploadedFile(
                                 "export.tar",
-                                create_encrypted_export_tarball(data, p).getvalue(),
+                                create_encrypted_export_tarball(
+                                    data, LocalFileEncryptor(p)
+                                ).getvalue(),
                                 content_type="application/tar",
                             ),
                             "orgs": ["testing", "foo"],
@@ -167,7 +173,9 @@ class RelocationCreateTest(APITestCase):
                             "owner": self.owner.username,
                             "file": SimpleUploadedFile(
                                 "export.tar",
-                                create_encrypted_export_tarball(data, p).getvalue(),
+                                create_encrypted_export_tarball(
+                                    data, LocalFileEncryptor(p)
+                                ).getvalue(),
                                 content_type="application/tar",
                             ),
                         },
@@ -189,7 +197,9 @@ class RelocationCreateTest(APITestCase):
                         {
                             "file": SimpleUploadedFile(
                                 "export.tar",
-                                create_encrypted_export_tarball(data, p).getvalue(),
+                                create_encrypted_export_tarball(
+                                    data, LocalFileEncryptor(p)
+                                ).getvalue(),
                                 content_type="application/tar",
                             ),
                             "orgs": ["testing", "foo"],
@@ -213,7 +223,9 @@ class RelocationCreateTest(APITestCase):
                             "owner": "doesnotexist",
                             "file": SimpleUploadedFile(
                                 "export.tar",
-                                create_encrypted_export_tarball(data, p).getvalue(),
+                                create_encrypted_export_tarball(
+                                    data, LocalFileEncryptor(p)
+                                ).getvalue(),
                                 content_type="application/tar",
                             ),
                             "orgs": ["testing", "foo"],
@@ -240,7 +252,7 @@ class RelocationCreateTest(APITestCase):
                 with open(tmp_pub_key_path, "rb") as p:
                     simple_file = SimpleUploadedFile(
                         "export.tar",
-                        create_encrypted_export_tarball(data, p).getvalue(),
+                        create_encrypted_export_tarball(data, LocalFileEncryptor(p)).getvalue(),
                         content_type="application/tar",
                     )
                     simple_file.name = None

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -84,7 +84,7 @@ class SanitizationTests(ImportTestCase):
     Ensure that potentially damaging data is properly scrubbed at import time.
     """
 
-    def test_user_sanitized_in_user_scope(self):
+    def test_users_sanitized_in_user_scope(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
             self.generate_tmp_users_json_file(tmp_path)
@@ -123,7 +123,7 @@ class SanitizationTests(ImportTestCase):
             assert UserRole.objects.count() == 0
             assert UserRoleUser.objects.count() == 0
 
-    def test_user_sanitized_in_organization_scope(self):
+    def test_users_sanitized_in_organization_scope(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
             self.generate_tmp_users_json_file(tmp_path)


### PR DESCRIPTION
This mirrors the already added `--decrypt-with-gcp-kms` flag, and makes working with encrypted data in our CloudBuild validation run much easier.

Issue: getsentry/team-ospo#215