### PR TITLE
fix(ci): Reduce the amount of test data that's stored

### DIFF
--- a/tests/snuba/test_metrics_layer.py
+++ b/tests/snuba/test_metrics_layer.py
@@ -47,7 +47,7 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
         self.org_id = self.project.organization_id
         for mri, metric_type in self.metrics.items():
             assert metric_type in {"counter", "distribution", "set", "gauge"}
-            for i in range(360):
+            for i in range(10):
                 value: int | dict[str, int]
                 if metric_type == "gauge":
                     value = {
@@ -66,8 +66,8 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
                     mri,
                     {
                         "transaction": f"transaction_{i % 2}",
-                        "status_code": "500" if i % 10 == 0 else "200",
-                        "device": "BlackBerry" if i % 3 == 0 else "Nokia",
+                        "status_code": "500" if i % 3 == 0 else "200",
+                        "device": "BlackBerry" if i % 2 == 0 else "Nokia",
                     },
                     self.ts(self.hour_ago + timedelta(minutes=1 * i)),
                     value,
@@ -100,9 +100,9 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
         result = run_query(request)
-        assert len(result["data"]) == 61
+        assert len(result["data"]) == 10
         rows = result["data"]
-        for i in range(61):
+        for i in range(10):
             assert rows[i]["aggregate_value"] == i
             assert (
                 rows[i]["time"]
@@ -139,9 +139,9 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
         result = run_query(request)
-        assert len(result["data"]) == 61
+        assert len(result["data"]) == 10
         rows = result["data"]
-        for i in range(61):
+        for i in range(10):
             assert rows[i]["aggregate_value"] == [i, i]
             assert rows[i]["transaction"] == f"transaction_{i % 2}"
             assert (
@@ -182,16 +182,10 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
         result = run_query(request)
-        assert len(result["data"]) == 3
+        assert len(result["data"]) == 2
         rows = result["data"]
-        for i in range(3):  # 500 status codes on Blackberry are sparse
-            assert rows[i]["aggregate_value"] == [i * 30]
-            assert (
-                rows[i]["time"]
-                == (
-                    self.hour_ago.replace(second=0, microsecond=0) + timedelta(minutes=30 * i)
-                ).isoformat()
-            )
+        assert rows[0]["aggregate_value"] == [0]
+        assert rows[1]["aggregate_value"] == [6.0]
 
     def test_complex(self) -> None:
         query = MetricsQuery(
@@ -225,17 +219,12 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
         result = run_query(request)
-        assert len(result["data"]) == 3
+        assert len(result["data"]) == 2
         rows = result["data"]
-        for i in range(3):  # 500 status codes on BB are sparse
-            assert rows[i]["aggregate_value"] == [i * 30]
-            assert rows[i]["transaction"] == "transaction_0"
-            assert (
-                rows[i]["time"]
-                == (
-                    self.hour_ago.replace(second=0, microsecond=0) + timedelta(minutes=30 * i)
-                ).isoformat()
-            )
+        assert rows[0]["aggregate_value"] == [0]
+        assert rows[0]["transaction"] == "transaction_0"
+        assert rows[1]["aggregate_value"] == [6.0]
+        assert rows[1]["transaction"] == "transaction_0"
 
     def test_totals(self) -> None:
         query = MetricsQuery(
@@ -268,10 +257,8 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
         assert len(result["data"]) == 2
         rows = result["data"]
 
-        assert rows[0]["aggregate_value"] == 58
-        assert rows[0]["transaction"] == "transaction_0"
-        assert rows[1]["aggregate_value"] == 59
-        assert rows[1]["transaction"] == "transaction_1"
+        assert rows[0]["aggregate_value"] == 7.0
+        assert rows[1]["aggregate_value"] == 8.0
 
     def test_meta_data_in_response(self) -> None:
         query = MetricsQuery(
@@ -364,8 +351,8 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
         result = run_query(request)
-        assert len(result["data"]) == 54
-        assert result["totals"]["aggregate_value"] == 59
+        assert len(result["data"]) == 6
+        assert result["totals"]["aggregate_value"] == 8.0
 
     def test_automatic_granularity(self) -> None:
         query = MetricsQuery(
@@ -392,9 +379,10 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
         result = run_query(request)
-        # 30 since it's every 2 minutes.
-        # # TODO(evanh): There's a flaky off by one error that comes from the interval rounding I don't care to fix right now, hence the 31 option.
-        assert len(result["data"]) in [30, 31]
+
+        # There's a flaky off by one error here that is very difficult to track down
+        # TODO: figure out why this is flaky and assert to one specific value
+        assert len(result["data"]) in [5, 6]
 
     def test_automatic_dataset(self) -> None:
         query = MetricsQuery(
@@ -451,8 +439,8 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
         )
         result = run_query(request)
 
-        assert len(result["data"]) == 61
-        assert result["totals"]["aggregate_value"] == 60
+        assert len(result["data"]) == 10
+        assert result["totals"]["aggregate_value"] == 9.0
 
     def test_failure_rate(self) -> None:
         query = MetricsQuery(
@@ -501,5 +489,5 @@ class SnQLTest(TestCase, BaseMetricsTestCase):
         )
         result = run_query(request)
 
-        assert len(result["data"]) == 61
+        assert len(result["data"]) == 10
         assert result["totals"]["aggregate_value"] == 1.0


### PR DESCRIPTION
This test stores a lot of test data, since it gives more granular results and
makes it easier to test different combinations of filters/group by etc.

However it also means the tests run super slowly, so reduce the amount of test
data to give this a bit of a speed boost.