### PR TITLE
style(ui): hide overflow on sidebar when window height is small

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -364,6 +364,7 @@ const SidebarItemLabel = styled('span')`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  overflow: hidden;
 `;
 
 const getCollapsedBadgeStyle = ({collapsed, theme}) => {


### PR DESCRIPTION
The 'User Feedback' sidebar label is so long, which caused some layout shifts when the window height was small. Let's apply `overflow: hidden` to avoid this.

<img width="741" alt="SCR-20231117-iwim" src="https://github.com/getsentry/sentry/assets/56095982/3f33fbff-093e-4f1e-bd27-d22af734602a">

https://github.com/getsentry/sentry/assets/56095982/b0d8a7a5-e738-42bf-9a5f-d074775f4940


