### PR TITLE
fix(hybridcloud) Close Account needs orgs from all regions

### DIFF
--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -11,7 +11,6 @@ import OrganizationsStore from 'sentry/stores/organizationsStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
-import {Organization} from 'sentry/types';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 type RedirectRemainingOrganizationParams = {
@@ -210,6 +209,9 @@ export async function fetchOrganizationDetails(
  *
  * Will perform a fan-out across all multi-tenant regions,
  * and single-tenant regions the user has membership in.
+ *
+ * This function is challenging to type as the structure of the response
+ * from /organizations can vary based on query parameters
  */
 export async function fetchOrganizations(api: Client, query?: Record<string, any>) {
   const regions = ConfigStore.get('regions');

--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -11,6 +11,7 @@ import OrganizationsStore from 'sentry/stores/organizationsStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
+import {Organization} from 'sentry/types';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 type RedirectRemainingOrganizationParams = {

--- a/static/app/views/settings/account/accountClose.spec.tsx
+++ b/static/app/views/settings/account/accountClose.spec.tsx
@@ -17,7 +17,7 @@ describe('AccountClose', function () {
   beforeEach(function () {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: '/organizations/?owner=1',
+      url: '/organizations/',
       body: [
         {
           organization: Organization({
@@ -46,7 +46,7 @@ describe('AccountClose', function () {
     renderGlobalModal();
 
     // Input for single owner org
-    const singleOwner = screen.getByRole('checkbox', {name: soloOrgSlug});
+    const singleOwner = await screen.findByRole('checkbox', {name: soloOrgSlug});
     expect(singleOwner).toBeChecked();
     expect(singleOwner).toBeDisabled();
 

--- a/tests/acceptance/test_account_settings.py
+++ b/tests/acceptance/test_account_settings.py
@@ -59,6 +59,6 @@ class AccountSettingsTest(AcceptanceTestCase):
             self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def test_close_account(self):
-        with self.feature("organizations:onboarding"):
+        with self.options({"system.url-prefix": self.browser.live_server_url}):
             self.browser.get("/account/remove/")
             self.browser.wait_until_not('[data-test-id="loading-indicator"]')


### PR DESCRIPTION
Update close account view to fetch organizations from all regions. The API endpoint is already able to delete orgs across all regions, but we need to fetch them to have the user choose the orgs that should be removed.

I've also refactored this view to not use AsyncView as we're moving away from those container classes.

Fixes HC-897