### PR TITLE
chore(slugs): Prevent numeric slugs in SentryAppInstallationsSerializer

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
@@ -1,4 +1,3 @@
-from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -6,6 +5,7 @@ from rest_framework.response import Response
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppInstallationsBaseEndpoint
+from sentry.api.fields.sentry_slug import SentrySlugField
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.constants import SENTRY_APP_SLUG_MAX_LENGTH
@@ -14,21 +14,7 @@ from sentry.sentry_apps.installations import SentryAppInstallationCreator
 
 
 class SentryAppInstallationsSerializer(serializers.Serializer):
-    slug = serializers.RegexField(
-        r"^[a-z0-9_\-]+$",
-        max_length=SENTRY_APP_SLUG_MAX_LENGTH,
-        error_messages={
-            "invalid": _(
-                "Enter a valid slug consisting of lowercase letters, "
-                "numbers, underscores or hyphens."
-            )
-        },
-    )
-
-    def validate(self, attrs):
-        if not attrs.get("slug"):
-            raise serializers.ValidationError("Sentry App slug is required")
-        return attrs
+    slug = SentrySlugField(required=True, max_length=SENTRY_APP_SLUG_MAX_LENGTH)
 
 
 @control_silo_endpoint

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -124,4 +124,8 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
 
     def test_invalid_numeric_slug(self):
         self.login_as(user=self.user)
-        self.get_error_response(self.org.slug, slug="1234", status_code=400)
+        response = self.get_error_response(self.org.slug, slug="1234", status_code=400)
+        assert (
+            response.data["slug"][0]
+            == "Enter a valid slug consisting of lowercase letters, numbers, underscores or hyphens. It cannot be entirely numeric."
+        )

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -121,3 +121,7 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
 
         assert SentryAppInstallation.objects.filter(sentry_app=app).count() == 1
         assert response.status_code == 200
+
+    def test_invalid_numeric_slug(self):
+        self.login_as(user=self.user)
+        self.get_error_response(self.org.slug, slug="1234", status_code=400)

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -1,3 +1,4 @@
+from sentry.api.fields.sentry_slug import DEFAULT_SLUG_ERROR_MESSAGE
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
@@ -125,7 +126,4 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
     def test_invalid_numeric_slug(self):
         self.login_as(user=self.user)
         response = self.get_error_response(self.org.slug, slug="1234", status_code=400)
-        assert (
-            response.data["slug"][0]
-            == "Enter a valid slug consisting of lowercase letters, numbers, underscores or hyphens. It cannot be entirely numeric."
-        )
+        assert response.data["slug"][0] == DEFAULT_SLUG_ERROR_MESSAGE


### PR DESCRIPTION
Now that all existing and future sentry apps cannot have entirely numeric slugs, we can disallow numeric slugs on the `SentryAppInstallationsSerializer`.