### PR TITLE
ref(weekly-reports): Add logging for org event counts

### DIFF
--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -278,6 +278,12 @@ def project_event_counts_for_organization(ctx):
     request = Request(dataset=Dataset.Outcomes.value, app_id="reports", query=query)
     data = raw_snql_query(request, referrer="weekly_reports.outcomes")["data"]
 
+    if ctx.organization.slug == "sentry":
+        logger.info(
+            "project_event_counts_for_organization_query_result",
+            extra={"num_query_rows": len(data)},
+        )
+
     for dat in data:
         project_id = dat["project_id"]
         # Project no longer in organization, but events still exist


### PR DESCRIPTION
Added logging to count how many rows the Snuba query for getting the event counts for each project in an org is returning to see if we're hitting the Snuba max. In that case, this might be why Weekly Report stats and Usage Stats are not matching up (see #59076).

Only logging for the sentry org to limit the number of logs to Looker (confirmed this is an issue that exists within the Sentry org; see below)

![image](https://github.com/getsentry/sentry/assets/45607721/ef9809d3-1631-4798-86a6-3dc4b78400db)<img width="983" alt="image" src="https://github.com/getsentry/sentry/assets/45607721/2daa33e6-037e-4455-8e68-874d8b373ddd">

<img width="984" alt="image" src="https://github.com/getsentry/sentry/assets/45607721/db849a24-6d05-4696-8e1b-f2afc78ddc99">

