### PR TITLE
fix(ingest): fix NEL event format mismatch between relay and sentry backend

### DIFF
--- a/src/sentry/culprit.py
+++ b/src/sentry/culprit.py
@@ -34,8 +34,8 @@ def generate_culprit(data):
     if not culprit and stacktraces:
         culprit = get_stacktrace_culprit(get_path(stacktraces, -1), platform=platform)
 
-    if not culprit and data.get("nel"):
-        culprit = get_nel_culprit(data.get("nel"))
+    if not culprit and data.get("type") and data.get("type") == "nel":
+        culprit = get_nel_culprit(data.get("contexts"))
 
     if not culprit and data.get("request"):
         culprit = get_path(data, "request", "url")
@@ -74,9 +74,8 @@ def get_frame_culprit(frame, platform):
     return "{} in {}".format(fileloc, frame.get("function") or "?")
 
 
-def get_nel_culprit(data_nel):
-    body = data_nel.get("body")
-    ty = body.get("type", "<missing>")
+def get_nel_culprit(contexts):
+    ty = contexts.get("nel").get("error_type", "<missing>")
     if ty == "http.error":
-        return NEL_CULPRITS[ty].format(body.get("status_code"))
+        return NEL_CULPRITS[ty].format(contexts.get("response").get("status_code"))
     return NEL_CULPRITS.get(ty, ty)

--- a/tests/sentry/event_manager/test_generate_culprit.py
+++ b/tests/sentry/event_manager/test_generate_culprit.py
@@ -108,17 +108,23 @@ def test_hash_from_values():
 
 
 def test_nel_culprit():
-    data = {"nel": {"body": {"phase": "application", "type": "http.error", "status_code": 418}}}
+    data = {
+        "type": "nel",
+        "contexts": {
+            "nel": {"phase": "application", "error_type": "http.error"},
+            "response": {"status_code": 418},
+        },
+    }
     assert (
         generate_culprit(data)
         == "The user agent successfully received a response, but it had a 418 status code"
     )
 
-    data = {"nel": {"body": {"phase": "connection", "type": "tcp.reset"}}}
+    data = {"type": "nel", "contexts": {"nel": {"phase": "connection", "error_type": "tcp.reset"}}}
     assert generate_culprit(data) == "The TCP connection was reset"
 
-    data = {"nel": {"body": {"phase": "dns", "type": "dns.weird"}}}
+    data = {"type": "nel", "contexts": {"nel": {"phase": "dns", "error_type": "dns.weird"}}}
     assert generate_culprit(data) == "dns.weird"
 
-    data = {"nel": {"body": {"phase": "dns"}}}
+    data = {"type": "nel", "contexts": {"nel": {"phase": "dns"}}}
     assert generate_culprit(data) == "<missing>"


### PR DESCRIPTION
This will make culprits "verbal" (similar to CSP):
![image](https://github.com/getsentry/sentry/assets/1127549/12ab1456-d4e8-44a6-8cf2-6ab2b5956581)
