### PR TITLE
feat(generic-metrics): Emit metric for stale keys in cache

### DIFF
--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -116,8 +116,8 @@ class StringIndexerCache:
 
         return formatted
 
-    def _is_valid_timestamp(self, timestamp: int) -> bool:
-        if timestamp < int(datetime.utcnow().timestamp() - timedelta(hours=3)):
+    def _is_valid_timestamp(self, timestamp: str) -> bool:
+        if int(timestamp) < int((datetime.utcnow() - timedelta(hours=3)).timestamp()):
             return False
         return True
 

--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -117,9 +117,7 @@ class StringIndexerCache:
         return formatted
 
     def _is_valid_timestamp(self, timestamp: str) -> bool:
-        if int(timestamp) < int((datetime.utcnow() - timedelta(hours=3)).timestamp()):
-            return False
-        return True
+        return int(timestamp) >= int((datetime.utcnow() - timedelta(hours=3)).timestamp())
 
     def _validate_result(self, result: Optional[str]) -> Optional[int]:
         if result is None:

--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import random
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Collection, Iterable, Mapping, MutableMapping, Optional, Sequence, Set
 
 from django.conf import settings
@@ -32,6 +32,7 @@ _INDEXER_CACHE_RESOLVE_CACHE_REPLENISHMENT_METRIC = (
 )
 _INDEXER_CACHE_DOUBLE_WRITE_METRIC = "sentry_metrics.indexer.memcache.double-write"
 _INDEXER_CACHE_DOUBLE_READ_METRIC = "sentry_metrics.indexer.memcache.new-schema-read"
+_INDEXER_CACHE_STALE_KEYS_METRIC = "sentry_metrics.indexer.memcache.stale-keys"
 
 # only used to compare to the older version of the PGIndexer
 _INDEXER_CACHE_FETCH_METRIC = "sentry_metrics.indexer.memcache.fetch"
@@ -115,10 +116,19 @@ class StringIndexerCache:
 
         return formatted
 
+    def _is_valid_timestamp(self, timestamp: int) -> bool:
+        if timestamp < int(datetime.utcnow().timestamp() - timedelta(hours=3)):
+            return False
+        return True
+
     def _validate_result(self, result: Optional[str]) -> Optional[int]:
         if result is None:
             return None
-        result, _ = result.split(":")
+        result, timestamp = result.split(":")
+
+        if not self._is_valid_timestamp(timestamp):
+            metrics.incr(_INDEXER_CACHE_STALE_KEYS_METRIC)
+
         return int(result)
 
     def get(self, namespace: str, key: str) -> Optional[int]:

--- a/tests/sentry/sentry_metrics/test_indexer_cache.py
+++ b/tests/sentry/sentry_metrics/test_indexer_cache.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 import pytest
 from django.conf import settings
 
@@ -209,3 +211,11 @@ def test_separate_namespacing() -> None:
         indexer_cache.set(namespace, "transactions:3:what", 2)
         assert indexer_cache.get(namespace, "sessions:3:what") == 1
         assert indexer_cache.get(namespace, "transactions:3:what") == 2
+
+
+def test_is_valid_timestamp() -> None:
+    stale_ts = int((datetime.utcnow() - timedelta(hours=5)).timestamp())
+    new_ts = int((datetime.utcnow() - timedelta(hours=1)).timestamp())
+
+    assert not indexer_cache._is_valid_timestamp(str(stale_ts))
+    assert indexer_cache._is_valid_timestamp(str(new_ts))


### PR DESCRIPTION
Now that we are recording timestamp information within the cache item's values, we should emit a metric to check when the timestamp is outside of our expected TTL bounds