### PR TITLE
feat(metrics): Reject stale keys in indexer cache

### DIFF
--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -126,6 +126,7 @@ class StringIndexerCache:
 
         if not self._is_valid_timestamp(timestamp):
             metrics.incr(_INDEXER_CACHE_STALE_KEYS_METRIC)
+            return None
 
         return int(result)
 

--- a/tests/sentry/sentry_metrics/test_indexer_cache.py
+++ b/tests/sentry/sentry_metrics/test_indexer_cache.py
@@ -93,6 +93,23 @@ def test_cache(use_case_id: str) -> None:
         assert indexer_cache.get(namespace_2, f"{use_case_id}:1:blah:123") is None
 
 
+def test_cache_validate_stale_timestamp():
+    with override_options(
+        {
+            "sentry-metrics.indexer.read-new-cache-namespace": True,
+            "sentry-metrics.indexer.write-new-cache-namespace": True,
+        }
+    ):
+        namespace = "test"
+        key = "spans:1:key"
+        cache.clear()
+        cache.set(
+            indexer_cache._make_namespaced_cache_key(namespace, key),
+            indexer_cache._make_cache_val(1, 0),
+        )
+        assert indexer_cache.get_many(namespace, [key]) == {key: None}
+
+
 def test_cache_many(use_case_id: str) -> None:
     with override_options(
         {

--- a/tests/sentry/sentry_metrics/test_indexer_cache.py
+++ b/tests/sentry/sentry_metrics/test_indexer_cache.py
@@ -109,6 +109,9 @@ def test_cache_validate_stale_timestamp():
         )
         assert indexer_cache.get_many(namespace, [key]) == {key: None}
 
+        indexer_cache.set_many(namespace, {key: 1})
+        assert indexer_cache.get_many(namespace, [key]) == {key: 1}
+
 
 def test_cache_many(use_case_id: str) -> None:
     with override_options(


### PR DESCRIPTION
### Overview

Reject keys that are too old in the indexer cache to enforce ttl