### PR TITLE
style(replays): add padding for timeline zoom

### DIFF
--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -161,7 +161,7 @@ function TimelineSizeBar() {
         aria-label={t('Zoom out')}
         disabled={timelineScale === 1}
       />
-      <span>
+      <span style={{padding: `${space(0.5)}`}}>
         {timelineScale}
         {t('x')}
       </span>


### PR DESCRIPTION
before:
<img width="121" alt="SCR-20231115-nmzf" src="https://github.com/getsentry/sentry/assets/56095982/70b628c7-ba3d-49be-9054-d0b7182d4889">
<img width="114" alt="SCR-20231115-nnll" src="https://github.com/getsentry/sentry/assets/56095982/795e1570-19f3-416b-8c8d-00fb08bba83e">

after:
<img width="129" alt="SCR-20231115-nnhq" src="https://github.com/getsentry/sentry/assets/56095982/4ac7fcba-3ae3-4de9-b43d-cfb2251bf0b0">
<img width="140" alt="SCR-20231115-nnke" src="https://github.com/getsentry/sentry/assets/56095982/549d1660-a136-4cc3-a852-ab15c0d8b66d">
