### PR TITLE
chore(opsgenie): add logger for opsgenie authorization errors

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1418,7 +1418,8 @@ def get_alert_rule_trigger_action_opsgenie_team(
     )
     try:
         client.authorize_integration(type="sentry")
-    except ApiError:
+    except ApiError as e:
+        logger.info("opsgenie.authorization_error", extra={"error": str(e)})
         raise InvalidTriggerActionError("Invalid integration key.")
     return team["id"], team["team"]
 


### PR DESCRIPTION
Currently we always return `InvalidTriggerActionError` with "Invalid integration key" when some error status code is returned from Opsgenie when 
attempting to authorize an integration, when that may not be the case.

Throwing a logger here to look at the actual error if possible.
