### PR TITLE
fix(discord): Pass bot auth token when overriding commands for the Discord app

### DIFF
--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -42,17 +42,20 @@ class DiscordNonProxyClient(ApiClient):
         self.application_id = options.get("discord.application-id")
         self.bot_token = options.get("discord.bot-token")
 
+    def prepare_auth_header(self) -> dict[str, str]:
+        return {"Authorization": f"Bot {self.bot_token}"}
+
     def overwrite_application_commands(self, commands: list[object]) -> None:
         self.put(
             APPLICATION_COMMANDS_URL.format(application_id=self.application_id),
+            headers=self.prepare_auth_header(),
             data=commands,
         )
 
     def get_guild_name(self, guild_id: str) -> str:
         url = GUILD_URL.format(guild_id=guild_id)
-        headers = {"Authorization": f"Bot {self.bot_token}"}
         try:
-            response = self.get(url, headers=headers)
+            response = self.get(url, headers=self.prepare_auth_header())
             return response["name"]  # type: ignore
         except (ApiError, AttributeError):
             return guild_id
@@ -60,7 +63,7 @@ class DiscordNonProxyClient(ApiClient):
 
 class DiscordClient(IntegrationProxyClient):
     integration_name: str = "discord"
-    base_url: str = "https://discord.com/api/v10"
+    base_url: str = DISCORD_BASE_URL
 
     def __init__(
         self,

--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+import sentry_sdk
 from rest_framework.request import Request
 
 from sentry.integrations.discord.requests.base import DiscordRequest
@@ -46,10 +47,12 @@ class DiscordRequestParser(BaseRequestParser):
 
             self.discord_request = discord_request
 
-            logger.info(
-                f"{self.provider}.get_integration_from_request.discord_interactions_endpoint",
-                extra={"path": self.request.path, "guild_id": discord_request.guild_id},
-            )
+            with sentry_sdk.push_scope() as scope:
+                scope.set_extra("path", self.request.path)
+                scope.set_extra("guild_id", discord_request.guild_id)
+                sentry_sdk.capture_message(
+                    f"{self.provider}.get_integration_from_request.discord_interactions_endpoint"
+                )
 
             return Integration.objects.filter(
                 provider=self.provider,


### PR DESCRIPTION
Overriding the app commands from the Discord integration results in `401: Unauthorized` error. This is because we're not passing any auth token to be able to do this.

This pull request addresses that, and I've also improved the debugging of the interactions endpoint to understand why it's not working as expected.