### PR TITLE
fix(metrics-extraction): Pass through on_demand_type for metricsEnhanced

### DIFF
--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -60,6 +60,7 @@ def query(
                 has_metrics,
                 use_metrics_layer,
                 on_demand_metrics_enabled,
+                on_demand_metrics_type=on_demand_metrics_type,
             )
             result["meta"]["datasetReason"] = dataset_reason
 
@@ -139,6 +140,7 @@ def timeseries_query(
                 functions_acl,
                 use_metrics_layer=use_metrics_layer,
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
+                on_demand_metrics_type=on_demand_metrics_type,
             )
         # raise Invalid Queries since the same thing will happen with discover
         except InvalidSearchQuery as error:
@@ -219,6 +221,7 @@ def top_events_timeseries(
                 include_other,
                 functions_acl,
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
+                on_demand_metrics_type=on_demand_metrics_type,
             )
         # raise Invalid Queries since the same thing will happen with discover
         except InvalidSearchQuery as error:

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1030,7 +1030,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemand(
                     "customtag2",
                 ],
                 "topEvents": 5,
-                "dataset": "metrics",
+                "dataset": "metricsEnhanced",
                 "useOnDemandMetrics": "true",
                 "onDemandType": "dynamic_query",
             },


### PR DESCRIPTION
Most pages send metrics enhanced still instead of metrics for a dataset, the params should also be passed through in that case.

Fixes SENTRY-18P8