### PR TITLE
ref(recommended-event): Remove 'new' badge from dropdown

### DIFF
--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -10,7 +10,6 @@ import {Button, ButtonProps} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import DateTime from 'sentry/components/dateTime';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import FeatureBadge from 'sentry/components/featureBadge';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
 import {
@@ -146,12 +145,7 @@ function EventNavigationDropdown({group, event, isDisabled}: GroupEventNavigatio
   const eventNavDropdownOptions = [
     {
       value: EventNavDropdownOption.RECOMMENDED,
-      label: (
-        <div>
-          {t('Recommended')}
-          <FeatureBadge type="new" />
-        </div>
-      ),
+      label: t('Recommended'),
       textValue: t('Recommended'),
       details: t('Event with the most context'),
     },


### PR DESCRIPTION
The feature has been out long enough to remove this.

![CleanShot 2023-11-20 at 14 32 05](https://github.com/getsentry/sentry/assets/10888943/2a623a6c-1c57-47eb-8a4d-8297eebdbb75)
