### PR TITLE
fix(metrics-extraction): Fix queries with environment / Split on-demand metrics extraction

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -296,7 +296,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
     def handle_on_demand(self, request: Request) -> tuple[bool, MetricSpecType]:
         use_on_demand_metrics = request.GET.get("useOnDemandMetrics") == "true"
         on_demand_metric_type = MetricSpecType.SIMPLE_QUERY
-        on_demand_metric_type_value = request.GET.get("useOnDemandType")
+        on_demand_metric_type_value = request.GET.get("onDemandType")
         if use_on_demand_metrics and on_demand_metric_type_value:
             on_demand_metric_type = MetricSpecType(on_demand_metric_type_value)
 

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -20,6 +20,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.snuba import discover, metrics_enhanced_performance, metrics_performance
+from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.referrer import Referrer
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -238,7 +239,13 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             or batch_features.get("organizations:dashboards-mep", False)
         )
 
-        use_on_demand_metrics = request.GET.get("useOnDemandMetrics") == "true"
+        try:
+            use_on_demand_metrics, on_demand_metrics_type = self.handle_on_demand(request)
+        except ValueError:
+            metric_type_values = [e.value for e in MetricSpecType]
+            metric_types = ",".join(metric_type_values)
+            return Response({"detail": f"Metric type must be one of: {metric_types}"}, status=400)
+
         on_demand_metrics_enabled = (
             batch_features.get("organizations:on-demand-metrics-extraction", False)
             and use_on_demand_metrics
@@ -275,6 +282,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                 has_metrics=use_metrics,
                 use_metrics_layer=batch_features.get("organizations:use-metrics-layer", False),
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
+                on_demand_metrics_type=on_demand_metrics_type,
             )
 
         with self.handle_query_errors():

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -244,7 +244,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
         except ValueError:
             metric_type_values = [e.value for e in MetricSpecType]
             metric_types = ",".join(metric_type_values)
