### PR TITLE
feat(database): Adaptive `interval` for duration charts

### DIFF
--- a/static/app/components/charts/utils.spec.tsx
+++ b/static/app/components/charts/utils.spec.tsx
@@ -1,6 +1,5 @@
 import {
   canIncludePreviousPeriod,
-  findGranularityIntervalForMinutes,
   getDiffInMinutes,
   getInterval,
   getSeriesApiInterval,
@@ -105,31 +104,22 @@ describe('Chart Utils', function () {
   });
 
   describe('findGranularityIntervalForMinutes()', function () {
-    const granularities: GranularityLadder = [
+    const ladder = new GranularityLadder([
       [THIRTY_DAYS, '1d'],
       [TWENTY_FOUR_HOURS, '30m'],
       [0, '15m'],
-    ];
+    ]);
 
     it('finds granularity at lower bound', function () {
-      expect(
-        findGranularityIntervalForMinutes(getDiffInMinutes({period: '2m'}), granularities)
-      ).toEqual('15m');
+      expect(ladder.getInterval(getDiffInMinutes({period: '2m'}))).toEqual('15m');
     });
 
     it('finds granularity between bounds', function () {
-      expect(
-        findGranularityIntervalForMinutes(getDiffInMinutes({period: '3d'}), granularities)
-      ).toEqual('30m');
+      expect(ladder.getInterval(getDiffInMinutes({period: '3d'}))).toEqual('30m');
     });
 
     it('finds granularity at upper bound', function () {
-      expect(
-        findGranularityIntervalForMinutes(
-          getDiffInMinutes({period: '60d'}),
-          granularities
-        )
-      ).toEqual('1d');
+      expect(ladder.getInterval(getDiffInMinutes({period: '60d'}))).toEqual('1d');
     });
   });
 

--- a/static/app/components/charts/utils.spec.tsx
+++ b/static/app/components/charts/utils.spec.tsx
@@ -1,10 +1,14 @@
 import {
   canIncludePreviousPeriod,
+  findGranularityIntervalForMinutes,
   getDiffInMinutes,
   getInterval,
   getSeriesApiInterval,
+  GranularityLadder,
   lightenHexToRgb,
   processTableResults,
+  THIRTY_DAYS,
+  TWENTY_FOUR_HOURS,
 } from 'sentry/components/charts/utils';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 
@@ -97,6 +101,35 @@ describe('Chart Utils', function () {
 
       expect(getSeriesApiInterval({period: '3h'})).toBe('5m');
       expect(getSeriesApiInterval({period: '1h'})).toBe('5m');
+    });
+  });
+
+  describe('findFinestGranularityForMinutes()', function () {
+    const granularities: GranularityLadder = [
+      [THIRTY_DAYS, '1d'],
+      [TWENTY_FOUR_HOURS, '30m'],
+      [0, '15m'],
+    ];
+
+    it('finds granularity at lower bound', function () {
+      expect(
+        findGranularityIntervalForMinutes(getDiffInMinutes({period: '2m'}), granularities)
+      ).toEqual('15m');
+    });
+
+    it('finds granularity between bounds', function () {
+      expect(
+        findGranularityIntervalForMinutes(getDiffInMinutes({period: '3d'}), granularities)
+      ).toEqual('30m');
+    });
+
+    it('finds granularity at upper bound', function () {
+      expect(
+        findGranularityIntervalForMinutes(
+          getDiffInMinutes({period: '60d'}),
+          granularities
+        )
+      ).toEqual('1d');
     });
   });
 

--- a/static/app/components/charts/utils.spec.tsx
+++ b/static/app/components/charts/utils.spec.tsx
@@ -104,7 +104,7 @@ describe('Chart Utils', function () {
     });
   });
 
