### PR TITLE
fix(slug): Create sentry_slugify to replace slugify calls

### DIFF
--- a/src/sentry/api/endpoints/organization_sentry_function.py
+++ b/src/sentry/api/endpoints/organization_sentry_function.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+from django.utils.text import slugify
 from rest_framework import serializers
 from rest_framework.response import Response
 
@@ -7,7 +8,6 @@ from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
-from sentry.api.helpers.slugs import sentry_slugify
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.models.sentryfunction import SentryFunction
@@ -53,8 +53,7 @@ class OrganizationSentryFunctionEndpoint(OrganizationEndpoint):
             return Response(serializer.errors, status=400)
 
         data = serializer.validated_data
-        # sentry_slugify ensures the slug is not entirely numeric
-        data["slug"] = sentry_slugify(data["name"])
+        data["slug"] = slugify(data["name"])
         # TODO: Make sure the slug is unique
         # Currently slug unique within organization
         # In future, may add "global_slug" so users can publish their functions

--- a/src/sentry/api/endpoints/organization_sentry_function.py
+++ b/src/sentry/api/endpoints/organization_sentry_function.py
@@ -1,6 +1,5 @@
 from uuid import uuid4
 
-from django.utils.text import slugify
 from rest_framework import serializers
 from rest_framework.response import Response
 
@@ -8,6 +7,7 @@ from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
+from sentry.api.helpers.slugs import sentry_slugify
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.models.sentryfunction import SentryFunction
@@ -53,7 +53,8 @@ class OrganizationSentryFunctionEndpoint(OrganizationEndpoint):
             return Response(serializer.errors, status=400)
 
         data = serializer.validated_data
-        data["slug"] = slugify(data["name"])
+        # sentry_slugify ensures the slug is not entirely numeric
+        data["slug"] = sentry_slugify(data["name"])
         # TODO: Make sure the slug is unique
         # Currently slug unique within organization
         # In future, may add "global_slug" so users can publish their functions

--- a/src/sentry/api/helpers/slugs.py
+++ b/src/sentry/api/helpers/slugs.py
@@ -1,5 +1,9 @@
+import random
+import string
+
 from django.core.validators import RegexValidator
 from django.utils.regex_helper import _lazy_re_compile
+from django.utils.text import slugify
 
 from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE, MIXED_SLUG_PATTERN
 
@@ -14,3 +18,14 @@ def validate_sentry_slug(slug: str) -> None:
         "invalid",
     )
     validator(slug)
+
+
+def sentry_slugify(slug: str, allow_unicode=False) -> str:
+    """
+    Slugify a string using Django's built-in slugify function. Ensures that the
+    slug is not entirely numeric by adding 3 letter suffix if necessary.
+    """
+    slug = slugify(slug, allow_unicode=allow_unicode)
+    if slug.isdecimal():
+        slug = f"{slug}-{''.join(random.choice(string.ascii_lowercase) for _ in range(3))}"
+    return slug

--- a/src/sentry/api/serializers/rest_framework/doc_integration.py
+++ b/src/sentry/api/serializers/rest_framework/doc_integration.py
@@ -45,12 +45,9 @@ class DocIntegrationSerializer(Serializer):
         choices=Feature.as_choices(), allow_blank=True, allow_null=True, required=False
     )
 
-    def _generate_slug(self, name: str) -> str:
-        # sentry_slugify ensures the slug is not entirely numeric
-        return sentry_slugify(name)
-
     def validate_name(self, value: str) -> str:
-        slug = self._generate_slug(value)
+        # sentry_slugify ensures the slug is not entirely numeric
+        slug = sentry_slugify(value)
         if len(slug) > DocIntegration._meta.get_field("slug").max_length:
             raise ValidationError(
                 f"Generated slug '{slug}' is too long, please use a shorter name."

--- a/src/sentry/api/serializers/rest_framework/doc_integration.py
+++ b/src/sentry/api/serializers/rest_framework/doc_integration.py
@@ -46,7 +46,6 @@ class DocIntegrationSerializer(Serializer):
     )
 
     def validate_name(self, value: str) -> str:
