### PR TITLE
feat(backup): Relocation failed email

### DIFF
--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -55,6 +55,7 @@
       <optgroup label="Relocation">
         <option value="mail/relocate-account/">Relocate Account</option>
         <option value="mail/relocation-started/">Relocation Started</option>
+        <option value="mail/relocation-failed/">Relocation Failed</option>
       </optgroup>
       <optgroup label="Reports">
         <option value="mail/weekly-reports/">Weekly Report</option>

--- a/src/sentry/templates/sentry/emails/relocation_failed.html
+++ b/src/sentry/templates/sentry/emails/relocation_failed.html
@@ -1,0 +1,17 @@
+{% extends "sentry/emails/base.html" %}
+
+{% load i18n %}
+
+{% block main %}
+    <h3>Relocation Failed</h3>
+    <p>Your relocation has failed for the following reason:</p>
+    {%if reason != "" %}
+    <code>
+        {{ reason }}
+    </code>
+    <br>
+    <br>
+    {% endif %}
+    <p>Please <a href="https://help.sentry.io">contact support</a> for further assistance if necessary.</p>
+    <p><small><i>ID: {{ uuid }}</i></small></p>
+{% endblock %}

--- a/src/sentry/templates/sentry/emails/relocation_failed.txt
+++ b/src/sentry/templates/sentry/emails/relocation_failed.txt
@@ -1,0 +1,9 @@
+Your relocation has failed for the following reason:
+
+{%if reason != "" %}
+{{ reason }}
+{% endif %}
+
+Please contact support at https://help.sentry.io for further assistance if necessary.
+
+ID: {{ uuid }}

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -123,6 +123,7 @@ urlpatterns = [
     re_path(r"^debug/mail/confirm-email/$", sentry.web.frontend.debug.mail.confirm_email),
     re_path(r"^debug/mail/recover-account/$", sentry.web.frontend.debug.mail.recover_account),
     re_path(r"^debug/mail/relocate-account/$", sentry.web.frontend.debug.mail.relocate_account),
+    re_path(r"^debug/mail/relocation-failed/$", sentry.web.frontend.debug.mail.relocation_failed),
     re_path(r"^debug/mail/relocation-started/$", sentry.web.frontend.debug.mail.relocation_started),
     re_path(r"^debug/mail/unable-to-delete-repo/$", DebugUnableToDeleteRepository.as_view()),
     re_path(r"^debug/mail/unable-to-fetch-commits/$", DebugUnableToFetchCommitsEmailView.as_view()),

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -739,6 +739,20 @@ def relocate_account(request):
 
 
 @login_required
+def relocation_failed(request):
+    return MailPreview(
+        html_template="sentry/emails/relocation_failed.html",
+        text_template="sentry/emails/relocation_failed.txt",
+        context={
+            "domain": get_server_hostname(),
+            "datetime": timezone.now(),
+            "uuid": str(uuid.uuid4().hex),
+            "reason": "This is a sample failure reason",
+        },
+    ).render(request)
+
+
+@login_required
 def relocation_started(request):
     return MailPreview(
         html_template="sentry/emails/relocation_started.html",

--- a/tests/sentry/utils/test_relocation.py
+++ b/tests/sentry/utils/test_relocation.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
 import pytest
@@ -29,18 +30,28 @@ class RelocationUtilsTestCase(TestCase):
         )
         self.uuid = self.relocation.uuid
 
+    def mock_message_builder(self, fake_message_builder: Mock):
+        fake_message_builder.return_value.send_async.return_value = MagicMock()
 
+
+@patch("sentry.utils.relocation.MessageBuilder")
 class RelocationStartTestCase(RelocationUtilsTestCase):
-    def test_bad_relocation_not_found(self):
+    def test_bad_relocation_not_found(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
         uuid = uuid4().hex
         (relocation, attempts_left) = start_relocation_task(
             uuid, Relocation.Step.UPLOADING, OrderedTask.UPLOADING_COMPLETE, 3
         )
 
+        assert fake_message_builder.call_count == 0
+
         assert relocation is None
         assert not attempts_left
 
-    def test_bad_relocation_completed(self):
+    def test_bad_relocation_completed(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
         self.relocation.status = Relocation.Status.FAILURE.value
         self.relocation.save()
 
@@ -48,20 +59,32 @@ class RelocationStartTestCase(RelocationUtilsTestCase):
             self.uuid, Relocation.Step.UPLOADING, OrderedTask.UPLOADING_COMPLETE, 3
         )
 
+        assert fake_message_builder.call_count == 0
+
         assert relocation is None
         assert not attempts_left
         assert Relocation.objects.get(uuid=self.uuid).status == Relocation.Status.FAILURE.value
 
-    def test_bad_unknown_task(self):
+    def test_bad_unknown_task(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
         (relocation, attempts_left) = start_relocation_task(
             self.uuid, Relocation.Step.UPLOADING, OrderedTask.NONE, 3
+        )
+
+        assert fake_message_builder.call_count == 1
+        assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
+        fake_message_builder.return_value.send_async.assert_called_once_with(
+            to=[self.owner.email, self.superuser.email]
         )
 
         assert relocation is None
         assert not attempts_left
         assert Relocation.objects.get(uuid=self.uuid).status == Relocation.Status.FAILURE.value
 
-    def test_bad_task_out_of_order(self):
+    def test_bad_task_out_of_order(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
         self.relocation.latest_task = OrderedTask.PREPROCESSING_SCAN.name
         self.relocation.save()
 
@@ -69,14 +92,24 @@ class RelocationStartTestCase(RelocationUtilsTestCase):
             self.uuid, Relocation.Step.UPLOADING, OrderedTask.UPLOADING_COMPLETE, 3
         )
 
+        assert fake_message_builder.call_count == 1
+        assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
+        fake_message_builder.return_value.send_async.assert_called_once_with(
+            to=[self.owner.email, self.superuser.email]
+        )
+
         assert relocation is None
         assert not attempts_left
         assert Relocation.objects.get(uuid=self.uuid).status == Relocation.Status.FAILURE.value
 
-    def test_good_first_task(self):
+    def test_good_first_task(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
         (relocation, attempts_left) = start_relocation_task(
             self.uuid, Relocation.Step.UPLOADING, OrderedTask.UPLOADING_COMPLETE, 3
         )
+
+        assert fake_message_builder.call_count == 0
 
         assert relocation is not None
         assert attempts_left == 2
@@ -86,7 +119,9 @@ class RelocationStartTestCase(RelocationUtilsTestCase):
         assert relocation.step == Relocation.Step.UPLOADING.value
         assert relocation.status != Relocation.Status.FAILURE.value
 
-    def test_good_next_task(self):
+    def test_good_next_task(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
         self.relocation.latest_task = OrderedTask.UPLOADING_COMPLETE.name
         self.relocation.save()
 
@@ -95,6 +130,8 @@ class RelocationStartTestCase(RelocationUtilsTestCase):
         (relocation, attempts_left) = start_relocation_task(
             self.uuid, Relocation.Step.PREPROCESSING, OrderedTask.PREPROCESSING_SCAN, 3
         )
+
+        assert fake_message_builder.call_count == 0
 
         assert relocation is not None
         assert attempts_left == 2
@@ -105,31 +142,55 @@ class RelocationStartTestCase(RelocationUtilsTestCase):
         assert relocation.status != Relocation.Status.FAILURE.value
 
 
+@patch("sentry.utils.relocation.MessageBuilder")
 class RelocationFailTestCase(RelocationUtilsTestCase):
-    def test_no_reason(self):
+    def test_no_reason(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
         fail_relocation(self.relocation, OrderedTask.UPLOADING_COMPLETE)
+
+        assert fake_message_builder.call_count == 1
+        assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
+        fake_message_builder.return_value.send_async.assert_called_once_with(
+            to=[self.owner.email, self.superuser.email]
+        )
 
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
         assert not relocation.failure_reason
 
-    def test_with_reason(self):
+    def test_with_reason(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
         fail_relocation(self.relocation, OrderedTask.UPLOADING_COMPLETE, "foo")
+
+        assert fake_message_builder.call_count == 1
+        assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
+        fake_message_builder.return_value.send_async.assert_called_once_with(
+            to=[self.owner.email, self.superuser.email]
+        )
 
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
         assert relocation.failure_reason == "foo"
 
 
+@patch("sentry.utils.relocation.MessageBuilder")
 class RelocationRetryOrFailTestCase(RelocationUtilsTestCase):
-    def test_no_reason_attempts_left(self):
+    def test_no_reason_attempts_left(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
         with pytest.raises(ValueError):
             with retry_task_or_fail_relocation(self.relocation, OrderedTask.UPLOADING_COMPLETE, 3):
                 raise ValueError("Some sort of failure")
 
+        assert fake_message_builder.call_count == 0
+
         assert Relocation.objects.get(uuid=self.uuid).status == Relocation.Status.IN_PROGRESS.value
 
-    def test_no_reason_last_attempt(self):
+    def test_no_reason_last_attempt(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
         # Wrap in `try/except` to make mypy happy.
         try:
             with retry_task_or_fail_relocation(self.relocation, OrderedTask.UPLOADING_COMPLETE, 0):
@@ -137,21 +198,33 @@ class RelocationRetryOrFailTestCase(RelocationUtilsTestCase):
         except Exception:
             pass
 
+        assert fake_message_builder.call_count == 1
+        assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
+        fake_message_builder.return_value.send_async.assert_called_once_with(
+            to=[self.owner.email, self.superuser.email]
+        )
+
         assert Relocation.objects.get(uuid=self.uuid).status == Relocation.Status.FAILURE.value
 
-    def test_with_reason_attempts_left(self):
+    def test_with_reason_attempts_left(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
         with pytest.raises(ValueError):
             with retry_task_or_fail_relocation(
                 self.relocation, OrderedTask.UPLOADING_COMPLETE, 3, "foo"
             ):
                 raise ValueError("Some sort of failure")
 
+        assert fake_message_builder.call_count == 0
+
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation is not None
         assert relocation.status == Relocation.Status.IN_PROGRESS.value
         assert not relocation.failure_reason
 
-    def test_with_reason_last_attempt(self):
+    def test_with_reason_last_attempt(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
         # Wrap in `try/except` to make mypy happy.
         try:
             with retry_task_or_fail_relocation(
@@ -160,6 +233,12 @@ class RelocationRetryOrFailTestCase(RelocationUtilsTestCase):
                 raise ValueError("Some sort of failure")
         except Exception:
             pass
+
+        assert fake_message_builder.call_count == 1
+        assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
+        fake_message_builder.return_value.send_async.assert_called_once_with(
+            to=[self.owner.email, self.superuser.email]
+        )
 
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation is not None


### PR DESCRIPTION
In any case where a relocation definitively fails (not merely retrying a failed task, but actually marking the relocation as a failure), we send the owner and/or creator of the relocation an email to this effect.

![Screenshot 2023-11-15 at 15 49 35](https://github.com/getsentry/sentry/assets/3709945/9b39dfdd-6384-4bce-928d-36e381d2e0fe)

![Screenshot 2023-11-15 at 15 49 44](https://github.com/getsentry/sentry/assets/3709945/04de61b1-7066-4124-97e7-6c408ce3ce1e)

Issue: getsentry/team-ospo#203