### PR TITLE
chore(hybrid-cloud): Adds Organization RPC method to query orgs by scope

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -117,6 +117,12 @@ class DatabaseBackedOrganizationService(OrganizationService):
         except Organization.DoesNotExist:
             return None
 
+    def get_organizations_by_user_and_scope(
+        self, *, region_name: str, user: RpcUser, scope: str
+    ) -> List[RpcOrganization]:
+        organizations = Organization.objects.get_for_user(user=user, scope=scope)
+        return list(map(serialize_rpc_organization, organizations))
+
     def get_default_organization(self) -> RpcOrganization:
         return serialize_rpc_organization(Organization.get_default())
 

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -92,6 +92,16 @@ class OrganizationService(RpcService):
         """
         pass
 
+    @regional_rpc_method(resolve=ByRegionName())
+    @abstractmethod
+    def get_organizations_by_user_and_scope(
+        self, *, region_name: str, user: RpcUser, scope: str
+    ) -> List[RpcOrganization]:
+        """
+        Fetches organizations for the given user, with the given organization member scope.
+        """
+        pass
+
     @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
     def update_flags(self, *, organization_id: int, flags: RpcOrganizationFlagsUpdate) -> None:


### PR DESCRIPTION
This will be used for refactors in getsentry around education sponsorships, which rely on this query.