### PR TITLE
fix(sso): Add logger to instantiated invitehelper

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -245,7 +245,7 @@ class AuthIdentityHandler:
         # from the invite token and member id in the session) OR an existing invite exists on this
         # organization for the email provided by the identity provider.
         invite_helper = ApiInviteHelper.from_session_or_email(
-            request=request, organization_id=organization.id, email=user.email
+            request=request, organization_id=organization.id, email=user.email, logger=logger
         )
 
         # If we are able to accept an existing invite for the user for this

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from random import randint
 from typing import Any, Optional, Union
 
@@ -43,6 +44,8 @@ from sentry.web.forms.accounts import AuthenticationForm, RegistrationForm
 from sentry.web.frontend.base import BaseView, control_silo_view
 
 ERR_NO_SSO = _("The organization does not exist or does not have Single Sign-On enabled.")
+
+logger = logging.getLogger("sentry.auth")
 
 
 # Stores callbacks that are called to get additional template context data before the login page
@@ -273,7 +276,6 @@ class AuthLoginView(BaseView):
             )
             return self.add_to_org_and_redirect_to_next_register_step(request=request, user=user)
         else:
-
             context.update(
                 {
                     "op": "register",
@@ -324,9 +326,7 @@ class AuthLoginView(BaseView):
         """
 
         # Attempt to directly accept any pending invites
-        invite_helper = ApiInviteHelper.from_session(
-            request=request,
-        )
+        invite_helper = ApiInviteHelper.from_session(request=request, logger=logger)
 
         # In single org mode, associate the user to the only organization.
         #
@@ -618,9 +618,7 @@ class AuthLoginView(BaseView):
             request.session.pop("invite_email", None)
 
             # Attempt to directly accept any pending invites
-            invite_helper = ApiInviteHelper.from_session(
-                request=request,
-            )
+            invite_helper = ApiInviteHelper.from_session(request=request, logger=logger)
 
             # In single org mode, associate the user to the only organization.
             #


### PR DESCRIPTION
Logs are not showing up when trying to accept an SSO invite when the member already exists or the SSO provider is missing.