### PR TITLE
ref: remove spurious return values from test functions

### DIFF
--- a/tests/sentry/api/endpoints/test_sentry_app_avatar.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_avatar.py
@@ -188,7 +188,7 @@ class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
             "avatar_type": "upload",
             "avatar_photo": b64encode(self.load_fixture("rookout-color.png")),
         }
-        return self.get_error_response(self.unpublished_app.slug, **data)
+        self.get_error_response(self.unpublished_app.slug, **data)
 
     def test_reject_jpgs(self):
         """Test that we reject a non-png file type"""
@@ -197,7 +197,7 @@ class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
             "avatar_type": "upload",
             "avatar_photo": b64encode(self.load_fixture("avatar.jpg")),
         }
-        return self.get_error_response(self.unpublished_app.slug, **data)
+        self.get_error_response(self.unpublished_app.slug, **data)
 
     def test_put_bad(self):
         SentryAppAvatar.objects.create(sentry_app=self.unpublished_app)


### PR DESCRIPTION
this is a warning in python 3.11




<!-- Describe your PR here. -->