### PR TITLE
feat(open-pr-comments): get PR files

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -229,17 +229,23 @@ class GitHubClientMixin(GithubProxyClient):
 
         Returns the merged pull request that introduced the commit to the repository. If the commit is not present in the default branch, will only return open pull requests associated with the commit.
         """
-        pullrequest: JSONData = self.get(f"/repos/{repo}/commits/{sha}/pulls")
-        return pullrequest
+        return self.get(f"/repos/{repo}/commits/{sha}/pulls")
 
     def get_pullrequest(self, repo: str, pull_number: int) -> JSONData:
         """
-        https://docs.github.com/en/free-pro-team@latest/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
+        https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
 
         Returns the pull request details
         """
-        pullrequest: JSONData = self.get(f"/repos/{repo}/pulls/{pull_number}")
-        return pullrequest
+        return self.get(f"/repos/{repo}/pulls/{pull_number}")
+
+    def get_pullrequest_files(self, repo: str, pull_number: int) -> JSONData:
+        """
+        https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
+
+        Returns up to 30 files associated with a pull request. Responses are paginated.
+        """
+        return self.get(f"/repos/{repo}/pulls/{pull_number}/files")
 
     def get_repo(self, repo: str) -> JSONData:
         """

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -231,7 +231,7 @@ class GitHubClientMixin(GithubProxyClient):
         """
         return self.get(f"/repos/{repo}/commits/{sha}/pulls")
 
-    def get_pullrequest(self, repo: str, pull_number: int) -> JSONData:
+    def get_pullrequest(self, repo: str, pull_number: str) -> JSONData:
         """
         https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
 
@@ -239,7 +239,7 @@ class GitHubClientMixin(GithubProxyClient):
         """
         return self.get(f"/repos/{repo}/pulls/{pull_number}")
 
-    def get_pullrequest_files(self, repo: str, pull_number: int) -> JSONData:
+    def get_pullrequest_files(self, repo: str, pull_number: str) -> JSONData:
         """
         https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
 

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import logging
+
+from sentry.integrations.github.client import GitHubAppsClient
+from sentry.models.pullrequest import PullRequest
+from sentry.models.repository import Repository
+from sentry.shared_integrations.exceptions.base import ApiError
+from sentry.tasks.integrations.github.pr_comment import RATE_LIMITED_MESSAGE, GithubAPIErrorType
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+OPEN_PR_METRIC_BASE = "github_open_pr_comment.{key}"
+
+# Caps the number of files that can be modified in a PR to leave a comment
+OPEN_PR_MAX_FILES_CHANGED = 7
+# Caps the number of lines that can be modified in a PR to leave a comment
+OPEN_PR_MAX_LINES_CHANGED = 500
+
+
+# TODO(cathy): Change the client typing to allow for multiple SCM Integrations
+def safe_for_comment(
+    gh_client: GitHubAppsClient, repository: Repository, pull_request: PullRequest
+) -> bool:
+    try:
+        pullrequest_resp = gh_client.get_pullrequest(
+            repo=repository.name, pull_number=pull_request.key
+        )
+    except ApiError as e:
+        if e.json and RATE_LIMITED_MESSAGE in e.json.get("message", ""):
+            metrics.incr(
+                OPEN_PR_METRIC_BASE.format(key="api_error"),
+                tags={"type": GithubAPIErrorType.RATE_LIMITED.value, "code": e.code},
+            )
+        elif e.code == 404:
+            metrics.incr(
+                OPEN_PR_METRIC_BASE.format(key="api_error"),
+                tags={"type": GithubAPIErrorType.MISSING_PULL_REQUEST.value, "code": e.code},
+            )
+        else:
+            metrics.incr(
+                OPEN_PR_METRIC_BASE.format(key="api_error"),
+                tags={"type": GithubAPIErrorType.UNKNOWN.value, "code": e.code},
+            )
+            logger.exception("github.open_pr_comment.unknown_api_error")
+        return False
+
+    safe_to_comment = True
+    if pullrequest_resp["state"] != "open":
+        metrics.incr(
+            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "incorrect_state"}
+        )
+        safe_to_comment = False
+    if pullrequest_resp["changed_files"] > OPEN_PR_MAX_FILES_CHANGED:
+        metrics.incr(
+            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "too_many_files"}
+        )
+        safe_to_comment = False
+    if pullrequest_resp["additions"] + pullrequest_resp["deletions"] > OPEN_PR_MAX_LINES_CHANGED:
+        metrics.incr(
+            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "too_many_lines"}
+        )
+        safe_to_comment = False
+    return safe_to_comment
+
+
+def get_pr_filenames(
+    gh_client: GitHubAppsClient, repository: Repository, pull_request: PullRequest
+):
+    pr_files = gh_client.get_pullrequest_files(repo=repository.name, pull_number=pull_request.key)
+
+    # new files will not have sentry issues associated with them
+    pr_filenames = [file["filename"] for file in pr_files if file["status"] != "added"]
+    return pr_filenames

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import List
 
 from sentry.integrations.github.client import GitHubAppsClient
 from sentry.models.pullrequest import PullRequest
