### PR TITLE
fix(ddm): Darkmode issue of smapled traces heading

### DIFF
--- a/static/app/views/ddm/traceTable.tsx
+++ b/static/app/views/ddm/traceTable.tsx
@@ -368,8 +368,8 @@ const TitleOverlay = styled('span')`
   height: 46px;
   max-width: 250px;
   padding: 0px 16px;
-  background-color: rgb(250, 249, 251);
-  color: rgb(128, 112, 143);
+  background-color: ${p => p.theme.backgroundSecondary};
+  color: ${p => p.theme.subText};
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;


### PR DESCRIPTION
Before

<img width="390" alt="Screenshot 2023-11-17 at 15 02 37" src="https://github.com/getsentry/sentry/assets/7033940/129cea94-ff98-4384-93e3-beeff2a484dc">

After

<img width="390" alt="Screenshot 2023-11-17 at 15 02 37" src="https://github.com/getsentry/sentry/assets/7033940/f7a49a6f-da6d-4e38-8f3a-7eb0d0908bca">

<img width="390" alt="Screenshot 2023-11-17 at 15 02 45" src="https://github.com/getsentry/sentry/assets/7033940/8147a402-038d-4094-92ae-a01f5bed8b49">
