### PR TITLE
fix(integrations): Prefer the Error title over type for attachments

### DIFF
--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -42,7 +42,10 @@ def build_attachment_title(obj: Group | GroupEvent) -> str:
     ev_type = obj.get_event_type()
     title = obj.title
 
-    if ev_type == "error" and "type" in ev_metadata:
+    if ev_type == "error" and "title" in ev_metadata:
+        title = ev_metadata["title"]
+
+    elif ev_type == "error" and "type" in ev_metadata:
         title = ev_metadata["type"]
 
     elif ev_type == "csp":
@@ -119,8 +122,15 @@ def build_attachment_text(group: Group, event: GroupEvent | None = None) -> Any 
         if important:
             return important.value
     elif ev_type == "error":
-        return ev_metadata.get("value") or ev_metadata.get("function")
-
+        parts = []
+        # If there is a title then that was shown as the attachment title
+        # instead of the type so include the type here instead, if available.
+        if "title" in ev_metadata and "type" in ev_metadata:
+            parts.append(ev_metadata.get("type"))
+        text = ev_metadata.get("value") or ev_metadata.get("function")
+        if text:
+            parts.append(text)
+        return ": ".join(parts)
     return None
 
 


### PR DESCRIPTION
The error type may not be very unique (e.g. `TypeError`) and a more useful custom title may have been specified in grouping rules.

Fixes GH-54613

In my case I would get Slack notifications from a JS project with:
Title: "TypeError"
Text: "Failed to fetch"

even though I have custom fingerprint rules to change the title to include the HTTP status code and path.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.