### PR TITLE
ref: work around pip not having retries for streamed downloads

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -109,7 +109,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache-dependency-path: ${{ inputs.workdir }}/requirements-dev-frozen.txt
-        install-cmd: pip install -r ${{ inputs.workdir }}/requirements-dev-frozen.txt
+        install-cmd: cd ${{ inputs.workdir }} && python3 -m tools.hack_pip && pip install -r requirements-dev-frozen.txt
 
     - name: Set up outputs
       id: config

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -197,7 +197,7 @@ jobs:
         with:
           python-version: 3.8.18
           cache-dependency-path: requirements-dev-frozen.txt
-          install-cmd: pip install -q --constraint requirements-dev-frozen.txt pip-tools
+          install-cmd: python3 -m tools.hack_pip && pip install -q --constraint requirements-dev-frozen.txt pip-tools
       - name: check requirements
         run: |
           python -S -m tools.freeze_requirements
@@ -280,7 +280,7 @@ jobs:
         with:
           python-version: 3.8.18
           cache-dependency-path: requirements-dev-frozen.txt
-          install-cmd: pip install -r requirements-dev-frozen.txt
+          install-cmd: python3 -m tools.hack_pip && pip install -r requirements-dev-frozen.txt
 
       - name: setup sentry (lite)
         run: |

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -112,7 +112,7 @@ jobs:
           cache-dependency-path: |
             requirements-dev.txt
             requirements-dev-frozen.txt
-          install-cmd: pip install -r requirements-dev.txt -c requirements-dev-frozen.txt
+          install-cmd: python3 -m tools.hack_pip && pip install -r requirements-dev.txt -c requirements-dev-frozen.txt
       - name: run tests
         run: make test-tools
       - name: Handle artifacts

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -59,7 +59,7 @@ jobs:
           cache-dependency-path: |
             requirements-dev.txt
             requirements-dev-frozen.txt
-          install-cmd: pip install -r requirements-dev.txt -c requirements-dev-frozen.txt
+          install-cmd: python3 -m tools.hack_pip && pip install -r requirements-dev.txt -c requirements-dev-frozen.txt
       - uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           path: ~/.cache/pre-commit

--- a/tools/hack_pip.py
+++ b/tools/hack_pip.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os.path
+import sys
+import sysconfig
+
+PTH = """\
+from pip._internal.network.download import Downloader
+from pip._vendor.tenacity import retry, stop_after_attempt
+Downloader.__call__ = retry(
+    reraise=True,
+    stop=stop_after_attempt(5),
+    after=lambda state: print(f'!!! retry: attempt {state.attempt_number + 1} !!!')
+)(Downloader.__call__)
+"""
+
+
+def main() -> int:
+    assert not sys.flags.no_site, sys.flags.no_site
+    target = os.path.join(sysconfig.get_path("purelib"), "sentry-pip-hack.pth")
+    assert "/.venv/" in target, target
+
+    print("working around https://github.com/pypa/pip/issues/12383#issuecomment-1808598097")
+    print(f"writing: {target}")
+    with open(target, "w") as f:
+        f.write(f"import sys;exec({PTH!r})\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
https://github.com/pypa/pip/issues/12383#issuecomment-1808598097

this is a terrible hack -- essentially:
- write a small `.pth` file to monkeypatch pip for any calls into the virtualenv site-packages
- add a retrier to `Downloader.__call__`
- instrument all of our virtualenv creation with it