### PR TITLE
feat(onboarding): Update NextJS onboarding page

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -10,12 +10,14 @@ export enum StepType {
   INSTALL = 'install',
   CONFIGURE = 'configure',
   VERIFY = 'verify',
+  ALTERNATVE = 'alternative',
 }
 
 export const StepTitle = {
   [StepType.INSTALL]: t('Install'),
   [StepType.CONFIGURE]: t('Configure SDK'),
   [StepType.VERIFY]: t('Verify'),
+  [StepType.ALTERNATVE]: t('Alternative Methods'),
 };
 
 interface CodeSnippetTab {

--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -10,14 +10,12 @@ export enum StepType {
   INSTALL = 'install',
   CONFIGURE = 'configure',
   VERIFY = 'verify',
-  MANUAL = 'manual',
 }
 
 export const StepTitle = {
   [StepType.INSTALL]: t('Install'),
   [StepType.CONFIGURE]: t('Configure SDK'),
   [StepType.VERIFY]: t('Verify'),
-  [StepType.MANUAL]: t('Manual Setup'),
 };
 
 interface CodeSnippetTab {

--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -10,14 +10,14 @@ export enum StepType {
   INSTALL = 'install',
   CONFIGURE = 'configure',
   VERIFY = 'verify',
-  ALTERNATVE = 'alternative',
+  MANUAL = 'manual',
 }
 
 export const StepTitle = {
   [StepType.INSTALL]: t('Install'),
   [StepType.CONFIGURE]: t('Configure SDK'),
   [StepType.VERIFY]: t('Verify'),
-  [StepType.ALTERNATVE]: t('Alternative Methods'),
+  [StepType.MANUAL]: t('Manual Setup'),
 };
 
 interface CodeSnippetTab {

--- a/static/app/gettingStartedDocs/javascript/nextjs.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.spec.tsx
@@ -1,3 +1,5 @@
+import {Organization} from 'sentry-fixture/organization';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
@@ -5,11 +7,22 @@ import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {GettingStartedWithNextJs, steps} from './nextjs';
 
 describe('GettingStartedWithNextJs', function () {
+  const organization = Organization();
   it('renders doc correctly', function () {
-    render(<GettingStartedWithNextJs dsn="test-dsn" projectSlug="test-project" />);
+    render(
+      <GettingStartedWithNextJs
+        dsn="test-dsn"
+        projectSlug="test-project"
+        organization={organization}
+      />
+    );
 
     // Steps
-    for (const step of steps({dsn: 'test-dsn', projectSlug: 'test-project'})) {
+    for (const step of steps({
+      dsn: 'test-dsn',
+      projectSlug: 'test-project',
+      organization,
+    })) {
       expect(
         screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
       ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/javascript/nextjs.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.spec.tsx
@@ -9,7 +9,7 @@ describe('GettingStartedWithNextJs', function () {
     render(<GettingStartedWithNextJs dsn="test-dsn" projectSlug="test-project" />);
 
     // Steps
-    for (const step of steps()) {
+    for (const step of steps({dsn: 'test-dsn', projectSlug: 'test-project'})) {
       expect(
         screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
       ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -10,13 +10,16 @@ import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {Organization} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
 
 type Props = {
   dsn: string;
+  organization: Organization | undefined;
   projectSlug: string;
 };
 
-export const steps = ({dsn, projectSlug}: Props): LayoutProps['steps'] => [
+export const steps = ({dsn, projectSlug, organization}: Props): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
     description: (
@@ -52,7 +55,7 @@ export const steps = ({dsn, projectSlug}: Props): LayoutProps['steps'] => [
           </ListItem>
           <ListItem>
             {tct(
-              'Create or update your Next.js config [nextConfig:next.confg.js] with the default Sentry configuration',
+              'Create or update your Next.js config [nextConfig:next.config.js] with the default Sentry configuration.',
               {
                 nextConfig: <code />,
               }
@@ -68,7 +71,7 @@ export const steps = ({dsn, projectSlug}: Props): LayoutProps['steps'] => [
             )}
           </ListItem>
           <ListItem>
-            {tct('add an example page to your app to verify your Sentry setup', {
+            {tct('Add an example page to your app to verify your Sentry setup.', {
               sentryClircCode: <code />,
             })}
           </ListItem>
@@ -77,7 +80,7 @@ export const steps = ({dsn, projectSlug}: Props): LayoutProps['steps'] => [
     ),
   },
   {
-    type: StepType.ALTERNATVE,
+    type: StepType.MANUAL,
     description: (
       <Fragment>
         <p>
@@ -91,14 +94,24 @@ export const steps = ({dsn, projectSlug}: Props): LayoutProps['steps'] => [
         <DSNText>
           <p>
             {tct(
-              "If you already have the code for Sentry in your application, and just need this project's ([projectSlug]) DSN, you can find it below:",
+              "If you already have the configuration for Sentry in your application, and just need this project's ([projectSlug]) DSN, you can find it below:",
               {
                 projectSlug: <code>{projectSlug}</code>,
               }
             )}
           </p>
         </DSNText>
-        <div>{<TextCopyInput>{dsn}</TextCopyInput>}</div>
+        <div>
+          {organization && (
+            <TextCopyInput
+              onCopy={() =>
+                trackAnalytics('onboarding:nextjs-dsn-copied', {organization})
+              }
+            >
+              {dsn}
+            </TextCopyInput>
+          )}
+        </div>
       </Fragment>
     ),
   },
@@ -107,9 +120,9 @@ export const steps = ({dsn, projectSlug}: Props): LayoutProps['steps'] => [
 // Configuration End
 
 export function GettingStartedWithNextJs({...props}: ModuleProps) {
-  const {projectSlug, dsn} = props;
+  const {projectSlug, dsn, organization} = props;
 
-  return <Layout steps={steps({dsn, projectSlug})} {...props} />;
+  return <Layout steps={steps({dsn, projectSlug, organization})} {...props} />;
 }
 
 export default GettingStartedWithNextJs;

--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -10,10 +10,13 @@ import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {ProjectKey} from 'sentry/types';
-import {useApiQuery} from 'sentry/utils/queryClient';
 
-export const steps = (dsn: string | null, projectSlug: string): LayoutProps['steps'] => [
+type Props = {
+  dsn: string;
+  projectSlug: string;
+};
+
+export const steps = ({dsn, projectSlug}: Props): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
     description: (
@@ -95,7 +98,7 @@ export const steps = (dsn: string | null, projectSlug: string): LayoutProps['ste
             )}
           </p>
         </DSNText>
-        <div>{dsn && <TextCopyInput>{dsn}</TextCopyInput>}</div>
+        <div>{<TextCopyInput>{dsn}</TextCopyInput>}</div>
       </Fragment>
     ),
   },
@@ -104,21 +107,9 @@ export const steps = (dsn: string | null, projectSlug: string): LayoutProps['ste
 // Configuration End
 
 export function GettingStartedWithNextJs({...props}: ModuleProps) {
-  const {organization, projectSlug} = props;
-  const {
-    data: projectKeys,
-    isError,
-    isLoading,
-  } = useApiQuery<ProjectKey[]>(
-    [`/projects/${organization?.slug}/${projectSlug}/keys/`],
-    {
-      staleTime: Infinity,
-    }
-  );
+  const {projectSlug, dsn} = props;
 
-  const dsn = isError || isLoading ? null : projectKeys[0].dsn.public;
-
-  return <Layout steps={steps(dsn, projectSlug)} {...props} />;
+  return <Layout steps={steps({dsn, projectSlug})} {...props} />;
 }
 
 export default GettingStartedWithNextJs;

--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -76,13 +76,8 @@ export const steps = ({dsn, projectSlug, organization}: Props): LayoutProps['ste
             })}
           </ListItem>
         </List>
-      </Fragment>
-    ),
-  },
-  {
-    type: StepType.MANUAL,
-    description: (
-      <Fragment>
+        <br />
+        <ManualSetupTitle>{t('Manual Setup')}</ManualSetupTitle>
         <p>
           {tct('Alternatively, you can also [manualSetupLink:set up the SDK manually].', {
             manualSetupLink: (
@@ -101,17 +96,13 @@ export const steps = ({dsn, projectSlug, organization}: Props): LayoutProps['ste
             )}
           </p>
         </DSNText>
-        <div>
-          {organization && (
-            <TextCopyInput
-              onCopy={() =>
-                trackAnalytics('onboarding:nextjs-dsn-copied', {organization})
-              }
-            >
-              {dsn}
-            </TextCopyInput>
-          )}
-        </div>
+        {organization && (
+          <TextCopyInput
+            onCopy={() => trackAnalytics('onboarding:nextjs-dsn-copied', {organization})}
+          >
+            {dsn}
+          </TextCopyInput>
+        )}
       </Fragment>
     ),
   },
@@ -129,4 +120,9 @@ export default GettingStartedWithNextJs;
 
 const DSNText = styled('div')`
   margin-bottom: ${space(0.5)};
+`;
+
+const ManualSetupTitle = styled('p')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  font-weight: bold;
 `;

--- a/static/app/gettingStartedDocs/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/javascript/nextjs.tsx
@@ -98,7 +98,7 @@ export const steps = ({dsn, projectSlug, organization}: Props): LayoutProps['ste
         </DSNText>
         {organization && (
           <TextCopyInput
-            onCopy={() => trackAnalytics('onboarding:nextjs-dsn-copied', {organization})}
+            onCopy={() => trackAnalytics('onboarding.nextjs-dsn-copied', {organization})}
           >
             {dsn}
           </TextCopyInput>

--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -28,6 +28,7 @@ export type OnboardingEventParameters = {
     platform: string;
     project_id: string;
   };
+  'onboarding.nextjs-dsn-copied': {};
   'onboarding.select_framework_modal_close_button_clicked': {
     platform: string;
   };
@@ -78,4 +79,5 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
     'Onboarding: Source Maps Wizard Copy Button Clicked',
   'onboarding.source_maps_wizard_selected_and_copied':
     'Onboarding: Source Maps Wizard Selected and Copied',
+  'onboarding.nextjs-dsn-copied': 'Onboarding: NextJS DSN Copied',
 };


### PR DESCRIPTION
this pr updates the NextJS onboarding page in a few ways. First, it correctly groups all the information about the Sentry wizard into one section. Second, it separates our the alternate method while adding in the project's DSN for users who just need to get that, since their application already has the rest of the starter code for Sentry. Third, it cleans up the bullet points of what the Wizard does and fixes a typo. 


<img width="1488" alt="Screenshot 2023-11-17 at 11 34 57 AM" src="https://github.com/getsentry/sentry/assets/46740234/dd4f06fd-958d-46b3-944e-64205327da72">

Closes https://github.com/getsentry/sentry/issues/60054