### PR TITLE
feat(metrics) Handle Investigation rules limit reached in UI 

### DIFF
--- a/static/app/components/dynamicSampling/investigationRule.spec.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.spec.tsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {fireEvent, render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {InvestigationRuleCreation} from 'sentry/components/dynamicSampling/investigationRule';
@@ -209,7 +209,6 @@ describe('InvestigationRule', function () {
     const labels = screen.queryAllByText(labelText);
     expect(labels).toHaveLength(0);
     // now the user creates a rule
-    fireEvent.click(button);
     // prepare a response with the created rule
     const sencondResponse = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dynamic-sampling/custom-rules/',
@@ -217,7 +216,7 @@ describe('InvestigationRule', function () {
       statusCode: 200,
       body: getCustomRule(),
     });
-    await tick();
+    await userEvent.click(button);
     expect(createRule).toHaveBeenCalledTimes(1);
     // now we should have a rule and therefore display the notification label
     // wait for the label to appear
@@ -251,9 +250,8 @@ describe('InvestigationRule', function () {
     const labels = screen.queryAllByText(labelText);
     expect(labels).toHaveLength(0);
     // now the user creates a rule
-    fireEvent.click(button);
+    await userEvent.click(button);
 
-    await tick();
     expect(createRule).toHaveBeenCalledTimes(1);
     // we should show some error that the rule could not be created
     expect(addErrorMessage).toHaveBeenCalledWith('Unable to create investigation rule');
@@ -280,7 +278,7 @@ describe('InvestigationRule', function () {
     const labels = screen.queryAllByText(labelText);
     expect(labels).toHaveLength(0);
     // now the user creates a rule
-    await userEvent.click((button);
+    await userEvent.click(button);
 
     expect(createRule).toHaveBeenCalledTimes(1);
     // we should show some error that the rule could not be created

--- a/static/app/components/dynamicSampling/investigationRule.spec.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.spec.tsx
@@ -280,9 +280,8 @@ describe('InvestigationRule', function () {
     const labels = screen.queryAllByText(labelText);
     expect(labels).toHaveLength(0);
     // now the user creates a rule
-    fireEvent.click(button);
+    await userEvent.click((button);
 
-    await tick();
     expect(createRule).toHaveBeenCalledTimes(1);
     // we should show some error that the rule could not be created
     expect(addErrorMessage).toHaveBeenCalledWith(

--- a/static/app/components/dynamicSampling/investigationRule.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.tsx
@@ -121,7 +121,7 @@ function useCreateInvestigationRuleMutation(vars: CreateCustomRuleVariables) {
   const queryClient = useQueryClient();
   const {mutate} = useMutation<
     CustomDynamicSamplingRule,
-    Error,
+    RequestError,
     CreateCustomRuleVariables
   >({
     mutationFn: (variables: CreateCustomRuleVariables) => {
@@ -145,8 +145,17 @@ function useCreateInvestigationRuleMutation(vars: CreateCustomRuleVariables) {
         success: true,
       });
     },
-    onError: (_error: Error) => {
-      addErrorMessage(t('Unable to create investigation rule'));
+    onError: (_error: RequestError) => {
+      if (_error.status === 429) {
+        addErrorMessage(
+          t(
+            'You have reached the maximum number of concurrent investigation rules allowed'
+          )
+        );
+      } else {
+        addErrorMessage(t('Unable to create investigation rule'));
+      }
+
       trackAnalytics('dynamic_sampling.custom_rule_add', {
         organization: vars.organization,
         projects: vars.projects,


### PR DESCRIPTION
This PR handles investigation rules limit reached errors by displaying a 
specific message to the user indicating that the maximum number of allowed
rules has been reached.

resolves https://github.com/getsentry/sentry/issues/59681