### PR TITLE
feat(ddm): Add option to forcefully use the new metrics layer

### DIFF
--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -313,8 +313,9 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
             )
         self.org_id = extra_fields["org_id"]
         self.time_window = time_window
+        # We want to use the metrics layer for ddm, since it supports custom metrics.
         self.use_metrics_layer = features.has(
-            "organizations:use-metrics-layer", Organization.objects.get_from_cache(id=self.org_id)
+            "organizations:ddm-experimental", Organization.objects.get_from_cache(id=self.org_id)
         )
         self.on_demand_metrics_enabled = features.has(
             "organizations:on-demand-metrics-extraction",

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -212,7 +212,7 @@ class EntitySubscriptionTestCase(TestCase):
         ]
 
     def test_get_entity_subscription_for_metrics_dataset_for_users_with_metrics_layer(self) -> None:
-        with Feature("organizations:use-metrics-layer"):
+        with Feature("organizations:ddm-experimental"):
             org_id = self.organization.id
             use_case_id = UseCaseID.SESSIONS
 
@@ -343,7 +343,7 @@ class EntitySubscriptionTestCase(TestCase):
     def test_get_entity_subscription_for_metrics_dataset_for_sessions_with_metrics_layer(
         self,
     ) -> None:
-        with Feature("organizations:use-metrics-layer"):
+        with Feature("organizations:ddm-experimental"):
             org_id = self.organization.id
             use_case_id = UseCaseID.SESSIONS
             aggregate = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
@@ -500,7 +500,7 @@ class EntitySubscriptionTestCase(TestCase):
     def test_get_entity_subscription_for_performance_metrics_dataset_with_metrics_layer(
         self,
     ) -> None:
-        with Feature("organizations:use-metrics-layer"):
+        with Feature("organizations:ddm-experimental"):
             aggregate = "percentile(transaction.duration,.95)"
             entity_subscription = get_entity_subscription(
                 query_type=SnubaQuery.Type.PERFORMANCE,
@@ -560,7 +560,7 @@ class EntitySubscriptionTestCase(TestCase):
         mri = "d:custom/sentry.process_profile.track_outcome@second"
         indexer.record(use_case_id=UseCaseID.CUSTOM, org_id=self.organization.id, string=mri)
 
-        with Feature("organizations:use-metrics-layer"):
+        with Feature("organizations:ddm-experimental"):
             aggregate = f"max({mri})"
             entity_subscription = get_entity_subscription(
                 query_type=SnubaQuery.Type.PERFORMANCE,
@@ -615,7 +615,7 @@ class EntitySubscriptionTestCase(TestCase):
     def test_get_entity_subscription_with_multiple_entities_with_metrics_layer(
         self,
     ) -> None:
-        with Feature("organizations:use-metrics-layer"):
+        with Feature("organizations:ddm-experimental"):
             aggregate = "percentile(transaction.duration,.95)"
             entity_subscription = get_entity_subscription(
                 query_type=SnubaQuery.Type.PERFORMANCE,
@@ -879,7 +879,7 @@ class GetEntityKeyFromSnubaQueryTest(TestCase):
                 )
 
             if supported_with_metrics_layer:
-                with Feature("organizations:use-metrics-layer"):
+                with Feature("organizations:ddm-experimental"):
                     assert expected_entity_key == get_entity_key_from_snuba_query(
                         snuba_query, self.organization.id, self.project.id
                     )

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -634,7 +634,7 @@ class BuildSnqlQueryTest(TestCase):
         )
 
     def test_simple_performance_metrics(self):
-        with Feature("organizations:use-metrics-layer"):
+        with Feature("organizations:ddm-experimental"):
             metric_id = resolve(UseCaseID.TRANSACTIONS, self.organization.id, METRICS_MAP["user"])
             self.run_test(
                 SnubaQuery.Type.PERFORMANCE,
@@ -693,7 +693,7 @@ class BuildSnqlQueryTest(TestCase):
         )
 
     def test_aliased_query_performance_metrics(self):
-        with Feature("organizations:use-metrics-layer"):
+        with Feature("organizations:ddm-experimental"):
             version = "something"
             self.create_release(self.project, version=version)
             metric_id = resolve(
@@ -765,7 +765,7 @@ class BuildSnqlQueryTest(TestCase):
         )
 
     def test_tag_query_performance_metrics(self):
-        with Feature("organizations:use-metrics-layer"):
+        with Feature("organizations:ddm-experimental"):
             # Note: We don't support user queries on the performance metrics dataset, so using a
             # different tag here.
             metric_id = resolve(
@@ -970,7 +970,7 @@ class BuildSnqlQueryTest(TestCase):
         )
 
     def test_simple_sessions_for_metrics(self):
-        with Feature("organizations:use-metrics-layer"):
+        with Feature("organizations:ddm-experimental"):
             org_id = self.organization.id
             for tag in [SessionMRI.RAW_SESSION.value, "session.status", "crashed", "init"]:
                 rh_indexer_record(org_id, tag)
@@ -1016,7 +1016,7 @@ class BuildSnqlQueryTest(TestCase):
             )
 
     def test_simple_users_for_metrics(self):
