### PR TITLE
fix(suspect-commits): Gracefully handle missing frames

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -213,7 +213,7 @@ def process_commit_context(
             if munged:
                 frames = munged[1]
 
-            in_app_frames = [f for f in frames if f.get("in_app", False)][::-1]
+            in_app_frames = [f for f in frames if f and f.get("in_app", False)][::-1]
             # First frame in the stacktrace that is "in_app"
             frame = next(iter(in_app_frames), None)
 

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -69,6 +69,7 @@ class TestCommitContextMixin(TestCase):
                             "lineno": 30,
                             "filename": "sentry/tasks.py",
                         },
+                        None,
                         {
                             "function": "set_commits",
                             "abs_path": "/usr/src/sentry/src/sentry/models/release.py",


### PR DESCRIPTION
Fixes SENTRY-189P

I'm not sure exactly how this is possible, but it seems that this was the case at least once so I'm adding a check for it.