### PR TITLE
fix(github-invite): rendering integer list in query

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -78,6 +78,8 @@ def _get_missing_organization_members(
             )
 
     date_added = (timezone.now() - timedelta(days=30)).strftime("%Y-%m-%d, %H:%M:%S")
+    integration_ids_string = ", ".join([str(id) for id in integration_ids])
+    integration_query = f" and integration_id in ({integration_ids_string}))"
 
     query = """
         SELECT sentry_commitauthor.id, sentry_commitauthor.organization_id, sentry_commitauthor.name, sentry_commitauthor.email, sentry_commitauthor.external_id, COUNT(sentry_commit.id) AS commit__count FROM sentry_commitauthor
@@ -93,9 +95,9 @@ def _get_missing_organization_members(
             select id
             from sentry_repository
             where provider = %(provider)s
-            and organization_id = %(org_id)s
-            and integration_id in (%(integration_ids)s)
-            )
+            and organization_id = %(org_id)s"""
+    query += integration_query
+    query += """
         AND sentry_commit.author_id IN
             (select id from sentry_commitauthor
                 WHERE sentry_commitauthor.organization_id = %(org_id)s
@@ -110,14 +112,12 @@ def _get_missing_organization_members(
         AND NOT (UPPER(sentry_commitauthor.email::text) LIKE UPPER('%%+%%'))
         )
 
-        GROUP BY sentry_commitauthor.id ORDER BY commit__count DESC limit 50
-        """
+        GROUP BY sentry_commitauthor.id ORDER BY commit__count DESC limit 50"""
 
     param_dict = {
         "org_id": org_id,
         "date_added": date_added,
         "provider": "integrations:" + provider,
-        "integration_ids": ", ".join([str(id) for id in integration_ids]),
     }
 
     return list(CommitAuthor.objects.raw(query, param_dict))

--- a/tests/sentry/api/endpoints/test_organization_missing_org_members.py
+++ b/tests/sentry/api/endpoints/test_organization_missing_org_members.py
@@ -56,6 +56,12 @@ class OrganizationMissingMembersTestCase(APITestCase):
         self.integration = self.create_integration(
             organization=self.organization, provider="github", name="Github", external_id="github:1"
         )
+        self.integration2 = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="Github2",
+            external_id="github:3",
+        )
         self.repo = self.create_repo(
             project=self.project, provider="integrations:github", integration_id=self.integration.id
         )
@@ -221,6 +227,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
     def test_no_github_integration(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.delete()
+            self.integration2.delete()
 
         response = self.get_success_response(self.organization.slug)
         assert len(response.data) == 0
@@ -229,6 +236,8 @@ class OrganizationMissingMembersTestCase(APITestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.status = ObjectStatus.DISABLED
             self.integration.save()
+            self.integration2.status = ObjectStatus.DISABLED
+            self.integration2.save()
 
         response = self.get_success_response(self.organization.slug)
         assert len(response.data) == 0
@@ -236,6 +245,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
     def test_nongithub_integration(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.delete()
+            self.integration2.delete()
 
         integration = self.create_integration(
             organization=self.organization,


### PR DESCRIPTION
Fixes [SENTRY-18TT](https://sentry.sentry.io/issues/4652913902/)

The query for a list of integration ids needs to be rendered outside of the formatting with the query param dict to escape Django putting extra quotations around the list of ids.