### PR TITLE
ref(crons): Always log invalid check-in GUIDs

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -194,6 +194,9 @@ def transform_checkin_uuid(
     try:
         check_in_guid = uuid.UUID(check_in_id)
     except ValueError:
+        pass
+
+    if check_in_guid is None:
         metrics.incr(
             "monitors.checkin.result",
             tags={**metric_kwargs, "status": "failed_guid_validation"},
@@ -203,9 +206,6 @@ def transform_checkin_uuid(
             "monitors.consumer.guid_validation_failed",
             extra={"guid": check_in_id, "slug": monitor_slug},
         )
-        return None, False
-
-    if check_in_guid is None:
         return None, False
 
     # When the UUID is empty we will default to looking for the most


### PR DESCRIPTION
Prior to this change we didn't always correctly log this