### PR TITLE
fix(database): Clear the spans cursor when selecting a table or command

### DIFF
--- a/static/app/views/performance/database/databaseLandingPage.spec.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.spec.tsx
@@ -1,0 +1,128 @@
+import {Organization} from 'sentry-fixture/organization';
+
+import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {DatabaseLandingPage} from 'sentry/views/performance/database/databaseLandingPage';
+
+jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/usePageFilters');
+jest.mock('sentry/utils/useOrganization');
+
+describe('DatabaseLandingPage', function () {
+  const organization = Organization();
+
+  jest.mocked(usePageFilters).mockReturnValue({
+    isReady: true,
+    desyncedFilters: new Set(),
+    pinnedFilters: new Set(),
+    shouldPersist: true,
+    selection: {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+      environments: [],
+      projects: [],
+    },
+  });
+
+  jest.mocked(useLocation).mockReturnValue({
+    pathname: '',
+    search: '',
+    query: {statsPeriod: '10d'},
+    hash: '',
+    state: undefined,
+    action: 'PUSH',
+    key: '',
+  });
+
+  jest.mocked(useOrganization).mockReturnValue(organization);
+
+  beforeAll(function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/sdk-updates/',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      match: [MockApiClient.matchQuery({referrer: 'span-metrics'})],
+      body: {
+        data: [],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      match: [MockApiClient.matchQuery({referrer: 'api.starfish.get-span-actions'})],
+      body: {
+        data: [{'span.action': 'SELECT', count: 1}],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      match: [MockApiClient.matchQuery({referrer: 'api.starfish.get-span-domains'})],
+      body: {
+        data: [{'span.domain': ['sentry_users'], count: 1}],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      match: [MockApiClient.matchQuery({referrer: 'api.starfish.use-span-list'})],
+      body: {
+        data: [
+          {
+            'span.group': '271536360c0b6f89',
+            'span.description': 'SELECT * FROM users',
+          },
+          {
+            'span.group': '360c0b6f89271536',
+            'span.description': 'SELECT * FROM organizations',
+          },
+        ],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      method: 'GET',
+      body: {
+        'spm()': {
+          data: [
+            [1699907700, [{count: 7810.2}]],
+            [1699908000, [{count: 1216.8}]],
+          ],
+        },
+      },
+    });
+  });
+
+  afterAll(function () {
+    jest.resetAllMocks();
+  });
+
+  it('renders a list of queries', async function () {
+    // eslint-disable-next-line no-console
+    jest.spyOn(console, 'error').mockImplementation(jest.fn()); // This silences pointless unique key errors that React throws because of the tokenized query descriptions
+
+    render(<DatabaseLandingPage />);
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
+
+    expect(screen.getByRole('cell', {name: 'SELECT * FROM users'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('cell', {name: 'SELECT * FROM organizations'})
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -51,7 +51,7 @@ function DatabaseLandingPage() {
       query: {
         ...location.query,
         'span.description': newQuery === '' ? undefined : newQuery,
-        spansCursor: undefined,
+        [QueryParameterNames.SPANS_CURSOR]: undefined,
       },
     });
   };

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -51,7 +51,7 @@ function DatabaseLandingPage() {
       query: {
         ...location.query,
         'span.description': newQuery === '' ? undefined : newQuery,
-        cursor: undefined,
+        spansCursor: undefined,
       },
     });
   };

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import React, {Fragment} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -34,7 +34,7 @@ import SpansTable from 'sentry/views/starfish/views/spans/spansTable';
 import {useModuleFilters} from 'sentry/views/starfish/views/spans/useModuleFilters';
 import {useModuleSort} from 'sentry/views/starfish/views/spans/useModuleSort';
 
-function DatabaseLandingPage() {
+export function DatabaseLandingPage() {
   const organization = useOrganization();
   const moduleName = ModuleName.DB;
   const location = useLocation();
@@ -75,7 +75,7 @@ function DatabaseLandingPage() {
   useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);
 
   return (
-    <ModulePageProviders title={[t('Performance'), t('Database')].join(' — ')}>
+    <React.Fragment>
       <Layout.Header>
         <Layout.HeaderContent>
           <Breadcrumbs
@@ -145,7 +145,7 @@ function DatabaseLandingPage() {
           )}
         </Layout.Main>
       </Layout.Body>
-    </ModulePageProviders>
+    </React.Fragment>
   );
 }
 
@@ -177,4 +177,12 @@ const SearchBarContainer = styled('div')`
 
 const LIMIT: number = 25;
 
-export default DatabaseLandingPage;
+function LandingPageWithProviders() {
+  return (
+    <ModulePageProviders title={[t('Performance'), t('Database')].join(' — ')}>
+      <DatabaseLandingPage />
+    </ModulePageProviders>
+  );
+}
+
+export default LandingPageWithProviders;

--- a/static/app/views/starfish/components/chart.tsx
+++ b/static/app/views/starfish/components/chart.tsx
@@ -187,7 +187,7 @@ function Chart({
   const defaultRef = useRef<ReactEchartsRef>(null);
   const chartRef = forwardedRef || defaultRef;
 
-  const echartsInstance = chartRef?.current?.getEchartsInstance();
+  const echartsInstance = chartRef?.current?.getEchartsInstance?.();
   if (echartsInstance && !echartsInstance.group) {
     echartsInstance.group = chartGroup ?? STARFISH_CHART_GROUP;
   }
@@ -483,7 +483,7 @@ export function useSynchronizeCharts(deps: boolean[] = []) {
   const [synchronized, setSynchronized] = useState<boolean>(false);
   useEffect(() => {
     if (deps.every(Boolean)) {
-      echarts.connect(STARFISH_CHART_GROUP);
+      echarts?.connect?.(STARFISH_CHART_GROUP);
       setSynchronized(true);
     }
   }, [deps, synchronized]);

--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -11,6 +11,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQuery';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
+import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {
   EMPTY_OPTION_VALUE,
   EmptyContainer,
@@ -76,7 +77,7 @@ export function ActionSelector({
           query: {
             ...location.query,
             [SPAN_ACTION]: newValue.value,
-            spansCursor: undefined,
+            [QueryParameterNames.SPANS_CURSOR]: undefined,
           },
         });
       }}

--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -76,6 +76,7 @@ export function ActionSelector({
           query: {
             ...location.query,
             [SPAN_ACTION]: newValue.value,
+            spansCursor: undefined,
           },
         });
       }}

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -140,6 +140,7 @@ export function DomainSelector({
           query: {
             ...location.query,
             [SpanMetricsField.SPAN_DOMAIN]: newValue.value,
+            spansCursor: undefined,
           },
         });
       }}

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -12,6 +12,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQuery';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
+import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {
   EMPTY_OPTION_VALUE,
   EmptyContainer,
@@ -140,7 +141,7 @@ export function DomainSelector({
           query: {
             ...location.query,
             [SpanMetricsField.SPAN_DOMAIN]: newValue.value,
-            spansCursor: undefined,
+            [QueryParameterNames.SPANS_CURSOR]: undefined,
           },
         });
       }}


### PR DESCRIPTION
Fixes an error where someone can navigate to the second page of queries, choose a different SQL command, and still end up on the second page.

- Clear spans cursor when changing filters
- Check before accessing eCharts properties
- Extract pure `DatabaseLandingPage` component
- Add a basic spec for the page