### PR TITLE
feat(database): Preserve default percentile selection in `localStorage`

### DIFF
--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -22,7 +22,7 @@ import {DurationChart} from 'sentry/views/performance/database/durationChart';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
 import {NoDataMessage} from 'sentry/views/performance/database/noDataMessage';
 import {ThroughputChart} from 'sentry/views/performance/database/throughputChart';
-import {useAvailableDurationAggregates} from 'sentry/views/performance/database/useAvailableDurationAggregates';
+import {useSelectedDurationAggregate} from 'sentry/views/performance/database/useSelectedDurationAggregate';
 import Onboarding from 'sentry/views/performance/onboarding';
 import {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
@@ -40,7 +40,7 @@ function DatabaseLandingPage() {
   const location = useLocation();
   const onboardingProject = useOnboardingProject();
 
-  const {selectedAggregate} = useAvailableDurationAggregates();
+  const [selectedAggregate] = useSelectedDurationAggregate();
   const spanDescription = decodeScalar(location.query?.['span.description'], '');
   const moduleFilters = useModuleFilters();
   const sort = useModuleSort(QueryParameterNames.SPANS_SORT);

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -17,7 +17,7 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {DurationChart} from 'sentry/views/performance/database/durationChart';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
 import {ThroughputChart} from 'sentry/views/performance/database/throughputChart';
-import {useAvailableDurationAggregates} from 'sentry/views/performance/database/useAvailableDurationAggregates';
+import {useSelectedDurationAggregate} from 'sentry/views/performance/database/useSelectedDurationAggregate';
 import {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import {SpanDescription} from 'sentry/views/starfish/components/spanDescription';
 import {useFullSpanFromTrace} from 'sentry/views/starfish/queries/useFullSpanFromTrace';
@@ -55,7 +55,7 @@ function SpanSummaryPage({params}: Props) {
   const organization = useOrganization();
   const location = useLocation<Query>();
 
-  const {selectedAggregate} = useAvailableDurationAggregates();
+  const [selectedAggregate] = useSelectedDurationAggregate();
 
   const {groupId} = params;
   const {transaction, transactionMethod, endpoint, endpointMethod} = location.query;

--- a/static/app/views/performance/database/durationAggregateSelector.tsx
+++ b/static/app/views/performance/database/durationAggregateSelector.tsx
@@ -1,31 +1,19 @@
-import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
 import {CompactSelect} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {useLocation} from 'sentry/utils/useLocation';
 import {useAvailableDurationAggregates} from 'sentry/views/performance/database/useAvailableDurationAggregates';
+import {useSelectedDurationAggregate} from 'sentry/views/performance/database/useSelectedDurationAggregate';
 
 export function DurationAggregateSelector() {
-  const location = useLocation();
-
-  const {selectedAggregate, availableAggregates} = useAvailableDurationAggregates();
+  const availableAggregates = useAvailableDurationAggregates();
+  const [selectedAggregate, setSelectedAggregate] = useSelectedDurationAggregate();
 
   // If only one aggregate is available, render a plain string
   if (availableAggregates.length === 1) {
     return DURATION_AGGREGATE_LABELS[selectedAggregate];
   }
-
-  const handleDurationFunctionChange = option => {
-    browserHistory.push({
-      ...location,
-      query: {
-        ...location.query,
-        aggregate: option.value,
-      },
-    });
-  };
 
   // If multiple aggregates are available, render a dropdown list
   return (
@@ -36,7 +24,9 @@ export function DurationAggregateSelector() {
         label: DURATION_AGGREGATE_LABELS[availableAggregate],
       }))}
       value={selectedAggregate}
-      onChange={handleDurationFunctionChange}
+      onChange={option => {
+        setSelectedAggregate(option.value);
+      }}
       triggerProps={{borderless: true, size: 'zero'}}
     />
   );

--- a/static/app/views/performance/database/useAvailableDurationAggregates.tsx
+++ b/static/app/views/performance/database/useAvailableDurationAggregates.tsx
@@ -1,4 +1,5 @@
 import useOrganization from 'sentry/utils/useOrganization';
+import {DEFAULT_DURATION_AGGREGATE} from 'sentry/views/performance/database/settings';
 
 // TODO: Type more strictly, these should be limited to only valid aggregate
 // functions
@@ -9,7 +10,7 @@ export function useAvailableDurationAggregates(): Result {
 
   let availableAggregates: string[] = [];
 
-  availableAggregates.push('avg');
+  availableAggregates.push(DEFAULT_DURATION_AGGREGATE);
 
   if (organization.features?.includes('performance-database-view-percentiles')) {
     availableAggregates = [...availableAggregates, ...['p50', 'p75', 'p95', 'p99']];

--- a/static/app/views/performance/database/useAvailableDurationAggregates.tsx
+++ b/static/app/views/performance/database/useAvailableDurationAggregates.tsx
@@ -1,7 +1,7 @@
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {DEFAULT_DURATION_AGGREGATE} from 'sentry/views/performance/database/settings';
+import {useDefaultDurationAggregate} from 'sentry/views/performance/database/useDefaultDurationAggregate';
 
 // TODO: Type more strictly, these should be limited to only valid aggregate
 // functions
@@ -18,6 +18,7 @@ export function useAvailableDurationAggregates(): Result {
   const organization = useOrganization();
   const location = useLocation<Query>();
 
+  const defaultDurationAggregate = useDefaultDurationAggregate();
   let availableAggregates = ['avg'];
 
   const arePercentilesEnabled = organization.features?.includes(
@@ -36,11 +37,11 @@ export function useAvailableDurationAggregates(): Result {
 
   let selectedAggregate = decodeScalar(
     location.query.aggregate,
-    DEFAULT_DURATION_AGGREGATE
+    defaultDurationAggregate
   );
 
   if (!availableAggregates.includes(selectedAggregate)) {
-    selectedAggregate = DEFAULT_DURATION_AGGREGATE;
+    selectedAggregate = defaultDurationAggregate;
   }
 
   return {

--- a/static/app/views/performance/database/useAvailableDurationAggregates.tsx
+++ b/static/app/views/performance/database/useAvailableDurationAggregates.tsx
@@ -8,12 +8,12 @@ type Result = string[];
 export function useAvailableDurationAggregates(): Result {
   const organization = useOrganization();
 
-  let availableAggregates: string[] = [];
+  const availableAggregates: string[] = [];
 
   availableAggregates.push(DEFAULT_DURATION_AGGREGATE);
 
   if (organization.features?.includes('performance-database-view-percentiles')) {
-    availableAggregates = [...availableAggregates, ...['p50', 'p75', 'p95', 'p99']];
+    availableAggregates.push(...['p50', 'p75', 'p95', 'p99']);
   }
 
   return availableAggregates;

--- a/static/app/views/performance/database/useAvailableDurationAggregates.tsx
+++ b/static/app/views/performance/database/useAvailableDurationAggregates.tsx
@@ -16,11 +16,5 @@ export function useAvailableDurationAggregates(): Result {
     availableAggregates = [...availableAggregates, ...['p50', 'p75', 'p95', 'p99']];
   }
 
-  // TODO: Enable this on the backend
-  const areLimitsEnabled = false;
-  if (areLimitsEnabled) {
-    availableAggregates.push('max');
-  }
-
   return availableAggregates;
 }

--- a/static/app/views/performance/database/useAvailableDurationAggregates.tsx
+++ b/static/app/views/performance/database/useAvailableDurationAggregates.tsx
@@ -1,51 +1,25 @@
-import {decodeScalar} from 'sentry/utils/queryString';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useDefaultDurationAggregate} from 'sentry/views/performance/database/useDefaultDurationAggregate';
 
 // TODO: Type more strictly, these should be limited to only valid aggregate
 // functions
-type Query = {
-  aggregate: string;
-};
-
-type Result = {
-  availableAggregates: string[];
-  selectedAggregate: string;
-};
+type Result = string[];
 
 export function useAvailableDurationAggregates(): Result {
   const organization = useOrganization();
-  const location = useLocation<Query>();
 
-  const defaultDurationAggregate = useDefaultDurationAggregate();
-  let availableAggregates = ['avg'];
+  let availableAggregates: string[] = [];
 
-  const arePercentilesEnabled = organization.features?.includes(
-    'performance-database-view-percentiles'
-  );
+  availableAggregates.push('avg');
 
-  if (arePercentilesEnabled) {
+  if (organization.features?.includes('performance-database-view-percentiles')) {
     availableAggregates = [...availableAggregates, ...['p50', 'p75', 'p95', 'p99']];
   }
 
   // TODO: Enable this on the backend
-  const isMaxEnabled = false;
-  if (isMaxEnabled) {
+  const areLimitsEnabled = false;
+  if (areLimitsEnabled) {
     availableAggregates.push('max');
   }
 
-  let selectedAggregate = decodeScalar(
-    location.query.aggregate,
-    defaultDurationAggregate
-  );
-
-  if (!availableAggregates.includes(selectedAggregate)) {
-    selectedAggregate = defaultDurationAggregate;
-  }
-
-  return {
-    selectedAggregate,
-    availableAggregates,
-  };
+  return availableAggregates;
 }

--- a/static/app/views/performance/database/useDefaultDurationAggregate.tsx
+++ b/static/app/views/performance/database/useDefaultDurationAggregate.tsx
@@ -1,5 +1,0 @@
-import {DEFAULT_DURATION_AGGREGATE} from 'sentry/views/performance/database/settings';
-
-export function useDefaultDurationAggregate(): string {
-  return DEFAULT_DURATION_AGGREGATE;
-}

--- a/static/app/views/performance/database/useDefaultDurationAggregate.tsx
+++ b/static/app/views/performance/database/useDefaultDurationAggregate.tsx
@@ -1,0 +1,5 @@
+import {DEFAULT_DURATION_AGGREGATE} from 'sentry/views/performance/database/settings';
+
+export function useDefaultDurationAggregate(): string {
+  return DEFAULT_DURATION_AGGREGATE;
+}

--- a/static/app/views/performance/database/useSelectedDurationAggregate.tsx
+++ b/static/app/views/performance/database/useSelectedDurationAggregate.tsx
@@ -1,0 +1,49 @@
+import {browserHistory} from 'react-router';
+
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+import {useLocation} from 'sentry/utils/useLocation';
+import {DEFAULT_DURATION_AGGREGATE} from 'sentry/views/performance/database/settings';
+import {useAvailableDurationAggregates} from 'sentry/views/performance/database/useAvailableDurationAggregates';
+
+type Query = {
+  aggregate: string;
+};
+
+// TODO: Type more strictly, these should be limited to only valid aggregate
+// functions
+type Result = [string, (string) => void];
+
+export function useSelectedDurationAggregate(): Result {
+  const [previouslySelectedAggregate, setPreviouslySelectedAggregate] =
+    useLocalStorageState(KEY, DEFAULT_DURATION_AGGREGATE);
+
+  const setSelectedAggregate = aggregate => {
+    setPreviouslySelectedAggregate(aggregate);
+
+    browserHistory.push({
+      ...location,
+      query: {
+        ...location.query,
+        aggregate,
+      },
+    });
+  };
+
+  const availableAggregates = useAvailableDurationAggregates();
+
+  const location = useLocation<Query>();
+
+  let selectedAggregate = decodeScalar(
+    location.query.aggregate,
+    previouslySelectedAggregate
+  );
+
+  if (!availableAggregates.includes(selectedAggregate)) {
+    selectedAggregate = DEFAULT_DURATION_AGGREGATE;
+  }
+
+  return [selectedAggregate, setSelectedAggregate];
+}
+
+const KEY = 'performance-database-default-aggregation-function';


### PR DESCRIPTION
The net effect of this PR is that the "Duration" charts in the Database module will always use the most recently selected percentile even if the URL doesn't have one. Handy!

The changes are a little confusing because of the refactor, but the gist is:

- split `useAvailableDurationAggregates` into `useAvailableDurationAggregates` which provides just the aggregation functions that are available, and `useSelectedDurationAggregate` which provides just the one that's selected
- `useSelectedDurationAggregate` is now in charge of filtering out unavailable aggregates, checking the URL parameter, checking local storage, etc.
- `DurationAggregateSelector` uses both the hooks in tandem to render the possibilities
