### PR TITLE
test(hc): Change inheritance from AlertRuleDetailsPutEndpointTest

### DIFF
--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -602,7 +602,10 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         assert len(audit_log_entry) == 1
 
 
-class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsPutEndpointTest):
+@region_silo_test(stable=True)
+class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
+    method = "put"
+
     def _mock_slack_response(self, url: str, body: dict[str, Any], status: int = 200) -> None:
         responses.add(
             method=responses.GET,
@@ -811,12 +814,13 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsPutEndpointTest):
         )
         self.login_as(self.user)
         mock_uuid4.return_value = self.get_mock_uuid()
-        self.integration = Integration.objects.create(
-            provider="slack",
-            name="Team A",
-            external_id="TXXXXXXX1",
-            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
-        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration = Integration.objects.create(
+                provider="slack",
+                name="Team A",
+                external_id="TXXXXXXX1",
+                metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+            )
         self.integration.add_organization(self.organization, self.user)
         test_params = self.valid_params.copy()
         test_params["triggers"] = [
@@ -936,7 +940,10 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsPutEndpointTest):
         )  # Did not increment from the last assertion because we early out on the validation error
 
 
-class AlertRuleDetailsSentryAppPutEndpointTest(AlertRuleDetailsPutEndpointTest):
+@region_silo_test(stable=True)
+class AlertRuleDetailsSentryAppPutEndpointTest(AlertRuleDetailsBase):
+    method = "put"
+
     def test_sentry_app(self):
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -821,7 +821,7 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
                 external_id="TXXXXXXX1",
                 metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
             )
-        self.integration.add_organization(self.organization, self.user)
+            self.integration.add_organization(self.organization, self.user)
         test_params = self.valid_params.copy()
         test_params["triggers"] = [
             {


### PR DESCRIPTION
Fix test class inheritance structure so that subclasses run correctly in region mode. Fix a SiloLimit.AvailabilityError from
AlertRuleDetailsSlackPutEndpointTest.