### PR TITLE
chore(stats-detectors): Update the various batch sizes

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -64,10 +64,10 @@ from sentry.utils.snuba import SnubaTSResult, raw_snql_query
 logger = logging.getLogger("sentry.tasks.statistical_detectors")
 
 
-FUNCTIONS_PER_PROJECT = 100
+FUNCTIONS_PER_PROJECT = 50
 FUNCTIONS_PER_BATCH = 1_000
 TRANSACTIONS_PER_PROJECT = 50
-TRANSACTIONS_PER_BATCH = 10
+TRANSACTIONS_PER_BATCH = 1_000
 PROJECTS_PER_BATCH = 1_000
 TIMESERIES_PER_BATCH = 10
 
@@ -273,7 +273,7 @@ def _detect_transaction_change_points(
     trend_function = "p95(transaction.duration)"
 
     for chunk in chunked(
-        query_transactions_timeseries(transactions, start, trend_function), TRANSACTIONS_PER_BATCH
+        query_transactions_timeseries(transactions, start, trend_function), TIMESERIES_PER_BATCH
     ):
         data = {}
         for project_id, transaction_name, result in chunk:


### PR DESCRIPTION
Some of these batch sizes were not well chosen. This uses some more sensible defaults.
- 50 functions per project - most project have <50 functions
- 1000 transactions per batch - handles multiple timeseries queries per task instead of just 1