### PR TITLE
feat(open-pr-comments): snuba query to get issues

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -112,7 +112,7 @@ def get_projects_and_filenames_from_source_file(
 
 
 def get_top_5_issues_by_count_for_file(
-    projects: Set[Project], sentry_filenames: Set[str]
+    projects: List[Project], sentry_filenames: List[str]
 ) -> list[dict[str, Any]]:
     """Given a list of issue group ids, return a sublist of the top 5 ordered by event count"""
     group_ids = list(

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -142,7 +142,7 @@ def get_top_5_issues_by_count_for_file(
                 [
                     Condition(Column("project_id"), Op.IN, project_ids),
                     Condition(Column("group_id"), Op.IN, group_ids),
-                    Condition(Column("timestamp"), Op.GTE, datetime.now() - timedelta(days=30)),
+                    Condition(Column("timestamp"), Op.GTE, datetime.now() - timedelta(days=14)),
                     Condition(Column("timestamp"), Op.LT, datetime.now()),
                     Condition(
                         Function("arrayElement", (Column("exception_frames.filename"), -1)),

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -134,9 +134,10 @@ def get_top_5_issues_by_count_for_file(
                     Column("group_id"),
                     Function("count", [], "event_count"),
                     Function("uniq", [Column("user_hash")], "affected_users"),
+                    Function("isHandled", [], "is_handled"),
                 ]
             )
-            .set_groupby([Column("group_id")])
+            .set_groupby([Column("group_id"), Column("exception_stacks.mechanism_handled")])
             .set_where(
                 [
                     Condition(Column("project_id"), Op.IN, project_ids),

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -133,10 +133,10 @@ def get_top_5_issues_by_count_for_file(
                 [
                     Column("group_id"),
                     Function("count", [], "event_count"),
-                    Column("exception_frames.filename"),
+                    Function("uniq", [Column("user_hash")], "affected_users"),
                 ]
             )
-            .set_groupby([Column("group_id"), Column("exception_frames.filename")])
+            .set_groupby([Column("group_id")])
             .set_where(
                 [
                     Condition(Column("project_id"), Op.IN, project_ids),

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -259,7 +259,6 @@ class TestGetIssues(TestCase):
                 "user": {"id": user_id},
             },
             project_id=project_id,
-            assert_no_errors=False,
         )
 
     def test_simple(self):
@@ -288,7 +287,7 @@ class TestGetIssues(TestCase):
 
     def test_event_too_old(self):
         group_id = self._create_event(
-            timestamp=iso_format(before_now(days=30)), filenames=["bar.py", "baz.py"]
+            timestamp=iso_format(before_now(days=15)), filenames=["bar.py", "baz.py"]
         ).group.id
 
         top_5_issues = get_top_5_issues_by_count_for_file([self.project], ["baz.py"])

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -8,6 +8,7 @@ from sentry.tasks.integrations.github.open_pr_comment import (
     get_top_5_issues_by_count_for_file,
     safe_for_comment,
 )
+from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
@@ -221,11 +222,13 @@ class TestGetFilenames(GithubCommentTestCase):
 
 
 @region_silo_test(stable=True)
-class TestGetIssues(GithubCommentTestCase):
+class TestGetIssues(TestCase):
     def setUp(self):
         super().setUp()
 
         self.group_id = [self._create_event(user_id=str(i)) for i in range(6)][0].group.id
+        self.another_org = self.create_organization()
+        self.another_org_project = self.create_project(organization=self.another_org)
 
     def _create_event(self, filenames=None, project_id=None, timestamp=None, user_id=None):
         if timestamp is None:

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -248,8 +248,7 @@ class TestGetIssues(TestCase):
                 "exception": {
                     "values": [
                         {
-                            "type": "Bleh",
-                            "value": "asdf",
+                            "type": "Error",
                             "stacktrace": {
                                 "frames": [{"filename": filename} for filename in filenames],
                             },


### PR DESCRIPTION
A Github filename can be reverse codemapped to a list of projects and filenames (aka how that Github filename is represented in Sentry). We then want to pass these into a Snuba query to fetch the top five issues based on event count to get the issues associated with a particular file in a Github PR. We also fetch the number of unique affected users and whether the issue is handled.

NOTE:
We are only looking at the filename at the top of the stack trace to determine whether the issue is related to the list of input filenames. The new suspect commits feature looks at the entire stack trace to find the suspect commit, but this information is not being stored such that we can find the issues in which a particular file (other than the top frame) is the suspected cause.

For ER-1808