### PR TITLE
feat(feedback): Feedback search

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItemLoader.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemLoader.tsx
@@ -3,12 +3,15 @@ import FeedbackErrorDetails from 'sentry/components/feedback/details/feedbackErr
 import FeedbackItem from 'sentry/components/feedback/feedbackItem/feedbackItem';
 import useCurrentFeedbackId from 'sentry/components/feedback/useCurrentFeedbackId';
 import useFetchFeedbackData from 'sentry/components/feedback/useFetchFeedbackData';
+import useFetchFeedbackInfiniteListData from 'sentry/components/feedback/useFetchFeedbackInfiniteListData';
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 
 export default function FeedbackItemLoader() {
   const feedbackId = useCurrentFeedbackId();
   const {issueResult, issueData, tags, eventData} = useFetchFeedbackData({feedbackId});
+  const {issues} = useFetchFeedbackInfiniteListData();
+  const inSearch = issues.find(issue => issue.id === feedbackId);
 
   // There is a case where we are done loading, but we're fetching updates
   // This happens when the user has seen a feedback, clicks around a bit, then
@@ -21,7 +24,7 @@ export default function FeedbackItemLoader() {
     <Placeholder height="100%" />
   ) : issueResult.isError ? (
     <FeedbackErrorDetails error={t('Unable to load feedback')} />
-  ) : !issueData ? (
+  ) : !issueData || !inSearch ? (
     <FeedbackEmptyDetails />
   ) : (
     <FeedbackItem eventData={eventData} feedbackItem={issueData} tags={tags} />

--- a/static/app/components/feedback/feedbackItem/feedbackItemLoader.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemLoader.tsx
@@ -11,7 +11,7 @@ export default function FeedbackItemLoader() {
   const feedbackId = useCurrentFeedbackId();
   const {issueResult, issueData, tags, eventData} = useFetchFeedbackData({feedbackId});
   const {issues} = useFetchFeedbackInfiniteListData();
-  const inSearch = issues.find(issue => issue.id === feedbackId);
+  const inFeedbackList = issues.find(issue => issue.id === feedbackId);
 
   // There is a case where we are done loading, but we're fetching updates
   // This happens when the user has seen a feedback, clicks around a bit, then
@@ -24,7 +24,7 @@ export default function FeedbackItemLoader() {
     <Placeholder height="100%" />
   ) : issueResult.isError ? (
     <FeedbackErrorDetails error={t('Unable to load feedback')} />
-  ) : !issueData || !inSearch ? (
+  ) : !issueData || !inFeedbackList ? (
     <FeedbackEmptyDetails />
   ) : (
     <FeedbackItem eventData={eventData} feedbackItem={issueData} tags={tags} />

--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -6,8 +6,7 @@ import {t} from 'sentry/locale';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
-import ReplaySearchBar from 'sentry/views/replays/list/replaySearchBar';
+import IssueListSearchBar from 'sentry/views/issueList/searchBar';
 
 interface Props {
   className?: string;
@@ -15,17 +14,15 @@ interface Props {
 }
 
 export default function FeedbackSearch({className, style}: Props) {
-  const {selection} = usePageFilters();
   const {pathname, query} = useLocation();
   const organization = useOrganization();
 
   return (
     <SearchContainer className={className} style={style}>
-      <ReplaySearchBar
+      <IssueListSearchBar
         placeholder={t('Search Feedback')}
-        disabled
         organization={organization}
-        pageFilters={selection}
+        defaultSearchGroup={undefined}
         defaultQuery=""
         query={decodeScalar(query.query, '')}
         onSearch={searchQuery => {

--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -1,25 +1,68 @@
-import {CSSProperties} from 'react';
+import {CSSProperties, useCallback} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
+import {fetchTagValues} from 'sentry/actionCreators/tags';
+import SmartSearchBar from 'sentry/components/smartSearchBar';
 import {t} from 'sentry/locale';
-import {FieldKey} from 'sentry/utils/fields';
+import {Tag, TagCollection, TagValue} from 'sentry/types';
+import {isAggregateField} from 'sentry/utils/discover/fields';
+import {
+  FEEDBACK_FIELDS,
+  FeedbackFieldKey,
+  FieldKey,
+  FieldKind,
+  getFieldDefinition,
+} from 'sentry/utils/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
+import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import IssueListSearchBar from 'sentry/views/issueList/searchBar';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useTags from 'sentry/utils/useTags';
 
-const excludedTags = [
-  FieldKey.EVENT_TYPE,
-  FieldKey.ISSUE_CATEGORY,
-  FieldKey.ERROR_HANDLED,
-  FieldKey.ERROR_UNHANDLED,
-  FieldKey.ERROR_MAIN_THREAD,
-  FieldKey.ERROR_MECHANISM,
-  FieldKey.ERROR_RECEIVED,
-  FieldKey.ERROR_TYPE,
-  FieldKey.ERROR_VALUE,
+const EXCLUDED_TAGS = [
+  FeedbackFieldKey.BROWSER_VERSION,
+  FeedbackFieldKey.EMAIL,
+  FeedbackFieldKey.LOCALE_LANG,
+  FeedbackFieldKey.LOCALE_TIMEZONE,
+  FeedbackFieldKey.MESSAGE,
+  FeedbackFieldKey.NAME,
+  FieldKey.PLATFORM,
+  FeedbackFieldKey.OS_VERSION,
 ];
+
+const getFeedbackFieldDefinition = (key: string) => getFieldDefinition(key, 'feedback');
+
+function fieldDefinitionsToTagCollection(fieldKeys: string[]): TagCollection {
+  return Object.fromEntries(
+    fieldKeys.map(key => [
+      key,
+      {
+        key,
+        name: key,
+        ...getFeedbackFieldDefinition(key),
+      },
+    ])
+  );
+}
+
+const FEEDBACK_FIELDS_AS_TAGS = fieldDefinitionsToTagCollection(FEEDBACK_FIELDS);
+
+function getSupportedTags(supportedTags: TagCollection) {
+  return {
+    ...Object.fromEntries(
+      Object.keys(supportedTags).map(key => [
+        key,
+        {
+          ...supportedTags[key],
+          kind: getFeedbackFieldDefinition(key)?.kind ?? FieldKind.TAG,
+        },
+      ])
+    ),
+    ...FEEDBACK_FIELDS_AS_TAGS,
+  };
+}
 
 interface Props {
   className?: string;
@@ -27,16 +70,47 @@ interface Props {
 }
 
 export default function FeedbackSearch({className, style}: Props) {
+  const projectIdStrings = usePageFilters().selection.projects?.map(String);
   const {pathname, query} = useLocation();
   const organization = useOrganization();
+  const tags = useTags();
+  const api = useApi();
+
+  const getTagValues = useCallback(
+    (tag: Tag, searchQuery: string, _params: object): Promise<string[]> => {
+      if (isAggregateField(tag.key)) {
+        // We can't really auto suggest values for aggregate fields
+        // or measurements, so we simply don't
+        return Promise.resolve([]);
+      }
+
+      return fetchTagValues({
+        api,
+        orgSlug: organization.slug,
+        tagKey: tag.key,
+        search: searchQuery,
+        projectIds: projectIdStrings,
+      }).then(
+        tagValues => (tagValues as TagValue[]).map(({value}) => value),
+        () => {
+          throw new Error('Unable to fetch event field values');
+        }
+      );
+    },
+    [api, organization.slug, projectIdStrings]
+  );
 
   return (
     <SearchContainer className={className} style={style}>
-      <IssueListSearchBar
+      <SmartSearchBar
+        hasRecentSearches
         placeholder={t('Search Feedback')}
         organization={organization}
-        defaultSearchGroup={undefined}
-        excludedTags={excludedTags}
+        onGetTagValues={getTagValues}
+        supportedTags={getSupportedTags(tags)}
+        excludedTags={EXCLUDED_TAGS}
+        fieldDefinitionGetter={getFeedbackFieldDefinition}
+        maxMenuHeight={500}
         defaultQuery=""
         query={decodeScalar(query.query, '')}
         onSearch={searchQuery => {

--- a/static/app/components/feedback/feedbackSearch.tsx
+++ b/static/app/components/feedback/feedbackSearch.tsx
@@ -3,10 +3,23 @@ import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
+import {FieldKey} from 'sentry/utils/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import IssueListSearchBar from 'sentry/views/issueList/searchBar';
+
+const excludedTags = [
+  FieldKey.EVENT_TYPE,
+  FieldKey.ISSUE_CATEGORY,
+  FieldKey.ERROR_HANDLED,
+  FieldKey.ERROR_UNHANDLED,
+  FieldKey.ERROR_MAIN_THREAD,
+  FieldKey.ERROR_MECHANISM,
+  FieldKey.ERROR_RECEIVED,
+  FieldKey.ERROR_TYPE,
+  FieldKey.ERROR_VALUE,
+];
 
 interface Props {
   className?: string;
@@ -23,6 +36,7 @@ export default function FeedbackSearch({className, style}: Props) {
         placeholder={t('Search Feedback')}
         organization={organization}
         defaultSearchGroup={undefined}
+        excludedTags={excludedTags}
         defaultQuery=""
         query={decodeScalar(query.query, '')}
         onSearch={searchQuery => {

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1504,12 +1504,12 @@ const FEEDBACK_FIELD_DEFINITIONS: Record<FeedbackFieldKey, FieldDefinition> = {
     valueType: FieldValueType.STRING,
   },
   [FeedbackFieldKey.OS_NAME]: {
-    desc: t('Name of the Operating System'),
+    desc: t('Name of the operating system'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },
   [FeedbackFieldKey.OS_VERSION]: {
-    desc: t('Version number of the Operating System'),
+    desc: t('Version number of the operating system'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
   },

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1422,9 +1422,107 @@ const REPLAY_CLICK_FIELD_DEFINITIONS: Record<ReplayClickFieldKey, FieldDefinitio
   },
 };
 
+export enum FeedbackFieldKey {
+  BROWSER_NAME = 'browser.name',
+  BROWSER_VERSION = 'browser.version',
+  EMAIL = 'contact_email',
+  LOCALE_LANG = 'locale.lang',
+  LOCALE_TIMEZONE = 'locale.timezone',
+  MESSAGE = 'message',
+  NAME = 'name',
+  OS_NAME = 'os.name',
+  OS_VERSION = 'os.version',
+  URL = 'url',
+}
+
+export const FEEDBACK_FIELDS = [
+  FieldKey.ASSIGNED,
+  FeedbackFieldKey.BROWSER_NAME,
+  FeedbackFieldKey.BROWSER_VERSION,
+  FieldKey.DEVICE_BRAND,
+  FieldKey.DEVICE_FAMILY,
+  FieldKey.DEVICE_MODEL_ID,
+  FieldKey.DEVICE_NAME,
+  FieldKey.DIST,
+  FeedbackFieldKey.EMAIL,
+  FieldKey.ENVIRONMENT,
+  FieldKey.ID,
+  FieldKey.IS,
+  FieldKey.LEVEL,
+  FeedbackFieldKey.LOCALE_LANG,
+  FeedbackFieldKey.LOCALE_TIMEZONE,
+  FeedbackFieldKey.MESSAGE,
+  FeedbackFieldKey.NAME,
+  FeedbackFieldKey.OS_NAME,
+  FeedbackFieldKey.OS_VERSION,
+  FieldKey.PLATFORM,
+  FieldKey.SDK_NAME,
+  FieldKey.SDK_VERSION,
+  FieldKey.TIMESTAMP,
+  FieldKey.TRANSACTION,
+  FeedbackFieldKey.URL,
+  FieldKey.USER_EMAIL,
+  FieldKey.USER_ID,
+  FieldKey.USER_IP,
+  FieldKey.USER_USERNAME,
+];
+
+const FEEDBACK_FIELD_DEFINITIONS: Record<FeedbackFieldKey, FieldDefinition> = {
+  [FeedbackFieldKey.BROWSER_NAME]: {
+    desc: t('Name of the browser'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FeedbackFieldKey.BROWSER_VERSION]: {
+    desc: t('Version number of the browser'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FeedbackFieldKey.EMAIL]: {
+    desc: t('Contact email of the user writing the feedback'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FeedbackFieldKey.LOCALE_LANG]: {
+    desc: t('Language preference of the user'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FeedbackFieldKey.LOCALE_TIMEZONE]: {
+    desc: t('Timezone the feedback was submitted from'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FeedbackFieldKey.MESSAGE]: {
+    desc: t('Message written by the user providing feedback'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FeedbackFieldKey.NAME]: {
+    desc: t('Name of the user writing feedback'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FeedbackFieldKey.OS_NAME]: {
+    desc: t('Name of the Operating System'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FeedbackFieldKey.OS_VERSION]: {
+    desc: t('Version number of the Operating System'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+  [FeedbackFieldKey.URL]: {
+    desc: t('URL of the page that the feedback is triggered on'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
+};
+
 export const getFieldDefinition = (
   key: string,
-  type: 'event' | 'replay' | 'replay_click' = 'event'
+  type: 'event' | 'replay' | 'replay_click' | 'feedback' = 'event'
 ): FieldDefinition | null => {
   switch (type) {
     case 'replay':
@@ -1435,6 +1533,14 @@ export const getFieldDefinition = (
         return REPLAY_CLICK_FIELD_DEFINITIONS[key];
       }
       if (REPLAY_FIELDS.includes(key as FieldKey)) {
+        return EVENT_FIELD_DEFINITIONS[key];
+      }
+      return null;
+    case 'feedback':
+      if (key in FEEDBACK_FIELD_DEFINITIONS) {
+        return FEEDBACK_FIELD_DEFINITIONS[key];
+      }
+      if (FEEDBACK_FIELDS.includes(key as FieldKey)) {
         return EVENT_FIELD_DEFINITIONS[key];
       }
       return null;

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -6,6 +6,7 @@ import {Button} from 'sentry/components/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeedbackFilters from 'sentry/components/feedback/feedbackFilters';
 import FeedbackItemLoader from 'sentry/components/feedback/feedbackItem/feedbackItemLoader';
+import FeedbackSearch from 'sentry/components/feedback/feedbackSearch';
 import FeedbackSetupPanel from 'sentry/components/feedback/feedbackSetupPanel';
 import FeedbackList from 'sentry/components/feedback/list/feedbackList';
 import {useHaveSelectedProjectsSetupFeedback} from 'sentry/components/feedback/useFeedbackOnboarding';
@@ -79,6 +80,7 @@ export default function FeedbackListPage({}: Props) {
                     <Container style={{gridArea: 'list'}}>
                       <FeedbackList />
                     </Container>
+                    <FeedbackSearch style={{gridArea: 'search'}} />
                     <Container style={{gridArea: 'details'}}>
                       <FeedbackItemLoader />
                     </Container>
@@ -109,7 +111,7 @@ const LayoutGrid = styled('div')`
   grid-template-columns: minmax(390px, 1fr) 2fr;
   grid-template-rows: max-content 1fr;
   grid-template-areas:
-    'filters details'
+    'filters search'
     'list details';
   gap: ${space(2)};
   place-items: stretch;


### PR DESCRIPTION
Implement search using Issue search bar. Ability to search for metadata (name, description etc) is WIP. If a feedback item has already been selected, the feedback item would remain even if it's not in the search results. This is to prevent people who come from alerts seeing an empty state based on the filters or mailbox.

relates to https://github.com/getsentry/team-replay/issues/278