### PR TITLE
fix(github-invite): check array length before emitting analytic

### DIFF
--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -114,7 +114,7 @@ export function InviteBanner({
     }
   }, [openInviteModal, location, isEligibleForBanner]);
 
-  if (isEligibleForBanner && showBanner && missingMembers) {
+  if (isEligibleForBanner && showBanner && missingMembers.length > 0) {
     trackAnalytics('github_invite_banner.viewed', {
       organization,
       members_shown: missingMembers.slice(0, MAX_MEMBERS_TO_SHOW).length,


### PR DESCRIPTION
An empty array is truthy in Javascript. Even if an org has no missing members, the analytic event will be emitted if the invite banner _can_ be rendered otherwise -- checking the length of the array fixes this.