### PR TITLE
ref(feedback): deeplink from replay to breadcrumbs tab

### DIFF
--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -26,9 +26,16 @@ type Props = {
   orgSlug: string;
   replaySlug: string;
   buttonProps?: Partial<ComponentProps<typeof LinkButton>>;
+  fromFeedback?: boolean;
 };
 
-function ReplayPreview({orgSlug, replaySlug, eventTimestampMs, buttonProps}: Props) {
+function ReplayPreview({
+  orgSlug,
+  replaySlug,
+  eventTimestampMs,
+  buttonProps,
+  fromFeedback,
+}: Props) {
   const routes = useRoutes();
   const {fetching, replay, replayRecord, fetchError, replayId} = useReplayReader({
     orgSlug,
@@ -111,11 +118,20 @@ function ReplayPreview({orgSlug, replaySlug, eventTimestampMs, buttonProps}: Pro
     );
   }
 
-  const fullReplayUrl = {
+  const fullReplayUrlErrors = {
     pathname: normalizeUrl(`/organizations/${orgSlug}/replays/${replayId}/`),
     query: {
       referrer: getRouteStringFromRoutes(routes),
       t_main: TabKey.ERRORS,
+      t: initialTimeOffsetMs / 1000,
+    },
+  };
+
+  const fullReplayUrlBreadcrumbs = {
+    pathname: normalizeUrl(`/organizations/${orgSlug}/replays/${replayId}/`),
+    query: {
+      referrer: getRouteStringFromRoutes(routes),
+      t_main: TabKey.BREADCRUMBS,
       t: initialTimeOffsetMs / 1000,
     },
   };
@@ -135,7 +151,7 @@ function ReplayPreview({orgSlug, replaySlug, eventTimestampMs, buttonProps}: Pro
             {...buttonProps}
             icon={<IconPlay />}
             priority="primary"
-            to={fullReplayUrl}
+            to={fromFeedback ? fullReplayUrlBreadcrumbs : fullReplayUrlErrors}
           >
             {t('Open Replay')}
           </LinkButton>

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -118,20 +118,11 @@ function ReplayPreview({
     );
   }
 
-  const fullReplayUrlErrors = {
+  const fullReplayUrl = {
     pathname: normalizeUrl(`/organizations/${orgSlug}/replays/${replayId}/`),
     query: {
       referrer: getRouteStringFromRoutes(routes),
-      t_main: TabKey.ERRORS,
-      t: initialTimeOffsetMs / 1000,
-    },
-  };
-
-  const fullReplayUrlBreadcrumbs = {
-    pathname: normalizeUrl(`/organizations/${orgSlug}/replays/${replayId}/`),
-    query: {
-      referrer: getRouteStringFromRoutes(routes),
-      t_main: TabKey.BREADCRUMBS,
+      t_main: fromFeedback ? TabKey.BREADCRUMBS : TabKey.ERRORS,
       t: initialTimeOffsetMs / 1000,
     },
   };
@@ -151,7 +142,7 @@ function ReplayPreview({
             {...buttonProps}
             icon={<IconPlay />}
             priority="primary"
-            to={fromFeedback ? fullReplayUrlBreadcrumbs : fullReplayUrlErrors}
+            to={fullReplayUrl}
           >
             {t('Open Replay')}
           </LinkButton>

--- a/static/app/components/feedback/feedbackItem/replaySection.tsx
+++ b/static/app/components/feedback/feedbackItem/replaySection.tsx
@@ -29,9 +29,10 @@ export default function ReplaySection({eventTimestampMs, organization, replayId}
             replaySlug={replayId}
             orgSlug={organization.slug}
             eventTimestampMs={eventTimestampMs}
+            fromFeedback
             buttonProps={{
-              analyticsEventKey: 'issue_details.open_replay_details_clicked',
-              analyticsEventName: 'Issue Details: Open Replay Details Clicked',
+              analyticsEventKey: 'feedback_details.open_replay_details_clicked',
+              analyticsEventName: 'Feedback Details: Open Replay Details Clicked',
               analyticsParams: {
                 organization,
               },


### PR DESCRIPTION



https://github.com/getsentry/sentry/assets/56095982/52de0df9-034d-4142-8dc9-32abadb9f68f

issues > replay still deeplinks to errors tab as before