### PR TITLE
fix(hybridcloud) Remove limit on project key query used in sdk wizard

### DIFF
--- a/src/sentry/services/hybrid_cloud/project_key/impl.py
+++ b/src/sentry/services/hybrid_cloud/project_key/impl.py
@@ -54,11 +54,11 @@ class DatabaseBackedProjectKeyService(ProjectKeyService):
         region_name: str,
         project_ids: List[str],
         role: ProjectKeyRole,
-        limit: int = 100,
     ) -> List[RpcProjectKey]:
+        # TODO: This query is unbounded and will need to be addressed in the future.
         project_keys = ProjectKey.objects.filter(
             project__in=project_ids,
             roles=F("roles").bitor(role.as_orm_role()),
             status=ProjectKeyStatus.ACTIVE,
-        ).order_by("-date_added")[:limit]
+        ).order_by("-date_added")
         return [serialize_project_key(pk) for pk in project_keys]

--- a/src/sentry/services/hybrid_cloud/project_key/service.py
+++ b/src/sentry/services/hybrid_cloud/project_key/service.py
@@ -51,7 +51,6 @@ class ProjectKeyService(RpcService):
         region_name: str,
         project_ids: List[str],
         role: ProjectKeyRole,
-        limit: int = 100,
     ) -> List[RpcProjectKey]:
         pass
 


### PR DESCRIPTION
Limiting these results can create user confusion as they aren't able to find the project/dsn they are interested in. We'll need to revisit this in the future as unbounded API requests will eventually timeout.