### PR TITLE
feat(backup): Send relocation started email

### DIFF
--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -11,9 +11,11 @@ from zipfile import ZipFile
 import yaml
 from cryptography.fernet import Fernet
 from django.db import router, transaction
+from django.utils import timezone as get_timezone
 from google.cloud.devtools.cloudbuild_v1 import Build
 from google.cloud.devtools.cloudbuild_v1 import CloudBuildClient as CloudBuildClient
 
+from sentry import options
 from sentry.api.serializers.rest_framework.base import camel_to_snake_case, convert_dict_key_case
 from sentry.backup.dependencies import NormalizedModelName, get_model
 from sentry.backup.exports import export_in_config_scope, export_in_user_scope
@@ -26,6 +28,7 @@ from sentry.backup.helpers import (
 )
 from sentry.backup.imports import import_in_organization_scope
 from sentry.filestore.gcs import GoogleCloudStorage
+from sentry.http import get_server_hostname
 from sentry.models.files.file import File
 from sentry.models.files.utils import get_storage
 from sentry.models.importchunk import RegionImportChunk
@@ -39,10 +42,12 @@ from sentry.models.relocation import (
 )
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.silo import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json
 from sentry.utils.db import atomic_transaction
+from sentry.utils.email.message_builder import MessageBuilder
 from sentry.utils.env import gcp_project_id
 from sentry.utils.relocation import (
     RELOCATION_BLOB_SIZE,
@@ -307,10 +312,34 @@ def preprocessing_scan(uuid: str) -> None:
             relocation.want_usernames = sorted(usernames)
             relocation.save()
 
-            # TODO(getsentry/team-ospo#203): The user's import data looks basically okay - we should
-            # use this opportunity to send a "your relocation request has been accepted and is in
-            # flight, please give it a couple hours" email.
             preprocessing_baseline_config.delay(uuid)
+
+            # The user's import data looks basically okay - we can use this opportunity to send a
+            # "your relocation request has been accepted and is in flight, please give it a few
+            # hours" email.
+            msg = MessageBuilder(
+                subject=f"{options.get('mail.subject-prefix')} Your Relocation has Started",
+                template="sentry/emails/relocation-started.txt",
+                html_template="sentry/emails/relocation-started.html",
+                type="relocation.started",
+                context={
+                    "domain": get_server_hostname(),
+                    "datetime": get_timezone.now(),
+                    "uuid": str(relocation.uuid),
+                    "orgs": relocation.want_org_slugs,
+                },
+            )
+            email_to = []
+            owner = user_service.get_user(user_id=relocation.owner_id)
+            if owner is not None:
+                email_to.append(owner.email)
+
+            if relocation.owner_id != relocation.creator_id:
+                creator = user_service.get_user(user_id=relocation.creator_id)
+                if creator is not None:
+                    email_to.append(creator.email)
+
+            msg.send_async(to=email_to)
 
 
 @instrumented_task(

--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -34,7 +34,6 @@
       <optgroup label="Account">
         <option value="mail/confirm-email/">Confirm Email</option>
         <option value="mail/recover-account/">Reset Password</option>
-        <option value="mail/relocate-account/">Relocate Account</option>
         <option value="mail/invalid-identity/">Invalid Identity</option>
         <option value="mail/sso-linked/">SSO Linked</option>
         <option value="mail/sso-unlinked/">SSO Unlinked</option>
@@ -52,6 +51,10 @@
         <option value="mail/notify-disable/">Notify Disable</option>
         <option value="mail/sentry-app-notify-disable/">Sentry App Notify Disable</option>
         <option value="mail/join-request/">Join Request</option>
+      </optgroup>
+      <optgroup label="Relocation">
+        <option value="mail/relocate-account/">Relocate Account</option>
+        <option value="mail/relocation-started/">Relocation Started</option>
       </optgroup>
       <optgroup label="Reports">
         <option value="mail/weekly-reports/">Weekly Report</option>

--- a/src/sentry/templates/sentry/emails/relocate_account.txt
+++ b/src/sentry/templates/sentry/emails/relocate_account.txt
@@ -1,7 +1,7 @@
 The following Sentry organizations that you are a member of have been migrated onto sentry.io:
 {% for org in orgs %}
-{{ org }}
-* {% endfor %}
+* {{ org }}
+{% endfor %}
 
 To continue with using these accounts at their new location, please claim your account with sentry.io.
 

--- a/src/sentry/templates/sentry/emails/relocation_started.html
+++ b/src/sentry/templates/sentry/emails/relocation_started.html
@@ -1,0 +1,17 @@
+{% extends "sentry/emails/base.html" %}
+
+{% load i18n %}
+
+{% block main %}
+    <h3>Relocation Accepted</h3>
+    <p>Your relocation request has been accepted. You requested that the following organizations be migrating to sentry.io:</p>
+<ul>
+{% for org in orgs %}
+<li>
+    <a>{{ org }}</a>
+</li>
+{% endfor %}
+</ul>
+    <p>Relocations usually complete in 24 hours or less. If you do not hear from us in that time frame, please <a href="https://help.sentry.io">contact support</a>.</p>
+    <p><small><i>ID: {{ uuid }}</i></small></p>
+{% endblock %}

--- a/src/sentry/templates/sentry/emails/relocation_started.txt
+++ b/src/sentry/templates/sentry/emails/relocation_started.txt
@@ -1,0 +1,9 @@
+Your relocation request has been accepted. You requested that the following organizations be migrating to sentry.io:
+
+{% for org in orgs %}
+* {{ org }}
+{% endfor %}
+
+Relocations usually complete in 24 hours or less. If you do not hear from us in that time frame, please contact support at https://help.sentry.io.
+
+ID: {{ uuid }}

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -123,6 +123,7 @@ urlpatterns = [
     re_path(r"^debug/mail/confirm-email/$", sentry.web.frontend.debug.mail.confirm_email),
     re_path(r"^debug/mail/recover-account/$", sentry.web.frontend.debug.mail.recover_account),
     re_path(r"^debug/mail/relocate-account/$", sentry.web.frontend.debug.mail.relocate_account),
+    re_path(r"^debug/mail/relocation-started/$", sentry.web.frontend.debug.mail.relocation_started),
     re_path(r"^debug/mail/unable-to-delete-repo/$", DebugUnableToDeleteRepository.as_view()),
     re_path(r"^debug/mail/unable-to-fetch-commits/$", DebugUnableToFetchCommitsEmailView.as_view()),
     re_path(r"^debug/mail/unassigned/$", DebugUnassignedEmailView.as_view()),

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -739,6 +739,20 @@ def relocate_account(request):
 
 
 @login_required
+def relocation_started(request):
+    return MailPreview(
+        html_template="sentry/emails/relocation_started.html",
+        text_template="sentry/emails/relocation_started.txt",
+        context={
+            "domain": get_server_hostname(),
+            "datetime": timezone.now(),
+            "uuid": str(uuid.uuid4().hex),
+            "orgs": ["testsentry", "testgetsentry"],
+        },
+    ).render(request)
+
+
+@login_required
 def org_delete_confirm(request):
     from sentry.models.auditlogentry import AuditLogEntry
 


### PR DESCRIPTION
Once we have decent confidence that a relocation is not obviously invalid, we send the owner (and creator, if they are different people) an email indicating that their relocation has started.

![Screenshot 2023-11-15 at 15 39 35](https://github.com/getsentry/sentry/assets/3709945/580c7a82-984b-4f66-9b7d-3be761a39a90)

![Screenshot 2023-11-15 at 15 39 43](https://github.com/getsentry/sentry/assets/3709945/6d2884e9-0f40-4c24-9735-bad3c72c2823)

Issue: getsentry/team-ospo#203
