### PR TITLE
ref(weekly-reports): stat logging for specific orgs

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1855,6 +1855,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:metric-alert-rate-limiting": False,
     # Enable the new suspect commits calculation that uses all frames in the stack trace
     "organizations:suspect-commits-all-frames": False,
+    # Enable logs for debugging weekly reports
+    "organizations:weekly-report-logs": False,
     # Enable data forwarding functionality for projects.
     "projects:data-forwarding": True,
     # Enable functionality to discard groups.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -268,6 +268,7 @@ default_manager.add("organizations:releases-v2", OrganizationFeature, FeatureHan
 default_manager.add("organizations:releases-v2-st", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:source-maps-debugger-blue-thunder-edition", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:suspect-commits-all-frames", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:weekly-report-logs", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:metrics-api-new-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.

--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -275,6 +275,7 @@ def project_event_counts_for_organization(ctx):
         logger.info(
             "project_event_counts_for_organization_query_result",
             extra={
+                "org_slug": ctx.organization.slug,
                 "report_start": ctx.start.isoformat(),
                 "report_end": (ctx.end + timedelta(days=1)).isoformat(),
                 "num_query_rows": len(data),
@@ -890,6 +891,7 @@ def render_template_context(ctx, user_id):
             logger.info(
                 "render_template_context.trends.totals",
                 extra={
+                    "org_slug": ctx.organization.slug,
                     "project_count": len(projects_associated_with_user),
                     "accepted_error_count": total_error,
                     "dropped_error_count": total_dropped_error,
@@ -1066,6 +1068,7 @@ def send_email(ctx, user_id, dry_run=False, email_override=None):
         logger.info(
             "send_email.counts_per_day",
             extra={
+                "org_slug": ctx.organization.slug,
                 "errors_per_day": json.dumps(template_ctx.trends.error_maximum),
                 "transactions_per_day": json.dumps(template_ctx.trends.transaction_maximum),
             },


### PR DESCRIPTION
Add flag for logging weekly report stats so that we can turn it on for specific orgs for debugging purposes 🐛  
additionally flagging while logging is being improved 🫡