### PR TITLE
fix(weekly-reports): Use ID of target user for override

### DIFF
--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -647,7 +647,17 @@ def fetch_key_performance_issue_groups(ctx):
 def deliver_reports(ctx, dry_run=False, target_user=None, email_override=None):
     # Specify a sentry user to send this email.
     if email_override:
-        send_email(ctx, target_user, dry_run=dry_run, email_override=email_override)
+        try:
+            send_email(ctx, target_user.id, dry_run=dry_run, email_override=email_override)
+        except AttributeError:
+            logger.exception(
+                "deliver_reports.email_override",
+                extra={
+                    "dry_run": dry_run,
+                    "target_user": json.dumps(target_user),
+                    "email_override": email_override,
+                },
+            )
     else:
         user_list = list(
             OrganizationMember.objects.filter(

--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -657,7 +657,10 @@ def fetch_key_performance_issue_groups(ctx):
 def deliver_reports(ctx, dry_run=False, target_user=None, email_override=None):
     # Specify a sentry user to send this email.
     if email_override:
-        send_email(ctx, target_user.id, dry_run=dry_run, email_override=email_override)
+        target_user_id = (
+            target_user.id if target_user else None
+        )  # if None, generates report for a user with access to all projects
+        send_email(ctx, target_user_id, dry_run=dry_run, email_override=email_override)
     else:
         user_list = list(
             OrganizationMember.objects.filter(

--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -178,6 +178,16 @@ def schedule_organizations(dry_run=False, timestamp=None, duration=None):
 def prepare_organization_report(
     timestamp, duration, organization_id, dry_run=False, target_user=None, email_override=None
 ):
+    if target_user and not hasattr(target_user, "id"):
+        logger.exception(
+            "Target user must have an ID",
+            extra={
+                "organization": organization_id,
+                "target_user": json.dumps(target_user),
+                "email_override": email_override,
+            },
+        )
+        return
     organization = Organization.objects.get(id=organization_id)
     set_tag("org.slug", organization.slug)
     set_tag("org.id", organization_id)
@@ -647,17 +657,7 @@ def fetch_key_performance_issue_groups(ctx):
 def deliver_reports(ctx, dry_run=False, target_user=None, email_override=None):
     # Specify a sentry user to send this email.
     if email_override:
-        try:
-            send_email(ctx, target_user.id, dry_run=dry_run, email_override=email_override)
-        except AttributeError:
-            logger.exception(
-                "deliver_reports.email_override.error",
-                extra={
-                    "dry_run": dry_run,
-                    "target_user": json.dumps(target_user),
-                    "email_override": email_override,
-                },
-            )
+        send_email(ctx, target_user.id, dry_run=dry_run, email_override=email_override)
     else:
         user_list = list(
             OrganizationMember.objects.filter(

--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -183,7 +183,7 @@ def prepare_organization_report(
             "Target user must have an ID",
             extra={
                 "organization": organization_id,
-                "target_user": json.dumps(target_user),
+                "target_user": target_user,
                 "email_override": email_override,
             },
         )

--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -651,7 +651,7 @@ def deliver_reports(ctx, dry_run=False, target_user=None, email_override=None):
             send_email(ctx, target_user.id, dry_run=dry_run, email_override=email_override)
         except AttributeError:
             logger.exception(
-                "deliver_reports.email_override",
+                "deliver_reports.email_override.error",
                 extra={
                     "dry_run": dry_run,
                     "target_user": json.dumps(target_user),

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -729,7 +729,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
             "Target user must have an ID",
             extra={
                 "organization": org.id,
-                "target_user": '"dummy"',
+                "target_user": "dummy",
                 "email_override": "doesntmatter@smad.com",
             },
         )

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -620,3 +620,69 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
 
         unique_enum_count = len(enum_values)
         assert len(group_status_to_color) == unique_enum_count
+
+    @mock.patch("sentry.analytics.record")
+    @mock.patch("sentry.tasks.weekly_reports.MessageBuilder")
+    def test_email_override_simple(self, message_builder, record):
+        now = django_timezone.now()
+        two_days_ago = now - timedelta(days=2)
+        timestamp = to_timestamp(floor_to_utc_day(now))
+
+        user = self.create_user()
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+        extra_team = self.create_team(organization=self.organization)
+        self.create_project(
+            teams=[extra_team]
+        )  # create an extra project to ensure our email only gets the user's project
+
+        # fill with data so report not skipped
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "message",
+                "timestamp": iso_format(two_days_ago),
+                "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+        self.store_outcomes(
+            {
+                "org_id": self.organization.id,
+                "project_id": self.project.id,
+                "outcome": Outcome.ACCEPTED,
+                "category": DataCategory.ERROR,
+                "timestamp": two_days_ago,
+                "key_id": 1,
+            },
+            num_times=2,
+        )
+
+        prepare_organization_report(
+            timestamp,
+            ONE_DAY * 7,
+            self.organization.id,
+            dry_run=False,
+            target_user=user,
+            email_override="joseph@speedwagon.org",
+        )
+
+        for call_args in message_builder.call_args_list:
+            message_params = call_args.kwargs
+            context = message_params["context"]
+
+            assert context["organization"] == self.organization
+            assert context["user_project_count"] == 1
+            assert f"Weekly Report for {self.organization.name}" in message_params["subject"]
+
+            assert isinstance(context["notification_uuid"], str)
+
+        record.assert_any_call(
+            "weekly_report.sent",
+            user_id=user.id,
+            organization_id=self.organization.id,
+            notification_uuid=mock.ANY,
+            user_project_count=1,
+        )
+
+        message_builder.return_value.send.assert_called_with(to=("joseph@speedwagon.org",))

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -636,16 +636,6 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
         )  # create an extra project to ensure our email only gets the user's project
 
         # fill with data so report not skipped
-        self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "message",
-                "timestamp": iso_format(two_days_ago),
-                "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
-                "fingerprint": ["group-1"],
-            },
-            project_id=self.project.id,
-        )
         self.store_outcomes(
             {
                 "org_id": self.organization.id,
@@ -697,16 +687,6 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
         self.create_project(organization=self.organization)
 
         # fill with data so report not skipped
-        self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "message",
-                "timestamp": iso_format(two_days_ago),
-                "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
-                "fingerprint": ["group-1"],
-            },
-            project_id=self.project.id,
-        )
         self.store_outcomes(
             {
                 "org_id": self.organization.id,
@@ -754,16 +734,6 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
         proj = self.create_project(organization=org)
 
         # fill with data so report not skipped
-        self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "message",
-                "timestamp": iso_format(two_days_ago),
-                "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
-                "fingerprint": ["group-1"],
-            },
-            project_id=proj.id,
-        )
         self.store_outcomes(
             {
                 "org_id": org.id,


### PR DESCRIPTION
This PR fixes a bug where when the weekly report tasks are ran with a target user, the associated projects are all the projects in the organization, rather than the projects associated with that user specifically. `target_user` is a `User`, but `send_email` treats it like an ID, so we want to change the call to send only the ID.