### PR TITLE
fix(browser-starfish): don't group by file_extension resource module

### DIFF
--- a/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
@@ -40,7 +40,6 @@ const {SPM} = SpanFunction;
 type Row = {
   'avg(http.response_content_length)': number;
   'avg(span.self_time)': number;
-  file_extension: string;
   'http.decoded_response_content_length': number;
   'project.id': number;
   'resource.render_blocking_status': string;
@@ -133,7 +132,7 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
       return <DurationCell milliseconds={row[key]} />;
     }
     if (key === SPAN_OP) {
-      const fileExtension = row[FILE_EXTENSION];
+      const fileExtension = row[SPAN_DESCRIPTION].split('.').slice(-1)[0];
       const spanOp = row[key];
       if (fileExtension === 'js' || spanOp === 'resource.script') {
         return <span>{t('JavaScript')}</span>;

--- a/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
@@ -132,7 +132,7 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
       return <DurationCell milliseconds={row[key]} />;
     }
     if (key === SPAN_OP) {
-      const fileExtension = row[SPAN_DESCRIPTION].split('.').slice(-1)[0];
+      const fileExtension = row[SPAN_DESCRIPTION].split('.').pop() || '';
       const spanOp = row[key];
       if (fileExtension === 'js' || spanOp === 'resource.script') {
         return <span>{t('JavaScript')}</span>;

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -80,7 +80,6 @@ export const useResourcesQuery = ({sort, defaultResourceTypes, query, limit}: Pr
         'project.id',
         `${TIME_SPENT_PERCENTAGE}()`,
         `sum(${SPAN_SELF_TIME})`,
-        FILE_EXTENSION,
       ],
       name: 'Resource module - resource table',
       query: queryConditions.join(' '),
@@ -124,7 +123,6 @@ export const useResourcesQuery = ({sort, defaultResourceTypes, query, limit}: Pr
     [`time_spent_percentage()`]: row[`${TIME_SPENT_PERCENTAGE}()`] as number,
     ['count_unique(transaction)']: row['count_unique(transaction)'] as number,
     [`sum(span.self_time)`]: row[`sum(${SPAN_SELF_TIME})`] as number,
-    [FILE_EXTENSION]: row[FILE_EXTENSION]?.toString(),
   }));
 
   return {...result, data: data || []};


### PR DESCRIPTION
We can't group by file_extension here because we only recently added that tag, grouping by extension results in duplicate entries for the same resource, one entry for the one with a missing extension, one with the extension.

I also removed the alpha badges in this PR

Before
<img width="312" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/e1f86485-eb71-4338-974a-ba88652c4365">


After
<img width="371" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/939fb2a9-9fac-434c-9005-8e681897ca5a">