### PR TITLE
chore(stacktrace linking): Remove feature flag

### DIFF
--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -306,7 +306,6 @@ detailed_project = {
             "performance-file-io-main-thread-ingest",
             "metrics-extraction",
             "profile-json-decode-main-thread-ingest",
-            "integrations-stacktrace-link",
             "onboarding",
             "promotion-mobperf-gift50kerr",
             "device-classification",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1563,8 +1563,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:integrations-deployment": True,
     # Allow orgs to automatically create Tickets in Issue Alerts
     "organizations:integrations-ticket-rules": True,
-    # Allow orgs to use the stacktrace linking feature
-    "organizations:integrations-stacktrace-link": False,
     # Enable Opsgenie integration
     "organizations:integrations-opsgenie": True,
     # Enable one-click migration from Opsgenie plugin

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -38,7 +38,6 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:integrations-incident-management",
         "organizations:integrations-issue-basic",
         "organizations:integrations-issue-sync",
-        "organizations:integrations-stacktrace-link",
         "organizations:integrations-ticket-rules",
         "organizations:performance-view",
         "organizations:profiling-view",

--- a/tests/acceptance/test_organization_integration_configuration_tabs.py
+++ b/tests/acceptance/test_organization_integration_configuration_tabs.py
@@ -59,13 +59,7 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
             organization=self.organization, teams=[self.team, self.team2, self.team3], slug="bengal"
         )
 
-        with self.feature(
-            {
-                "organizations:integrations-codeowners": True,
-                "organizations:integrations-stacktrace-link": True,
-            }
-        ):
-
+        with self.feature("organizations:integrations-codeowners"):
             self.browser.get(
                 f"/settings/{self.organization.slug}/integrations/{self.provider}/{self.integration.id}/"
             )
@@ -91,13 +85,7 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
             self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def test_external_team_mappings(self):
-        with self.feature(
-            {
-                "organizations:integrations-codeowners": True,
-                "organizations:integrations-stacktrace-link": True,
-            }
-        ):
-
+        with self.feature("organizations:integrations-codeowners"):
             self.browser.get(
                 f"/settings/{self.organization.slug}/integrations/{self.provider}/{self.integration.id}/"
             )


### PR DESCRIPTION
Remove the stacktrace linking feature flag as it's been out for all plans for a long time now. 

Removing getsentry references here: https://github.com/getsentry/getsentry/pull/12021
Removed front end references here: https://github.com/getsentry/sentry/pull/59575

There are still kind of mentions of it for the `IntegrationFeature` [here](https://github.com/getsentry/sentry/blob/master/src/sentry/models/integrations/integration_feature.py#L41) but this is used for defining features a sentry app has, like so: 
<img width="617" alt="Screenshot 2023-11-09 at 10 38 53 AM" src="https://github.com/getsentry/sentry/assets/29959063/3b762e86-4407-445e-88ec-cf937ffd66d0">

I checked and there are ones like `integrations-project-management` for example that are not a feature flag, so it seems okay to remove this. 


Closes #56416 