### PR TITLE
fix(hc): Fix silo availability error in create_cloudbuild_yaml

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -109,6 +109,10 @@ class DatabaseBackedUserService(UserService):
                 return [serialize_rpc_user(u) for u in qs.filter(email__iexact=username)]
         return []
 
+    def get_existing_usernames(self, *, usernames: List[str]) -> List[str]:
+        users = User.objects.filter(username__in=usernames)
+        return list(users.values_list("username", flat=True))
+
     def get_organizations(
         self,
         *,

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -90,6 +90,11 @@ class UserService(RpcService):
 
     @rpc_method
     @abstractmethod
+    def get_existing_usernames(self, *, usernames: List[str]) -> List[str]:
+        """Get all usernames from the set that belong to existing users."""
+
+    @rpc_method
+    @abstractmethod
     def get_organizations(
         self,
         *,

--- a/src/sentry/utils/relocation.py
+++ b/src/sentry/utils/relocation.py
@@ -15,7 +15,6 @@ from sentry.backup.scopes import RelocationScope
 from sentry.http import get_server_hostname
 from sentry.models.files.utils import get_storage
 from sentry.models.relocation import Relocation, RelocationFile
-from sentry.models.user import User
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.utils.email.message_builder import MessageBuilder as MessageBuilder
 
@@ -474,9 +473,7 @@ def get_bucket_name():
 
 def create_cloudbuild_yaml(relocation: Relocation) -> bytes:
     # Only test existing users for collision and mutation.
-    existing_usernames = User.objects.filter(username__in=relocation.want_usernames).values_list(
-        "username", flat=True
-    )
+    existing_usernames = user_service.get_existing_usernames(usernames=relocation.want_usernames)
     filter_usernames_args = [
         "--filter-usernames",
         ",".join(existing_usernames) if existing_usernames else ",",

--- a/tests/sentry/tasks/test_relocation.py
+++ b/tests/sentry/tasks/test_relocation.py
@@ -947,7 +947,7 @@ class PreprocessingCompleteTest(RelocationTaskTestCase):
         assert relocation.failure_reason == ERR_PREPROCESSING_INTERNAL
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @patch(
     "sentry.tasks.relocation.CloudBuildClient",
     new_callable=lambda: FakeCloudBuildClient,
@@ -1784,7 +1784,7 @@ class CompletedTest(RelocationTaskTestCase):
         assert not relocation.failure_reason
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 @patch(
     "sentry.backup.helpers.KeyManagementServiceClient",
     new_callable=lambda: FakeKeyManagementServiceClient,


### PR DESCRIPTION
Add `UserService.get_existing_usernames` to replace query.

Mark affected tests as stable.