### PR TITLE
chore(starfish): Use short release names in screens charts

### DIFF
--- a/static/app/views/starfish/views/screens/screenBarChart.tsx
+++ b/static/app/views/starfish/views/screens/screenBarChart.tsx
@@ -15,6 +15,7 @@ import {
   tooltipFormatter,
 } from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
+import {formatVersion} from 'sentry/utils/formatters';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useRouter from 'sentry/utils/useRouter';
@@ -105,7 +106,12 @@ export function ScreensBarChart({
           <BarChart
             {...chartProps}
             height={chartHeight ?? 180}
-            series={chartOptions[selectedDisplay].series ?? []}
+            series={
+              chartOptions[selectedDisplay].series?.map(series => ({
+                ...series,
+                name: formatVersion(series.seriesName),
+              })) ?? []
+            }
             grid={{
               left: '0',
               right: '0',

--- a/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
@@ -12,6 +12,7 @@ import {defined} from 'sentry/utils';
 import {tooltipFormatterUsingAggregateOutputType} from 'sentry/utils/discover/charts';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {formatVersion} from 'sentry/utils/formatters';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -119,7 +120,7 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
 
           const color = isPrimary ? CHART_PALETTE[3][0] : CHART_PALETTE[3][1];
           transformedReleaseSeries[yAxis][release] = {
-            seriesName: label,
+            seriesName: formatVersion(label),
             color,
             data,
           };


### PR DESCRIPTION
Modify the series name to be the shorter version. I was going to use the `formatVersionAndCenterTruncate` util but realized that if we're seeing these labels in charts, we probably want them to be the full label if possible. It makes sense to truncate these in the subtitles though.