### PR TITLE
feat(feedback): filter out unreal feedbacks auto generated by sdk

### DIFF
--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import Mock
+
+import pytest
 
 from sentry.feedback.usecases.create_feedback import (
+    FeedbackCreationSource,
+    create_feedback_issue,
     fix_for_issue_platform,
     validate_issue_platform_event_schema,
 )
+from sentry.testutils.pytest.fixtures import django_db_all
+
+
+@pytest.fixture
+def mock_produce_occurrence_to_kafka(monkeypatch):
+    mock = Mock()
+    monkeypatch.setattr(
+        "sentry.feedback.usecases.create_feedback.produce_occurrence_to_kafka", mock
+    )
+    return mock
 
 
 def test_fix_for_issue_platform():
@@ -189,3 +204,42 @@ def test_corrected_still_works():
         "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
     }
     assert isinstance(fixed_event["received"], str)
+
+
+@django_db_all
+def test_create_feedback_filters_unreal(default_project, mock_produce_occurrence_to_kafka):
+    event = {
+        "project_id": 1,
+        "request": {
+            "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            "headers": {
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+            },
+        },
+        "event_id": "56b08cf7852c42cbb95e4a6998c66ad6",
+        "timestamp": 1698255009.574,
+        "received": "2021-10-24T22:23:29.574000+00:00",
+        "environment": "prod",
+        "release": "frontend@daf1316f209d961443664cd6eb4231ca154db502",
+        "user": {
+            "ip_address": "72.164.175.154",
+            "email": "josh.ferge@sentry.io",
+            "id": 880461,
+            "isStaff": False,
+            "name": "Josh Ferge",
+        },
+        "contexts": {
+            "feedback": {
+                "contact_email": "josh.ferge@sentry.io",
+                "name": "Josh Ferge",
+                "message": "Sent in the unattended mode",
+                "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
+                "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            },
+        },
+        "breadcrumbs": [],
+        "platform": "javascript",
+    }
+    create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+
+    assert mock_produce_occurrence_to_kafka.call_count == 0


### PR DESCRIPTION
The unreal SDK sends a User Report even if there is no user report. This results in many millions of user reports with the same message across the various projects that use the Unreal SDK. Let's prevent these messages from being created as new user feedbacks.