### PR TITLE
Refactor Post Process

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -175,18 +175,12 @@ def should_issue_owners_ratelimit(project_id, group_id):
     Make sure that we do not accept more groups than ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT at the project level.
     """
     cache_key = f"issue_owner_assignment_ratelimiter:{project_id}"
-    data = cache.get(cache_key)
+    groups, window_start = cache.get(cache_key, (set(), datetime.now()))
 
-    if data is None:
-        groups = {group_id}
-        window_start = datetime.now()
-        cache.set(cache_key, (groups, window_start), 60)
-    else:
-        groups = set(data[0])
-        groups.add(group_id)
-        window_start = data[1]
-        timeout = max(60 - (datetime.now() - window_start).total_seconds(), 0)
-        cache.set(cache_key, (groups, window_start), timeout)
+    timeout = max(60 - (datetime.now() - window_start).total_seconds(), 0)
+    groups.add(group_id)
+
+    cache.set(cache_key, (groups, window_start), timeout)
 
     return len(groups) > ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT
 


### PR DESCRIPTION
Utilizamos la función cache.get con un valor por defecto (set(), datetime.now()) para obtener los datos del caché. Esto evita tener que verificar si data es None.

Calculamos el timeout y luego actualizamos el conjunto de grupos groups y el tiempo de inicio window_start en una sola operación.

Simplificamos la lógica del cálculo del timeout al calcularlo directamente en una sola línea.

--------

_[EDIT: Here's the English translation, courtesy of google translate:_

_- Use the `cache.get` function with a default value `(set(), datetime.now())` to get the data from the cache. This avoids having to check if data is `None`._

_- Calculate the timeout and then update the group set `groups` and the `window_start` start time in a single operation._ 

_- Simplify the timeout calculation logic by calculating it directly in a single line.]_