### PR TITLE
nit(ui): Change jira integration icon to blue

### DIFF
--- a/src/sentry/static/sentry/images/logos/logo-jira.svg
+++ b/src/sentry/static/sentry/images/logos/logo-jira.svg
@@ -1,1 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 80 80"><defs><linearGradient id="a" x1="37.88" y1="449.8" x2="21.37" y2="433.28" gradientTransform="matrix(1 0 0 -1 0 466)" gradientUnits="userSpaceOnUse"><stop offset=".18" stop-color="#344563"/><stop offset="1" stop-color="#5f6672"/></linearGradient><linearGradient id="b" x1="42.26" y1="402.35" x2="58.74" y2="418.83" xlink:href="#a"/></defs><path d="M77.76 37.76 43.34 3.34 40 0 14.09 25.91 2.24 37.76a3.16 3.16 0 0 0 0 4.48l23.67 23.67L40 80l25.91-25.91.4-.4 11.45-11.45a3.16 3.16 0 0 0 0-4.48zM40 51.83 28.17 40 40 28.17 51.83 40z" fill="#5f6672"/><path d="M40 28.17A19.91 19.91 0 0 1 39.92.1L14 26l14.12 14.05z" fill="url(#a)"/><path d="M51.86 40 40 51.83A19.91 19.91 0 0 1 40 80l26-25.95z" fill="url(#b)"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 80
+80"><defs><linearGradient id="a" x1="37.88" y1="449.8" x2="21.37" y2="433.28"
+gradientTransform="matrix(1 0 0 -1 0 466)" gradientUnits="userSpaceOnUse"><stop
+offset=".18" stop-color="#0052cc"/><stop offset="1"
+stop-color="#2684ff"/></linearGradient><linearGradient id="b" x1="42.26"
+y1="402.35" x2="58.74" y2="418.83" xlink:href="#a"/></defs><path d="M77.76 37.76
+43.34 3.34 40 0 14.09 25.91 2.24 37.76a3.16 3.16 0 0 0 0 4.48l23.67 23.67L40
+80l25.91-25.91.4-.4 11.45-11.45a3.16 3.16 0 0 0 0-4.48zM40 51.83 28.17 40 40
+28.17 51.83 40z" fill="#2684ff"/><path d="M40 28.17A19.91 19.91 0 0 1 39.92.1L14
+26l14.12 14.05z" fill="url(#a)"/><path d="M51.86 40 40 51.83A19.91 19.91 0 0 1
+40 80l26-25.95z" fill="url(#b)"/></svg>


### PR DESCRIPTION
I basically just replaced the jira svg file with a copy paste of the jira server svg. I'm hoping this doesn't affect the Jira (Legacy) plugin icon which uses the grey one, but for some reason doesn't show up in my local devserver.

### Before
<img width="1226" alt="Screenshot 2023-11-15 at 2 26 53 PM" src="https://github.com/getsentry/sentry/assets/67301797/c90a3dd5-6260-4e2b-baa5-e7b9c83832ad">

### After
<img width="1224" alt="Screenshot 2023-11-15 at 2 24 21 PM" src="https://github.com/getsentry/sentry/assets/67301797/4caa4bdc-7982-418c-9050-565cdf844308">