### PR TITLE
feat(provisioning): Making user optional for provisioning - Sentry changes

### DIFF
--- a/src/sentry/hybridcloud/rpc_services/control_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/rpc_services/control_organization_provisioning/impl.py
@@ -155,6 +155,7 @@ class DatabaseBackedControlOrganizationProvisioningService(
         with outbox_context(
             transaction.atomic(using=router.db_for_write(OrganizationSlugReservation))
         ):
+            # TODO @GabeVillalobos: add email/user_id pair to be able to check for idempotency
             org_slug_res = OrganizationSlugReservation(
                 slug=slug,
                 organization_id=org_id,

--- a/src/sentry/hybridcloud/rpc_services/control_organization_provisioning/model.py
+++ b/src/sentry/hybridcloud/rpc_services/control_organization_provisioning/model.py
@@ -1,10 +1,12 @@
+from typing import Optional
+
 import pydantic
 
 
 class RpcOrganizationSlugReservation(pydantic.BaseModel):
     id: int
     organization_id: int
-    user_id: int
+    user_id: Optional[int]
     slug: str
     region_name: str
     reservation_type: int

--- a/src/sentry/hybridcloud/rpc_services/region_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/rpc_services/region_organization_provisioning/impl.py
@@ -42,12 +42,16 @@ class DatabaseBackedRegionOrganizationProvisioningRpcService(
     def _create_organization_and_team(
         self,
         organization_name: str,
-        user_id: int,
         slug: str,
         create_default_team: bool,
         organization_id: int,
         is_test: bool = False,
+        user_id: Optional[int] = None,
+        email: Optional[str] = None,
     ) -> Organization:
+        assert (user_id is None and email) or (
+            user_id and email is None
+        ), "Must set either user_id or email"
         org = Organization.objects.create(
             id=organization_id, name=organization_name, slug=slug, is_test=is_test
         )
@@ -56,8 +60,14 @@ class DatabaseBackedRegionOrganizationProvisioningRpcService(
         # or a bug in the slugify implementation, so we reject the organization creation
         assert org.slug == slug, "Organization slug should not have been modified on save"
 
-        om = OrganizationMember.objects.create(
-            user_id=user_id, organization=org, role=roles.get_top_dog().id
+        om = (
+            OrganizationMember.objects.create(
+                user_id=user_id, organization=org, role=roles.get_top_dog().id
+            )
+            if user_id
+            else OrganizationMember.objects.create(
+                email=email, organization=org, role=roles.get_top_dog().id
+            )
         )
 
         if create_default_team:
@@ -140,6 +150,7 @@ class DatabaseBackedRegionOrganizationProvisioningRpcService(
         with outbox_context(transaction.atomic(router.db_for_write(Organization))):
             organization = self._create_organization_and_team(
                 user_id=provision_options.owning_user_id,
+                email=provision_options.owning_email,
                 slug=provision_options.slug,
                 organization_name=provision_options.name,
                 create_default_team=provision_options.create_default_team,

--- a/src/sentry/services/organization/model.py
+++ b/src/sentry/services/organization/model.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import pydantic
 
@@ -6,7 +6,7 @@ import pydantic
 class OrganizationOptions(pydantic.BaseModel):
     name: str
     slug: str
-    owning_user_id: int
+    owning_user_id: Optional[int] = None
     create_default_team: bool = True
     is_test = False
 

--- a/src/sentry/services/organization/model.py
+++ b/src/sentry/services/organization/model.py
@@ -7,6 +7,7 @@ class OrganizationOptions(pydantic.BaseModel):
     name: str
     slug: str
     owning_user_id: Optional[int] = None
+    owning_email: Optional[str] = None
     create_default_team: bool = True
     is_test = False
 

--- a/tests/sentry/hybrid_cloud/rpc_services/test_control_organization_provisioning.py
+++ b/tests/sentry/hybrid_cloud/rpc_services/test_control_organization_provisioning.py
@@ -109,9 +109,11 @@ class TestControlOrganizationProvisioning(TestControlOrganizationProvisioningBas
         provisioning_options = self.generate_provisioning_args(
             name="sentry", slug="sentry", email="test-owner@sentry.io", default_team=True
         )
+        print("options created", provisioning_options)
         slug = control_organization_provisioning_rpc_service.provision_organization(
             region_name="us", org_provision_args=provisioning_options
         )
+        print("slug created", slug)
         self.assert_slug_reservation_and_org_exist(
             rpc_org_slug=slug,
         )

--- a/tests/sentry/hybrid_cloud/rpc_services/test_control_organization_provisioning.py
+++ b/tests/sentry/hybrid_cloud/rpc_services/test_control_organization_provisioning.py
@@ -13,6 +13,7 @@ from sentry.hybridcloud.rpc_services.control_organization_provisioning.impl impo
     InvalidOrganizationProvisioningException,
 )
 from sentry.models.organization import Organization
+from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationslugreservation import (
     OrganizationSlugReservation,
     OrganizationSlugReservationType,
@@ -85,6 +86,8 @@ class TestControlOrganizationProvisioningBase(TestCase):
         with assume_test_silo_mode(SiloMode.REGION):
             organization = Organization.objects.get(id=rpc_org_slug.organization_id)
             owner_id = organization.default_owner_id
+            owner = OrganizationMember.objects.get(organization=organization)
+            assert owner.role == "owner"
 
         assert org_slug_reservation.organization_id == organization.id
         assert rpc_org_slug.slug == org_slug_reservation.slug == organization.slug

--- a/tests/sentry/hybrid_cloud/rpc_services/test_control_organization_provisioning.py
+++ b/tests/sentry/hybrid_cloud/rpc_services/test_control_organization_provisioning.py
@@ -109,11 +109,9 @@ class TestControlOrganizationProvisioning(TestControlOrganizationProvisioningBas
         provisioning_options = self.generate_provisioning_args(
             name="sentry", slug="sentry", email="test-owner@sentry.io", default_team=True
         )
-        print("options created", provisioning_options)
         slug = control_organization_provisioning_rpc_service.provision_organization(
             region_name="us", org_provision_args=provisioning_options
         )
-        print("slug created", slug)
         self.assert_slug_reservation_and_org_exist(
             rpc_org_slug=slug,
         )


### PR DESCRIPTION
user is marked as required at the time of provisioning the org. This is not the fact because at the moment we create user only after the email is getting verified. In this PR I make `user or email`  required to cover the case where user is not created at the time of org creation. Model changes are merged already.