### PR TITLE
feat(backup): Copy out directory from CloudBuild

### DIFF
--- a/src/sentry/utils/relocation.py
+++ b/src/sentry/utils/relocation.py
@@ -180,16 +180,15 @@ IMPORT_VALIDATION_STEP_TEMPLATE = Template(
       - "import"
       - "$scope"
       - "/in/$tarfile"
-      - "--findings-file"
-      - "/findings/import-$jsonfile"
       - "--decrypt-with-gcp-kms"
       - "/in/kms-config.json"
+      - "--findings-file"
+      - "/findings/import-$jsonfile"
       $args
     timeout: 30s
     """
 )
 
-# TODO(getsentry/team-ospo#203): Encrypt outgoing as well.
 EXPORT_VALIDATION_STEP_TEMPLATE = Template(
     """
   - name: "gcr.io/cloud-builders/docker"
@@ -209,7 +208,9 @@ EXPORT_VALIDATION_STEP_TEMPLATE = Template(
       - "web"
       - "export"
       - "$scope"
-      - "/out/$jsonfile"
+      - "/out/$tarfile"
+      - "--encrypt-with-gcp-kms"
+      - "/in/kms-config.json"
       - "--findings-file"
       - "/findings/export-$jsonfile"
       $args
@@ -217,7 +218,21 @@ EXPORT_VALIDATION_STEP_TEMPLATE = Template(
     """
 )
 
-# TODO(getsentry/team-ospo#203): Encrypt right side as well.
+COPY_OUT_DIR_TEMPLATE = Template(
+    """
+  - name: 'gcr.io/cloud-builders/gsutil'
+    id: copy-out-dir
+    waitFor:
+      $wait_for
+    args:
+      - 'cp'
+      - '-r'
+      - '/workspace/out'
+      - '$bucket_root/relocations/runs/$uuid/out'
+    timeout: 30s
+    """
+)
+
 COMPARE_VALIDATION_STEP_TEMPLATE = Template(
     """
   - name: "gcr.io/cloud-builders/docker"
@@ -238,11 +253,13 @@ COMPARE_VALIDATION_STEP_TEMPLATE = Template(
       - "backup"
       - "compare"
       - "/in/$tarfile"
-      - "/out/$jsonfile"
-      - "--findings-file"
-      - "/findings/compare-$jsonfile"
+      - "/out/$tarfile"
       - "--decrypt-left-with-gcp-kms"
       - "/in/kms-config.json"
+      - "--decrypt-right-with-gcp-kms"
+      - "/in/kms-config.json"
+      - "--findings-file"
+      - "/findings/compare-$jsonfile"
       $args
     timeout: 30s
     """
@@ -463,6 +480,11 @@ def create_cloudbuild_yaml(relocation: Relocation) -> bytes:
             wait_for=["export-colliding-users"],
             kind=RelocationFile.Kind.RAW_USER_DATA,
             args=filter_org_slugs_args,
+        ),
+        COPY_OUT_DIR_TEMPLATE.substitute(
+            bucket_root=bucket_root,
+            uuid=relocation.uuid,
+            wait_for=["export-raw-relocation-data"],
         ),
         create_cloudbuild_validation_step(
             id="compare-baseline-config",

--- a/tests/sentry/tasks/snapshots/PreprocessingCompleteTest/test_success.pysnap
+++ b/tests/sentry/tasks/snapshots/PreprocessingCompleteTest/test_success.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-11-08T16:54:13.403961Z'
+created: '2023-11-08T18:50:27.519701Z'
 creator: sentry
 source: tests/sentry/tasks/test_relocation.py
 ---
@@ -120,10 +120,10 @@ steps:
   - import
   - config
   - /in/baseline-config.tar
-  - --findings-file
-  - /findings/import-baseline-config.json
   - --decrypt-with-gcp-kms
   - /in/kms-config.json
+  - --findings-file
+  - /findings/import-baseline-config.json
   - --overwrite-configs
   id: import-baseline-config
   name: gcr.io/cloud-builders/docker
@@ -149,10 +149,10 @@ steps:
   - import
   - users
   - /in/colliding-users.tar
-  - --findings-file
-  - /findings/import-colliding-users.json
   - --decrypt-with-gcp-kms
   - /in/kms-config.json
+  - --findings-file
+  - /findings/import-colliding-users.json
   - --filter-usernames
   - importing
   id: import-colliding-users
@@ -180,10 +180,10 @@ steps:
   - import
   - organizations
   - /in/raw-relocation-data.tar
-  - --findings-file
-  - /findings/import-raw-relocation-data.json
   - --decrypt-with-gcp-kms
   - /in/kms-config.json
+  - --findings-file
+  - /findings/import-raw-relocation-data.json
   - --filter-org-slugs
   - testing
   id: import-raw-relocation-data
@@ -212,7 +212,9 @@ steps:
   - web
   - export
   - config
-  - /out/baseline-config.json
+  - /out/baseline-config.tar
+  - --encrypt-with-gcp-kms
+  - /in/kms-config.json
   - --findings-file
   - /findings/export-baseline-config.json
   id: export-baseline-config
@@ -239,7 +241,9 @@ steps:
   - web
   - export
   - users
-  - /out/colliding-users.json
+  - /out/colliding-users.tar
+  - --encrypt-with-gcp-kms
+  - /in/kms-config.json
   - --findings-file
   - /findings/export-colliding-users.json
   - --filter-usernames
@@ -268,7 +272,9 @@ steps:
   - web
   - export
   - organizations
-  - /out/raw-relocation-data.json
+  - /out/raw-relocation-data.tar
+  - --encrypt-with-gcp-kms
+  - /in/kms-config.json
   - --findings-file
   - /findings/export-raw-relocation-data.json
   - --filter-org-slugs
@@ -279,6 +285,16 @@ steps:
   waitFor:
   - import-raw-relocation-data
   - export-colliding-users
+- args:
+  - cp
+  - -r
+  - /workspace/out
+  - gs://<BUCKET>/relocations/runs/<UUID>/out
+  id: copy-out-dir
+  name: gcr.io/cloud-builders/gsutil
+  timeout: 30s
+  waitFor:
+  - export-raw-relocation-data
 - args:
   - compose
   - -f
@@ -298,11 +314,13 @@ steps:
   - backup
   - compare
   - /in/baseline-config.tar
-  - /out/baseline-config.json
-  - --findings-file
-  - /findings/compare-baseline-config.json
+  - /out/baseline-config.tar
   - --decrypt-left-with-gcp-kms
   - /in/kms-config.json
+  - --decrypt-right-with-gcp-kms
+  - /in/kms-config.json
+  - --findings-file
+  - /findings/compare-baseline-config.json
   id: compare-baseline-config
   name: gcr.io/cloud-builders/docker
   timeout: 30s
@@ -328,11 +346,13 @@ steps:
   - backup
   - compare
   - /in/colliding-users.tar
-  - /out/colliding-users.json
-  - --findings-file
-  - /findings/compare-colliding-users.json
+  - /out/colliding-users.tar
   - --decrypt-left-with-gcp-kms
   - /in/kms-config.json
+  - --decrypt-right-with-gcp-kms
+  - /in/kms-config.json
+  - --findings-file
+  - /findings/compare-colliding-users.json
   id: compare-colliding-users
   name: gcr.io/cloud-builders/docker
   timeout: 30s

--- a/tests/sentry/tasks/test_relocation.py
+++ b/tests/sentry/tasks/test_relocation.py
@@ -656,6 +656,7 @@ class PreprocessingCompleteTest(RelocationTaskTestCase):
         cb_conf["artifacts"]["objects"][
             "location"
         ] = "gs://<BUCKET>/relocations/runs/<UUID>/findings/"
+        cb_conf["steps"][12]["args"][3] = "gs://<BUCKET>/relocations/runs/<UUID>/out"
         self.insta_snapshot(cb_conf)
 
         (_, files) = self.storage.listdir(f"relocations/runs/{self.relocation.uuid}/in")


### PR DESCRIPTION
Just a small modification that copies the out directory from cloudbuilds, which allows for easier debugging. The output files are now encrypted using GCP KMS as well, ensuring that we only ever hold encrypted data.

Closes getsentry/team-ospo#215