### PR TITLE
fix(hybridcloud) Use RpcUser in sentry app tasks

### DIFF
--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -31,6 +31,7 @@ from sentry.models.project import Project
 from sentry.models.sentryfunction import SentryFunction
 from sentry.models.servicehook import ServiceHook, ServiceHookProject
 from sentry.models.user import User
+from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import metrics
@@ -258,9 +259,8 @@ def installation_webhook(installation_id, user_id, *args, **kwargs):
         logger.info("installation_webhook.missing_installation", extra=extra)
         return
 
-    try:
-        user = User.objects.get(id=user_id)
-    except User.DoesNotExist:
+    user = user_service.get_user(user_id=user_id)
+    if not user:
         logger.info("installation_webhook.missing_user", extra=extra)
         return
 

--- a/tests/sentry/sentry_apps/test_sentry_app_installation_creator.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_installation_creator.py
@@ -8,6 +8,7 @@ from sentry.models.apigrant import ApiGrant
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.servicehook import ServiceHook, ServiceHookProject
 from sentry.sentry_apps.installations import SentryAppInstallationCreator
+from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -89,10 +90,11 @@ class TestCreator(TestCase):
     @responses.activate
     @patch("sentry.mediators.sentry_app_installations.InstallationNotifier.run")
     def test_notifies_service(self, run):
+        rpc_user = user_service.get_user(user_id=self.user.id)
         with self.tasks():
             responses.add(responses.POST, "https://example.com/webhook")
             install = self.run_creator()
-            run.assert_called_once_with(install=install, user=self.user, action="created")
+            run.assert_called_once_with(install=install, user=rpc_user, action="created")
 
     @responses.activate
     def test_associations(self):

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -23,6 +23,7 @@ from sentry.models.integrations.sentry_app_installation import SentryAppInstalla
 from sentry.models.integrations.utils import get_redis_key
 from sentry.models.rule import Rule
 from sentry.models.sentryfunction import SentryFunction
+from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.shared_integrations.exceptions import ClientError
 from sentry.silo import unguarded_write
 from sentry.tasks.post_process import post_process_group
@@ -503,6 +504,7 @@ class TestInstallationWebhook(TestCase):
     def setUp(self):
         self.project = self.create_project()
         self.user = self.create_user()
+        self.rpc_user = user_service.get_user(user_id=self.user.id)
 
         self.sentry_app = self.create_sentry_app(organization=self.project.organization)
 
@@ -513,7 +515,7 @@ class TestInstallationWebhook(TestCase):
     def test_sends_installation_notification(self, run):
         installation_webhook(self.install.id, self.user.id)
 
-        run.assert_called_with(install=self.install, user=self.user, action="created")
+        run.assert_called_with(install=self.install, user=self.rpc_user, action="created")
 
     def test_gracefully_handles_missing_install(self, run):
         installation_webhook(999, self.user.id)


### PR DESCRIPTION
Align parameter type to RpcUser so that InstallationNotifier can be used in both web and celery contexts with the same type.

Fixes SENTRY-18P7