### PR TITLE
perf(metrics-extraction): Add OnDemandSpec span and hash info to trace

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -933,7 +933,7 @@ class OnDemandMetricSpec:
         str_to_hash = self._query_str_for_hash
         hash = hashlib.shake_128(bytes(str_to_hash, encoding="ascii")).hexdigest(4)
         with sentry_sdk.start_span(op="OnDemandMetricSpec.query_hash", description=hash) as span:
-            span.set_tag("str_to_hash", hash)
+            span.set_tag("str_to_hash", str_to_hash)
         return hash
 
     def _field_for_hash(self) -> Optional[str]:

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import sentry_sdk
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -20,6 +19,7 @@ from typing import (
     cast,
 )
 
+import sentry_sdk
 from django.utils.functional import cached_property
 from typing_extensions import NotRequired
 

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import sentry_sdk
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -930,7 +931,10 @@ class OnDemandMetricSpec:
     @cached_property
     def query_hash(self) -> str:
         str_to_hash = self._query_str_for_hash
-        return hashlib.shake_128(bytes(str_to_hash, encoding="ascii")).hexdigest(4)
+        hash = hashlib.shake_128(bytes(str_to_hash, encoding="ascii")).hexdigest(4)
+        with sentry_sdk.start_span(op="OnDemandMetricSpec.query_hash", description=hash) as span:
+            span.set_tag("str_to_hash", hash)
+        return hash
 
     def _field_for_hash(self) -> Optional[str]:
         # Since derived metrics are a special case, we want to make sure that the hashing is different from the other


### PR DESCRIPTION
### Summary
This adds the hash and str that is being hashed to a span on the trace, to be able to hunt down how hashes are getting calculated.


