### PR TITLE
ref(notifications): remove code related to should_use_notifications_v2

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -17,7 +17,6 @@ from typing import (
 )
 
 import sentry_sdk
-from django.contrib.auth.models import AnonymousUser
 from django.db import connection
 from django.db.models import prefetch_related_objects
 from django.db.models.aggregates import Count
@@ -50,19 +49,7 @@ from sentry.models.release import Release
 from sentry.models.team import Team
 from sentry.models.user import User
 from sentry.models.userreport import UserReport
-from sentry.notifications.helpers import (
-    get_most_specific_notification_setting_value,
-    should_use_notifications_v2,
-    transform_to_notification_settings_by_scope,
-)
-from sentry.notifications.types import (
-    NotificationSettingEnum,
-    NotificationSettingOptionValues,
-    NotificationSettingTypes,
-)
 from sentry.roles import organization_roles
-from sentry.services.hybrid_cloud.actor import RpcActor
-from sentry.services.hybrid_cloud.notifications import notifications_service
 from sentry.snuba import discover
 from sentry.tasks.symbolication import should_demote_symbolication
 from sentry.utils import json
@@ -315,10 +302,6 @@ class ProjectSerializer(Serializer):
             span.set_data("Object Count", len(item_list))
             return span
 
-        use_notifications_v2 = should_use_notifications_v2(item_list[0].organization)
-        skip_subscriptions = features.has(
-            "organizations:cleanup-project-serializer", item_list[0].organization
-        )
         with measure_span("preamble"):
             project_ids = [i.id for i in item_list]
             if user.is_authenticated and item_list:
@@ -327,31 +310,8 @@ class ProjectSerializer(Serializer):
                         user_id=user.id, project_id__in=project_ids
                     ).values_list("project_id", flat=True)
                 )
-
-                if not skip_subscriptions:
-                    if use_notifications_v2:
-                        subscriptions = notifications_service.get_subscriptions_for_projects(
-                            user_id=user.id,
-                            project_ids=project_ids,
-                            type=NotificationSettingEnum.ISSUE_ALERTS,
-                        )
-                    else:
-                        notification_settings_by_scope = (
-                            transform_to_notification_settings_by_scope(
-                                notifications_service.get_settings_for_user_by_projects(
-                                    type=NotificationSettingTypes.ISSUE_ALERTS,
-                                    user_id=user.id,
-                                    parent_ids=project_ids,
-                                )
-                            )
-                        )
             else:
                 bookmarks = set()
-                if not skip_subscriptions:
-                    if use_notifications_v2:
-                        subscriptions = {}
-                    else:
-                        notification_settings_by_scope = {}
 
         with measure_span("stats"):
             stats = None
@@ -388,32 +348,7 @@ class ProjectSerializer(Serializer):
                 serialized["features"] = features_by_project[project]
 
         with measure_span("other"):
-            # Avoid duplicate queries for actors.
-            if isinstance(user, AnonymousUser):
-                recipient_actor = user
-            else:
-                recipient_actor = RpcActor.from_object(user)
             for project, serialized in result.items():
-                if not skip_subscriptions:
-                    is_subscribed = False
-                    if use_notifications_v2:
-                        if project.id in subscriptions:
-                            (_, has_enabled_subscriptions, _) = subscriptions[project.id]
-                            is_subscribed = has_enabled_subscriptions
-                        else:
-                            # If there are no settings, default to the EMAIL default
-                            # setting, which is ALWAYS.
-                            is_subscribed = True
-                    else:
-                        value = get_most_specific_notification_setting_value(
-                            notification_settings_by_scope,
-                            recipient=recipient_actor,
-                            parent_id=project.id,
-                            type=NotificationSettingTypes.ISSUE_ALERTS,
-                        )
-                        is_subscribed = value == NotificationSettingOptionValues.ALWAYS
-                        serialized["isSubscribed"] = is_subscribed
-
                 serialized.update(
                     {
                         "is_bookmarked": project.id in bookmarks,

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -689,11 +689,6 @@ def get_providers_for_recipient(
     return user_providers
 
 
-def should_use_notifications_v2(organization: Organization):
-    # TODO: remove function
-    return True
-
-
 def recipient_is_user(recipient: RpcActor | Team | RpcUser | User) -> bool:
     from sentry.models.user import User
 


### PR DESCRIPTION
This PR removes the last bit of code that references `should_use_notifications_v2` which is hardcoded to returning True right now. As it turns out, when we built out Notifications 2.0 we didn't properly set `isSubscribed` and it was removed from the output. This was a mistake but it's OK: we don't document the field in our [docs](https://docs.sentry.io/api/projects/retrieve-a-project/) and it's not used in our UI. That field is very confusing as it's user-dependent: it's set to true if a user has issue alert notifications for that project. We will also remove the field from the PUT API for projects because we now have notification settings endpoints we can use.