-            return Response({"detail": f"Metric type must be one of: {metric_types}"}, status=400)
+            return Response({"detail": f"On demand metric type must be one of: {metric_types}"}, status=400)
 
         on_demand_metrics_enabled = (
             batch_features.get("organizations:on-demand-metrics-extraction", False)

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -244,7 +244,9 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
         except ValueError:
             metric_type_values = [e.value for e in MetricSpecType]
             metric_types = ",".join(metric_type_values)
-            return Response({"detail": f"On demand metric type must be one of: {metric_types}"}, status=400)
+            return Response(
+                {"detail": f"On demand metric type must be one of: {metric_types}"}, status=400
+            )
 
         on_demand_metrics_enabled = (
             batch_features.get("organizations:on-demand-metrics-extraction", False)

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -20,6 +20,7 @@ from sentry.snuba import (
     spans_indexed,
     spans_metrics,
 )
+from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.referrer import Referrer
 from sentry.utils.snuba import SnubaTSResult
 
@@ -200,7 +201,12 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
             allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
             sentry_sdk.set_tag("performance.metrics_enhanced", metrics_enhanced)
 
-        use_on_demand_metrics = request.GET.get("useOnDemandMetrics") == "true"
+        try:
+            use_on_demand_metrics, on_demand_metrics_type = self.handle_on_demand(request)
+        except ValueError:
+            metric_type_values = [e.value for e in MetricSpecType]
+            metric_types = ",".join(metric_type_values)
+            return Response({"detail": f"Metric type must be one of: {metric_types}"}, status=400)
 
         def get_event_stats(
             query_columns: Sequence[str],
@@ -225,6 +231,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                     allow_empty=False,
                     zerofill_results=zerofill_results,
                     on_demand_metrics_enabled=use_on_demand_metrics,
+                    on_demand_metrics_type=on_demand_metrics_type,
                     include_other=include_other,
                 )
             return dataset.timeseries_query(
@@ -240,6 +247,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                 use_metrics_layer=batch_features.get("organizations:use-metrics-layer", False),
                 on_demand_metrics_enabled=use_on_demand_metrics
                 and batch_features.get("organizations:on-demand-metrics-extraction", False),
+                on_demand_metrics_type=on_demand_metrics_type,
             )
 
         try:

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -22,6 +22,7 @@ from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import (
     MetricSpec,
+    MetricSpecType,
     OnDemandMetricSpec,
     RuleCondition,
     should_use_on_demand_metrics,
@@ -270,6 +271,7 @@ def _convert_widget_query_to_metric(
             None,
             prefilling,
             groupbys=widget_query.columns,
+            spec_type=MetricSpecType.DYNAMIC_QUERY,
         ):
             _log_on_demand_metric_spec(
                 project_id=project.id,
@@ -371,6 +373,7 @@ def _convert_aggregate_and_query_to_metric(
     query: str,
     environment: Optional[str],
     prefilling: bool,
+    spec_type: MetricSpecType = MetricSpecType.SIMPLE_QUERY,
     groupbys: Optional[Sequence[str]] = None,
 ) -> Optional[HashedMetricSpec]:
     """
@@ -388,6 +391,7 @@ def _convert_aggregate_and_query_to_metric(
             query=query,
             environment=environment,
             groupbys=groupbys,
+            spec_type=spec_type,
         )
 
         return on_demand_spec.query_hash, on_demand_spec.to_metric_spec(project)

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -53,7 +53,6 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import create_result_key
 from sentry.snuba.metrics.extraction import (
     QUERY_HASH_KEY,
-    MetricSpecType,
     OnDemandMetricSpec,
     should_use_on_demand_metrics,
 )

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -53,6 +53,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import create_result_key
 from sentry.snuba.metrics.extraction import (
     QUERY_HASH_KEY,
+    MetricSpecType,
     OnDemandMetricSpec,
     should_use_on_demand_metrics,
 )
@@ -134,17 +135,12 @@ class MetricsQueryBuilder(QueryBuilder):
             if self.params.environments:
                 environment = self.params.environments[0].name
 
-            if not self.builder_config.on_demand_metrics_type:
-                raise InvalidSearchQuery(
-                    "Must include on demand metrics type when querying on demand"
-                )
-
             return OnDemandMetricSpec(
                 field=field,
                 query=self.query,
                 environment=environment,
                 groupbys=groupby_columns,
-                spec_type=self.builder_config.on_demand_metrics_type,
+                spec_type=self.builder_config.on_demand_metrics_type or MetricSpecType.SIMPLE_QUERY,
             )
         except Exception as e:
             sentry_sdk.capture_exception(e)

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -136,7 +136,9 @@ class MetricsQueryBuilder(QueryBuilder):
                 environment = self.params.environments[0].name
 
             if not self.builder_config.on_demand_metrics_type:
-                raise InvalidSearchQuery("Must include on demand metrics type when querying on demand")
+                raise InvalidSearchQuery(
+                    "Must include on demand metrics type when querying on demand"
+                )
 
             return OnDemandMetricSpec(
                 field=field,
@@ -266,7 +268,7 @@ class MetricsQueryBuilder(QueryBuilder):
         )
 
     def validate_aggregate_arguments(self) -> None:
-        if not self.builder_config.use_metrics_layer:
+        if not self.use_metrics_layer:
             super().validate_aggregate_arguments()
 
     @property
@@ -281,6 +283,12 @@ class MetricsQueryBuilder(QueryBuilder):
             return UseCaseID.SPANS
         else:
             return UseCaseID.SESSIONS
+
+    @property
+    def use_metrics_layer(self) -> bool:
+        # We want to use the metrics layer only for normal metrics, since span metrics are currently
+        # NOT supported.
+        return self.builder_config.use_metrics_layer and not self.spans_metrics_builder
 
     def resolve_query(
         self,
@@ -319,7 +327,7 @@ class MetricsQueryBuilder(QueryBuilder):
             with sentry_sdk.start_span(op="QueryBuilder", description="resolve_groupby"):
                 self.groupby = self.resolve_groupby(groupby_columns)
 
-        if len(self.metric_ids) > 0 and not self.builder_config.use_metrics_layer:
+        if len(self.metric_ids) > 0 and not self.use_metrics_layer:
             self.where.append(
                 # Metric id is intentionally sorted, so we create consistent queries here both for testing & caching.
                 Condition(Column("metric_id"), Op.IN, sorted(self.metric_ids))
@@ -331,7 +339,7 @@ class MetricsQueryBuilder(QueryBuilder):
             col = tag_match.group("tag") if tag_match else col
 
         # on-demand metrics require metrics layer behavior
-        if self.builder_config.use_metrics_layer or self._has_on_demand_specs:
+        if self.use_metrics_layer or self._has_on_demand_specs:
             if col in ["project_id", "timestamp"]:
                 return col
             # TODO: update resolve params so this isn't needed
@@ -541,7 +549,7 @@ class MetricsQueryBuilder(QueryBuilder):
         return self._indexer_cache[value]
 
     def resolve_tag_value(self, value: str) -> Optional[Union[int, str]]:
-        if self.is_performance or self.builder_config.use_metrics_layer:
+        if self.is_performance or self.use_metrics_layer:
             return value
         return self.resolve_metric_index(value)
 
@@ -671,10 +679,7 @@ class MetricsQueryBuilder(QueryBuilder):
         This dialect should NEVER be used outside of the transformer as it will create problems if parsed by the
         snuba SDK.
         """
-        if (
-            not self.builder_config.use_metrics_layer
-            and not self.builder_config.on_demand_metrics_enabled
-        ):
+        if not self.use_metrics_layer and not self.builder_config.on_demand_metrics_enabled:
             # The reasoning for this error is because if "use_metrics_layer" is false, the MQB will not generate the
             # snql dialect explained below as there is not need for that because it will directly generate normal snql
             # that can be returned via the "get_snql_query" method.
@@ -708,7 +713,7 @@ class MetricsQueryBuilder(QueryBuilder):
         """
         This method returns the normal snql of the query being built for execution.
         """
-        if self.builder_config.use_metrics_layer:
+        if self.use_metrics_layer:
             # The reasoning for this error is because if "use_metrics_layer" is true, the snql built within MQB will
             # be a slight variation of snql that is understood only by the "mqb_query_transformer" thus we don't
             # want to return it to users.
@@ -799,7 +804,7 @@ class MetricsQueryBuilder(QueryBuilder):
         for orderby in self.orderby:
             for entity, framework in query_framework.items():
                 # Metrics layer can't have aliases in the functions for some reason
-                if self.builder_config.use_metrics_layer:
+                if self.use_metrics_layer:
                     framework_functions = [
                         function.exp if isinstance(function, AliasedExpression) else function
                         for function in framework.functions
@@ -950,7 +955,7 @@ class MetricsQueryBuilder(QueryBuilder):
         self.tenant_ids = self.tenant_ids or dict()
         self.tenant_ids["use_case_id"] = self.use_case_id.value
 
-        if self.builder_config.use_metrics_layer or self._has_on_demand_specs:
+        if self.use_metrics_layer or self._has_on_demand_specs:
             from sentry.snuba.metrics.datasource import get_series
             from sentry.snuba.metrics.mqb_query_transformer import (
                 transform_mqb_query_to_metrics_query,
@@ -1175,7 +1180,7 @@ class AlertMetricsQueryBuilder(MetricsQueryBuilder):
         we are going to import the purposfully hidden SnubaQueryBuilder which is a component that takes a MetricsQuery
         and returns one or more equivalent snql query(ies).
         """
-        if self.builder_config.use_metrics_layer or self._has_on_demand_specs:
+        if self.use_metrics_layer or self._has_on_demand_specs:
             from sentry.snuba.metrics import SnubaQueryBuilder
             from sentry.snuba.metrics.mqb_query_transformer import (
                 transform_mqb_query_to_metrics_query,
@@ -1373,7 +1378,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
         """
 
         # No need for primary from the query framework since there's no orderby to worry about
-        if self.builder_config.use_metrics_layer:
+        if self.use_metrics_layer:
             prefix = "generic_" if self.dataset is Dataset.PerformanceMetrics else ""
 
             return [
@@ -1426,7 +1431,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
         return queries
 
     def run_query(self, referrer: str, use_cache: bool = False) -> Any:
-        if self.builder_config.use_metrics_layer or self._has_on_demand_specs:
+        if self.use_metrics_layer or self._has_on_demand_specs:
             from sentry.snuba.metrics.datasource import get_series
             from sentry.snuba.metrics.mqb_query_transformer import (
                 transform_mqb_query_to_metrics_query,
@@ -1439,7 +1444,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
                         metrics_query = self._get_metrics_query_from_on_demand_spec(
                             spec=spec, require_time_range=True
                         )
-                    elif self.builder_config.use_metrics_layer:
+                    elif self.use_metrics_layer:
                         snuba_query = self.get_snql_query()[0].query
                         metrics_query = transform_mqb_query_to_metrics_query(
                             snuba_query, self.is_alerts_query
@@ -1625,7 +1630,7 @@ class TopMetricsQueryBuilder(TimeseriesMetricQueryBuilder):
         results = []
         meta_dict = {}
 
-        if self.builder_config.use_metrics_layer or self._has_on_demand_specs:
+        if self.use_metrics_layer or self._has_on_demand_specs:
             from sentry.snuba.metrics.datasource import get_series
             from sentry.snuba.metrics.mqb_query_transformer import (
                 transform_mqb_query_to_metrics_query,
@@ -1656,7 +1661,7 @@ class TopMetricsQueryBuilder(TimeseriesMetricQueryBuilder):
                             )
                             metrics_queries.append(metrics_query)
 
-                    elif self.builder_config.use_metrics_layer:
+                    elif self.use_metrics_layer:
                         snuba_query = self.get_snql_query()[0].query
                         metrics_queries.append(
                             transform_mqb_query_to_metrics_query(snuba_query, self.is_alerts_query)

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -135,12 +135,15 @@ class MetricsQueryBuilder(QueryBuilder):
             if self.params.environments:
                 environment = self.params.environments[0].name
 
+            if not self.builder_config.on_demand_metrics_type:
+                raise InvalidSearchQuery("Must include on demand metrics type when querying on demand")
+
             return OnDemandMetricSpec(
                 field=field,
                 query=self.query,
                 environment=environment,
                 groupbys=groupby_columns,
-                spec_type=self.builder_config.on_demand_metrics_type or MetricSpecType.SIMPLE_QUERY,
+                spec_type=self.builder_config.on_demand_metrics_type,
             )
         except Exception as e:
             sentry_sdk.capture_exception(e)

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -118,5 +118,6 @@ class QueryBuilderConfig:
     # of a top events request
     skip_tag_resolution: bool = False
     on_demand_metrics_enabled: bool = False
+    on_demand_metrics_type: Optional[Any] = (None,)
     skip_field_validation_for_entity_subscription_deletion: bool = False
     allow_metric_aggregates: Optional[bool] = False

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -187,6 +187,7 @@ def query(
     skip_tag_resolution=False,
     extra_columns=None,
     on_demand_metrics_enabled=False,
+    on_demand_metrics_type=None,
 ) -> EventsResponse:
     """
     High-level API for doing arbitrary user queries against events.
@@ -267,6 +268,7 @@ def timeseries_query(
     has_metrics=False,
     use_metrics_layer=False,
     on_demand_metrics_enabled=False,
+    on_demand_metrics_type=None,
 ):
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -413,6 +415,7 @@ def top_events_timeseries(
     include_other=False,
     functions_acl=None,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type=None,
 ):
     """
     High-level API for doing arbitrary user timeseries queries for a limited number of top events
@@ -726,6 +729,7 @@ def spans_histogram_query(
     normalize_results=True,
     use_metrics_layer=False,
     on_demand_metrics_enabled=False,
+    on_demand_metrics_type=None,
 ):
     """
     API for generating histograms for span exclusive time.
@@ -814,6 +818,7 @@ def histogram_query(
     normalize_results=True,
     use_metrics_layer=False,
     on_demand_metrics_enabled=False,
+    on_demand_metrics_type=None,
 ):
     """
     API for generating histograms for numeric columns.

--- a/src/sentry/snuba/functions.py
+++ b/src/sentry/snuba/functions.py
@@ -14,6 +14,7 @@ from sentry.search.events.fields import get_json_meta_type
 from sentry.search.events.types import ParamsType, QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import transform_tips, zerofill
+from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,7 @@ def query(
     functions_acl: Optional[List[str]] = None,
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
 ) -> Any:
     if not selected_columns:
         raise InvalidSearchQuery("No columns selected")
@@ -82,6 +84,7 @@ def timeseries_query(
     has_metrics: bool = False,
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
 ) -> Any:
     builder = ProfileFunctionsTimeseriesQueryBuilder(
         dataset=Dataset.Functions,
@@ -138,6 +141,7 @@ def top_events_timeseries(
     functions_acl=None,
     result_key_order=None,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
 ):
     assert not include_other, "Other is not supported"  # TODO: support other
 

--- a/src/sentry/snuba/issue_platform.py
+++ b/src/sentry/snuba/issue_platform.py
@@ -11,6 +11,7 @@ from sentry.search.events.fields import get_json_meta_type
 from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import EventsResponse, transform_tips, zerofill
+from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.utils.snuba import SnubaTSResult, bulk_snql_query
 
 
@@ -37,6 +38,7 @@ def query(
     use_metrics_layer=False,
     skip_tag_resolution=False,
     on_demand_metrics_enabled=False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
 ) -> EventsResponse:
     """
     High-level API for doing arbitrary user queries against events.
@@ -114,6 +116,7 @@ def timeseries_query(
     has_metrics=False,
     use_metrics_layer=False,
     on_demand_metrics_enabled=False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
 ):
     """
     High-level API for doing arbitrary user timeseries queries against events.

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -982,7 +982,7 @@ class OnDemandMetricSpec:
 
     @cached_property
     def condition_for_query_hash(self) -> Optional[RuleCondition]:
-        """ Returns the same as self.condition but removes anything that 
+        """Returns the same as self.condition but removes anything that
         shouldn't be added to the spec hash."""
         return self._process_query(True)
 
@@ -1040,7 +1040,7 @@ class OnDemandMetricSpec:
         # First step is to parse the query string into our internal AST format.
         parsed_query = self._parse_query(self.query)
         # We extend the parsed query with other conditions that we want to inject externally from the query.
-        # We skip adding environment if we are reprocessing the query for hashing. 
+        # We skip adding environment if we are reprocessing the query for hashing.
         if not is_for_hash:
             parsed_query = self._extend_parsed_query(parsed_query)
 

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -1048,7 +1048,7 @@ class OnDemandMetricSpec:
         # First step is to parse the query string into our internal AST format.
         parsed_query = self._parse_query(self.query)
         # We extend the parsed query with other conditions that we want to inject externally from the query.
-        # We skip adding environment if this is a dynamic query (eg. dashboard query) as environment is a tag.
+        # If it is a simple query, we encode the environment in the query hash, instead of emitting it as a tag of the metric.
         if self.spec_type == MetricSpecType.SIMPLE_QUERY:
             parsed_query = self._extend_parsed_query(parsed_query)
 

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -1049,7 +1049,7 @@ class OnDemandMetricSpec:
         parsed_query = self._parse_query(self.query)
         # We extend the parsed query with other conditions that we want to inject externally from the query.
         # We skip adding environment if this is a dynamic query (eg. dashboard query) as environment is a tag.
-        if not self.spec_type == MetricSpecType.DYNAMIC_QUERY:
+        if self.spec_type == MetricSpecType.SIMPLE_QUERY:
             parsed_query = self._extend_parsed_query(parsed_query)
 
         # Second step is to extract the conditions that might be present in the aggregate function (e.g. count_if).

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -33,6 +33,7 @@ def query(
     has_metrics: bool = True,
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type=None,
 ):
     metrics_compatible = not equations
     dataset_reason = discover.DEFAULT_DATASET_REASON
@@ -115,6 +116,7 @@ def timeseries_query(
     has_metrics: bool = True,
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type=None,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -191,6 +193,7 @@ def top_events_timeseries(
     include_other=False,
     functions_acl=None,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type=None,
 ):
     metrics_compatible = False
     equations, columns = categorize_columns(selected_columns)
@@ -277,6 +280,7 @@ def histogram_query(
     normalize_results=True,
     use_metrics_layer=False,
     on_demand_metrics_enabled=False,
+    on_demand_metrics_type=None,
 ):
     """
     High-level API for doing arbitrary user timeseries queries against events.

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -17,6 +17,7 @@ from sentry.search.events.fields import get_function_alias
 from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.utils.snuba import SnubaTSResult, bulk_snql_query
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,7 @@ def query(
     has_metrics: bool = True,
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
     granularity: Optional[int] = None,
 ):
     with sentry_sdk.start_span(op="mep", description="MetricQueryBuilder"):
@@ -68,6 +70,7 @@ def query(
                 transform_alias_to_input_format=transform_alias_to_input_format,
                 use_metrics_layer=use_metrics_layer,
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
+                on_demand_metrics_type=on_demand_metrics_type,
             ),
         )
         metrics_referrer = referrer + ".metrics-enhanced"
@@ -92,6 +95,7 @@ def bulk_timeseries_query(
     has_metrics: bool = True,
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
     groupby: Optional[Column] = None,
     apply_formatting: Optional[bool] = True,
 ) -> SnubaTSResult:
@@ -193,6 +197,7 @@ def timeseries_query(
     has_metrics: bool = True,
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
     groupby: Optional[Column] = None,
 ) -> SnubaTSResult:
     """
@@ -216,6 +221,7 @@ def timeseries_query(
                     allow_metric_aggregates=allow_metric_aggregates,
                     use_metrics_layer=use_metrics_layer,
                     on_demand_metrics_enabled=on_demand_metrics_enabled,
+                    on_demand_metrics_type=on_demand_metrics_type,
                 ),
             )
             metrics_referrer = referrer + ".metrics-enhanced"
@@ -331,6 +337,7 @@ def top_events_timeseries(
     include_other=False,
     functions_acl=None,
     on_demand_metrics_enabled=False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
 ):
     if top_events is None:
         top_events = query(
@@ -344,6 +351,7 @@ def top_events_timeseries(
             auto_aggregations=True,
             use_aggregate_conditions=True,
             on_demand_metrics_enabled=on_demand_metrics_enabled,
+            on_demand_metrics_type=on_demand_metrics_type,
         )
 
     top_events_builder = TopMetricsQueryBuilder(
@@ -358,6 +366,7 @@ def top_events_timeseries(
         config=QueryBuilderConfig(
             functions_acl=functions_acl,
             on_demand_metrics_enabled=on_demand_metrics_enabled,
+            on_demand_metrics_type=on_demand_metrics_type,
         ),
     )
     if len(top_events["data"]) == limit and include_other:
@@ -372,6 +381,7 @@ def top_events_timeseries(
             timeseries_columns=timeseries_columns,
             config=QueryBuilderConfig(
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
+                on_demand_metrics_type=on_demand_metrics_type,
             ),
         )
 

--- a/src/sentry/snuba/profiles.py
+++ b/src/sentry/snuba/profiles.py
@@ -7,6 +7,7 @@ from sentry.search.events.fields import get_json_meta_type
 from sentry.search.events.types import ParamsType, QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.discover import transform_tips, zerofill
+from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.utils.snuba import SnubaTSResult
 
 
@@ -29,6 +30,7 @@ def query(
     functions_acl: Optional[List[str]] = None,
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
 ) -> Any:
     if not selected_columns:
         raise InvalidSearchQuery("No columns selected")
@@ -68,6 +70,7 @@ def timeseries_query(
     has_metrics: bool = False,
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
 ) -> Any:
     builder = ProfilesTimeseriesQueryBuilder(
         dataset=Dataset.Profiles,

--- a/src/sentry/snuba/spans_indexed.py
+++ b/src/sentry/snuba/spans_indexed.py
@@ -13,6 +13,7 @@ from sentry.search.events.builder import (
 from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.utils.snuba import SnubaTSResult, bulk_snql_query
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,7 @@ def query(
     skip_tag_resolution=False,
     extra_columns=None,
     on_demand_metrics_enabled=False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
 ):
     builder = SpansIndexedQueryBuilder(
         Dataset.SpansIndexed,
@@ -83,6 +85,7 @@ def timeseries_query(
     has_metrics: bool = True,
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
 ) -> SnubaTSResult:
     """
     High-level API for doing arbitrary user timeseries queries against events.
@@ -144,6 +147,7 @@ def top_events_timeseries(
     include_other=False,
     functions_acl=None,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
 ):
     """
     High-level API for doing arbitrary user timeseries queries for a limited number of top events

--- a/src/sentry/snuba/spans_metrics.py
+++ b/src/sentry/snuba/spans_metrics.py
@@ -12,6 +12,7 @@ from sentry.search.events.builder.spans_metrics import TopSpansMetricsQueryBuild
 from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba import discover
 from sentry.snuba.dataset import Dataset
+from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.utils.snuba import SnubaTSResult
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ def query(
     skip_tag_resolution=False,
     extra_columns=None,
     on_demand_metrics_enabled=False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
 ):
     builder = SpansMetricsQueryBuilder(
         dataset=Dataset.PerformanceMetrics,
@@ -83,6 +85,7 @@ def timeseries_query(
     has_metrics: bool = True,
     use_metrics_layer: bool = False,
     on_demand_metrics_enabled: bool = False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
     groupby: Optional[Column] = None,
 ) -> SnubaTSResult:
     """
@@ -148,6 +151,7 @@ def top_events_timeseries(
     include_other=False,
     functions_acl=None,
     on_demand_metrics_enabled=False,
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
 ):
     """
     High-level API for doing arbitrary user timeseries queries for a limited number of top events

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -207,7 +207,10 @@ def test_get_metric_extraction_config_single_widget(default_project):
             "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
             "field": None,
             "mri": "c:transactions/on_demand@none",
-            "tags": [{"key": "query_hash", "value": ANY}],
+            "tags": [
+                {"key": "query_hash", "value": ANY},
+                {"field": "event.environment", "key": "environment"},
+            ],
         }
 
 
@@ -228,14 +231,20 @@ def test_get_metric_extraction_config_single_widget_multiple_aggregates(default_
             "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
             "field": None,
             "mri": "c:transactions/on_demand@none",
-            "tags": [{"key": "query_hash", "value": ANY}],
+            "tags": [
+                {"key": "query_hash", "value": ANY},
+                {"field": "event.environment", "key": "environment"},
+            ],
         }
         assert config["metrics"][1] == {
             "category": "transaction",
             "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
             "field": "event.duration",
             "mri": "d:transactions/on_demand@none",
-            "tags": [{"key": "query_hash", "value": ANY}],
+            "tags": [
+                {"key": "query_hash", "value": ANY},
+                {"field": "event.environment", "key": "environment"},
+            ],
         }
 
 
@@ -259,7 +268,10 @@ def test_get_metric_extraction_config_single_widget_multiple_count_if(default_pr
             "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
             "field": None,
             "mri": "c:transactions/on_demand@none",
-            "tags": [{"key": "query_hash", "value": ANY}],
+            "tags": [
+                {"key": "query_hash", "value": ANY},
+                {"field": "event.environment", "key": "environment"},
+            ],
         }
         assert config["metrics"][1] == {
             "category": "transaction",
@@ -272,7 +284,10 @@ def test_get_metric_extraction_config_single_widget_multiple_count_if(default_pr
             },
             "field": None,
             "mri": "c:transactions/on_demand@none",
-            "tags": [{"key": "query_hash", "value": ANY}],
+            "tags": [
+                {"key": "query_hash", "value": ANY},
+                {"field": "event.environment", "key": "environment"},
+            ],
         }
         assert config["metrics"][2] == {
             "category": "transaction",
@@ -285,7 +300,10 @@ def test_get_metric_extraction_config_single_widget_multiple_count_if(default_pr
             },
             "field": None,
             "mri": "c:transactions/on_demand@none",
-            "tags": [{"key": "query_hash", "value": ANY}],
+            "tags": [
+                {"key": "query_hash", "value": ANY},
+                {"field": "event.environment", "key": "environment"},
+            ],
         }
 
 
@@ -308,7 +326,10 @@ def test_get_metric_extraction_config_multiple_aggregates_single_field(default_p
             "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
             "field": "event.duration",
             "mri": "d:transactions/on_demand@none",
-            "tags": [{"key": "query_hash", "value": ANY}],
+            "tags": [
+                {"key": "query_hash", "value": ANY},
+                {"field": "event.environment", "key": "environment"},
+            ],
         }
 
 
@@ -330,14 +351,20 @@ def test_get_metric_extraction_config_multiple_widgets_duplicated(default_projec
             "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
             "field": None,
             "mri": "c:transactions/on_demand@none",
-            "tags": [{"key": "query_hash", "value": ANY}],
+            "tags": [
+                {"key": "query_hash", "value": ANY},
+                {"field": "event.environment", "key": "environment"},
+            ],
         }
         assert config["metrics"][1] == {
             "category": "transaction",
             "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
             "field": "event.duration",
             "mri": "d:transactions/on_demand@none",
-            "tags": [{"key": "query_hash", "value": ANY}],
+            "tags": [
+                {"key": "query_hash", "value": ANY},
+                {"field": "event.environment", "key": "environment"},
+            ],
         }
 
 
@@ -379,14 +406,20 @@ def test_get_metric_extraction_config_alerts_and_widgets(default_project):
             "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
             "field": None,
             "mri": "c:transactions/on_demand@none",
-            "tags": [{"key": "query_hash", "value": ANY}],
+            "tags": [
+                {"key": "query_hash", "value": ANY},
+                {"field": "event.environment", "key": "environment"},
+            ],
         }
         assert config["metrics"][1] == {
             "category": "transaction",
             "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
             "field": "event.duration",
             "mri": "d:transactions/on_demand@none",
-            "tags": [{"key": "query_hash", "value": ANY}],
+            "tags": [
+                {"key": "query_hash", "value": ANY},
+                {"key": "environment", "field": "event.environment"},
+            ],
         }
 
 
@@ -418,6 +451,7 @@ def test_get_metric_extraction_config_with_failure_count(default_project):
                     "value": "true",
                 },
                 {"key": "query_hash", "value": ANY},
+                {"key": "environment", "field": "event.environment"},
             ],
         }
 
@@ -504,6 +538,7 @@ def test_get_metric_extraction_config_with_count_web_vitals(
                         "value": "matches_hash",
                     },
                     {"key": "query_hash", "value": ANY},
+                    {"key": "environment", "field": "event.environment"},
                 ],
             }
 
@@ -534,6 +569,7 @@ def test_get_metric_extraction_config_with_count_web_vitals(
                         "value": "matches_hash",
                     },
                     {"key": "query_hash", "value": ANY},
+                    {"key": "environment", "field": "event.environment"},
                 ],
             }
 
@@ -554,6 +590,7 @@ def test_get_metric_extraction_config_with_count_web_vitals(
                         "value": "matches_hash",
                     },
                     {"key": "query_hash", "value": ANY},
+                    {"key": "environment", "field": "event.environment"},
                 ],
             }
 
@@ -574,6 +611,7 @@ def test_get_metric_extraction_config_with_count_web_vitals(
                         "value": "matches_hash",
                     },
                     {"key": "query_hash", "value": ANY},
+                    {"key": "environment", "field": "event.environment"},
                 ],
             }
 
@@ -583,7 +621,9 @@ def test_get_metric_extraction_config_with_count_web_vitals(
                 "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
                 "field": None,
                 "mri": "c:transactions/on_demand@none",
-                "tags": [],
+                "tags": [
+                    {"key": "environment", "field": "event.environment"},
+                ],
             }
 
 
@@ -615,6 +655,7 @@ def test_get_metric_extraction_config_with_user_misery(default_project):
                         "value": "frustrated",
                     },
                     {"key": "query_hash", "value": ANY},
+                    {"key": "environment", "field": "event.environment"},
                 ],
             }
         ]
