### PR TITLE
fix(ddm-alerts): Enable on-demand querying behaviour in alert charts

### DIFF
--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -622,6 +622,7 @@ class MetricChart extends PureComponent<Props, State> {
         partial={false}
         queryExtras={queryExtras}
         referrer="api.alerts.alert-rule-chart"
+        useOnDemandMetrics
       >
         {({loading, timeseriesData, comparisonTimeseriesData}) => (
           <Fragment>

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -508,6 +508,7 @@ class TriggersChart extends PureComponent<Props, State> {
         currentSeriesNames={[aggregate]}
         partial={false}
         queryExtras={queryExtras}
+        useOnDemandMetrics
         dataLoadedCallback={onDataLoaded}
       >
         {({


### PR DESCRIPTION
When requesting alert chart data via `events-stats` we need to pass the `useOnDemandMetrics` query param to enable the same query behaviour the alert subscriptions have.

- requires https://github.com/getsentry/sentry/pull/60119