### PR TITLE
feat(metric-alerts): Allow metric alerts to be filtered by status

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -268,6 +268,9 @@ def convert_query_values(
                     for child in search_filter.children
                 ]
             )
+        elif isinstance(search_filter, str):
+            return search_filter
+
         if search_filter.key.name == "empty_stacktrace.js_console":
             if not features.has(
                 "organizations:javascript-console-error-tag", organization, actor=None

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -6,6 +6,7 @@ from typing import Callable, Iterable, List, Mapping, Optional, Sequence, Set, U
 from sentry import features
 from sentry.api.event_search import (
     AggregateFilter,
+    ParenExpression,
     SearchConfig,
     SearchFilter,
     SearchKey,
@@ -26,7 +27,7 @@ from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.models.user import User
 from sentry.search.events.constants import EQUALITY_OPERATORS, INEQUALITY_OPERATORS
-from sentry.search.events.filter import to_list
+from sentry.search.events.filter import ParsedTerms, to_list
 from sentry.search.utils import (
     DEVICE_CLASS,
     get_teams_for_users,
@@ -239,10 +240,11 @@ value_converters: Mapping[str, ValueConverter] = {
 
 
 def convert_query_values(
-    search_filters: list[SearchFilter],
+    search_filters: ParsedTerms,
     projects: Sequence[Project],
     user: User,
     environments: Optional[Sequence[Environment]],
+    value_converters=value_converters,
 ) -> List[SearchFilter]:
     """
     Accepts a collection of SearchFilter objects and converts their values into
@@ -251,21 +253,29 @@ def convert_query_values(
     :param projects: List of projects being searched across
     :param user: The user making the search
     :param environments: The environments to consider when making the search
+    :param value_converters: A dictionary of functions that convert search filter values into different formats.
     :return: New collection of `SearchFilters`, which may have converted values.
     """
 
     def convert_search_filter(
         search_filter: SearchFilter, organization: Organization
     ) -> SearchFilter:
-        if search_filter.key.name == "empty_stacktrace.js_console":
-            if not features.has(
-                "organizations:javascript-console-error-tag", organization, actor=None
-            ):
-                raise InvalidSearchQuery(
-                    "The empty_stacktrace.js_console filter is not supported for this organization"
-                )
+        if isinstance(search_filter, ParenExpression):
+            search_filter = search_filter._replace(
+                children=[
+                    child if isinstance(child, str) else convert_search_filter(child, organization)
+                    for child in search_filter.children
+                ]
+            )
+        elif isinstance(search_filter, SearchFilter) and search_filter.key.name in value_converters:
+            if search_filter.key.name == "empty_stacktrace.js_console":
+                if not features.has(
+                    "organizations:javascript-console-error-tag", organization, actor=None
+                ):
+                    raise InvalidSearchQuery(
+                        "The empty_stacktrace.js_console filter is not supported for this organization"
+                    )
 
-        if search_filter.key.name in value_converters:
             converter = value_converters[search_filter.key.name]
             new_value = converter(
                 to_list(search_filter.value.raw_value), projects, user, environments
@@ -287,13 +297,15 @@ def convert_query_values(
         return search_filter
 
     def expand_substatus_query_values(
-        search_filters: list[SearchFilter], org: Organization
+        search_filters: ParsedTerms, org: Organization
     ) -> list[SearchFilter]:
         first_status_incl = None
         first_status_excl = None
         includes_status_filter = False
         includes_substatus_filter = False
         for search_filter in search_filters:
+            if isinstance(search_filter, (ParenExpression, str)):
+                continue
             if search_filter.key.name == "substatus":
                 if not features.has("organizations:escalating-issues", org):
                     raise InvalidSearchQuery(

--- a/src/sentry/search/events/builder/errors.py
+++ b/src/sentry/search/events/builder/errors.py
@@ -2,18 +2,42 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from snuba_sdk import Column, Entity, Flags, Query, Request
+from snuba_sdk import Column, Entity, Flags, Join, Query, Relationship, Request
 
+from sentry.api.issue_search import convert_query_values, convert_status_value
 from sentry.search.events.builder import QueryBuilder
+from sentry.search.events.filter import ParsedTerms
+
+value_converters = {"status": convert_status_value}
 
 
 class ErrorsQueryBuilder(QueryBuilder):
     def __init__(self, *args, **kwargs):
         self.match = None
+        self.entities = set()
         super().__init__(*args, **kwargs)
 
+    def parse_query(self, query: Optional[str]) -> ParsedTerms:
+        parsed_terms = super().parse_query(query)
+        parsed_terms = convert_query_values(
+            parsed_terms,
+            self.params.projects,
+            self.params.user,
+            self.params.environments,
+            value_converters=value_converters,
+        )
+        return parsed_terms
+
     def resolve_match(self):
-        self.match = Entity(self.dataset.value, alias=self.dataset.value, sample=self.sample_rate)
+        error_entity = Entity(self.dataset.value, alias=self.dataset.value, sample=self.sample_rate)
+        if len(self.entities) == 1:
+            self.match = error_entity
+        elif len(self.entities) == 2:
+            group_entity = Entity("group_attributes", alias="ga")
+            self.match = Join([Relationship(error_entity, "attributes", group_entity)])
+        else:
+            # TODO: Better exception
+            raise Exception("Unexpected number of entities")
 
     def resolve_query(
         self,
@@ -53,4 +77,10 @@ class ErrorsQueryBuilder(QueryBuilder):
         :param name: The unresolved sentry name.
         """
         resolved_column = self.resolve_column_name(name)
-        return Column(resolved_column, entity=Entity(self.dataset.value, alias=self.dataset.value))
+        if resolved_column == "status":
+            resolved_column = f"group_{resolved_column}"
+            entity = Entity("group_attributes", alias="ga")
+        else:
+            entity = Entity(self.dataset.value, alias=self.dataset.value)
+        self.entities.add(entity)
+        return Column(resolved_column, entity=entity)

--- a/src/sentry/search/events/builder/errors.py
+++ b/src/sentry/search/events/builder/errors.py
@@ -23,7 +23,7 @@ class ErrorsQueryBuilder(QueryBuilder):
             parsed_terms,
             self.params.projects,
             self.params.user,
-            self.params.environments,
+            list(filter(None, self.params.environments)),
             value_converters=value_converters,
         )
         return parsed_terms

--- a/src/sentry/search/events/builder/errors.py
+++ b/src/sentry/search/events/builder/errors.py
@@ -36,7 +36,6 @@ class ErrorsQueryBuilder(QueryBuilder):
             group_entity = Entity("group_attributes", alias="ga")
             self.match = Join([Relationship(error_entity, "attributes", group_entity)])
         else:
-            # TODO: Better exception
             raise Exception("Unexpected number of entities")
 
     def resolve_query(

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -947,5 +947,5 @@ def format_search_filter(term, params):
 
 
 # Not a part of search.events.types to avoid a circular loop
-ParsedTerm = Union[SearchFilter, AggregateFilter]
+ParsedTerm = Union[SearchFilter, AggregateFilter, ParenExpression]
 ParsedTerms = Sequence[ParsedTerm]

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -18,7 +18,7 @@ from typing import (
     Union,
 )
 
-from snuba_sdk import Column, Condition, Op
+from snuba_sdk import Column, Condition, Join, Op, Request
 
 from sentry import features
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS, CRASH_RATE_ALERT_SESSION_COUNT_ALIAS
@@ -672,8 +672,16 @@ def determine_crash_rate_alert_entity(aggregate: str) -> EntityKey:
     return EntityKey.MetricsCounters if count_col_matched == "sessions" else EntityKey.MetricsSets
 
 
+def get_entity_key_from_request(request: Request) -> EntityKey:
+    match = request.query.match
+    if isinstance(match, Join):
+        # XXX: Is there a better way to handle this
+        match = match.relationships[0].lhs
+    return EntityKey(match.name)
+
+
 def get_entity_key_from_query_builder(query_builder: QueryBuilder) -> EntityKey:
-    return EntityKey(query_builder.get_snql_query().query.match.name)
+    return get_entity_key_from_request(query_builder.get_snql_query())
 
 
 def get_entity_subscription_from_snuba_query(

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -37,6 +37,14 @@ class Columns(Enum):
         issue_platform_name="group_id",
         alias="issue.id",
     )
+    ISSUE_STATUS = Column(
+        group_name="status",
+        event_name="status",
+        transaction_name=None,
+        discover_name="status",
+        issue_platform_name="status",
+        alias="status",
+    )
     # This is needed to query transactions by group id
     # in the Issue Details page. This will not be
     # exposed to users through discover search.

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -14,6 +14,7 @@ from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.entity_subscription import (
     BaseEntitySubscription,
     get_entity_key_from_query_builder,
+    get_entity_key_from_request,
     get_entity_key_from_snuba_query,
     get_entity_subscription,
     get_entity_subscription_from_snuba_query,
@@ -21,7 +22,7 @@ from sentry.snuba.entity_subscription import (
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json, metrics
-from sentry.utils.snuba import SnubaError, _snuba_pool
+from sentry.utils.snuba import SNUBA_INFO, SnubaError, _snuba_pool
 
 if TYPE_CHECKING:
     from sentry.search.events.builder import QueryBuilder
@@ -243,10 +244,17 @@ def _create_snql_in_snuba(subscription, snuba_query, snql_query, entity_subscrip
         "resolution": snuba_query.resolution,
         **entity_subscription.get_entity_extra_params(),
     }
+    if SNUBA_INFO:
+        import pprint
 
+        print(  # NOQA: only prints when an env variable is set
+            f"subscription.body:\n {pprint.pformat(body)}"
+        )
+
+    entity_key = get_entity_key_from_request(snql_query)
     response = _snuba_pool.urlopen(
         "POST",
-        f"/{snuba_query.dataset}/{snql_query.query.match.name}/subscriptions",
+        f"/{snuba_query.dataset}/{entity_key.value}/subscriptions",
         body=json.dumps(body),
     )
     if response.status != 202:

--- a/src/sentry/testutils/pytest/metrics.py
+++ b/src/sentry/testutils/pytest/metrics.py
@@ -2,6 +2,7 @@ import dataclasses
 import functools
 
 import pytest
+from snuba_sdk import Entity
 
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 
@@ -65,8 +66,8 @@ def control_metrics_access(monkeypatch, request, set_sentry_option):
             if isinstance(query, MetricsQuery):
                 is_performance_metrics = is_metrics = False
             else:
-                is_performance_metrics = query.match.name.startswith("generic_metrics")
-                is_metrics = "metrics" in query.match.name
+                is_performance_metrics = False
+                is_metrics = False
 
             if is_performance_metrics:
                 _validate_query(query, True)
@@ -81,8 +82,11 @@ def control_metrics_access(monkeypatch, request, set_sentry_option):
 
         def new_create_snql_in_snuba(subscription, snuba_query, snql_query, entity_subscription):
             query = snql_query.query
-            is_performance_metrics = query.match.name.startswith("generic_metrics")
-            is_metrics = "metrics" in query.match.name
+            is_performance_metrics = False
+            is_metrics = False
+            if isinstance(query.match, Entity):
+                is_performance_metrics = query.match.name.startswith("generic_metrics")
+                is_metrics = "metrics" in query.match.name
 
             if is_performance_metrics:
                 _validate_query(query, True)

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -469,6 +469,43 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert alert_rule.resolve_threshold == resolve_threshold
         assert alert_rule.threshold_period == threshold_period
 
+    def test_ignore(self):
+        name = "hello"
+        query = "status:unresolved"
+        aggregate = "count(*)"
+        time_window = 10
+        threshold_type = AlertRuleThresholdType.ABOVE
+        resolve_threshold = 10
+        threshold_period = 1
+        event_types = [SnubaQueryEventType.EventType.ERROR]
+        alert_rule = create_alert_rule(
+            self.organization,
+            [self.project],
+            name,
+            query,
+            aggregate,
+            time_window,
+            threshold_type,
+            threshold_period,
+            resolve_threshold=resolve_threshold,
+            event_types=event_types,
+        )
+        assert alert_rule.snuba_query.subscriptions.get().project == self.project
+        assert alert_rule.name == name
+        assert alert_rule.owner is None
+        assert alert_rule.status == AlertRuleStatus.PENDING.value
+        assert alert_rule.snuba_query.subscriptions.all().count() == 1
+        assert alert_rule.snuba_query.type == SnubaQuery.Type.ERROR.value
+        assert alert_rule.snuba_query.dataset == Dataset.Events.value
+        assert alert_rule.snuba_query.query == query
+        assert alert_rule.snuba_query.aggregate == aggregate
+        assert alert_rule.snuba_query.time_window == time_window * 60
+        assert alert_rule.snuba_query.resolution == DEFAULT_ALERT_RULE_RESOLUTION * 60
+        assert set(alert_rule.snuba_query.event_types) == set(event_types)
+        assert alert_rule.threshold_type == threshold_type.value
+        assert alert_rule.resolve_threshold == resolve_threshold
+        assert alert_rule.threshold_period == threshold_period
+
     def test_release_version(self):
         name = "hello"
         query = "release.version:1.2.3"

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -478,18 +478,19 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         resolve_threshold = 10
         threshold_period = 1
         event_types = [SnubaQueryEventType.EventType.ERROR]
-        alert_rule = create_alert_rule(
-            self.organization,
-            [self.project],
-            name,
-            query,
-            aggregate,
-            time_window,
-            threshold_type,
-            threshold_period,
-            resolve_threshold=resolve_threshold,
-            event_types=event_types,
-        )
+        with self.feature("organizations:metric-alert-ignore-archived"):
+            alert_rule = create_alert_rule(
+                self.organization,
+                [self.project],
+                name,
+                query,
+                aggregate,
+                time_window,
+                threshold_type,
+                threshold_period,
+                resolve_threshold=resolve_threshold,
+                event_types=event_types,
+            )
         assert alert_rule.snuba_query.subscriptions.get().project == self.project
         assert alert_rule.name == name
         assert alert_rule.owner is None

--- a/tests/sentry/search/events/builder/test_errors.py
+++ b/tests/sentry/search/events/builder/test_errors.py
@@ -19,19 +19,20 @@ class ErrorsQueryBuilderTest(TestCase):
         self.projects = [self.project.id]
 
     def test_simple_query(self):
-        query = ErrorsQueryBuilder(
-            dataset=Dataset.Events,
-            query="status:unresolved",
-            selected_columns=["count_unique(user)"],
-            params={
-                "project_id": self.projects,
-            },
-            offset=None,
-            limit=None,
-            config=QueryBuilderConfig(
-                skip_time_conditions=True,
-            ),
-        ).get_snql_query()
+        with self.feature("organizations:metric-alert-ignore-archived"):
+            query = ErrorsQueryBuilder(
+                dataset=Dataset.Events,
+                query="status:unresolved",
+                selected_columns=["count_unique(user)"],
+                params={
+                    "project_id": self.projects,
+                },
+                offset=None,
+                limit=None,
+                config=QueryBuilderConfig(
+                    skip_time_conditions=True,
+                ),
+            ).get_snql_query()
         query.validate()
         e_entity = Entity(Dataset.Events.value, alias=Dataset.Events.value)
         g_entity = Entity("group_attributes", alias="ga")

--- a/tests/sentry/search/events/builder/test_errors.py
+++ b/tests/sentry/search/events/builder/test_errors.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+from snuba_sdk import Entity, Join, Relationship
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import Condition, Op
+from snuba_sdk.function import Function
+
+from sentry.search.events.builder import ErrorsQueryBuilder
+from sentry.search.events.types import QueryBuilderConfig
+from sentry.snuba.dataset import Dataset
+from sentry.testutils.cases import TestCase
+
+pytestmark = pytest.mark.sentry_metrics
+
+
+class ErrorsQueryBuilderTest(TestCase):
+    def setUp(self):
+        self.projects = [self.project.id]
+
+    def test_simple_query(self):
+        query = ErrorsQueryBuilder(
+            dataset=Dataset.Events,
+            query="status:unresolved",
+            selected_columns=["count_unique(user)"],
+            params={
+                "project_id": self.projects,
+            },
+            offset=None,
+            limit=None,
+            config=QueryBuilderConfig(
+                skip_time_conditions=True,
+            ),
+        ).get_snql_query()
+        query.validate()
+        e_entity = Entity(Dataset.Events.value, alias=Dataset.Events.value)
+        g_entity = Entity("group_attributes", alias="ga")
+
+        assert query.query.match == Join([Relationship(e_entity, "attributes", g_entity)])
+        assert query.query.select == [
+            Function(
+                function="uniq",
+                parameters=[Column(name="tags[sentry:user]", entity=e_entity)],
+                alias="count_unique_user",
+            )
+        ]
+        assert query.query.where == [
+            Condition(
+                Column("group_status", entity=Entity("group_attributes", alias="ga")), Op.IN, [0]
+            ),
+            Condition(
+                Column("project_id", entity=Entity("events", alias="events")),
+                Op.IN,
+                self.projects,
+            ),
+        ]

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from snuba_sdk import And, Column, Condition, Entity, Function, Op
+from snuba_sdk import And, Column, Condition, Entity, Function, Join, Op, Relationship
 
 from sentry.exceptions import (
     IncompatibleMetricsQuery,
@@ -9,6 +9,7 @@ from sentry.exceptions import (
     InvalidSearchQuery,
     UnsupportedQuerySubscription,
 )
+from sentry.models.group import GroupStatus
 from sentry.search.events.constants import METRICS_MAP
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
@@ -679,6 +680,46 @@ class EntitySubscriptionTestCase(TestCase):
                 ]
             ),
             Condition(Column("project_id", entity=entity), Op.IN, [self.project.id]),
+        ]
+
+    def test_get_entity_subscription_for_events_dataset_with_join(self) -> None:
+        aggregate = "count_unique(user)"
+        entity_subscription = get_entity_subscription(
+            query_type=SnubaQuery.Type.ERROR,
+            dataset=Dataset.Events,
+            aggregate=aggregate,
+            time_window=3600,
+        )
+        assert isinstance(entity_subscription, EventsEntitySubscription)
+        assert entity_subscription.aggregate == aggregate
+        assert entity_subscription.get_entity_extra_params() == {}
+        assert entity_subscription.dataset == Dataset.Events
+
+        e_entity = Entity(Dataset.Events.value, alias=Dataset.Events.value)
+        g_entity = Entity("group_attributes", alias="ga")
+
+        with self.feature("organizations:metric-alert-ignore-archived"):
+            snql_query = entity_subscription.build_query_builder(
+                "status:unresolved", [self.project.id], None
+            ).get_snql_query()
+        assert snql_query.query.match == Join([Relationship(e_entity, "attributes", g_entity)])
+        assert snql_query.query.select == [
+            Function(
+                function="uniq",
+                parameters=[Column(name="tags[sentry:user]", entity=e_entity)],
+                alias="count_unique_user",
+            )
+        ]
+        assert snql_query.query.where == [
+            And(
+                [
+                    Condition(Column("type", entity=e_entity), Op.EQ, "error"),
+                    Condition(
+                        Column("group_status", entity=g_entity), Op.IN, [GroupStatus.UNRESOLVED]
+                    ),
+                ]
+            ),
+            Condition(Column("project_id", entity=e_entity), Op.IN, [self.project.id]),
         ]
 
 

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -10,9 +10,10 @@ from uuid import uuid4
 import pytest
 import responses
 from django.utils import timezone
-from snuba_sdk import And, Column, Condition, Entity, Function, Op, Or, Query
+from snuba_sdk import And, Column, Condition, Entity, Function, Join, Op, Or, Query, Relationship
 
 from sentry.incidents.logic import query_datasets_to_type
+from sentry.models.group import GroupStatus
 from sentry.search.events.constants import METRICS_MAP
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.configuration import UseCaseKey
@@ -149,6 +150,16 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest):
     def test(self):
         sub = self.create_subscription(QuerySubscription.Status.CREATING)
         create_subscription_in_snuba(sub.id)
+        sub = QuerySubscription.objects.get(id=sub.id)
+        assert sub.status == QuerySubscription.Status.ACTIVE.value
+        assert sub.subscription_id is not None
+
+    def test_status_join(self):
+        with self.feature("organizations:metric-alert-ignore-archived"):
+            sub = self.create_subscription(
+                QuerySubscription.Status.CREATING, query="status:unresolved"
+            )
+            create_subscription_in_snuba(sub.id)
         sub = QuerySubscription.objects.get(id=sub.id)
         assert sub.status == QuerySubscription.Status.ACTIVE.value
         assert sub.subscription_id is not None
@@ -562,10 +573,11 @@ class BuildSnqlQueryTest(TestCase):
         # This flag is used to expect None clauses instead of [], it has been done in order to account for how the
         # metrics layer generates snql.
         use_none_clauses=False,
+        expected_match=None,
     ):
+        aggregate_kwargs = aggregate_kwargs if aggregate_kwargs else {}
+        time_window = 3600
         with self.feature("organizations:metric-alert-ignore-archived"):
-            aggregate_kwargs = aggregate_kwargs if aggregate_kwargs else {}
-            time_window = 3600
             entity_subscription = get_entity_subscription(
                 query_type=query_type,
                 dataset=dataset,
@@ -584,34 +596,34 @@ class BuildSnqlQueryTest(TestCase):
                 },
             )
             snql_query = query_builder.get_snql_query()
-            select = self.string_aggregate_to_snql(query_type, dataset, aggregate, aggregate_kwargs)
-            if dataset == Dataset.Sessions:
-                col_name = "sessions" if "sessions" in aggregate else "users"
-                select.insert(
-                    0,
-                    Function(
-                        function="identity",
-                        parameters=[Column(name=col_name)],
-                        alias="_total_count",
-                    ),
-                )
-            # Select order seems to be unstable, so just arbitrarily sort by name, alias so that it's consistent
-            snql_query.query.select.sort(key=lambda q: (q.function, q.alias))
+        select = self.string_aggregate_to_snql(query_type, dataset, aggregate, aggregate_kwargs)
+        if dataset == Dataset.Sessions:
+            col_name = "sessions" if "sessions" in aggregate else "users"
+            select.insert(
+                0,
+                Function(
+                    function="identity", parameters=[Column(name=col_name)], alias="_total_count"
+                ),
+            )
+        # Select order seems to be unstable, so just arbitrarily sort by name, alias so that it's consistent
+        snql_query.query.select.sort(key=lambda q: (q.function, q.alias))
+        if expected_match is None:
             entity_name = get_entity_key_from_query_builder(query_builder).value
             entity_args = {"name": entity_name}
             if dataset == Dataset.Events:
                 entity_args["alias"] = entity_name
-            expected_query = Query(
-                match=Entity(**entity_args),
-                select=select,
-                where=expected_conditions,
-                groupby=None if use_none_clauses else [],
-                having=[],
-                orderby=None if use_none_clauses else [],
-            )
-            if granularity is not None:
-                expected_query = expected_query.set_granularity(granularity)
-            assert snql_query.query == expected_query
+            expected_match = Entity(**entity_args)
+        expected_query = Query(
+            match=expected_match,
+            select=select,
+            where=expected_conditions,
+            groupby=None if use_none_clauses else [],
+            having=[],
+            orderby=None if use_none_clauses else [],
+        )
+        if granularity is not None:
+            expected_query = expected_query.set_granularity(granularity)
+        assert snql_query.query == expected_query
 
     def string_aggregate_to_snql(self, query_type, dataset, aggregate, aggregate_kwargs):
         aggregate_builder_func = self.aggregate_mappings[query_type][dataset].get(
@@ -633,6 +645,28 @@ class BuildSnqlQueryTest(TestCase):
                 Condition(Column(name="type", entity=entity), Op.EQ, "error"),
                 Condition(Column(name="project_id", entity=entity), Op.IN, [self.project.id]),
             ],
+        )
+
+    def test_join_status(self):
+        entity = Entity(Dataset.Events.value, alias=Dataset.Events.value)
+        g_entity = Entity("group_attributes", alias="ga")
+        self.run_test(
+            SnubaQuery.Type.ERROR,
+            Dataset.Events,
+            "count_unique(user)",
+            "status:unresolved",
+            [
+                And(
+                    [
+                        Condition(Column("type", entity=entity), Op.EQ, "error"),
+                        Condition(
+                            Column("group_status", entity=g_entity), Op.IN, [GroupStatus.UNRESOLVED]
+                        ),
+                    ]
+                ),
+                Condition(Column(name="project_id", entity=entity), Op.IN, [self.project.id]),
+            ],
+            expected_match=Join([Relationship(entity, "attributes", g_entity)]),
         )
 
     def test_simple_performance_transactions(self):

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2411,7 +2411,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
                 self.fail(f"Query {query} errored. Error info: {e}")  # type:ignore[attr-defined]
 
         for key in SENTRY_SNUBA_MAP:
-            if key in ["project.id", "issue.id", "performance.issue_ids"]:
+            if key in ["project.id", "issue.id", "performance.issue_ids", "status"]:
                 continue
             test_query("has:%s" % key)
             test_query("!has:%s" % key)


### PR DESCRIPTION
This pr allows us to filter metric alerts by status. CI will fail until https://github.com/getsentry/snuba/pull/5006 is merged, since it adds support for joins to the subscription system in Snuba.

Relies on https://github.com/getsentry/sentry/pull/59249

