### PR TITLE
Fix(DateRangeSelector interaction): Fixed interaction of DateRangeSelector

### DIFF
--- a/static/app/components/timeRangeSelector/index.tsx
+++ b/static/app/components/timeRangeSelector/index.tsx
@@ -171,16 +171,19 @@ export function TimeRangeSelector({
   const [hasDateRangeErrors, setHasDateRangeErrors] = useState(false);
   const [showAbsoluteSelector, setShowAbsoluteSelector] = useState(!showRelative);
 
-  const [internalValue, setInternalValue] = useState<ChangeData>(() => {
+  const getDefaultInternalValue = useCallback(() => {
     const internalUtc = utc ?? getUserTimezone() === 'UTC';
-
     return {
       start: start ? getInternalDate(start, internalUtc) : undefined,
       end: end ? getInternalDate(end, internalUtc) : undefined,
       utc: internalUtc,
       relative: relative ?? null,
     };
-  });
+  }, [end, relative, start, utc]);
+
+  const [internalValue, setInternalValue] = useState<ChangeData>(
+    getDefaultInternalValue()
+  );
 
   const getOptions = useCallback(
     (items: Item[]): SelectOption<string>[] => {
@@ -335,7 +338,7 @@ export function TimeRangeSelector({
             setHasChanges(false);
             setSearch('');
           }}
-          onInteractOutside={commitChanges}
+          onInteractOutside={() => !showAbsoluteSelector && commitChanges()}
           onKeyDown={e => e.key === 'Escape' && commitChanges()}
           trigger={
             trigger ??
@@ -440,7 +443,14 @@ export function TimeRangeSelector({
                               size="xs"
                               borderless
                               icon={<IconArrow size="xs" direction="left" />}
-                              onClick={() => setShowAbsoluteSelector(false)}
+                              onClick={() => {
+                                setHasChanges(false);
+                                setInternalValue((prev: ChangeData) => ({
+                                  ...prev,
+                                  ...getDefaultInternalValue(),
+                                }));
+                                setShowAbsoluteSelector(false);
+                              }}
                             >
                               {t('Back')}
                             </Button>


### PR DESCRIPTION
Fixes: #59814 

- Fixed onInteactOutside condition as t should not run when showAbsoluteSelector is true because the user should select the Apply button in order to set the range.
- Cleaning internalValue when the back button is clicked in absoluteSelector

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
