### PR TITLE
ref(code-owners): Updating rules for GroupEventDetails and ViewHierarchy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -158,6 +158,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /static/app/views/settings/projectAlerts/                 @getsentry/issues
 /static/app/views/alerts/                                 @getsentry/issues
 /static/app/views/issueDetails/                           @getsentry/issues
+/static/app/views/issueDetails/groupEventDetails/         @getsentry/issues
 /static/app/views/projects/                               @getsentry/issues
 /static/app/views/projectDetail/                          @getsentry/issues
 /static/app/views/releases/                               @getsentry/issues
@@ -207,6 +208,7 @@ yarn.lock                                                @getsentry/owners-js-de
 /tests/snuba/api/endpoints/test_organization_events_vitals.py               @getsentry/performance
 /tests/snuba/api/endpoints/test_organization_tagkey_values.py               @getsentry/performance
 /tests/snuba/api/endpoints/test_organization_tags.py                        @getsentry/performance
+/static/app/components/events/viewHierarchy/*                               @getsentry/performance
 
 /src/sentry/api/serializers/snuba.py                                        @getsentry/discover-n-dashboards
 /src/sentry/snuba/discover.py                                               @getsentry/discover-n-dashboards


### PR DESCRIPTION
Recently we've been getting a lot of errors in feed-performance due to the error boundary on the group event details page via one of the few rules apply which happens to be the `quickTrace` (trace navigator) on issues detail page, which definitely isn't right since it's way up the callstack. 

This splits up ownership of the overall page back to issues but takes `ViewHierarchy` which was mostly built by the perf team. 

If there are any sub pages / files within group events that the perf team should own within those folders go ahead and add it 🙏 

