### PR TITLE
chore: Add logging for redirects

### DIFF
--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Callable
 
 from django.conf import settings
@@ -14,6 +15,8 @@ from sentry.api.utils import generate_organization_url
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.utils import auth
 from sentry.utils.http import absolute_uri
+
+logger = logging.getLogger(__name__)
 
 
 def _org_exists(slug):
@@ -92,6 +95,7 @@ class CustomerDomainMiddleware:
             # We kick any request to the logout view.
             logout(request)
             redirect_url = absolute_uri(reverse("sentry-logout"))
+            logger.info("customer_domain.redirect.logout", extra={"location": redirect_url})
             return HttpResponseRedirect(redirect_url)
 
         activeorg = _resolve_activeorg(request)
@@ -103,5 +107,6 @@ class CustomerDomainMiddleware:
         auth.set_active_org(request, activeorg)
         redirect_url = _resolve_redirect_url(request, activeorg)
         if redirect_url is not None and len(redirect_url) > 0:
+            logger.info("customer_domain.redirect", extra={"location": redirect_url})
             return HttpResponseRedirect(redirect_url)
         return self.get_response(request)

--- a/src/sentry/middleware/subdomain.py
+++ b/src/sentry/middleware/subdomain.py
@@ -41,7 +41,7 @@ class SubdomainMiddleware:
             url_prefix = options.get("system.url-prefix")
             logger.info(
                 "subdomain.disallowed_host",
-                extra={"location": url_prefix, "host": request.get_host()},
+                extra={"location": url_prefix, "uri": request.get_raw_uri()},
             )
             return HttpResponseRedirect(url_prefix)
 

--- a/src/sentry/middleware/subdomain.py
+++ b/src/sentry/middleware/subdomain.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Callable
 
 from django.core.exceptions import DisallowedHost
@@ -8,6 +9,8 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 
 from sentry import options
+
+logger = logging.getLogger(__name__)
 
 
 class SubdomainMiddleware:
@@ -36,6 +39,10 @@ class SubdomainMiddleware:
             host = request.get_host().lower()
         except DisallowedHost:
             url_prefix = options.get("system.url-prefix")
+            logger.info(
+                "subdomain.disallowed_host",
+                extra={"location": url_prefix, "host": request.get_host()},
+            )
             return HttpResponseRedirect(url_prefix)
 
         if not host.endswith(f".{self.base_hostname}"):


### PR DESCRIPTION
With customer domains and django host allow lists debugging redirect loops can be frustrating. Having logging on the redirect sources helps debugging.