-        # sentry_slugify ensures the slug is not entirely numeric
         slug = sentry_slugify(value)
         if len(slug) > DocIntegration._meta.get_field("slug").max_length:
             raise ValidationError(
@@ -60,7 +59,8 @@ class DocIntegrationSerializer(Serializer):
         return value
 
     def create(self, validated_data: MutableMapping[str, Any]) -> DocIntegration:
-        slug = self._generate_slug(validated_data["name"])
+        # sentry_slugify ensures the slug is not entirely numeric
+        slug = sentry_slugify(validated_data["name"])
 
         features = validated_data.pop("features") if validated_data.get("features") else []
         with transaction.atomic(router.db_for_write(DocIntegration)):

--- a/src/sentry/models/integrations/sentry_app.py
+++ b/src/sentry/models/integrations/sentry_app.py
@@ -7,7 +7,6 @@ from typing import ClassVar, List
 from django.db import models, router, transaction
 from django.db.models import QuerySet
 from django.utils import timezone
-from django.utils.text import slugify
 from rest_framework.request import Request
 
 from sentry.backup.scopes import RelocationScope
@@ -73,15 +72,6 @@ UUID_CHARS_IN_SLUG = 6
 
 def default_uuid():
     return str(uuid.uuid4())
-
-
-def generate_slug(name: str, is_internal=False) -> str:
-    slug = slugify(name)
-    # for internal, add some uuid to make it unique
-    if is_internal:
-        slug = f"{slug}-{default_uuid()[:UUID_CHARS_IN_SLUG]}"
-
-    return slug
 
 
 def track_response_code(status, integration_slug, webhook_event):

--- a/src/sentry/sentry_apps/apps.py
+++ b/src/sentry/sentry_apps/apps.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import dataclasses
-import random
-import string
 from itertools import chain
 from typing import Any, Iterable, List, Mapping, Set
 
@@ -15,6 +13,7 @@ from rest_framework.exceptions import ValidationError
 from sentry_sdk.api import push_scope
 
 from sentry import analytics, audit_log
+from sentry.api.helpers.slugs import sentry_slugify
 from sentry.constants import SentryAppStatus
 from sentry.coreapi import APIError
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
@@ -24,9 +23,9 @@ from sentry.models.integrations.integration_feature import IntegrationFeature, I
 from sentry.models.integrations.sentry_app import (
     EVENT_EXPANSION,
     REQUIRED_EVENT_PERMISSIONS,
+    UUID_CHARS_IN_SLUG,
     SentryApp,
     default_uuid,
-    generate_slug,
 )
 from sentry.models.integrations.sentry_app_component import SentryAppComponent
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
@@ -297,12 +296,11 @@ class SentryAppCreator:
         return sentry_app
 
     def _generate_and_validate_slug(self) -> str:
-        slug = generate_slug(self.name, is_internal=self.is_internal)
-
-        # If option is set, add random 3 lowercase letter suffix to prevent numeric slug
-        # eg: 123 -> 123-abc
-        if slug.isdecimal():
-            slug = f"{slug}-{''.join(random.choice(string.ascii_lowercase) for _ in range(3))}"
+        # sentry_slugify ensures the slug is not entirely numeric
+        slug = sentry_slugify(self.name)
+        # for internal, add some uuid to make it unique
+        if self.is_internal:
+            slug = f"{slug}-{default_uuid()[:UUID_CHARS_IN_SLUG]}"
 
         # validate globally unique slug
         queryset = SentryApp.with_deleted.filter(slug=slug)
@@ -327,7 +325,6 @@ class SentryAppCreator:
     def _create_sentry_app(
         self, user: User | RpcUser, slug: str, proxy: User, api_app: ApiApplication
     ) -> SentryApp:
-
         kwargs = {
             "name": self.name,
             "slug": slug,


### PR DESCRIPTION
I was previously manually adding the suffix after the `slugify` call in code. Creating this helper allows me to leave the original code intact except replacing the one `slugify` call.