### PR TITLE
feat(codeonwers): remove growth from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -413,6 +413,7 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /tests/sentry/api/endpoints/test_organization_projects_experiment.py    @getsentry/enterprise
 /src/sentry/models/release_threshold                                    @getsentry/enterprise
 /src/sentry/api/endpoints/release_threshold*.py                         @getsentry/enterprise
+/src/sentry/web/frontend/auth_login.py                                 @getsentry/enterprise
 ## End of Enterprise
 
 
@@ -457,6 +458,7 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /src/sentry/dynamic_sampling/                                                    @getsentry/telemetry-experience
 /src/sentry/release_health/metrics_sessions_v2.py                                @getsentry/telemetry-experience
 /src/sentry/utils/platform_categories.py                                         @getsentry/telemetry-experience
+/src/sentry/api/endpoints/organization_onboarding*                               @getsentry/telemetry-experience
 /tests/sentry/api/endpoints/test_organization_metric_data.py                     @getsentry/telemetry-experience
 /tests/sentry/api/endpoints/test_organization_metric_details.py                  @getsentry/telemetry-experience
 /tests/sentry/api/endpoints/test_organization_metric_tag_details.py              @getsentry/telemetry-experience
@@ -479,16 +481,8 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /static/app/views/performance/landing/dynamicSamplingMetricsAccuracy.spec.tsx    @getsentry/telemetry-experience
 /static/app/views/performance/landing/dynamicSamplingMetricsAccuracyAlert.tsx    @getsentry/telemetry-experience
 /static/app/views/settings/project/dynamicSampling/                              @getsentry/telemetry-experience
+/static/app/views/onboarding*                                                    @getsentry/telemetry-experience
 ## End of Telemetry Experience
-
-
-## Growth
-/src/sentry/api/endpoints/organization_onboarding*              @getsentry/growth
-/src/sentry/web/frontend/auth_login.py                          @getsentry/growth
-/static/app/utils/analytics.tsx                                 @getsentry/growth
-/static/app/utils/routeAnalytics*                               @getsentry/growth
-/static/app/views/onboarding*                                   @getsentry/growth
-## End of Growth
 
 
 ## Issues
@@ -511,4 +505,6 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /src/sentry/api/endpoints/actionable_items.py                @getsentry/issues
 /src/sentry/api/helpers/actionable_items_helper.py                  @getsentry/issues
 /static/app/components/events/interfaces/crashContent/exception/actionableItems   @getsentry/issues
+/static/app/utils/analytics.tsx                                 @getsentry/issues
+/static/app/utils/routeAnalytics*                               @getsentry/issues
 ## End of Issues

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -413,7 +413,7 @@ static/app/components/events/eventStatisticalDetector/                    @getse
 /tests/sentry/api/endpoints/test_organization_projects_experiment.py    @getsentry/enterprise
 /src/sentry/models/release_threshold                                    @getsentry/enterprise
 /src/sentry/api/endpoints/release_threshold*.py                         @getsentry/enterprise
-/src/sentry/web/frontend/auth_login.py                                 @getsentry/enterprise
+/src/sentry/web/frontend/auth_login.py                                  @getsentry/enterprise
 ## End of Enterprise
 
 

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -16,7 +16,6 @@ class ApiOwner(Enum):
     PERFORMANCE = "performance"
     TEAM_STARFISH = "team-starfish"
     PROFILING = "profiling"
-    GROWTH = "growth"
     OWNERS_INGEST = "owners-ingest"
     OWNERS_NATIVE = "owners-native"
     RELOCATION = "open-source"

--- a/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
+++ b/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
@@ -46,7 +46,7 @@ class OrganizationOnboardingContinuationEmail(OrganizationEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.UNKNOWN,
     }
-    owner = ApiOwner.GROWTH
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     # let anyone in the org use this endpoint
     permission_classes = ()
 


### PR DESCRIPTION
Growth team doesn't exist, redistributing the load:

* Login to enterprise
* Onboarding to Telemetry experience
* Analytics to issues team