### PR TITLE
feat(open-pr-comments): get sentry projects and filenames

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -79,12 +79,12 @@ def get_pr_filenames(
 
 
 def get_projects_and_filenames_from_source_file(
+    org_id: int,
     pr_filename: str,
 ) -> Tuple[Set[Project], Set[str]]:
-    query = (
-        "SELECT * FROM sentry_repositoryprojectpathconfig WHERE %s LIKE CONCAT(source_root, '%%')"
-    )
-    code_mappings = list(RepositoryProjectPathConfig.objects.raw(query, [pr_filename]))
+    query = "SELECT * FROM sentry_repositoryprojectpathconfig WHERE organization_id = %s and %s LIKE CONCAT(source_root, '%%')"
+    code_mappings = list(RepositoryProjectPathConfig.objects.raw(query, [org_id, pr_filename]))
+
     project_list: Set[Project] = set()
     sentry_filenames = set()
 

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import List, Set, Union
+from typing import List, Set, Tuple
 
 from sentry.integrations.github.client import GitHubAppsClient
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
@@ -80,12 +80,12 @@ def get_pr_filenames(
 
 def get_projects_and_filenames_from_source_file(
     pr_filename: str,
-) -> Union[Set[Project], Set[str]]:
+) -> Tuple[Set[Project], Set[str]]:
     query = (
         "SELECT * FROM sentry_repositoryprojectpathconfig WHERE %s LIKE CONCAT(source_root, '%%')"
     )
     code_mappings = list(RepositoryProjectPathConfig.objects.raw(query, [pr_filename]))
-    project_list = set()
+    project_list: Set[Project] = set()
     sentry_filenames = set()
 
     if len(code_mappings):

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -181,6 +181,16 @@ class TestGetFilenames(GithubCommentTestCase):
                 default_branch="master",
             )
 
+        # matching code mapping from a different org
+        other_org_code_mapping = self.create_code_mapping(
+            project=self.another_org_project,
+            repo=self.another_org_repo,
+            source_root="",
+            stack_root="./",
+        )
+        other_org_code_mapping.organization_id = self.another_organization.id
+        other_org_code_mapping.save()
+
         source_stack_nonmatches = [
             ("/src/sentry", "sentry"),
             ("tests/", "tests/"),
@@ -201,6 +211,8 @@ class TestGetFilenames(GithubCommentTestCase):
             for source_root, stack_root in source_stack_pairs
         ]
 
-        project_list, sentry_filenames = get_projects_and_filenames_from_source_file(filename)
+        project_list, sentry_filenames = get_projects_and_filenames_from_source_file(
+            self.organization.id, filename
+        )
         assert project_list == set(projects)
         assert sentry_filenames == set(correct_filenames)


### PR DESCRIPTION
Reverse code map filenames from Github (`source_root`) to filenames as stored in Sentry (`stack_root`). Also fetch the projects associated with these code mappings.

For ER-1807