### PR TITLE
fix(stats-detectors): Use regression fingerprint in redis key

### DIFF
--- a/src/sentry/statistical_detectors/detector.py
+++ b/src/sentry/statistical_detectors/detector.py
@@ -17,6 +17,7 @@ class TrendType(Enum):
 class DetectorPayload:
     project_id: int
     group: str | int
+    fingerprint: str | int
     count: float
     value: float
     timestamp: datetime

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -46,7 +46,6 @@ from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.discover import zerofill
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.snuba.referrer import Referrer
-from sentry.statistical_detectors import redis
 from sentry.statistical_detectors.algorithm import (
     MovingAverageDetectorState,
     MovingAverageRelativeChangeDetector,
@@ -57,6 +56,7 @@ from sentry.statistical_detectors.issue_platform_adapter import (
     fingerprint_regression,
     send_regression_to_platform,
 )
+from sentry.statistical_detectors.redis import DetectorType, RedisDetectorStore
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json, metrics
 from sentry.utils.iterators import chunked
@@ -328,7 +328,7 @@ def _detect_transaction_trends(
         threshold=0.2,
     )
 
-    detector_store = redis.RedisDetectorStore(object_type="e")  # e for endpoint
+    detector_store = RedisDetectorStore(detector_type=DetectorType.ENDPOINT)  # e for endpoint
 
     start = start - timedelta(hours=1)
     start = start.replace(minute=0, second=0, microsecond=0)
@@ -654,7 +654,7 @@ def _detect_function_trends(
         threshold=0.2,
     )
 
-    detector_store = redis.RedisDetectorStore(object_type="f")  # f for functions
+    detector_store = RedisDetectorStore(detector_type=DetectorType.FUNCTION)
 
     projects = Project.objects.filter(id__in=project_ids)
 

--- a/tests/sentry/statistical_detectors/test_algorithm.py
+++ b/tests/sentry/statistical_detectors/test_algorithm.py
@@ -244,6 +244,7 @@ def test_moving_average_cross_over_detector(
         DetectorPayload(
             project_id=1,
             group=0,
+            fingerprint=0,
             count=i + 1,
             value=value,
             timestamp=now + timedelta(hours=i + 1),
@@ -301,6 +302,7 @@ def test_moving_average_cross_over_detector_bad_order(
     payload = DetectorPayload(
         project_id=1,
         group=0,
+        fingerprint=0,
         count=2,
         value=100,
         timestamp=now,
@@ -311,6 +313,7 @@ def test_moving_average_cross_over_detector_bad_order(
     payload = DetectorPayload(
         project_id=1,
         group=0,
+        fingerprint=0,
         count=1,
         value=100,
         timestamp=now - timedelta(hours=1),
@@ -377,6 +380,7 @@ def test_moving_average_relative_change_detector(
         DetectorPayload(
             project_id=1,
             group=0,
+            fingerprint=0,
             count=i + 1,
             value=value,
             timestamp=now + timedelta(hours=i + 1),

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -287,6 +287,7 @@ def test_detect_transaction_trends(
             DetectorPayload(
                 project_id=project.id,
                 group="/123",
+                fingerprint="/123",
                 count=100,
                 value=100 if i < n / 2 else 300,
                 timestamp=ts,
@@ -325,6 +326,7 @@ def test_detect_transaction_trends_ratelimit(
             DetectorPayload(
                 project_id=project.id,
                 group="/1",
+                fingerprint="/1",
                 count=100,
                 value=100 if i < n / 2 else 301,
                 timestamp=ts,
@@ -332,6 +334,7 @@ def test_detect_transaction_trends_ratelimit(
             DetectorPayload(
                 project_id=project.id,
                 group="/2",
+                fingerprint="/2",
                 count=100,
                 value=100 if i < n / 2 else 302,
                 timestamp=ts,
@@ -339,6 +342,7 @@ def test_detect_transaction_trends_ratelimit(
             DetectorPayload(
                 project_id=project.id,
                 group="/3",
+                fingerprint="/3",
                 count=100,
                 value=100 if i < n / 2 else 303,
                 timestamp=ts,
@@ -390,6 +394,7 @@ def test_limit_regressions_by_project(ratelimit, timestamp, expected_idx):
         (project_id, group): DetectorPayload(
             project_id=project_id,
             group=f"{project_id}_{group}",
+            fingerprint=f"{project_id}_{group}",
             count=int(f"{project_id}_{group}"),
             value=int(f"{project_id}_{group}"),
             timestamp=timestamp,
@@ -433,6 +438,7 @@ def test_detect_function_trends(
             DetectorPayload(
                 project_id=project.id,
                 group=123,
+                fingerprint=123,
                 count=100,
                 value=100 if i < n / 2 else 300,
                 timestamp=ts,
@@ -470,6 +476,7 @@ def test_detect_function_trends_ratelimit(
             DetectorPayload(
                 project_id=project.id,
                 group=1,
+                fingerprint=1,
                 count=100,
                 value=100 if i < n / 2 else 301,
                 timestamp=ts,
@@ -477,6 +484,7 @@ def test_detect_function_trends_ratelimit(
             DetectorPayload(
                 project_id=project.id,
                 group=2,
+                fingerprint=2,
                 count=100,
                 value=100 if i < n / 2 else 302,
                 timestamp=ts,
@@ -484,6 +492,7 @@ def test_detect_function_trends_ratelimit(
             DetectorPayload(
                 project_id=project.id,
                 group=3,
+                fingerprint=3,
                 count=100,
                 value=100 if i < n / 2 else 303,
                 timestamp=ts,
@@ -637,6 +646,7 @@ class FunctionsTasksTest(ProfilesSnubaTestCase):
             DetectorPayload(
                 project_id=project.id,
                 group=self.function_fingerprint({"package": "foo", "function": "foo"}),
+                fingerprint=self.function_fingerprint({"package": "foo", "function": "foo"}),
                 count=100,
                 value=pytest.approx(100),  # type: ignore[arg-type]
                 timestamp=self.hour_ago,


### PR DESCRIPTION
We were using the full transaction name which is of arbitrary length as part of the redis key. This uses the transaction hash instead. This has the implication that we invalidate all the existing keys but that is acceptable and they will expire in 24 hours.