### PR TITLE
feat(hybrid-cloud): Add more logging info on Discord request parser

### DIFF
--- a/src/sentry/integrations/discord/commands.py
+++ b/src/sentry/integrations/discord/commands.py
@@ -42,9 +42,17 @@ class DiscordCommandManager:
 
         if result is None:
             cache.set(cache_key, True, 3600)
+            client = DiscordNonProxyClient()
             try:
-                DiscordNonProxyClient().overwrite_application_commands(self.COMMANDS)
+                client.overwrite_application_commands(self.COMMANDS)
             except ApiError as e:
                 sentry_sdk.capture_exception(e)
-                logger.error("discord.setup.update_bot_commands_failure", extra={"status": e.code})
+                logger.error(
+                    "discord.setup.update_bot_commands_failure",
+                    extra={
+                        "status": e.code,
+                        "error": str(e),
+                        "application_id": client.application_id,
+                    },
+                )
                 cache.delete(cache_key)

--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -32,7 +32,13 @@ class DiscordRequestParser(BaseRequestParser):
     def get_integration_from_request(self) -> Integration | None:
         if self.view_class in self.control_classes:
             params = unsign(self.match.kwargs.get("signed_params"))
-            return Integration.objects.filter(id=params.get("integration_id")).first()
+            integration_id = params.get("integration_id")
+
+            logger.info(
+                f"{self.provider}.get_integration_from_request.{self.view_class.__name__}",
+                extra={"path": self.request.path, "integration_id": integration_id},
+            )
+            return Integration.objects.filter(id=integration_id).first()
 
         if self.view_class == DiscordInteractionsEndpoint:
             drf_request: Request = DiscordInteractionsEndpoint().initialize_request(self.request)
@@ -40,10 +46,20 @@ class DiscordRequestParser(BaseRequestParser):
 
             self.discord_request = discord_request
 
+            logger.info(
+                f"{self.provider}.get_integration_from_request.discord_interactions_endpoint",
+                extra={"path": self.request.path, "guild_id": discord_request.guild_id},
+            )
+
             return Integration.objects.filter(
                 provider=self.provider,
                 external_id=discord_request.guild_id,
             ).first()
+
+        logger.info(
+            f"{self.provider}.get_integration_from_request.no_view_class",
+            extra={"path": self.request.path},
+        )
 
         return None
 


### PR DESCRIPTION
Logs seem to hint that the Discord interaction endpoint is failing here at the Discord request parser. I'm adding logging to uncover clues.