### PR TITLE
feat(metrics-extraction): Add internal tag to widgets for extraction

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -273,11 +273,13 @@ export type EventsStats = {
   end?: number;
   isExtrapolatedData?: boolean;
   isMetricsData?: boolean;
+  isMetricsExtractedData?: boolean;
   meta?: {
     fields: Record<string, AggregationOutputType>;
     isMetricsData: boolean;
     tips: {columns?: string; query?: string};
     units: Record<string, string>;
+    isMetricsExtractedData?: boolean;
   };
   order?: number;
   start?: number;

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -64,6 +64,7 @@ import {getSortField} from './fieldRenderers';
 // Metadata mapping for discover results.
 export type MetaType = Record<string, any> & {
   isMetricsData?: boolean;
+  isMetricsExtractedData?: boolean;
   tips?: {columns: string; query: string};
   units?: Record<string, string>;
 };
@@ -71,6 +72,7 @@ export type EventsMetaType = {fields: Record<string, ColumnType>} & {
   units: Record<string, string>;
 } & {
   isMetricsData?: boolean;
+  isMetricsExtractedData?: boolean;
 };
 
 // Data in discover results.

--- a/static/app/utils/performance/contexts/metricsEnhancedPerformanceDataContext.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedPerformanceDataContext.tsx
@@ -132,7 +132,13 @@ export function MEPTag() {
 export function ExtractedMetricsTag(props: {queryKey: MetricsResultsMetaMapKey}) {
   const resultsMeta = useMetricsResultsMeta();
   const organization = useOrganization();
-  const {forceOnDemand} = useOnDemandControl();
+  const _onDemandControl = useOnDemandControl();
+
+  if (!_onDemandControl) {
+    return null;
+  }
+
+  const {forceOnDemand} = _onDemandControl;
 
   const isMetricsExtractedData =
     resultsMeta?.metricsExtractedDataMap.get(props.queryKey) || undefined;

--- a/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
@@ -24,6 +24,7 @@ export interface MetricsEnhancedSettingContext {
 const [_MEPSettingProvider, _useMEPSettingContext, _MEPSettingContext] =
   createDefinedContext<MetricsEnhancedSettingContext>({
     name: 'MetricsEnhancedSettingContext',
+    strict: false,
   });
 
 export const MEPConsumer = _MEPSettingContext.Consumer;

--- a/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
@@ -24,7 +24,6 @@ export interface MetricsEnhancedSettingContext {
 const [_MEPSettingProvider, _useMEPSettingContext, _MEPSettingContext] =
   createDefinedContext<MetricsEnhancedSettingContext>({
     name: 'MetricsEnhancedSettingContext',
-    strict: false,
   });
 
 export const MEPConsumer = _MEPSettingContext.Consumer;

--- a/static/app/utils/performance/contexts/onDemandControl.tsx
+++ b/static/app/utils/performance/contexts/onDemandControl.tsx
@@ -23,6 +23,7 @@ export interface OnDemandControlContext {
 const [_OnDemandControlProvider, _useOnDemandControl, _context] =
   createDefinedContext<OnDemandControlContext>({
     name: 'OnDemandControlContext',
+    strict: false,
   });
 
 export const OnDemandControlConsumer = _context.Consumer;
@@ -136,6 +137,10 @@ export function ToggleOnDemand() {
   const toggle = useCallback(() => {
     onDemand.setForceOnDemand(!onDemand.forceOnDemand);
   }, [onDemand]);
+
+  if (!onDemand) {
+    return null;
+  }
 
   if (!org.features.includes('on-demand-metrics-extraction-experimental')) {
     return null;

--- a/static/app/utils/performance/contexts/onDemandControl.tsx
+++ b/static/app/utils/performance/contexts/onDemandControl.tsx
@@ -20,12 +20,13 @@ export interface OnDemandControlContext {
   isControlEnabled?: boolean;
 }
 
-const [_OnDemandControlProvider, useOnDemandControl, _context] =
+const [_OnDemandControlProvider, _useOnDemandControl, _context] =
   createDefinedContext<OnDemandControlContext>({
     name: 'OnDemandControlContext',
   });
 
 export const OnDemandControlConsumer = _context.Consumer;
+export const useOnDemandControl = _useOnDemandControl;
 
 export function OnDemandControlProvider({
   children,
@@ -130,7 +131,7 @@ export const shouldUseOnDemandMetrics = (
 
 export function ToggleOnDemand() {
   const org = useOrganization();
-  const onDemand = useOnDemandControl();
+  const onDemand = _useOnDemandControl();
 
   const toggle = useCallback(() => {
     onDemand.setForceOnDemand(!onDemand.forceOnDemand);

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -31,6 +31,7 @@ import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
+import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {OnDemandControlProvider} from 'sentry/utils/performance/contexts/onDemandControl';
 import withApi from 'sentry/utils/withApi';
@@ -657,65 +658,70 @@ class DashboardDetail extends Component<Props, State> {
       >
         <Layout.Page withPadding>
           <OnDemandControlProvider location={location}>
-            <NoProjectMessage organization={organization}>
-              <StyledPageHeader>
-                <Layout.Title>
-                  <DashboardTitle
-                    dashboard={modifiedDashboard ?? dashboard}
-                    onUpdate={this.setModifiedDashboard}
-                    isEditing={this.isEditing}
+            <MetricsResultsMetaProvider>
+              <NoProjectMessage organization={organization}>
+                <StyledPageHeader>
+                  <Layout.Title>
+                    <DashboardTitle
+                      dashboard={modifiedDashboard ?? dashboard}
+                      onUpdate={this.setModifiedDashboard}
+                      isEditing={this.isEditing}
+                    />
+                  </Layout.Title>
+                  <Controls
+                    organization={organization}
+                    dashboards={dashboards}
+                    onEdit={this.onEdit}
+                    onCancel={this.onCancel}
+                    onCommit={this.onCommit}
+                    onAddWidget={this.onAddWidget}
+                    onDelete={this.onDelete(dashboard)}
+                    dashboardState={dashboardState}
+                    widgetLimitReached={widgetLimitReached}
                   />
-                </Layout.Title>
-                <Controls
-                  organization={organization}
-                  dashboards={dashboards}
-                  onEdit={this.onEdit}
-                  onCancel={this.onCancel}
-                  onCommit={this.onCommit}
-                  onAddWidget={this.onAddWidget}
-                  onDelete={this.onDelete(dashboard)}
-                  dashboardState={dashboardState}
-                  widgetLimitReached={widgetLimitReached}
+                </StyledPageHeader>
+                <HookHeader organization={organization} />
+                <FiltersBar
+                  filters={{}} // Default Dashboards don't have filters set
+                  location={location}
+                  hasUnsavedChanges={false}
+                  isEditingDashboard={false}
+                  isPreview={false}
+                  onDashboardFilterChange={this.handleChangeFilter}
                 />
-              </StyledPageHeader>
-              <HookHeader organization={organization} />
-              <FiltersBar
-                filters={{}} // Default Dashboards don't have filters set
-                location={location}
-                hasUnsavedChanges={false}
-                isEditingDashboard={false}
-                isPreview={false}
-                onDashboardFilterChange={this.handleChangeFilter}
-              />
-              <MetricsCardinalityProvider organization={organization} location={location}>
-                <MetricsDataSwitcher
+                <MetricsCardinalityProvider
                   organization={organization}
-                  eventView={EventView.fromLocation(location)}
                   location={location}
                 >
-                  {metricsDataSide => (
-                    <MEPSettingProvider
-                      location={location}
-                      forceTransactions={metricsDataSide.forceTransactionsOnly}
-                    >
-                      <Dashboard
-                        paramDashboardId={dashboardId}
-                        dashboard={modifiedDashboard ?? dashboard}
-                        organization={organization}
-                        isEditing={this.isEditing}
-                        widgetLimitReached={widgetLimitReached}
-                        onUpdate={this.onUpdateWidget}
-                        handleUpdateWidgetList={this.handleUpdateWidgetList}
-                        handleAddCustomWidget={this.handleAddCustomWidget}
-                        isPreview={this.isPreview}
-                        router={router}
+                  <MetricsDataSwitcher
+                    organization={organization}
+                    eventView={EventView.fromLocation(location)}
+                    location={location}
+                  >
+                    {metricsDataSide => (
+                      <MEPSettingProvider
                         location={location}
-                      />
-                    </MEPSettingProvider>
-                  )}
-                </MetricsDataSwitcher>
-              </MetricsCardinalityProvider>
-            </NoProjectMessage>
+                        forceTransactions={metricsDataSide.forceTransactionsOnly}
+                      >
+                        <Dashboard
+                          paramDashboardId={dashboardId}
+                          dashboard={modifiedDashboard ?? dashboard}
+                          organization={organization}
+                          isEditing={this.isEditing}
+                          widgetLimitReached={widgetLimitReached}
+                          onUpdate={this.onUpdateWidget}
+                          handleUpdateWidgetList={this.handleUpdateWidgetList}
+                          handleAddCustomWidget={this.handleAddCustomWidget}
+                          isPreview={this.isPreview}
+                          router={router}
+                          location={location}
+                        />
+                      </MEPSettingProvider>
+                    )}
+                  </MetricsDataSwitcher>
+                </MetricsCardinalityProvider>
+              </NoProjectMessage>
+            </MetricsResultsMetaProvider>
           </OnDemandControlProvider>
         </Layout.Page>
       </PageFiltersContainer>
@@ -778,149 +784,152 @@ class DashboardDetail extends Component<Props, State> {
         >
           <Layout.Page>
             <OnDemandControlProvider location={location}>
-              <NoProjectMessage organization={organization}>
-                <Layout.Header>
-                  <Layout.HeaderContent>
-                    <Breadcrumbs
-                      crumbs={[
-                        {
-                          label: t('Dashboards'),
-                          to: `/organizations/${organization.slug}/dashboards/`,
-                        },
-                        {
-                          label: this.getBreadcrumbLabel(),
-                        },
-                      ]}
-                    />
-                    <Layout.Title>
-                      <DashboardTitle
-                        dashboard={modifiedDashboard ?? dashboard}
-                        onUpdate={this.setModifiedDashboard}
-                        isEditing={this.isEditing}
+              <MetricsResultsMetaProvider>
+                <NoProjectMessage organization={organization}>
+                  <Layout.Header>
+                    <Layout.HeaderContent>
+                      <Breadcrumbs
+                        crumbs={[
+                          {
+                            label: t('Dashboards'),
+                            to: `/organizations/${organization.slug}/dashboards/`,
+                          },
+                          {
+                            label: this.getBreadcrumbLabel(),
+                          },
+                        ]}
                       />
-                    </Layout.Title>
-                  </Layout.HeaderContent>
-                  <Layout.HeaderActions>
-                    <Controls
-                      organization={organization}
-                      dashboards={dashboards}
-                      hasUnsavedFilters={hasUnsavedFilters}
-                      onEdit={this.onEdit}
-                      onCancel={this.onCancel}
-                      onCommit={this.onCommit}
-                      onAddWidget={this.onAddWidget}
-                      onDelete={this.onDelete(dashboard)}
-                      dashboardState={dashboardState}
-                      widgetLimitReached={widgetLimitReached}
-                    />
-                  </Layout.HeaderActions>
-                </Layout.Header>
-                <Layout.Body>
-                  <Layout.Main fullWidth>
-                    <MetricsCardinalityProvider
-                      organization={organization}
-                      location={location}
-                    >
-                      <MetricsDataSwitcher
+                      <Layout.Title>
+                        <DashboardTitle
+                          dashboard={modifiedDashboard ?? dashboard}
+                          onUpdate={this.setModifiedDashboard}
+                          isEditing={this.isEditing}
+                        />
+                      </Layout.Title>
+                    </Layout.HeaderContent>
+                    <Layout.HeaderActions>
+                      <Controls
                         organization={organization}
-                        eventView={eventView}
+                        dashboards={dashboards}
+                        hasUnsavedFilters={hasUnsavedFilters}
+                        onEdit={this.onEdit}
+                        onCancel={this.onCancel}
+                        onCommit={this.onCommit}
+                        onAddWidget={this.onAddWidget}
+                        onDelete={this.onDelete(dashboard)}
+                        dashboardState={dashboardState}
+                        widgetLimitReached={widgetLimitReached}
+                      />
+                    </Layout.HeaderActions>
+                  </Layout.Header>
+                  <Layout.Body>
+                    <Layout.Main fullWidth>
+                      <MetricsCardinalityProvider
+                        organization={organization}
                         location={location}
                       >
-                        {metricsDataSide => (
-                          <MEPSettingProvider
-                            location={location}
-                            forceTransactions={metricsDataSide.forceTransactionsOnly}
-                          >
-                            {isDashboardUsingTransaction ? (
-                              <MetricsDataSwitcherAlert
-                                organization={organization}
-                                eventView={eventView}
-                                projects={projects}
-                                location={location}
-                                router={router}
-                                source={DiscoverQueryPageSource.DISCOVER}
-                                {...metricsDataSide}
-                              />
-                            ) : null}
-                            <FiltersBar
-                              filters={(modifiedDashboard ?? dashboard).filters}
+                        <MetricsDataSwitcher
+                          organization={organization}
+                          eventView={eventView}
+                          location={location}
+                        >
+                          {metricsDataSide => (
+                            <MEPSettingProvider
                               location={location}
-                              hasUnsavedChanges={hasUnsavedFilters}
-                              isEditingDashboard={
-                                dashboardState !== DashboardState.CREATE && this.isEditing
-                              }
-                              isPreview={this.isPreview}
-                              onDashboardFilterChange={this.handleChangeFilter}
-                              onCancel={() => {
-                                resetPageFilters(dashboard, location);
-                                this.setState({
-                                  modifiedDashboard: {
-                                    ...(modifiedDashboard ?? dashboard),
-                                    filters: dashboard.filters,
-                                  },
-                                });
-                              }}
-                              onSave={() => {
-                                const newModifiedDashboard = {
-                                  ...cloneDashboard(modifiedDashboard ?? dashboard),
-                                  ...getCurrentPageFilters(location),
-                                  filters:
-                                    getDashboardFiltersFromURL(location) ??
-                                    (modifiedDashboard ?? dashboard).filters,
-                                };
-                                updateDashboard(
-                                  api,
-                                  organization.slug,
-                                  newModifiedDashboard
-                                ).then(
-                                  (newDashboard: DashboardDetails) => {
-                                    if (onDashboardUpdate) {
-                                      onDashboardUpdate(newDashboard);
-                                      this.setState({
-                                        modifiedDashboard: null,
-                                      });
-                                    }
-                                    addSuccessMessage(t('Dashboard filters updated'));
-                                    browserHistory.replace(
-                                      normalizeUrl({
-                                        pathname: `/organizations/${organization.slug}/dashboard/${newDashboard.id}/`,
-                                        query: omit(
-                                          location.query,
-                                          Object.values(DashboardFilterKeys)
-                                        ),
-                                      })
-                                    );
-                                  },
-                                  // `updateDashboard` does its own error handling
-                                  () => undefined
-                                );
-                              }}
-                            />
-
-                            <WidgetViewerContext.Provider value={{seriesData, setData}}>
-                              <Dashboard
-                                paramDashboardId={dashboardId}
-                                dashboard={modifiedDashboard ?? dashboard}
-                                organization={organization}
-                                isEditing={this.isEditing}
-                                widgetLimitReached={widgetLimitReached}
-                                onUpdate={this.onUpdateWidget}
-                                handleUpdateWidgetList={this.handleUpdateWidgetList}
-                                handleAddCustomWidget={this.handleAddCustomWidget}
-                                router={router}
+                              forceTransactions={metricsDataSide.forceTransactionsOnly}
+                            >
+                              {isDashboardUsingTransaction ? (
+                                <MetricsDataSwitcherAlert
+                                  organization={organization}
+                                  eventView={eventView}
+                                  projects={projects}
+                                  location={location}
+                                  router={router}
+                                  source={DiscoverQueryPageSource.DISCOVER}
+                                  {...metricsDataSide}
+                                />
+                              ) : null}
+                              <FiltersBar
+                                filters={(modifiedDashboard ?? dashboard).filters}
                                 location={location}
-                                newWidget={newWidget}
-                                onSetNewWidget={onSetNewWidget}
+                                hasUnsavedChanges={hasUnsavedFilters}
+                                isEditingDashboard={
+                                  dashboardState !== DashboardState.CREATE &&
+                                  this.isEditing
+                                }
                                 isPreview={this.isPreview}
+                                onDashboardFilterChange={this.handleChangeFilter}
+                                onCancel={() => {
+                                  resetPageFilters(dashboard, location);
+                                  this.setState({
+                                    modifiedDashboard: {
+                                      ...(modifiedDashboard ?? dashboard),
+                                      filters: dashboard.filters,
+                                    },
+                                  });
+                                }}
+                                onSave={() => {
+                                  const newModifiedDashboard = {
+                                    ...cloneDashboard(modifiedDashboard ?? dashboard),
+                                    ...getCurrentPageFilters(location),
+                                    filters:
+                                      getDashboardFiltersFromURL(location) ??
+                                      (modifiedDashboard ?? dashboard).filters,
+                                  };
+                                  updateDashboard(
+                                    api,
+                                    organization.slug,
+                                    newModifiedDashboard
+                                  ).then(
+                                    (newDashboard: DashboardDetails) => {
+                                      if (onDashboardUpdate) {
+                                        onDashboardUpdate(newDashboard);
+                                        this.setState({
+                                          modifiedDashboard: null,
+                                        });
+                                      }
+                                      addSuccessMessage(t('Dashboard filters updated'));
+                                      browserHistory.replace(
+                                        normalizeUrl({
+                                          pathname: `/organizations/${organization.slug}/dashboard/${newDashboard.id}/`,
+                                          query: omit(
+                                            location.query,
+                                            Object.values(DashboardFilterKeys)
+                                          ),
+                                        })
+                                      );
+                                    },
+                                    // `updateDashboard` does its own error handling
+                                    () => undefined
+                                  );
+                                }}
                               />
-                            </WidgetViewerContext.Provider>
-                          </MEPSettingProvider>
-                        )}
-                      </MetricsDataSwitcher>
-                    </MetricsCardinalityProvider>
-                  </Layout.Main>
-                </Layout.Body>
-              </NoProjectMessage>
+
+                              <WidgetViewerContext.Provider value={{seriesData, setData}}>
+                                <Dashboard
+                                  paramDashboardId={dashboardId}
+                                  dashboard={modifiedDashboard ?? dashboard}
+                                  organization={organization}
+                                  isEditing={this.isEditing}
+                                  widgetLimitReached={widgetLimitReached}
+                                  onUpdate={this.onUpdateWidget}
+                                  handleUpdateWidgetList={this.handleUpdateWidgetList}
+                                  handleAddCustomWidget={this.handleAddCustomWidget}
+                                  router={router}
+                                  location={location}
+                                  newWidget={newWidget}
+                                  onSetNewWidget={onSetNewWidget}
+                                  isPreview={this.isPreview}
+                                />
+                              </WidgetViewerContext.Provider>
+                            </MEPSettingProvider>
+                          )}
+                        </MetricsDataSwitcher>
+                      </MetricsCardinalityProvider>
+                    </Layout.Main>
+                  </Layout.Body>
+                </NoProjectMessage>
+              </MetricsResultsMetaProvider>
             </OnDemandControlProvider>
           </Layout.Page>
         </PageFiltersContainer>

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -35,7 +35,9 @@ import {
   QueryFieldValue,
 } from 'sentry/utils/discover/fields';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
+import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {OnDemandControlProvider} from 'sentry/utils/performance/contexts/onDemandControl';
 import useApi from 'sentry/utils/useApi';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withPageFilters from 'sentry/utils/withPageFilters';
@@ -1041,221 +1043,231 @@ function WidgetBuilder({
         }}
       >
         <CustomMeasurementsProvider organization={organization} selection={selection}>
-          <DashboardsMEPProvider>
-            <MetricsCardinalityProvider organization={organization} location={location}>
-              <MetricsDataSwitcher
-                organization={organization}
-                eventView={EventView.fromLocation(location)}
-                location={location}
-                hideLoadingIndicator
-              >
-                {metricsDataSide => (
-                  <MEPSettingProvider
+          <OnDemandControlProvider>
+            <MetricsResultsMetaProvider>
+              <DashboardsMEPProvider>
+                <MetricsCardinalityProvider
+                  organization={organization}
+                  location={location}
+                >
+                  <MetricsDataSwitcher
+                    organization={organization}
+                    eventView={EventView.fromLocation(location)}
                     location={location}
-                    forceTransactions={metricsDataSide.forceTransactionsOnly}
+                    hideLoadingIndicator
                   >
-                    <Layout.Page>
-                      <Header
-                        orgSlug={orgSlug}
-                        dashboardTitle={dashboard.title}
-                        goBackLocation={previousLocation}
-                      />
-                      <Body>
-                        <MainWrapper>
-                          <Main>
-                            <BuildSteps symbol="colored-numeric">
-                              <NameWidgetStep title={t('Name your widget')}>
-                                <TitleInput
-                                  name="title"
-                                  inline={false}
-                                  aria-label={t('Widget title')}
-                                  placeholder={t('Enter title')}
-                                  error={state.errors?.title}
-                                  data-test-id="widget-builder-title-input"
-                                  onChange={newTitle => {
-                                    handleDisplayTypeOrAnnotationChange(
-                                      'title',
-                                      newTitle
-                                    );
-                                  }}
-                                  value={state.title}
-                                />
-                                <StyledTextAreaField
-                                  name="description"
-                                  rows={4}
-                                  autosize
-                                  inline={false}
-                                  aria-label={t('Widget Description')}
-                                  placeholder={t('Enter description (Optional)')}
-                                  error={state.errors?.description}
-                                  onChange={newDescription => {
-                                    handleDisplayTypeOrAnnotationChange(
-                                      'description',
-                                      newDescription
-                                    );
-                                  }}
-                                  value={state.description}
-                                />
-                              </NameWidgetStep>
-                              <VisualizationStep
-                                location={location}
-                                onDataFetched={handleWidgetDataFetched}
-                                widget={currentWidget}
-                                dashboardFilters={dashboard.filters}
-                                organization={organization}
-                                pageFilters={pageFilters}
-                                displayType={state.displayType}
-                                error={state.errors?.displayType}
-                                onChange={newDisplayType => {
-                                  handleDisplayTypeOrAnnotationChange(
-                                    'displayType',
-                                    newDisplayType
-                                  );
-                                }}
-                                noDashboardsMEPProvider
-                                isWidgetInvalid={!state.queryConditionsValid}
-                              />
-                              <DataSetStep
-                                dataSet={state.dataSet}
-                                displayType={state.displayType}
-                                onChange={handleDataSetChange}
-                                hasReleaseHealthFeature={hasReleaseHealthFeature}
-                                hasCustomMetricsFeature={hasCustomMetricsFeature}
-                              />
-                              {isTabularChart && (
-                                <DashboardsMEPConsumer>
-                                  {({isMetricsData}) => (
-                                    <ColumnsStep
+                    {metricsDataSide => (
+                      <MEPSettingProvider
+                        location={location}
+                        forceTransactions={metricsDataSide.forceTransactionsOnly}
+                      >
+                        <Layout.Page>
+                          <Header
+                            orgSlug={orgSlug}
+                            dashboardTitle={dashboard.title}
+                            goBackLocation={previousLocation}
+                          />
+                          <Body>
+                            <MainWrapper>
+                              <Main>
+                                <BuildSteps symbol="colored-numeric">
+                                  <NameWidgetStep title={t('Name your widget')}>
+                                    <TitleInput
+                                      name="title"
+                                      inline={false}
+                                      aria-label={t('Widget title')}
+                                      placeholder={t('Enter title')}
+                                      error={state.errors?.title}
+                                      data-test-id="widget-builder-title-input"
+                                      onChange={newTitle => {
+                                        handleDisplayTypeOrAnnotationChange(
+                                          'title',
+                                          newTitle
+                                        );
+                                      }}
+                                      value={state.title}
+                                    />
+                                    <StyledTextAreaField
+                                      name="description"
+                                      rows={4}
+                                      autosize
+                                      inline={false}
+                                      aria-label={t('Widget Description')}
+                                      placeholder={t('Enter description (Optional)')}
+                                      error={state.errors?.description}
+                                      onChange={newDescription => {
+                                        handleDisplayTypeOrAnnotationChange(
+                                          'description',
+                                          newDescription
+                                        );
+                                      }}
+                                      value={state.description}
+                                    />
+                                  </NameWidgetStep>
+                                  <VisualizationStep
+                                    location={location}
+                                    onDataFetched={handleWidgetDataFetched}
+                                    widget={currentWidget}
+                                    dashboardFilters={dashboard.filters}
+                                    organization={organization}
+                                    pageFilters={pageFilters}
+                                    displayType={state.displayType}
+                                    error={state.errors?.displayType}
+                                    onChange={newDisplayType => {
+                                      handleDisplayTypeOrAnnotationChange(
+                                        'displayType',
+                                        newDisplayType
+                                      );
+                                    }}
+                                    noDashboardsMEPProvider
+                                    isWidgetInvalid={!state.queryConditionsValid}
+                                  />
+                                  <DataSetStep
+                                    dataSet={state.dataSet}
+                                    displayType={state.displayType}
+                                    onChange={handleDataSetChange}
+                                    hasReleaseHealthFeature={hasReleaseHealthFeature}
+                                    hasCustomMetricsFeature={hasCustomMetricsFeature}
+                                  />
+                                  {isTabularChart && (
+                                    <DashboardsMEPConsumer>
+                                      {({isMetricsData}) => (
+                                        <ColumnsStep
+                                          dataSet={state.dataSet}
+                                          queries={state.queries}
+                                          displayType={state.displayType}
+                                          widgetType={widgetType}
+                                          queryErrors={state.errors?.queries}
+                                          onQueryChange={handleQueryChange}
+                                          handleColumnFieldChange={getHandleColumnFieldChange(
+                                            isMetricsData
+                                          )}
+                                          explodedFields={explodedFields}
+                                          tags={tags}
+                                          organization={organization}
+                                        />
+                                      )}
+                                    </DashboardsMEPConsumer>
+                                  )}
+                                  {![DisplayType.TABLE].includes(state.displayType) && (
+                                    <YAxisStep
                                       dataSet={state.dataSet}
-                                      queries={state.queries}
                                       displayType={state.displayType}
                                       widgetType={widgetType}
                                       queryErrors={state.errors?.queries}
-                                      onQueryChange={handleQueryChange}
-                                      handleColumnFieldChange={getHandleColumnFieldChange(
-                                        isMetricsData
-                                      )}
-                                      explodedFields={explodedFields}
+                                      onYAxisChange={newFields => {
+                                        handleYAxisChange(newFields);
+                                      }}
+                                      aggregates={explodedAggregates}
                                       tags={tags}
                                       organization={organization}
                                     />
                                   )}
-                                </DashboardsMEPConsumer>
-                              )}
-                              {![DisplayType.TABLE].includes(state.displayType) && (
-                                <YAxisStep
-                                  dataSet={state.dataSet}
-                                  displayType={state.displayType}
-                                  widgetType={widgetType}
-                                  queryErrors={state.errors?.queries}
-                                  onYAxisChange={newFields => {
-                                    handleYAxisChange(newFields);
-                                  }}
-                                  aggregates={explodedAggregates}
-                                  tags={tags}
-                                  organization={organization}
-                                />
-                              )}
-                              <FilterResultsStep
-                                queries={state.queries}
-                                hideLegendAlias={hideLegendAlias}
-                                canAddSearchConditions={canAddSearchConditions}
-                                organization={organization}
-                                queryErrors={state.errors?.queries}
-                                onAddSearchConditions={handleAddSearchConditions}
-                                onQueryChange={handleQueryChange}
-                                onQueryRemove={handleQueryRemove}
-                                selection={pageFilters}
-                                widgetType={widgetType}
-                                dashboardFilters={dashboard.filters}
-                                location={location}
-                                onQueryConditionChange={setQueryConditionsValid}
-                              />
-                              {isTimeseriesChart && (
-                                <GroupByStep
-                                  columns={columns
-                                    .filter(field => !(field === 'equation|'))
-                                    .map((field, index) =>
-                                      explodeField({field, alias: fieldAliases[index]})
-                                    )}
-                                  onGroupByChange={handleGroupByChange}
-                                  organization={organization}
-                                  tags={tags}
-                                  dataSet={state.dataSet}
-                                />
-                              )}
-                              {displaySortByStep && (
-                                <SortByStep
-                                  limit={state.limit}
-                                  displayType={state.displayType}
-                                  queries={state.queries}
-                                  dataSet={state.dataSet}
-                                  error={state.errors?.orderby}
-                                  onSortByChange={handleSortByChange}
-                                  onLimitChange={handleLimitChange}
-                                  organization={organization}
-                                  widgetType={widgetType}
-                                  tags={tags}
-                                />
-                              )}
-                              {state.displayType === 'big_number' &&
-                                state.dataType !== 'date' &&
-                                organization.features.includes(
-                                  'dashboard-widget-indicators'
-                                ) && (
-                                  <ThresholdsStep
-                                    onThresholdChange={handleThresholdChange}
-                                    onUnitChange={handleThresholdUnitChange}
-                                    thresholdsConfig={state.thresholds ?? null}
-                                    dataType={state.dataType}
-                                    dataUnit={state.dataUnit}
-                                    errors={state.errors?.thresholds}
+                                  <FilterResultsStep
+                                    queries={state.queries}
+                                    hideLegendAlias={hideLegendAlias}
+                                    canAddSearchConditions={canAddSearchConditions}
+                                    organization={organization}
+                                    queryErrors={state.errors?.queries}
+                                    onAddSearchConditions={handleAddSearchConditions}
+                                    onQueryChange={handleQueryChange}
+                                    onQueryRemove={handleQueryRemove}
+                                    selection={pageFilters}
+                                    widgetType={widgetType}
+                                    dashboardFilters={dashboard.filters}
+                                    location={location}
+                                    onQueryConditionChange={setQueryConditionsValid}
                                   />
-                                )}
-                            </BuildSteps>
-                          </Main>
-                          <Footer
-                            goBackLocation={previousLocation}
-                            isEditing={isEditing}
-                            onSave={handleSave}
-                            onDelete={handleDelete}
-                            invalidForm={isFormInvalid()}
-                          />
-                        </MainWrapper>
-                        <Side>
-                          <WidgetLibrary
-                            organization={organization}
-                            selectedWidgetId={
-                              state.userHasModified ? null : state.prebuiltWidgetId
-                            }
-                            onWidgetSelect={prebuiltWidget => {
-                              setLatestLibrarySelectionTitle(prebuiltWidget.title);
-                              setDataSetConfig(
-                                getDatasetConfig(
-                                  prebuiltWidget.widgetType || WidgetType.DISCOVER
-                                )
-                              );
-                              const {id, ...prebuiltWidgetProps} = prebuiltWidget;
-                              setState({
-                                ...state,
-                                ...prebuiltWidgetProps,
-                                dataSet: prebuiltWidget.widgetType
-                                  ? WIDGET_TYPE_TO_DATA_SET[prebuiltWidget.widgetType]
-                                  : DataSet.EVENTS,
-                                userHasModified: false,
-                                prebuiltWidgetId: id || null,
-                              });
-                            }}
-                            bypassOverwriteModal={!state.userHasModified}
-                          />
-                        </Side>
-                      </Body>
-                    </Layout.Page>
-                  </MEPSettingProvider>
-                )}
-              </MetricsDataSwitcher>
-            </MetricsCardinalityProvider>
-          </DashboardsMEPProvider>
+                                  {isTimeseriesChart && (
+                                    <GroupByStep
+                                      columns={columns
+                                        .filter(field => !(field === 'equation|'))
+                                        .map((field, index) =>
+                                          explodeField({
+                                            field,
+                                            alias: fieldAliases[index],
+                                          })
+                                        )}
+                                      onGroupByChange={handleGroupByChange}
+                                      organization={organization}
+                                      tags={tags}
+                                      dataSet={state.dataSet}
+                                    />
+                                  )}
+                                  {displaySortByStep && (
+                                    <SortByStep
+                                      limit={state.limit}
+                                      displayType={state.displayType}
+                                      queries={state.queries}
+                                      dataSet={state.dataSet}
+                                      error={state.errors?.orderby}
+                                      onSortByChange={handleSortByChange}
+                                      onLimitChange={handleLimitChange}
+                                      organization={organization}
+                                      widgetType={widgetType}
+                                      tags={tags}
+                                    />
+                                  )}
+                                  {state.displayType === 'big_number' &&
+                                    state.dataType !== 'date' &&
+                                    organization.features.includes(
+                                      'dashboard-widget-indicators'
+                                    ) && (
+                                      <ThresholdsStep
+                                        onThresholdChange={handleThresholdChange}
+                                        onUnitChange={handleThresholdUnitChange}
+                                        thresholdsConfig={state.thresholds ?? null}
+                                        dataType={state.dataType}
+                                        dataUnit={state.dataUnit}
+                                        errors={state.errors?.thresholds}
+                                      />
+                                    )}
+                                </BuildSteps>
+                              </Main>
+                              <Footer
+                                goBackLocation={previousLocation}
+                                isEditing={isEditing}
+                                onSave={handleSave}
+                                onDelete={handleDelete}
+                                invalidForm={isFormInvalid()}
+                              />
+                            </MainWrapper>
+                            <Side>
+                              <WidgetLibrary
+                                organization={organization}
+                                selectedWidgetId={
+                                  state.userHasModified ? null : state.prebuiltWidgetId
+                                }
+                                onWidgetSelect={prebuiltWidget => {
+                                  setLatestLibrarySelectionTitle(prebuiltWidget.title);
+                                  setDataSetConfig(
+                                    getDatasetConfig(
+                                      prebuiltWidget.widgetType || WidgetType.DISCOVER
+                                    )
+                                  );
+                                  const {id, ...prebuiltWidgetProps} = prebuiltWidget;
+                                  setState({
+                                    ...state,
+                                    ...prebuiltWidgetProps,
+                                    dataSet: prebuiltWidget.widgetType
+                                      ? WIDGET_TYPE_TO_DATA_SET[prebuiltWidget.widgetType]
+                                      : DataSet.EVENTS,
+                                    userHasModified: false,
+                                    prebuiltWidgetId: id || null,
+                                  });
+                                }}
+                                bypassOverwriteModal={!state.userHasModified}
+                              />
+                            </Side>
+                          </Body>
+                        </Layout.Page>
+                      </MEPSettingProvider>
+                    )}
+                  </MetricsDataSwitcher>
+                </MetricsCardinalityProvider>
+              </DashboardsMEPProvider>
+            </MetricsResultsMetaProvider>
+          </OnDemandControlProvider>
         </CustomMeasurementsProvider>
       </PageFiltersContainer>
     </SentryDocumentTitle>

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -1043,7 +1043,7 @@ function WidgetBuilder({
         }}
       >
         <CustomMeasurementsProvider organization={organization} selection={selection}>
-          <OnDemandControlProvider>
+          <OnDemandControlProvider location={location}>
             <MetricsResultsMetaProvider>
               <DashboardsMEPProvider>
                 <MetricsCardinalityProvider

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -25,6 +25,7 @@ import {Series} from 'sentry/types/echarts';
 import {getFormattedDate} from 'sentry/utils/dates';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {AggregationOutputType, parseFunction} from 'sentry/utils/discover/fields';
+import {ExtractedMetricsTag} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {
   MEPConsumer,
   MEPState,
@@ -323,6 +324,7 @@ class WidgetCard extends Component<Props, State> {
                           widget.thresholds,
                           this.state.tableData
                         )}
+                      <ExtractedMetricsTag queryKey={widget} />
                     </WidgetTitleRow>
                     {widget.description && (
                       <Tooltip

--- a/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
@@ -5,6 +5,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFilters} from 'sentry/types';
+import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {DashboardFilterKeys, DisplayType} from 'sentry/views/dashboards/types';
 import {DashboardsMEPContext} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
@@ -18,7 +19,9 @@ describe('Dashboards > WidgetQueries', function () {
 
   const renderWithProviders = component =>
     render(
-      <MEPSettingProvider forceTransactions={false}>{component}</MEPSettingProvider>
+      <MetricsResultsMetaProvider>
+        <MEPSettingProvider forceTransactions={false}>{component}</MEPSettingProvider>
+      </MetricsResultsMetaProvider>
     );
 
   const multipleQueryWidget = {
@@ -682,31 +685,33 @@ describe('Dashboards > WidgetQueries', function () {
 
     // Simulate a re-render with a new query alias
     rerender(
-      <MEPSettingProvider forceTransactions={false}>
-        <WidgetQueries
-          api={new MockApiClient()}
-          widget={{
-            ...lineWidget,
-            queries: [
-              {
-                conditions: 'event.type:error',
-                fields: ['count()'],
-                aggregates: ['count()'],
-                columns: [],
-                name: 'this query alias changed',
-                orderby: '',
-              },
-            ],
-          }}
-          organization={initialData.organization}
-          selection={selection}
-        >
-          {props => {
-            childProps = props;
-            return <div data-test-id="child" />;
-          }}
-        </WidgetQueries>
-      </MEPSettingProvider>
+      <MetricsResultsMetaProvider>
+        <MEPSettingProvider forceTransactions={false}>
+          <WidgetQueries
+            api={new MockApiClient()}
+            widget={{
+              ...lineWidget,
+              queries: [
+                {
+                  conditions: 'event.type:error',
+                  fields: ['count()'],
+                  aggregates: ['count()'],
+                  columns: [],
+                  name: 'this query alias changed',
+                  orderby: '',
+                },
+              ],
+            }}
+            organization={initialData.organization}
+            selection={selection}
+          >
+            {props => {
+              childProps = props;
+              return <div data-test-id="child" />;
+            }}
+          </WidgetQueries>
+        </MEPSettingProvider>
+      </MetricsResultsMetaProvider>
     );
 
     // Did not re-query

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -156,6 +156,9 @@ function WidgetQueries({
       if (rawResults.isMetricsData !== undefined) {
         isSeriesMetricsDataResults.push(rawResults.isMetricsData);
       }
+      if (rawResults.isMetricsExtractedData !== undefined) {
+        isSeriesMetricsExtractedDataResults.push(rawResults.isMetricsExtractedData);
+      }
       isSeriesMetricsExtractedDataResults.push(rawResults.isMetricsExtractedData);
     } else {
       Object.keys(rawResults).forEach(key => {
@@ -163,7 +166,9 @@ function WidgetQueries({
         if (rawResult.isMetricsData !== undefined) {
           isSeriesMetricsDataResults.push(rawResult.isMetricsData);
         }
-        isSeriesMetricsExtractedDataResults.push(rawResult.isMetricsExtractedData);
+        if (rawResult.isMetricsExtractedData !== undefined) {
+          isSeriesMetricsExtractedDataResults.push(rawResult.isMetricsExtractedData);
+        }
       });
     }
     // If one of the queries is sampled, then mark the whole thing as sampled
@@ -181,7 +186,9 @@ function WidgetQueries({
     if (rawResults.meta?.isMetricsData !== undefined) {
       isTableMetricsDataResults.push(rawResults.meta.isMetricsData);
     }
-    isTableMetricsExtractedDataResults.push(rawResults.meta.isMetricsExtractedData);
+    if (rawResults.meta?.isMetricsExtractedData !== undefined) {
+      isTableMetricsExtractedDataResults.push(rawResults.meta.isMetricsExtractedData);
+    }
     // If one of the queries is sampled, then mark the whole thing as sampled
     setIsMetricsData?.(!isTableMetricsDataResults.includes(false));
     setIsMetricsExtractedData?.(

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -143,6 +143,8 @@ function WidgetQueries({
 
   if (context) {
     setIsMetricsData = context.setIsMetricsData;
+  }
+  if (metricsMeta) {
     setIsMetricsExtractedData = metricsMeta.setIsMetricsExtractedData;
   }
 

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -171,7 +171,7 @@ function WidgetQueries({
     setIsMetricsExtractedData?.(
       widget,
       isSeriesMetricsExtractedDataResults.every(Boolean) &&
-        isSerieswMetricsExtractedDataResults.some(Boolean)
+        isSeriesMetricsExtractedDataResults.some(Boolean)
     );
   };
 

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -13,6 +13,10 @@ import {Series} from 'sentry/types/echarts';
 import {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
 import {DURATION_UNITS, SIZE_UNITS} from 'sentry/utils/discover/fieldRenderers';
 import {getAggregateAlias} from 'sentry/utils/discover/fields';
+import {
+  MetricsResultsMetaMapKey,
+  useMetricsResultsMeta,
+} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {OnDemandControlConsumer} from 'sentry/utils/performance/contexts/onDemandControl';
 
@@ -129,40 +133,60 @@ function WidgetQueries({
 }: Props) {
   const config = ErrorsAndTransactionsConfig;
   const context = useContext(DashboardsMEPContext);
+  const metricsMeta = useMetricsResultsMeta();
   const mepSettingContext = useMEPSettingContext();
 
   let setIsMetricsData: undefined | ((value?: boolean) => void);
+  let setIsMetricsExtractedData:
+    | undefined
+    | ((mapKey: MetricsResultsMetaMapKey, value?: boolean) => void);
 
   if (context) {
     setIsMetricsData = context.setIsMetricsData;
+    setIsMetricsExtractedData = metricsMeta.setIsMetricsExtractedData;
   }
 
   const isSeriesMetricsDataResults: boolean[] = [];
+  const isSeriesMetricsExtractedDataResults: (boolean | undefined)[] = [];
   const afterFetchSeriesData = (rawResults: SeriesResult) => {
     if (rawResults.data) {
       rawResults = rawResults as EventsStats;
       if (rawResults.isMetricsData !== undefined) {
         isSeriesMetricsDataResults.push(rawResults.isMetricsData);
       }
+      isSeriesMetricsExtractedDataResults.push(rawResults.isMetricsExtractedData);
     } else {
       Object.keys(rawResults).forEach(key => {
         const rawResult: EventsStats = rawResults[key];
         if (rawResult.isMetricsData !== undefined) {
           isSeriesMetricsDataResults.push(rawResult.isMetricsData);
         }
+        isSeriesMetricsExtractedDataResults.push(rawResult.isMetricsExtractedData);
       });
     }
     // If one of the queries is sampled, then mark the whole thing as sampled
     setIsMetricsData?.(!isSeriesMetricsDataResults.includes(false));
+    setIsMetricsExtractedData?.(
+      widget,
+      isSeriesMetricsExtractedDataResults.every(Boolean) &&
+        isSerieswMetricsExtractedDataResults.some(Boolean)
+    );
   };
 
   const isTableMetricsDataResults: boolean[] = [];
+  const isTableMetricsExtractedDataResults: boolean[] = [];
   const afterFetchTableData = (rawResults: TableResult) => {
     if (rawResults.meta?.isMetricsData !== undefined) {
       isTableMetricsDataResults.push(rawResults.meta.isMetricsData);
     }
+    isTableMetricsExtractedDataResults.push(rawResults.meta.isMetricsExtractedData);
     // If one of the queries is sampled, then mark the whole thing as sampled
     setIsMetricsData?.(!isTableMetricsDataResults.includes(false));
+    setIsMetricsExtractedData?.(
+      widget,
+      isTableMetricsExtractedDataResults.every(Boolean) &&
+        isTableMetricsExtractedDataResults.some(Boolean)
+    );
   };
 
   return (

--- a/static/app/views/performance/landing/widgets/components/queryHandler.tsx
+++ b/static/app/views/performance/landing/widgets/components/queryHandler.tsx
@@ -3,7 +3,6 @@ import {Fragment, useEffect} from 'react';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {
   getIsMetricsDataFromResults,
-  getIsOnDemandDataFromResults,
   useMEPDataContext,
 } from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 
@@ -105,12 +104,7 @@ function QueryResultSaver<T extends WidgetDataConstraint>(
       results,
       props.queryProps.fields[0]
     );
-    const isOnDemandData = getIsOnDemandDataFromResults(
-      results,
-      props.queryProps.fields[0]
-    );
     mepContext.setIsMetricsData(isMetricsData);
-    mepContext.setIsOnDemandData(isOnDemandData);
     props.setWidgetDataForKey(query.queryKey, transformed);
   }, [transformed?.hasData, transformed?.isLoading, transformed?.isErrored]);
   return <Fragment />;


### PR DESCRIPTION
### Summary
This will consume the 'isMetricsExtractedData' out of the meta and show the extracted state on the widget for visual spot checks of data quality. Had to re-arrange some providers since widget component rendering and their queries aren't local and able to fit into a per-widget provider.

### Screenshots
![Screenshot 2023-11-17 at 3 23 17 PM](https://github.com/getsentry/sentry/assets/6111995/12de1398-18d5-4aa5-908d-165c6a52dfae)
