### PR TITLE
fix(JAVASCRIPT-2PCW)

### DIFF
--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -198,8 +198,12 @@ export function formatBytesBase10(bytes: number, u: number = 0) {
 export function formatBytesBase2(bytes?: number, fixPoints: number = 1): string {
   const units = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
   const thresh = 1024;
+  if (!bytes) {
+    return '--B'
+  }
+  
   if (bytes < thresh) {
-    return bytes?.toFixed(fixPoints) || '--' + ' B';
+    return bytes.toFixed(fixPoints) + ' B';
   }
 
   let u = -1;

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -201,7 +201,7 @@ export function formatBytesBase2(bytes?: number, fixPoints: number = 1): string 
   if (!bytes) {
     return '--B'
   }
-  
+
   if (bytes < thresh) {
     return bytes.toFixed(fixPoints) + ' B';
   }

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -195,11 +195,11 @@ export function formatBytesBase10(bytes: number, u: number = 0) {
  * For billing-related code around attachments. please take a look at
  * formatBytesBase10
  */
-export function formatBytesBase2(bytes: number, fixPoints: number = 1): string {
+export function formatBytesBase2(bytes?: number, fixPoints: number = 1): string {
   const units = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
   const thresh = 1024;
   if (bytes < thresh) {
-    return bytes.toFixed(fixPoints) + ' B';
+    return bytes?.toFixed(fixPoints) || '--' + ' B';
   }
 
   let u = -1;

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -199,7 +199,7 @@ export function formatBytesBase2(bytes?: number, fixPoints: number = 1): string 
   const units = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
   const thresh = 1024;
   if (!bytes) {
-    return '--B'
+    return '--B';
   }
 
   if (bytes < thresh) {


### PR DESCRIPTION
Resolves JAVASCRIPT-2PCW , when no bytes are provided, we display `--B`, similar to what we already to in the queries module.

Something is messed with our types here, because `formatBytesBase2` always expects bytes to be a number, but apparently it can also be null, I put a conditional on the bytes param to address this.