### PR TITLE
fix(issue-platform): allow addtl properties on user obj

### DIFF
--- a/src/sentry/issues/json_schemas.py
+++ b/src/sentry/issues/json_schemas.py
@@ -147,7 +147,7 @@ LEGACY_EVENT_PAYLOAD_SCHEMA: Mapping[str, Any] = {
                 "segment": {"type": ["string", "null"], "minLength": 1},
                 "username": {"type": ["string", "null"], "minLength": 1},
             },
-            "additionalProperties": False,
+            "additionalProperties": True,
         },
     },
     "required": [


### PR DESCRIPTION
Modifies the event schema to allow additional properties on the user object. see documentation below. Not sure why this event is also failing the non-legacy validation, but this PR will get the user feedback ingest working for our customers who are setting custom user properties.

https://docs.sentry.io/platforms/javascript/enriching-events/identify-user/

> Additionally, you can provide arbitrary key/value pairs beyond the reserved names, and the Sentry SDK will store those with the user.

