### PR TITLE
fix(metrics-extraction): Fix dashboards not sending useOnDemandMetrics

### DIFF
--- a/static/app/utils/performance/contexts/onDemandControl.tsx
+++ b/static/app/utils/performance/contexts/onDemandControl.tsx
@@ -99,8 +99,8 @@ export const shouldUseOnDemandMetrics = (
     return false;
   }
 
-  if (onDemandControlContext && onDemandControlContext.forceOnDemand) {
-    return true;
+  if (onDemandControlContext && onDemandControlContext.isControlEnabled) {
+    return onDemandControlContext.forceOnDemand;
   }
 
   return _isOnDemandMetricWidget(widget);

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -14,6 +14,7 @@ import {
   QueryFieldValue,
 } from 'sentry/utils/discover/fields';
 import {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import {FieldValueOption} from 'sentry/views/discover/table/queryField';
 import {FieldValue} from 'sentry/views/discover/table/types';
 
@@ -140,6 +141,7 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     queryIndex: number,
     organization: Organization,
     pageFilters: PageFilters,
+    onDemandControlContext?: OnDemandControlContext,
     referrer?: string,
     mepSetting?: MEPState | null
   ) => Promise<[SeriesResponse, string | undefined, ResponseMeta | undefined]>;
@@ -160,6 +162,7 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     query: WidgetQuery,
     organization: Organization,
     pageFilters: PageFilters,
+    onDemandControlContext?: OnDemandControlContext,
     limit?: number,
     cursor?: string,
     referrer?: string,

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -6,6 +6,7 @@ import {Group, Organization, PageFilters} from 'sentry/types';
 import {getIssueFieldRenderer} from 'sentry/utils/dashboards/issueFieldRenderers';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
+import {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import {
   DISCOVER_EXCLUSION_FIELDS,
   getSortLabel,
@@ -162,6 +163,7 @@ function getTableRequest(
   query: WidgetQuery,
   organization: Organization,
   pageFilters: PageFilters,
+  __?: OnDemandControlContext,
   limit?: number,
   cursor?: string
 ) {

--- a/static/app/views/dashboards/datasetConfig/releases.tsx
+++ b/static/app/views/dashboards/datasetConfig/releases.tsx
@@ -20,6 +20,7 @@ import {statsPeriodToDays} from 'sentry/utils/dates';
 import {TableData} from 'sentry/utils/discover/discoverQuery';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {QueryFieldValue} from 'sentry/utils/discover/fields';
+import {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import {FieldValueOption} from 'sentry/views/discover/table/queryField';
 import {FieldValue, FieldValueKind} from 'sentry/views/discover/table/types';
 
@@ -75,6 +76,7 @@ export const ReleasesConfig: DatasetConfig<
     query: WidgetQuery,
     organization: Organization,
     pageFilters: PageFilters,
+    __?: OnDemandControlContext,
     limit?: number,
     cursor?: string
   ) =>

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -11,6 +11,7 @@ import {Series} from 'sentry/types/echarts';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {OnDemandControlContext} from 'sentry/utils/performance/contexts/onDemandControl';
 import {dashboardFiltersToString} from 'sentry/views/dashboards/utils';
 
 import {DatasetConfig} from '../datasetConfig/base';
@@ -83,6 +84,7 @@ export type GenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
     pageLinks,
     timeseriesResultsTypes,
   }: OnDataFetchedProps) => void;
+  onDemandControlContext?: OnDemandControlContext;
 };
 
 type State<SeriesResponse> = {
@@ -232,6 +234,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
       cursor,
       afterFetchTableData,
       onDataFetched,
+      onDemandControlContext,
       mepSetting,
     } = this.props;
     const widget = this.applyDashboardFilters(cloneDeep(originalWidget));
@@ -252,6 +255,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
           query,
           organization,
           selection,
+          onDemandControlContext,
           requestLimit,
           cursor,
           getReferrer(widget.displayType),
@@ -305,6 +309,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
       afterFetchSeriesData,
       onDataFetched,
       mepSetting,
+      onDemandControlContext,
     } = this.props;
     const widget = this.applyDashboardFilters(cloneDeep(originalWidget));
 
@@ -316,6 +321,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
           index,
           organization,
           selection,
+          onDemandControlContext,
           getReferrer(widget.displayType),
           mepSetting
         );

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -167,7 +167,7 @@ function WidgetQueries({
 
   return (
     <OnDemandControlConsumer>
-      {value => (
+      {OnDemandControlContext => (
         <GenericWidgetQueries<SeriesResult, TableResult>
           config={config}
           api={api}
@@ -181,7 +181,8 @@ function WidgetQueries({
           afterFetchSeriesData={afterFetchSeriesData}
           afterFetchTableData={afterFetchTableData}
           mepSetting={mepSettingContext.metricSettingState}
-          {...value}
+          onDemandControlContext={OnDemandControlContext}
+          {...OnDemandControlContext}
         >
           {children}
         </GenericWidgetQueries>


### PR DESCRIPTION
### Summary
It wasn't being sent in all cases since the context wasn't passed down to the request
