### PR TITLE
feat(browser-starifish): add ability to query for custom fields in spans-sample endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -126,7 +126,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
         second_bound = request.GET.get("secondBound")
         upper_bound = request.GET.get("upperBound")
         column = request.GET.get("column", "span.self_time")
-        selected_columns = request.GET.getlist("field", [],) + [
+        selected_columns = request.GET.getlist("additonalFields", []) + [
             "project",
             "transaction.id",
             column,

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -126,6 +126,17 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
         second_bound = request.GET.get("secondBound")
         upper_bound = request.GET.get("upperBound")
         column = request.GET.get("column", "span.self_time")
+        selected_columns = request.GET.getlist(
+            "field",
+            [
+                "project",
+                "transaction.id",
+                column,
+                "timestamp",
+                "span_id",
+                "profile_id",
+            ],
+        )
 
         if lower_bound is None or upper_bound is None:
             bound_results = spans_metrics.query(
@@ -174,14 +185,7 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
             query = request.query_params.get("query")
 
         result = spans_indexed.query(
-            selected_columns=[
-                "project",
-                "transaction.id",
-                column,
-                "timestamp",
-                "span_id",
-                "profile_id",
-            ],
+            selected_columns=selected_columns,
             orderby=["timestamp"],
             params=params,
             query=query,

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -126,17 +126,14 @@ class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
         second_bound = request.GET.get("secondBound")
         upper_bound = request.GET.get("upperBound")
         column = request.GET.get("column", "span.self_time")
-        selected_columns = request.GET.getlist(
-            "field",
-            [
-                "project",
-                "transaction.id",
-                column,
-                "timestamp",
-                "span_id",
-                "profile_id",
-            ],
-        )
+        selected_columns = request.GET.getlist("field", [],) + [
+            "project",
+            "transaction.id",
+            column,
+            "timestamp",
+            "span_id",
+            "profile_id",
+        ]
 
         if lower_bound is None or upper_bound is None:
             bound_results = spans_metrics.query(


### PR DESCRIPTION
Add ability to query for additional fields when getting span samples. 
I'm concatenating the existing fields as those fields are usually relevant to any span sample.

Also, I couldn't find any associated tests with this endpoint, but given the small change, I don't suspect any issues here.
