### PR TITLE
feat(ddm): Add support for avg in gauges

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -439,6 +439,16 @@ class RawOp(MetricOperation):
 
         return function
 
+    def _gauge_avg(self, aggregate_filter: Function, alias: str) -> Function:
+        return Function(
+            "divide",
+            [
+                Function("sumIf", [Column("value"), aggregate_filter]),
+                Function("countIf", [Column("value"), aggregate_filter]),
+            ],
+            alias=alias,
+        )
+
     def generate_snql_function(
         self,
         entity: MetricEntity,
@@ -458,7 +468,15 @@ class RawOp(MetricOperation):
         else:
             snuba_function = OP_TO_SNUBA_FUNCTION[entity][self.op]
 
-        function = Function(snuba_function, [Column("value"), aggregate_filter], alias=alias)
+        # The average of a gauge is a special case of operation that is derived of two sub-operations
+        # , and it could have been implemented with `DerivedOp` but in order to disambiguate between `avg` of
+        # a gauge or `avg` of a distribution, significant code changes would have to be done, since metric
+        # factory is used all over the code and lacks the entity parameter that would make the dataset inference
+        # simpler.
+        if entity == "generic_metrics_gauges" and self.op == "avg":
+            function = self._gauge_avg(aggregate_filter, alias)
+        else:
+            function = Function(snuba_function, [Column("value"), aggregate_filter], alias=alias)
 
         return self._wrap_quantiles(function, alias)
 

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -133,7 +133,6 @@ def parse_mri_field(field: str, allow_private: bool = False) -> MetricField:
 
 
 def parse_public_field(field: str) -> MetricField:
-
     matches = PUBLIC_EXPRESSION_REGEX.match(field)
 
     try:
@@ -142,6 +141,7 @@ def parse_public_field(field: str) -> MetricField:
     except (TypeError, IndexError):
         operation = None
         metric_name = field
+
     return MetricField(operation, get_mri(metric_name))
 
 

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -221,9 +221,12 @@ def generate_operation_regex():
     """
     Generates a regex of all supported operations defined in OP_TO_SNUBA_FUNCTION
     """
-    operations = []
+    operations = set()
     for item in OP_TO_SNUBA_FUNCTION.values():
-        operations += list(item.keys())
+        operations.update(set(item.keys()))
+    for item in GENERIC_OP_TO_SNUBA_FUNCTION.values():
+        operations.update(set(item.keys()))
+
     return rf"({'|'.join(map(str, operations))})"
 
 

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -177,20 +177,20 @@ OP_TO_SNUBA_FUNCTION = {
         "min_timestamp": "minIf",
         "max_timestamp": "maxIf",
     },
-    "metrics_gauges": {
-        "min": "minIf",
-        "max": "maxIf",
-        "sum": "sumIf",
-        "count": "countIf",
-        "last": "lastIf",
-        # TODO; avg will have to be supported as a derived operation.
-    },
 }
 GENERIC_OP_TO_SNUBA_FUNCTION = {
     "generic_metrics_counters": OP_TO_SNUBA_FUNCTION["metrics_counters"],
     "generic_metrics_distributions": OP_TO_SNUBA_FUNCTION["metrics_distributions"],
     "generic_metrics_sets": OP_TO_SNUBA_FUNCTION["metrics_sets"],
-    "generic_metrics_gauges": OP_TO_SNUBA_FUNCTION["metrics_gauges"],
+    # Gauges are not supported by non-generic metrics.
+    "generic_metrics_gauges": {
+        "min": "minIf",
+        "max": "maxIf",
+        "sum": "sumIf",
+        "count": "countIf",
+        "last": "lastIf",
+        "avg": "avg",
+    },
 }
 
 # This set contains all the operations that require the "rhs" condition to be resolved

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -1606,7 +1606,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         gauge_2 = {
             "min": 2.0,
             "max": 21.0,
-            "sum": 25.0,
+            "sum": 21.0,
             "count": 3,
             "last": 4.0,
         }
@@ -1622,6 +1622,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
                 f"max({mri})",
                 f"last({mri})",
                 f"sum({mri})",
+                f"avg({mri})",
             ],
             query="",
             statsPeriod="1h",
@@ -1642,14 +1643,16 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
                     "max(g:custom/page_load@millisecond)": [20.0, 21.0],
                     "min(g:custom/page_load@millisecond)": [1.0, 2.0],
                     "last(g:custom/page_load@millisecond)": [20.0, 4.0],
-                    "sum(g:custom/page_load@millisecond)": [21.0, 25.0],
+                    "sum(g:custom/page_load@millisecond)": [21.0, 21.0],
+                    "avg(g:custom/page_load@millisecond)": [10.5, 7.0],
                 },
                 "totals": {
                     "count(g:custom/page_load@millisecond)": 5,
                     "max(g:custom/page_load@millisecond)": 21.0,
                     "min(g:custom/page_load@millisecond)": 1.0,
                     "last(g:custom/page_load@millisecond)": 4.0,
-                    "sum(g:custom/page_load@millisecond)": 46.0,
+                    "sum(g:custom/page_load@millisecond)": 42.0,
+                    "avg(g:custom/page_load@millisecond)": 8.4,
                 },
             }
         ]


### PR DESCRIPTION
This PR adds the support for the `avg` operation for gauges, which requires special handling since it's not an operation that is directly supported by the database.

Closes https://github.com/getsentry/sentry/issues/59409