### PR TITLE
fix(discord): Fix error causing 401 bot command failures

### DIFF
--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -47,7 +47,7 @@ class DiscordNonProxyClient(ApiClient):
 
     def overwrite_application_commands(self, commands: list[object]) -> None:
         self.put(
-            self.with_base_url(APPLICATION_COMMANDS_URL.format(application_id=self.application_id)),
+            APPLICATION_COMMANDS_URL.format(application_id=self.application_id),
             data=commands,
         )
 

--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -42,9 +42,6 @@ class DiscordNonProxyClient(ApiClient):
         self.application_id = options.get("discord.application-id")
         self.bot_token = options.get("discord.bot-token")
 
-    def with_base_url(self, url: str) -> str:
-        return f"{DISCORD_BASE_URL}{url}"
-
     def overwrite_application_commands(self, commands: list[object]) -> None:
         self.put(
             APPLICATION_COMMANDS_URL.format(application_id=self.application_id),


### PR DESCRIPTION
There are a significant number of logs with `discord.setup.update_bot_commands_failure` resulting in 401 errors. 