### PR TITLE
feat(hybrid-cloud): Validate region addresses on app initialization

### DIFF
--- a/src/sentry/testutils/helpers/socket.py
+++ b/src/sentry/testutils/helpers/socket.py
@@ -1,25 +1,19 @@
 import ipaddress
+from contextlib import contextmanager
 
 from sentry.net import socket as net_socket
 
 __all__ = ["override_blacklist"]
 
 
+@contextmanager
 def override_blacklist(*ip_addresses):
-    def decorator(func):
-        def wrapper(*args, **kwargs):
-            disallowed_ips = frozenset(net_socket.DISALLOWED_IPS)
-            net_socket.DISALLOWED_IPS = frozenset(
-                ipaddress.ip_network(str(ip)) for ip in ip_addresses
-            )
-            try:
-                func(*args, **kwargs)
-            finally:
-                net_socket.DISALLOWED_IPS = disallowed_ips
-                # We end up caching these disallowed ips on this function, so
-                # make sure we clear the cache as part of cleanup
-                net_socket.is_ipaddress_allowed.cache_clear()
-
-        return wrapper
-
-    return decorator
+    disallowed_ips = frozenset(net_socket.DISALLOWED_IPS)
+    net_socket.DISALLOWED_IPS = frozenset(ipaddress.ip_network(str(ip)) for ip in ip_addresses)
+    try:
+        yield
+    finally:
+        net_socket.DISALLOWED_IPS = disallowed_ips
+        # We end up caching these disallowed ips on this function, so
+        # make sure we clear the cache as part of cleanup
+        net_socket.is_ipaddress_allowed.cache_clear()

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -64,9 +64,14 @@ class Region:
     """Unused will be removed in the future"""
 
     def validate(self) -> None:
+        from sentry import http
         from sentry.utils.snowflake import REGION_ID
 
         REGION_ID.validate(self.snowflake_id)
+
+        # Validate that each region address is reachable from the control silo.
+        if SiloMode.get_current_mode() == SiloMode.CONTROL:
+            http.safe_urlopen(self.address)
 
     def to_url(self, path: str) -> str:
         """Resolve a path into a customer facing URL on this region's silo.

--- a/tests/sentry/types/test_region.py
+++ b/tests/sentry/types/test_region.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.db import router
 from django.test import RequestFactory, override_settings
 
-from sentry.exceptions import RestrictedIPAddress
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.silo import SiloLimit, SiloMode, unguarded_write


### PR DESCRIPTION
While testing integrations in test region silos, I've noticed that we would rely on Sentry errors emitted at the integration request proxy to discover that region addresses may be unreachable from the control silo.

This is because we have a fairly exhaustive and restrictive list of IP addresses configured in `SENTRY_DISALLOWED_IPS` within `getsentry`. Internal IP addresses of region silos would match against `SENTRY_DISALLOWED_IPS`. 

We regenerate `SENTRY_DISALLOWED_IPS` to intentionally exclude allowed IP addresses (e.g. region silo IP addresses). I've done that here https://github.com/getsentry/ops/pull/8082.

In this pull request, I'm validating that region silo addresses are reachable from the control silo. We validate this during the app initialization step.