### PR TITLE
ref(feedback): always display feedback details if from alert

### DIFF
--- a/static/app/components/feedback/useFeedbackOnboarding.tsx
+++ b/static/app/components/feedback/useFeedbackOnboarding.tsx
@@ -5,6 +5,7 @@ import {Project} from 'sentry/types';
 import {PageFilters} from 'sentry/types/core';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import useUrlParams from 'sentry/utils/useUrlParams';
 
 function getSelectedProjectList(
   selectedProjects: PageFilters['projects'],
@@ -44,4 +45,11 @@ export function useHaveSelectedProjectsSetupFeedback() {
     hasSetupOneFeedback: orgSetupOneOrMoreFeedback,
     fetching,
   };
+}
+
+export function useFeedbackFromSlack() {
+  const {getParamValue: getReferrer} = useUrlParams('referrer', '');
+  const isFromSlack = getReferrer() === 'slack';
+
+  return {isFromSlack};
 }

--- a/static/app/components/feedback/useFeedbackOnboarding.tsx
+++ b/static/app/components/feedback/useFeedbackOnboarding.tsx
@@ -47,9 +47,9 @@ export function useHaveSelectedProjectsSetupFeedback() {
   };
 }
 
-export function useFeedbackFromSlack() {
-  const {getParamValue: getReferrer} = useUrlParams('referrer', '');
-  const isFromSlack = getReferrer() === 'slack';
+export function useFeedbackHasSlug() {
+  const {getParamValue: getSlug} = useUrlParams('feedbackSlug', '');
+  const hasSlug = getSlug().length > 0;
 
-  return {isFromSlack};
+  return {hasSlug};
 }

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -9,7 +9,10 @@ import FeedbackItemLoader from 'sentry/components/feedback/feedbackItem/feedback
 import FeedbackSearch from 'sentry/components/feedback/feedbackSearch';
 import FeedbackSetupPanel from 'sentry/components/feedback/feedbackSetupPanel';
 import FeedbackList from 'sentry/components/feedback/list/feedbackList';
-import {useHaveSelectedProjectsSetupFeedback} from 'sentry/components/feedback/useFeedbackOnboarding';
+import {
+  useFeedbackFromSlack,
+  useHaveSelectedProjectsSetupFeedback,
+} from 'sentry/components/feedback/useFeedbackOnboarding';
 import {FeedbackQueryKeys} from 'sentry/components/feedback/useFeedbackQueryKeys';
 import FullViewport from 'sentry/components/layouts/fullViewport';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -29,6 +32,7 @@ interface Props extends RouteComponentProps<{}, {}, {}> {}
 export default function FeedbackListPage({}: Props) {
   const organization = useOrganization();
   const {hasSetupOneFeedback} = useHaveSelectedProjectsSetupFeedback();
+  const {isFromSlack} = useFeedbackFromSlack();
   const location = useLocation();
 
   return (
@@ -72,7 +76,7 @@ export default function FeedbackListPage({}: Props) {
             <ErrorBoundary>
               <LayoutGrid>
                 <FeedbackFilters style={{gridArea: 'filters'}} />
-                {hasSetupOneFeedback ? (
+                {hasSetupOneFeedback || isFromSlack ? (
                   <Fragment>
                     <Container style={{gridArea: 'list'}}>
                       <FeedbackList />

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -10,7 +10,7 @@ import FeedbackSearch from 'sentry/components/feedback/feedbackSearch';
 import FeedbackSetupPanel from 'sentry/components/feedback/feedbackSetupPanel';
 import FeedbackList from 'sentry/components/feedback/list/feedbackList';
 import {
-  useFeedbackFromSlack,
+  useFeedbackHasSlug,
   useHaveSelectedProjectsSetupFeedback,
 } from 'sentry/components/feedback/useFeedbackOnboarding';
 import {FeedbackQueryKeys} from 'sentry/components/feedback/useFeedbackQueryKeys';
@@ -32,7 +32,7 @@ interface Props extends RouteComponentProps<{}, {}, {}> {}
 export default function FeedbackListPage({}: Props) {
   const organization = useOrganization();
   const {hasSetupOneFeedback} = useHaveSelectedProjectsSetupFeedback();
-  const {isFromSlack} = useFeedbackFromSlack();
+  const {hasSlug} = useFeedbackHasSlug();
   const location = useLocation();
 
   return (
@@ -76,7 +76,7 @@ export default function FeedbackListPage({}: Props) {
             <ErrorBoundary>
               <LayoutGrid>
                 <FeedbackFilters style={{gridArea: 'filters'}} />
-                {hasSetupOneFeedback || isFromSlack ? (
+                {hasSetupOneFeedback || hasSlug ? (
                   <Fragment>
                     <Container style={{gridArea: 'list'}}>
                       <FeedbackList />


### PR DESCRIPTION
closes https://github.com/getsentry/team-replay/issues/285

- will change the project selector to include the new project, if it isn't already selected, in a following PR