### PR TITLE
fix(replays): don't show jump down buttons if no scrolling is needed

### DIFF
--- a/static/app/components/replays/useJumpButtons.tsx
+++ b/static/app/components/replays/useJumpButtons.tsx
@@ -57,7 +57,7 @@ export default function useJumpButtons({
     handleClick,
     onRowsRendered,
     onSectionRendered,
-    showJumpDownButton: rowIndex > visibleRange.stopIndex,
+    showJumpDownButton: rowIndex > visibleRange.stopIndex + 1,
     showJumpUpButton: rowIndex < visibleRange.startIndex,
   };
 }


### PR DESCRIPTION
this was happening due to an off-by-one error. if we reach the end of the replay and scroll to the bottom of the tab (e.g. the last error/network/etc frame is visible), `rowIndex` is always 1 more than the `visibleRange.stopIndex`. this was causing the button to render again in this instance, which we don't want. 

before:

https://github.com/getsentry/sentry/assets/56095982/1c619d60-c137-4340-a06c-261a3348a83b



after:

https://github.com/getsentry/sentry/assets/56095982/930917e7-5932-4727-b975-10a9cad955a5

fixes https://github.com/getsentry/sentry/issues/58902