### PR TITLE
fix(webvitals): Hardcode some spacing in webvitals slideout panels to prevent the feedback button from overlapping on top of slideout content

### DIFF
--- a/static/app/views/performance/browser/webVitals/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverviewWebVitalsDetailPanel.tsx
@@ -288,17 +288,19 @@ export function PageOverviewWebVitalsDetailPanel({
         <ChartContainer>
           {webVital && <WebVitalStatusLineChart webVitalSeries={webVitalData} />}
         </ChartContainer>
-        <GridEditable
-          data={tableData}
-          isLoading={isTransactionWebVitalsQueryLoading}
-          columnOrder={columnOrder}
-          columnSortBy={[sort]}
-          grid={{
-            renderHeadCell,
-            renderBodyCell,
-          }}
-          location={location}
-        />
+        <TableContainer>
+          <GridEditable
+            data={tableData}
+            isLoading={isTransactionWebVitalsQueryLoading}
+            columnOrder={columnOrder}
+            columnSortBy={[sort]}
+            grid={{
+              renderHeadCell,
+              renderBodyCell,
+            }}
+            location={location}
+          />
+        </TableContainer>
         <PageErrorAlert />
       </DetailPanel>
     </PageErrorProvider>
@@ -328,4 +330,8 @@ const ChartContainer = styled('div')`
 
 const NoValue = styled('span')`
   color: ${p => p.theme.gray300};
+`;
+
+const TableContainer = styled('div')`
+  margin-bottom: 80px;
 `;

--- a/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
@@ -226,18 +226,21 @@ export function WebVitalsDetailPanel({
         <ChartContainer>
           {webVital && <WebVitalStatusLineChart webVitalSeries={webVitalData} />}
         </ChartContainer>
+
         {!transaction && (
-          <GridEditable
-            data={dataByOpportunity}
-            isLoading={isLoading}
-            columnOrder={columnOrder}
-            columnSortBy={[sort]}
-            grid={{
-              renderHeadCell,
-              renderBodyCell,
-            }}
-            location={location}
-          />
+          <TableContainer>
+            <GridEditable
+              data={dataByOpportunity}
+              isLoading={isLoading}
+              columnOrder={columnOrder}
+              columnSortBy={[sort]}
+              grid={{
+                renderHeadCell,
+                renderBodyCell,
+              }}
+              location={location}
+            />
+          </TableContainer>
         )}
         <PageErrorAlert />
       </DetailPanel>
@@ -285,4 +288,8 @@ const AlignCenter = styled('span')`
 
 const OpportunityHeader = styled('span')`
   ${p => p.theme.tooltipUnderline()};
+`;
+
+const TableContainer = styled('div')`
+  margin-bottom: 80px;
 `;


### PR DESCRIPTION
Hardcode some spacing in webvitals slideout panels to prevent the feedback button from overlapping on top of slideout content