### PR TITLE
fix(security): allow `gravatar.com` as img-src

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -482,6 +482,7 @@ CSP_IMG_SRC = [
     "'self'",
     "blob:",
     "data:",
+    "https://gravatar.com",
     "https://secure.gravatar.com",
 ]
 


### PR DESCRIPTION
Fixes this CSP violation, e.g. on self-hosted:
```
{
  "csp-report": {
    "effective_directive": "img-src",
    "blocked_uri": "https://gravatar.com/avatar/951cdbe3fc41f2c54b1b882068b55bdb?d=404&s=120",
    "document_uri": "https://SELF-HOSTED-INSTANCE/organizations/sentry/issues/xxx/",
    "original_policy": "connect-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https://secure.gravatar.com; script-src 'self' 'unsafe-inline' 'report-sample' 'nonce-6RD/pgY6WrqWS/ykbPEa9A=='; font-src 'self' data:; frame-ancestors 'none'; base-uri 'none'; object-src 'none'; default-src 'none'; report-uri https://SELF-HOSTED-INSTANCE/api/6/security/?sentry_key=xxx",
    "referrer": "",
    "status_code": 200,
    "violated_directive": "img-src",
    "script_sample": "",
    "disposition": "enforce"
  }
}
```