### PR TITLE
ref(ui): make tooltip always visible when sidebar is at the top

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -7,6 +7,7 @@ import FeatureBadge from 'sentry/components/featureBadge';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import Link from 'sentry/components/links/link';
+import {Flex} from 'sentry/components/profiling/flex';
 import TextOverflow from 'sentry/components/textOverflow';
 import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
@@ -159,13 +160,13 @@ function SidebarItem({
   );
 
   const tooltipLabel = (
-    <Fragment>
+    <Flex align="center">
       {label} {badges}
-    </Fragment>
+    </Flex>
   );
 
   return (
-    <Tooltip disabled={!collapsed} title={tooltipLabel} position={placement}>
+    <Tooltip disabled={!collapsed && !isTop} title={tooltipLabel} position={placement}>
       <StyledSidebarItem
         {...props}
         id={`sidebar-item-${id}`}


### PR DESCRIPTION
<!-- Describe your PR here. -->
<img width="639" alt="SCR-20231116-mpjr" src="https://github.com/getsentry/sentry/assets/56095982/436a0300-1d25-4c21-8ecf-ed7124d1029b">


also fixed some alignment with the tooltips:

before:
<img width="204" alt="SCR-20231116-mphw" src="https://github.com/getsentry/sentry/assets/56095982/5f5bcad0-173e-4db6-a955-e4c3a6853ded">

after:
<img width="204" alt="SCR-20231116-mpgx" src="https://github.com/getsentry/sentry/assets/56095982/8eefcf11-65fc-4ae7-9797-de6dfcc45e9d">

