### PR TITLE
feat(ci): Add ability to random sample tests in CI

### DIFF
--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections
 import math
 import os
-import random as random_module
+import random
 import shutil
 import sys
 from datetime import datetime
@@ -356,7 +356,7 @@ def _shuffle(items: list[pytest.Item], seed: int) -> None:
     # this prevents duplicate setup/teardown work
     nodes: dict[str, dict[str, pytest.Item | dict[str, pytest.Item]]]
     nodes = collections.defaultdict(dict)
-    random = random_module.Random(seed)
+    rng = random.Random(seed)
     for item in items:
         parts = item.nodeid.split("::", maxsplit=2)
         if len(parts) == 2:
@@ -369,7 +369,7 @@ def _shuffle(items: list[pytest.Item], seed: int) -> None:
             raise AssertionError(f"unexpected nodeid: {item.nodeid}")
 
     def _shuffle_d(dct: dict[K, V]) -> dict[K, V]:
-        return dict(random.sample(tuple(dct.items()), len(dct)))
+        return dict(rng.sample(tuple(dct.items()), len(dct)))
 
     new_items = []
     for first_v in _shuffle_d(nodes).values():

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -386,12 +386,12 @@ def _shuffle(items: list[pytest.Item], seed: int) -> None:
 
 def _get_keep_and_discard_items(
     items: list[pytest.Item],
-    total_groups: int,
-    current_group: int,
-    grouping_strategy: str,
-    shuffle_tests: bool,
-    shuffler_seed: int,
-    sample_rate: float,
+    total_groups: int = 1,
+    current_group: int = 0,
+    grouping_strategy: str = "scope",
+    shuffle_tests: bool = False,
+    shuffler_seed: int = 0,
+    sample_rate: float = 1.0,
 ) -> tuple[list[pytest.Item], list[pytest.Item]]:
     keep, discard = [], []
     # First decide what to discard based on the test shard

--- a/tests/sentry/testutils/test_collection_modify_items.py
+++ b/tests/sentry/testutils/test_collection_modify_items.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, cast
+
+import pytest
+
+from sentry.testutils.pytest.sentry import _get_keep_and_discard_items
+
+
+@dataclass(frozen=True)
+class MockItem:
+    nodeid: str
+
+
+def _assert_shuffled(
+    keep: list[pytest.Item], discard: list[pytest.Item], items: list[pytest.Item]
+) -> None:
+    assert len(keep) == len(items)
+    assert set(keep) == set(items)
+    out_of_order = False
+    for i in range(len(items)):
+        if keep[i] != items[i]:
+            out_of_order = True
+    assert out_of_order
+
+
+@pytest.mark.parametrize(
+    "num_items,total_groups,current_group,grouping_strategy,shuffle_tests,shuffler_seed,sample_rate,num_expected_keep_items,check_function",
+    [
+        pytest.param(100, 1, 0, "scope", False, 0, 1.0, 100, None, id="no deselection"),
+        pytest.param(12, 3, 0, "scope", False, 0, 1.0, 5, None, id="basic sharding"),
+        pytest.param(12, 3, 0, "scope", False, 0, 0.25, 2, None, id="sampling and sharding"),
+        pytest.param(100, 1, 0, "scope", True, 0, 1.0, 100, _assert_shuffled, id="basic shuffle"),
+    ],
+)
+def test_keep_discard(
+    num_items: int,
+    total_groups: int,
+    current_group: int,
+    grouping_strategy: str,
+    shuffle_tests: bool,
+    shuffler_seed: int,
+    sample_rate: float,
+    num_expected_keep_items: int,
+    check_function: Callable[[list[pytest.Item], list[pytest.Item], list[pytest.Item]], None]
+    | None,
+) -> None:
+    items = cast(
+        "list[pytest.Item]", [MockItem(f"TestClass{i}::function_name{i}") for i in range(num_items)]
+    )
+    keep, discard = _get_keep_and_discard_items(
+        items,
+        total_groups,
+        current_group,
+        grouping_strategy,
+        shuffle_tests,
+        shuffler_seed,
+        sample_rate,
+    )
+    assert len(keep) == num_expected_keep_items
+    assert len(keep) + len(discard) == len(items)
+    if check_function is not None:
+        check_function(keep, discard, items)
+
+
+def test_deterministic_sample():
+    # make sure that the same parameters (with sampling and shuffling) product the same test set
+    num_items = 100
+    items = cast(
+        "list[pytest.Item]", [MockItem(f"TestClass{i}::function_name{i}") for i in range(num_items)]
+    )
+    items_copy = items[:]
+    keep_1, discard_1 = _get_keep_and_discard_items(
+        items=items,
+        total_groups=4,
+        current_group=1,
+        grouping_strategy="scope",
+        shuffle_tests=True,
+        shuffler_seed=420,
+        sample_rate=0.1,
+    )
+
+    keep_2, discard_2 = _get_keep_and_discard_items(
+        items=items_copy,
+        total_groups=4,
+        current_group=1,
+        grouping_strategy="scope",
+        shuffle_tests=True,
+        shuffler_seed=420,
+        sample_rate=0.1,
+    )
+
+    assert keep_1 == keep_2
+    assert discard_1 == discard_2
+
+
+def test_sample_change_seed():
+    # make sure that the same parameters (with sampling and shuffling) produce a different test
+    # set given a different seed
+    num_items = 100
+    items = cast(
+        "list[pytest.Item]", [MockItem(f"TestClass{i}::function_name{i}") for i in range(num_items)]
+    )
+    items_copy = items[:]
+    keep_1, discard_1 = _get_keep_and_discard_items(
+        items=items,
+        total_groups=4,
+        current_group=1,
+        grouping_strategy="scope",
+        shuffle_tests=True,
+        shuffler_seed=420,
+        sample_rate=0.1,
+    )
+
+    keep_2, discard_2 = _get_keep_and_discard_items(
+        items=items_copy,
+        total_groups=4,
+        current_group=1,
+        grouping_strategy="scope",
+        shuffle_tests=True,
+        shuffler_seed=69,
+        sample_rate=0.1,
+    )
+
+    assert len(keep_1) == len(keep_2)
+    assert len(discard_1) == len(discard_2)
+    assert keep_1 != keep_2
+    assert discard_1 != discard_2


### PR DESCRIPTION
### Why

snuba runs every sentry snuba tests in its CI. This slows us down a lot but we still like having a smoke test to tell us if we have broken sentry to give us a sanity check. 

### This PR

* Introduces random sampling capability to our pytest plugin in the `pytest_collection_modifyitems` function
* moves out test selection into its own testable function
* writes the first tests for this functionality