### PR TITLE
feat(metrics-extraction): Add new param for dashboard metrics

### DIFF
--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.tsx
@@ -136,6 +136,7 @@ export const ErrorsAndTransactionsConfig: DatasetConfig<
         widget,
         onDemandControlContext
       ),
+      onDemandType: 'dynamic_query',
     };
     return getEventsRequest(
       url,
@@ -631,6 +632,7 @@ async function doOnDemandMetricsRequest(
       queryExtras: {
         ...requestData.queryExtras,
         useOnDemandMetrics: true,
+        onDemandType: 'dynamic_query',
       },
       dataset: 'metricsEnhanced',
       generatePathname: isEditing ? fetchEstimatedStats : undefined,


### PR DESCRIPTION
### Summary
This sends dynamic_query, which adds env properly as a tag and builds the correct query hash. This is safe to send even without useOnDemandMetrics being set to true.
