### PR TITLE
chore(participants): Remove backend usage of feature flag

### DIFF
--- a/src/sentry/api/endpoints/group_notes.py
+++ b/src/sentry/api/endpoints/group_notes.py
@@ -5,14 +5,12 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.group_notes import NoteSerializer
-from sentry.api.serializers.rest_framework.mentions import extract_user_ids_from_mentions
 from sentry.models.activity import Activity
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.notifications.types import GroupSubscriptionReason
@@ -53,8 +51,6 @@ class GroupNotesEndpoint(GroupEndpoint):
 
         data = dict(serializer.validated_data)
 
-        mentions = data.pop("mentions", [])
-
         if Activity.objects.filter(
             group=group,
             type=ActivityType.NOTE.value,
@@ -70,29 +66,6 @@ class GroupNotesEndpoint(GroupEndpoint):
         GroupSubscription.objects.subscribe(
             group=group, subscriber=request.user, reason=GroupSubscriptionReason.comment
         )
-        mentioned_users = extract_user_ids_from_mentions(group.organization.id, mentions)
-        if not features.has("organizations:participants-purge", group.organization):
-            GroupSubscription.objects.bulk_subscribe(
-                group=group,
-                user_ids=mentioned_users["users"],
-                reason=GroupSubscriptionReason.mentioned,
-            )
-
-        if features.has(
-            "organizations:team-workflow-notifications", group.organization
-        ) and not features.has("organizations:participants-purge", group.organization):
-            GroupSubscription.objects.bulk_subscribe(
-                group=group,
-                team_ids=mentioned_users["teams"],
-                reason=GroupSubscriptionReason.team_mentioned,
-            )
-        else:
-            if not features.has("organizations:participants-purge", group.organization):
-                GroupSubscription.objects.bulk_subscribe(
-                    group=group,
-                    user_ids=mentioned_users["team_users"],
-                    reason=GroupSubscriptionReason.team_mentioned,
-                )
 
         activity = Activity.objects.create_group_activity(
             group, ActivityType.NOTE, user_id=request.user.id, data=data

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -3,7 +3,6 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
@@ -59,15 +58,14 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
             data=webhook_data,
             sender="delete",
         )
-        if features.has("organizations:participants-purge", group.organization):
-            # if the user left more than one comment, we want to keep the subscription
-            if len(notes_by_user) == 1:
-                GroupSubscription.objects.filter(
-                    user_id=request.user.id,
-                    group=group,
-                    project=group.project,
-                    reason=GroupSubscriptionReason.comment,
-                ).delete()
+        # if the user left more than one comment, we want to keep the subscription
+        if len(notes_by_user) == 1:
+            GroupSubscription.objects.filter(
+                user_id=request.user.id,
+                group=group,
+                project=group.project,
+                reason=GroupSubscriptionReason.comment,
+            ).delete()
 
         return Response(status=204)
 

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -735,11 +735,10 @@ def handle_is_bookmarked(
             user_id=acting_user.id if acting_user else None,
         ).delete()
         if group_list:
-            if features.has("organizations:participants-purge", group_list[0].organization):
-                GroupSubscription.objects.filter(
-                    user_id=acting_user.id,
-                    group__in=group_ids,
-                ).delete()
+            GroupSubscription.objects.filter(
+                user_id=acting_user.id,
+                group__in=group_ids,
+            ).delete()
 
 
 def handle_has_seen(

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1467,8 +1467,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:higher-ownership-limit": False,
     # Enable Monitors (Crons) view
     "organizations:monitors": False,
-    # Enable participants purge
-    "organizations:participants-purge": False,
     # Enable Performance view
     "organizations:performance-view": True,
     # Enable profiling

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -130,7 +130,6 @@ default_manager.add("organizations:noisy-alert-warning", OrganizationFeature, Fe
 default_manager.add("organizations:notification-all-recipients", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:onboarding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)  # Only enabled in sentry.io to enable onboarding flows.
 default_manager.add("organizations:org-subdomains", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:participants-purge", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-anomaly-detection-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-change-explorer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:performance-chart-interpolation", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -76,9 +76,6 @@ class GroupAssigneeManager(BaseManager["GroupAssignee"]):
     ) -> None:
         from sentry.models.team import Team
 
-        if not features.has("organizations:participants-purge", group.organization):
-            return
-
         if not previous_assignee:
             return
 

--- a/tests/sentry/api/endpoints/test_group_notes.py
+++ b/tests/sentry/api/endpoints/test_group_notes.py
@@ -9,7 +9,6 @@ from sentry.notifications.types import GroupSubscriptionReason
 from sentry.silo import SiloMode
 from sentry.tasks.merge import merge_groups
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
@@ -169,12 +168,12 @@ class GroupNoteCreateTest(APITestCase):
             project=group.project,
             reason=GroupSubscriptionReason.comment,
         )
-        assert GroupSubscription.objects.get(
+        assert not GroupSubscription.objects.filter(
             user_id=user_on_team.id,
             group=group,
             project=group.project,
             reason=GroupSubscriptionReason.mentioned,
-        )
+        ).exists()
 
         # mentioning a member that exists but NOT in the team returns
         # validation error
@@ -188,43 +187,6 @@ class GroupNoteCreateTest(APITestCase):
         )
 
         assert response.data == {"mentions": ["Cannot mention a non team member"]}
-
-    @with_feature("organizations:participants-purge")
-    @with_feature("organizations:team-workflow-notifications")
-    def test_mentions_with_participants_purge_flag(self):
-        self.org = self.create_organization(name="Gnarly Org", owner=None)
-        self.team = self.create_team(organization=self.org, name="Ultra Rad Team")
-        user_on_team = self.create_user(email="hello@woof.com")
-        self.create_member(user=self.user, organization=self.org, role="member", teams=[self.team])
-        # member that IS part of the team
-        self.create_member(
-            user=user_on_team, organization=self.org, role="member", teams=[self.team]
-        )
-        group = self.group
-
-        self.login_as(user=self.user)
-
-        url = f"/api/0/issues/{group.id}/comments/"
-
-        # mentioning a member does NOT subscribe them to the issue
-        response = self.client.post(
-            url,
-            format="json",
-            data={"text": "**hello@woof.com** is so fun", "mentions": [f"{user_on_team.id}"]},
-        )
-        assert response.status_code == 201, response.content
-        assert GroupSubscription.objects.get(
-            user_id=self.user.id,
-            group=group,
-            project=group.project,
-            reason=GroupSubscriptionReason.comment,
-        )
-        assert not GroupSubscription.objects.filter(
-            user_id=user_on_team.id,
-            group=group,
-            project=group.project,
-            reason=GroupSubscriptionReason.mentioned,
-        ).exists()
 
         # mentioning a team does NOT subscribe the team to the issue
         response = self.client.post(
@@ -245,54 +207,6 @@ class GroupNoteCreateTest(APITestCase):
             project=group.project,
             reason=GroupSubscriptionReason.mentioned,
         ).exists()
-
-    def test_with_team_user_mentions(self):
-        user = self.create_user(email="redTeamUser@example.com")
-
-        self.org = self.create_organization(name="Gnarly Org", owner=None)
-        # team that IS part of the project
-        self.team = self.create_team(organization=self.org, name="Red Team", members=[user])
-        # team that IS NOT part of the project
-        self.team2 = self.create_team(organization=self.org, name="Blue Team")
-
-        self.create_member(user=self.user, organization=self.org, role="member", teams=[self.team])
-
-        group = self.group
-
-        self.login_as(user=self.user)
-
-        url = f"/api/0/issues/{group.id}/comments/"
-
-        # mentioning a team that does not exist returns 400
-        response = self.client.post(
-            url,
-            format="json",
-            data={
-                "text": "hey **blue-team** fix this bug",
-                "mentions": ["team:%s" % self.team2.id],
-            },
-        )
-        assert response.status_code == 400, response.content
-
-        assert response.data == {
-            "mentions": ["Mentioned team not found or not associated with project"]
-        }
-
-        # mentioning a team in the project returns 201
-        response = self.client.post(
-            url,
-            format="json",
-            data={"text": "hey **red-team** fix this bug", "mentions": ["team:%s" % self.team.id]},
-        )
-        assert response.status_code == 201, response.content
-        assert (
-            len(
-                GroupSubscription.objects.filter(
-                    group=group, reason=GroupSubscriptionReason.team_mentioned
-                )
-            )
-            == 1
-        )
 
     def test_with_group_link(self):
         group = self.group
@@ -341,73 +255,3 @@ class GroupNoteCreateTest(APITestCase):
                 assert activity.user_id == self.user.id
                 assert activity.group == group
                 assert activity.data == {"text": comment, "external_id": "123456789"}
-
-    @with_feature("organizations:team-workflow-notifications")
-    def test_with_team_mentions(self):
-        """
-        This test assures teams can be subscribed via mention, rather than subscribing the individual users on the team.
-        """
-        user = self.create_user(email="grunt@teamgalactic.com")
-
-        self.org = self.create_organization(name="Galactic Org", owner=None)
-        self.team = self.create_team(organization=self.org, name="Team Galactic", members=[user])
-        self.create_member(user=self.user, organization=self.org, role="member", teams=[self.team])
-
-        group = self.group
-
-        self.login_as(user=self.user)
-
-        url = f"/api/0/issues/{group.id}/comments/"
-
-        # mentioning a team in the project returns 201
-        response = self.client.post(
-            url,
-            format="json",
-            data={
-                "text": "hey **team-galactic** check out this bug",
-                "mentions": ["team:%s" % self.team.id],
-            },
-        )
-        assert response.status_code == 201, response.content
-
-        # should subscribe the team and not the user with the team_mentioned reason
-        assert GroupSubscription.objects.filter(
-            group=group, team=self.team, reason=GroupSubscriptionReason.team_mentioned
-        ).exists()
-        assert not GroupSubscription.objects.filter(group=group, user_id=user.id)
-
-    @with_feature("organizations:team-workflow-notifications")
-    def test_with_user_on_team_mentions(self):
-        """
-        This test assures that if a user is mentioned along with their team, they get subscribed both individually and as part of the team.
-        """
-        user = self.create_user(email="maxie@teammagma.com")
-
-        self.org = self.create_organization(name="Emerald Org", owner=None)
-        self.team = self.create_team(organization=self.org, name="Team Magma", members=[user])
-        self.create_member(user=self.user, organization=self.org, role="member", teams=[self.team])
-
-        group = self.group
-
-        self.login_as(user=self.user)
-
-        url = f"/api/0/issues/{group.id}/comments/"
-
-        # mentioning a team and a user in the project returns 201
-        response = self.client.post(
-            url,
-            format="json",
-            data={
-                "text": "look at this **team-magma** **maxie@teammagma.com**",
-                "mentions": ["team:%s" % self.team.id, "%s" % user.id],
-            },
-        )
-        assert response.status_code == 201, response.content
-
-        # should subscribe the team and the user
-        assert GroupSubscription.objects.filter(
-            group=group, team=self.team, reason=GroupSubscriptionReason.team_mentioned
-        ).exists()
-        assert GroupSubscription.objects.filter(
-            group=group, user_id=user.id, reason=GroupSubscriptionReason.mentioned
-        )

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -58,7 +58,7 @@ class GroupNotesDetailsTest(APITestCase):
 
         assert Group.objects.get(id=self.group.id).num_comments == 0
 
-    def test_delete_with_participants_flag(self):
+    def test_delete_comment_and_subscription(self):
         """Test that if a user deletes their comment on an issue, we delete the subscription too"""
         self.login_as(user=self.user)
         event = self.store_event(data={}, project_id=self.project.id)
@@ -79,9 +79,8 @@ class GroupNotesDetailsTest(APITestCase):
             group=group, type=ActivityType.NOTE.value, user_id=self.user.id
         )
 
