### PR TITLE
ref(backup): Use burst task runner for better tests

### DIFF
--- a/src/sentry/utils/relocation.py
+++ b/src/sentry/utils/relocation.py
@@ -373,6 +373,11 @@ def fail_relocation(relocation: Relocation, task: OrderedTask, reason: str = "")
     instead.
     """
 
+    # Another nested exception handler could have already failed this relocation - in this case, do
+    # nothing.
+    if relocation.status == Relocation.Status.FAILURE.value:
+        return
+
     if reason:
         relocation.failure_reason = reason
 


### PR DESCRIPTION
Instead of using the default task runner, which runs celery tasks at their call sites and causes all sorts of shenanigans with nested transactions, we switch to the "burst" task runner. This allows us to add "max" retry test cases as well, and helped catch a couple of sneaky bugs.

Closes getsentry/team-ospo#169
Closes getsentry/team-ospo#203