### PR TITLE
fix(releases): Remove old sentry-cli version

### DIFF
--- a/static/app/views/releases/list/releasesPromo.tsx
+++ b/static/app/views/releases/list/releasesPromo.tsx
@@ -177,7 +177,7 @@ const ReleasesPromo = ({organization, project}: Props) => {
   const codeChunks = useMemo(
     () => [
       `# Install the cli
-curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION="2.2.0" bash
+      curl -sL https://sentry.io/get-cli/ | bash
 
 # Setup configuration values
 SENTRY_AUTH_TOKEN=`,

--- a/static/app/views/releases/list/releasesPromo.tsx
+++ b/static/app/views/releases/list/releasesPromo.tsx
@@ -177,7 +177,7 @@ const ReleasesPromo = ({organization, project}: Props) => {
   const codeChunks = useMemo(
     () => [
       `# Install the cli
-      curl -sL https://sentry.io/get-cli/ | bash
+curl -sL https://sentry.io/get-cli/ | bash
 
 # Setup configuration values
 SENTRY_AUTH_TOKEN=`,


### PR DESCRIPTION
Just use the latest version since we clearly don't update it here. 2.2.0 is years old
