### PR TITLE
feat(database): "View Query Summary" links in span waterfall

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
@@ -96,7 +96,6 @@ describe('SpanDetail', function () {
             hash: 'a',
             description: 'SELECT * FROM users;',
             sentry_tags: {
-              module: 'db',
               group: 'a7ebd21614897',
             },
           }),

--- a/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
@@ -97,6 +97,7 @@ describe('SpanDetail', function () {
             description: 'SELECT * FROM users;',
             sentry_tags: {
               group: 'a7ebd21614897',
+              category: 'db',
             },
           }),
           organization: Organization({

--- a/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
@@ -96,6 +96,7 @@ describe('SpanDetail', function () {
             hash: 'a',
             description: 'SELECT * FROM users;',
             sentry_tags: {
+              module: 'db',
               group: 'a7ebd21614897',
             },
           }),

--- a/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
@@ -1,0 +1,122 @@
+import {Event} from 'sentry-fixture/event';
+import {Organization} from 'sentry-fixture/organization';
+import {Project} from 'sentry-fixture/project';
+import {Span} from 'sentry-fixture/span';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import SpanDetail from 'sentry/components/events/interfaces/spans/spanDetail';
+import {TransactionProfileIdProvider} from 'sentry/components/profiling/transactionProfileIdProvider';
+import {EventTransaction} from 'sentry/types';
+
+describe('SpanDetail', function () {
+  const organization = Organization();
+  const project = Project();
+
+  const trace = {
+    op: 'http.server',
+    spans: [],
+    traceID: '',
+    traceStartTimestamp: 0,
+    traceEndTimestamp: 0,
+    childSpans: {},
+    rootSpanID: '',
+    rootSpanStatus: undefined,
+  };
+
+  const event = Event({
+    title: '/api/0/detail',
+    projectID: project.id,
+    startTimestamp: 0,
+  }) as EventTransaction;
+
+  const span = Span({
+    op: 'db',
+    hash: 'a',
+    description: 'SELECT * FROM users;',
+  });
+
+  beforeEach(function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+    });
+  });
+
+  function renderSpanDetail(props: Partial<React.ComponentProps<typeof SpanDetail>>) {
+    return (
+      <TransactionProfileIdProvider
+        projectId={project.id}
+        transactionId={event.id}
+        timestamp={event.dateReceived}
+      >
+        <SpanDetail
+          organization={organization}
+          event={event}
+          resetCellMeasureCache={jest.fn()}
+          scrollToHash={jest.fn()}
+          isRoot={false}
+          relatedErrors={[]}
+          trace={trace}
+          childTransactions={[]}
+          span={span}
+          {...props}
+        />
+      </TransactionProfileIdProvider>
+    );
+  }
+
+  describe('db spans', function () {
+    it('renders "Similar Span" button but no Query Details button by default', function () {
+      render(
+        renderSpanDetail({
+          span: Span({
+            op: 'db',
+            hash: 'a',
+            description: 'SELECT * FROM users;',
+          }),
+        })
+      );
+
+      expect(screen.getByText('SELECT * FROM users;')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'View Similar Spans'})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('button', {name: 'View Query Summary'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders "View Query Details" button if "Queries" view is enabled and span group is available', function () {
+      render(
+        renderSpanDetail({
+          span: Span({
+            op: 'db',
+            hash: 'a',
+            description: 'SELECT * FROM users;',
+            sentry_tags: {
+              group: 'a7ebd21614897',
+            },
+          }),
+          organization: Organization({
+            ...organization,
+            features: ['performance-database-view'],
+          }),
+        })
+      );
+
+      expect(screen.getByText('SELECT * FROM users;')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'View Similar Spans'})
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'View Query Summary'})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'View Query Summary'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/database/spans/span/a7ebd21614897/?project=2'
+      );
+    });
+  });
+});

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -254,7 +254,7 @@ function SpanDetail(props: Props) {
     );
   }
 
