### PR TITLE
ref(notifications): stop providing organization_id_for_team argument

### DIFF
--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -203,7 +203,6 @@ class SlackLinkTeamView(BaseView):
                 notification_type=NotificationSettingTypes.ISSUE_ALERTS,
                 setting_option=NotificationSettingOptionValues.ALWAYS,
                 actor=RpcActor(id=team.id, actor_type=ActorType.TEAM),
-                organization_id_for_team=team.organization_id,
             )
         message = SUCCESS_LINKED_MESSAGE.format(
             slug=team.slug,

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -140,7 +140,6 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
         organization: Organization | int | None = None,
         actor: RpcActor | None = None,
         skip_provider_updates: bool = False,
-        organization_id_for_team: Optional[int] = None,
     ) -> None:
         """
         Save a target's notification preferences.
@@ -185,7 +184,6 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
                 team_id=team_id,
                 project=project,
                 organization=organization,
-                organization_id_for_team=organization_id_for_team,
             )
         else:
             if not validate(type, value):

--- a/src/sentry/services/hybrid_cloud/notifications/impl.py
+++ b/src/sentry/services/hybrid_cloud/notifications/impl.py
@@ -66,7 +66,6 @@ class DatabaseBackedNotificationsService(NotificationsService):
             organization=organization_id,
             actor=actor,
             skip_provider_updates=skip_provider_updates,
-            organization_id_for_team=organization_id_for_team,
         )
 
     def bulk_update_settings(

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -292,7 +292,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             notification_type=NotificationSettingTypes.ISSUE_ALERTS,
             setting_option=NotificationSettingOptionValues.ALWAYS,
             actor=RpcActor.from_object(self.team),
-            organization_id_for_team=self.organization.id,
         )
 
         rule = GrammarRule(Matcher("path", "*"), [Owner("team", self.team.slug)])
@@ -350,7 +349,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_disabled_org_integration_for_team(self, mock_func):
-
         # update the team's notification settings
         ExternalActor.objects.create(
             team_id=self.team.id,
@@ -365,7 +363,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             notification_type=NotificationSettingTypes.ISSUE_ALERTS,
             setting_option=NotificationSettingOptionValues.ALWAYS,
             actor=RpcActor.from_object(self.team),
-            organization_id_for_team=self.organization.id,
         )
 
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -466,7 +463,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             notification_type=NotificationSettingTypes.ISSUE_ALERTS,
             setting_option=NotificationSettingOptionValues.ALWAYS,
             actor=RpcActor.from_object(self.team),
-            organization_id_for_team=self.organization.id,
         )
 
         g_rule = GrammarRule(Matcher("path", "*"), [Owner("team", self.team.slug)])
@@ -566,7 +562,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             notification_type=NotificationSettingTypes.ISSUE_ALERTS,
             setting_option=NotificationSettingOptionValues.ALWAYS,
             actor=RpcActor.from_object(self.team),
-            organization_id_for_team=self.organization.id,
         )
 
         event = self.store_event(
@@ -647,7 +642,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             notification_type=NotificationSettingTypes.ISSUE_ALERTS,
             setting_option=NotificationSettingOptionValues.ALWAYS,
             actor=RpcActor.from_object(self.team),
-            organization_id_for_team=self.organization.id,
         )
         # add a new project
         project2 = self.create_project(
@@ -711,7 +705,6 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             notification_type=NotificationSettingTypes.ISSUE_ALERTS,
             setting_option=NotificationSettingOptionValues.ALWAYS,
             actor=RpcActor.from_object(self.team),
-            organization_id_for_team=self.organization.id,
         )
         # remove the project from the team
         self.project.remove_team(self.team)

--- a/tests/sentry/models/test_notificationsetting.py
+++ b/tests/sentry/models/test_notificationsetting.py
@@ -52,7 +52,6 @@ class NotificationSettingTest(TestCase):
         create_setting(
             team_id=self.team.id,
             project=self.project,
-            organization_id_for_team=self.organization.id,
         )
 
         # Deletion is deferred and tasks aren't run in tests.
@@ -68,7 +67,6 @@ class NotificationSettingTest(TestCase):
         create_setting(
             user_id=self.user.id,
             project=self.project,
-            organization_id_for_team=self.organization.id,
         )
         with assume_test_silo_mode(SiloMode.REGION):
             self.project.delete()
@@ -78,7 +76,6 @@ class NotificationSettingTest(TestCase):
         create_setting(
             user_id=self.user.id,
             organization=self.organization,
-            organization_id_for_team=self.organization.id,
         )
         with assume_test_silo_mode(SiloMode.REGION), outbox_runner():
             self.organization.delete()
@@ -105,7 +102,6 @@ class NotificationSettingTest(TestCase):
             NotificationSettingTypes.ISSUE_ALERTS,
             NotificationSettingOptionValues.ALWAYS,
             team_id=self.team.id,
-            organization_id_for_team=self.organization.id,
         )
         ns = NotificationSetting.objects.find_settings(
             provider=ExternalProviders.EMAIL,
@@ -171,7 +167,6 @@ class NotificationSettingTest(TestCase):
                 ),
             ],
             team=self.team,
-            organization_id_for_team=self.organization.id,
         )
 
         ns1 = NotificationSetting.objects.find_settings(

--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -192,7 +192,6 @@ class TeamDeletionTest(TestCase):
                 NotificationSettingTypes.ISSUE_ALERTS,
                 NotificationSettingOptionValues.ALWAYS,
                 team_id=team.id,
-                organization_id_for_team=org.id,
             )
 
         assert Team.objects.filter(id=team.id).exists()

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -73,7 +73,7 @@ class _ParticipantsTest(TestCase):
         slack: Iterable[int] = (),
     ) -> None:
         expected: dict[ExternalProviders, set[RpcActor]] = collections.defaultdict(set)
-        for (provider, user_ids) in [
+        for provider, user_ids in [
             (ExternalProviders.EMAIL, email),
             (ExternalProviders.SLACK, slack),
         ]:
@@ -319,7 +319,6 @@ class GetSendToOwnersTest(_ParticipantsTest):
                 NotificationSettingTypes.ISSUE_ALERTS,
                 NotificationSettingOptionValues.NEVER,
                 team_id=self.team2.id,
-                organization_id_for_team=self.organization.id,
             )
 
             self.integration.add_organization(self.project.organization, self.user)


### PR DESCRIPTION
This argument isn't needed anymore so we can stop providing it. I will remove it from the RPC function definitions later in a follow-up PR.