### PR TITLE
feat(starfish): always show side nav dots for queries, web vitals, screens, and resources modules

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -248,7 +248,9 @@ function Sidebar({location, organization}: Props) {
                   }
                   to={`/organizations/${organization.slug}/performance/database/`}
                   id="performance-database"
-                  icon={<SubitemDot collapsed={collapsed} />}
+                  // collapsed controls whether the dot is visible or not.
+                  // We always want it visible for these sidebar items so force it to true.
+                  icon={<SubitemDot collapsed />}
                 />
               </Feature>
               <Feature
@@ -267,7 +269,7 @@ function Sidebar({location, organization}: Props) {
                   }
                   to={`/organizations/${organization.slug}/performance/browser/pageloads/`}
                   id="performance-webvitals"
-                  icon={<SubitemDot collapsed={collapsed} />}
+                  icon={<SubitemDot collapsed />}
                 />
               </Feature>
               <Feature
@@ -282,7 +284,7 @@ function Sidebar({location, organization}: Props) {
                   label={t('Screens')}
                   to={`/organizations/${organization.slug}/performance/mobile/screens/`}
                   id="performance-mobile-screens"
-                  icon={<SubitemDot collapsed={collapsed} />}
+                  icon={<SubitemDot collapsed />}
                 />
               </Feature>
               <Feature features={['starfish-browser-resource-module-ui']}>
@@ -291,7 +293,7 @@ function Sidebar({location, organization}: Props) {
                   label={<GuideAnchor target="starfish">{t('Resources')}</GuideAnchor>}
                   to={`/organizations/${organization.slug}/performance/browser/resources`}
                   id="performance-browser-resources"
-                  icon={<SubitemDot collapsed={collapsed} />}
+                  icon={<SubitemDot collapsed />}
                 />
               </Feature>
             </SidebarAccordion>


### PR DESCRIPTION
always show side nav dots for queries, web vitals, screens, and resources modules
![image](https://github.com/getsentry/sentry/assets/83961295/badd88b7-86e4-4aca-8e8b-9c0ffe185be6)


rather than changing SubitemDot, I think we can just use the collapsed prop for now in case there are other items depending on SubitemDot