### PR TITLE
ref(feedback): add text overflow and tooltip on tags

### DIFF
--- a/static/app/components/feedback/feedbackItem/tagsSection.tsx
+++ b/static/app/components/feedback/feedbackItem/tagsSection.tsx
@@ -1,6 +1,8 @@
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Section from 'sentry/components/feedback/feedbackItem/feedbackItemSection';
 import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
+import TextOverflow from 'sentry/components/textOverflow';
+import {Tooltip} from 'sentry/components/tooltip';
 import {IconTag} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
@@ -19,7 +21,15 @@ export default function TagsSection({tags}: Props) {
       <ErrorBoundary mini>
         <KeyValueTable noMargin>
           {entries.map(([key, value]) => (
-            <KeyValueTableRow key={key} keyName={key} value={value} />
+            <KeyValueTableRow
+              key={key}
+              keyName={key}
+              value={
+                <Tooltip showOnlyOnOverflow title={value}>
+                  <TextOverflow>{value}</TextOverflow>
+                </Tooltip>
+              }
+            />
           ))}
         </KeyValueTable>
       </ErrorBoundary>


### PR DESCRIPTION
small UI fix

before:
<img width="325" alt="SCR-20231117-lgrm" src="https://github.com/getsentry/sentry/assets/56095982/713cce36-8ac3-426c-ae63-0b883ad2fe21">


after:

https://github.com/getsentry/sentry/assets/56095982/000ff29d-8666-47f8-9d3e-8f01024ab14c

