### PR TITLE
fix(starfish): Properly quote transaction names

### DIFF
--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -488,6 +488,11 @@ describe('utils/tokenizeSearch', function () {
         object: new MutableSearch(['release:4.9.0 build (0.0.01)', 'error.handled:0']),
         string: 'release:"4.9.0 build (0.0.01)" error.handled:0',
       },
+      {
+        name: 'should preserve array values',
+        object: new MutableSearch(['transaction:["app store","appstore"]']),
+        string: 'transaction:["app store","appstore"]',
+      },
     ];
 
     for (const {name, string, object} of cases) {

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -110,19 +110,24 @@ export class MutableSearch {
 
   formatString() {
     const formattedTokens: string[] = [];
+    const escapeableCharacters = /[\s\(\)\\"]/g;
     for (const token of this.tokens) {
       switch (token.type) {
         case TokenType.FILTER:
           if (token.value === '' || token.value === null) {
             formattedTokens.push(`${token.key}:""`);
-          } else if (/[\s\(\)\\"]/g.test(token.value)) {
+          } else if (
+            escapeableCharacters.test(token.value) &&
+            token.value[0] !== '[' &&
+            token.value[token.value.length - 1] !== ']'
+          ) {
             formattedTokens.push(`${token.key}:"${escapeDoubleQuotes(token.value)}"`);
           } else {
             formattedTokens.push(`${token.key}:${token.value}`);
           }
           break;
         case TokenType.FREE_TEXT:
-          if (/[\s\(\)\\"]/g.test(token.value)) {
+          if (escapeableCharacters.test(token.value)) {
             formattedTokens.push(`"${escapeDoubleQuotes(token.value)}"`);
           } else {
             formattedTokens.push(token.value);

--- a/static/app/views/starfish/views/screens/index.tsx
+++ b/static/app/views/starfish/views/screens/index.tsx
@@ -173,7 +173,9 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
   const topEventsQuery = new MutableSearch([
     'event.type:transaction',
     'transaction.op:ui.load',
-    ...(topTransactions.length > 0 ? [`transaction:[${topTransactions.join()}]`] : []),
+    ...(topTransactions.length > 0
+      ? [`transaction:[${topTransactions.map(transaction => `"${transaction}"`).join()}]`]
+      : []),
     ...(additionalFilters ?? []),
   ]);
 


### PR DESCRIPTION
If a transaction name as a space, MutableSearch applied improper quotes around the value, leading to the query for subsequent APIs to have the wrong filters. This adds a check to avoid quoting when there are spaces in an array value.