### PR TITLE
feat(browser-starfish): move data around in resource summary

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -43,8 +43,10 @@ function ResourceSummary() {
     `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
     `avg(${HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`,
     `avg(${HTTP_RESPONSE_TRANSFER_SIZE})`,
+    `sum(${SPAN_SELF_TIME})`,
     'spm()',
     SPAN_DESCRIPTION,
+    'time_spent_percentage()',
   ]);
 
   return (
@@ -98,6 +100,8 @@ function ResourceSummary() {
               avgTransferSize={spanMetrics[`avg(${HTTP_RESPONSE_TRANSFER_SIZE})`]}
               avgDuration={spanMetrics[`avg(${SPAN_SELF_TIME})`]}
               throughput={spanMetrics['spm()']}
+              timeSpentTotal={spanMetrics[`sum(${SPAN_SELF_TIME})`]}
+              timeSpentPercentage={spanMetrics[`time_spent_percentage()`]}
             />
           </HeaderContainer>
           <ResourceSummaryCharts groupId={groupId} />

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceInfo.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceInfo.tsx
@@ -9,6 +9,7 @@ import {RESOURCE_THROUGHPUT_UNIT} from 'sentry/views/performance/browser/resourc
 import ResourceSize from 'sentry/views/performance/browser/resources/shared/resourceSize';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
+import {TimeSpentCell} from 'sentry/views/starfish/components/tableCells/timeSpentCell';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
 
@@ -18,6 +19,8 @@ type Props = {
   avgDuration: number;
   avgTransferSize: number;
   throughput: number;
+  timeSpentPercentage: number;
+  timeSpentTotal: number;
 };
 
 function ResourceInfo(props: Props) {
@@ -27,6 +30,8 @@ function ResourceInfo(props: Props) {
     avgDuration,
     avgTransferSize,
     throughput,
+    timeSpentPercentage,
+    timeSpentTotal,
   } = props;
 
   const tooltips = {
@@ -62,6 +67,9 @@ function ResourceInfo(props: Props) {
   return (
     <Fragment>
       <BlockContainer>
+        <Block title={getThroughputTitle('http')}>
+          <ThroughputCell rate={throughput} unit={RESOURCE_THROUGHPUT_UNIT} />
+        </Block>
         <Block title={DataTitles['avg(http.response_content_length)']}>
           <Tooltip
             isHoverable
@@ -95,8 +103,8 @@ function ResourceInfo(props: Props) {
         <Block title={DataTitles.avg}>
           <DurationCell milliseconds={avgDuration} />
         </Block>
-        <Block title={getThroughputTitle('http')}>
-          <ThroughputCell rate={throughput} unit={RESOURCE_THROUGHPUT_UNIT} />
+        <Block title={DataTitles.timeSpent}>
+          <TimeSpentCell percentage={timeSpentPercentage} total={timeSpentTotal} />
         </Block>
       </BlockContainer>
       {hasNoData && (


### PR DESCRIPTION
1. Add time spent cell
2. Move resource info around to match mocks
![image](https://github.com/getsentry/sentry/assets/44422760/0d4caa46-3c86-4feb-a20b-4931fb38fec3)
