### PR TITLE
fix(ddm): Fix count_web_vitals with any

### DIFF
--- a/src/sentry/search/events/datasets/metrics_layer.py
+++ b/src/sentry/search/events/datasets/metrics_layer.py
@@ -599,16 +599,17 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
         ]:
             raise InvalidSearchQuery("count_web_vitals only supports measurements")
 
+        column = Column(constants.METRICS_MAP.get(column, column))
         if quality == "any":
             return Function(
                 "count",
-                [],
+                [column],
                 alias,
             )
 
         return Function(
             "count_web_vitals",
-            [Column(constants.METRICS_MAP.get(column, column)), quality],
+            [column, quality],
             alias,
         )
 

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -1143,6 +1143,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                     "count_web_vitals(measurements.fcp, meh)",
                     "count_web_vitals(measurements.fid, meh)",
                     "count_web_vitals(measurements.cls, good)",
+                    "count_web_vitals(measurements.lcp, any)",
                 ],
                 "query": "event.type:transaction",
                 "dataset": "metricsEnhanced",
@@ -1160,6 +1161,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[0]["count_web_vitals(measurements.fcp, meh)"] == 1
         assert data[0]["count_web_vitals(measurements.fid, meh)"] == 1
         assert data[0]["count_web_vitals(measurements.cls, good)"] == 1
+        assert data[0]["count_web_vitals(measurements.lcp, any)"] == 1
 
         assert meta["isMetricsData"]
         assert field_meta["count_web_vitals(measurements.lcp, good)"] == "integer"
@@ -1167,6 +1169,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert field_meta["count_web_vitals(measurements.fcp, meh)"] == "integer"
         assert field_meta["count_web_vitals(measurements.fid, meh)"] == "integer"
         assert field_meta["count_web_vitals(measurements.cls, good)"] == "integer"
+        assert field_meta["count_web_vitals(measurements.lcp, any)"] == "integer"
 
     def test_measurement_rating_that_does_not_exist(self):
         self.store_transaction_metric(


### PR DESCRIPTION
This PR fixes a problem with the query builder that passes an empty `count` to the mqb transformer when `count_web_vitals` was invoked with `any`.