### PR TITLE
feat(relocation): Support FormData in api request

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -415,7 +415,7 @@ export class Client {
 
     let data = options.data;
 
-    if (data !== undefined && method !== 'GET') {
+    if (data !== undefined && method !== 'GET' && !(data instanceof FormData)) {
       data = JSON.stringify(data);
     }
 


### PR DESCRIPTION
In order to hit the `/api/0/relocations` endpoint, a POST request must be made with a payload with type `multipart/form-data`. This appears to not be supported right now, as invoking `JSON.stringify` on a `FormData` object will result in an empty object. 

I don't think this can be tested easily, because `Api.request` is completely mocked out