### PR TITLE
feat(backup): Relocation succeeded email

### DIFF
--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -55,6 +55,7 @@
       <optgroup label="Relocation">
         <option value="mail/relocate-account/">Relocate Account</option>
         <option value="mail/relocation-started/">Relocation Started</option>
+        <option value="mail/relocation-succeeded/">Relocation Succeeded</option>
         <option value="mail/relocation-failed/">Relocation Failed</option>
       </optgroup>
       <optgroup label="Reports">

--- a/src/sentry/templates/sentry/emails/relocation_succeeded.html
+++ b/src/sentry/templates/sentry/emails/relocation_succeeded.html
@@ -1,0 +1,17 @@
+{% extends "sentry/emails/base.html" %}
+
+{% load i18n %}
+
+{% block main %}
+    <h3>Relocation Succeeded</h3>
+    <p>Your relocation request was successful! The following organizations were migrated to sentry.io:</p>
+<ul>
+{% for org in orgs %}
+<li>
+    <a>{{ org }}</a>
+</li>
+{% endfor %}
+</ul>
+    <p>You are now an owner of all of these organizations. Welcome to sentry.io!</p>
+    <p><small><i>ID: {{ uuid }}</i></small></p>
+{% endblock %}

--- a/src/sentry/templates/sentry/emails/relocation_succeeded.txt
+++ b/src/sentry/templates/sentry/emails/relocation_succeeded.txt
@@ -1,0 +1,9 @@
+Your relocation request was successful! The following organizations were migrated to sentry.io:
+
+{% for org in orgs %}
+* {{ org }}
+{% endfor %}
+
+You are now an owner of all of these organizations. Welcome to sentry.io!
+
+ID: {{ uuid }}

--- a/src/sentry/utils/relocation.py
+++ b/src/sentry/utils/relocation.py
@@ -37,7 +37,8 @@ class OrderedTask(Enum):
     VALIDATING_COMPLETE = 8
     IMPORTING = 9
     POSTPROCESSING = 10
-    COMPLETED = 11
+    NOTIFYING_OWNER = 11
+    COMPLETED = 12
 
 
 # The file type for a relocation export tarball of any kind.

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -125,6 +125,9 @@ urlpatterns = [
     re_path(r"^debug/mail/relocate-account/$", sentry.web.frontend.debug.mail.relocate_account),
     re_path(r"^debug/mail/relocation-failed/$", sentry.web.frontend.debug.mail.relocation_failed),
     re_path(r"^debug/mail/relocation-started/$", sentry.web.frontend.debug.mail.relocation_started),
+    re_path(
+        r"^debug/mail/relocation-succeeded/$", sentry.web.frontend.debug.mail.relocation_succeeded
+    ),
     re_path(r"^debug/mail/unable-to-delete-repo/$", DebugUnableToDeleteRepository.as_view()),
     re_path(r"^debug/mail/unable-to-fetch-commits/$", DebugUnableToFetchCommitsEmailView.as_view()),
     re_path(r"^debug/mail/unassigned/$", DebugUnassignedEmailView.as_view()),

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -767,6 +767,20 @@ def relocation_started(request):
 
 
 @login_required
+def relocation_succeeded(request):
+    return MailPreview(
+        html_template="sentry/emails/relocation_succeeded.html",
+        text_template="sentry/emails/relocation_succeeded.txt",
+        context={
+            "domain": get_server_hostname(),
+            "datetime": timezone.now(),
+            "uuid": str(uuid.uuid4().hex),
+            "orgs": ["testsentry", "testgetsentry"],
+        },
+    ).render(request)
+
+
+@login_required
 def org_delete_confirm(request):
     from sentry.models.auditlogentry import AuditLogEntry
 


### PR DESCRIPTION
The last thing we do before marking a `Relocation` instance as a `SUCCESS` is send an email to the owner and/or creator of that relocation that it has completed successfully.

![Screenshot 2023-11-15 at 15 49 56](https://github.com/getsentry/sentry/assets/3709945/5f7f5468-5708-4965-aa66-e70554151b36)

![Screenshot 2023-11-15 at 15 50 03](https://github.com/getsentry/sentry/assets/3709945/7b68861c-1f1e-48d2-8ff0-f091ffd0e210)

Issue: getsentry/team-ospo#203