### PR TITLE
fix(view-hierarchy): Account for string or object in attachment download

### DIFF
--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -37,7 +37,7 @@ function EventViewHierarchyContent({event, project}: Props) {
   const hierarchyMeta: IssueAttachment | undefined = viewHierarchies[0];
 
   // There should be only one view hierarchy
-  const {isLoading, data} = useApiQuery<string>(
+  const {isLoading, data} = useApiQuery<string | ViewHierarchyData>(
     [
       defined(hierarchyMeta)
         ? getAttachmentUrl({
@@ -63,6 +63,10 @@ function EventViewHierarchyContent({event, project}: Props) {
       return null;
     }
 
+    if (data && typeof data !== 'string') {
+      return data;
+    }
+
     try {
       return JSON.parse(data);
     } catch (err) {
@@ -75,7 +79,6 @@ function EventViewHierarchyContent({event, project}: Props) {
     return null;
   }
 
-  // TODO(nar): This loading behaviour is subject to change
   if (isLoading || !data) {
     return <LoadingIndicator />;
   }


### PR DESCRIPTION
The request to download the view hierarchy seems to be returning a string in some cases and an object in others. For now this checks for the type and avoids trying to JSON.parse an object. The JSON seems valid in the examples I looked at that were affected by this issue

Fixes JAVASCRIPT-2PNS, JAVASCRIPT-2PNQ, JAVASCRIPT-2GNM