### PR TITLE
feat(integrations): make sure stacktrace-link feature is set

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1597,6 +1597,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:integrations-opsgenie": True,
     # Enable one-click migration from Opsgenie plugin
     "organizations:integrations-opsgenie-migration": False,
+    # Enable stacktrace linking
+    "organizations:integrations-stacktrace-link": True,
     # Limit project events endpoint to only query back a certain number of days
     "organizations:project-event-date-limit": False,
     # Enable data forwarding functionality for organizations.

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -38,6 +38,7 @@ def register_permanent_features(manager: FeatureManager):
         "organizations:integrations-incident-management",
         "organizations:integrations-issue-basic",
         "organizations:integrations-issue-sync",
+        "organizations:integrations-stacktrace-link",
         "organizations:integrations-ticket-rules",
         "organizations:performance-view",
         "organizations:profiling-view",

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -84,6 +84,7 @@ class OrganizationSerializerTest(TestCase):
             "integrations-incident-management",
             "integrations-issue-basic",
             "integrations-issue-sync",
+            "integrations-stacktrace-link",
             "integrations-ticket-rules",
             "invite-members",
             "invite-members-rate-limits",


### PR DESCRIPTION
Before:
<img width="691" alt="Screenshot 2023-11-20 at 3 26 00 PM" src="https://github.com/getsentry/sentry/assets/8533851/00960b1d-cfb6-4af5-97e0-b097d6803af0">

After:
<img width="719" alt="Screenshot 2023-11-20 at 3 26 13 PM" src="https://github.com/getsentry/sentry/assets/8533851/a9d309c5-24be-41cd-b1a8-cce977d11108">
