### PR TITLE
fix(security): do not reflect back `error` GET parameter

### DIFF
--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -319,7 +319,7 @@ class OAuth2CallbackView(PipelineView):
 
         if error:
             pipeline.logger.info("identity.token-exchange-error", extra={"error": error})
-            return pipeline.error(error)
+            return pipeline.error(ERR_INVALID_STATE)
 
         if state != pipeline.fetch_state("state"):
             pipeline.logger.info(


### PR DESCRIPTION
In the past 3 months, there was no legitimate uses for reflecting the `error` GET parameter on a pipeline error view. It was only used as a target for automated scanners.