### PR TITLE
fix(ddm): Reset widget on MRI meta change

### DIFF
--- a/static/app/views/alerts/rules/metric/mriField.tsx
+++ b/static/app/views/alerts/rules/metric/mriField.tsx
@@ -39,7 +39,7 @@ function filterAndSortOperations(operations: string[]) {
 }
 
 function MriField({aggregate, project, onChange}: Props) {
-  const meta = useMetricsMeta([parseInt(project.id, 10)], {
+  const {data: meta} = useMetricsMeta([parseInt(project.id, 10)], {
     useCases: ['transactions', 'custom'],
   });
   const metaArr = useMemo(() => {

--- a/static/app/views/ddm/queryBuilder.tsx
+++ b/static/app/views/ddm/queryBuilder.tsx
@@ -40,7 +40,7 @@ export function QueryBuilder({
   powerUserMode,
   onChange,
 }: QueryBuilderProps) {
-  const meta = useMetricsMeta(projects);
+  const {data: meta, isLoading: isMetaLoading} = useMetricsMeta(projects);
   const mriModeKeyPressed = useKeyPress('`', undefined, true);
   const [mriMode, setMriMode] = useState(powerUserMode); // power user mode that shows raw MRI instead of metrics names
 
@@ -62,6 +62,16 @@ export function QueryBuilder({
       metric => metric.mri.includes(':custom/') || metric.mri === metricsQuery.mri
     );
   }, [meta, metricsQuery.mri, mriMode]);
+
+  useEffect(() => {
+    if (
+      metricsQuery.mri &&
+      !isMetaLoading &&
+      !metaArr.find(metric => metric.mri === metricsQuery.mri)
+    ) {
+      onChange({mri: '', op: '', groupBy: []});
+    }
+  }, [isMetaLoading, metaArr, metricsQuery.mri, onChange]);
 
   if (!meta) {
     return null;
@@ -184,6 +194,8 @@ interface MetricSearchBarProps
   query?: string;
 }
 
+const EMPTY_ARRAY = [];
+
 export function MetricSearchBar({
   mri,
   disabled,
@@ -200,7 +212,7 @@ export function MetricSearchBar({
     [projectIds]
   );
 
-  const {data: tags = []} = useMetricsTags(mri, projectIdNumbers);
+  const {data: tags = EMPTY_ARRAY} = useMetricsTags(mri, projectIdNumbers);
 
   const supportedTags: TagCollection = useMemo(
     () => tags.reduce((acc, tag) => ({...acc, [tag.key]: tag}), {}),

--- a/static/app/views/ddm/queryBuilder.tsx
+++ b/static/app/views/ddm/queryBuilder.tsx
@@ -63,6 +63,7 @@ export function QueryBuilder({
     );
   }, [meta, metricsQuery.mri, mriMode]);
 
+  // Reset the query data if the selected metric is no longer available
   useEffect(() => {
     if (
       metricsQuery.mri &&


### PR DESCRIPTION
When changing projects the available metrics (mri meta) can change. 
This PR resets the widget if the selected MRI cannot be found in the updated MRI meta.