### PR TITLE
feat(browser-starfish): filter span samples by render blocking status

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
@@ -75,6 +75,12 @@ function ResourceSummaryTable() {
       return <FileSize bytes={row[key]} />;
     }
     if (key === 'transaction') {
+      const blockingStatus = row['resource.render_blocking_status'];
+      let query = `!has:${RESOURCE_RENDER_BLOCKING_STATUS}`;
+      if (blockingStatus) {
+        query = `${RESOURCE_RENDER_BLOCKING_STATUS}:${blockingStatus}`;
+      }
+
       return (
         <Link
           to={{
@@ -82,6 +88,7 @@ function ResourceSummaryTable() {
             query: {
               ...location.query,
               transaction: row[key],
+              query: [query],
             },
           }}
         >

--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -19,6 +19,7 @@ const {SPAN_SELF_TIME, SPAN_GROUP} = SpanIndexedField;
 type Options = {
   groupId: string;
   transactionName: string;
+  query?: string[];
   release?: string;
   transactionMethod?: string;
 };
@@ -38,12 +39,19 @@ export const useSpanSamples = (options: Options) => {
   const url = `/api/0/organizations/${organization.slug}/spans-samples/`;
   const api = useApi();
   const pageFilter = usePageFilters();
-  const {groupId, transactionName, transactionMethod, release} = options;
+  const {
+    groupId,
+    transactionName,
+    transactionMethod,
+    release,
+    query: extraQuery = [],
+  } = options;
   const location = useLocation();
 
   const query = new MutableSearch([
     `${SPAN_GROUP}:${groupId}`,
     `transaction:"${transactionName}"`,
+    ...extraQuery,
   ]);
 
   const filters: SpanSummaryQueryFilters = {

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -30,6 +30,7 @@ type Props = {
   onClickSample?: (sample: SpanSample) => void;
   onMouseLeaveSample?: () => void;
   onMouseOverSample?: (sample: SpanSample) => void;
+  query?: string[];
   release?: string;
   spanDescription?: string;
   transactionMethod?: string;
@@ -67,6 +68,7 @@ function DurationChart({
   highlightedSpanId,
   transactionMethod,
   release,
+  query,
 }: Props) {
   const theme = useTheme();
   const {setPageError} = usePageError();
@@ -113,6 +115,7 @@ function DurationChart({
     transactionName,
     transactionMethod,
     release,
+    query,
   });
 
   const baselineAvgSeries: Series = {

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -90,7 +90,7 @@ export function SampleList({
   function defaultOnClose() {
     router.replace({
       pathname: router.location.pathname,
-      query: omit(router.location.query, 'transaction', 'transactionMethod'),
+      query: omit(router.location.query, 'transaction', 'transactionMethod', 'query'),
     });
   }
 

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -82,6 +82,11 @@ export function SampleList({
     transaction: transactionName,
   })}`;
 
+  let extraQuery: string[] | undefined = undefined;
+  if (query.query) {
+    extraQuery = Array.isArray(query.query) ? query.query : [query.query];
+  }
+
   function defaultOnClose() {
     router.replace({
       pathname: router.location.pathname,
@@ -144,6 +149,7 @@ export function SampleList({
           onMouseOverSample={sample => setHighlightedSpanId(sample.span_id)}
           groupId={groupId}
           transactionName={transactionName}
+          query={extraQuery}
         />
       </DetailPanel>
     </PageErrorProvider>

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -34,6 +34,7 @@ type Props = {
   highlightedSpanId?: string;
   onMouseLeaveSample?: () => void;
   onMouseOverSample?: (sample: SpanSample) => void;
+  query?: string[];
   release?: string;
   transactionMethod?: string;
 };
@@ -47,6 +48,7 @@ function SampleTable({
   transactionMethod,
   columnOrder,
   release,
+  query,
 }: Props) {
   const filters: SpanSummaryQueryFilters = {
     transactionName,
@@ -81,6 +83,7 @@ function SampleTable({
     transactionName,
     transactionMethod,
     release,
+    query,
   });
 
   const {


### PR DESCRIPTION
When you click a page on the resource summary, we now ensure samples have the same render blocking status

For example in the below example, all samples seen will be non-blocking
<img width="1255" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/27f2dcf4-62ef-4c50-8b2e-87fbf2ddb643">
