### PR TITLE
ref: use enum value / name due to 3.11 repr changes

### DIFF
--- a/src/sentry/services/hybrid_cloud/import_export/model.py
+++ b/src/sentry/services/hybrid_cloud/import_export/model.py
@@ -155,7 +155,7 @@ class RpcImportError(RpcModel, Finding):
         return RpcImportErrorKind(self.kind)
 
     def pretty(self) -> str:
-        return f"RpcImportError(\n    kind: {self.get_kind()},{self._pretty_inner()}\n)"
+        return f"RpcImportError(\n    kind: {self.get_kind().value},{self._pretty_inner()}\n)"
 
     def to_dict(self) -> Dict[str, Any]:
         d = dict(self)
@@ -243,7 +243,7 @@ class RpcExportError(RpcModel, Finding):
         return RpcExportErrorKind(self.kind)
 
     def pretty(self) -> str:
-        return f"RpcExportError(\n    kind: {self.get_kind()},{self._pretty_inner()}\n)"
+        return f"RpcExportError(\n    kind: {self.get_kind().value},{self._pretty_inner()}\n)"
 
     def to_dict(self) -> Dict[str, Any]:
         d = dict(self)

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -477,21 +477,21 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
 
         response = self.get_success_response(
             self.organization.slug,
-            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED}",
+            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED.value}",
             environment=self.environment.name,
         )
         self.assert_expected_versions(response, [adopted_release])
 
         response = self.get_success_response(
             self.organization.slug,
-            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.LOW_ADOPTION}",
+            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.LOW_ADOPTION.value}",
             environment=self.environment.name,
         )
         self.assert_expected_versions(response, [not_adopted_release])
 
         response = self.get_success_response(
             self.organization.slug,
-            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.REPLACED}",
+            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.REPLACED.value}",
             environment=self.environment.name,
         )
         self.assert_expected_versions(response, [replaced_release])
@@ -499,21 +499,21 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         # NOT release stage
         response = self.get_success_response(
             self.organization.slug,
-            query=f"!{RELEASE_STAGE_ALIAS}:{ReleaseStages.REPLACED}",
+            query=f"!{RELEASE_STAGE_ALIAS}:{ReleaseStages.REPLACED.value}",
             environment=self.environment.name,
         )
         self.assert_expected_versions(response, [not_adopted_release, adopted_release])
 
         response = self.get_success_response(
             self.organization.slug,
-            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED},{ReleaseStages.REPLACED}]",
+            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED.value},{ReleaseStages.REPLACED.value}]",
             environment=self.environment.name,
         )
         self.assert_expected_versions(response, [adopted_release, replaced_release])
 
         response = self.get_success_response(
             self.organization.slug,
-            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.LOW_ADOPTION}]",
+            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.LOW_ADOPTION.value}]",
             environment=self.environment.name,
         )
 
@@ -577,7 +577,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
 
         response = self.get_success_response(
             self.organization.slug,
-            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.LOW_ADOPTION},{ReleaseStages.REPLACED}]",
+            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.LOW_ADOPTION.value},{ReleaseStages.REPLACED.value}]",
             sort="adoption",
             environment=self.environment.name,
         )
@@ -592,7 +592,7 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
 
         response = self.get_response(
             self.organization.slug,
-            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED}",
+            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED.value}",
             # No environment
         )
         assert response.status_code == 400
@@ -961,28 +961,28 @@ class OrganizationReleasesStatsTest(APITestCase):
 
         response = self.get_success_response(
             self.organization.slug,
-            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED}",
+            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED.value}",
             environment=self.environment.name,
         )
         assert [r["version"] for r in response.data] == [adopted_release.version]
 
         response = self.get_success_response(
             self.organization.slug,
-            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.LOW_ADOPTION}",
+            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.LOW_ADOPTION.value}",
             environment=self.environment.name,
         )
         assert [r["version"] for r in response.data] == [not_adopted_release.version]
 
         response = self.get_success_response(
             self.organization.slug,
-            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.REPLACED}",
+            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.REPLACED.value}",
             environment=self.environment.name,
         )
         assert [r["version"] for r in response.data] == [replaced_release.version]
 
         response = self.get_success_response(
             self.organization.slug,
-            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED},{ReleaseStages.REPLACED}]",
+            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED.value},{ReleaseStages.REPLACED.value}]",
             environment=self.environment.name,
         )
         assert [r["version"] for r in response.data] == [
@@ -992,7 +992,7 @@ class OrganizationReleasesStatsTest(APITestCase):
 
         response = self.get_success_response(
             self.organization.slug,
-            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.LOW_ADOPTION}]",
+            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.LOW_ADOPTION.value}]",
             environment=self.environment.name,
         )
         assert [r["version"] for r in response.data] == [not_adopted_release.version]
@@ -1006,7 +1006,7 @@ class OrganizationReleasesStatsTest(APITestCase):
 
         response = self.get_response(
             self.organization.slug,
-            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED}",
+            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED.value}",
             # No environment
         )
         assert response.status_code == 400

--- a/tests/sentry/api/test_release_search.py
+++ b/tests/sentry/api/test_release_search.py
@@ -37,14 +37,14 @@ class ParseSearchQueryTest(TestCase):
 
     def test_release_stage(self):
 
-        assert parse_search_query(f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED}") == [
+        assert parse_search_query(f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED.value}") == [
             SearchFilter(
                 key=SearchKey(name=RELEASE_STAGE_ALIAS),
                 operator="=",
                 value=SearchValue(ReleaseStages.ADOPTED),
             )
         ]
