### PR TITLE
feat(browser-starfish): add resource type icons to table

### DIFF
--- a/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
@@ -1,4 +1,6 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
+import {PlatformIcon} from 'platformicons';
 
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
@@ -7,6 +9,7 @@ import GridEditable, {
 } from 'sentry/components/gridEditable';
 import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
 import {RESOURCE_THROUGHPUT_UNIT} from 'sentry/views/performance/browser/resources';
 import ResourceSize from 'sentry/views/performance/browser/resources/shared/resourceSize';
@@ -93,14 +96,22 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
 
   const renderBodyCell = (col: Column, row: Row) => {
     const {key} = col;
+    const opPlatformMap = {
+      'resource.script': 'javascript',
+      'resource.css': 'css',
+    };
+
     if (key === SPAN_DESCRIPTION) {
       return (
-        <SpanDescriptionCell
-          moduleName={ModuleName.HTTP}
-          projectId={row[PROJECT_ID]}
-          description={row[SPAN_DESCRIPTION]}
-          group={row[SPAN_GROUP]}
-        />
+        <DescriptionWrapper>
+          <PlatformIcon platform={opPlatformMap[row[SPAN_OP]] || 'javascript'} />
+          <SpanDescriptionCell
+            moduleName={ModuleName.HTTP}
+            projectId={row[PROJECT_ID]}
+            description={row[SPAN_DESCRIPTION]}
+            group={row[SPAN_GROUP]}
+          />
+        </DescriptionWrapper>
       );
     }
     if (key === 'spm()') {
@@ -167,3 +178,9 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
 }
 
 export default ResourceTable;
+
+const DescriptionWrapper = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${space(1)};
+`;

--- a/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
@@ -104,7 +104,7 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
     if (key === SPAN_DESCRIPTION) {
       return (
         <DescriptionWrapper>
-          <PlatformIcon platform={opPlatformMap[row[SPAN_OP]] || 'javascript'} />
+          <PlatformIcon platform={opPlatformMap[row[SPAN_OP]] || 'unknown'} />
           <SpanDescriptionCell
             moduleName={ModuleName.HTTP}
             projectId={row[PROJECT_ID]}


### PR DESCRIPTION
Adds icon next to resource name in the main resources table.
Note, the css icon is missing in the below screenshot, we have to publish and consume the new platform icons package before they appear.
![image](https://github.com/getsentry/sentry/assets/44422760/b444bc92-2dca-4988-8303-e87aa8e6d1bf)
