### PR TITLE
feat(metrics-extraction): /events should accept useOnDemandMetrics

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -239,9 +239,10 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
         )
 
         use_on_demand_metrics = request.GET.get("useOnDemandMetrics") == "true"
-        on_demand_metrics_enabled = batch_features.get(
-            "organizations:on-demand-metrics-extraction", False
-        ) and use_on_demand_metrics
+        on_demand_metrics_enabled = (
+            batch_features.get("organizations:on-demand-metrics-extraction", False)
+            and use_on_demand_metrics
+        )
 
         dataset = self.get_dataset(request)
         metrics_enhanced = dataset in {metrics_performance, metrics_enhanced_performance}

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -238,9 +238,10 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             or batch_features.get("organizations:dashboards-mep", False)
         )
 
+        use_on_demand_metrics = request.GET.get("useOnDemandMetrics") == "true"
         on_demand_metrics_enabled = batch_features.get(
             "organizations:on-demand-metrics-extraction", False
-        ) and batch_features.get("organizations:on-demand-metrics-extraction-experimental", False)
+        ) and use_on_demand_metrics
 
         dataset = self.get_dataset(request)
         metrics_enhanced = dataset in {metrics_performance, metrics_enhanced_performance}


### PR DESCRIPTION
This allow the frontend to control which dataset gets fired, similar to event-stats