-        with Feature("organizations:use-metrics-layer"):
+        with Feature("organizations:ddm-experimental"):
             org_id = self.organization.id
             for tag in [SessionMRI.RAW_USER.value, "session.status", "crashed"]:
                 rh_indexer_record(org_id, tag)
@@ -1049,7 +1049,7 @@ class BuildSnqlQueryTest(TestCase):
             )
 
     def test_query_and_environment_sessions_metrics(self):
-        with Feature("organizations:use-metrics-layer"):
+        with Feature("organizations:ddm-experimental"):
             env = self.create_environment(self.project, name="development")
             org_id = self.organization.id
             for tag in [
@@ -1129,7 +1129,7 @@ class BuildSnqlQueryTest(TestCase):
             )
 
     def test_query_and_environment_users_metrics(self):
-        with Feature("organizations:use-metrics-layer"):
+        with Feature("organizations:ddm-experimental"):
             env = self.create_environment(self.project, name="development")
             org_id = self.organization.id
             for tag in [

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -37,6 +37,8 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             "organizations:performance-use-metrics": True,
         }
 
+        self.additional_params = dict()
+
     def do_request(self, data, url=None, features=None):
         if features is None:
             features = {"organizations:discover-basic": True}
@@ -63,6 +65,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                     "yAxis": axis,
                     "project": self.project.id,
                     "dataset": "metricsEnhanced",
+                    **self.additional_params,
                 },
             )
             assert response.status_code == 200, response.content
@@ -92,6 +95,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                     "yAxis": axis,
                     "project": self.project.id,
                     "dataset": "metricsEnhanced",
+                    **self.additional_params,
                 },
             )
             assert response.status_code == 200, response.content
@@ -119,6 +123,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                     "yAxis": axis,
                     "project": self.project.id,
                     "dataset": "metricsEnhanced",
+                    **self.additional_params,
                 },
             )
             assert response.status_code == 200, response.content
@@ -148,6 +153,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                     "yAxis": axis,
                     "project": self.project.id,
                     "dataset": "metricsEnhanced",
+                    **self.additional_params,
                 },
             )
             assert response.status_code == 200, response.content
@@ -176,6 +182,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "yAxis": ["failure_rate()"],
                 "project": self.project.id,
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
         assert response.status_code == 200, response.content
@@ -205,6 +212,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "yAxis": ["p75(measurements.lcp)", "p75(transaction.duration)"],
                 "project": self.project.id,
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
         assert response.status_code == 200, response.content
@@ -229,6 +237,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "interval": "1h",
                 "yAxis": ["epm()", "eps()", "tpm()", "p50(transaction.duration)"],
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
 
