### PR TITLE
feat(ddm): Change feature flag to enable the metrics layer in alerts

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1833,6 +1833,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enable new release UI
     "organizations:releases-v2": False,
     "organizations:releases-v2-st": False,
+    # Enable the metrics layer for alerts queries.
+    "organizations:use-metrics-layer-in-alerts": False,
     # Enable User Feedback v2 ingest
     "organizations:user-feedback-ingest": False,
     # Enable User Feedback v2 UI

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -237,6 +237,7 @@ default_manager.add("organizations:transaction-name-mark-scrubbed-as-sanitized",
 default_manager.add("organizations:transaction-name-sanitization", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:transaction-metrics-extraction", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:use-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:use-metrics-layer-in-alerts", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:user-feedback-ingest", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:user-feedback-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:old-user-feedback", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -322,9 +322,9 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
             )
         self.org_id = extra_fields["org_id"]
         self.time_window = time_window
-        # We want to use the metrics layer for ddm, since it supports custom metrics.
         self.use_metrics_layer = features.has(
-            "organizations:ddm-experimental", Organization.objects.get_from_cache(id=self.org_id)
+            "organizations:use-metrics-layer-in-alerts",
+            Organization.objects.get_from_cache(id=self.org_id),
         )
         self.on_demand_metrics_enabled = features.has(
             "organizations:on-demand-metrics-extraction",
@@ -372,13 +372,6 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
             return strings
 
         return resolve_tag_values(self._get_use_case_id(), self.org_id, strings)
-
-    def _get_environment_condition(self, environment_name: str) -> Condition:
-        return Condition(
-            Column(self.resolve_tag_key_if_needed("environment")),
-            Op.EQ,
-            self.resolve_tag_value_if_needed(environment_name),
-        )
 
     def build_query_builder(
         self,

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -753,6 +753,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
                 "organizations:mep-rollout-flag",
                 "organizations:dynamic-sampling",
                 "organizations:ddm-experimental",
+                "organizations:use-metrics-layer-in-alerts",
             ]
         ):
             for mri in (
@@ -785,6 +786,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
                 "organizations:mep-rollout-flag",
                 "organizations:dynamic-sampling",
                 "organizations:ddm-experimental",
+                "organizations:use-metrics-layer-in-alerts",
             ]
         ):
             test_params = {

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -213,7 +213,7 @@ class EntitySubscriptionTestCase(TestCase):
         ]
 
     def test_get_entity_subscription_for_metrics_dataset_for_users_with_metrics_layer(self) -> None:
-        with Feature("organizations:ddm-experimental"):
+        with Feature("organizations:use-metrics-layer-in-alerts"):
             org_id = self.organization.id
             use_case_id = UseCaseID.SESSIONS
 
@@ -344,7 +344,7 @@ class EntitySubscriptionTestCase(TestCase):
     def test_get_entity_subscription_for_metrics_dataset_for_sessions_with_metrics_layer(
         self,
     ) -> None:
-        with Feature("organizations:ddm-experimental"):
+        with Feature("organizations:use-metrics-layer-in-alerts"):
             org_id = self.organization.id
             use_case_id = UseCaseID.SESSIONS
             aggregate = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
@@ -501,7 +501,7 @@ class EntitySubscriptionTestCase(TestCase):
     def test_get_entity_subscription_for_performance_metrics_dataset_with_metrics_layer(
         self,
     ) -> None:
