### PR TITLE
chore(hybrid-cloud): Add tags to outbox metrics indicating synchronicity

### DIFF
--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -570,10 +570,12 @@ class OutboxBase(Model):
             yield next_shard_row
 
     @contextlib.contextmanager
-    def process_coalesced(self) -> Generator[OutboxBase | None, None, None]:
+    def process_coalesced(
+        self, is_synchronous_flush: bool
+    ) -> Generator[OutboxBase | None, None, None]:
         coalesced: OutboxBase | None = self.select_coalesced_messages().last()
         first_coalesced: OutboxBase | None = self.select_coalesced_messages().first() or coalesced
-        tags = {"category": "None"}
+        tags: dict[str, int | str] = {"category": "None", "synchronous": int(is_synchronous_flush)}
 
         if coalesced is not None:
             tags["category"] = OutboxCategory(self.category).name
@@ -616,12 +618,15 @@ class OutboxBase(Model):
         span.set_tag("outbox_category", OutboxCategory(message.category).name)
         span.set_tag("outbox_scope", OutboxScope(message.shard_scope).name)
 
-    def process(self) -> bool:
-        with self.process_coalesced() as coalesced:
+    def process(self, is_synchronous_flush: bool) -> bool:
+        with self.process_coalesced(is_synchronous_flush=is_synchronous_flush) as coalesced:
             if coalesced is not None:
                 with metrics.timer(
                     "outbox.send_signal.duration",
-                    tags={"category": OutboxCategory(coalesced.category).name},
+                    tags={
+                        "category": OutboxCategory(coalesced.category).name,
+                        "synchronous": int(is_synchronous_flush),
+                    },
                 ), sentry_sdk.start_span(op="outbox.process") as span:
                     self._set_span_data_for_coalesced_message(span=span, message=coalesced)
                     try:
@@ -663,7 +668,7 @@ class OutboxBase(Model):
                 if _test_processing_barrier:
                     _test_processing_barrier.wait()
 
-                shard_row.process()
+                shard_row.process(is_synchronous_flush=not flush_all)
 
                 if _test_processing_barrier:
                     _test_processing_barrier.wait()

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -418,7 +418,7 @@ class RegionOutboxTest(TestCase):
 
         assert len(list(RegionOutbox.find_scheduled_shards())) == 2
 
-        ctx: ContextManager = outbox.process_coalesced()
+        ctx: ContextManager = outbox.process_coalesced(is_synchronous_flush=True)
         try:
             ctx.__enter__()
             assert RegionOutbox.objects.count() == 4
@@ -443,7 +443,11 @@ class RegionOutboxTest(TestCase):
                 call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
                 call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
                 call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
-                call("outbox.processed", 2, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
+                call(
+                    "outbox.processed",
+                    2,
+                    tags={"category": "ORGANIZATION_MEMBER_UPDATE", "synchronous": 1},
+                ),
             ]
             assert mock_metrics.incr.mock_calls == expected
         except Exception as e:


### PR DESCRIPTION
Adds tagging to better differentiate between lag/processing times for outboxes queued synchronously vs asynchronously. This will allow us to better monitor potential outage situations by potentially reducing alerting thresholds for synchronous events.

