### PR TITLE
fix(logos): Fix mobile browser logos

### DIFF
--- a/static/app/components/events/contextSummary/contextIcon.tsx
+++ b/static/app/components/events/contextSummary/contextIcon.tsx
@@ -47,7 +47,6 @@ import {IconSize} from 'sentry/utils/theme';
 const LOGO_MAPPING = {
   'android-phone': logoAndroidPhone,
   'android-tablet': logoAndroidTablet,
-  'chrome-mobile': logoChrome,
   'chrome-mobile-ios': logoChrome,
   'google-chrome': logoChrome,
   'internet-explorer': logoIe,

--- a/static/app/components/events/contextSummary/utils.tsx
+++ b/static/app/components/events/contextSummary/utils.tsx
@@ -78,5 +78,9 @@ export function generateIconName(
     return isLegacyEdge ? 'legacy-edge' : 'edge';
   }
 
+  if (formattedName.endsWith('-mobile')) {
+    return formattedName.split('-')[0];
+  }
+
   return formattedName;
 }


### PR DESCRIPTION
for a number of browsers, they have an "-mobile" added at the end of the name so we don't show any logo for it. examples are "firefox-mobile", "opera-mobile". this pr adds an extra check to remove the mobile from the formatted name so we can find the logo