### PR TITLE
feat(feedbacks): add source to feedback creation

### DIFF
--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -9,6 +9,7 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.user_reports import user_reports_filter_to_unresolved
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import UserReportWithGroupSerializer, serialize
+from sentry.feedback.usecases.create_feedback import FeedbackCreationSource
 from sentry.ingest.userreport import Conflict, save_userreport
 from sentry.models.environment import Environment
 from sentry.models.projectkey import ProjectKey
@@ -108,7 +109,9 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         report = serializer.validated_data
         try:
-            report_instance = save_userreport(project, report)
+            report_instance = save_userreport(
+                project, report, FeedbackCreationSource.USER_REPORT_DJANGO_ENDPOINT
+            )
         except Conflict as e:
             return self.respond({"detail": str(e)}, status=409)
 

--- a/src/sentry/feedback/endpoints/feedback_ingest.py
+++ b/src/sentry/feedback/endpoints/feedback_ingest.py
@@ -22,7 +22,7 @@ from sentry.api.bases.project import ProjectPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.constants import ObjectStatus
 from sentry.feedback.models import Feedback
-from sentry.feedback.usecases.create_feedback import create_feedback_issue
+from sentry.feedback.usecases.create_feedback import FeedbackCreationSource, create_feedback_issue
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -176,7 +176,9 @@ class FeedbackIngestEndpoint(Endpoint):
         Feedback.objects.create(**result)
 
         _convert_feedback_to_context(request.data)
-        create_feedback_issue(request.data, project.id)
+        create_feedback_issue(
+            request.data, project.id, FeedbackCreationSource.NEW_FEEDBACK_DJANGO_ENDPOINT
+        )
 
         return self.respond(status=201)
 

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
+from enum import Enum
 from typing import Any, TypedDict
 from uuid import uuid4
 
@@ -14,10 +15,19 @@ from sentry.issues.json_schemas import EVENT_PAYLOAD_SCHEMA, LEGACY_EVENT_PAYLOA
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.models.project import Project
 from sentry.signals import first_feedback_received
+from sentry.utils import metrics
 from sentry.utils.dates import ensure_aware
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)
+
+
+class FeedbackCreationSource(Enum):
+    NEW_FEEDBACK_ENVELOPE = "new_feedback_envelope"
+    NEW_FEEDBACK_DJANGO_ENDPOINT = "new_feedback_sentry_django_endpoint"
+    USER_REPORT_DJANGO_ENDPOINT = "user_report_sentry_django_endpoint"
+    USER_REPORT_ENVELOPE = "user_report_envelope"
+    CRASH_REPORT_EMBED_FORM = "crash_report_embed_form"
 
 
 def make_evidence(feedback):
@@ -89,7 +99,8 @@ def fix_for_issue_platform(event_data):
     return ret_event
 
 
-def create_feedback_issue(event, project_id):
+def create_feedback_issue(event, project_id, source: FeedbackCreationSource):
+    metrics.incr("feedback.created", tags={"referrer": source.value})
     # Note that some of the fields below like title and subtitle
     # are not used by the feedback UI, but are required.
     event["event_id"] = event.get("event_id") or uuid4().hex
@@ -153,7 +164,12 @@ class UserReportShimDict(TypedDict):
     level: str
 
 
