### PR TITLE
feat(ddm): Allow MRI in alert rule

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -61,6 +61,7 @@ from sentry.snuba.entity_subscription import (
     get_entity_subscription_from_snuba_query,
 )
 from sentry.snuba.metrics.extraction import should_use_on_demand_metrics
+from sentry.snuba.metrics.naming_layer.mapping import is_mri
 from sentry.snuba.models import SnubaQuery
 from sentry.snuba.subscriptions import (
     bulk_create_snuba_subscriptions,
@@ -1518,11 +1519,12 @@ def get_column_from_aggregate(aggregate):
     return None
 
 
-def check_aggregate_column_support(aggregate):
+def check_aggregate_column_support(aggregate, allow_mri=False):
     column = get_column_from_aggregate(aggregate)
     return (
         column is None
         or is_measurement(column)
+        or (is_mri(column) and allow_mri)
         or column in SUPPORTED_COLUMNS
         or column in TRANSLATABLE_COLUMNS
     )

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -134,7 +134,14 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
 
     def validate_aggregate(self, aggregate):
         try:
-            if not check_aggregate_column_support(aggregate):
+            if not check_aggregate_column_support(
+                aggregate,
+                allow_mri=features.has(
+                    "organizations:ddm-experimental",
+                    self.context["organization"],
+                    actor=self.context.get("user", None),
+                ),
+            ):
                 raise serializers.ValidationError(
                     "Invalid Metric: We do not currently support this field."
                 )

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -21,6 +21,7 @@ from sentry.incidents.logic import (
     check_aggregate_column_support,
     create_alert_rule,
     delete_alert_rule_trigger,
+    get_column_from_aggregate,
     query_datasets_to_type,
     translate_aggregate_field,
     update_alert_rule,
@@ -35,6 +36,7 @@ from sentry.snuba.entity_subscription import (
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.tasks import build_query_builder
 
+from ...snuba.metrics.naming_layer.mapping import is_mri
 from . import (
     CRASH_RATE_ALERTS_ALLOWED_TIME_WINDOWS,
     QUERY_TYPE_VALID_DATASETS,
@@ -134,13 +136,15 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
 
     def validate_aggregate(self, aggregate):
         try:
+            allow_mri = features.has(
+                "organizations:ddm-experimental",
+                self.context["organization"],
+                actor=self.context.get("user", None),
+            )
+
             if not check_aggregate_column_support(
                 aggregate,
-                allow_mri=features.has(
-                    "organizations:ddm-experimental",
-                    self.context["organization"],
-                    actor=self.context.get("user", None),
-                ),
+                allow_mri=allow_mri,
             ):
                 raise serializers.ValidationError(
                     "Invalid Metric: We do not currently support this field."
@@ -249,6 +253,17 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             actor=self.context.get("user", None),
         ):
             dataset = data["dataset"] = Dataset.Metrics
+
+        if features.has(
+            "organizations:ddm-experimental",
+            self.context["organization"],
+            actor=self.context.get("user", None),
+        ):
+            column = get_column_from_aggregate(data["aggregate"])
+            if is_mri(column) and dataset != Dataset.PerformanceMetrics:
+                raise serializers.ValidationError(
+                    "You can use an MRI only on alerts on performance metrics"
+                )
 
         query_type = data.setdefault("query_type", query_datasets_to_type[dataset])
 

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -1086,9 +1086,10 @@ class NumericColumn(ColumnArg):
         self.allow_array_value = allow_array_value
 
     def _normalize(self, value: str) -> str:
+        from sentry.snuba.metrics.naming_layer.mapping import is_mri
+
         # This method is written in this way so that `get_type` can always call
         # this even in child classes where `normalize` have been overridden.
-
         # Shortcutting this for now
         # TODO: handle different datasets better here
         if self.spans and value in ["span.duration", "span.self_time"]:
@@ -1097,6 +1098,8 @@ class NumericColumn(ColumnArg):
         if not snuba_column and is_measurement(value):
             return value
         if not snuba_column and is_span_op_breakdown(value):
+            return value
+        if not snuba_column and is_mri(value):
             return value
         if not snuba_column:
             raise InvalidFunctionArgument(f"{value} is not a valid column")


### PR DESCRIPTION
This PR adds the support for MRI in the metric alerts creation, such feature was implemented in the following way:
* `NumericColumn` now supports the MRI as column.
* `check_aggregate_column_support` now has a parameter to control whether the `mri` is allowed in the alert column.