-        assert parse_search_query(f"!{RELEASE_STAGE_ALIAS}:{ReleaseStages.REPLACED}") == [
+        assert parse_search_query(f"!{RELEASE_STAGE_ALIAS}:{ReleaseStages.REPLACED.value}") == [
             SearchFilter(
                 key=SearchKey(name=RELEASE_STAGE_ALIAS),
                 operator="!=",
@@ -52,7 +52,7 @@ class ParseSearchQueryTest(TestCase):
             )
         ]
         assert parse_search_query(
-            f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED}, {ReleaseStages.LOW_ADOPTION}]"
+            f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED.value}, {ReleaseStages.LOW_ADOPTION.value}]"
         ) == [
             SearchFilter(
                 key=SearchKey(name=RELEASE_STAGE_ALIAS),
@@ -61,7 +61,7 @@ class ParseSearchQueryTest(TestCase):
             ),
         ]
         assert parse_search_query(
-            f"!{RELEASE_STAGE_ALIAS}:[{ReleaseStages.REPLACED}, {ReleaseStages.ADOPTED}]"
+            f"!{RELEASE_STAGE_ALIAS}:[{ReleaseStages.REPLACED.value}, {ReleaseStages.ADOPTED.value}]"
         ) == [
             SearchFilter(
                 key=SearchKey(name=RELEASE_STAGE_ALIAS),

--- a/tests/sentry/snuba/test_discover_query.py
+++ b/tests/sentry/snuba/test_discover_query.py
@@ -2495,7 +2495,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
         result = discover.query(
             selected_columns=["id"],
-            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED}",
+            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED.value}",
             params=self.params,
             referrer="discover",
         )
@@ -2506,7 +2506,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
         result = discover.query(
             selected_columns=["id"],
-            query=f"!{RELEASE_STAGE_ALIAS}:{ReleaseStages.LOW_ADOPTION}",
+            query=f"!{RELEASE_STAGE_ALIAS}:{ReleaseStages.LOW_ADOPTION.value}",
             params=self.params,
             referrer="discover",
         )
@@ -2518,7 +2518,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         }
         result = discover.query(
             selected_columns=["id"],
-            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED}, {ReleaseStages.REPLACED}]",
+            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED.value}, {ReleaseStages.REPLACED.value}]",
             params=self.params,
             referrer="discover",
         )

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -1291,7 +1291,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
 
         query = {
             "field": ["id"],
-            "query": f"{constants.RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED}",
+            "query": f"{constants.RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED.value}",
             "environment": [self.environment.name],
         }
         response = self.do_request(query)
@@ -1303,7 +1303,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
 
         query = {
             "field": ["id"],
-            "query": f"!{constants.RELEASE_STAGE_ALIAS}:{ReleaseStages.LOW_ADOPTION}",
+            "query": f"!{constants.RELEASE_STAGE_ALIAS}:{ReleaseStages.LOW_ADOPTION.value}",
             "environment": [self.environment.name],
         }
         response = self.do_request(query)
@@ -1317,7 +1317,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
 
         query = {
             "field": ["id"],
-            "query": f"{constants.RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED}, {ReleaseStages.REPLACED}]",
+            "query": f"{constants.RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED.value}, {ReleaseStages.REPLACED.value}]",
             "environment": [self.environment.name],
         }
         response = self.do_request(query)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1452,7 +1452,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         response = self.get_response(
             sort_by="date",
             limit=10,
-            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED}",
+            query=f"{RELEASE_STAGE_ALIAS}:{ReleaseStages.ADOPTED.value}",
             environment=self.environment.name,
         )
         assert response.status_code == 200, response.content
@@ -1464,21 +1464,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         response = self.get_response(
             sort_by="date",
             limit=10,
-            query=f"!{RELEASE_STAGE_ALIAS}:{ReleaseStages.LOW_ADOPTION}",
-            environment=self.environment.name,
-        )
-        assert response.status_code == 200, response.content
-        assert [int(r["id"]) for r in response.json()] == [
-            adopted_release_g_1,
-            adopted_release_g_2,
-            replaced_release_g_1,
-            replaced_release_g_2,
-        ]
-
-        response = self.get_response(
-            sort_by="date",
-            limit=10,
-            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED}, {ReleaseStages.REPLACED}]",
+            query=f"!{RELEASE_STAGE_ALIAS}:{ReleaseStages.LOW_ADOPTION.value}",
             environment=self.environment.name,
         )
         assert response.status_code == 200, response.content
@@ -1492,7 +1478,21 @@ class GroupListTest(APITestCase, SnubaTestCase):
         response = self.get_response(
             sort_by="date",
             limit=10,
-            query=f"!{RELEASE_STAGE_ALIAS}:[{ReleaseStages.LOW_ADOPTION}, {ReleaseStages.REPLACED}]",
+            query=f"{RELEASE_STAGE_ALIAS}:[{ReleaseStages.ADOPTED.value}, {ReleaseStages.REPLACED.value}]",
+            environment=self.environment.name,
+        )
+        assert response.status_code == 200, response.content
+        assert [int(r["id"]) for r in response.json()] == [
+            adopted_release_g_1,
+            adopted_release_g_2,
+            replaced_release_g_1,
+            replaced_release_g_2,
+        ]
+
+        response = self.get_response(
+            sort_by="date",
+            limit=10,
+            query=f"!{RELEASE_STAGE_ALIAS}:[{ReleaseStages.LOW_ADOPTION.value}, {ReleaseStages.REPLACED.value}]",
             environment=self.environment.name,
         )
         assert response.status_code == 200, response.content


### PR DESCRIPTION
basically `repr(A.B)` used to be `B` but now it is `A.B` -- this PR adjusts to either .value or .name appropriately