### PR TITLE
feat(browser-starfish): add fonts to resource module + misc improvements

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -289,6 +289,7 @@ function Sidebar({location, organization}: Props) {
               <Feature features={['starfish-browser-resource-module-ui']}>
                 <SidebarItem
                   {...sidebarItemProps}
+                  isNew
                   label={<GuideAnchor target="starfish">{t('Resources')}</GuideAnchor>}
                   to={`/organizations/${organization.slug}/performance/browser/resources`}
                   id="performance-browser-resources"

--- a/static/app/views/performance/browser/resources/index.tsx
+++ b/static/app/views/performance/browser/resources/index.tsx
@@ -78,7 +78,8 @@ function ResourcesLandingPage() {
 
           {(!filters[SPAN_OP] ||
             filters[SPAN_OP] === 'resource.script' ||
-            filters[SPAN_OP] === 'resource.css') && <JSCSSView />}
+            filters[SPAN_OP] === 'resource.css' ||
+            filters[SPAN_OP] === 'resource.font') && <JSCSSView />}
 
           {filters[SPAN_OP] === 'resource.img' && <ImageView />}
         </Layout.Main>

--- a/static/app/views/performance/browser/resources/jsCssView/index.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/index.tsx
@@ -27,7 +27,11 @@ const {
   RESOURCE_RENDER_BLOCKING_STATUS,
 } = BrowserStarfishFields;
 
-export const DEFAULT_RESOURCE_TYPES = ['resource.script', 'resource.css'];
+export const DEFAULT_RESOURCE_TYPES = [
+  'resource.script',
+  'resource.css',
+  'resource.font',
+];
 
 type Option = {
   label: string;
@@ -71,6 +75,7 @@ function ResourceTypeSelector({value}: {value?: string}) {
     {value: '', label: 'All'},
     {value: 'resource.script', label: `${t('JavaScript')} (.js)`},
     {value: 'resource.css', label: `${t('Stylesheet')} (.css)`},
+    {value: 'resource.font', label: `${t('Font')} (.woff, .woff2, .ttf, .otf, .eot)`},
   ];
   return (
     <SelectControlWithProps

--- a/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
@@ -139,10 +139,10 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
         return <span>{t('JavaScript')}</span>;
       }
       if (fileExtension === 'css') {
-        return <span>Stylesheet</span>;
+        return <span>{t('Stylesheet')}</span>;
       }
       if (['woff', 'woff2', 'ttf', 'otf', 'eot'].includes(fileExtension)) {
-        return <span>Font</span>;
+        return <span>{t('Font')}</span>;
       }
       return <span>{spanOp}</span>;
     }

--- a/static/app/views/performance/browser/resources/utils/useResourceFilters.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourceFilters.ts
@@ -18,7 +18,11 @@ export type ModuleFilters = {
     | 'blocking'
     | '!blocking';
   [BrowserStarfishFields.SPAN_DOMAIN]?: string;
-  [BrowserStarfishFields.SPAN_OP]?: 'resource.script' | 'resource.css' | 'resource.img';
+  [BrowserStarfishFields.SPAN_OP]?:
+    | 'resource.script'
+    | 'resource.css'
+    | 'resource.font'
+    | 'resource.img';
   [BrowserStarfishFields.TRANSACTION]?: string;
   [BrowserStarfishFields.SPAN_DOMAIN]?: string;
 };

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -925,7 +925,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
           per_page: QUERY_LIMIT_PARAM,
           project: ['-42'],
           query:
-            '!span.description:browser-extension://* span.op:resource.script OR file_extension:css !resource.render_blocking_status:blocking transaction.op:pageload',
+            '!span.description:browser-extension://* span.op:resource.script OR file_extension:css OR file_extension:[woff,woff2,ttf,otf,eot] !resource.render_blocking_status:blocking transaction.op:pageload',
           sort: '-time_spent_percentage()',
           statsPeriod: '7d',
         }),


### PR DESCRIPTION
Adds fonts to resource module as its own section
![image](https://github.com/getsentry/sentry/assets/44422760/f6872f16-d055-4a32-b269-580b0dd94356)

Also 2 misc fixes
1. Add new badge in sidebar (to prepare for release)
2. Translate some stuff that wasn't translated