-  function renderViewSimilarSpansButton() {
+  function renderSpanDetailActions() {
     const {span, organization, event} = props;
 
     if (isGapSpan(span) || !span.op || !span.hash) {
@@ -478,7 +478,7 @@ function SpanDetail(props: Props) {
                   {profileId}
                 </Row>
               )}
-              <Row title="Description" extra={renderViewSimilarSpansButton()}>
+              <Row title="Description" extra={renderSpanDetailActions()}>
                 {span?.description ?? ''}
               </Row>
               <Row title="Status">{span.status || ''}</Row>

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -44,7 +44,10 @@ import {
 } from 'sentry/utils/performance/quickTrace/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
-import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
+import {
+  querySummaryRouteWithQuery,
+  spanDetailsRouteWithQuery,
+} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {getPerformanceDuration} from 'sentry/views/performance/utils';
 
@@ -263,18 +266,36 @@ function SpanDetail(props: Props) {
 
     const transactionName = event.title;
 
-    const target = spanDetailsRouteWithQuery({
-      orgSlug: organization.slug,
-      transaction: transactionName,
-      query: location.query,
-      spanSlug: {op: span.op, group: span.hash},
-      projectID: event.projectID,
-    });
-
     return (
-      <StyledButton size="xs" to={target}>
-        {t('View Similar Spans')}
-      </StyledButton>
+      <ButtonGroup>
+        {organization.features.includes('performance-database-view') &&
+        span.sentry_tags?.group ? (
+          <StyledButton
+            size="xs"
+            to={querySummaryRouteWithQuery({
+              orgSlug: organization.slug,
+              query: location.query,
+              group: span.sentry_tags.group,
+              projectID: event.projectID,
+            })}
+          >
+            {t('View Query Summary')}
+          </StyledButton>
+        ) : null}
+
+        <StyledButton
+          size="xs"
+          to={spanDetailsRouteWithQuery({
+            orgSlug: organization.slug,
+            transaction: transactionName,
+            query: location.query,
+            spanSlug: {op: span.op, group: span.hash},
+            projectID: event.projectID,
+          })}
+        >
+          {t('View Similar Spans')}
+        </StyledButton>
+      </ButtonGroup>
     );
   }
 

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -51,6 +51,7 @@ import {
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {getPerformanceDuration} from 'sentry/views/performance/utils';
 import {ModuleName} from 'sentry/views/starfish/types';
+import {resolveSpanModule} from 'sentry/views/starfish/utils/resolveSpanModule';
 
 import {OpsDot} from '../../opsBreakdown';
 
@@ -270,7 +271,8 @@ function SpanDetail(props: Props) {
     return (
       <ButtonGroup>
         {organization.features.includes('performance-database-view') &&
-        span.sentry_tags?.module === ModuleName.DB &&
+        resolveSpanModule(span.sentry_tags?.op, span.sentry_tags?.category) ===
+          ModuleName.DB &&
         span.sentry_tags?.group ? (
           <StyledButton
             size="xs"

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -50,6 +50,7 @@ import {
 } from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {getPerformanceDuration} from 'sentry/views/performance/utils';
+import {ModuleName} from 'sentry/views/starfish/types';
 
 import {OpsDot} from '../../opsBreakdown';
 
@@ -269,6 +270,7 @@ function SpanDetail(props: Props) {
     return (
       <ButtonGroup>
         {organization.features.includes('performance-database-view') &&
+        span.sentry_tags?.module === ModuleName.DB &&
         span.sentry_tags?.group ? (
           <StyledButton
             size="xs"

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -28,6 +28,7 @@ export type RawSpanType = {
   origin?: string;
   parent_span_id?: string;
   same_process_as_parent?: boolean;
+  sentry_tags?: Record<string, string>;
   status?: string;
   tags?: {[key: string]: string};
 };

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/utils.tsx
@@ -45,6 +45,44 @@ export function spanDetailsRouteWithQuery({
   };
 }
 
+export function generateQuerySummaryRoute({
+  orgSlug,
+  group,
+}: {
+  group: string;
+  orgSlug: string;
+}): string {
+  return `/organizations/${orgSlug}/performance/database/spans/span/${group}/`;
+}
+
+export function querySummaryRouteWithQuery({
+  orgSlug,
+  query,
+  group,
+  projectID,
+}: {
+  group: string;
+  orgSlug: string;
+  query: Query;
+  projectID?: string | string[];
+}) {
+  const pathname = generateQuerySummaryRoute({
+    orgSlug,
+    group,
+  });
+
+  return {
+    pathname,
+    query: {
+      project: projectID,
+      environment: query.environment,
+      statsPeriod: query.statsPeriod,
+      start: query.start,
+      end: query.end,
+    },
+  };
+}
+
 export enum ZoomKeys {
   MIN = 'min',
   MAX = 'max',

--- a/static/app/views/starfish/utils/resolveSpanModule.tsx
+++ b/static/app/views/starfish/utils/resolveSpanModule.tsx
@@ -1,0 +1,11 @@
+const OP_MAPPING = {
+  'db.redis': 'cache',
+  'db.sql.room': 'other',
+};
+
+/**
+ * This is a frontend copy of `resolve_span_module` in Discover. `span.category` is a synthetic tag, computed from a combination of the span op and the span category.
+ */
+export function resolveSpanModule(op?: string, category?: string) {
+  return OP_MAPPING[op ?? ''] ?? category ?? 'other';
+}


### PR DESCRIPTION
Adds a "View Query Summary" link to database spans in the span waterfall for anyone who has the "Queries" feature enabled.

**e.g.,**
<img width="851" alt="Screenshot 2023-11-10 at 9 51 58 AM" src="https://github.com/getsentry/sentry/assets/989898/43f99ae2-6239-4191-aa85-aa2bf4183fee">
