### PR TITLE
fix(starfish): Check result data length prior to accessing array

### DIFF
--- a/static/app/views/starfish/queries/useHasTtfdConfigured.tsx
+++ b/static/app/views/starfish/queries/useHasTtfdConfigured.tsx
@@ -47,7 +47,7 @@ export function useTTFDConfigured(additionalFilters?: string[]) {
     staleTime: Infinity,
   });
 
-  const hasTTFD: boolean | undefined = result.data
+  const hasTTFD: boolean | undefined = result.data?.data?.length
     ? !(
         result.data.data?.[0]['avg(measurements.time_to_initial_display)'] !== 0 &&
         result.data.data?.[0]['avg(measurements.time_to_full_display)'] === 0


### PR DESCRIPTION
Check the data array length because an empty array indexed at 0 returns undefined, which throws an error in this code.