### PR TITLE
Adding first devenv doctor check for github access

### DIFF
--- a/devenv/checks/check_github_access.py
+++ b/devenv/checks/check_github_access.py
@@ -1,0 +1,33 @@
+from typing import Set, Tuple
+
+from devenv.lib import github
+
+tags: Set[str] = {"github"}
+name = "Check Github Access"
+
+
+def check() -> Tuple[bool, str]:
+    result = github.check_ssh_access()
+    if result:
+        return True, "You have access to Github"
+    return False, "You do not have access to Github"
+
+
+def fix() -> Tuple[bool, str]:
+    github.add_to_known_hosts()
+    if not github.check_ssh_access():
+        pubkey = github.generate_and_configure_ssh_keypair()
+        return (
+            False,
+            f"""
+        Failed to authenticate with an ssh key to GitHub.
+We've generated and configured one for you at ~/.ssh/sentry-github.
+Visit https://github.com/settings/ssh/new and add the following Authentication key:
+
+{pubkey}
+
+Then, you need to go to https://github.com/settings/keys, find your key,
+and click Configure SSO, for the getsentry organization.
+""",
+        )
+    return True, "You have access to Github"

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -171,7 +171,7 @@ s3transfer==0.6.1
 selenium==4.3.0
 sentry-arroyo==2.14.19
 sentry-cli==2.16.0
-sentry-devenv==1.1.1
+sentry-devenv==1.1.2
 sentry-forked-django-stubs==4.2.6.post3
 sentry-forked-djangorestframework-stubs==3.14.4.post2
 sentry-kafka-schemas==0.1.34

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -171,6 +171,7 @@ s3transfer==0.6.1
 selenium==4.3.0
 sentry-arroyo==2.14.19
 sentry-cli==2.16.0
+sentry-devenv==1.1.1
 sentry-forked-django-stubs==4.2.6.post3
 sentry-forked-djangorestframework-stubs==3.14.4.post2
 sentry-kafka-schemas==0.1.34

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -171,7 +171,7 @@ s3transfer==0.6.1
 selenium==4.3.0
 sentry-arroyo==2.14.19
 sentry-cli==2.16.0
-sentry-devenv==1.1.2
+sentry-devenv==1.1.3
 sentry-forked-django-stubs==4.2.6.post3
 sentry-forked-djangorestframework-stubs==3.14.4.post2
 sentry-kafka-schemas==0.1.34

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,7 +36,7 @@ sentry-forked-djangorestframework-stubs>=3.14.4.post2
 lxml-stubs
 msgpack-types>=0.2.0
 mypy>=1.6.1
-sentry-devenv>=1.1.1
+sentry-devenv>=1.1.2
 types-beautifulsoup4
 types-cachetools
 types-croniter

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,6 +36,7 @@ sentry-forked-djangorestframework-stubs>=3.14.4.post2
 lxml-stubs
 msgpack-types>=0.2.0
 mypy>=1.6.1
+sentry-devenv>=1.1.1
 types-beautifulsoup4
 types-cachetools
 types-croniter

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,7 +36,7 @@ sentry-forked-djangorestframework-stubs>=3.14.4.post2
 lxml-stubs
 msgpack-types>=0.2.0
 mypy>=1.6.1
-sentry-devenv>=1.1.2
+sentry-devenv>=1.1.3
 types-beautifulsoup4
 types-cachetools
 types-croniter


### PR DESCRIPTION
The first check for the [dev env doctor](https://github.com/getsentry/devenv/blob/main/doctor.py). It aims to check if a user has access to GitHub. It is worth noting that this is only relevant to Sentry employees (I believe), so we should make sure there is logic that can differentiate Sentry employees from others and only run certain checks accordingly.

Also adds new dev requirement for sentry-devenv.