### PR TITLE
ref(grouping): Inject SDK tag into group metadata

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -145,8 +145,6 @@ CRASH_REPORT_TIMEOUT = 24 * 3600  # one day
 
 NON_TITLE_EVENT_TITLES = ["<untitled>", "<unknown>", "<unlabeled event>"]
 
-SDK_METADATA_FIELDS_TO_KEEP = ("name", "version", "integrations")
-
 
 @dataclass
 class GroupInfo:
@@ -213,13 +211,13 @@ def sdk_metadata_from_event(event: Event) -> Mapping[str, Any]:
     if not (sdk_metadata := event.data.get("sdk")):
         return {}
 
-    metadata = {"sdk": {}}
     try:
-        for key in SDK_METADATA_FIELDS_TO_KEEP:
-            if sdk_metadata.get(key):
-                metadata["sdk"][key] = sdk_metadata[key]
-        metadata["sdk"]["name_normalized"] = normalized_sdk_tag_from_event(event)
-        return metadata
+        return {
+            "sdk": {
+                "name": sdk_metadata.get("name") or "unknown",
+                "name_normalized": normalized_sdk_tag_from_event(event),
+            }
+        }
     except Exception:
         logger.warning("failed to set normalized SDK name", exc_info=True)
         return {}

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -138,7 +138,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("sentry.events")
 
-SECURITY_REPORT_INTERFACES = ("csp", "hpkp", "expectct", "expectstaple")
+SECURITY_REPORT_INTERFACES = ("csp", "hpkp", "expectct", "expectstaple", "nel")
 
 # Timeout for cached group crash report counts
 CRASH_REPORT_TIMEOUT = 24 * 3600  # one day

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1334,7 +1334,8 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         group = event.group
         assert group is not None
         assert group.data.get("type") == "default"
-        assert group.data.get("metadata").get("title") == "foo bar"
+        assert group.data.get("metadata")
+        assert group.data.get("metadata").get("title") == "foo bar"  # type: ignore[union-attr]
 
     def test_message_event_type(self):
         manager = EventManager(
@@ -1352,7 +1353,8 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         group = event.group
         assert group is not None
         assert group.data.get("type") == "default"
-        assert group.data.get("metadata").get("title") == "foo bar"
+        assert group.data.get("metadata")
+        assert group.data.get("metadata").get("title") == "foo bar"  # type: ignore[union-attr]
 
     def test_error_event_type(self):
         manager = EventManager(
@@ -1503,7 +1505,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         manager.normalize()
         event = manager.save(self.project.id)
 
-        assert event.group.data.get("metadata").get("sdk") == "sentry.native.unity"
+        assert event.group.data.get("metadata").get("sdk") == "sentry.native.unity"  # type: ignore[union-attr]
 
     def test_no_message(self):
         # test that the message is handled gracefully

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -185,7 +185,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert group.last_seen == event2.datetime
         assert group.message == event2.message
         assert group.data.get("type") == "default"
-        assert group.data.get("metadata") == {"title": "foo bar"}
+        assert group.data.get("metadata").get("title") == "foo bar"
 
     def test_materialze_metadata_simple(self):
         manager = EventManager(make_event(transaction="/dogs/are/great/"))
@@ -1334,7 +1334,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         group = event.group
         assert group is not None
         assert group.data.get("type") == "default"
-        assert group.data.get("metadata") == {"title": "foo bar"}
+        assert group.data.get("metadata").get("title") == "foo bar"
 
     def test_message_event_type(self):
         manager = EventManager(
@@ -1352,7 +1352,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         group = event.group
         assert group is not None
         assert group.data.get("type") == "default"
-        assert group.data.get("metadata") == {"title": "foo bar"}
+        assert group.data.get("metadata").get("title") == "foo bar"
 
     def test_error_event_type(self):
         manager = EventManager(
@@ -1369,6 +1369,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             "type": "Foo",
             "value": "bar",
             "display_title_with_tree_label": False,
+            "sdk": "other",
         }
 
     def test_csp_event_type(self):
@@ -1395,6 +1396,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             "directive": "script-src",
             "uri": "example.com",
             "message": "Blocked 'script' from 'example.com'",
+            "sdk": "other",
         }
         assert group.title == "Blocked 'script' from 'example.com'"
 
@@ -1493,6 +1495,15 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             "integrations": None,
             "packages": None,
         }
+
+    def test_sdk_group_tagging(self):
+        manager = EventManager(
+            make_event(**{"sdk": {"name": "sentry.native.unity", "version": "1.0"}})
+        )
+        manager.normalize()
+        event = manager.save(self.project.id)
+
+        assert event.group.data.get("metadata").get("sdk") == "sentry.native.unity"
 
     def test_no_message(self):
         # test that the message is handled gracefully
@@ -2257,6 +2268,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
                 "location": "/books/",
                 "title": "N+1 Query",
                 "value": description,
+                "sdk": "other",
             }
             assert (
                 event.search_message

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1371,7 +1371,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             "type": "Foo",
             "value": "bar",
             "display_title_with_tree_label": False,
-            "sdk": "other",
         }
 
     def test_csp_event_type(self):
