### PR TITLE
ref(hybrid-cloud): Removes unused onboarding task handling

### DIFF
--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -25,7 +25,6 @@ from sentry.signals import (
     event_processed,
     first_cron_checkin_received,
     first_cron_monitor_created,
-    first_event_pending,
     first_event_received,
     first_event_with_minified_stack_trace_received,
     first_feedback_received,
@@ -100,17 +99,6 @@ def record_new_project(project, user=None, user_id=None, **kwargs):
             status=OnboardingTaskStatus.PENDING,
             project_id=project.id,
         )
-
-
-@first_event_pending.connect(weak=False)
-def record_raven_installed(project, user, **kwargs):
-    OrganizationOnboardingTask.objects.record(
-        organization_id=project.organization_id,
-        task=OnboardingTask.FIRST_EVENT,
-        status=OnboardingTaskStatus.PENDING,
-        user_id=user.id if user else None,
-        project_id=project.id,
-    )
 
 
 @first_event_received.connect(weak=False)

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -640,7 +640,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
     def record_pending_first_event_onboarding_task(
         self, *, organization_id: str, project_id: str, user_id: Optional[int]
     ) -> None:
-        project = Project.objects.get(organization_id=organization_id, project_id=project_id)
+        project = Project.objects.get(organization_id=organization_id, id=project_id)
 
         OrganizationOnboardingTask.objects.record(
             organization_id=project.organization_id,

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -18,13 +18,7 @@ from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
-from sentry.models.organizationonboardingtask import (
-    OnboardingTask,
-    OnboardingTaskStatus,
-    OrganizationOnboardingTask,
-)
 from sentry.models.outbox import ControlOutbox, OutboxCategory, OutboxScope, outbox_context
-from sentry.models.project import Project
 from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.models.team import Team, TeamStatus
 from sentry.services.hybrid_cloud import OptionValue, logger
@@ -636,19 +630,6 @@ class DatabaseBackedOrganizationService(OrganizationService):
         owner_members = org.get_members_with_org_roles(roles=[roles.get_top_dog().id])
 
         return list(map(serialize_member, owner_members))
-
-    def record_pending_first_event_onboarding_task(
-        self, *, organization_id: str, project_id: str, user_id: Optional[int]
-    ) -> None:
-        project = Project.objects.get(organization_id=organization_id, id=project_id)
-
-        OrganizationOnboardingTask.objects.record(
-            organization_id=project.organization_id,
-            task=OnboardingTask.FIRST_EVENT,
-            status=OnboardingTaskStatus.PENDING,
-            user_id=user_id,
-            project_id=project.id,
-        )
 
 
 class OutboxBackedOrganizationSignalService(OrganizationSignalService):

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -363,7 +363,16 @@ class OrganizationService(RpcService):
 
     @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
-    def get_organization_owner_members(self, organization_id: int) -> List[RpcOrganizationMember]:
+    def get_organization_owner_members(
+        self, *, organization_id: int
+    ) -> List[RpcOrganizationMember]:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def record_pending_first_event_onboarding_task(
+        self, *, organization_id: str, project_id: str, user_id: Optional[int]
+    ) -> None:
         pass
 
 

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -368,13 +368,6 @@ class OrganizationService(RpcService):
     ) -> List[RpcOrganizationMember]:
         pass
 
-    @regional_rpc_method(resolve=ByOrganizationId())
-    @abstractmethod
-    def record_pending_first_event_onboarding_task(
-        self, *, organization_id: str, project_id: str, user_id: Optional[int]
-    ) -> None:
-        pass
-
 
 class OrganizationSignalService(abc.ABC):
     @abc.abstractmethod

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -122,7 +122,6 @@ event_accepted = BetterSignal()  # ["ip", "data", "project"]
 
 # Organization Onboarding Signals
 project_created = BetterSignal()  # ["project", "user", "user_id", "default_rules"]
-first_event_pending = BetterSignal()  # ["project", "user"]
 
 first_event_received = BetterSignal()  # ["project", "event"]
 # We use signal for consistency with other places but

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -119,12 +119,6 @@ class ReactPageView(ControlSiloOrganizationView, ReactMixin):
         return super().handle_auth_required(request, *args, **kwargs)
 
     def handle(self, request: Request, organization, **kwargs) -> HttpResponse:
