### PR TITLE
feat(starfish): Add samples to screen summary page

### DIFF
--- a/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
@@ -1,10 +1,15 @@
 import {CSSProperties} from 'react';
 import {Link} from 'react-router';
+import styled from '@emotion/styled';
 
+import {LinkButton} from 'sentry/components/button';
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
   GridColumnHeader,
 } from 'sentry/components/gridEditable';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconProfiling} from 'sentry/icons/iconProfiling';
+import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
 import {DurationComparisonCell} from 'sentry/views/starfish/components/samplesTable/common';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
@@ -120,15 +125,21 @@ export function SpanSamplesTable({
     }
 
     if (column.key === 'profile_id') {
-      return row.profile_id ? (
-        <Link
-          {...commonProps}
-          to={`/profiling/profile/${row.project}/${row.profile_id}/flamechart/`}
-        >
-          {row.profile_id.slice(0, 8)}
-        </Link>
-      ) : (
-        <div {...commonProps}>(no value)</div>
+      return (
+        <IconWrapper>
+          {row.profile_id ? (
+            <Tooltip title={t('View Profile')}>
+              <LinkButton
+                to={`/profiling/profile/${row.project}/${row.profile_id}/flamechart/`}
+                size="xs"
+              >
+                <IconProfiling size="xs" />
+              </LinkButton>
+            </Tooltip>
+          ) : (
+            <div {...commonProps}>(no value)</div>
+          )}
+        </IconWrapper>
       );
     }
 
@@ -167,3 +178,9 @@ export function SpanSamplesTable({
     </div>
   );
 }
+
+const IconWrapper = styled('div')`
+  text-align: right;
+  width: 100%;
+  height: 26px;
+`;

--- a/static/app/views/starfish/views/screens/screenLoadSpans/deviceClassSelector.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/deviceClassSelector.tsx
@@ -1,0 +1,37 @@
+import {browserHistory} from 'react-router';
+
+import {CompactSelect} from 'sentry/components/compactSelect';
+import {t} from 'sentry/locale';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+
+export function DeviceClassSelector() {
+  const location = useLocation();
+
+  const value = decodeScalar(location.query['device.class']) ?? '';
+
+  const options = [
+    {value: '', label: t('All')},
+    {value: 'high', label: t('High')},
+    {value: 'medium', label: t('Medium')},
+    {value: 'low', label: t('Low')},
+    {value: 'Unknown', label: t('Unknown')},
+  ];
+
+  return (
+    <CompactSelect
+      triggerProps={{prefix: t('Device Class'), size: 'xs'}}
+      value={value}
+      options={options ?? []}
+      onChange={newValue => {
+        browserHistory.push({
+          ...location,
+          query: {
+            ...location.query,
+            ['device.class']: newValue.value,
+          },
+        });
+      }}
+    />
+  );
+}

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.tsx
@@ -1,0 +1,275 @@
+import {Fragment} from 'react';
+import {browserHistory} from 'react-router';
+import styled from '@emotion/styled';
+
+import {LinkButton} from 'sentry/components/button';
+import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
+import SortLink from 'sentry/components/gridEditable/sortLink';
+import Link from 'sentry/components/links/link';
+import Pagination, {CursorHandler} from 'sentry/components/pagination';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconProfiling} from 'sentry/icons/iconProfiling';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {NewQuery} from 'sentry/types';
+import {defined} from 'sentry/utils';
+import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
+import EventView, {
+  fromSorts,
+  isFieldSortable,
+  MetaType,
+} from 'sentry/utils/discover/eventView';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {fieldAlignment, Sort} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {TableColumn} from 'sentry/views/discover/table/types';
+import {centerTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {DeviceClassSelector} from 'sentry/views/starfish/views/screens/screenLoadSpans/deviceClassSelector';
+import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
+
+type Props = {
+  cursorName: string;
+  release: string;
+  sortKey: string;
+  transaction: string;
+  showDeviceClassSelector?: boolean;
+};
+
+const ICON_FIELDS = ['profile.id'];
+
+export function ScreenLoadEventSamples({
+  cursorName,
+  transaction,
+  release,
+  sortKey,
+  showDeviceClassSelector,
+}: Props) {
+  const location = useLocation();
+  const {selection} = usePageFilters();
+  const organization = useOrganization();
+  const cursor = decodeScalar(location.query?.[cursorName]);
+
+  const searchQuery = new MutableSearch([
+    'transaction.op:ui.load',
+    `transaction:${transaction}`,
+    `release:${release}`,
+  ]);
+
+  const deviceClass = decodeScalar(location.query['device.class']);
+
+  if (deviceClass) {
+    searchQuery.addFilterValue('device.class', deviceClass);
+  }
+
+  const sort = fromSorts(decodeScalar(location.query[sortKey]))[0] ?? {
+    kind: 'desc',
+    field: 'measurements.time_to_initial_display',
+  };
+
+  const columnNameMap = {
+    id: t('Event ID (%s)', centerTruncate(release)),
+    'profile.id': t('Profile'),
+    'measurements.time_to_initial_display': t('TTID'),
+    'measurements.time_to_full_display': t('TTFD'),
+  };
+
+  const newQuery: NewQuery = {
+    name: '',
+    fields: [
+      'id',
+      'project.name',
+      'profile.id',
+      'measurements.time_to_initial_display',
+      'measurements.time_to_full_display',
+    ],
+    query: searchQuery.formatString(),
+    dataset: DiscoverDatasets.DISCOVER,
+    version: 2,
+    projects: selection.projects,
+  };
+
+  const eventView = EventView.fromNewQueryWithLocation(newQuery, location);
+  eventView.sorts = [sort];
+
+  const {data, isLoading, pageLinks} = useTableQuery({
+    eventView,
+    enabled: true,
+    limit: 4,
+    cursor,
+  });
+
+  const eventViewColumns = eventView.getColumns();
+
+  function renderBodyCell(column, row): React.ReactNode {
+    if (!data?.meta || !data?.meta.fields) {
+      return row[column.key];
+    }
+
+    if (column.key === 'id') {
+      return (
+        <Link to={`/performance/${row['project.name']}:${row.id}`}>
+          {row.id.slice(0, 8)}
+        </Link>
+      );
+    }
+
+    if (column.key === 'profile.id') {
+      const profileTarget =
+        defined(row['project.name']) && defined(row['profile.id'])
+          ? generateProfileFlamechartRoute({
+              orgSlug: organization.slug,
+              projectSlug: row['project.name'],
+              profileId: String(row['profile.id']),
+            })
+          : null;
+      return (
+        <IconWrapper>
+          {profileTarget && (
+            <Tooltip title={t('View Profile')}>
+              <LinkButton to={profileTarget} size="xs">
+                <IconProfiling size="xs" />
+              </LinkButton>
+            </Tooltip>
+          )}
+        </IconWrapper>
+      );
+    }
+
+    const renderer = getFieldRenderer(column.key, data?.meta.fields, false);
+    const rendered = renderer(row, {
+      location,
+      organization,
+      unit: data?.meta.units?.[column.key],
+    });
+    return rendered;
+  }
+
+  function renderHeadCell(
+    column: GridColumnHeader,
+    tableMeta?: MetaType
+  ): React.ReactNode {
+    const fieldType = tableMeta?.fields?.[column.key];
+    let alignment = fieldAlignment(column.key as string, fieldType);
+    if (ICON_FIELDS.includes(column.key as string)) {
+      alignment = 'right';
+    }
+    const field = {
+      field: column.key as string,
+      width: column.width,
+    };
+
+    function generateSortLink() {
+      if (!tableMeta) {
+        return undefined;
+      }
+
+      let newSortDirection: Sort['kind'] = 'desc';
+      if (sort?.field === column.key) {
+        if (sort.kind === 'desc') {
+          newSortDirection = 'asc';
+        }
+      }
+
+      const newSort = `${newSortDirection === 'desc' ? '-' : ''}${column.key}`;
+
+      return {
+        ...location,
+        query: {...location.query, [sortKey]: newSort},
+      };
+    }
+
+    const canSort = isFieldSortable(field, tableMeta?.fields, true);
+
+    const sortLink = (
+      <SortLink
+        align={alignment}
+        title={column.name}
+        direction={sort?.field === column.key ? sort.kind : undefined}
+        canSort={canSort}
+        generateSortLink={generateSortLink}
+      />
+    );
+    return sortLink;
+  }
+
+  const columnSortBy = eventView.getSorts();
+
+  const handleCursor: CursorHandler = (newCursor, pathname, query) => {
+    browserHistory.push({
+      pathname,
+      query: {...query, [cursorName]: newCursor},
+    });
+  };
+
+  return (
+    <Fragment>
+      <Header>
+        {showDeviceClassSelector && <DeviceClassSelector />}
+        <StyledPagination size="xs" pageLinks={pageLinks} onCursor={handleCursor} />
+      </Header>
+      <GridContainer>
+        <GridEditable
+          isLoading={isLoading}
+          data={data?.data as TableDataRow[]}
+          columnOrder={eventViewColumns
+            .filter((col: TableColumn<React.ReactText>) => col.name !== 'project.name')
+            .map((col: TableColumn<React.ReactText>) => {
+              return {...col, name: columnNameMap[col.key]};
+            })}
+          columnSortBy={columnSortBy}
+          location={location}
+          grid={{
+            renderHeadCell: column => renderHeadCell(column, data?.meta),
+            renderBodyCell,
+          }}
+        />
+      </GridContainer>
+    </Fragment>
+  );
+}
+
+const StyledPagination = styled(Pagination)`
+  margin: 0 0 0 ${space(1)};
+`;
+
+const Header = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr auto;
+  margin-bottom: ${space(1)};
+  align-items: center;
+  height: 26px;
+`;
+
+const IconWrapper = styled('div')`
+  text-align: right;
+  width: 100%;
+  height: 26px;
+`;
+
+// Not pretty but we need to override gridEditable styles since the original
+// styles have too much padding for small spaces
+const GridContainer = styled('div')`
+  margin-bottom: ${space(1)};
+  th {
+    padding: 0 ${space(1)};
+  }
+  th:first-child {
+    padding-left: ${space(2)};
+  }
+  th:last-child {
+    padding-right: ${space(2)};
+  }
+  td {
+    padding: ${space(0.5)} ${space(1)};
+  }
+  td:first-child {
+    padding-right: ${space(1)};
+    padding-left: ${space(2)};
+  }
+`;

--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
@@ -25,6 +25,7 @@ import {
   ScreenCharts,
   YAxis,
 } from 'sentry/views/starfish/views/screens/screenLoadSpans/charts';
+import {ScreenLoadEventSamples} from 'sentry/views/starfish/views/screens/screenLoadSpans/eventSamples';
 import {ScreenMetricsRibbon} from 'sentry/views/starfish/views/screens/screenLoadSpans/metricsRibbon';
 import {ScreenLoadSpanSamples} from 'sentry/views/starfish/views/screens/screenLoadSpans/samples';
 import {ScreenLoadSpansTable} from 'sentry/views/starfish/views/screens/screenLoadSpans/table';
@@ -104,6 +105,25 @@ function ScreenLoadSpans() {
                 additionalFilters={[`transaction:${transactionName}`]}
                 chartHeight={120}
               />
+              <SampleContainer>
+                <SampleContainerItem>
+                  <ScreenLoadEventSamples
+                    release={primaryRelease}
+                    sortKey="release1Samples"
+                    cursorName="release1Cursor"
+                    transaction={transactionName}
+                    showDeviceClassSelector
+                  />
+                </SampleContainerItem>
+                <SampleContainerItem>
+                  <ScreenLoadEventSamples
+                    release={secondaryRelease}
+                    sortKey="release2Samples"
+                    cursorName="release2Cursor"
+                    transaction={transactionName}
+                  />
+                </SampleContainerItem>
+              </SampleContainer>
               <ScreenLoadSpansTable
                 transaction={transactionName}
                 primaryRelease={primaryRelease}
@@ -153,4 +173,15 @@ const FilterContainer = styled('div')`
   column-gap: ${space(1)};
   grid-template-rows: auto;
   grid-template-columns: auto 1fr;
+`;
+
+const SampleContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: ${space(2)};
+`;
+
+const SampleContainerItem = styled('div')`
+  flex: 1;
 `;

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/index.tsx
@@ -19,7 +19,6 @@ import useRouter from 'sentry/utils/useRouter';
 import DetailPanel from 'sentry/views/starfish/components/detailPanel';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {ScreenLoadSampleContainer} from 'sentry/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer';
-import SampleInfo from 'sentry/views/starfish/views/spanSummaryPage/sampleList/sampleInfo';
 
 type Props = {
   groupId: string;
@@ -107,14 +106,6 @@ export function ScreenLoadSpanSamples({
           </TitleContainer>
         </HeaderContainer>
         <PageErrorAlert />
-
-        <SampleInfo
-          groupId={groupId}
-          transactionName={transactionName}
-          transactionMethod={transactionMethod}
-          displayedMetrics={['count()', 'time_spent_percentage()']}
-        />
-
         <ChartsContainer>
           <ChartsContainerItem key="release1">
             <ScreenLoadSampleContainer

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
@@ -86,7 +86,7 @@ export function ScreenLoadSampleContainer({
                   )}/`,
                 }}
               >
-                {release && centerTruncate(release)}
+                {centerTruncate(release)}
               </Link>
             </Tooltip>
           </SectionTitle>

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
@@ -3,16 +3,20 @@ import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
 import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
-import Version from 'sentry/components/version';
+import Link from 'sentry/components/links/link';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
+import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {
   SpanSummaryQueryFilters,
   useSpanMetrics,
 } from 'sentry/views/starfish/queries/useSpanMetrics';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {centerTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 import {Block} from 'sentry/views/starfish/views/spanSummaryPage/block';
 import DurationChart from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart';
@@ -33,7 +37,6 @@ export function ScreenLoadSampleContainer({
   groupId,
   transactionName,
   transactionMethod,
-  sectionTitle,
   release,
 }: Props) {
   const router = useRouter();
@@ -66,28 +69,51 @@ export function ScreenLoadSampleContainer({
   const {data: spanMetrics} = useSpanMetrics(
     groupId,
     filters,
-    [`avg(${SPAN_SELF_TIME})`, SPAN_OP],
+    [`avg(${SPAN_SELF_TIME})`, 'count()', SPAN_OP],
     'api.starfish.span-summary-panel-samples-table-avg'
   );
 
   return (
     <Fragment>
       <PaddedTitle>
-        {sectionTitle && <SectionTitle>{sectionTitle}</SectionTitle>}
         {release && (
-          <Version organization={organization} version={release} tooltipRawVersion />
+          <SectionTitle>
+            <Tooltip title={release}>
+              <Link
+                to={{
+                  pathname: `/organizations/${organization?.slug}/releases/${encodeURIComponent(
+                    release
+                  )}/`,
+                }}
+              >
+                {release && centerTruncate(release)}
+              </Link>
+            </Tooltip>
+          </SectionTitle>
         )}
       </PaddedTitle>
-      <Block title={DataTitles.avg} alignment="left">
-        <DurationCell
-          containerProps={{
-            style: {
-              textAlign: 'left',
-            },
-          }}
-          milliseconds={spanMetrics?.[`avg(${SPAN_SELF_TIME})`]}
-        />
-      </Block>
+      <Container>
+        <Block title={DataTitles.avg} alignment="left">
+          <DurationCell
+            containerProps={{
+              style: {
+                textAlign: 'left',
+              },
+            }}
+            milliseconds={spanMetrics?.[`avg(${SPAN_SELF_TIME})`]}
+          />
+        </Block>
+        <Block title={DataTitles.count} alignment="left">
+          <CountCell
+            containerProps={{
+              style: {
+                textAlign: 'left',
+              },
+            }}
+            count={spanMetrics?.['count()'] ?? 0}
+          />
+        </Block>
+      </Container>
       <DurationChart
         groupId={groupId}
         transactionName={transactionName}
@@ -113,17 +139,17 @@ export function ScreenLoadSampleContainer({
         columnOrder={[
           {
             key: 'transaction_id',
-            name: 'Event ID',
+            name: t('Event ID'),
             width: COL_WIDTH_UNDEFINED,
           },
           {
             key: 'profile_id',
-            name: 'Profile ID',
+            name: t('Profile'),
             width: COL_WIDTH_UNDEFINED,
           },
           {
-            key: 'duration',
-            name: 'Span Duration',
+            key: 'avg_comparison',
+            name: t('Compared to Average'),
             width: COL_WIDTH_UNDEFINED,
           },
         ]}
@@ -138,4 +164,8 @@ const SectionTitle = styled('div')`
 
 const PaddedTitle = styled('div')`
   margin-bottom: ${space(1)};
+`;
+
+const Container = styled('div')`
+  display: flex;
 `;

--- a/static/app/views/starfish/views/screens/screensTable.tsx
+++ b/static/app/views/starfish/views/screens/screensTable.tsx
@@ -179,8 +179,10 @@ export function useTableQuery({
   initialData,
   limit,
   staleTime,
+  cursor,
 }: {
   eventView: EventView;
+  cursor?: string;
   enabled?: boolean;
   excludeOther?: boolean;
   initialData?: TableData;
@@ -197,6 +199,7 @@ export function useTableQuery({
     orgSlug: organization.slug,
     limit: limit ?? 25,
     referrer,
+    cursor,
     options: {
       refetchOnWindowFocus: false,
       enabled,


### PR DESCRIPTION
Adds event samples to screen summary page
Also changes profile id column to be icon in slideout panel

![Screenshot 2023-11-10 at 5 15 51 PM](https://github.com/getsentry/sentry/assets/63818634/8e510acd-6a02-4d24-b3fb-afcfbeb834aa)
![Screenshot 2023-11-10 at 5 16 13 PM](https://github.com/getsentry/sentry/assets/63818634/64a69d3d-e266-42f1-964b-e8eb031e1827)