@@ -1398,7 +1397,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             "directive": "script-src",
             "uri": "example.com",
             "message": "Blocked 'script' from 'example.com'",
-            "sdk": "other",
         }
         assert group.title == "Blocked 'script' from 'example.com'"
 
@@ -1500,12 +1498,14 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
     def test_sdk_group_tagging(self):
         manager = EventManager(
-            make_event(**{"sdk": {"name": "sentry.native.unity", "version": "1.0"}})
+            make_event(**{"sdk": {"name": "sentry-native-unity", "version": "1.0"}})
         )
         manager.normalize()
         event = manager.save(self.project.id)
 
-        assert event.group.data.get("metadata").get("sdk") == "sentry.native.unity"  # type: ignore[union-attr]
+        assert (sdk_metadata := event.group.data.get("metadata").get("sdk"))  # type: ignore[union-attr]
+        assert sdk_metadata.get("name") == "sentry-native-unity"  # type: ignore[union-attr]
+        assert sdk_metadata.get("name_normalized") == "sentry.native.unity"  # type: ignore[union-attr]
 
     def test_no_message(self):
         # test that the message is handled gracefully
@@ -2270,7 +2270,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
                 "location": "/books/",
                 "title": "N+1 Query",
                 "value": description,
-                "sdk": "other",
             }
             assert (
                 event.search_message

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1504,8 +1504,8 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         event = manager.save(self.project.id)
 
         assert (sdk_metadata := event.group.data.get("metadata").get("sdk"))  # type: ignore[union-attr]
-        assert sdk_metadata.get("name") == "sentry-native-unity"  # type: ignore[union-attr]
-        assert sdk_metadata.get("name_normalized") == "sentry.native.unity"  # type: ignore[union-attr]
+        assert sdk_metadata.get("name") == "sentry-native-unity"
+        assert sdk_metadata.get("name_normalized") == "sentry.native.unity"
 
     def test_no_message(self):
         # test that the message is handled gracefully

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -64,7 +64,7 @@ class EventManagerGroupingTest(TestCase):
         assert group.last_seen == event2.datetime
         assert group.message == event2.message
         assert group.data.get("type") == "default"
-        assert group.data.get("metadata") == {"title": "foo 123"}
+        assert group.data.get("metadata").get("title") == "foo 123"
 
         # After expiry, new events are still assigned to the same group:
         project.update_option("sentry:secondary_grouping_expiry", 0)
@@ -227,7 +227,6 @@ class EventManagerGroupingTest(TestCase):
 
     @mock.patch("sentry.event_manager._calculate_background_grouping")
     def test_background_grouping_sample_rate(self, mock_calc_grouping):
-
         timestamp = time() - 300
         manager = EventManager(
             make_event(message="foo 123", event_id="a" * 32, timestamp=timestamp)


### PR DESCRIPTION
Implements #59748

Injects normalized SDK name into group's `"metadata"` field.  