### PR TITLE
fix(github-invite): return empty array if no integration

### DIFF
--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -81,7 +81,7 @@ describe('inviteBanner', function () {
     ).not.toBeInTheDocument();
   });
 
-  it('does not render banner if no missing members', function () {
+  it('does not render banner if no option', function () {
     const org = Organization({
       features: ['integrations-gh-invite'],
     });
@@ -102,10 +102,10 @@ describe('inviteBanner', function () {
     ).not.toBeInTheDocument();
   });
 
-  it('does not render banner if lacking org:write', function () {
+  it('does not render banner if no missing members', async function () {
     const org = Organization({
       features: ['integrations-gh-invite'],
-      access: [],
+      githubNudgeInvite: true,
     });
 
     MockApiClient.addMockResponse({
@@ -114,14 +114,71 @@ describe('inviteBanner', function () {
       body: [noMissingMembers],
     });
 
-    render(
-      <InviteBanner
-        onSendInvite={() => {}}
-        organization={org}
-        allowedRoles={[]}
-        onModalClose={() => {}}
-      />
-    );
+    await act(async () => {
+      await render(
+        <InviteBanner
+          onSendInvite={() => {}}
+          organization={org}
+          allowedRoles={[]}
+          onModalClose={() => {}}
+        />
+      );
+    });
+
+    expect(
+      screen.queryByRole('heading', {
+        name: 'Bring your full GitHub team on board in Sentry',
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render banner if no integration', async function () {
+    const org = Organization({
+      features: ['integrations-gh-invite'],
+      githubNudgeInvite: true,
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/missing-members/',
+      method: 'GET',
+      body: [],
+    });
+
+    await act(async () => {
+      await render(
+        <InviteBanner
+          onSendInvite={() => {}}
+          organization={org}
+          allowedRoles={[]}
+          onModalClose={() => {}}
+        />
+      );
+    });
+
+    expect(
+      screen.queryByRole('heading', {
+        name: 'Bring your full GitHub team on board in Sentry',
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render banner if lacking org:write', async function () {
+    const org = Organization({
+      features: ['integrations-gh-invite'],
+      access: [],
+      githubNudgeInvite: true,
+    });
+
+    await act(async () => {
+      await render(
+        <InviteBanner
+          onSendInvite={() => {}}
+          organization={org}
+          allowedRoles={[]}
+          onModalClose={() => {}}
+        />
+      );
+    });
 
     expect(
       screen.queryByRole('heading', {

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -85,7 +85,7 @@ export function InviteBanner({
       const githubMissingMembers = data?.filter(
         integrationMissingMembers => integrationMissingMembers.integration === 'github'
       )[0];
-      setMissingMembers(githubMissingMembers?.users);
+      setMissingMembers(githubMissingMembers?.users || []);
     } catch (err) {
       if (err.status !== 403) {
         addErrorMessage(t('Unable to fetching missing commit authors'));


### PR DESCRIPTION
Fixes [JAVASCRIPT-2PPG](https://sentry.sentry.io/issues/4639993111/?project=11276)

Fixes up the tests for the invite banner. If the org doesn't have a Github integration, the API returns `[]` and was erroring out.