### PR TITLE
feat(database): Add query description search

### DIFF
--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -41,7 +41,7 @@ function DatabaseLandingPage() {
       ...location,
       query: {
         ...location.query,
-        'span.description': newQuery === '' ? undefined : `${newQuery}`,
+        'span.description': newQuery === '' ? undefined : newQuery,
         cursor: undefined,
       },
     });

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -1,3 +1,4 @@
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
@@ -8,8 +9,11 @@ import {DatePageFilter} from 'sentry/components/organizations/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/organizations/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilter';
+import SearchBar from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
@@ -26,9 +30,22 @@ import {useModuleSort} from 'sentry/views/starfish/views/spans/useModuleSort';
 function DatabaseLandingPage() {
   const organization = useOrganization();
   const moduleName = ModuleName.DB;
+  const location = useLocation();
 
+  const spanDescription = decodeScalar(location.query?.['span.description'], '');
   const moduleFilters = useModuleFilters();
   const sort = useModuleSort(QueryParameterNames.SPANS_SORT);
+
+  const handleSearch = (newQuery: string) => {
+    browserHistory.push({
+      ...location,
+      query: {
+        ...location.query,
+        'span.description': newQuery === '' ? undefined : `${newQuery}`,
+        cursor: undefined,
+      },
+    });
+  };
 
   return (
     <ModulePageProviders title={[t('Performance'), t('Database')].join(' — ')}>
@@ -77,6 +94,14 @@ function DatabaseLandingPage() {
             />
           </FilterOptionsContainer>
 
+          <SearchBarContainer>
+            <SearchBar
+              query={spanDescription}
+              placeholder={t('Search for more Queries')}
+              onSearch={handleSearch}
+            />
+          </SearchBarContainer>
+
           <SpansTable moduleName={moduleName} sort={sort} limit={LIMIT} />
         </Layout.Main>
       </Layout.Body>
@@ -98,6 +123,10 @@ const FilterOptionsContainer = styled('div')`
   gap: ${space(2)};
   margin-bottom: ${space(2)};
   max-width: 800px;
+`;
+
+const SearchBarContainer = styled('div')`
+  margin-bottom: ${space(2)};
 `;
 
 const LIMIT: number = 25;

--- a/static/app/views/starfish/queries/useSpanList.spec.tsx
+++ b/static/app/views/starfish/queries/useSpanList.spec.tsx
@@ -1,0 +1,109 @@
+import {ReactNode} from 'react';
+import {Organization} from 'sentry-fixture/organization';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useSpanList} from 'sentry/views/starfish/queries/useSpanList';
+import {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
+
+jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/useOrganization');
+
+function wrapper({children}: {children?: ReactNode}) {
+  return (
+    <QueryClientProvider client={makeTestQueryClient()}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useSpanList', () => {
+  const organization = Organization();
+
+  jest.mocked(useOrganization).mockReturnValue(organization);
+
+  it('queries for current selection', async () => {
+    jest.mocked(useLocation).mockReturnValue({
+      pathname: '',
+      search: '',
+      query: {
+        statsPeriod: '10d',
+      },
+      hash: '',
+      state: undefined,
+      action: 'PUSH',
+      key: '',
+    });
+
+    const eventsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            'span.description': 'SELECT .. FROM sentry_apitoken;',
+            'spm()': 44,
+          },
+        ],
+      },
+    });
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(
+      ({filters, sorts, limit}) => useSpanList(filters, sorts, limit),
+      {
+        wrapper,
+        initialProps: {
+          filters: {
+            'span.module': 'db',
+            'span.action': 'SELECT',
+          } as SpanMetricsQueryFilters,
+          sorts: [],
+          limit: 11,
+        },
+      }
+    );
+
+    expect(result.current.isLoading).toEqual(true);
+
+    expect(eventsRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        method: 'GET',
+
+        query: {
+          query: `span.module:db span.action:SELECT has:span.description`,
+          dataset: 'spansMetrics',
+          statsPeriod: '10d',
+          environment: [],
+          project: [],
+          referrer: 'api.starfish.use-span-list',
+          field: [
+            'project.id',
+            'span.op',
+            'span.group',
+            'span.description',
+            'span.domain',
+            'spm()',
+            'sum(span.self_time)',
+            'avg(span.self_time)',
+            'http_error_count()',
+            'time_spent_percentage()',
+          ],
+          per_page: 11,
+        },
+      })
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLoading).toEqual(false);
+    expect(result.current.data).toEqual([
+      {
+        'span.description': 'SELECT .. FROM sentry_apitoken;',
+        'spm()': 44,
+      },
+    ]);
+  });
+});

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -8,6 +8,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {SpanMetricsField, SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
 import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery';
+import {EMPTY_OPTION_VALUE} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
 const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, SPAN_DOMAIN, PROJECT_ID} =
   SpanMetricsField;
