### PR TITLE
fix(starfish): Snippet overflow should cause scroll

### DIFF
--- a/static/app/views/starfish/views/screens/index.tsx
+++ b/static/app/views/starfish/views/screens/index.tsx
@@ -380,6 +380,7 @@ const ChartsContainer = styled('div')`
 
 const ChartsContainerItem = styled('div')`
   flex: 1;
+  overflow: hidden;
 `;
 
 export const Spacer = styled('div')`

--- a/static/app/views/starfish/views/screens/index.tsx
+++ b/static/app/views/starfish/views/screens/index.tsx
@@ -292,12 +292,14 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
             />
           </ChartsContainerItem>
 
-          <ChartsContainerItem key="ttfd">
-            {defined(hasTTFD) && !hasTTFD && yAxes[1] === YAxis.TTFD ? (
+          {defined(hasTTFD) && !hasTTFD && yAxes[1] === YAxis.TTFD ? (
+            <ChartsContainerWithHiddenOverflow>
               <ChartPanel title={CHART_TITLES[yAxes[1]]}>
                 <TabbedCodeSnippet tabs={SETUP_CONTENT} />
               </ChartPanel>
-            ) : (
+            </ChartsContainerWithHiddenOverflow>
+          ) : (
+            <ChartsContainerItem key="ttfd">
               <ScreensBarChart
                 chartOptions={[
                   {
@@ -322,8 +324,8 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
                 isLoading={isReleaseEventsLoading}
                 chartKey="screensChart1"
               />
-            )}
-          </ChartsContainerItem>
+            </ChartsContainerItem>
+          )}
         </Fragment>
       </ChartsContainer>
       <StyledSearchBar
@@ -378,9 +380,13 @@ const ChartsContainer = styled('div')`
   gap: ${space(2)};
 `;
 
-const ChartsContainerItem = styled('div')`
+const ChartsContainerWithHiddenOverflow = styled('div')`
   flex: 1;
   overflow: hidden;
+`;
+
+const ChartsContainerItem = styled('div')`
+  flex: 1;
 `;
 
 export const Spacer = styled('div')`


### PR DESCRIPTION
Snippet overflow should cause scroll, it was changing the
size of the container when switching between tabs.