### PR TITLE
chore(github-invite): track total missing members when viewing banner

### DIFF
--- a/static/app/utils/analytics/growthAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/growthAnalyticsEvents.tsx
@@ -63,7 +63,7 @@ export type GrowthEventParameters = {
     guide: string;
   };
   'github_invite_banner.snoozed': {};
-  'github_invite_banner.viewed': {members_shown: number};
+  'github_invite_banner.viewed': {members_shown: number; total_members: number};
   'growth.clicked_enter_sandbox': {
     scenario: string;
     source?: string;

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -118,6 +118,7 @@ export function InviteBanner({
     trackAnalytics('github_invite_banner.viewed', {
       organization,
       members_shown: missingMembers.slice(0, MAX_MEMBERS_TO_SHOW).length,
+      total_members: missingMembers.length,
     });
   }
   if (!isEligibleForBanner || !showBanner || missingMembers.length === 0) {


### PR DESCRIPTION
Also track the total number of missing members when viewing the invite banner.