### PR TITLE
fix(on-demand): Fix issues with extraction

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -1323,6 +1323,15 @@ class SearchQueryConverter:
         if not operator:
             raise ValueError(f"Unsupported operator {token.operator}")
 
+        # If we have a `message` field, we want to convert it to a glob matching, since in the UI `message` will perform
+        # a contains style match.
+        if token.key.name == "message":
+            token = SearchFilter(
+                key=SearchKey(name=token.key.name),
+                operator=token.operator,
+                value=SearchValue(raw_value=f"*{token.value.raw_value}*"),
+            )
+
         # We propagate the filter in order to give as output a better error message with more context.
         key: str = token.key.name
         value: Any = token.value.raw_value

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -427,7 +427,9 @@ def test_spec_with_has():
 
 
 def test_spec_with_message():
-    spec = OnDemandMetricSpec("avg(measurements.lcp)", 'message:"issues" AND !message:"alerts"')
+    spec = OnDemandMetricSpec(
+        "avg(measurements.lcp)", 'message:"issues" AND !message:"alerts" AND "api"'
+    )
 
     assert spec._metric_type == "d"
     assert spec.field_to_extract == "event.measurements.lcp.value"
@@ -439,6 +441,7 @@ def test_spec_with_message():
                 "inner": {"name": "event.transaction", "op": "glob", "value": ["*alerts*"]},
                 "op": "not",
             },
+            {"name": "event.transaction", "op": "glob", "value": ["*api*"]},
         ],
         "op": "and",
     }

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -426,6 +426,24 @@ def test_spec_with_has():
     }
 
 
+def test_spec_with_message():
+    spec = OnDemandMetricSpec("avg(measurements.lcp)", 'message:"issues" AND !message:"alerts"')
+
+    assert spec._metric_type == "d"
+    assert spec.field_to_extract == "event.measurements.lcp.value"
+    assert spec.op == "avg"
+    assert spec.condition == {
+        "inner": [
+            {"name": "event.transaction", "op": "glob", "value": ["*issues*"]},
+            {
+                "inner": {"name": "event.transaction", "op": "glob", "value": ["*alerts*"]},
+                "op": "not",
+            },
+        ],
+        "op": "and",
+    }
+
+
 def test_spec_ignore_fields():
     with_ignored_field = OnDemandMetricSpec("count()", "transaction.duration:>=1 project:sentry")
     without_ignored_field = OnDemandMetricSpec("count()", "transaction.duration:>=1")


### PR DESCRIPTION
This PR fixes an issue with extraction in which we are now performing glob matching for `message`.