### PR TITLE
feat(starfish): Use short release version and truncate

### DIFF
--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -16,7 +16,7 @@ import {
   useReleases,
   useReleaseSelection,
 } from 'sentry/views/starfish/queries/useReleases';
-import {centerTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 
 type Props = {
   selectorKey: string;
@@ -71,7 +71,9 @@ export function ReleaseSelector({selectorKey, selectorValue}: Props) {
         icon: <IconReleases />,
         title: selectorValue,
       }}
-      triggerLabel={selectorValue ? centerTruncate(selectorValue, 16) : selectorValue}
+      triggerLabel={
+        selectorValue ? formatVersionAndCenterTruncate(selectorValue, 16) : selectorValue
+      }
       menuTitle={t('Filter Release')}
       loading={isLoading}
       searchable

--- a/static/app/views/starfish/utils/centerTruncate.ts
+++ b/static/app/views/starfish/utils/centerTruncate.ts
@@ -1,7 +1,14 @@
+import {formatVersion} from 'sentry/utils/formatters';
+
 export function centerTruncate(value: string, maxLength: number = 20) {
   const divider = Math.floor(maxLength / 2);
   if (value.length > maxLength) {
     return `${value.slice(0, divider)}\u2026${value.slice(value.length - divider)}`;
   }
   return value;
+}
+
+export function formatVersionAndCenterTruncate(value: string, maxLength?: number) {
+  const formattedVersion = formatVersion(value);
+  return centerTruncate(formattedVersion, maxLength);
 }

--- a/static/app/views/starfish/views/screens/index.tsx
+++ b/static/app/views/starfish/views/screens/index.tsx
@@ -28,6 +28,7 @@ import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {useTTFDConfigured} from 'sentry/views/starfish/queries/useHasTtfdConfigured';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 import {ScreensBarChart} from 'sentry/views/starfish/views/screens/screenBarChart';
 import {
@@ -271,11 +272,18 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
             <ScreensBarChart
               chartOptions={[
                 {
-                  title: t('Comparing Release %s', CHART_TITLES[yAxes[0]]),
+                  title: t('%s by Top Screen', CHART_TITLES[yAxes[0]]),
                   yAxis: YAXIS_COLUMNS[yAxes[0]],
                   xAxisLabel: topTransactions,
                   series: Object.values(
                     transformedReleaseEvents[YAXIS_COLUMNS[yAxes[0]]]
+                  ),
+                  subtitle: t(
+                    '%s v. %s',
+                    formatVersionAndCenterTruncate(primaryRelease, 12),
+                    secondaryRelease
+                      ? formatVersionAndCenterTruncate(secondaryRelease, 12)
+                      : ''
                   ),
                 },
               ]}
@@ -295,11 +303,18 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
               <ScreensBarChart
                 chartOptions={[
                   {
-                    title: t('Comparing Release %s', CHART_TITLES[yAxes[1]]),
+                    title: t('%s by Top Screen', CHART_TITLES[yAxes[1]]),
                     yAxis: YAXIS_COLUMNS[yAxes[1]],
                     xAxisLabel: topTransactions,
                     series: Object.values(
                       transformedReleaseEvents[YAXIS_COLUMNS[yAxes[1]]]
+                    ),
+                    subtitle: t(
+                      '%s v. %s',
+                      formatVersionAndCenterTruncate(primaryRelease, 12),
+                      secondaryRelease
+                        ? formatVersionAndCenterTruncate(secondaryRelease, 12)
+                        : ''
                     ),
                   },
                 ]}

--- a/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
@@ -18,7 +18,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import Chart from 'sentry/views/starfish/components/chart';
 import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
-import {centerTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 import {useEventsStatsQuery} from 'sentry/views/starfish/utils/useEventsStatsQuery';
@@ -220,8 +220,10 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
                   title={t('Average TTID')}
                   subtitle={t(
                     '%s v. %s',
-                    centerTruncate(primaryRelease, 12),
-                    secondaryRelease ? centerTruncate(secondaryRelease, 12) : ''
+                    formatVersionAndCenterTruncate(primaryRelease, 12),
+                    secondaryRelease
+                      ? formatVersionAndCenterTruncate(secondaryRelease, 12)
+                      : ''
                   )}
                 >
                   <Chart
@@ -275,8 +277,10 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
                   title={t('Average TTFD')}
                   subtitle={t(
                     '%s v. %s',
-                    centerTruncate(primaryRelease, 12),
-                    secondaryRelease ? centerTruncate(secondaryRelease, 12) : ''
+                    formatVersionAndCenterTruncate(primaryRelease, 12),
+                    secondaryRelease
+                      ? formatVersionAndCenterTruncate(secondaryRelease, 12)
+                      : ''
                   )}
                 >
                   <Chart
@@ -314,8 +318,10 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
               title={CHART_TITLES[YAxis.COUNT]}
               subtitle={t(
                 '%s v. %s',
-                centerTruncate(primaryRelease, 12),
-                secondaryRelease ? centerTruncate(secondaryRelease, 12) : ''
+                formatVersionAndCenterTruncate(primaryRelease, 12),
+                secondaryRelease
+                  ? formatVersionAndCenterTruncate(secondaryRelease, 12)
+                  : ''
               )}
             >
               <Chart

--- a/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
@@ -203,11 +203,17 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
                 <ScreensBarChart
                   chartOptions={[
                     {
-                      title: t('Comparing Release TTID'),
+                      title: t('TTID by Device Class'),
                       yAxis: YAXIS_COLUMNS[yAxes[0]],
                       series: Object.values(transformedEvents[YAXIS_COLUMNS[yAxes[0]]]),
                       xAxisLabel: ['high', 'medium', 'low', 'Unknown'],
-                      subtitle: t('Device Classes'),
+                      subtitle: t(
+                        '%s v. %s',
+                        formatVersionAndCenterTruncate(primaryRelease, 12),
+                        secondaryRelease
+                          ? formatVersionAndCenterTruncate(secondaryRelease, 12)
+                          : ''
+                      ),
                     },
                   ]}
                   chartKey="spansChart"
@@ -260,11 +266,17 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
                 <ScreensBarChart
                   chartOptions={[
                     {
-                      title: t('Comparing Release TTFD'),
+                      title: t('TTFD by Device Class'),
                       yAxis: YAXIS_COLUMNS[yAxes[1]],
                       series: Object.values(transformedEvents[YAXIS_COLUMNS[yAxes[1]]]),
                       xAxisLabel: ['high', 'medium', 'low', 'Unknown'],
-                      subtitle: t('Device Classes'),
+                      subtitle: t(
+                        '%s v. %s',
+                        formatVersionAndCenterTruncate(primaryRelease, 12),
+                        secondaryRelease
+                          ? formatVersionAndCenterTruncate(secondaryRelease, 12)
+                          : ''
+                      ),
                     },
                   ]}
                   chartKey="spansChart"

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.tsx
@@ -29,7 +29,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {TableColumn} from 'sentry/views/discover/table/types';
-import {centerTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {DeviceClassSelector} from 'sentry/views/starfish/views/screens/screenLoadSpans/deviceClassSelector';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
@@ -73,7 +73,7 @@ export function ScreenLoadEventSamples({
   };
 
   const columnNameMap = {
-    id: t('Event ID (%s)', centerTruncate(release)),
+    id: t('Event ID (%s)', formatVersionAndCenterTruncate(release)),
     'profile.id': t('Profile'),
     'measurements.time_to_initial_display': t('TTID'),
     'measurements.time_to_full_display': t('TTFD'),

--- a/static/app/views/starfish/views/screens/screenLoadSpans/metricsRibbon.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/metricsRibbon.tsx
@@ -11,7 +11,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {CountCell} from 'sentry/views/starfish/components/tableCells/countCell';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
-import {centerTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 import {Block} from 'sentry/views/starfish/views/spanSummaryPage/block';
@@ -31,8 +31,8 @@ export function ScreenMetricsRibbon({additionalFilters}: {additionalFilters?: st
     isLoading: isReleasesLoading,
   } = useReleaseSelection();
 
-  const truncatedPrimary = centerTruncate(primaryRelease ?? '', 10);
-  const truncatedSecondary = centerTruncate(secondaryRelease ?? '', 10);
+  const truncatedPrimary = formatVersionAndCenterTruncate(primaryRelease ?? '', 10);
+  const truncatedSecondary = formatVersionAndCenterTruncate(secondaryRelease ?? '', 10);
 
   const queryStringPrimary = appendReleaseFilters(
     searchQuery,

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
@@ -16,7 +16,7 @@ import {
   useSpanMetrics,
 } from 'sentry/views/starfish/queries/useSpanMetrics';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {centerTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {DataTitles} from 'sentry/views/starfish/views/spans/types';
 import {Block} from 'sentry/views/starfish/views/spanSummaryPage/block';
 import DurationChart from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart';
@@ -86,7 +86,7 @@ export function ScreenLoadSampleContainer({
                   )}/`,
                 }}
               >
-                {centerTruncate(release)}
+                {formatVersionAndCenterTruncate(release)}
               </Link>
             </Tooltip>
           </SectionTitle>

--- a/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
@@ -25,7 +25,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {TableColumn} from 'sentry/views/discover/table/types';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {centerTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
@@ -51,8 +51,8 @@ export function ScreenLoadSpansTable({
   const organization = useOrganization();
 
   const spanOp = decodeScalar(location.query[SpanMetricsField.SPAN_OP]) ?? '';
-  const truncatedPrimary = centerTruncate(primaryRelease ?? '', 15);
-  const truncatedSecondary = centerTruncate(secondaryRelease ?? '', 15);
+  const truncatedPrimary = formatVersionAndCenterTruncate(primaryRelease ?? '', 15);
+  const truncatedSecondary = formatVersionAndCenterTruncate(secondaryRelease ?? '', 15);
 
   const searchQuery = new MutableSearch([
     'transaction.op:ui.load',

--- a/static/app/views/starfish/views/screens/screensTable.tsx
+++ b/static/app/views/starfish/views/screens/screensTable.tsx
@@ -20,7 +20,7 @@ import TopResultsIndicator from 'sentry/views/discover/table/topResultsIndicator
 import {TableColumn} from 'sentry/views/discover/table/types';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {centerTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {TOP_SCREENS} from 'sentry/views/starfish/views/screens';
 
 type Props = {
@@ -34,8 +34,8 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
   const location = useLocation();
   const organization = useOrganization();
   const {primaryRelease, secondaryRelease} = useReleaseSelection();
-  const truncatedPrimary = centerTruncate(primaryRelease ?? '', 15);
-  const truncatedSecondary = centerTruncate(secondaryRelease ?? '', 15);
+  const truncatedPrimary = formatVersionAndCenterTruncate(primaryRelease ?? '', 15);
+  const truncatedSecondary = formatVersionAndCenterTruncate(secondaryRelease ?? '', 15);
 
   const eventViewColumns = eventView.getColumns();
 


### PR DESCRIPTION
Release formatter strips the bundle identifier to make
it easier to parse the release version.