### PR TITLE
fix(hybridcloud) Gather more info on deprecated invite path

### DIFF
--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -35,8 +35,6 @@ def get_invite_state(
     user_id: int,
 ) -> Optional[RpcUserInviteContext]:
     if organization_slug is None:
-        logger.info("organization.member_invite.no_slug", extra={"member_id": member_id})
-
         member_mapping: OrganizationMemberMapping | None = None
         member_mappings: Mapping[int, OrganizationMemberMapping] = {
             omm.organization_id: omm
@@ -57,6 +55,11 @@ def get_invite_state(
 
         if member_mapping is None:
             return None
+
+        logger.info(
+            "organization.member_invite.no_slug",
+            extra={"member_id": member_id, "org_id": member_mapping.organization_id},
+        )
         invite_context = organization_service.get_invite_by_id(
             organization_id=member_mapping.organization_id,
             organization_member_id=member_id,


### PR DESCRIPTION
I would like to know more about the member invites that are using a slug-less path. The membership records for the handful of hits on these log messages in the past day have been deleted.
