### PR TITLE
feat(browser-starfish): remove resource icon sidebar

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -15,7 +15,6 @@ import {isDone} from 'sentry/components/sidebar/utils';
 import {
   IconChevron,
   IconDashboard,
-  IconFile,
   IconGraph,
   IconIssues,
   IconLightning,
@@ -292,7 +291,7 @@ function Sidebar({location, organization}: Props) {
                   label={<GuideAnchor target="starfish">{t('Resources')}</GuideAnchor>}
                   to={`/organizations/${organization.slug}/performance/browser/resources`}
                   id="performance-browser-resources"
-                  icon={<IconFile />}
+                  icon={<SubitemDot collapsed={collapsed} />}
                 />
               </Feature>
             </SidebarAccordion>


### PR DESCRIPTION
For consistency, we don't want anything under performance to have an icon
<img width="203" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/80fc076d-2561-4c43-ad76-4731fadf188d">
