### PR TITLE
feat(ddm-alerts): Add force metrics layer params

### DIFF
--- a/static/app/utils/ddm/features.tsx
+++ b/static/app/utils/ddm/features.tsx
@@ -1,0 +1,21 @@
+import type {Organization} from 'sentry/types';
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+
+export function hasDdmAlertsSupport(organization: Organization) {
+  return organization.features.includes('ddm-experimental');
+}
+
+/**
+ * Returns the forceMetricsLayer query param for the alert
+ * wrapped in an object so it can be spread into existing query params
+ * @param organization current organization
+ * @param alertDataset dataset of the alert
+ */
+export function getForceMetricsLayerQueryExtras(
+  organization: Organization,
+  alertDataset: Dataset
+): {forceMetricsLayer: 'true'} | Record<string, never> {
+  return hasDdmAlertsSupport(organization) && alertDataset === Dataset.GENERIC_METRICS
+    ? {forceMetricsLayer: 'true'}
+    : {};
+}

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -43,6 +43,7 @@ import {space} from 'sentry/styles/space';
 import {DateString, Organization, Project} from 'sentry/types';
 import {ReactEchartsRef, Series} from 'sentry/types/echarts';
 import {getUtcDateString} from 'sentry/utils/dates';
+import {getForceMetricsLayerQueryExtras} from 'sentry/utils/ddm/features';
 import {getDuration} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {shouldShowOnDemandMetricAlertUI} from 'sentry/utils/onDemandMetrics/features';
@@ -572,13 +573,16 @@ class MetricChart extends PureComponent<Props, State> {
       moment.utc(timePeriod.end).add(timeWindow, 'minutes')
     );
 
-    const queryExtras = getMetricDatasetQueryExtras({
-      organization,
-      location,
-      dataset,
-      newAlertOrQuery: false,
-      useOnDemandMetrics: isOnDemandAlert,
-    });
+    const queryExtras = {
+      ...getMetricDatasetQueryExtras({
+        organization,
+        location,
+        dataset,
+        newAlertOrQuery: false,
+        useOnDemandMetrics: isOnDemandAlert,
+      }),
+      ...getForceMetricsLayerQueryExtras(organization, dataset),
+    };
 
     return isCrashFreeAlert(dataset) ? (
       <SessionsRequest

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -29,6 +29,7 @@ import {space} from 'sentry/styles/space';
 import {EventsStats, MultiSeriesEventsStats, Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {metric, trackAnalytics} from 'sentry/utils/analytics';
+import {getForceMetricsLayerQueryExtras} from 'sentry/utils/ddm/features';
 import type EventView from 'sentry/utils/discover/eventView';
 import {isOnDemandQueryString} from 'sentry/utils/onDemandMetrics';
 import {
@@ -626,7 +627,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       transaction.setData('actions', sanitizedTriggers);
 
       const hasMetricDataset = organization.features.includes('mep-rollout-flag');
-
+      const dataset = this.determinePerformanceDataset();
       this.setState({loading: true});
       const [data, , resp] = await addOrUpdateRule(
         this.api,
@@ -647,13 +648,14 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
             : {}),
           // Remove eventTypes as it is no longer required for crash free
           eventTypes: isCrashFreeAlert(rule.dataset) ? undefined : eventTypes,
-          dataset: this.determinePerformanceDataset(),
+          dataset,
         },
         {
           duplicateRule: this.isDuplicateRule ? 'true' : 'false',
           wizardV3: 'true',
           referrer: location?.query?.referrer,
           sessionId,
+          ...getForceMetricsLayerQueryExtras(organization, dataset),
         }
       );
       // if we get a 202 back it means that we have an async task

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -33,7 +33,8 @@ import type {
   Project,
 } from 'sentry/types';
 import type {Series} from 'sentry/types/echarts';
-import type {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {getForceMetricsLayerQueryExtras} from 'sentry/utils/ddm/features';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {shouldShowOnDemandMetricAlertUI} from 'sentry/utils/onDemandMetrics/features';
 import {
   getCrashFreeRateSeries,
@@ -385,12 +386,15 @@ class TriggersChart extends PureComponent<Props, State> {
       organization.features.includes('change-alerts') && comparisonDelta
     );
 
-    const queryExtras = getMetricDatasetQueryExtras({
-      organization,
-      location,
-      dataset,
-      newAlertOrQuery,
-    });
+    const queryExtras = {
+      ...getMetricDatasetQueryExtras({
+        organization,
+        location,
+        dataset,
+        newAlertOrQuery,
+      }),
+      ...getForceMetricsLayerQueryExtras(organization, dataset),
+    };
 
     if (isOnDemandMetricAlert) {
       return (


### PR DESCRIPTION
Save alerts and load their charts with the `forceMetricsLayer` param added if their dataset is `generic_metrics` and the `ddm-experimental` feature flag is enabled.

- part of #59823 
- relates to #59898