### PR TITLE
fix(ddm): Fix mri in metric alerts

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -61,7 +61,7 @@ from sentry.snuba.entity_subscription import (
     get_entity_subscription_from_snuba_query,
 )
 from sentry.snuba.metrics.extraction import should_use_on_demand_metrics
-from sentry.snuba.metrics.naming_layer.mapping import is_mri
+from sentry.snuba.metrics.naming_layer.mri import is_mri
 from sentry.snuba.models import SnubaQuery
 from sentry.snuba.subscriptions import (
     bulk_create_snuba_subscriptions,

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -36,7 +36,7 @@ from sentry.snuba.entity_subscription import (
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.tasks import build_query_builder
 
-from ...snuba.metrics.naming_layer.mapping import is_mri
+from ...snuba.metrics.naming_layer.mri import is_mri
 from . import (
     CRASH_RATE_ALERTS_ALLOWED_TIME_WINDOWS,
     QUERY_TYPE_VALID_DATASETS,

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -400,9 +400,8 @@ def _convert_aggregate_and_query_to_metric(
         validate_sampling_condition(json.dumps(metric_spec["condition"]))
 
         return on_demand_spec.query_hash, metric_spec
-
-    except ValueError:
-        # raised by validate_sampling_condition
+    except (ValueError, KeyError):
+        # raised by validate_sampling_condition or metric_spec lacking "condition"
         metrics.incr(
             "on_demand_metrics.invalid_metric_spec",
             tags={"prefilling": prefilling},
@@ -417,8 +416,8 @@ def _convert_aggregate_and_query_to_metric(
                 "groupbys": groupbys,
             },
         )
-        return None
 
+        return None
     except Exception as e:
         # Since prefilling might include several non-ondemand-compatible alerts, we want to not trigger errors in the
         # Sentry console.

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -1086,7 +1086,7 @@ class NumericColumn(ColumnArg):
         self.allow_array_value = allow_array_value
 
     def _normalize(self, value: str) -> str:
-        from sentry.snuba.metrics.naming_layer.mapping import is_mri
+        from sentry.snuba.metrics.naming_layer.mri import is_mri
 
         # This method is written in this way so that `get_type` can always call
         # this even in child classes where `normalize` have been overridden.
@@ -2139,7 +2139,7 @@ class MetricArg(FunctionArg):
         self.allow_mri = allow_mri
 
     def normalize(self, value: str, params: ParamsType, combinator: Optional[Combinator]) -> str:
-        from sentry.snuba.metrics.naming_layer.mapping import is_mri
+        from sentry.snuba.metrics.naming_layer.mri import is_mri
 
         allowed_column = True
         if self.allowed_columns is not None and len(self.allowed_columns) > 0:

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -44,10 +44,11 @@ from sentry.snuba.metrics.fields.base import (
     get_derived_metrics,
     org_id_from_projects,
 )
-from sentry.snuba.metrics.naming_layer.mapping import get_mri, is_mri
+from sentry.snuba.metrics.naming_layer.mapping import get_mri
 from sentry.snuba.metrics.naming_layer.mri import (
     get_available_operations,
     is_custom_measurement,
+    is_mri,
     parse_mri,
 )
 from sentry.snuba.metrics.query import Groupable, MetricField, MetricsQuery

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -41,12 +41,7 @@ from sentry.search.events import fields
 from sentry.search.events.builder import UnresolvedQuery
 from sentry.search.events.constants import VITAL_THRESHOLDS
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.metrics.naming_layer.mri import (
-    ParsedMRI,
-    is_custom_metric,
-    is_transaction_metric,
-    parse_mri,
-)
+from sentry.snuba.metrics.naming_layer.mri import ParsedMRI, is_custom_metric, parse_mri
 from sentry.snuba.metrics.utils import MetricOperationType
 from sentry.utils.snuba import is_measurement, is_span_op_breakdown, resolve_column
 
@@ -418,18 +413,6 @@ def should_use_on_demand_metrics(
     if mri_aggregate is not None:
         if is_custom_metric(mri_aggregate):
             return False
-        elif is_transaction_metric(mri_aggregate):
-            from sentry.snuba.metrics import get_public_name_from_mri
-
-            # We extract the mri and try to compute its public name.
-            mri_string = mri_aggregate.mri_string
-            public_name = get_public_name_from_mri(mri_string)
-            if public_name == mri_string:
-                raise InvalidSearchQuery("The MRI doesn't belong to a publicly exposed metric")
-
-            # We convert the passed name to its public counterpart since this is required for the on demand
-            # check.
-            args[0] = public_name
         else:
             raise InvalidSearchQuery(
                 f"The supplied MRI belongs to an unsupported namespace '{mri_aggregate.namespace}'"

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -447,7 +447,6 @@ def _extract_aggregate_components(aggregate: str) -> Optional[Tuple[str, List[st
 
 
 def _extract_mri(args: List[str]) -> Optional[ParsedMRI]:
-    # We assume that you can't have an aggregate on an implicit custom metric, since if you pass just `count()`
     if len(args) == 0:
         return None
 
@@ -455,15 +454,10 @@ def _extract_mri(args: List[str]) -> Optional[ParsedMRI]:
 
 
 def _get_aggregate_supported_by(function: str, args: List[str]) -> SupportedBy:
-    try:
-        function_support = _get_function_support(function, args)
-        args_support = _get_args_support(args, function)
+    function_support = _get_function_support(function, args)
+    args_support = _get_args_support(args, function)
 
-        return SupportedBy.combine(function_support, args_support)
-    except InvalidSearchQuery:
-        logger.error(f"Failed to parse aggregate: {function}", exc_info=True)
-
-    return SupportedBy.neither()
+    return SupportedBy.combine(function_support, args_support)
 
 
 def _get_function_support(function: str, args: Sequence[str]) -> SupportedBy:

--- a/src/sentry/snuba/metrics/naming_layer/mapping.py
+++ b/src/sentry/snuba/metrics/naming_layer/mapping.py
@@ -56,10 +56,6 @@ NAME_TO_MRI: Dict[str, Enum] = {}
 MRI_TO_NAME: Dict[str, str] = {}
 
 
-def is_mri(value: str) -> bool:
-    return MRI_SCHEMA_REGEX.match(value) is not None
-
-
 def get_mri(external_name: Union[Enum, str]) -> str:
     if not len(NAME_TO_MRI):
         create_name_mapping_layers()

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -182,7 +182,9 @@ class ParsedMRI:
 
 
 def parse_mri(mri_string: str) -> Optional[ParsedMRI]:
-    """Parse a mri string to determine its entity, namespace, name and unit"""
+    """
+    Parse a mri string to determine its entity, namespace, name and unit.
+    """
     match = MRI_SCHEMA_REGEX.match(mri_string)
     if match is None:
         return None
@@ -190,11 +192,33 @@ def parse_mri(mri_string: str) -> Optional[ParsedMRI]:
     return ParsedMRI(**match.groupdict())
 
 
+def is_mri(mri_string: Optional[str]) -> bool:
+    """
+    Returns true if the passed value is a mri.
+    """
+    return parse_mri(mri_string) is not None
+
+
+def is_custom_metric(parsed_mri: ParsedMRI) -> bool:
+    """
+    A custom mri is a mri which uses the custom namespace, and it's different from a custom measurement.
+    """
+    return parsed_mri.namespace == "custom"
+
+
+def is_transaction_metric(parsed_mri: ParsedMRI) -> bool:
+    """
+    A transaction mri is a mri which uses the transactions namespace.
+    """
+    return parsed_mri.namespace == "transactions"
+
+
 def is_custom_measurement(parsed_mri: ParsedMRI) -> bool:
-    """A custom measurement won't use the custom namespace, but will be under the transaction namespace
+    """
+    A custom measurement won't use the custom namespace, but will be under the transaction namespace.
 
     This checks the namespace, and name to match what we expect first before iterating through the
-    members of the transaction MRI enum to make sure it isn't a standard measurement
+    members of the transaction MRI enum to make sure it isn't a standard measurement.
     """
     return (
         parsed_mri.namespace == "transactions"

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -181,10 +181,13 @@ class ParsedMRI:
         return f"{self.entity}:{self.namespace}/{self.name}@{self.unit}"
 
 
-def parse_mri(mri_string: str) -> Optional[ParsedMRI]:
+def parse_mri(mri_string: Optional[str]) -> Optional[ParsedMRI]:
     """
     Parse a mri string to determine its entity, namespace, name and unit.
     """
+    if mri_string is None:
+        return None
+
     match = MRI_SCHEMA_REGEX.match(mri_string)
     if match is None:
         return None

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -209,13 +209,6 @@ def is_custom_metric(parsed_mri: ParsedMRI) -> bool:
     return parsed_mri.namespace == "custom"
 
 
-def is_transaction_metric(parsed_mri: ParsedMRI) -> bool:
-    """
-    A transaction mri is a mri which uses the transactions namespace.
-    """
-    return parsed_mri.namespace == "transactions"
-
-
 def is_custom_measurement(parsed_mri: ParsedMRI) -> bool:
     """
     A custom measurement won't use the custom namespace, but will be under the transaction namespace.

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -133,6 +133,23 @@ def test_get_metric_extraction_config_single_alert(default_project):
 
 
 @django_db_all
+def test_get_metric_extraction_config_single_alert_with_mri(default_project):
+    with Feature(ON_DEMAND_METRICS):
+        create_alert(
+            "sum(c:custom/page_load@millisecond)", "transaction.duration:>=1000", default_project
+        )
+        create_alert(
+            "count(d:transactions/measurements.fcp@millisecond)",
+            "transaction.duration:>=1000",
+            default_project,
+        )
+
+        config = get_metric_extraction_config(default_project)
+
+        assert config is None
+
+
+@django_db_all
 def test_get_metric_extraction_config_multiple_alerts(default_project):
     with Feature(ON_DEMAND_METRICS):
         create_alert("count()", "transaction.duration:>=1000", default_project)

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -3352,6 +3352,11 @@ class CustomMetricsWithMetricsLayerTest(MetricBuilderBaseTest):
             dataset=Dataset.PerformanceMetrics,
             selected_columns=[f"max({mri})"],
             config=QueryBuilderConfig(
+                # We want to replicate the condition for the alerts in production, which has to cohexist
+                # with on demand metrics.
+                skip_time_conditions=True,
+                on_demand_metrics_enabled=True,
+                on_demand_metrics_type=MetricSpecType.SIMPLE_QUERY,
                 use_metrics_layer=True,
             ),
         )

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -44,7 +44,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
             "transaction.duration:>1",
             True,
         ),  # transaction.duration query is on-demand
-        ("count[)", "", False),  # Malformed aggregate should return false
+        ("count()", "", False),  # Malformed aggregate should return false
         (
             "count()",
             "event.type:error transaction.duration:>0",
@@ -63,6 +63,17 @@ from sentry.testutils.pytest.fixtures import django_db_all
     ],
 )
 def test_should_use_on_demand(agg, query, result):
+    assert should_use_on_demand_metrics(Dataset.PerformanceMetrics, agg, query) is result
+
+
+@pytest.mark.parametrize(
+    "agg, query, result",
+    [
+        ("sum(c:custom/page_load@millisecond)", "release:a", False),
+        ("avg(d:transactions/duration@millisecond)", "release:a", False),
+    ],
+)
+def test_should_use_on_demand_with_mri(agg, query, result):
     assert should_use_on_demand_metrics(Dataset.PerformanceMetrics, agg, query) is result
 
 

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -72,10 +72,6 @@ def test_should_use_on_demand(agg, query, result):
     [
         ("sum(c:custom/page_load@millisecond)", "release:a", False),
         ("sum(c:custom/page_load@millisecond)", "transaction.duration:>0", False),
-        ("avg(d:transactions/duration@millisecond)", "release:a", False),
-        ("avg(d:transactions/duration@millisecond)", "transaction.duration:>0", True),
-        ("p75(d:transactions/measurements.fcp@millisecond)", "release:a", False),
-        ("p75(d:transactions/measurements.fcp@millisecond)", "transaction.duration:>0", True),
     ],
 )
 def test_should_use_on_demand_with_mri(agg, query, result):
@@ -86,14 +82,14 @@ def test_should_use_on_demand_with_mri(agg, query, result):
     "agg, query, error",
     [
         (
-            "sum(c:transactions/count_per_root_project@none)",
+            "p75(d:transactions/measurements.fcp@millisecond)",
             "release:a",
-            "The MRI doesn't belong to a publicly exposed metric",
+            "The supplied MRI belongs to an unsupported namespace 'transactions'",
         ),
         (
-            "sum(c:transactions/count_per_root_project@none)",
+            "p75(d:transactions/measurements.fcp@millisecond)",
             "transaction.duration:>0",
-            "The MRI doesn't belong to a publicly exposed metric",
+            "The supplied MRI belongs to an unsupported namespace 'transactions'",
         ),
         (
             "p95(d:spans/duration@millisecond)",
@@ -132,7 +128,7 @@ class TestCreatesOndemandMetricSpec:
             ("p75(measurements.fp)", "transaction.duration:>0"),
             ("p75(transaction.duration)", "transaction.duration:>0"),
             ("p100(transaction.duration)", "transaction.duration:>0"),
-            # we dont support custom percentiles that can be mapped to one of standard percentiles
+            # we don't support custom percentiles that can be mapped to one of standard percentiles
             ("percentile(transaction.duration, 0.5)", "transaction.duration>0"),
             ("percentile(transaction.duration, 0.50)", "transaction.duration>0"),
             ("percentile(transaction.duration, 0.95)", "transaction.duration>0"),


### PR DESCRIPTION
This PR fixes a problem with the on-demand check which was considering mris as valid on demand metrics but the new
logic now checks if it's an MRI and if it is:
* custom -> we don't use on demand
* any other namespace -> we throw an error since you can't use mris in on demand