### PR TITLE
fix(releases): Align collapsed avatars

### DIFF
--- a/static/app/components/avatar/avatarList.tsx
+++ b/static/app/components/avatar/avatarList.tsx
@@ -45,7 +45,7 @@ function AvatarList({
   return (
     <AvatarListWrapper className={className}>
       {!!numCollapsedAvatars && (
-        <Tooltip title={`${numCollapsedAvatars} other ${typeAvatars}`}>
+        <Tooltip title={`${numCollapsedAvatars} other ${typeAvatars}`} skipWrapper>
           <CollapsedAvatars size={avatarSize} data-test-id="avatarList-collapsedavatars">
             {numCollapsedAvatars < 99 && <Plus>+</Plus>}
             {numCollapsedAvatars}
@@ -80,6 +80,7 @@ export default AvatarList;
 // used in releases list page to do some alignment
 export const AvatarListWrapper = styled('div')`
   display: flex;
+  align-items: center;
   flex-direction: row-reverse;
 `;
 


### PR DESCRIPTION
move's the little +2 at the end to be more in line with the other avatars

before
![Screenshot 2023-11-15 at 1 41 27 PM](https://github.com/getsentry/sentry/assets/1400464/03085fd6-30d4-4510-a768-de68fff4b6be)

after
![Screenshot 2023-11-15 at 1 41 19 PM](https://github.com/getsentry/sentry/assets/1400464/cb232174-a151-4cc3-92b4-9904b2ef81aa)