### PR TITLE
fix(ddm): Remove error from on demand check

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -41,7 +41,7 @@ from sentry.search.events import fields
 from sentry.search.events.builder import UnresolvedQuery
 from sentry.search.events.constants import VITAL_THRESHOLDS
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.metrics.naming_layer.mri import ParsedMRI, is_custom_metric, parse_mri
+from sentry.snuba.metrics.naming_layer.mri import ParsedMRI, parse_mri
 from sentry.snuba.metrics.utils import MetricOperationType
 from sentry.utils.snuba import is_measurement, is_span_op_breakdown, resolve_column
 
@@ -411,12 +411,8 @@ def should_use_on_demand_metrics(
     function, args = components
     mri_aggregate = _extract_mri(args)
     if mri_aggregate is not None:
-        if is_custom_metric(mri_aggregate):
-            return False
-        else:
-            raise InvalidSearchQuery(
-                f"The supplied MRI belongs to an unsupported namespace '{mri_aggregate.namespace}'"
-            )
+        # For now, we do not support MRIs in on demand metrics.
+        return False
 
     aggregate_supported_by = _get_aggregate_supported_by(function, args)
     query_supported_by = _get_query_supported_by(query)

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -199,6 +199,9 @@ def is_mri(mri_string: Optional[str]) -> bool:
     """
     Returns true if the passed value is a mri.
     """
+    if mri_string is None:
+        return False
+
     return parse_mri(mri_string) is not None
 
 

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -199,9 +199,6 @@ def is_mri(mri_string: Optional[str]) -> bool:
     """
     Returns true if the passed value is a mri.
     """
-    if mri_string is None:
-        return False
-
     return parse_mri(mri_string) is not None
 
 


### PR DESCRIPTION
This PR removes the error when a query has an MRI on the transactions dataset. The decision was rolled back since the goal is to silently have it fail and not throw any errors, since we want to fallback to standard metrics as much as possible.