### PR TITLE
fix(database): Improve command and table filters

### DIFF
--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -80,7 +80,7 @@ function DatabaseLandingPage() {
             </PageFilterBar>
           </PaddedContainer>
 
-          <SpanTimeCharts moduleName={moduleName} appliedFilters={moduleFilters} />
+          <SpanTimeCharts moduleName={moduleName} appliedFilters={{}} />
 
           <FilterOptionsContainer>
             <ActionSelector

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -45,6 +45,7 @@ export type SpanStringFields =
   | 'span.description'
   | 'span.module'
   | 'span.action'
+  | 'span.domain'
   | 'span.group'
   | 'project.id'
   | 'transaction'

--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -101,7 +101,7 @@ const LABEL_FOR_MODULE_NAME: {[key in ModuleName]: ReactNode} = {
 function getEventView(location: Location, moduleName: ModuleName, spanCategory?: string) {
   const query = buildEventViewQuery({
     moduleName,
-    location: {...location, query: omit(location.query, SPAN_ACTION)},
+    location: {...location, query: omit(location.query, ['span.action', 'span.domain'])},
     spanCategory,
   }).join(' ');
   return EventView.fromNewQueryWithLocation(

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -155,7 +155,7 @@ function getEventView(
       moduleName,
       location: {
         ...location,
-        query: omit(location.query, SpanMetricsField.SPAN_DOMAIN),
+        query: omit(location.query, ['span.action', 'span.domain']),
       },
       spanCategory,
     }),

--- a/static/app/views/starfish/views/spans/spansTable.tsx
+++ b/static/app/views/starfish/views/spans/spansTable.tsx
@@ -61,11 +61,15 @@ export default function SpansTable({
   const organization = useOrganization();
 
   const spanDescription = decodeScalar(location.query?.['span.description']);
+  const spanAction = decodeScalar(location.query?.['span.action']);
+  const spanDomain = decodeScalar(location.query?.['span.domain']);
   const cursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);
 
   const {isLoading, data, meta, pageLinks} = useSpanList(
     {
       'span.description': spanDescription ? `*${spanDescription}*` : undefined,
+      'span.action': spanAction,
+      'span.domain': spanDomain,
       'span.module': moduleName ?? ModuleName.ALL,
       transaction: endpoint,
       'transaction.method': method,


### PR DESCRIPTION
Fix two bugs with the selectors that accumulated over the last few weeks.

1. Prevents charts from obeying the "Table" selector, that should never have been the case
2. Ensures the "Table" and "SQL Command" selectors actually update the table
