### PR TITLE
fix(browser-starfish): add units to resource size graphs

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryCharts.tsx
@@ -98,6 +98,7 @@ function ResourceSummaryCharts(props: {groupId: string}) {
         <ChartPanel title={t('Average Resource Size')}>
           <Chart
             height={160}
+            aggregateOutputFormat="size"
             data={[
               spanMetricsSeriesData?.[`avg(${HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`],
               spanMetricsSeriesData?.[`avg(${HTTP_RESPONSE_TRANSFER_SIZE})`],


### PR DESCRIPTION
Adds units here, there's something weird going on with how the generic chart chooses yaxis labels, but that's a seperate issue.

<img width="319" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/68718b78-4584-4b54-909d-7af01b6a9a29">
