### PR TITLE
fix(replays): Reduce max height of timeline overlay

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -196,7 +196,7 @@ const IconNode = styled('div')<{colors: Color[]; frameCount: number}>`
 `;
 
 const TooltipWrapper = styled('div')`
-  max-height: calc(100vh - ${space(4)});
+  max-height: 80vh;
   overflow: auto;
 `;
 


### PR DESCRIPTION
Max-height was too tall with the new timeline position

<img width="1482" alt="Screenshot 2023-11-08 at 6 41 52 PM" src="https://github.com/getsentry/sentry/assets/55311782/3db73373-a3fe-4189-a5fb-6e6244716e01">

Fixes https://github.com/getsentry/sentry/issues/59660