### PR TITLE
fix(browser-starfish): rely on file extension to display resource in resource module

### DIFF
--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -925,7 +925,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
           per_page: QUERY_LIMIT_PARAM,
           project: ['-42'],
           query:
-            '!span.description:browser-extension://* span.op:[resource.script,resource.css] !resource.render_blocking_status:blocking transaction.op:pageload',
+            '!span.description:browser-extension://* span.op:resource.script OR file_extension:css !resource.render_blocking_status:blocking transaction.op:pageload',
           sort: '-time_spent_percentage()',
           statsPeriod: '7d',
         }),

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -31,6 +31,7 @@ export enum SpanMetricsField {
   HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length',
   HTTP_DECODED_RESPONSE_CONTENT_LENGTH = 'http.decoded_response_content_length',
   HTTP_RESPONSE_TRANSFER_SIZE = 'http.response_transfer_size',
+  FILE_EXTENSION = 'file_extension',
 }
 
 export type SpanNumberFields =


### PR DESCRIPTION
This PR ensures we only have css resources within the resources dropdown.

I don't love this because we have to rely on both spanOp and file extension so it seems a bit funky. but it works well.

1. When the spanOp is resources.script, we just assume this is javascript, because only javascript can be in the scrip tag. We don't rely on file extension here because its possible to obtain javascript without a extension.
2. With css resources (and fonts in the future) we purely use file extensions, as fonts will come up as `resource.css`.

I think we may want to consider the case where a span has `resource.css` without an extension, this can probably be assumed to be a stylesheet? @AbhiPrasad i'm not sure about this