### PR TITLE
fix(starfish): Tooltip is hidden due to overflow

### DIFF
--- a/static/app/views/starfish/views/screens/index.tsx
+++ b/static/app/views/starfish/views/screens/index.tsx
@@ -384,7 +384,6 @@ const ChartsContainer = styled('div')`
 
 const ChartsContainerItem = styled('div')`
   flex: 1;
-  overflow: hidden;
 `;
 
 export const Spacer = styled('div')`


### PR DESCRIPTION
Remove overflow: hidden so tooltip doesn't become hidden by container boundaries.
