### PR TITLE
fix(github-invite): use coalesce instead of concat

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -100,7 +100,7 @@ def _get_missing_organization_members(
             (select id from sentry_commitauthor
                 WHERE sentry_commitauthor.organization_id = %(org_id)s
                 AND NOT (
-                    (sentry_commitauthor.email IN (select concat(email, user_email) from sentry_organizationmember where organization_id = %(org_id)s and (email is not null or user_email is not null)
+                    (sentry_commitauthor.email IN (select coalesce(email, user_email) from sentry_organizationmember where organization_id = %(org_id)s and (email is not null or user_email is not null)
                 )
         OR sentry_commitauthor.external_id IS NULL))
     """

--- a/tests/sentry/api/endpoints/test_organization_missing_org_members.py
+++ b/tests/sentry/api/endpoints/test_organization_missing_org_members.py
@@ -73,6 +73,19 @@ class OrganizationMissingMembersTestCase(APITestCase):
         not_shared_domain_author.save()
         self.create_commit(repo=self.repo, author=not_shared_domain_author)
 
+        self.invited_member = self.create_member(
+            email="invited@example.com",
+            organization=self.organization,
+        )
+        self.invited_member.user_email = "invited@example.com"
+        self.invited_member.save()
+        self.invited_member_commit_author = self.create_commit_author(
+            project=self.project, email="invited@example.com"
+        )
+        self.invited_member_commit_author.external_id = "github:invited"
+        self.invited_member_commit_author.save()
+        self.create_commit(repo=self.repo, author=self.invited_member_commit_author)
+
         self.login_as(self.user)
 
     def test_shared_domain_filter(self):


### PR DESCRIPTION
`CONCAT` on two columns literally takes the two columns row by row and concats them. So if there are two columns in which the rows are `email@example.com` and `email@example.com`, `CONCAT` outputs `email@example.comemail@example.com`.

`COALESCE` is the correct command for what we want to accomplish, which is just to output `email@example.com`.

This was causing invited members to be shown in the invite banner because their `email` and `user_email` columns were being concatenated.