### PR TITLE
chore(stats-detectors): Loosen regression criteria

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -291,8 +291,8 @@ def _detect_transaction_change_points(
             "data": data,
             "sort": "-trend_percentage()",
             "min_change()": 200,  # require a minimum 200ms increase (in ms)
-            "trend_percentage()": 0.5,  # require a minimum 50% increase
-            "validate_tail_hours": 6,
+            # "trend_percentage()": 0.5,  # require a minimum 50% increase
+            # "validate_tail_hours": 6,
             # Disable the fall back to use the midpoint as the breakpoint
             # which was originally intended to detect a gradual regression
             # for the trends use case. That does not apply here.
@@ -768,8 +768,8 @@ def _detect_function_change_points(
             "data": data,
             "sort": "-trend_percentage()",
             "min_change()": 100_000_000,  # require a minimum 100ms increase (in ns)
-            "trend_percentage()": 0.5,  # require a minimum 50% increase
-            "validate_tail_hours": 6,
+            # "trend_percentage()": 0.5,  # require a minimum 50% increase
+            # "validate_tail_hours": 6,
             # Disable the fall back to use the midpoint as the breakpoint
             # which was originally intended to detect a gradual regression
             # for the trends use case. That does not apply here.


### PR DESCRIPTION
Requiring a 50% change overall as well as in the tail period is too strict. Let's only use min change for now.