### PR TITLE
fix(hybrid-cloud): Respond to PINGs at the Discord request parser

### DIFF
--- a/src/sentry/integrations/discord/webhooks/base.py
+++ b/src/sentry/integrations/discord/webhooks/base.py
@@ -38,6 +38,11 @@ class DiscordInteractionsEndpoint(Endpoint):
     def __init__(self) -> None:
         super().__init__()
 
+    @classmethod
+    def respond_ping(cls) -> Response:
+        # https://discord.com/developers/docs/tutorials/upgrading-to-application-commands#adding-an-interactions-endpoint-url
+        return Response({"type": DiscordResponseTypes.PONG}, status=200)
+
     @csrf_exempt
     @transaction_start("DiscordInteractionsEndpoint")
     def post(self, request: Request) -> Response:
@@ -46,8 +51,7 @@ class DiscordInteractionsEndpoint(Endpoint):
             discord_request.validate()
 
             if discord_request.is_ping():
-                # https://discord.com/developers/docs/tutorials/upgrading-to-application-commands#adding-an-interactions-endpoint-url
-                return self.respond({"type": DiscordResponseTypes.PONG}, status=200)
+                return DiscordInteractionsEndpoint.respond_ping()
 
             elif discord_request.is_command():
                 analytics.record(

--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -77,7 +77,10 @@ class DiscordRequestParser(BaseRequestParser):
 
         if self.view_class == DiscordInteractionsEndpoint:
             if self.discord_request:
-                if self.discord_request.is_command() or self.discord_request.is_ping():
+                if self.discord_request.is_ping():
+                    return DiscordInteractionsEndpoint.respond_ping()
+
+                if self.discord_request.is_command():
                     return self.get_response_from_first_region()
 
                 if self.discord_request.is_message_component():

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -54,8 +54,10 @@ class DiscordRequestParserTest(TestCase):
         ) as get_response_from_first_region, assume_test_silo_mode(
             SiloMode.CONTROL, can_be_monolith=False
         ):
-            parser.get_response()
-            assert get_response_from_first_region.called
+            response = parser.get_response()
+            assert response.status_code == 200
+            assert response.data == {"type": 1}
+            assert not get_response_from_first_region.called
 
     def test_interactions_endpoint_routing_command(self):
         data = {"guild_id": self.integration.external_id, "type": int(DiscordRequestTypes.COMMAND)}


### PR DESCRIPTION
We rely on the `guild_id` to fetch the associated `Integration` instance to be able to properly proxy Discord webhook requests. But for `PING`s, Discord does not provide the `guild_id` value. I was able to verify this by capturing the ping payload that Discord sends.

For the Discord request parser, we respond to `PING`s immediately rather than delegating to the Interaction endpoint (which is marked as Region only silo).