### PR TITLE
ref(crons): Remove cross-consumer per-monitor-env lock

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -12,7 +12,6 @@ from arroyo.processing.strategies.abstract import ProcessingStrategy, Processing
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.run_task import RunTask
 from arroyo.types import BrokerValue, Commit, Message, Partition
-from django.conf import settings
 from django.db import router, transaction
 from django.utils.text import slugify
 from sentry_sdk.tracing import Span, Transaction
@@ -46,11 +45,6 @@ from sentry.monitors.utils import (
 from sentry.monitors.validators import ConfigValidator, MonitorCheckInValidator
 from sentry.utils import json, metrics
 from sentry.utils.dates import to_datetime
-from sentry.utils.locking import UnableToAcquireLock
-from sentry.utils.locking.manager import LockManager
-from sentry.utils.services import build_instance_from_options
-
-locks = LockManager(build_instance_from_options(settings.SENTRY_POST_PROCESS_LOCKS_BACKEND_OPTIONS))
 
 logger = logging.getLogger(__name__)
 
@@ -435,14 +429,9 @@ def _process_checkin(
 
     # 03
     # Create or update check-in
-    lock = locks.get(f"checkin-creation:{guid.hex}", duration=LOCK_TIMEOUT, name="checkin_creation")
+
     try:
-        # use lock.blocking_acquire() as default lock.acquire() fast fails if
-        # lock is in use. We absolutely want to wait to acquire this lock
-        # otherwise we would drop the check-in.
-        with lock.blocking_acquire(
-            INITIAL_LOCK_DELAY, float(LOCK_TIMEOUT), exp_base=LOCK_EXP_BASE
-        ), transaction.atomic(router.db_for_write(Monitor)):
+        with transaction.atomic(router.db_for_write(Monitor)):
             status = getattr(CheckInStatus, validated_params["status"].upper())
             trace_id = validated_params.get("contexts", {}).get("trace", {}).get("trace_id")
             duration = validated_params["duration"]
@@ -574,16 +563,6 @@ def _process_checkin(
                 "monitors.checkin.result",
                 tags={**metric_kwargs, "status": "complete"},
             )
-    except UnableToAcquireLock:
-        metrics.incr(
-            "monitors.checkin.result",
-            tags={**metric_kwargs, "status": "failed_checkin_creation_lock"},
-        )
-        txn.set_tag("result", "failed_checkin_creation_lock")
-        logger.info(
-            "monitors.consumer.lock_failed",
-            extra={"guid": guid.hex, "slug": monitor_slug},
-        )
     except Exception:
         # Skip this message and continue processing in the consumer.
         metrics.incr(

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -197,18 +197,6 @@ class MonitorConsumerTest(TestCase):
             checkin.date_added
         )
 
-    def test_create_lock(self):
-        monitor = self._create_monitor(slug="my-monitor")
-        guid = uuid.uuid4().hex
-
-        lock = locks.get(f"checkin-creation:{guid}", duration=2, name="checkin_creation")
-        lock.acquire()
-
-        self.send_checkin(monitor.slug, guid=guid)
-
-        # Lock should prevent creation of new check-in
-        assert len(MonitorCheckIn.objects.filter(monitor=monitor)) == 0
-
     def test_check_in_timeout_at(self):
         monitor = self._create_monitor(slug="my-monitor")
         self.send_checkin(monitor.slug, status="in_progress")


### PR DESCRIPTION
After the changes made in relay

See: https://github.com/getsentry/relay/pull/2496

We can now guarantee that all check-ins consumed in a single consumer
are part of the same monitor (and monitor environment). This means we no
longer need to do any locking across consumers (or even within a
consumer right now, since they are single threaded).