### PR TITLE
ref: upgrade selenium to stop installing pyopenssl

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -134,7 +134,6 @@ pycparser==2.21
 pydantic==1.10.9
 pyflakes==3.1.0
 pyjwt==2.4.0
-pyopenssl==23.0.0
 pyparsing==3.0.9
 pyrsistent==0.18.1
 pysocks==1.7.1
@@ -168,7 +167,7 @@ rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 rsa==4.8
 s3transfer==0.6.1
-selenium==4.3.0
+selenium==4.11.2
 sentry-arroyo==2.14.19
 sentry-cli==2.16.0
 sentry-forked-django-stubs==4.2.6.post3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,8 @@ pytest-rerunfailures>=11
 pytest-sentry>=0.1.11
 pytest-xdist>=3
 responses>=0.23.1
-selenium>=4.3.0
+selenium>=4.11.2
+
 sentry-cli>=2.16.0
 
 # pre-commit dependencies

--- a/src/sentry/testutils/pytest/selenium.py
+++ b/src/sentry/testutils/pytest/selenium.py
@@ -1,11 +1,13 @@
 # TODO(dcramer): this heavily inspired by pytest-selenium, and it's possible
 # we could simply inherit from the plugin at this point
+from __future__ import annotations
+
 import logging
 import os
 import sys
 from contextlib import contextmanager
 from datetime import datetime
-from typing import MutableSequence
+from typing import Callable, MutableSequence
 from urllib.parse import urlparse
 
 import pytest
@@ -219,6 +221,7 @@ class Browser:
         Waits until ``selector`` is found in the browser, or until ``timeout``
         is hit, whichever happens first.
         """
+        condition: Callable[[expected_conditions.AnyDriver], object]
         if selector:
             condition = expected_conditions.presence_of_element_located((By.CSS_SELECTOR, selector))
         elif xpath:
@@ -240,6 +243,7 @@ class Browser:
         Waits until ``selector`` is NOT found in the browser, or until
         ``timeout`` is hit, whichever happens first.
         """
+        condition: Callable[[expected_conditions.AnyDriver], object]
         if selector:
             condition = expected_conditions.presence_of_element_located((By.CSS_SELECTOR, selector))
         elif title:


### PR DESCRIPTION
pyopenssl is old py2 compat for broken ssl module which we don't need

this also I believe is the last blocker to allowing an upgrade to urllib3 2.x