### PR TITLE
chore(hybridcloud) Remove option gate on unsubscribe links

### DIFF
--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -17,7 +17,7 @@ from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 from sentry.utils.email import MessageBuilder, group_id_to_email
-from sentry.utils.linksign import generate_signed_link, generate_signed_unsubscribe_link
+from sentry.utils.linksign import generate_signed_unsubscribe_link
 
 logger = logging.getLogger(__name__)
 
@@ -62,23 +62,13 @@ def get_subject_with_prefix(
 
 
 def get_unsubscribe_link(user_id: int, data: UnsubscribeContext) -> str:
-    use_react = options.get("unsubscribe_link.use_react_views")
-    if use_react:
-        return generate_signed_unsubscribe_link(
-            organization=data.organization,
-            user_id=user_id,
-            resource=data.key,
-            referrer=data.referrer,
-            resource_id=data.resource_id,
-        )
-
-    else:
-        return generate_signed_link(
-            user_id,
-            f"sentry-account-email-unsubscribe-{data.key}",
-            data.referrer,
-            kwargs={f"{data.key}_id": data.resource_id},
-        )
+    return generate_signed_unsubscribe_link(
+        organization=data.organization,
+        user_id=user_id,
+        resource=data.key,
+        referrer=data.referrer,
+        resource_id=data.resource_id,
+    )
 
 
 def _log_message(notification: BaseNotification, recipient: RpcActor) -> None:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1691,5 +1691,3 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 # END: SDK Crash Detection
-
-register("unsubscribe_link.use_react_views", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)


### PR DESCRIPTION
The new links and views are working well in production and test silos so we don't need to keep the old path around. I've not removed the link generation method yet as we could use it in the future.