-  describe('findFinestGranularityForMinutes()', function () {
+  describe('findGranularityIntervalForMinutes()', function () {
     const granularities: GranularityLadder = [
       [THIRTY_DAYS, '1d'],
       [TWENTY_FOUR_HOURS, '30m'],

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -18,6 +18,7 @@ export const SIXTY_DAYS = 86400;
 export const THIRTY_DAYS = 43200;
 export const TWO_WEEKS = 20160;
 export const ONE_WEEK = 10080;
+export const FORTY_EIGHT_HOURS = 2880;
 export const TWENTY_FOUR_HOURS = 1440;
 export const SIX_HOURS = 360;
 export const ONE_HOUR = 60;

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -180,6 +180,23 @@ export function getSeriesApiInterval(datetimeObj: DateTimeObject) {
   return '1h';
 }
 
+export type GranularityStep = [number, string];
+export type GranularityLadder = GranularityStep[];
+
+/**
+ * Given a duration in minutes and a `GranularityLadder` object picks the correct granularity at that duration and return the interval as a string e.g. `"10m"`
+ */
+export function findGranularityIntervalForMinutes(
+  minutes: number,
+  granularities: GranularityLadder
+) {
+  const step = granularities.find(([threshold]) => {
+    return minutes >= threshold;
+  }) as GranularityStep; // This can never be undefined, because the first step is 0, so any duration has to be larger than at least the first
+
+  return step[1];
+}
+
 export function getDiffInMinutes(datetimeObj: DateTimeObject): number {
   const {period, start, end} = datetimeObj;
 

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -181,7 +181,7 @@ export function getSeriesApiInterval(datetimeObj: DateTimeObject) {
   return '1h';
 }
 
-export type GranularityStep = [number, string];
+export type GranularityStep = [timeDiff: number, interval: string];
 export type GranularityLadder = GranularityStep[];
 
 /**

--- a/static/app/views/performance/database/getIntervalForMetricFunction.tsx
+++ b/static/app/views/performance/database/getIntervalForMetricFunction.tsx
@@ -1,0 +1,44 @@
+import {
+  DateTimeObject,
+  findGranularityIntervalForMinutes,
+  getDiffInMinutes,
+  GranularityLadder,
+} from 'sentry/components/charts/utils';
+import {
+  COUNTER_GRANULARITIES,
+  DISTRIBUTION_GRANULARITIES,
+} from 'sentry/views/performance/database/settings';
+import {
+  Aggregate,
+  COUNTER_AGGREGATES,
+  DISTRIBUTION_AGGREGATES,
+  SPAN_FUNCTIONS,
+  SpanFunctions,
+} from 'sentry/views/starfish/types';
+
+export function getIntervalForMetricFunction(
+  metricFunction: Aggregate | SpanFunctions,
+  datetimeObj: DateTimeObject
+) {
+  const granularities = GRANULARITIES[metricFunction] ?? COUNTER_GRANULARITIES;
+  return findGranularityIntervalForMinutes(getDiffInMinutes(datetimeObj), granularities);
+}
+
+type GranularityLookup = {
+  [metricName: string]: GranularityLadder;
+};
+
+const GRANULARITIES: GranularityLookup = {};
+
+function registerGranularities(
+  spanFunctionNames: readonly string[],
+  granularities: GranularityLadder
+) {
+  spanFunctionNames.forEach(spanFunctionName => {
+    GRANULARITIES[spanFunctionName] = granularities;
+  });
+}
+
+registerGranularities(COUNTER_AGGREGATES, COUNTER_GRANULARITIES);
+registerGranularities(DISTRIBUTION_AGGREGATES, DISTRIBUTION_GRANULARITIES);
+registerGranularities(SPAN_FUNCTIONS, COUNTER_GRANULARITIES);

--- a/static/app/views/performance/database/getIntervalForMetricFunction.tsx
+++ b/static/app/views/performance/database/getIntervalForMetricFunction.tsx
@@ -16,7 +16,7 @@ import {
 } from 'sentry/views/starfish/types';
 
 export function getIntervalForMetricFunction(
-  metricFunction: Aggregate | SpanFunctions,
+  metricFunction: Aggregate | SpanFunctions | string,
   datetimeObj: DateTimeObject
 ) {
   const ladder = GRANULARITIES[metricFunction] ?? COUNTER_GRANULARITIES;

--- a/static/app/views/performance/database/getIntervalForMetricFunction.tsx
+++ b/static/app/views/performance/database/getIntervalForMetricFunction.tsx
@@ -1,6 +1,5 @@
 import {
   DateTimeObject,
-  findGranularityIntervalForMinutes,
   getDiffInMinutes,
   GranularityLadder,
 } from 'sentry/components/charts/utils';
@@ -20,8 +19,8 @@ export function getIntervalForMetricFunction(
   metricFunction: Aggregate | SpanFunctions,
   datetimeObj: DateTimeObject
 ) {
-  const granularities = GRANULARITIES[metricFunction] ?? COUNTER_GRANULARITIES;
-  return findGranularityIntervalForMinutes(getDiffInMinutes(datetimeObj), granularities);
+  const ladder = GRANULARITIES[metricFunction] ?? COUNTER_GRANULARITIES;
+  return ladder.getInterval(getDiffInMinutes(datetimeObj));
 }
 
 type GranularityLookup = {

--- a/static/app/views/performance/database/settings.ts
+++ b/static/app/views/performance/database/settings.ts
@@ -1,6 +1,6 @@
-import type {GranularityLadder} from 'sentry/components/charts/utils';
 import {
   FORTY_EIGHT_HOURS,
+  GranularityLadder,
   ONE_HOUR,
   SIX_HOURS,
   SIXTY_DAYS,
@@ -27,7 +27,7 @@ export const DEFAULT_DURATION_AGGREGATE = 'avg';
 
 export const CHART_HEIGHT = 160;
 
-export const COUNTER_GRANULARITIES: GranularityLadder = [
+export const COUNTER_GRANULARITIES = new GranularityLadder([
   [SIXTY_DAYS, '1d'],
   [THIRTY_DAYS, '12h'],
   [TWO_WEEKS, '4h'],
@@ -35,13 +35,13 @@ export const COUNTER_GRANULARITIES: GranularityLadder = [
   [SIX_HOURS, '5m'],
   [ONE_HOUR, '1m'],
   [0, '1m'],
-];
+]);
 
-export const DISTRIBUTION_GRANULARITIES: GranularityLadder = [
+export const DISTRIBUTION_GRANULARITIES = new GranularityLadder([
   [TWO_WEEKS, '1d'],
   [FORTY_EIGHT_HOURS, '1h'],
   [TWENTY_FOUR_HOURS, '30m'],
   [SIX_HOURS, '5m'],
   [ONE_HOUR, '1m'],
   [0, '1m'],
-];
+]);

--- a/static/app/views/performance/database/settings.ts
+++ b/static/app/views/performance/database/settings.ts
@@ -1,3 +1,14 @@
+import type {GranularityLadder} from 'sentry/components/charts/utils';
+import {
+  FORTY_EIGHT_HOURS,
+  ONE_HOUR,
+  SIX_HOURS,
+  SIXTY_DAYS,
+  THIRTY_DAYS,
+  TWENTY_FOUR_HOURS,
+  TWO_WEEKS,
+} from 'sentry/components/charts/utils';
+
 export const MIN_SDK_VERSION_BY_PLATFORM: {[platform: string]: string} = {
   'sentry.python': '1.29.2',
   'sentry.javascript': '7.63.0',
@@ -10,6 +21,27 @@ export const MIN_SDK_VERSION_BY_PLATFORM: {[platform: string]: string} = {
   'sentry.android': '6.30.0',
 };
 
+export const DEFAULT_INTERVAL = '10m';
+
 export const DEFAULT_DURATION_AGGREGATE = 'avg';
 
 export const CHART_HEIGHT = 160;
+
+export const COUNTER_GRANULARITIES: GranularityLadder = [
+  [SIXTY_DAYS, '1d'],
+  [THIRTY_DAYS, '12h'],
+  [TWO_WEEKS, '4h'],
+  [TWENTY_FOUR_HOURS, '30m'],
+  [SIX_HOURS, '5m'],
+  [ONE_HOUR, '1m'],
+  [0, '1m'],
+];
+
+export const DISTRIBUTION_GRANULARITIES: GranularityLadder = [
+  [TWO_WEEKS, '1d'],
+  [FORTY_EIGHT_HOURS, '1h'],
+  [TWENTY_FOUR_HOURS, '30m'],
+  [SIX_HOURS, '5m'],
+  [ONE_HOUR, '1m'],
+  [0, '1m'],
+];

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -1,14 +1,21 @@
 import keyBy from 'lodash/keyBy';
+import sortBy from 'lodash/sortBy';
 
-import {getInterval} from 'sentry/components/charts/utils';
 import {PageFilters} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
+import {intervalToMilliseconds} from 'sentry/utils/dates';
 import EventView from 'sentry/utils/discover/eventView';
+import {parseFunction} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
-import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
+import {getIntervalForMetricFunction} from 'sentry/views/performance/database/getIntervalForMetricFunction';
+import {DEFAULT_INTERVAL} from 'sentry/views/performance/database/settings';
+import {
+  Aggregate,
+  SpanFunctions,
+  SpanMetricsQueryFilters,
+} from 'sentry/views/starfish/types';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {EMPTY_OPTION_VALUE} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
@@ -78,6 +85,25 @@ function getEventView(
   // TODO: This condition should be enforced everywhere
   // query.addFilterValue('has', 'span.description');
 
+  // Pick the highest possible interval for the given yAxis selection. Find the ideal interval for each function, then choose the largest one. This results in the lowest granularity, but best performance.
+  const interval = sortBy(
+    yAxis.map(yAxisFunctionName => {
+      const parseResult = parseFunction(yAxisFunctionName);
+
+      if (!parseResult) {
+        return DEFAULT_INTERVAL;
+      }
+
+      return getIntervalForMetricFunction(
+        parseResult.name as Aggregate | SpanFunctions,
+        pageFilters.datetime
+      );
+    }),
+    result => {
+      return intervalToMilliseconds(result);
+    }
+  ).at(-1);
+
   return EventView.fromNewQueryWithPageFilters(
     {
       name: '',
@@ -85,7 +111,7 @@ function getEventView(
       fields: [],
       yAxis,
       dataset: DiscoverDatasets.SPANS_METRICS,
-      interval: getInterval(pageFilters.datetime, STARFISH_CHART_INTERVAL_FIDELITY),
+      interval,
       version: 2,
     },
     pageFilters

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -11,11 +11,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {getIntervalForMetricFunction} from 'sentry/views/performance/database/getIntervalForMetricFunction';
 import {DEFAULT_INTERVAL} from 'sentry/views/performance/database/settings';
-import {
-  Aggregate,
-  SpanFunctions,
-  SpanMetricsQueryFilters,
-} from 'sentry/views/starfish/types';
+import {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {EMPTY_OPTION_VALUE} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
@@ -94,10 +90,7 @@ function getEventView(
         return DEFAULT_INTERVAL;
       }
 
-      return getIntervalForMetricFunction(
-        parseResult.name as Aggregate | SpanFunctions,
-        pageFilters.datetime
-      );
+      return getIntervalForMetricFunction(parseResult.name, pageFilters.datetime);
     }),
     result => {
       return intervalToMilliseconds(result);

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -58,12 +58,22 @@ export type SpanMetricsQueryFilters = {
 
 export type SpanStringArrayFields = 'span.domain';
 
-export type SpanFunctions =
-  | 'sps'
-  | 'spm'
-  | 'count'
-  | 'time_spent_percentage'
-  | 'http_error_count';
+export const COUNTER_AGGREGATES = ['avg', 'min', 'max', 'p100'] as const;
+export const DISTRIBUTION_AGGREGATES = ['p50', 'p75', 'p95', 'p99'] as const;
+
+export const AGGREGATES = [...COUNTER_AGGREGATES, ...DISTRIBUTION_AGGREGATES] as const;
+
+export type Aggregate = (typeof AGGREGATES)[number];
+
+export const SPAN_FUNCTIONS = [
+  'sps',
+  'spm',
+  'count',
+  'time_spent_percentage',
+  'http_error_count',
+] as const;
+
+export type SpanFunctions = (typeof SPAN_FUNCTIONS)[number];
 
 export type MetricsResponse = {
   [Property in SpanNumberFields as `avg(${Property})`]: number;


### PR DESCRIPTION
Preparation for releasing percentiles. Percentiles have much worse performance than counters, so we need to reduce the granularity that we fetch by reducing the `interval` we ask for. _However_ I don't want to sacrifice the high granularity we get for simple counter metrics like `avg`. This PR sets the `interval` query parameter based on the `yAxis` value. If the `yAxis` includes any distribution metrics, it turns the granularity down.

I had to add some helpers and specs along the way to support this.

- `GranularityLadder` is an array object that specifies granularities for minute intervals. Check out `COUNTER_GRANULARITIES` for an example. This is way easier and cleaner to tweak than constantly updating the `getInterval` function
- Add `findGranularityIntervalForMinutes` helper function to complement the `GranularityLadder` type
- Declare correct granularities for Database metrics
- Dynamically adjust granularity based on metric series