@@ -67,9 +68,9 @@ def safe_for_comment(
 
 def get_pr_filenames(
     gh_client: GitHubAppsClient, repository: Repository, pull_request: PullRequest
-):
+) -> List[str]:
     pr_files = gh_client.get_pullrequest_files(repo=repository.name, pull_number=pull_request.key)
 
     # new files will not have sentry issues associated with them
-    pr_filenames = [file["filename"] for file in pr_files if file["status"] != "added"]
+    pr_filenames: List[str] = [file["filename"] for file in pr_files if file["status"] != "added"]
     return pr_filenames

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -18,7 +18,7 @@ from sentry.models.groupowner import GroupOwnerType
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.models.pullrequest import CommentType, PullRequest, PullRequestComment
+from sentry.models.pullrequest import CommentType, PullRequestComment
 from sentry.models.repository import Repository
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions.base import ApiError
@@ -63,13 +63,6 @@ SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url})"
 ISSUE_LOCKED_ERROR_MESSAGE = "Unable to create comment because issue is locked."
 
 RATE_LIMITED_MESSAGE = "API rate limit exceeded"
-
-OPEN_PR_METRIC_BASE = "github_open_pr_comment.{key}"
-
-# Caps the number of files that can be modified in a PR to leave a comment
-OPEN_PR_MAX_FILES_CHANGED = 7
-# Caps the number of lines that can be modified in a PR to leave a comment
-OPEN_PR_MAX_LINES_CHANGED = 500
 
 
 def format_comment(issues: List[PullRequestIssue]):
@@ -336,49 +329,3 @@ def github_comment_reactions():
             continue
 
         metrics.incr("github_pr_comment.comment_reactions.success")