@@ -652,6 +693,7 @@ def test_get_metric_extraction_config_user_misery_with_tag_columns(default_proje
                     {"key": "query_hash", "value": ANY},
                     {"key": "lcp.element", "field": "event.tags.lcp.element"},
                     {"key": "custom", "field": "event.tags.custom"},
+                    {"key": "environment", "field": "event.environment"},
                 ],
             }
         ]
@@ -682,6 +724,7 @@ def test_get_metric_extraction_config_epm_with_non_tag_columns(default_project):
                     {"key": "query_hash", "value": ANY},
                     {"key": "user.id", "field": "event.user.id"},
                     {"key": "release", "field": "event.release"},
+                    {"key": "environment", "field": "event.environment"},
                 ],
             }
         ]
@@ -719,7 +762,10 @@ def test_get_metric_extraction_config_with_no_tag_spec(default_project, metric):
             "condition": {"name": "event.duration", "op": "gte", "value": 1000.0},
             "field": None,
             "mri": "c:transactions/on_demand@none",
-            "tags": [{"key": "query_hash", "value": ANY}],
+            "tags": [
+                {"key": "query_hash", "value": ANY},
+                {"field": "event.environment", "key": "environment"},
+            ],
         }
 
 

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -2032,7 +2032,9 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
     def test_run_query_with_on_demand_distribution_and_environment(self):
         field = "p75(measurements.fp)"
         query_s = "transaction.duration:>0"