@@ -55,10 +56,17 @@ function getEventView(
   sorts?: Sort[]
 ) {
   const query = new MutableSearch('');
+
   Object.entries(filters).forEach(([key, value]) => {
-    if (value) {
-      query.addFilterValue(key, value);
+    if (!value) {
+      return;
     }
+
+    if (value === EMPTY_OPTION_VALUE) {
+      query.addFilterValue('!has', key);
+    }
+
+    query.addFilterValue(key, value, !ALLOWED_WILDCARD_FIELDS.includes(key));
   });
 
   query.addFilterValue('has', 'span.description');
@@ -93,3 +101,5 @@ function getEventView(
 
   return eventView;
 }
+
+const ALLOWED_WILDCARD_FIELDS = ['span.description'];

--- a/static/app/views/starfish/queries/useSpanList.tsx
+++ b/static/app/views/starfish/queries/useSpanList.tsx
@@ -36,6 +36,8 @@ export const useSpanList = (
 
   const eventView = getEventView(filters, location, sorts);
 
+  // TODO: Add correct typing. The response should only include the fields
+  // we're querying for
   const {isLoading, data, meta, pageLinks} = useWrappedDiscoverQuery<SpanMetrics[]>({
     eventView,
     initialData: [],

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -50,6 +50,10 @@ export type SpanStringFields =
   | 'transaction'
   | 'transaction.method';
 
+export type SpanMetricsQueryFilters = {
+  [Field in SpanStringFields]?: string;
+};
+
 export type SpanStringArrayFields = 'span.domain';
 
 export type SpanFunctions =

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -63,10 +63,11 @@ export default function SpansTable({
   const cursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);
 
   const {isLoading, data, meta, pageLinks} = useSpanList(
-    moduleName ?? ModuleName.ALL,
-    endpoint,
-    method,
-    spanCategory,
+    {
+      'span.module': moduleName ?? ModuleName.ALL,
+      transaction: endpoint,
+      'transaction.method': method,
+    },
     [sort],
     limit,
     'api.starfish.use-span-list',

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -60,10 +60,12 @@ export default function SpansTable({
   const location = useLocation();
   const organization = useOrganization();
 
+  const spanDescription = decodeScalar(location.query?.['span.description']);
   const cursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);
 
   const {isLoading, data, meta, pageLinks} = useSpanList(
     {
+      'span.description': spanDescription ? `*${spanDescription}*` : undefined,
       'span.module': moduleName ?? ModuleName.ALL,
       transaction: endpoint,
       'transaction.method': method,


### PR DESCRIPTION
I rigged it up so the `span.description=token` URL query parameter gets turned into a `span.description:*token*` query. I think this is a good compromise between keeping things simple but leaving room for more advanced queries in the future. i.e., we can introduce a `query=` URL parameter that accepts complex conditions, if we want.

I also added some specs for `useSpanList` because I refactored it to accept filters as an object, rather than parameters. I got tired of renaming things and moving variables around. Instead, just specifying the query exactly as it gets sent.

**e.g.,**
<img width="782" alt="Screenshot 2023-11-09 at 11 04 49 AM" src="https://github.com/getsentry/sentry/assets/989898/20cb6367-77e4-448a-a75f-fb328d0e97ad">