-        if "project_id" in kwargs and request.GET.get("onboarding"):
-            organization_service.record_pending_first_event_onboarding_task(
-                organization_id=organization.id,
-                project_id=kwargs["project_id"],
-                user_id=request.user.id,
-            )
         request.organization = organization
         return self.handle_react(request)
 

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -3,11 +3,6 @@ from fnmatch import fnmatch
 from django.urls import URLResolver, get_resolver, reverse
 
 from sentry.models.organization import OrganizationStatus
-from sentry.models.organizationonboardingtask import (
-    OnboardingTask,
-    OnboardingTaskStatus,
-    OrganizationOnboardingTask,
-)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.web.frontend.react_page import NON_CUSTOMER_DOMAIN_URL_NAMES, ReactMixin
@@ -370,23 +365,3 @@ class ReactPageViewTest(TestCase):
         )
         assert response.status_code == 200
         assert "Document-Policy" not in response.headers
-
-    def test_onboarding_with_project_id(self):
-        org = self.create_organization(owner=self.user)
-        project = self.create_project(organization=org)
-
-        self.login_as(self.user)
-        response = self.client.get(
-            f"/{org.slug}/{project.id}/?onboarding=1",
-            SERVER_NAME=f"{org.slug}.testserver",
-            follow=True,
-        )
-
-        assert response.status_code == 200
-        org_onboarding_task_qs = OrganizationOnboardingTask.objects.filter(organization_id=org.id)
-        assert org_onboarding_task_qs.count() == 1
-        onboarding_task = org_onboarding_task_qs.first()
-        assert onboarding_task.project_id == project.id
-        assert onboarding_task.user_id == self.user.id
-        assert onboarding_task.status == OnboardingTaskStatus.PENDING
-        assert onboarding_task.task == OnboardingTask.FIRST_EVENT

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -3,6 +3,11 @@ from fnmatch import fnmatch
 from django.urls import URLResolver, get_resolver, reverse
 
 from sentry.models.organization import OrganizationStatus
+from sentry.models.organizationonboardingtask import (
+    OnboardingTask,
+    OnboardingTaskStatus,
+    OrganizationOnboardingTask,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.web.frontend.react_page import NON_CUSTOMER_DOMAIN_URL_NAMES, ReactMixin
@@ -365,3 +370,24 @@ class ReactPageViewTest(TestCase):
         )
         assert response.status_code == 200
         assert "Document-Policy" not in response.headers
+
+    def test_onboarding_with_project_id(self):
+        org = self.create_organization(owner=self.user)
+        project = self.create_project(organization=org)
+        group = self.create_group(project=project)
+
+        self.login_as(self.user)
+        response = self.client.get(
+            f"/{org.slug}/{project.id}/issues/{group.id}/?onboarding=1",
+            SERVER_NAME=f"{org.slug}.testserver",
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        org_onboarding_task_qs = OrganizationOnboardingTask.objects.filter(organization_id=org.id)
+        assert org_onboarding_task_qs.count() == 1
+        onboarding_task = org_onboarding_task_qs.first()
+        assert onboarding_task.project_id == project.id
+        assert onboarding_task.user_id == self.user.id
+        assert onboarding_task.status == OnboardingTaskStatus.PENDING
+        assert onboarding_task.task == OnboardingTask.FIRST_EVENT

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -374,11 +374,10 @@ class ReactPageViewTest(TestCase):
     def test_onboarding_with_project_id(self):
         org = self.create_organization(owner=self.user)
         project = self.create_project(organization=org)
-        group = self.create_group(project=project)
 
         self.login_as(self.user)
         response = self.client.get(
-            f"/{org.slug}/{project.id}/issues/{group.id}/?onboarding=1",
+            f"/{org.slug}/{project.id}/?onboarding=1",
             SERVER_NAME=f"{org.slug}.testserver",
             follow=True,
         )


### PR DESCRIPTION
~~Moves the creation of an `OrganizationOnboardingTask` when invoking the `ReactPageView` handler to an RPC call instead of a signal.~~

Turns out this code path appears to be unused. Last recorded onboarding tasks matching this signature date back to 2016.
