### PR TITLE
fix(alerts): query on demand metrics

### DIFF
--- a/static/app/actionCreators/events.spec.tsx
+++ b/static/app/actionCreators/events.spec.tsx
@@ -119,4 +119,23 @@ describe('Events ActionCreator', function () {
       })
     );
   });
+
+  it('spreads query extras', async function () {
+    await doEventsRequest(api, {
+      ...opts,
+      queryExtras: {useOnDemandMetrics: 'true'},
+      partial: true,
+    });
+
+    expect(mock).toHaveBeenLastCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          project: [project.id],
+          environment: [],
+          useOnDemandMetrics: 'true',
+        }),
+      })
+    );
+  });
 });

--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -106,6 +106,7 @@ export const doEventsRequest = <IncludeAllArgsType extends boolean = false>(
     excludeOther,
     includeAllArgs,
     dataset,
+    useOnDemandMetrics,
   }: {includeAllArgs?: IncludeAllArgsType} & Options
 ): IncludeAllArgsType extends true
   ? Promise<
@@ -134,6 +135,7 @@ export const doEventsRequest = <IncludeAllArgsType extends boolean = false>(
       referrer: referrer ? referrer : 'api.organization-event-stats',
       excludeOther: excludeOther ? '1' : undefined,
       dataset,
+      useOnDemandMetrics,
     }).filter(([, value]) => typeof value !== 'undefined')
   );
 

--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -54,7 +54,6 @@ type Options = {
   start?: DateString;
   team?: Readonly<string | string[]>;
   topEvents?: number;
-  useOnDemandMetrics?: boolean;
   withoutZerofill?: boolean;
   yAxis?: string | string[];
 };
@@ -106,7 +105,6 @@ export const doEventsRequest = <IncludeAllArgsType extends boolean = false>(
     excludeOther,
     includeAllArgs,
     dataset,
-    useOnDemandMetrics,
   }: {includeAllArgs?: IncludeAllArgsType} & Options
 ): IncludeAllArgsType extends true
   ? Promise<
@@ -135,7 +133,6 @@ export const doEventsRequest = <IncludeAllArgsType extends boolean = false>(
       referrer: referrer ? referrer : 'api.organization-event-stats',
       excludeOther: excludeOther ? '1' : undefined,
       dataset,
-      useOnDemandMetrics,
     }).filter(([, value]) => typeof value !== 'undefined')
   );
 

--- a/static/app/components/charts/eventsRequest.spec.tsx
+++ b/static/app/components/charts/eventsRequest.spec.tsx
@@ -713,4 +713,43 @@ describe('EventsRequest', function () {
       );
     });
   });
+
+  describe('on demand metrics', function () {
+    beforeEach(function () {
+      (doEventsRequest as jest.Mock).mockClear();
+    });
+
+    it('passes useOnDemandMetrics param', async function () {
+      (doEventsRequest as jest.Mock).mockImplementation(({useOnDemandMetrics}) =>
+        Promise.resolve({
+          data: [[new Date(), [COUNT_OBJ]]],
+          start: 1627402280,
+          end: 1627402398,
+          isMetricsData: useOnDemandMetrics,
+          meta: {
+            isMetricsData: useOnDemandMetrics,
+            fields: {
+              p95_measurements_custom: 'size',
+            },
+            units: {
+              p95_measurements_custom: 'kibibyte',
+            },
+          },
+        })
+      );
+      render(
+        <EventsRequest {...DEFAULTS} yAxis="p95(measurements.custom)" useOnDemandMetrics>
+          {mock}
+        </EventsRequest>
+      );
+
+      await waitFor(() =>
+        expect(mock).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            isMetricsData: true,
+          })
+        )
+      );
+    });
+  });
 });

--- a/static/app/components/charts/eventsRequest.spec.tsx
+++ b/static/app/components/charts/eventsRequest.spec.tsx
@@ -713,43 +713,4 @@ describe('EventsRequest', function () {
       );
     });
   });
-
-  describe('on demand metrics', function () {
-    beforeEach(function () {
-      (doEventsRequest as jest.Mock).mockClear();
-    });
-
-    it('passes useOnDemandMetrics param', async function () {
-      (doEventsRequest as jest.Mock).mockImplementation(({useOnDemandMetrics}) =>
-        Promise.resolve({
-          data: [[new Date(), [COUNT_OBJ]]],
-          start: 1627402280,
-          end: 1627402398,
-          isMetricsData: useOnDemandMetrics,
-          meta: {
-            isMetricsData: useOnDemandMetrics,
-            fields: {
-              p95_measurements_custom: 'size',
-            },
-            units: {
-              p95_measurements_custom: 'kibibyte',
-            },
-          },
-        })
-      );
-      render(
-        <EventsRequest {...DEFAULTS} yAxis="p95(measurements.custom)" useOnDemandMetrics>
-          {mock}
-        </EventsRequest>
-      );
-
-      await waitFor(() =>
-        expect(mock).toHaveBeenLastCalledWith(
-          expect.objectContaining({
-            isMetricsData: true,
-          })
-        )
-      );
-    });
-  });
 });

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -577,6 +577,7 @@ class MetricChart extends PureComponent<Props, State> {
       location,
       dataset,
       newAlertOrQuery: false,
+      useOnDemandMetrics: isOnDemandAlert,
     });
 
     return isCrashFreeAlert(dataset) ? (
@@ -617,7 +618,6 @@ class MetricChart extends PureComponent<Props, State> {
         partial={false}
         queryExtras={queryExtras}
         referrer="api.alerts.alert-rule-chart"
-        useOnDemandMetrics={isOnDemandAlert}
       >
         {({loading, timeseriesData, comparisonTimeseriesData}) => (
           <Fragment>

--- a/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
@@ -31,7 +31,9 @@ export function getMetricDatasetQueryExtras({
       ? {dataset: getMEPAlertsDataset(dataset, newAlertOrQuery)}
       : {};
 
-  queryExtras.useOnDemandMetrics = useOnDemandMetrics ? 'true' : 'false';
+  if (useOnDemandMetrics) {
+    queryExtras.useOnDemandMetrics = 'true';
+  }
 
   return queryExtras;
 }

--- a/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
@@ -12,11 +12,13 @@ export function getMetricDatasetQueryExtras({
   location,
   dataset,
   newAlertOrQuery,
+  useOnDemandMetrics,
 }: {
   dataset: MetricRule['dataset'];
   newAlertOrQuery: boolean;
   organization: Organization;
   location?: Location;
+  useOnDemandMetrics?: boolean;
 }) {
   const hasMetricDataset =
     hasOnDemandMetricAlertFeature(organization) ||
@@ -28,6 +30,8 @@ export function getMetricDatasetQueryExtras({
     hasMetricDataset && !disableMetricDataset
       ? {dataset: getMEPAlertsDataset(dataset, newAlertOrQuery)}
       : {};
+
+  queryExtras.useOnDemandMetrics = useOnDemandMetrics ? 'true' : 'false';
 
   return queryExtras;
 }


### PR DESCRIPTION
Fixes #59821 
Ensures that on demand alerts pass `useOnDemandMetrics` flag to events-stats