### PR TITLE
feat(hybrid-cloud): Add test coverage for installation deletion event for Github integration

### DIFF
--- a/fixtures/github.py
+++ b/fixtures/github.py
@@ -602,6 +602,53 @@ INSTALLATION_EVENT_EXAMPLE = """{
   }
 }"""
 
+INSTALLATION_DELETE_EVENT_EXAMPLE = """{
+  "action": "deleted",
+  "installation": {
+    "id": 2,
+    "account": {
+      "login": "octocat",
+      "id": 1,
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/octocat",
+      "html_url": "https://github.com/octocat",
+      "followers_url": "https://api.github.com/users/octocat/followers",
+      "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+      "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+      "organizations_url": "https://api.github.com/users/octocat/orgs",
+      "repos_url": "https://api.github.com/users/octocat/repos",
+      "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/octocat/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "access_tokens_url": "https://api.github.com/installations/2/access_tokens",
+    "repositories_url": "https://api.github.com/installation/repositories"
+  },
+  "sender": {
+    "login": "octocat",
+    "id": 1,
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}"""
+
 INSTALLATION_REPO_EVENT = """{
   "action": "added",
   "installation": {

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -6,6 +6,7 @@ import responses
 
 from fixtures.github import (
     INSTALLATION_API_RESPONSE,
+    INSTALLATION_DELETE_EVENT_EXAMPLE,
     INSTALLATION_EVENT_EXAMPLE,
     PULL_REQUEST_CLOSED_EVENT_EXAMPLE,
     PULL_REQUEST_EDITED_EVENT_EXAMPLE,
@@ -14,16 +15,23 @@ from fixtures.github import (
 )
 from sentry import options
 from sentry.constants import ObjectStatus
+from sentry.middleware.integrations.parsers.github import GithubRequestParser
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.commitfilechange import CommitFileChange
 from sentry.models.grouplink import GroupLink
 from sentry.models.integrations.integration import Integration
+from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, region_silo_test
+from sentry.testutils.silo import (
+    all_silo_test,
+    assume_test_silo_mode,
+    control_silo_test,
+    region_silo_test,
+)
 
 
 @region_silo_test(stable=True)
@@ -101,6 +109,87 @@ class InstallationEventWebhookTest(APITestCase):
         assert integration.metadata["sender"]["id"] == 1
         assert integration.metadata["sender"]["login"] == "octocat"
         assert integration.status == ObjectStatus.ACTIVE
+
+
+@all_silo_test(stable=True)
+class InstallationDeleteEventWebhookTest(APITestCase):
+    base_url = "https://api.github.com"
+
+    def setUp(self):
+        self.url = "/extensions/github/webhook/"
+        self.secret = "b3002c3e321d4b7880360d397db2ccfd"
+        options.set("github-app.webhook-secret", self.secret)
+
+    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    def test_installation_deleted(self, get_jwt):
+        project = self.project  # force creation
+
+        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = self.create_integration(
+                name="octocat",
+                organization=self.organization,
+                external_id="2",
+                provider="github",
+                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
+            )
+            integration.add_organization(project.organization.id, self.user)
+            assert integration.status == ObjectStatus.ACTIVE
+
+        with patch.object(GithubRequestParser, "get_regions_from_organizations", return_value=[]):
+            response = self.client.post(
+                path=self.url,
+                data=INSTALLATION_DELETE_EVENT_EXAMPLE,
+                content_type="application/json",
+                HTTP_X_GITHUB_EVENT="installation",
+                HTTP_X_HUB_SIGNATURE="sha1=8f73a86cf0a0cfa6d05626ce425cef5d3c4062aa",
+                HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+            )
+            assert response.status_code == 204
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(external_id=2)
+            assert integration.external_id == "2"
+            assert integration.name == "octocat"
+            assert integration.status == ObjectStatus.DISABLED
+
+    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    def test_installation_deleted_no_org_integration(self, get_jwt):
+        project = self.project  # force creation
+
+        future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = self.create_integration(
+                name="octocat",
+                organization=self.organization,
+                external_id="2",
+                provider="github",
+                metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
+            )
+            integration.add_organization(project.organization.id, self.user)
+            assert integration.status == ObjectStatus.ACTIVE
+
+            # Set up condition that the OrganizationIntegration is deleted prior to the webhook event
+            OrganizationIntegration.objects.filter(
+                integration_id=integration.id,
+                organization_id=self.organization.id,
+            ).delete()
+
+        response = self.client.post(
+            path=self.url,
+            data=INSTALLATION_DELETE_EVENT_EXAMPLE,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="installation",
+            HTTP_X_HUB_SIGNATURE="sha1=8f73a86cf0a0cfa6d05626ce425cef5d3c4062aa",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+        assert response.status_code == 204
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(external_id=2)
+            assert integration.external_id == "2"
+            assert integration.name == "octocat"
+            assert integration.status == ObjectStatus.DISABLED
 
 
 @region_silo_test(stable=True)


### PR DESCRIPTION
Fixes https://sentry-st.sentry.io/issues/4635767208/

The integration request parser may fall back to the control silo in cases when an organization integration cannot be found. 

This pull request makes the some Github webhook code paths a little more bulletproof.