### PR TITLE
ref(jira): Use issue contexts

### DIFF
--- a/src/sentry/integrations/jira/endpoints/descriptor.py
+++ b/src/sentry/integrations/jira/endpoints/descriptor.py
@@ -60,7 +60,7 @@ class JiraDescriptorEndpoint(Endpoint):
                         "name": {"value": "Configure Sentry Add-on"},
                         "key": "configure-sentry",
                     },
-                    "jiraIssueGlances": [
+                    "jiraIssueContexts": [
                         {
                             "icon": {"width": 24, "height": 24, "url": sentry_logo},
                             "content": {"type": "label", "label": {"value": "Linked Issues"}},


### PR DESCRIPTION
Jira is deprecating the glance panel and replacing it with issue contexts (changelog announcement [here](https://developer.atlassian.com/cloud/jira/platform/changelog/#CHANGE-897)). According to their [documentation](https://developer.atlassian.com/cloud/jira/platform/modules/issue-context/) it looks like the format for the data is exactly the same as what glances used, so hopefully we can just change the variable name to `jiraIssueContexts`. 

Closes #58676 