### PR TITLE
ref(database): Extract chart components

### DIFF
--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -14,13 +14,11 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
-import {DurationAggregateSelector} from 'sentry/views/performance/database/durationAggregateSelector';
+import {DurationChart} from 'sentry/views/performance/database/durationChart';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
 import {ThroughputChart} from 'sentry/views/performance/database/throughputChart';
 import {useAvailableDurationAggregates} from 'sentry/views/performance/database/useAvailableDurationAggregates';
-import {AVG_COLOR} from 'sentry/views/starfish/colours';
-import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
-import ChartPanel from 'sentry/views/starfish/components/chartPanel';
+import {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import {SpanDescription} from 'sentry/views/starfish/components/spanDescription';
 import {useFullSpanFromTrace} from 'sentry/views/starfish/queries/useFullSpanFromTrace';
 import {
@@ -176,21 +174,12 @@ function SpanSummaryPage({params}: Props) {
             </Block>
 
             <Block>
-              <ChartPanel title={<DurationAggregateSelector />}>
-                <Chart
-                  height={CHART_HEIGHT}
-                  data={[
-                    durationData[
-                      `${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`
-                    ],
-                  ]}
-                  loading={isDurationDataLoading}
-                  utc={false}
-                  chartColors={[AVG_COLOR]}
-                  isLineChart
-                  definedAxisTicks={4}
-                />
-              </ChartPanel>
+              <DurationChart
+                series={
+                  durationData[`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`]
+                }
+                isLoading={isDurationDataLoading}
+              />
             </Block>
           </BlockContainer>
 
@@ -213,8 +202,6 @@ function SpanSummaryPage({params}: Props) {
     </ModulePageProviders>
   );
 }
-
-const CHART_HEIGHT = 160;
 
 const DEFAULT_SORT: Sort = {
   kind: 'desc',

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -11,15 +11,14 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Sort} from 'sentry/utils/discover/fields';
-import {RateUnits} from 'sentry/utils/discover/fields';
-import {formatRate} from 'sentry/utils/formatters';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {DurationAggregateSelector} from 'sentry/views/performance/database/durationAggregateSelector';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
+import {ThroughputChart} from 'sentry/views/performance/database/throughputChart';
 import {useAvailableDurationAggregates} from 'sentry/views/performance/database/useAvailableDurationAggregates';
-import {AVG_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
+import {AVG_COLOR} from 'sentry/views/starfish/colours';
 import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {SpanDescription} from 'sentry/views/starfish/components/spanDescription';
@@ -31,7 +30,6 @@ import {
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
-import {getThroughputChartTitle} from 'sentry/views/starfish/views/spans/types';
 import {useModuleSort} from 'sentry/views/starfish/views/spans/useModuleSort';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
 import {SampleList} from 'sentry/views/starfish/views/spanSummaryPage/sampleList';
@@ -171,24 +169,10 @@ function SpanSummaryPage({params}: Props) {
 
           <BlockContainer>
             <Block>
-              <ChartPanel
-                title={getThroughputChartTitle(span?.[SpanMetricsField.SPAN_OP])}
-              >
-                <Chart
-                  height={CHART_HEIGHT}
-                  data={[throughputData['spm()']]}
-                  loading={isThroughputDataLoading}
-                  utc={false}
-                  chartColors={[THROUGHPUT_COLOR]}
-                  isLineChart
-                  definedAxisTicks={4}
-                  aggregateOutputFormat="rate"
-                  rateUnit={RateUnits.PER_MINUTE}
-                  tooltipFormatterOptions={{
-                    valueFormatter: value => formatRate(value, RateUnits.PER_MINUTE),
-                  }}
-                />
-              </ChartPanel>
+              <ThroughputChart
+                series={throughputData['spm()']}
+                isLoading={isThroughputDataLoading}
+              />
             </Block>
 
             <Block>

--- a/static/app/views/performance/database/durationAggregateSelector.tsx
+++ b/static/app/views/performance/database/durationAggregateSelector.tsx
@@ -2,16 +2,20 @@ import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
 import {CompactSelect} from 'sentry/components/compactSelect';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useLocation} from 'sentry/utils/useLocation';
-import {AVAILABLE_DURATION_AGGREGATE_OPTIONS} from 'sentry/views/performance/database/settings';
+import {useAvailableDurationAggregates} from 'sentry/views/performance/database/useAvailableDurationAggregates';
 
-interface Props {
-  aggregate: string;
-}
-
-export function DurationAggregateSelector({aggregate}: Props) {
+export function DurationAggregateSelector() {
   const location = useLocation();
+
+  const {selectedAggregate, availableAggregates} = useAvailableDurationAggregates();
+
+  // If only one aggregate is available, render a plain string
+  if (availableAggregates.length === 1) {
+    return DURATION_AGGREGATE_LABELS[selectedAggregate];
+  }
 
   const handleDurationFunctionChange = option => {
     browserHistory.push({
@@ -23,19 +27,31 @@ export function DurationAggregateSelector({aggregate}: Props) {
     });
   };
 
+  // If multiple aggregates are available, render a dropdown list
   return (
     <StyledCompactSelect
       size="md"
-      options={AVAILABLE_DURATION_AGGREGATE_OPTIONS}
-      value={aggregate}
+      options={availableAggregates.map(availableAggregate => ({
+        value: availableAggregate,
+        label: DURATION_AGGREGATE_LABELS[availableAggregate],
+      }))}
+      value={selectedAggregate}
       onChange={handleDurationFunctionChange}
       triggerProps={{borderless: true, size: 'zero'}}
     />
   );
 }
 
-// TODO: Talk to UI folks about making this a built-in dropdown size if we end
-// up using this element
+const DURATION_AGGREGATE_LABELS = {
+  avg: t('Average Duration'),
+  max: t('Max Duration'),
+  p50: t('Duration p50'),
+  p75: t('Duration p75'),
+  p95: t('Duration p95'),
+  p99: t('Duration p99'),
+};
+
+// TODO: Talk to UI folks about making this a built-in dropdown size, we use this in a few places
 const StyledCompactSelect = styled(CompactSelect)`
   text-align: left;
   font-weight: normal;

--- a/static/app/views/performance/database/durationChart.tsx
+++ b/static/app/views/performance/database/durationChart.tsx
@@ -1,0 +1,28 @@
+import {Series} from 'sentry/types/echarts';
+import {DurationAggregateSelector} from 'sentry/views/performance/database/durationAggregateSelector';
+import {AVG_COLOR} from 'sentry/views/starfish/colours';
+import Chart from 'sentry/views/starfish/components/chart';
+import ChartPanel from 'sentry/views/starfish/components/chartPanel';
+
+interface Props {
+  isLoading: boolean;
+  series: Series;
+}
+
+export function DurationChart({series, isLoading}: Props) {
+  return (
+    <ChartPanel title={<DurationAggregateSelector />}>
+      <Chart
+        height={CHART_HEIGHT}
+        data={[series]}
+        loading={isLoading}
+        utc={false}
+        chartColors={[AVG_COLOR]}
+        isLineChart
+        definedAxisTicks={4}
+      />
+    </ChartPanel>
+  );
+}
+
+const CHART_HEIGHT = 160;

--- a/static/app/views/performance/database/durationChart.tsx
+++ b/static/app/views/performance/database/durationChart.tsx
@@ -15,6 +15,12 @@ export function DurationChart({series, isLoading}: Props) {
     <ChartPanel title={<DurationAggregateSelector />}>
       <Chart
         height={CHART_HEIGHT}
+        grid={{
+          left: '0',
+          right: '0',
+          top: '8px',
+          bottom: '0',
+        }}
         data={[series]}
         loading={isLoading}
         utc={false}

--- a/static/app/views/performance/database/durationChart.tsx
+++ b/static/app/views/performance/database/durationChart.tsx
@@ -1,5 +1,6 @@
 import {Series} from 'sentry/types/echarts';
 import {DurationAggregateSelector} from 'sentry/views/performance/database/durationAggregateSelector';
+import {CHART_HEIGHT} from 'sentry/views/performance/database/settings';
 import {AVG_COLOR} from 'sentry/views/starfish/colours';
 import Chart from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
@@ -24,5 +25,3 @@ export function DurationChart({series, isLoading}: Props) {
     </ChartPanel>
   );
 }
-
-const CHART_HEIGHT = 160;

--- a/static/app/views/performance/database/durationChart.tsx
+++ b/static/app/views/performance/database/durationChart.tsx
@@ -26,7 +26,6 @@ export function DurationChart({series, isLoading}: Props) {
         utc={false}
         chartColors={[AVG_COLOR]}
         isLineChart
-        definedAxisTicks={4}
       />
     </ChartPanel>
   );

--- a/static/app/views/performance/database/settings.ts
+++ b/static/app/views/performance/database/settings.ts
@@ -1,5 +1,3 @@
-import {t} from 'sentry/locale';
-
 export const MIN_SDK_VERSION_BY_PLATFORM: {[platform: string]: string} = {
   'sentry.python': '1.29.2',
   'sentry.javascript': '7.63.0',
@@ -13,20 +11,3 @@ export const MIN_SDK_VERSION_BY_PLATFORM: {[platform: string]: string} = {
 };
 
 export const DEFAULT_DURATION_AGGREGATE = 'avg';
-
-export const AVAILABLE_DURATION_AGGREGATES = ['avg', 'p50', 'p75', 'p95', 'p99']; // TODO: `max` is not a supported aggregate for this dataset on the backend. Why?
-
-const DURATION_AGGREGATE_LABELS = {
-  avg: t('Average Duration'),
-  p50: t('Duration p50'),
-  p75: t('Duration p75'),
-  p95: t('Duration p95'),
-  p99: t('Duration p99'),
-};
-
-export const AVAILABLE_DURATION_AGGREGATE_OPTIONS = AVAILABLE_DURATION_AGGREGATES.map(
-  aggregate => ({
-    value: aggregate,
-    label: DURATION_AGGREGATE_LABELS[aggregate],
-  })
-);

--- a/static/app/views/performance/database/settings.ts
+++ b/static/app/views/performance/database/settings.ts
@@ -11,3 +11,5 @@ export const MIN_SDK_VERSION_BY_PLATFORM: {[platform: string]: string} = {
 };
 
 export const DEFAULT_DURATION_AGGREGATE = 'avg';
+
+export const CHART_HEIGHT = 160;

--- a/static/app/views/performance/database/throughputChart.tsx
+++ b/static/app/views/performance/database/throughputChart.tsx
@@ -17,6 +17,12 @@ export function ThroughputChart({series, isLoading}: Props) {
     <ChartPanel title={getThroughputChartTitle('db')}>
       <Chart
         height={CHART_HEIGHT}
+        grid={{
+          left: '0',
+          right: '0',
+          top: '8px',
+          bottom: '0',
+        }}
         data={[series]}
         loading={isLoading}
         utc={false}

--- a/static/app/views/performance/database/throughputChart.tsx
+++ b/static/app/views/performance/database/throughputChart.tsx
@@ -1,6 +1,7 @@
 import {Series} from 'sentry/types/echarts';
 import {RateUnits} from 'sentry/utils/discover/fields';
 import {formatRate} from 'sentry/utils/formatters';
+import {CHART_HEIGHT} from 'sentry/views/performance/database/settings';
 import {THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
 import Chart from 'sentry/views/starfish/components/chart';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
@@ -30,5 +31,3 @@ export function ThroughputChart({series, isLoading}: Props) {
     </ChartPanel>
   );
 }
-
-const CHART_HEIGHT = 160;

--- a/static/app/views/performance/database/throughputChart.tsx
+++ b/static/app/views/performance/database/throughputChart.tsx
@@ -1,0 +1,34 @@
+import {Series} from 'sentry/types/echarts';
+import {RateUnits} from 'sentry/utils/discover/fields';
+import {formatRate} from 'sentry/utils/formatters';
+import {THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
+import Chart from 'sentry/views/starfish/components/chart';
+import ChartPanel from 'sentry/views/starfish/components/chartPanel';
+import {getThroughputChartTitle} from 'sentry/views/starfish/views/spans/types';
+
+interface Props {
+  isLoading: boolean;
+  series: Series;
+}
+
+export function ThroughputChart({series, isLoading}: Props) {
+  return (
+    <ChartPanel title={getThroughputChartTitle('db')}>
+      <Chart
+        height={CHART_HEIGHT}
+        data={[series]}
+        loading={isLoading}
+        utc={false}
+        chartColors={[THROUGHPUT_COLOR]}
+        isLineChart
+        aggregateOutputFormat="rate"
+        rateUnit={RateUnits.PER_MINUTE}
+        tooltipFormatterOptions={{
+          valueFormatter: value => formatRate(value, RateUnits.PER_MINUTE),
+        }}
+      />
+    </ChartPanel>
+  );
+}
+
+const CHART_HEIGHT = 160;

--- a/static/app/views/performance/database/useAvailableDurationAggregates.tsx
+++ b/static/app/views/performance/database/useAvailableDurationAggregates.tsx
@@ -1,0 +1,50 @@
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {DEFAULT_DURATION_AGGREGATE} from 'sentry/views/performance/database/settings';
+
+// TODO: Type more strictly, these should be limited to only valid aggregate
+// functions
+type Query = {
+  aggregate: string;
+};
+
+type Result = {
+  availableAggregates: string[];
+  selectedAggregate: string;
+};
+
+export function useAvailableDurationAggregates(): Result {
+  const organization = useOrganization();
+  const location = useLocation<Query>();
+
+  let availableAggregates = ['avg'];
+
+  const arePercentilesEnabled = organization.features?.includes(
+    'performance-database-view-percentiles'
+  );
+
+  if (arePercentilesEnabled) {
+    availableAggregates = [...availableAggregates, ...['p50', 'p75', 'p95', 'p99']];
+  }
+
+  // TODO: Enable this on the backend
+  const isMaxEnabled = false;
+  if (isMaxEnabled) {
+    availableAggregates.push('max');
+  }
+
+  let selectedAggregate = decodeScalar(
+    location.query.aggregate,
+    DEFAULT_DURATION_AGGREGATE
+  );
+
+  if (!availableAggregates.includes(selectedAggregate)) {
+    selectedAggregate = DEFAULT_DURATION_AGGREGATE;
+  }
+
+  return {
+    selectedAggregate,
+    availableAggregates,
+  };
+}


### PR DESCRIPTION
Some refactoring, cleanup, preparation for future. There are two main changes.

- The logic that controls the percentile selector is consolidated, and put into a hook and a component. `useAvailableDurationAggregates` is responsible for checking feature flags and so forth while we work on this. `DurationAggregateSelector` is in charge of listing the options. The logic is now simpler! We just check how many options are available
- Extra `ThroughputChart` and `DurationChart`. This is much easier to re-use (which I will do soon), and also I improved their layout a bit to match the landing page

**e.g.,**
<img width="1259" alt="Screenshot 2023-11-14 at 5 56 49 PM" src="https://github.com/getsentry/sentry/assets/989898/bcc69493-66d0-4f7c-bb01-a7ab9ebff5c3">