-
-
-# TODO(cathy): Change the client typing to allow for multiple SCM Integrations
-def safe_for_comment(
-    gh_client: GitHubAppsClient, repository: Repository, pull_request: PullRequest
-) -> bool:
-    try:
-        pullrequest_resp = gh_client.get_pullrequest(
-            repo=repository.name, pull_number=pull_request.key
-        )
-    except ApiError as e:
-        if e.json and RATE_LIMITED_MESSAGE in e.json.get("message", ""):
-            metrics.incr(
-                OPEN_PR_METRIC_BASE.format(key="api_error"),
-                tags={"type": GithubAPIErrorType.RATE_LIMITED.value, "code": e.code},
-            )
-        elif e.code == 404:
-            metrics.incr(
-                OPEN_PR_METRIC_BASE.format(key="api_error"),
-                tags={"type": GithubAPIErrorType.MISSING_PULL_REQUEST.value, "code": e.code},
-            )
-        else:
-            metrics.incr(
-                OPEN_PR_METRIC_BASE.format(key="api_error"),
-                tags={"type": GithubAPIErrorType.UNKNOWN.value, "code": e.code},
-            )
-            logger.exception("github.open_pr_comment.unknown_api_error")
-        return False
-
-    safe_to_comment = True
-    if pullrequest_resp["state"] != "open":
-        metrics.incr(
-            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "incorrect_state"}
-        )
-        safe_to_comment = False
-    if pullrequest_resp["changed_files"] > OPEN_PR_MAX_FILES_CHANGED:
-        metrics.incr(
-            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "too_many_files"}
-        )
-        safe_to_comment = False
-    if pullrequest_resp["additions"] + pullrequest_resp["deletions"] > OPEN_PR_MAX_LINES_CHANGED:
-        metrics.incr(
-            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "too_many_lines"}
-        )
-        safe_to_comment = False
-    return safe_to_comment

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -1,0 +1,159 @@
+from unittest.mock import patch
+
+import responses
+
+from sentry.tasks.integrations.github.open_pr_comment import get_pr_filenames, safe_for_comment
+from sentry.testutils.silo import region_silo_test
+from sentry.testutils.skips import requires_snuba
+from tests.sentry.tasks.integrations.github.test_pr_comment import GithubCommentTestCase
+
+pytestmark = [requires_snuba]
+
+
+@region_silo_test(stable=True)
+class TestSafeForComment(GithubCommentTestCase):
+    def setUp(self):
+        super().setUp()
+        self.pr = self.create_pr_issues()
+        self.mock_metrics = patch(
+            "sentry.tasks.integrations.github.open_pr_comment.metrics"
+        ).start()
+        self.gh_path = self.base_url + "/repos/getsentry/sentry/pulls/{pull_number}"
+        installation = self.integration.get_installation(organization_id=self.organization.id)
+        self.gh_client = installation.get_client()
+
+    @responses.activate
+    def test_simple(self):
+        responses.add(
+            responses.GET,
+            self.gh_path.format(pull_number=self.pr.key),
+            status=200,
+            json={"changed_files": 5, "additions": 100, "deletions": 100, "state": "open"},
+        )
+
+        assert safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+
+    @responses.activate
+    def test_error__rate_limited(self):
+        responses.add(
+            responses.GET,
+            self.gh_path.format(pull_number=self.pr.key),
+            status=429,
+            json={
+                "message": "API rate limit exceeded",
+                "documentation_url": "https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting",
+            },
+        )
+
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        self.mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.api_error", tags={"type": "gh_rate_limited", "code": 429}
+        )
+
+    @responses.activate
+    def test_error__missing_pr(self):
+        responses.add(
+            responses.GET, self.gh_path.format(pull_number=self.pr.key), status=404, json={}
+        )
+
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        self.mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.api_error",
+            tags={"type": "missing_gh_pull_request", "code": 404},
+        )
+
+    @responses.activate
+    def test_error__api_error(self):
+        responses.add(
+            responses.GET, self.gh_path.format(pull_number=self.pr.key), status=400, json={}
+        )
+
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        self.mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.api_error", tags={"type": "unknown_api_error", "code": 400}
+        )
+
+    @responses.activate
+    def test_not_open_pr(self):
+        responses.add(
+            responses.GET,
+            self.gh_path.format(pull_number=self.pr.key),
+            status=200,
+            json={"changed_files": 5, "additions": 100, "deletions": 100, "state": "closed"},
+        )
+
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        self.mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.rejected_comment", tags={"reason": "incorrect_state"}
+        )
+
+    @responses.activate
+    def test_too_many_files(self):
+        responses.add(
+            responses.GET,
+            self.gh_path.format(pull_number=self.pr.key),
+            status=200,
+            json={"changed_files": 11, "additions": 100, "deletions": 100, "state": "open"},
+        )
+
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        self.mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.rejected_comment", tags={"reason": "too_many_files"}
+        )
+
+    @responses.activate
+    def test_too_many_lines(self):
+        responses.add(
+            responses.GET,
+            self.gh_path.format(pull_number=self.pr.key),
+            status=200,
+            json={"changed_files": 5, "additions": 300, "deletions": 300, "state": "open"},
+        )
+
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        self.mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.rejected_comment", tags={"reason": "too_many_lines"}
+        )
+
+    @responses.activate
+    def test_too_many_files_and_lines(self):
+        responses.add(
+            responses.GET,
+            self.gh_path.format(pull_number=self.pr.key),
+            status=200,
+            json={"changed_files": 11, "additions": 300, "deletions": 300, "state": "open"},
+        )
+
+        assert not safe_for_comment(self.gh_client, self.gh_repo, self.pr)
+        self.mock_metrics.incr.assert_any_call(
+            "github_open_pr_comment.rejected_comment", tags={"reason": "too_many_lines"}
+        )
+        self.mock_metrics.incr.assert_any_call(
+            "github_open_pr_comment.rejected_comment", tags={"reason": "too_many_files"}
+        )
+
+
+@region_silo_test(stable=True)
+class TestGetFilenames(GithubCommentTestCase):
+    def setUp(self):
+        super().setUp()
+        self.pr = self.create_pr_issues()
+        self.mock_metrics = patch("sentry.tasks.integrations.github.pr_comment.metrics").start()
+        self.gh_path = self.base_url + "/repos/getsentry/sentry/pulls/{pull_number}/files"
+        installation = self.integration.get_installation(organization_id=self.organization.id)
+        self.gh_client = installation.get_client()
+
+    @responses.activate
+    def test_simple(self):
+        responses.add(
+            responses.GET,
+            self.gh_path.format(pull_number=self.pr.key),
+            status=200,
+            json=[
+                {"filename": "foo.py", "status": "added"},
+                {"filename": "bar.py", "status": "modified"},
+                {"filename": "baz.py", "status": "deleted"},
+            ],
+        )
+
+        assert set(get_pr_filenames(self.gh_client, self.gh_repo, self.pr)) == {"bar.py", "baz.py"}


### PR DESCRIPTION
Fetch the filenames in a pull request. These will be passed into some reverse code mapping logic to map Github filenames to how filenames are stored alongside issues in Sentry.

This PR also refactors the open PR comment logic into its own file (separate from the merged PR comment).

For ER-1806