-        spec = OnDemandMetricSpec(field=field, query=query_s, environment="prod", spec_type=MetricSpecType.SIMPLE_QUERY)
+        spec = OnDemandMetricSpec(
+            field=field, query=query_s, environment="prod", spec_type=MetricSpecType.SIMPLE_QUERY
+        )
 
         self.create_environment(project=self.project, name="prod")
 
@@ -2053,8 +2055,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
             query=query_s,
             selected_columns=[field],
             config=QueryBuilderConfig(
-                on_demand_metrics_enabled=True,
-                on_demand_metrics_type=MetricSpecType.SIMPLE_QUERY
+                on_demand_metrics_enabled=True, on_demand_metrics_type=MetricSpecType.SIMPLE_QUERY
             ),
         )
         result = query.run_query("test_query")
@@ -2733,8 +2734,8 @@ class AlertMetricsQueryBuilderTest(MetricBuilderBaseTest):
         specs = []
         for environment, value in environments:
             spec = OnDemandMetricSpec(
-                field=field, 
-                query=query_s, 
+                field=field,
+                query=query_s,
                 environment=environment,
                 spec_type=MetricSpecType.SIMPLE_QUERY,
             )

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -9,7 +9,6 @@ from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.metrics.extraction import OnDemandMetricSpec
 from sentry.testutils.cases import MetricsEnhancedPerformanceTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.testutils.pytest.fixtures import default_project
 from sentry.testutils.silo import region_silo_test
 
 pytestmark = pytest.mark.sentry_metrics

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -892,7 +892,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemand(
                 "topEvents": 5,
                 "dataset": "metrics",
                 "useOnDemandMetrics": "true",
-                "useOnDemandType": "not_real",
+                "onDemandType": "not_real",
             },
         )
 
@@ -977,7 +977,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemand(
                 "topEvents": 5,
                 "dataset": "metrics",
                 "useOnDemandMetrics": "true",
-                "useOnDemandType": "dynamic_query",
+                "onDemandType": "dynamic_query",
             },
         )
 


### PR DESCRIPTION
### Summary
#### Update:
We have divergent behaviour between alerts and dashboards extracted metrics for the time being while we decide on the long term product requirements . 

This PR now splits extraction and querying for dashboards and alerts with a 'spec type' for `MetricSpec` (`simple_query` or `dynamic_query`) since that is relatively descriptive of the behaviour.

Environment (and potentially other future values) do also need to be added to the specs, but this is just for product on dashboards, alerts doesn't have this constraint. Alerts currently will create a brand new spec each time environment etc. is changed, but dashboards are meant for live viewing. 

#### Original:
If environment is passed to the query builder, it currently gets picked up and passed to the hash, which breaks querying on existing extracted metrics.

The metrics extraction doesn't store environment, environment should only be dynamically accessed as it's own tag on the on-demand metrics, since dashboards can dynamically change environment.

