### PR TITLE
add: log json path and keys

### DIFF
--- a/src/sentry/utils/env.py
+++ b/src/sentry/utils/env.py
@@ -49,7 +49,11 @@ def log_gcp_credentials_details(logger) -> None:
 
             logger.info(
                 "gcp.credentials.file_found",
-                extra={"adc": adc.get("quota_project_id", "")},
+                extra={
+                    "adc": adc.get("quota_project_id", ""),
+                    "adc_path": adc_path,
+                    "adc_json": adc.keys(),
+                },
             )
 
     # Checking User credentials set up by using the Google Cloud CLI


### PR DESCRIPTION
added more logging for entire Application Default Credentials strategy to figure out why cloud KMS can't get credentials in test-region