### PR TITLE
Revert "add: logging for service account (#60230)"

### DIFF
--- a/src/sentry/utils/env.py
+++ b/src/sentry/utils/env.py
@@ -63,26 +63,6 @@ def log_gcp_credentials_details(logger) -> None:
         },
     )
 
-    try:
-        # this will only work inside a GCP machine
-        service_accounts = requests.get(
-            "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/",
-            headers={
-                "Metadata-Flavor": "Google",
-            },
-        ).text
-
-        logger.info(
-            "gcp.credentials.service_accounts",
-            extra={
-                "service_accounts": service_accounts,
-            },
-        )
-    except requests.exceptions.RequestException:
-        logger.info(
-            "Unable to get service accounts from metadata server, this only works inside gke pod or gcp machine"
-        )
-
 
 def is_split_db() -> bool:
     if len(settings.DATABASES) != 1:  # type: ignore


### PR DESCRIPTION
This reverts commit 6676b111fd5c5d55f0b3339cf5bff995a866c779.
because it seesm to be breaking deploys?
https://github.com/getsentry/sentry/actions/runs/6910868843/job/18804680943
