### PR TITLE
fix(database): Prevent flapping "No Data" message

### DIFF
--- a/static/app/views/performance/database/noDataMessage.spec.tsx
+++ b/static/app/views/performance/database/noDataMessage.spec.tsx
@@ -31,6 +31,30 @@ describe('NoDataMessage', () => {
     }));
   });
 
+  it('does not show anything while data is loading', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/sdk-updates/',
+      body: [],
+    });
+
+    const eventsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [],
+      },
+    });
+
+    render(<NoDataMessage />);
+
+    await waitFor(() => expect(eventsMock).toHaveBeenCalled());
+
+    expect(
+      screen.queryByText(textWithMarkupMatcher('No queries found.'))
+    ).not.toBeInTheDocument();
+
+    await tick();
+  });
+
   it('does not show anything if there is recent data', async function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/sdk-updates/',

--- a/static/app/views/performance/database/noDataMessage.tsx
+++ b/static/app/views/performance/database/noDataMessage.tsx
@@ -22,25 +22,31 @@ export function NoDataMessage({Wrapper = DivWrapper}: Props) {
 
   const selectedProjectIds = selection.projects.map(projectId => projectId.toString());
 
-  const {data: projectSpanMetricsCounts} = useProjectSpanMetricCounts({
-    query: 'span.module:db',
-    statsPeriod: SAMPLE_STATS_PERIOD,
-    enabled: pageFilterIsReady,
-    projectId: selectedProjectIds,
-  });
+  const {data: projectSpanMetricsCounts, isLoading: areSpanMetricCountsLoading} =
+    useProjectSpanMetricCounts({
+      query: 'span.module:db',
+      statsPeriod: SAMPLE_STATS_PERIOD,
+      enabled: pageFilterIsReady,
+      projectId: selectedProjectIds,
+    });
 
   const doesAnySelectedProjectHaveMetrics =
     sumBy(projectSpanMetricsCounts, 'count()') > 0;
 
-  const {ineligibleProjects} = useIneligibleProjects({
-    projectId: selectedProjectIds,
-    enabled: pageFilterIsReady && !doesAnySelectedProjectHaveMetrics,
-  });
+  const {ineligibleProjects, isFetching: areIneligibleProjectsFetching} =
+    useIneligibleProjects({
+      projectId: selectedProjectIds,
+      enabled: pageFilterIsReady && !doesAnySelectedProjectHaveMetrics,
+    });
 
   const organization = useOrganization();
 
   const hasMoreIneligibleProjectsThanVisible =
     ineligibleProjects.length > MAX_LISTED_PROJECTS;
+
+  if (areSpanMetricCountsLoading || areIneligibleProjectsFetching) {
+    return null;
+  }
 
   if (!projectSpanMetricsCounts) {
     return null;


### PR DESCRIPTION
Do not render the no-data warning while data is still loading!
