### PR TITLE
style(profiling): Add missing parenthesis to profile table

### DIFF
--- a/static/app/components/profiling/profileEventsTable.tsx
+++ b/static/app/components/profiling/profileEventsTable.tsx
@@ -450,7 +450,7 @@ const COLUMN_ORDERS: Record<FieldType, GridColumnOrder<FieldType>> = {
   },
   'p75()': {
     key: 'p75()',
-    name: t('P75'),
+    name: t('P75()'),
     width: COL_WIDTH_UNDEFINED,
   },
   'p95()': {


### PR DESCRIPTION
This was missing a `()` previously.