### PR TITLE
fix(hybridcloud) Fix host used for accept-project transfer

### DIFF
--- a/static/app/views/acceptProjectTransfer/index.spec.tsx
+++ b/static/app/views/acceptProjectTransfer/index.spec.tsx
@@ -37,6 +37,29 @@ describe('AcceptProjectTransfer', function () {
     expect(getMock).toHaveBeenCalled();
   });
 
+  it('renders and fetches data from the region url', function () {
+    window.__initialData = {
+      ...window.__initialData,
+      links: {
+        regionUrl: 'http://us.sentry.io',
+        sentryUrl: 'http://sentry.io',
+        organizationUrl: 'http://acme.sentry.io',
+      },
+    };
+    getMock = MockApiClient.addMockResponse({
+      url: '/accept-transfer/',
+      method: 'GET',
+      body: {
+        project: TestStubs.Project(),
+        organizations: [Organization({teams: [TestStubs.Team()]})],
+      },
+      match: [(_url, options) => options.host === 'http://us.sentry.io'],
+    });
+    render(<AcceptProjectTransfer {...routerProps} />);
+
+    expect(getMock).toHaveBeenCalled();
+  });
+
   it('submits', async function () {
     render(<AcceptProjectTransfer {...routerProps} />);
 

--- a/static/app/views/acceptProjectTransfer/index.tsx
+++ b/static/app/views/acceptProjectTransfer/index.tsx
@@ -26,7 +26,15 @@ class AcceptProjectTransfer extends DeprecatedAsyncView<Props, State> {
 
   getEndpoints(): ReturnType<DeprecatedAsyncView['getEndpoints']> {
     const query = this.props.location.query;
-    return [['transferDetails', '/accept-transfer/', {query}]];
+    // Because this route happens outside of OrganizationContext we
+    // need to use initial data to decide which host to send the request to
+    // as `/accept-transfer/` cannot be resolved to a region.
+    const initialData = window.__initialData;
+    let host: string | undefined = undefined;
+    if (initialData && initialData.links?.regionUrl !== initialData.links?.sentryUrl) {
+      host = initialData.links.regionUrl;
+    }
+    return [['transferDetails', '/accept-transfer/', {query, host}]];
   }
 
   getTitle() {


### PR DESCRIPTION
When running in siloed mode, the accept-transfer request needs to be sent to the region domain as /accept-transfer/ cannot be resolved to a region by control silo.

This view is rendered outside of the organization context so we aren't able to rely on the organization based feature flag in `Client` to resolve this host.

Fixes HC-920