-        with self.feature("organizations:participants-purge"):
-            url = f"/api/0/issues/{group.id}/comments/{activity.id}/"
-            response = self.client.delete(url, format="json")
+        url = f"/api/0/issues/{group.id}/comments/{activity.id}/"
+        response = self.client.delete(url, format="json")
 
         assert response.status_code == 204, response.status_code
         assert not GroupSubscription.objects.filter(
@@ -91,7 +90,7 @@ class GroupNotesDetailsTest(APITestCase):
             reason=GroupSubscriptionReason.comment,
         ).exists()
 
-    def test_delete_with_participants_flag_multiple_comments(self):
+    def test_delete_multiple_comments(self):
         """Test that if a user has commented multiple times on an issue and deletes one, we don't remove the subscription"""
         self.login_as(user=self.user)
         event = self.store_event(data={}, project_id=self.project.id)
@@ -117,9 +116,8 @@ class GroupNotesDetailsTest(APITestCase):
             group=group, type=ActivityType.NOTE.value, user_id=self.user.id
         ).first()
 
-        with self.feature("organizations:participants-purge"):
-            url = f"/api/0/issues/{group.id}/comments/{activity.id}/"
-            response = self.client.delete(url, format="json")
+        url = f"/api/0/issues/{group.id}/comments/{activity.id}/"
+        response = self.client.delete(url, format="json")
 
         assert response.status_code == 204, response.status_code
         assert GroupSubscription.objects.filter(

--- a/tests/sentry/notifications/notifications/test_assigned.py
+++ b/tests/sentry/notifications/notifications/test_assigned.py
@@ -7,7 +7,7 @@ from sentry.models.notificationsetting import NotificationSetting
 from sentry.models.options.user_option import UserOption
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import get_attachment, get_channel, install_slack, with_feature
+from sentry.testutils.helpers import get_attachment, get_channel, install_slack
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 from sentry.types.integrations import ExternalProviders
@@ -89,7 +89,6 @@ class AssignedNotificationAPITest(APITestCase):
         assert self.project.slug in attachment["footer"]
 
     @responses.activate
-    @with_feature("organizations:participants-purge")
     def test_sends_reassignment_notification_user(self):
         """Test that if a user is assigned to an issue and then the issue is reassigned to a different user
         that the original assignee receives an unassignment notification as well as the new assignee
@@ -150,7 +149,6 @@ class AssignedNotificationAPITest(APITestCase):
         self.validate_slack_message(msg, self.group, self.project, user1.id, index=2)
 
     @responses.activate
-    @with_feature("organizations:participants-purge")
     def test_sends_reassignment_notification_team(self):
         """Test that if a team is assigned to an issue and then the issue is reassigned to a different team
         that the originally assigned team receives an unassignment notification as well as the new assigned


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/60304 where I removed the front end usages, this removes all remaining feature flag references on the backend. 