-def shim_to_feedback(report: UserReportShimDict, event: Event, project: Project):
+def shim_to_feedback(
+    report: UserReportShimDict,
+    event: Event,
+    project: Project,
+    source: FeedbackCreationSource,
+):
     """
     takes user reports from the legacy user report form/endpoint and
     user reports that come from relay envelope ingestion and
@@ -192,7 +208,7 @@ def shim_to_feedback(report: UserReportShimDict, event: Event, project: Project)
             if report.get("event_id"):
                 feedback_event["contexts"]["feedback"]["associated_event_id"] = report["event_id"]
 
-        create_feedback_issue(feedback_event, project.id)
+        create_feedback_issue(feedback_event, project.id, source)
     except Exception:
         logger.exception(
             "Error attempting to create new User Feedback from Shiming old User Report"

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -11,6 +11,7 @@ from sentry import eventstore, features
 from sentry.attachments import CachedAttachment, attachment_cache
 from sentry.event_manager import save_attachment
 from sentry.eventstore.processing import event_processing_store
+from sentry.feedback.usecases.create_feedback import FeedbackCreationSource
 from sentry.ingest.userreport import Conflict, save_userreport
 from sentry.killswitches import killswitch_matches_context
 from sentry.models.project import Project
@@ -259,7 +260,12 @@ def process_userreport(message: IngestMessage, project: Project) -> bool:
     feedback = json.loads(message["payload"], use_rapid_json=True)
 
     try:
-        save_userreport(project, feedback, start_time=start_time)
+        save_userreport(
+            project,
+            feedback,
+            FeedbackCreationSource.USER_REPORT_ENVELOPE,
+            start_time=start_time,
+        )
         return True
     except Conflict as e:
         logger.info("Invalid userreport: %s", e)

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -23,7 +23,12 @@ class Conflict(Exception):
     pass
 
 
-def save_userreport(project, report, start_time=None):
+def save_userreport(
+    project,
+    report,
+    source,
+    start_time=None,
+):
     with metrics.timer("sentry.ingest.userreport.save_userreport"):
         if start_time is None:
             start_time = timezone.now()
@@ -99,7 +104,7 @@ def save_userreport(project, report, start_time=None):
         user_feedback_received.send(project=project, sender=save_userreport)
 
         if features.has("organizations:user-feedback-ingest", project.organization, actor=None):
-            shim_to_feedback(report, event, project)
+            shim_to_feedback(report, event, project, source)
 
         return report_instance
 

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -14,7 +14,7 @@ from sentry.constants import DEFAULT_STORE_NORMALIZER_ARGS
 from sentry.datascrubbing import scrub_data
 from sentry.eventstore import processing
 from sentry.eventstore.processing.base import Event
-from sentry.feedback.usecases.create_feedback import create_feedback_issue
+from sentry.feedback.usecases.create_feedback import FeedbackCreationSource, create_feedback_issue
 from sentry.killswitches import killswitch_matches_context
 from sentry.lang.native.symbolicator import SymbolicatorTaskKind
 from sentry.models.activity import Activity
@@ -879,7 +879,7 @@ def save_event_feedback(
     project_id: Optional[int] = None,
     **kwargs: Any,
 ) -> None:
-    create_feedback_issue(data, project_id)
+    create_feedback_issue(data, project_id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
 
 @instrumented_task(

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -12,7 +12,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
 from sentry import eventstore, features
-from sentry.feedback.usecases.create_feedback import shim_to_feedback
+from sentry.feedback.usecases.create_feedback import FeedbackCreationSource, shim_to_feedback
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey
@@ -205,6 +205,7 @@ class ErrorPageEmbedView(View):
                     },
                     event,
                     project,
+                    FeedbackCreationSource.CRASH_REPORT_EMBED_FORM,
                 )
 
             return self._smart_response(request)

--- a/tests/sentry/api/endpoints/test_organization_user_reports.py
+++ b/tests/sentry/api/endpoints/test_organization_user_reports.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from sentry.feedback.usecases.create_feedback import FeedbackCreationSource
 from sentry.ingest.userreport import save_userreport
 from sentry.models.group import GroupStatus
 from sentry.models.userreport import UserReport
@@ -138,7 +139,9 @@ class OrganizationUserReportListTest(APITestCase, SnubaTestCase):
             "email": "",
             "comments": "It broke",
         }
-        save_userreport(self.project_1, report_data)
+        save_userreport(
+            self.project_1, report_data, FeedbackCreationSource.USER_REPORT_DJANGO_ENDPOINT
+        )
         response = self.get_response(self.project_1.organization.slug, project=[self.project_1.id])
         assert response.status_code == 200
         assert response.data[0]["comments"] == "It broke"


### PR DESCRIPTION
- [x] Adds source to various feedback creation paths, based on API vs Ingest etc.
- [x] Increment a counter based on this.
- [x] Will be used in a follow up PR to control post_processing