### PR TITLE
fix(starfish): Fix incorrect transaction parameter when fetching metrics series

### DIFF
--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -26,7 +26,11 @@ import {
   useSpanMetrics,
 } from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
-import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
+import {
+  SpanFunction,
+  SpanMetricsField,
+  SpanMetricsQueryFilters,
+} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {useModuleSort} from 'sentry/views/starfish/views/spans/useModuleSort';
 import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
@@ -58,6 +62,13 @@ function SpanSummaryPage({params}: Props) {
 
   const queryFilter: SpanSummaryQueryFilters = endpoint
     ? {transactionName: endpoint, 'transaction.method': endpointMethod}
+    : {};
+
+  const seriesQueryFilters: SpanMetricsQueryFilters = endpoint
+    ? {
+        transaction: endpoint,
+        'transaction.method': endpointMethod,
+      }
     : {};
 
   const sort = useModuleSort(QueryParameterNames.ENDPOINTS_SORT, DEFAULT_SORT);
@@ -94,13 +105,13 @@ function SpanSummaryPage({params}: Props) {
   };
 
   const {isLoading: isThroughputDataLoading, data: throughputData} = useSpanMetricsSeries(
-    {transaction: endpoint, 'transaction.method': endpointMethod, 'span.group': groupId},
+    {...seriesQueryFilters, 'span.group': groupId},
     ['spm()'],
     'api.starfish.span-summary-page-metrics-chart'
   );
 
   const {isLoading: isDurationDataLoading, data: durationData} = useSpanMetricsSeries(
-    {transaction: endpoint, 'transaction.method': endpointMethod, 'span.group': groupId},
+    {...seriesQueryFilters, 'span.group': groupId},
     [`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`],
     'api.starfish.span-summary-page-metrics-chart'
   );

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -94,13 +94,13 @@ function SpanSummaryPage({params}: Props) {
   };
 
   const {isLoading: isThroughputDataLoading, data: throughputData} = useSpanMetricsSeries(
-    {...queryFilter, 'span.group': groupId},
+    {transaction: endpoint, 'transaction.method': endpointMethod, 'span.group': groupId},
     ['spm()'],
     'api.starfish.span-summary-page-metrics-chart'
   );
 
   const {isLoading: isDurationDataLoading, data: durationData} = useSpanMetricsSeries(
-    {...queryFilter, 'span.group': groupId},
+    {transaction: endpoint, 'transaction.method': endpointMethod, 'span.group': groupId},
     [`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`],
     'api.starfish.span-summary-page-metrics-chart'
   );

--- a/static/app/views/starfish/queries/useSpanSamples.tsx
+++ b/static/app/views/starfish/queries/useSpanSamples.tsx
@@ -8,9 +8,12 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {computeAxisMax} from 'sentry/views/starfish/components/chart';
-import {SpanSummaryQueryFilters} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
-import {SpanIndexedField, SpanIndexedFieldTypes} from 'sentry/views/starfish/types';
+import {
+  SpanIndexedField,
+  SpanIndexedFieldTypes,
+  SpanMetricsQueryFilters,
+} from 'sentry/views/starfish/types';
 import {getDateConditions} from 'sentry/views/starfish/utils/getDateConditions';
 import {DATE_FORMAT} from 'sentry/views/starfish/utils/useSpansQuery';
 
@@ -57,8 +60,8 @@ export const useSpanSamples = (options: Options) => {
     ...extraQuery,
   ]);
 
-  const filters: SpanSummaryQueryFilters = {
-    transactionName,
+  const filters: SpanMetricsQueryFilters = {
+    transaction: transactionName,
   };
 
   if (transactionMethod) {

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -81,6 +81,7 @@ function DurationChart({
   };
 
   const seriesQueryFilters: SpanMetricsQueryFilters = {
+    'span.group': groupId,
     transaction: transactionName,
   };
 

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/durationChart/index.tsx
@@ -14,7 +14,7 @@ import {
 } from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import {SpanSample, useSpanSamples} from 'sentry/views/starfish/queries/useSpanSamples';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {SpanMetricsField, SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
 import {
   crossIconPath,
   downwardPlayIconPath,
@@ -80,12 +80,18 @@ function DurationChart({
     transactionName,
   };
 
+  const seriesQueryFilters: SpanMetricsQueryFilters = {
+    transaction: transactionName,
+  };
+
   if (transactionMethod) {
     filters['transaction.method'] = transactionMethod;
+    seriesQueryFilters['transaction.method'] = transactionMethod;
   }
 
   if (release) {
     filters.release = release;
+    seriesQueryFilters.release = release;
   }
 
   const {
@@ -93,7 +99,7 @@ function DurationChart({
     data: spanMetricsSeriesData,
     error: spanMetricsSeriesError,
   } = useSpanMetricsSeries(
-    {...filters, 'span.group': groupId},
+    seriesQueryFilters,
     [`avg(${SPAN_SELF_TIME})`],
     'api.starfish.sidebar-span-metrics-chart'
   );

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -13,7 +13,11 @@ import {SpanDescription} from 'sentry/views/starfish/components/spanDescription'
 import {useFullSpanFromTrace} from 'sentry/views/starfish/queries/useFullSpanFromTrace';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
-import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
+import {
+  SpanFunction,
+  SpanMetricsField,
+  SpanMetricsQueryFilters,
+} from 'sentry/views/starfish/types';
 import {
   DataTitles,
   getThroughputChartTitle,
@@ -65,6 +69,13 @@ export function SpanSummaryView({groupId}: Props) {
     'api.starfish.span-summary-page-metrics'
   );
 
+  const seriesQueryFilter: SpanMetricsQueryFilters = endpoint
+    ? {
+        transaction: endpoint,
+        'transaction.method': endpointMethod,
+      }
+    : {};
+
   const span = {
     ...spanMetrics,
     [SpanMetricsField.SPAN_GROUP]: groupId,
@@ -78,7 +89,7 @@ export function SpanSummaryView({groupId}: Props) {
 
   const {isLoading: areSpanMetricsSeriesLoading, data: spanMetricsSeriesData} =
     useSpanMetricsSeries(
-      {'span.group': groupId, ...queryFilter},
+      {'span.group': groupId, ...seriesQueryFilter},
       [`avg(${SpanMetricsField.SPAN_SELF_TIME})`, 'spm()', 'http_error_count()'],
       'api.starfish.span-summary-page-metrics-chart'
     );


### PR DESCRIPTION
`transactionName` is not a valid generic filter, it should be `transaction`. This is a bug caused by https://github.com/getsentry/sentry/pull/59932. This causes some temporary duplication while I also change the API for `useSpanMetrics` to accept filters in the same format.
