### PR TITLE
ref: Move team workflow notification flag to flagr

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -234,7 +234,7 @@ default_manager.add("organizations:symbol-sources", OrganizationFeature, Feature
 default_manager.add("organizations:sentry-pride-logo-footer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add('organizations:team-project-creation-all', OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add('organizations:team-project-creation-all-allowlist', OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:team-workflow-notifications", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:team-workflow-notifications", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:transaction-name-normalize", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:transaction-name-mark-scrubbed-as-sanitized", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:transaction-name-sanitization", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION
Move team workflow notification flag to flagr so that we can turn it on for a singular team.
Note that the flag is currently not being used in ingest or post process.
