### PR TITLE
ref(browser-starfish): use the shared domain selector in resource module

### DIFF
--- a/static/app/views/performance/browser/resources/index.tsx
+++ b/static/app/views/performance/browser/resources/index.tsx
@@ -16,12 +16,13 @@ import JSCSSView, {
   DEFAULT_RESOURCE_TYPES,
   FilterOptionsContainer,
 } from 'sentry/views/performance/browser/resources/jsCssView';
-import DomainSelector from 'sentry/views/performance/browser/resources/shared/domainSelector';
 import {
   BrowserStarfishFields,
   useResourceModuleFilters,
 } from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
+import {DEFAULT_RESOURCE_FILTERS} from 'sentry/views/performance/browser/resources/utils/useResourcesQuery';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
+import {DomainSelector} from 'sentry/views/starfish/views/spans/selectors/domainSelector';
 
 const {SPAN_OP, SPAN_DOMAIN} = BrowserStarfishFields;
 
@@ -66,8 +67,12 @@ function ResourcesLandingPage() {
               <DatePageFilter />
             </PageFilterBar>
             <DomainSelector
+              emptyOptionLocation="top"
               value={filters[SPAN_DOMAIN] || ''}
-              defaultResourceTypes={DEFAULT_RESOURCE_TYPES}
+              additionalQuery={[
+                ...DEFAULT_RESOURCE_FILTERS,
+                `${SPAN_OP}:[${DEFAULT_RESOURCE_TYPES.join(',')}]`,
+              ]}
             />
           </FilterOptionsContainer>
 


### PR DESCRIPTION
We already have a domain dropdown that does most of what we need for resource module, additionally it also fetches more results if there are more domains then on the dropdown. This PR performs the necessary changes to use this shared domainFilter in resource module.
One thing to note, I added `emptyOptionLocation = 'top' | 'bottom'` because for resources, the case where a domain is not present is pretty important, it typically means the resource was fetch from a relative url which often times means your own resources vs 3rd party.