### PR TITLE
fix(browser-starfish): resource summary render blocking dropdown, unselected state

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -88,7 +88,9 @@ function ResourceSummary() {
                 <ProjectPageFilter />
                 <DatePageFilter />
               </PageFilterBar>
-              <RenderBlockingSelector value={filters[RESOURCE_RENDER_BLOCKING_STATUS]} />
+              <RenderBlockingSelector
+                value={filters[RESOURCE_RENDER_BLOCKING_STATUS] || ''}
+              />
             </FilterOptionsContainer>
             <ResourceInfo
               avgContentLength={spanMetrics[`avg(${HTTP_RESPONSE_CONTENT_LENGTH})`]}

--- a/static/app/views/performance/browser/resources/shared/renderBlockingSelector.tsx
+++ b/static/app/views/performance/browser/resources/shared/renderBlockingSelector.tsx
@@ -11,9 +11,10 @@ const {RESOURCE_RENDER_BLOCKING_STATUS} = SpanMetricsField;
 
 function RenderBlockingSelector({value}: {value?: string}) {
   const location = useLocation();
+  const defaultValue = '';
 
   const options: Option[] = [
-    {value: '', label: 'All'},
+    {value: defaultValue, label: 'All'},
     {value: 'non-blocking', label: t('No')},
     {value: 'blocking', label: t('Yes')},
   ];
@@ -22,7 +23,7 @@ function RenderBlockingSelector({value}: {value?: string}) {
     <SelectControlWithProps
       inFieldLabel={`${t('Blocking')}:`}
       options={options}
-      value={value}
+      value={value || defaultValue}
       onChange={newValue => {
         browserHistory.push({
           ...location,

--- a/static/app/views/performance/browser/resources/shared/renderBlockingSelector.tsx
+++ b/static/app/views/performance/browser/resources/shared/renderBlockingSelector.tsx
@@ -11,10 +11,9 @@ const {RESOURCE_RENDER_BLOCKING_STATUS} = SpanMetricsField;
 
 function RenderBlockingSelector({value}: {value?: string}) {
   const location = useLocation();
-  const defaultValue = '';
 
   const options: Option[] = [
-    {value: defaultValue, label: 'All'},
+    {value: '', label: 'All'},
     {value: 'non-blocking', label: t('No')},
     {value: 'blocking', label: t('Yes')},
   ];
@@ -23,7 +22,7 @@ function RenderBlockingSelector({value}: {value?: string}) {
     <SelectControlWithProps
       inFieldLabel={`${t('Blocking')}:`}
       options={options}
-      value={value || defaultValue}
+      value={value}
       onChange={newValue => {
         browserHistory.push({
           ...location,


### PR DESCRIPTION
Fix a bug where the render blocking selector would display `select` (as if it's in the unselected state), when in reality it is `All` that is selected
![image](https://github.com/getsentry/sentry/assets/44422760/4f3e4bf1-5601-4b05-90c3-66b89197111d)
