### PR TITLE
fix(recommended-event): Use event ID as tie breaker to match latest event

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -211,6 +211,7 @@ class EventOrdering(Enum):
         "num_processing_errors",
         "-trace.sampled",
         "-timestamp",
+        "-event_id",
     ]
 
 


### PR DESCRIPTION
Sometimes the recommended event would not match the latest event despite everything about the event being the same. I believe this is because the latest event logic uses event_id in the sort, but recommended does not: 

https://github.com/getsentry/sentry/blob/a3a743c46e51d14bf21d0a55d8a5165e91b49dc8/src/sentry/models/group.py#L206

Adds `event_id` as the last item in the sort to break ties when the timestamp and everything else is the same.