@@ -248,6 +257,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "interval": "1h",
                 "yAxis": "count_unique(user)",
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
         assert response.status_code == 200, response.content
@@ -267,6 +277,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                     "query": query,
                     "yAxis": ["epm()"],
                     "dataset": "metricsEnhanced",
+                    **self.additional_params,
                 },
             )
             assert response.status_code == 200, response.content
@@ -295,6 +306,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "yAxis": ["epm()"],
                 "dataset": "metricsEnhanced",
                 "preventMetricAggregates": "1",
+                **self.additional_params,
             },
         )
         assert response.status_code == 200, response.content
@@ -313,6 +325,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "query": "",
                 "yAxis": ["epm()"],
                 "metricsEnhanced": "0",
+                **self.additional_params,
             },
         )
         assert response.status_code == 200, response.content
@@ -331,6 +344,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "interval": "1h",
                 "yAxis": "sum(transaction.duration)",
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
         assert response.status_code == 200, response.content
@@ -363,6 +377,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "yAxis": "sum(transaction.duration)",
                 "comparisonDelta": 86400,
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
         assert response.status_code == 200, response.content
@@ -410,6 +425,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "interval": "1h",
                 "yAxis": "sum(measurements.datacenter_memory)",
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
         assert response.status_code == 200, response.content
@@ -437,6 +453,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "interval": "1h",
                 "yAxis": "p99(measurements.custom)",
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
         meta = response.data["meta"]
@@ -481,6 +498,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                     "p50(measurements.datacenter_memory)",
                 ],
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
         assert response.status_code == 200, response.content
@@ -535,6 +553,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "query": "transaction.duration:<5s",
                 "yAxis": "sum(transaction.duration)",
                 "dataset": "metrics",
+                **self.additional_params,
             },
         )
         assert response.status_code == 400, response.content
@@ -555,6 +574,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                     "sum(transaction.duration)",
                 ],
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
         assert response.status_code == 200, response.content
@@ -580,6 +600,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                     "sum(transaction.duration)",
                 ],
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
         assert response.status_code == 200, response.content
@@ -603,6 +624,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "interval": "1h",
                 "yAxis": "p99(measurements.custom)",
                 "query": "",
+                **self.additional_params,
             },
         )
 
@@ -635,6 +657,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                     "p99(measurements.another.custom)",
                 ],
                 "query": "",
+                **self.additional_params,
             },
         )
 
@@ -669,6 +692,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "field": ["count()", "project"],
                 "topEvents": 5,
                 "dataset": "metrics",
+                **self.additional_params,
             },
         )
 
@@ -700,6 +724,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
                 "field": ["p75(transaction.duration)", "transaction"],
                 "topEvents": 5,
                 "dataset": "metrics",
+                **self.additional_params,
             },
         )
 
@@ -717,6 +742,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithMetricLay
     def setUp(self):
         super().setUp()
         self.features["organizations:use-metrics-layer"] = True
+        self.additional_params = {"forceMetricsLayer": "true"}
 
     def test_counter_custom_metric(self):
         mri = "c:custom/sentry.process_profile.track_outcome@second"
@@ -738,6 +764,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithMetricLay
                 "yAxis": [f"sum({mri})"],
                 "project": self.project.id,
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
 
@@ -767,6 +794,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithMetricLay
                 "yAxis": [f"min({mri})", f"max({mri})", f"p90({mri})"],
                 "project": self.project.id,
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
 
@@ -806,6 +834,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithMetricLay
                 "yAxis": [f"count_unique({mri})"],
                 "project": self.project.id,
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
 
@@ -843,6 +872,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithMetricLay
                 ],
                 "project": self.project.id,
                 "dataset": "metricsEnhanced",
+                **self.additional_params,
             },
         )
 


### PR DESCRIPTION
This PR adds a flag for the events stats endpoint that would force the user of the metrics layer via the `forceMetricsLayer` flag.