### PR TITLE
fix(dashboards): Remove datetime filter for release selector

### DIFF
--- a/static/app/utils/releases/releasesProvider.tsx
+++ b/static/app/utils/releases/releasesProvider.tsx
@@ -2,7 +2,6 @@ import {createContext, useContext, useEffect, useState} from 'react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
-import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import {Organization, PageFilters, Release} from 'sentry/types';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
@@ -16,7 +15,7 @@ function fetchReleases(
   selection: PageFilters,
   search: string
 ) {
-  const {environments, projects, datetime} = selection;
+  const {environments, projects} = selection;
 
   return api.requestPromise(`/organizations/${orgSlug}/releases/`, {
     method: 'GET',
@@ -26,7 +25,6 @@ function fetchReleases(
       per_page: 50,
       environment: environments,
       query: search,
-      ...normalizeDateTimeParams(datetime),
     },
   });
 }


### PR DESCRIPTION
The filter filters on the release creation date, which means if a person wants to view data r.e. an older active release, that release may not be included in the results

Closes #59433