### PR TITLE
fix(starfish): Screens duplicating TTFD in metrics ribbon

### DIFF
--- a/static/app/views/starfish/views/screens/screenLoadSpans/metricsRibbon.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/metricsRibbon.tsx
@@ -94,7 +94,7 @@ export function ScreenMetricsRibbon({additionalFilters}: {additionalFilters?: st
           <DurationCell
             milliseconds={
               data.data[0]?.[
-                `avg_if(measurements.time_to_full_display,release,${secondaryRelease})`
+                `avg_if(measurements.time_to_full_display,release,${primaryRelease})`
               ] as number
             }
           />


### PR DESCRIPTION
We're accidentally using the second release for both TTFD metrics