### PR TITLE
ref(github-invite): use raw sql for missing members query

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -118,7 +118,7 @@ def _get_missing_organization_members(
         org_id, date_added, provider, integration_ids, domain_query
     )
 
-    return CommitAuthor.objects.raw(query)
+    return list(CommitAuthor.objects.raw(query))
 
 
 def _get_shared_email_domain(organization: Organization) -> str | None:

--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -4,9 +4,9 @@ from collections import defaultdict
 from datetime import timedelta
 from email.headerregistry import Address
 from functools import reduce
-from typing import TYPE_CHECKING, Dict, Sequence
+from typing import Any, Dict, List, Sequence
 
-from django.db.models import Q, QuerySet
+from django.db.models import Q
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.request import Request
@@ -23,12 +23,6 @@ from sentry.integrations.base import IntegrationFeatures
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.organization import Organization
 from sentry.services.hybrid_cloud.integration import integration_service
-
-if TYPE_CHECKING:
-    # XXX: this should use WithAnnotations but it breaks the cache typeddjango/django-stubs#760
-    class CommitAuthor___commit__count(CommitAuthor):
-        commit__count: int
-
 
 FILTERED_EMAIL_DOMAINS = {
     "gmail.com",
@@ -72,7 +66,7 @@ def _get_missing_organization_members(
     provider: str,
     integration_ids: Sequence[int],
     shared_domain: str | None,
-) -> QuerySet[CommitAuthor___commit__count]:
+) -> List[Any]:
     org_id = organization.id
     domain_query = ""
     if shared_domain:

--- a/src/sentry/tasks/invite_missing_org_members.py
+++ b/src/sentry/tasks/invite_missing_org_members.py
@@ -86,7 +86,7 @@ def send_nudge_email(org_id):
         shared_domain=shared_domain,
     )
 
-    if not commit_author_query.exists():  # don't email if no missing commit authors
+    if not len(commit_author_query):  # don't email if no missing commit authors
         logger.info(
             "invite_missing_org_members.send_nudge_email.no_commit_authors",
             extra={"organization_id": org_id},


### PR DESCRIPTION
Limit the number of commits parsed through to find missing members to the latest 1000 commits from the last 30 days. This reduces the query time significantly -- an org whose previous query took 3 minutes now takes < 1 second (also thanks to (#59447).

The filters for specific emails can also be formatted as subqueries after already filtering down the list of commits to check.