### PR TITLE
feat(metric-alerts): Allow metric alerts that filter by status to be created via the api

### DIFF
--- a/tests/sentry/search/events/builder/test_errors.py
+++ b/tests/sentry/search/events/builder/test_errors.py
@@ -46,11 +46,14 @@ class ErrorsQueryBuilderTest(TestCase):
             )
         ]
         assert query.query.where == [
-            Condition(
-                Column("group_status", entity=Entity("group_attributes", alias="ga")), Op.IN, [0]
-            ),
+            Condition(Column("group_status", entity=g_entity), Op.IN, [0]),
             Condition(
                 Column("project_id", entity=Entity("events", alias="events")),
+                Op.IN,
+                self.projects,
+            ),
+            Condition(
+                Column("project_id", entity=g_entity),
                 Op.IN,
                 self.projects,
             ),

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -720,6 +720,7 @@ class EntitySubscriptionTestCase(TestCase):
                 ]
             ),
             Condition(Column("project_id", entity=e_entity), Op.IN, [self.project.id]),
+            Condition(Column("project_id", entity=g_entity), Op.IN, [self.project.id]),
         ]
 
 

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -665,6 +665,11 @@ class BuildSnqlQueryTest(TestCase):
                     ]
                 ),
                 Condition(Column(name="project_id", entity=entity), Op.IN, [self.project.id]),
+                Condition(
+                    Column(name="project_id", entity=g_entity),
+                    Op.IN,
+                    [self.project.id],
+                ),
             ],
             expected_match=Join([Relationship(entity, "attributes", g_entity)]),
         )


### PR DESCRIPTION
This changes the validation function to succeed when we're making joins to support status query metric alerts
