### PR TITLE
feat(browser-starfish): add resource size to span samples page

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -112,6 +112,7 @@ function ResourceSummary() {
             transactionRoute="/performance/browser/pageloads/"
             groupId={groupId}
             transactionName={transaction as string}
+            additionalFields={[HTTP_RESPONSE_CONTENT_LENGTH]}
           />
         </Layout.Main>
       </Layout.Body>

--- a/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
+++ b/static/app/views/starfish/components/samplesTable/spanSamplesTable.tsx
@@ -11,6 +11,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconProfiling} from 'sentry/icons/iconProfiling';
 import {t} from 'sentry/locale';
 import {useLocation} from 'sentry/utils/useLocation';
+import ResourceSize from 'sentry/views/performance/browser/resources/shared/resourceSize';
 import {DurationComparisonCell} from 'sentry/views/starfish/components/samplesTable/common';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {
@@ -18,6 +19,9 @@ import {
   TextAlignRight,
 } from 'sentry/views/starfish/components/textAlign';
 import {SpanSample} from 'sentry/views/starfish/queries/useSpanSamples';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
+
+const {HTTP_RESPONSE_CONTENT_LENGTH} = SpanMetricsField;
 
 type Keys =
   | 'transaction_id'
@@ -25,10 +29,11 @@ type Keys =
   | 'timestamp'
   | 'duration'
   | 'p95_comparison'
-  | 'avg_comparison';
+  | 'avg_comparison'
+  | 'http.response_content_length';
 export type SamplesTableColumnHeader = GridColumnHeader<Keys>;
 
-const DEFAULT_COLUMN_ORDER: SamplesTableColumnHeader[] = [
+export const DEFAULT_COLUMN_ORDER: SamplesTableColumnHeader[] = [
   {
     key: 'transaction_id',
     name: 'Event ID',
@@ -124,6 +129,10 @@ export function SpanSamplesTable({
       );
     }
 
+    if (column.key === HTTP_RESPONSE_CONTENT_LENGTH) {
+      const size = parseInt(row[HTTP_RESPONSE_CONTENT_LENGTH], 10);
+      return <ResourceSize bytes={size} />;
+    }
     if (column.key === 'profile_id') {
       return (
         <IconWrapper>

--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -19,6 +19,7 @@ const {SPAN_SELF_TIME, SPAN_GROUP} = SpanIndexedField;
 type Options = {
   groupId: string;
   transactionName: string;
+  additionalFields?: string[];
   query?: string[];
   release?: string;
   transactionMethod?: string;
@@ -32,6 +33,7 @@ export type SpanSample = Pick<
   | SpanIndexedField.TIMESTAMP
   | SpanIndexedField.ID
   | SpanIndexedField.PROFILE_ID
+  | SpanIndexedField.HTTP_RESPONSE_CONTENT_LENGTH
 >;
 
 export const useSpanSamples = (options: Options) => {
@@ -45,6 +47,7 @@ export const useSpanSamples = (options: Options) => {
     transactionMethod,
     release,
     query: extraQuery = [],
+    additionalFields,
   } = options;
   const location = useLocation();
 
@@ -94,6 +97,7 @@ export const useSpanSamples = (options: Options) => {
       dateCondtions.start,
       dateCondtions.end,
       queryString,
+      additionalFields?.join(','),
     ],
     queryFn: async () => {
       const {data} = await api.requestPromise(
@@ -106,6 +110,7 @@ export const useSpanSamples = (options: Options) => {
           upperBound: maxYValue,
           project: pageFilter.selection.projects,
           query: queryString,
+          ...(additionalFields?.length ? {additonalFields: additionalFields} : {}),
         })}`
       );
       return data

--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -110,7 +110,7 @@ export const useSpanSamples = (options: Options) => {
           upperBound: maxYValue,
           project: pageFilter.selection.projects,
           query: queryString,
-          ...(additionalFields?.length ? {additonalFields: additionalFields} : {}),
+          ...(additionalFields?.length ? {additionalFields} : {}),
         })}`
       );
       return data

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -118,6 +118,8 @@ export type SpanIndexedFieldTypes = {
   [SpanIndexedField.TIMESTAMP]: string;
   [SpanIndexedField.PROJECT]: string;
   [SpanIndexedField.PROFILE_ID]: string;
+  [SpanIndexedField.RESOURCE_RENDER_BLOCKING_STATUS]: '' | 'non-blocking' | 'blocking';
+  [SpanIndexedField.HTTP_RESPONSE_CONTENT_LENGTH]: string;
 };
 
 export type Op = SpanIndexedFieldTypes[SpanIndexedField.SPAN_OP];

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -26,6 +26,7 @@ const {SPAN_SELF_TIME, SPAN_OP} = SpanMetricsField;
 type Props = {
   groupId: string;
   transactionName: string;
+  additionalFields?: string[];
   highlightedSpanId?: string;
   onClickSample?: (sample: SpanSample) => void;
   onMouseLeaveSample?: () => void;
@@ -67,6 +68,7 @@ function DurationChart({
   onMouseOverSample,
   highlightedSpanId,
   transactionMethod,
+  additionalFields,
   release,
   query,
 }: Props) {
@@ -116,6 +118,7 @@ function DurationChart({
     transactionMethod,
     release,
     query,
+    additionalFields,
   });
 
   const baselineAvgSeries: Series = {

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -5,7 +5,9 @@ import omit from 'lodash/omit';
 import * as qs from 'query-string';
 
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
+import {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
@@ -17,13 +19,18 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
 import DetailPanel from 'sentry/views/starfish/components/detailPanel';
+import {DEFAULT_COLUMN_ORDER} from 'sentry/views/starfish/components/samplesTable/spanSamplesTable';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 import DurationChart from 'sentry/views/starfish/views/spanSummaryPage/sampleList/durationChart';
 import SampleInfo from 'sentry/views/starfish/views/spanSummaryPage/sampleList/sampleInfo';
 import SampleTable from 'sentry/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable';
 
+const {HTTP_RESPONSE_CONTENT_LENGTH} = SpanMetricsField;
+
 type Props = {
   groupId: string;
   transactionName: string;
+  additionalFields?: string[];
   onClose?: () => void;
   spanDescription?: string;
   transactionMethod?: string;
@@ -35,6 +42,7 @@ export function SampleList({
   transactionName,
   transactionMethod,
   spanDescription,
+  additionalFields,
   onClose,
   transactionRoute = '/performance/summary/',
 }: Props) {
@@ -94,6 +102,19 @@ export function SampleList({
     });
   }
 
+  let columnOrder = DEFAULT_COLUMN_ORDER;
+
+  if (additionalFields?.includes(HTTP_RESPONSE_CONTENT_LENGTH)) {
+    columnOrder = [
+      ...DEFAULT_COLUMN_ORDER,
+      {
+        key: HTTP_RESPONSE_CONTENT_LENGTH,
+        name: t('Encoded Size'),
+        width: COL_WIDTH_UNDEFINED,
+      },
+    ];
+  }
+
   return (
     <PageErrorProvider>
       <DetailPanel
@@ -132,6 +153,7 @@ export function SampleList({
           groupId={groupId}
           transactionName={transactionName}
           transactionMethod={transactionMethod}
+          additionalFields={additionalFields}
           onClickSample={span => {
             router.push(
               `/performance/${span.project}:${span['transaction.id']}/#span-${span.span_id}`
@@ -150,6 +172,8 @@ export function SampleList({
           groupId={groupId}
           transactionName={transactionName}
           query={extraQuery}
+          columnOrder={columnOrder}
+          additionalFields={additionalFields}
         />
       </DetailPanel>
     </PageErrorProvider>

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/sampleTable/sampleTable.tsx
@@ -30,6 +30,7 @@ const SpanSamplesTableContainer = styled('div')`
 type Props = {
   groupId: string;
   transactionName: string;
+  additionalFields?: string[];
   columnOrder?: SamplesTableColumnHeader[];
   highlightedSpanId?: string;
   onMouseLeaveSample?: () => void;
@@ -49,6 +50,7 @@ function SampleTable({
   columnOrder,
   release,
   query,
+  additionalFields,
 }: Props) {
   const filters: SpanSummaryQueryFilters = {
     transactionName,
@@ -84,6 +86,7 @@ function SampleTable({
     transactionMethod,
     release,
     query,
+    additionalFields,
   });
 
   const {


### PR DESCRIPTION
Adds resource size to span samples page, there's probably a cleaner approach to this, but this should go good for now imo

<img width="735" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/151a08fd-84de-410d-8ae0-c366c5a33267">