### PR TITLE
Only enable InvestigationRuleCreation in discover and performance

### DIFF
--- a/static/app/components/discover/transactionsList.tsx
+++ b/static/app/components/discover/transactionsList.tsx
@@ -120,6 +120,7 @@ type Props = {
   handleOpenInDiscoverClick?: (e: React.MouseEvent<Element>) => void;
   referrer?: string;
   showTransactions?: TransactionFilterOptions;
+  supportsInvestigationRule?: boolean;
   /**
    * A list of preferred table headers to use over the field names.
    */
@@ -267,9 +268,11 @@ class _TransactionsList extends Component<Props> {
   renderHeader({
     cursor,
     numSamples,
+    supportsInvestigationRule,
   }: {
     numSamples: number | null | undefined;
     cursor?: string | undefined;
+    supportsInvestigationRule?: boolean;
   }): React.ReactNode {
     const {
       organization,
@@ -295,13 +298,15 @@ class _TransactionsList extends Component<Props> {
             onChange={opt => handleDropdownChange(opt.value)}
           />
         </div>
-        <InvestigationRuleWrapper>
-          <InvestigationRuleCreation
-            buttonProps={{size: 'xs'}}
-            eventView={eventView}
-            numSamples={totalNumSamples}
-          />
-        </InvestigationRuleWrapper>
+        {supportsInvestigationRule && (
+          <InvestigationRuleWrapper>
+            <InvestigationRuleCreation
+              buttonProps={{size: 'xs'}}
+              eventView={eventView}
+              numSamples={totalNumSamples}
+            />
+          </InvestigationRuleWrapper>
+        )}
         {!this.isTrend() &&
           (handleOpenAllEventsClick ? (
             <GuideAnchor target="release_transactions_open_in_transaction_events">
@@ -401,6 +406,7 @@ class _TransactionsList extends Component<Props> {
             tableData={tableData}
             header={this.renderHeader({
               numSamples: tableData?.data?.length ?? null,
+              supportsInvestigationRule: this.props.supportsInvestigationRule,
               cursor,
             })}
           />
@@ -441,7 +447,10 @@ class _TransactionsList extends Component<Props> {
             pageLinks={pageLinks}
             onCursor={this.handleCursor}
             paginationCursorSize="sm"
-            header={this.renderHeader({numSamples: null})}
+            header={this.renderHeader({
+              numSamples: null,
+              supportsInvestigationRule: false,
+            })}
             titles={['transaction', 'percentage', 'difference']}
             columnOrder={decodeColumnOrder([
               {field: 'transaction'},

--- a/static/app/views/discover/table/tableActions.tsx
+++ b/static/app/views/discover/table/tableActions.tsx
@@ -30,6 +30,7 @@ type Props = {
   showTags: boolean;
   tableData: TableData | null | undefined;
   title: string;
+  supportsInvestigationRule?: boolean;
 };
 
 function handleDownloadAsCsv(title: string, {organization, eventView, tableData}: Props) {
@@ -161,12 +162,14 @@ function TableActions(props: Props) {
   const totalNumSamples = numSamples === null ? null : numSamples + cursorOffset;
   return (
     <Fragment>
-      <InvestigationRuleCreation
-        {...props}
-        buttonProps={{size: 'sm'}}
-        numSamples={totalNumSamples}
-        key="investigationRuleCreation"
-      />
+      {props.supportsInvestigationRule && (
+        <InvestigationRuleCreation
+          {...props}
+          buttonProps={{size: 'sm'}}
+          numSamples={totalNumSamples}
+          key="investigationRuleCreation"
+        />
+      )}
       <FeatureWrapper {...props} key="edit">
         {renderEditButton}
       </FeatureWrapper>

--- a/static/app/views/discover/table/tableView.tsx
+++ b/static/app/views/discover/table/tableView.tsx
@@ -591,6 +591,7 @@ function TableView(props: TableViewProps) {
         location={location}
         onChangeShowTags={onChangeShowTags}
         showTags={showTags}
+        supportsInvestigationRule
       />
     );
   }

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -399,6 +399,7 @@ function SummaryContent({
             })}
             forceLoading={isLoading}
             referrer="performance.transactions_summary"
+            supportsInvestigationRule
           />
         </PerformanceAtScaleContextProvider>
 

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -573,6 +573,7 @@ class ReleaseOverview extends DeprecatedAsyncView<Props> {
                                 }
                                 titles={titles}
                                 generateLink={generateLink}
+                                supportsInvestigationRule={false}
                               />
                             )}
                           </Feature>


### PR DESCRIPTION
This PR fixes a bug that was trying to render the `InvestigationRuleCreation` UI in Release detail.

Now the users of `InvestigationRuleCreation`, `TableActions` and `TableViews` accept an optional parameter that controls whether the `InvestigantionRuleCreation` UI is rendered or not, usages of `TableActions` or `TableViews` without explicitly enabling the `InvestigationRuleCreation` will not render the UI.

resolves https://github.com/getsentry/sentry/issues/59979