-        with Feature("organizations:ddm-experimental"):
+        with Feature("organizations:use-metrics-layer-in-alerts"):
             aggregate = "percentile(transaction.duration,.95)"
             entity_subscription = get_entity_subscription(
                 query_type=SnubaQuery.Type.PERFORMANCE,
@@ -561,7 +561,7 @@ class EntitySubscriptionTestCase(TestCase):
         mri = "d:custom/sentry.process_profile.track_outcome@second"
         indexer.record(use_case_id=UseCaseID.CUSTOM, org_id=self.organization.id, string=mri)
 
-        with Feature("organizations:ddm-experimental"):
+        with Feature("organizations:use-metrics-layer-in-alerts"):
             aggregate = f"max({mri})"
             entity_subscription = get_entity_subscription(
                 query_type=SnubaQuery.Type.PERFORMANCE,
@@ -616,7 +616,7 @@ class EntitySubscriptionTestCase(TestCase):
     def test_get_entity_subscription_with_multiple_entities_with_metrics_layer(
         self,
     ) -> None:
-        with Feature("organizations:ddm-experimental"):
+        with Feature("organizations:use-metrics-layer-in-alerts"):
             aggregate = "percentile(transaction.duration,.95)"
             entity_subscription = get_entity_subscription(
                 query_type=SnubaQuery.Type.PERFORMANCE,
@@ -924,7 +924,7 @@ class GetEntityKeyFromSnubaQueryTest(TestCase):
                 )
 
             if supported_with_metrics_layer:
-                with Feature("organizations:ddm-experimental"):
+                with Feature("organizations:use-metrics-layer-in-alerts"):
                     assert expected_entity_key == get_entity_key_from_snuba_query(
                         snuba_query, self.organization.id, self.project.id
                     )

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -681,7 +681,7 @@ class BuildSnqlQueryTest(TestCase):
         )
 
     def test_simple_performance_metrics(self):
-        with Feature("organizations:ddm-experimental"):
+        with Feature("organizations:use-metrics-layer-in-alerts"):
             metric_id = resolve(UseCaseID.TRANSACTIONS, self.organization.id, METRICS_MAP["user"])
             self.run_test(
                 SnubaQuery.Type.PERFORMANCE,
@@ -741,7 +741,7 @@ class BuildSnqlQueryTest(TestCase):
         )
 
     def test_aliased_query_performance_metrics(self):
-        with Feature("organizations:ddm-experimental"):
+        with Feature("organizations:use-metrics-layer-in-alerts"):
             version = "something"
             self.create_release(self.project, version=version)
             metric_id = resolve(
@@ -814,7 +814,7 @@ class BuildSnqlQueryTest(TestCase):
         )
 
     def test_tag_query_performance_metrics(self):
-        with Feature("organizations:ddm-experimental"):
+        with Feature("organizations:use-metrics-layer-in-alerts"):
             # Note: We don't support user queries on the performance metrics dataset, so using a
             # different tag here.
             metric_id = resolve(
@@ -1038,7 +1038,7 @@ class BuildSnqlQueryTest(TestCase):
         )
 
     def test_simple_sessions_for_metrics(self):
-        with Feature("organizations:ddm-experimental"):
+        with Feature("organizations:use-metrics-layer-in-alerts"):
             org_id = self.organization.id
             for tag in [SessionMRI.RAW_SESSION.value, "session.status", "crashed", "init"]:
                 rh_indexer_record(org_id, tag)
@@ -1084,7 +1084,7 @@ class BuildSnqlQueryTest(TestCase):
             )
 
     def test_simple_users_for_metrics(self):
-        with Feature("organizations:ddm-experimental"):
+        with Feature("organizations:use-metrics-layer-in-alerts"):
             org_id = self.organization.id
             for tag in [SessionMRI.RAW_USER.value, "session.status", "crashed"]:
                 rh_indexer_record(org_id, tag)
@@ -1117,7 +1117,7 @@ class BuildSnqlQueryTest(TestCase):
             )
 
     def test_query_and_environment_sessions_metrics(self):
-        with Feature("organizations:ddm-experimental"):
+        with Feature("organizations:use-metrics-layer-in-alerts"):
             env = self.create_environment(self.project, name="development")
             org_id = self.organization.id
             for tag in [
@@ -1197,7 +1197,7 @@ class BuildSnqlQueryTest(TestCase):
             )
 
     def test_query_and_environment_users_metrics(self):
-        with Feature("organizations:ddm-experimental"):
+        with Feature("organizations:use-metrics-layer-in-alerts"):
             env = self.create_environment(self.project, name="development")
             org_id = self.organization.id
             for tag in [


### PR DESCRIPTION
This PR adds a new feature flag `organizations:use-metrics-layer-in-alerts` to power the new alerts experience. Due to technical limitations we can't have a feature flag that is scoped down to the user level in alerts, thus we decided to opt for a org wide tag that enables the new metrics layer across the entire org but ONLY for snql generation for alerts.

As a drive-by fix, I have removed `_get_environment_condition` since it was left unused after a refactor that was done a few months ago.