### PR TITLE
ref: Refactor ExternalIssueList to make it easier to re-skin for User Feedback

### DIFF
--- a/static/app/components/group/externalIssuesList/externalIssueActions.spec.tsx
+++ b/static/app/components/group/externalIssuesList/externalIssueActions.spec.tsx
@@ -5,7 +5,7 @@ import {
   userEvent,
 } from 'sentry-test/reactTestingLibrary';
 
-import ExternalIssueActions from 'sentry/components/group/externalIssueActions';
+import ExternalIssueActions from 'sentry/components/group/externalIssuesList/externalIssueActions';
 
 describe('ExternalIssueActions', function () {
   const group = TestStubs.Group();

--- a/static/app/components/group/externalIssuesList/externalIssueActions.tsx
+++ b/static/app/components/group/externalIssuesList/externalIssueActions.tsx
@@ -13,7 +13,7 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import IntegrationItem from 'sentry/views/settings/organizationIntegrations/integrationItem';
 
-import ExternalIssueForm from './externalIssueForm';
+import ExternalIssueForm from '../externalIssueForm';
 
 type Props = {
   configurations: GroupIntegration[];

--- a/static/app/components/group/externalIssuesList/index.spec.tsx
+++ b/static/app/components/group/externalIssuesList/index.spec.tsx
@@ -72,7 +72,6 @@ describe('ExternalIssuesList', () => {
     mockUseSentryAppComponentsStore.mockReturnValue([component]);
     render(
       <ExternalIssuesList
-        // components={[component]}
         group={group}
         project={project}
         event={event}

--- a/static/app/components/group/externalIssuesList/index.spec.tsx
+++ b/static/app/components/group/externalIssuesList/index.spec.tsx
@@ -45,7 +45,6 @@ describe('ExternalIssuesList', () => {
     mockUseSentryAppComponentsStore.mockReturnValue([]);
     render(
       <ExternalIssuesList
-        // components={[]}
         group={group}
         project={project}
         event={event}

--- a/static/app/components/group/externalIssuesList/index.spec.tsx
+++ b/static/app/components/group/externalIssuesList/index.spec.tsx
@@ -9,8 +9,12 @@ import {SentryAppInstallation} from 'sentry-fixture/sentryAppInstallation';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import SentryAppInstallationStore from 'sentry/stores/sentryAppInstallationsStore';
+import useSentryAppComponentsStore from 'sentry/utils/useSentryAppComponentsStore';
 
 import ExternalIssuesList from '.';
+
+jest.mock('sentry/utils/useSentryAppComponentsStore');
+const mockUseSentryAppComponentsStore = jest.mocked(useSentryAppComponentsStore);
 
 describe('ExternalIssuesList', () => {
   const event = Event();
@@ -38,9 +42,10 @@ describe('ExternalIssuesList', () => {
       url: `/organizations/${organization.slug}/issues/1/external-issues/`,
       body: [],
     });
+    mockUseSentryAppComponentsStore.mockReturnValue([]);
     render(
       <ExternalIssuesList
-        components={[]}
+        // components={[]}
         group={group}
         project={project}
         event={event}
@@ -65,9 +70,10 @@ describe('ExternalIssuesList', () => {
         app: component.sentryApp,
       }),
     ]);
+    mockUseSentryAppComponentsStore.mockReturnValue([component]);
     render(
       <ExternalIssuesList
-        components={[component]}
+        // components={[component]}
         group={group}
         project={project}
         event={event}
@@ -103,9 +109,10 @@ describe('ExternalIssuesList', () => {
       body: [],
     });
     const component = SentryAppComponent();
+    mockUseSentryAppComponentsStore.mockReturnValue([component]);
     render(
       <ExternalIssuesList
-        components={[component]}
+        // components={[component]}
         group={group}
         project={project}
         event={event}

--- a/static/app/components/group/externalIssuesList/index.spec.tsx
+++ b/static/app/components/group/externalIssuesList/index.spec.tsx
@@ -3,6 +3,8 @@ import {Group} from 'sentry-fixture/group';
 import {JiraIntegration} from 'sentry-fixture/jiraIntegration';
 import {Organization} from 'sentry-fixture/organization';
 import {Project} from 'sentry-fixture/project';
+import {SentryAppComponent} from 'sentry-fixture/sentryAppComponent';
+import {SentryAppInstallation} from 'sentry-fixture/sentryAppInstallation';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -57,9 +59,9 @@ describe('ExternalIssuesList', () => {
       url: `/organizations/${organization.slug}/issues/${group.id}/external-issues/`,
       body: [],
     });
-    const component = TestStubs.SentryAppComponent();
+    const component = SentryAppComponent();
     SentryAppInstallationStore.load([
-      TestStubs.SentryAppInstallation({
+      SentryAppInstallation({
         app: component.sentryApp,
       }),
     ]);
@@ -100,7 +102,7 @@ describe('ExternalIssuesList', () => {
       url: `/organizations/${organization.slug}/issues/${group.id}/external-issues/`,
       body: [],
     });
-    const component = TestStubs.SentryAppComponent();
+    const component = SentryAppComponent();
     render(
       <ExternalIssuesList
         components={[component]}

--- a/static/app/components/group/externalIssuesList/index.spec.tsx
+++ b/static/app/components/group/externalIssuesList/index.spec.tsx
@@ -1,16 +1,19 @@
+import {Event} from 'sentry-fixture/event';
+import {Group} from 'sentry-fixture/group';
 import {JiraIntegration} from 'sentry-fixture/jiraIntegration';
 import {Organization} from 'sentry-fixture/organization';
+import {Project} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import SentryAppInstallationStore from 'sentry/stores/sentryAppInstallationsStore';
 
-import ExternalIssuesList from './externalIssuesList';
+import ExternalIssuesList from '.';
 
 describe('ExternalIssuesList', () => {
-  const event = TestStubs.Event();
-  const group = TestStubs.Group();
-  const project = TestStubs.Project();
+  const event = Event();
+  const group = Group();
+  const project = Project();
   const organization = Organization();
 
   beforeEach(() => {

--- a/static/app/components/group/externalIssuesList/index.spec.tsx
+++ b/static/app/components/group/externalIssuesList/index.spec.tsx
@@ -43,14 +43,9 @@ describe('ExternalIssuesList', () => {
       body: [],
     });
     mockUseSentryAppComponentsStore.mockReturnValue([]);
-    render(
-      <ExternalIssuesList
-        group={group}
-        project={project}
-        event={event}
-      />,
-      {organization}
-    );
+    render(<ExternalIssuesList group={group} project={project} event={event} />, {
+      organization,
+    });
     expect(await screen.findByText(setupCTA)).toBeInTheDocument();
   });
 
@@ -70,14 +65,9 @@ describe('ExternalIssuesList', () => {
       }),
     ]);
     mockUseSentryAppComponentsStore.mockReturnValue([component]);
-    render(
-      <ExternalIssuesList
-        group={group}
-        project={project}
-        event={event}
-      />,
-      {organization}
-    );
+    render(<ExternalIssuesList group={group} project={project} event={event} />, {
+      organization,
+    });
     expect(await screen.findByText('Foo Issue')).toBeInTheDocument();
     expect(screen.queryByText(setupCTA)).not.toBeInTheDocument();
   });
@@ -108,14 +98,9 @@ describe('ExternalIssuesList', () => {
     });
     const component = SentryAppComponent();
     mockUseSentryAppComponentsStore.mockReturnValue([component]);
-    render(
-      <ExternalIssuesList
-        group={group}
-        project={project}
-        event={event}
-      />,
-      {organization}
-    );
+    render(<ExternalIssuesList group={group} project={project} event={event} />, {
+      organization,
+    });
     expect(await screen.findByText('Test-Sentry/github-test#13')).toBeInTheDocument();
     const externalIssues = screen.getAllByTestId('external-issue-item');
     expect(externalIssues[0]).toHaveTextContent('Test-Sentry/github-test#13');

--- a/static/app/components/group/externalIssuesList/index.spec.tsx
+++ b/static/app/components/group/externalIssuesList/index.spec.tsx
@@ -110,7 +110,6 @@ describe('ExternalIssuesList', () => {
     mockUseSentryAppComponentsStore.mockReturnValue([component]);
     render(
       <ExternalIssuesList
-        // components={[component]}
         group={group}
         project={project}
         event={event}

--- a/static/app/components/group/externalIssuesList/index.tsx
+++ b/static/app/components/group/externalIssuesList/index.tsx
@@ -1,172 +1,35 @@
-import {Fragment} from 'react';
+import {Fragment, ReactNode} from 'react';
 
 import AlertLink from 'sentry/components/alertLink';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import ExternalIssueActions from 'sentry/components/group/externalIssuesList/externalIssueActions';
-import useFetchIntegrations from 'sentry/components/group/externalIssuesList/useFetchIntegrations';
-import useFetchSentryAppData from 'sentry/components/group/externalIssuesList/useFetchSentryAppData';
-import useIssueTrackingFilter from 'sentry/components/group/externalIssuesList/useIssueTrackingFilter';
+import {
+  ExternalIssueType,
+  IntegrationComponent,
+  PluginActionComponent,
+  PluginIssueComponent,
+  SentryAppIssueComponent,
+} from 'sentry/components/group/externalIssuesList/types';
+import useExternalIssueData from 'sentry/components/group/externalIssuesList/useExternalIssueData';
 import PluginActions from 'sentry/components/group/pluginActions';
 import SentryAppExternalIssueActions from 'sentry/components/group/sentryAppExternalIssueActions';
 import IssueSyncListElement from 'sentry/components/issueSyncListElement';
 import Placeholder from 'sentry/components/placeholder';
 import * as SidebarSection from 'sentry/components/sidebarSection';
 import {t} from 'sentry/locale';
-import ExternalIssueStore from 'sentry/stores/externalIssueStore';
-import SentryAppInstallationStore from 'sentry/stores/sentryAppInstallationsStore';
-import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {Group, GroupIntegration, Project, SentryAppComponent} from 'sentry/types';
+import type {Group, Project} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 import useOrganization from 'sentry/utils/useOrganization';
-import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
 
 type Props = {
-  components: SentryAppComponent[];
   event: Event;
   group: Group;
   project: Project;
 };
 
-type ExternalIssueComponent = {
-  key: string;
-  render: () => React.ReactNode;
-  disabled?: boolean;
-  hasLinkedIssue?: boolean;
-};
-
-function useExternalIssueData({components, group, event, project}: Props) {
+export default function ExternalIssueList({group, event, project}: Props) {
   const organization = useOrganization();
-  const {
-    data: integrations,
-    isLoading,
-    refetch: refetchIntegrations,
-  } = useFetchIntegrations({group, organization});
-  useFetchSentryAppData({group, organization});
-  const issueTrackingFilter = useIssueTrackingFilter();
-
-  const externalIssues = useLegacyStore(ExternalIssueStore);
-  const sentryAppInstallations = useLegacyStore(SentryAppInstallationStore);
-
-  const renderIntegrationIssues = (): ExternalIssueComponent[] => {
-    if (!integrations) {
-      return [];
-    }
-
-    const activeIntegrations = integrations.filter(
-      integration => integration.status === 'active'
-    );
-
-    const activeIntegrationsByProvider: Map<string, GroupIntegration[]> =
-      activeIntegrations.reduce((acc, curr) => {
-        const items = acc.get(curr.provider.key);
-
-        if (items) {
-          acc.set(curr.provider.key, [...items, curr]);
-        } else {
-          acc.set(curr.provider.key, [curr]);
-        }
-        return acc;
-      }, new Map());
-
-    return [...activeIntegrationsByProvider.entries()].map(
-      ([provider, configurations]) => ({
-        key: provider,
-        disabled: false,
-        hasLinkedIssue: configurations.some(x => x.externalIssues.length > 0),
-        render: () => (
-          <ExternalIssueActions
-            configurations={configurations}
-            group={group}
-            onChange={() => refetchIntegrations()}
-          />
-        ),
-      })
-    );
-  };
-
-  const renderSentryAppIssues = (): ExternalIssueComponent[] => {
-    return components
-      .map<ExternalIssueComponent | null>(component => {
-        const {sentryApp, error: disabled} = component;
-        const installation = sentryAppInstallations.find(
-          i => i.app.uuid === sentryApp.uuid
-        );
-        // should always find a match but TS complains if we don't handle this case
-        if (!installation) {
-          return null;
-        }
-
-        const issue = (externalIssues || []).find(i => i.serviceType === sentryApp.slug);
-
-        return {
-          key: sentryApp.slug,
-          disabled,
-          hasLinkedIssue: !!issue,
-          render: () => (
-            <ErrorBoundary key={sentryApp.slug} mini>
-              <SentryAppExternalIssueActions
-                group={group}
-                organization={organization}
-                event={event}
-                sentryAppComponent={component}
-                sentryAppInstallation={installation}
-                externalIssue={issue}
-                disabled={disabled}
-              />
-            </ErrorBoundary>
-          ),
-        };
-      })
-      .filter((x): x is ExternalIssueComponent => x !== null);
-  };
-
-  const renderPluginIssues = (): ExternalIssueComponent[] => {
-    return group.pluginIssues?.map((plugin, i) => ({
-      key: `plugin-issue-${i}`,
-      disabled: false,
-      hasLinkedIssue: true,
-      render: () => <PluginActions group={group} project={project} plugin={plugin} />,
-    }));
-  };
-
-  const renderPluginActions = (): ExternalIssueComponent[] => {
-    return (
-      group.pluginActions?.map((plugin, i) => ({
-        key: `plugin-action-${i}`,
-        disabled: false,
-        hasLinkedIssue: false,
-        render: () => (
-          <IssueSyncListElement externalIssueLink={plugin[1]}>
-            {plugin[0]}
-          </IssueSyncListElement>
-        ),
-      })) ?? []
-    );
-  };
-
-  const actions = [
-    ...renderSentryAppIssues(),
-    ...renderIntegrationIssues(),
-    ...renderPluginIssues(),
-    ...renderPluginActions(),
-  ]
-    .filter(action => !issueTrackingFilter || action.key === issueTrackingFilter)
-    // Put disabled actions last
-    .sort((a, b) => Number(a.disabled) - Number(b.disabled))
-    // Put actions with linked issues first
-    .sort((a, b) => Number(b.hasLinkedIssue) - Number(a.hasLinkedIssue));
-
-  return {
-    isLoading,
-    actions,
-  };
-}
-
-function ExternalIssueList({components, group, event, project}: Props) {
-  const organization = useOrganization();
-
   const {isLoading, actions} = useExternalIssueData({
-    components,
     group,
     event,
     project,
@@ -183,12 +46,33 @@ function ExternalIssueList({components, group, event, project}: Props) {
     );
   }
 
+  const renderers: Record<ExternalIssueType, (props) => ReactNode> = {
+    'sentry-app-issue': ({sentryApp, ...props}: SentryAppIssueComponent['props']) => (
+      <ErrorBoundary key={sentryApp.slug} mini>
+        <SentryAppExternalIssueActions {...props} />
+      </ErrorBoundary>
+    ),
+    'integration-issue': (props: IntegrationComponent['props']) => (
+      <ExternalIssueActions {...props} />
+    ),
+    'plugin-action': ({plugin}: PluginActionComponent['props']) => (
+      <IssueSyncListElement externalIssueLink={plugin[1]}>
+        {plugin[0]}
+      </IssueSyncListElement>
+    ),
+    'plugin-issue': (props: PluginIssueComponent['props']) => (
+      <PluginActions {...props} />
+    ),
+  };
+
   return (
     <SidebarSection.Wrap data-test-id="linked-issues">
       <SidebarSection.Title>{t('Issue Tracking')}</SidebarSection.Title>
       <SidebarSection.Content>
         {actions.length ? (
-          actions.map(({render, key}) => <Fragment key={key}>{render()}</Fragment>)
+          actions.map(({type, key, props}) => (
+            <Fragment key={key}>{renderers[type](props)}</Fragment>
+          ))
         ) : (
           <AlertLink
             priority="muted"
@@ -203,7 +87,3 @@ function ExternalIssueList({components, group, event, project}: Props) {
     </SidebarSection.Wrap>
   );
 }
-
-export default withSentryAppComponents(ExternalIssueList, {
-  componentType: 'issue-link',
-});

--- a/static/app/components/group/externalIssuesList/types.tsx
+++ b/static/app/components/group/externalIssuesList/types.tsx
@@ -1,0 +1,67 @@
+import type {
+  Group,
+  GroupIntegration,
+  Organization,
+  PlatformExternalIssue,
+  Project,
+  SentryAppComponent,
+  SentryAppInstallation,
+} from 'sentry/types';
+import type {Event} from 'sentry/types/event';
+
+export type ExternalIssueType =
+  | 'sentry-app-issue'
+  | 'integration-issue'
+  | 'plugin-issue'
+  | 'plugin-action';
+
+interface BaseIssueComponent {
+  key: string;
+  disabled?: boolean;
+  hasLinkedIssue?: boolean;
+}
+
+export interface SentryAppIssueComponent extends BaseIssueComponent {
+  props: {
+    disabled: undefined | boolean;
+    event: Event;
+    externalIssue: PlatformExternalIssue | undefined;
+    group: Group;
+    organization: Organization;
+    sentryApp: SentryAppComponent['sentryApp'];
+    sentryAppComponent: SentryAppComponent;
+    sentryAppInstallation: SentryAppInstallation;
+  };
+  type: 'sentry-app-issue';
+}
+
+export interface IntegrationComponent extends BaseIssueComponent {
+  props: {
+    configurations: GroupIntegration[];
+    group: Group;
+    onChange: () => void;
+  };
+  type: 'integration-issue';
+}
+
+export interface PluginIssueComponent extends BaseIssueComponent {
+  props: {
+    group: Group;
+    plugin: Group['pluginIssues'][number];
+    project: Project;
+  };
+  type: 'plugin-issue';
+}
+
+export interface PluginActionComponent extends BaseIssueComponent {
+  props: {
+    plugin: Group['pluginActions'][number];
+  };
+  type: 'plugin-action';
+}
+
+export type ExternalIssueComponent =
+  | SentryAppIssueComponent
+  | IntegrationComponent
+  | PluginIssueComponent
+  | PluginActionComponent;

--- a/static/app/components/group/externalIssuesList/useExternalIssueData.tsx
+++ b/static/app/components/group/externalIssuesList/useExternalIssueData.tsx
@@ -1,6 +1,3 @@
-import {Fragment} from 'react';
-
-import AlertLink from 'sentry/components/alertLink';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import ExternalIssueActions from 'sentry/components/group/externalIssuesList/externalIssueActions';
 import useFetchIntegrations from 'sentry/components/group/externalIssuesList/useFetchIntegrations';
@@ -9,16 +6,12 @@ import useIssueTrackingFilter from 'sentry/components/group/externalIssuesList/u
 import PluginActions from 'sentry/components/group/pluginActions';
 import SentryAppExternalIssueActions from 'sentry/components/group/sentryAppExternalIssueActions';
 import IssueSyncListElement from 'sentry/components/issueSyncListElement';
-import Placeholder from 'sentry/components/placeholder';
-import * as SidebarSection from 'sentry/components/sidebarSection';
-import {t} from 'sentry/locale';
 import ExternalIssueStore from 'sentry/stores/externalIssueStore';
 import SentryAppInstallationStore from 'sentry/stores/sentryAppInstallationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Group, GroupIntegration, Project, SentryAppComponent} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
 import useOrganization from 'sentry/utils/useOrganization';
-import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
 
 type Props = {
   components: SentryAppComponent[];
@@ -34,7 +27,7 @@ type ExternalIssueComponent = {
   hasLinkedIssue?: boolean;
 };
 
-function useExternalIssueData({components, group, event, project}: Props) {
+export default function useExternalIssueData({components, group, event, project}: Props) {
   const organization = useOrganization();
   const {
     data: integrations,
@@ -161,49 +154,3 @@ function useExternalIssueData({components, group, event, project}: Props) {
     actions,
   };
 }
-
-function ExternalIssueList({components, group, event, project}: Props) {
-  const organization = useOrganization();
-
-  const {isLoading, actions} = useExternalIssueData({
-    components,
-    group,
-    event,
-    project,
-  });
-
-  if (isLoading) {
-    return (
-      <SidebarSection.Wrap data-test-id="linked-issues">
-        <SidebarSection.Title>{t('Issue Tracking')}</SidebarSection.Title>
-        <SidebarSection.Content>
-          <Placeholder height="120px" />
-        </SidebarSection.Content>
-      </SidebarSection.Wrap>
-    );
-  }
-
-  return (
-    <SidebarSection.Wrap data-test-id="linked-issues">
-      <SidebarSection.Title>{t('Issue Tracking')}</SidebarSection.Title>
-      <SidebarSection.Content>
-        {actions.length ? (
-          actions.map(({render, key}) => <Fragment key={key}>{render()}</Fragment>)
-        ) : (
-          <AlertLink
-            priority="muted"
-            size="small"
-            to={`/settings/${organization.slug}/integrations/?category=issue%20tracking`}
-          >
-            {t('Track this issue in Jira, GitHub, etc.')}
-          </AlertLink>
-        )}
-        {}
-      </SidebarSection.Content>
-    </SidebarSection.Wrap>
-  );
-}
-
-export default withSentryAppComponents(ExternalIssueList, {
-  componentType: 'issue-link',
-});

--- a/static/app/components/group/externalIssuesList/useFetchIntegrations.tsx
+++ b/static/app/components/group/externalIssuesList/useFetchIntegrations.tsx
@@ -1,0 +1,21 @@
+import type {Group, GroupIntegration, OrganizationSummary} from 'sentry/types';
+import {ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
+
+function makeIntegrationsQueryKey(
+  group: Group,
+  organization: OrganizationSummary
+): ApiQueryKey {
+  return [`/organizations/${organization.slug}/issues/${group.id}/integrations/`];
+}
+
+export default function useFetchIntegrations({
+  group,
+  organization,
+}: {
+  group: Group;
+  organization: OrganizationSummary;
+}) {
+  return useApiQuery<GroupIntegration[]>(makeIntegrationsQueryKey(group, organization), {
+    staleTime: Infinity,
+  });
+}

--- a/static/app/components/group/externalIssuesList/useFetchSentryAppData.tsx
+++ b/static/app/components/group/externalIssuesList/useFetchSentryAppData.tsx
@@ -1,0 +1,31 @@
+import {useEffect} from 'react';
+
+import ExternalIssueStore from 'sentry/stores/externalIssueStore';
+import type {Group, OrganizationSummary, PlatformExternalIssue} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
+
+// We want to do this explicitly so that we can handle errors gracefully,
+// instead of the entire component not rendering.
+//
+// Part of the API request here is fetching data from the Sentry App, so
+// we need to be more conservative about error cases since we don't have
+// control over those services.
+//
+export default function useFetchSentryAppData({
+  group,
+  organization,
+}: {
+  group: Group;
+  organization: OrganizationSummary;
+}) {
+  const {data} = useApiQuery<PlatformExternalIssue[]>(
+    [`/organizations/${organization.slug}/issues/${group.id}/external-issues/`],
+    {staleTime: 30_000}
+  );
+
+  useEffect(() => {
+    if (data) {
+      ExternalIssueStore.load(data);
+    }
+  }, [data]);
+}

--- a/static/app/components/group/externalIssuesList/useIssueTrackingFilter.tsx
+++ b/static/app/components/group/externalIssuesList/useIssueTrackingFilter.tsx
@@ -1,0 +1,26 @@
+import {useEffect} from 'react';
+
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+import {useLocation} from 'sentry/utils/useLocation';
+
+const issueTrackingFilterKey = 'issueTrackingFilter';
+
+export default function useIssueTrackingFilter() {
+  const location = useLocation();
+  const issueTrackingQueryParam = location.query.issueTracking;
+  const [issueTracking, setIssueTracking] = useLocalStorageState<string>(
+    issueTrackingFilterKey,
+    'all'
+  );
+  const issueTrackingFilter = ['', 'all'].includes(issueTracking)
+    ? undefined
+    : issueTracking;
+
+  useEffect(() => {
+    if (typeof issueTrackingQueryParam === 'string') {
+      setIssueTracking(issueTrackingQueryParam);
+    }
+  }, [issueTrackingQueryParam, setIssueTracking]);
+
+  return issueTrackingFilter;
+}

--- a/static/app/utils/useSentryAppComponentsStore.tsx
+++ b/static/app/utils/useSentryAppComponentsStore.tsx
@@ -1,0 +1,30 @@
+import {useEffect, useMemo, useState} from 'react';
+
+import SentryAppComponentsStore from 'sentry/stores/sentryAppComponentsStore';
+import type {SentryAppComponent} from 'sentry/types';
+
+export default function useSentryAppComponentsStore({
+  componentType,
+}: {
+  componentType: undefined | SentryAppComponent['type'];
+}) {
+  const [components, setComponents] = useState(SentryAppComponentsStore.getAll());
+
+  useEffect(() => {
+    const unsubscribe = SentryAppComponentsStore.listen(
+      () => setComponents(SentryAppComponentsStore.getAll()),
+      undefined
+    );
+
+    return unsubscribe as () => void;
+  }, []);
+
+  const filteredComponents = useMemo(() => {
+    if (componentType) {
+      return components.filter(item => item.type === componentType);
+    }
+    return components;
+  }, [components, componentType]);
+
+  return filteredComponents;
+}


### PR DESCRIPTION
I'm refactoring the existing externalIssuesList so that we can separate the data fetching + filtering, from the visual representation. This way we can re-use all that data logic, but change the UI a bit for User Feedback.

Related to: https://github.com/getsentry/team-replay/issues/284
Related to: https://github.com/getsentry/sentry/pull/60307
