### PR TITLE
fix(hybrid-cloud): Delegate Discord pings to the first region

### DIFF
--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -57,10 +57,11 @@ class DiscordRequestParser(BaseRequestParser):
             return self.get_response_from_control_silo()
 
         if self.view_class == DiscordInteractionsEndpoint:
-            if self.discord_request and self.discord_request.is_command():
-                return self.get_response_from_first_region()
+            if self.discord_request:
+                if self.discord_request.is_command() or self.discord_request.is_ping():
+                    return self.get_response_from_first_region()
 
-            if self.discord_request and self.discord_request.is_message_component():
-                return self.get_response_from_all_regions()
+                if self.discord_request.is_message_component():
+                    return self.get_response_from_all_regions()
 
         return self.get_response_from_control_silo()

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -50,12 +50,12 @@ class DiscordRequestParserTest(TestCase):
         integration = parser.get_integration_from_request()
         assert integration == self.integration
         with patch.object(
-            parser, "get_response_from_control_silo"
-        ) as mock_response_from_control, assume_test_silo_mode(
+            parser, "get_response_from_first_region"
+        ) as get_response_from_first_region, assume_test_silo_mode(
             SiloMode.CONTROL, can_be_monolith=False
         ):
             parser.get_response()
-            assert mock_response_from_control.called
+            assert get_response_from_first_region.called
 
     def test_interactions_endpoint_routing_command(self):
         data = {"guild_id": self.integration.external_id, "type": int(DiscordRequestTypes.COMMAND)}


### PR DESCRIPTION
We will want to delegate Discord pings to the first region as delegating them to the control silo doesn't do anything.