### PR TITLE
feat(open-pr-comments): comment workflow task

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -125,7 +125,7 @@ def get_issue_table_contents(issue_list: List[Dict[str, int]]) -> List[PullReque
         )
         for issue in issues
     ]
-    pull_request_issues.sort(key=lambda k: k.event_count, reverse=True)
+    pull_request_issues.sort(key=lambda k: k.event_count or 0, reverse=True)
 
     return pull_request_issues
 
@@ -318,7 +318,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
     ]
 
     top_issues_per_file = [
-        get_top_5_issues_by_count_for_file(projects, sentry_filenames)
+        get_top_5_issues_by_count_for_file(list(projects), list(sentry_filenames))
         for projects, sentry_filenames in reverse_codemappings
     ]
 
@@ -336,8 +336,8 @@ def open_pr_comment_workflow(pr_id: int) -> None:
     comment_body = format_open_pr_comment(issue_tables)
 
     # list all issues in the comment
-    issue_list = list(itertools.chain.from_iterable(top_issues_per_file))
-    issue_list = [issue["group_id"] for issue in issue_list]
+    issue_list: List[Dict[str, Any]] = list(itertools.chain.from_iterable(top_issues_per_file))
+    issue_id_list: List[int] = [issue["group_id"] for issue in issue_list]
 
     try:
         create_or_update_comment(
@@ -347,7 +347,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
             pr_key=pull_request.key,
             comment_body=comment_body,
             pullrequest_id=pull_request.id,
-            issue_list=issue_list,
+            issue_list=issue_id_list,
             comment_type=CommentType.OPEN_PR,
             metrics_base=OPEN_PR_METRICS_BASE,
         )

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Set, Tuple
@@ -12,16 +13,23 @@ from snuba_sdk import Request as SnubaRequest
 from sentry.integrations.github.client import GitHubAppsClient
 from sentry.models.group import Group
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.models.options.organization_option import OrganizationOption
+from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.models.pullrequest import PullRequest
+from sentry.models.pullrequest import CommentType, PullRequest
 from sentry.models.repository import Repository
+from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions.base import ApiError
+from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
+from sentry.tasks.base import instrumented_task
 from sentry.tasks.integrations.github.pr_comment import (
+    ISSUE_LOCKED_ERROR_MESSAGE,
     RATE_LIMITED_MESSAGE,
     GithubAPIErrorType,
     PullRequestIssue,
+    create_or_update_comment,
     format_comment_url,
 )
 from sentry.templatetags.sentry_helpers import small_count
@@ -31,7 +39,7 @@ from sentry.utils.snuba import raw_snql_query
 
 logger = logging.getLogger(__name__)
 
-OPEN_PR_METRIC_BASE = "github_open_pr_comment.{key}"
+OPEN_PR_METRICS_BASE = "github_open_pr_comment.{key}"
 
 # Caps the number of files that can be modified in a PR to leave a comment
 OPEN_PR_MAX_FILES_CHANGED = 7
@@ -101,11 +109,12 @@ def format_issue_table(diff_filename: str, issues: List[PullRequestIssue], toggl
 def get_issue_table_contents(issue_list: List[Dict[str, int]]) -> List[PullRequestIssue]:
     group_id_to_info = {}
     for issue in issue_list:
-        group_id = issue.pop("group_id")
-        group_id_to_info[group_id] = issue
+        group_id = issue["group_id"]
+        group_id_to_info[group_id] = {k: v for k, v in issue.items() if k != "group_id"}
 
     issues = Group.objects.filter(id__in=list(group_id_to_info.keys())).all()
-    return [
+
+    pull_request_issues = [
         PullRequestIssue(
             title=issue.title,
             subtitle=issue.culprit,
@@ -116,6 +125,9 @@ def get_issue_table_contents(issue_list: List[Dict[str, int]]) -> List[PullReque
         )
         for issue in issues
     ]
+    pull_request_issues.sort(key=lambda k: k.event_count, reverse=True)
+
+    return pull_request_issues
 
 
 # TODO(cathy): Change the client typing to allow for multiple SCM Integrations
@@ -129,17 +141,17 @@ def safe_for_comment(
     except ApiError as e:
         if e.json and RATE_LIMITED_MESSAGE in e.json.get("message", ""):
             metrics.incr(
-                OPEN_PR_METRIC_BASE.format(key="api_error"),
+                OPEN_PR_METRICS_BASE.format(key="api_error"),
                 tags={"type": GithubAPIErrorType.RATE_LIMITED.value, "code": e.code},
             )
         elif e.code == 404:
             metrics.incr(
-                OPEN_PR_METRIC_BASE.format(key="api_error"),
+                OPEN_PR_METRICS_BASE.format(key="api_error"),
                 tags={"type": GithubAPIErrorType.MISSING_PULL_REQUEST.value, "code": e.code},
             )
         else:
             metrics.incr(
-                OPEN_PR_METRIC_BASE.format(key="api_error"),
+                OPEN_PR_METRICS_BASE.format(key="api_error"),
                 tags={"type": GithubAPIErrorType.UNKNOWN.value, "code": e.code},
             )
             logger.exception("github.open_pr_comment.unknown_api_error", extra={"error": str(e)})
@@ -148,17 +160,17 @@ def safe_for_comment(
     safe_to_comment = True
     if pullrequest_resp["state"] != "open":
         metrics.incr(
-            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "incorrect_state"}
+            OPEN_PR_METRICS_BASE.format(key="rejected_comment"), tags={"reason": "incorrect_state"}
         )
         safe_to_comment = False
     if pullrequest_resp["changed_files"] > OPEN_PR_MAX_FILES_CHANGED:
         metrics.incr(
-            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "too_many_files"}
+            OPEN_PR_METRICS_BASE.format(key="rejected_comment"), tags={"reason": "too_many_files"}
         )
         safe_to_comment = False
     if pullrequest_resp["additions"] + pullrequest_resp["deletions"] > OPEN_PR_MAX_LINES_CHANGED:
         metrics.incr(
-            OPEN_PR_METRIC_BASE.format(key="rejected_comment"), tags={"reason": "too_many_lines"}
+            OPEN_PR_METRICS_BASE.format(key="rejected_comment"), tags={"reason": "too_many_lines"}
         )
         safe_to_comment = False
     return safe_to_comment
@@ -230,6 +242,7 @@ def get_top_5_issues_by_count_for_file(
                     Condition(Column("group_id"), Op.IN, group_ids),
                     Condition(Column("timestamp"), Op.GTE, datetime.now() - timedelta(days=14)),
                     Condition(Column("timestamp"), Op.LT, datetime.now()),
+                    # NOTE: this currently looks at the top frame of the stack trace (old suspect commit logic)
                     Condition(
                         Function("arrayElement", (Column("exception_frames.filename"), -1)),
                         Op.IN,
@@ -242,3 +255,117 @@ def get_top_5_issues_by_count_for_file(
         ),
     )
     return raw_snql_query(request, referrer=Referrer.GITHUB_PR_COMMENT_BOT.value)["data"]
+
+
+@instrumented_task(
+    name="sentry.tasks.integrations.open_pr_comment_workflow", silo_mode=SiloMode.REGION
+)
+def open_pr_comment_workflow(pr_id: int) -> None:
+    try:
+        pull_request = PullRequest.objects.get(id=pr_id)
+    except PullRequest.DoesNotExist:
+        metrics.incr(OPEN_PR_METRICS_BASE.format(key="error"), tags={"type": "missing_pr"})
+        return
+
+    org_id = pull_request.organization_id
+    try:
+        organization = Organization.objects.get_from_cache(id=org_id)
+    except Organization.DoesNotExist:
+        logger.error("github.open_pr_comment.org_missing")
+        metrics.incr(OPEN_PR_METRICS_BASE.format(key="error"), tags={"type": "missing_org"})
+        return
+
+    if not OrganizationOption.objects.get_value(
+        organization=organization,
+        key="sentry:github_open_pr_bot",
+        default=True,
+    ):
+        logger.info("github.open_pr_comment.option_missing", extra={"organization_id": org_id})
+        return
+
+    try:
+        repo = Repository.objects.get(id=pull_request.repository_id)
+    except Repository.DoesNotExist:
+        logger.info("github.open_pr_comment.repo_missing", extra={"organization_id": org_id})
+        metrics.incr(OPEN_PR_METRICS_BASE.format(key="error"), tags={"type": "missing_repo"})
+        return
+
+    integration = integration_service.get_integration(integration_id=repo.integration_id)
+    if not integration:
+        logger.info("github.open_pr_comment.integration_missing", extra={"organization_id": org_id})
+        metrics.incr(OPEN_PR_METRICS_BASE.format(key="error"), tags={"type": "missing_integration"})
+        return
+
+    installation = integration.get_installation(organization_id=org_id)
+
+    # GitHubAppsClient (GithubClientMixin)
+    # TODO(cathy): create helper function to fetch client for repo
+    client = installation.get_client()
+
+    if not safe_for_comment(gh_client=client, repository=repo, pull_request=pull_request):
+        metrics.incr(
+            OPEN_PR_METRICS_BASE.format(key="error"),
+            tags={"type": "unsafe_for_comment"},
+        )
+        return
+
+    pr_filenames = get_pr_filenames(gh_client=client, repository=repo, pull_request=pull_request)
+
+    # projects and filenames in sentry for each PR filename
+    reverse_codemappings = [
+        get_projects_and_filenames_from_source_file(org_id, pr_filename)
+        for pr_filename in pr_filenames
+    ]
+
+    top_issues_per_file = [
+        get_top_5_issues_by_count_for_file(projects, sentry_filenames)
+        for projects, sentry_filenames in reverse_codemappings
+    ]
+
+    # format tables in the comment
+    issue_table_contents = [
+        get_issue_table_contents(issue_list) for issue_list in top_issues_per_file
+    ]
+    issue_tables = [format_issue_table(pr_filenames[0], issue_table_contents[0])]
+    issue_tables.extend(
+        [
+            format_issue_table(pr_filenames[i], issue_table_contents[i], toggle=True)
+            for i in range(1, len(pr_filenames))
+        ]
+    )
+    comment_body = format_open_pr_comment(issue_tables)
+
+    # list all issues in the comment
+    issue_list = list(itertools.chain.from_iterable(top_issues_per_file))
+    issue_list = [issue["group_id"] for issue in issue_list]
+
+    try:
+        create_or_update_comment(
+            pr_comment=None,
+            client=client,
+            repo=repo,
+            pr_key=pull_request.key,
+            comment_body=comment_body,
+            pullrequest_id=pull_request.id,
+            issue_list=issue_list,
+            comment_type=CommentType.OPEN_PR,
+            metrics_base=OPEN_PR_METRICS_BASE,
+        )
+    except ApiError as e:
+        if e.json:
+            if ISSUE_LOCKED_ERROR_MESSAGE in e.json.get("message", ""):
+                metrics.incr(
+                    OPEN_PR_METRICS_BASE.format(key="error"),
+                    tags={"type": "issue_locked_error"},
+                )
+                return
+
+            elif RATE_LIMITED_MESSAGE in e.json.get("message", ""):
+                metrics.incr(
+                    OPEN_PR_METRICS_BASE.format(key="error"),
+                    tags={"type": "rate_limited_error"},
+                )
+                return
+
+        metrics.incr(OPEN_PR_METRICS_BASE.format(key="error"), tags={"type": "api_error"})
+        raise e

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -155,7 +155,7 @@ def create_or_update_comment(
     comment_body: str,
     pullrequest_id: int,
     issue_list: List[int],
-    comment_type: CommentType = CommentType.MERGED_PR,
+    comment_type: int = CommentType.MERGED_PR,
     metrics_base=MERGED_PR_METRICS_BASE,
 ):
     # client will raise ApiError if the request is not successful

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -35,7 +35,7 @@ from sentry.utils.snuba import raw_snql_query
 
 logger = logging.getLogger(__name__)
 
-METRICS_BASE = "github_pr_comment.{key}"
+MERGED_PR_METRICS_BASE = "github_pr_comment.{key}"
 
 
 @dataclass
@@ -156,6 +156,7 @@ def create_or_update_comment(
     pullrequest_id: int,
     issue_list: List[int],
     comment_type: CommentType = CommentType.MERGED_PR,
+    metrics_base=MERGED_PR_METRICS_BASE,
 ):
     # client will raise ApiError if the request is not successful
     if pr_comment is None:
@@ -170,12 +171,12 @@ def create_or_update_comment(
             group_ids=issue_list,
             comment_type=comment_type,
         )
-        metrics.incr(METRICS_BASE.format(key="comment_created"))
+        metrics.incr(metrics_base.format(key="comment_created"))
     else:
         resp = client.update_comment(
             repo=repo.name, comment_id=pr_comment.external_id, data={"body": comment_body}
         )
-        metrics.incr(METRICS_BASE.format(key="comment_updated"))
+        metrics.incr(metrics_base.format(key="comment_updated"))
         pr_comment.updated_at = timezone.now()
         pr_comment.group_ids = issue_list
         pr_comment.save()
@@ -200,8 +201,8 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
         organization = Organization.objects.get_from_cache(id=org_id)
     except Organization.DoesNotExist:
         cache.delete(cache_key)
-        logger.error("github.pr_comment.org_missing")
-        metrics.incr(METRICS_BASE.format(key="error"), tags={"type": "missing_org"})
+        logger.info("github.pr_comment.org_missing")
+        metrics.incr(MERGED_PR_METRICS_BASE.format(key="error"), tags={"type": "missing_org"})
         return
 
     if not OrganizationOption.objects.get_value(
@@ -209,7 +210,7 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
         key="sentry:github_pr_bot",
         default=True,
     ):
-        logger.error("github.pr_comment.option_missing", extra={"organization_id": org_id})
+        logger.info("github.pr_comment.option_missing", extra={"organization_id": org_id})
         return
 
     pr_comment = None
@@ -223,8 +224,8 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
         project = Project.objects.get_from_cache(id=project_id)
     except Project.DoesNotExist:
         cache.delete(cache_key)
-        logger.error("github.pr_comment.project_missing", extra={"organization_id": org_id})
-        metrics.incr(METRICS_BASE.format(key="error"), tags={"type": "missing_project"})
+        logger.info("github.pr_comment.project_missing", extra={"organization_id": org_id})
+        metrics.incr(MERGED_PR_METRICS_BASE.format(key="error"), tags={"type": "missing_project"})
         return
 
     top_5_issues = get_top_5_issues_by_count(issue_list, project)
@@ -235,15 +236,17 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
         repo = Repository.objects.get(id=gh_repo_id)
     except Repository.DoesNotExist:
         cache.delete(cache_key)
-        logger.error("github.pr_comment.repo_missing", extra={"organization_id": org_id})
-        metrics.incr(METRICS_BASE.format(key="error"), tags={"type": "missing_repo"})
+        logger.info("github.pr_comment.repo_missing", extra={"organization_id": org_id})
+        metrics.incr(MERGED_PR_METRICS_BASE.format(key="error"), tags={"type": "missing_repo"})
         return
 
     integration = integration_service.get_integration(integration_id=repo.integration_id)
     if not integration:
         cache.delete(cache_key)
-        logger.error("github.pr_comment.integration_missing", extra={"organization_id": org_id})
-        metrics.incr(METRICS_BASE.format(key="error"), tags={"type": "missing_integration"})
+        logger.info("github.pr_comment.integration_missing", extra={"organization_id": org_id})
+        metrics.incr(
+            MERGED_PR_METRICS_BASE.format(key="error"), tags={"type": "missing_integration"}
+        )
         return
 
     installation = integration.get_installation(organization_id=org_id)
@@ -272,14 +275,18 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
 
         if e.json:
             if ISSUE_LOCKED_ERROR_MESSAGE in e.json.get("message", ""):
-                metrics.incr(METRICS_BASE.format(key="error"), tags={"type": "issue_locked_error"})
+                metrics.incr(
+                    MERGED_PR_METRICS_BASE.format(key="error"), tags={"type": "issue_locked_error"}
+                )
                 return
 
             elif RATE_LIMITED_MESSAGE in e.json.get("message", ""):
-                metrics.incr(METRICS_BASE.format(key="error"), tags={"type": "rate_limited_error"})
+                metrics.incr(
+                    MERGED_PR_METRICS_BASE.format(key="error"), tags={"type": "rate_limited_error"}
+                )
                 return
 
-        metrics.incr(METRICS_BASE.format(key="error"), tags={"type": "api_error"})
+        metrics.incr(MERGED_PR_METRICS_BASE.format(key="error"), tags={"type": "api_error"})
         raise e
 
 
@@ -303,7 +310,7 @@ def github_comment_reactions():
 
         integration = integration_service.get_integration(integration_id=repo.integration_id)
         if not integration:
-            logger.error(
+            logger.info(
                 "github.pr_comment.comment_reactions.integration_missing",
                 extra={"organization_id": pr.organization_id},
             )

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -646,3 +646,16 @@ class TestOpenPRCommentWorkflow(GithubCommentTestCase):
         mock_metrics.incr.assert_called_with(
             "github_open_pr_comment.error", tags={"type": "missing_integration"}
         )
+
+    @patch("sentry.tasks.integrations.github.open_pr_comment.safe_for_comment", return_value=False)
+    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_filenames")
+    @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
+    def test_comment_workflow_not_safe_for_comment(
+        self, mock_metrics, mock_pr_filenames, mock_safe_for_comment
+    ):
+        open_pr_comment_workflow(self.pr.id)
+
+        assert not mock_pr_filenames.called
+        mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.error", tags={"type": "unsafe_for_comment"}
+        )

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -1,7 +1,12 @@
 from unittest.mock import patch
 
+import pytest
 import responses
 
+from sentry.models.group import Group
+from sentry.models.options.organization_option import OrganizationOption
+from sentry.models.pullrequest import CommentType, PullRequest, PullRequestComment
+from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.tasks.integrations.github.open_pr_comment import (
     format_issue_table,
     format_open_pr_comment,
@@ -9,6 +14,7 @@ from sentry.tasks.integrations.github.open_pr_comment import (
     get_pr_filenames,
     get_projects_and_filenames_from_source_file,
     get_top_5_issues_by_count_for_file,
+    open_pr_comment_workflow,
     safe_for_comment,
 )
 from sentry.tasks.integrations.github.pr_comment import PullRequestIssue
@@ -450,4 +456,193 @@ You modified these files in this pull request and we noticed these issues associ
 ---
 
 <sub>Did you find this useful? React with a 👍 or 👎 or let us know in #proj-github-pr-comments</sub>"""
+        )
+
+
+@region_silo_test(stable=True)
+class TestOpenPRCommentWorkflow(GithubCommentTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user_id = "user_1"
+        self.app_id = "app_1"
+        self.pr = self.create_pr_issues()
+        self.groups = [
+            {
+                "group_id": g.id,
+                "event_count": 1000 * (i + 1),
+                "affected_users": 1000 * (i + 1),
+                "is_handled": True,
+            }
+            for i, g in enumerate(Group.objects.all())
+        ]
+        self.groups.reverse()
+        self.group_ids = [g["group_id"] for g in self.groups]
+
+    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_filenames")
+    @patch(
+        "sentry.tasks.integrations.github.open_pr_comment.get_projects_and_filenames_from_source_file"
+    )
+    @patch("sentry.tasks.integrations.github.open_pr_comment.get_top_5_issues_by_count_for_file")
+    @patch("sentry.tasks.integrations.github.open_pr_comment.safe_for_comment", return_value=True)
+    @patch("sentry.tasks.integrations.github.pr_comment.metrics")
+    @responses.activate
+    def test_comment_workflow(
+        self,
+        mock_metrics,
+        mock_safe_for_comment,
+        mock_issues,
+        mock_reverse_codemappings,
+        mock_pr_filenames,
+    ):
+        # two filenames, the second one has a toggle table
+        mock_pr_filenames.return_value = ["foo.py", "bar.py"]
+        mock_reverse_codemappings.return_value = ([self.project], ["foo.py"])
+
+        mock_issues.return_value = self.groups
+
+        responses.add(
+            responses.POST,
+            self.base_url + "/repos/getsentry/sentry/issues/1/comments",
+            json={"id": 1},
+            headers={"X-Ratelimit-Limit": "60", "X-Ratelimit-Remaining": "59"},
+        )
+
+        open_pr_comment_workflow(self.pr.id)
+
+        assert (
+            responses.calls[0].request.body
+            == f'{{"body": "## \\ud83d\\ude80 Sentry Issue Report\\nYou modified these files in this pull request and we noticed these issues associated with them.\\n\\n\\ud83d\\udcc4 **foo.py**\\n\\n| Issue  | Additional Info |\\n| :--------- | :-------- |\\n| \\u203c\\ufe0f [**issue 2**](http://testserver/organizations/foobar/issues/{self.group_ids[0]}/?referrer=github-open-pr-bot) issue2 | `Handled:` **True** `Event Count:` **2k** `Users:` **2k** |\\n| \\u203c\\ufe0f [**issue 1**](http://testserver/organizations/foo/issues/{self.group_ids[1]}/?referrer=github-open-pr-bot) issue1 | `Handled:` **True** `Event Count:` **1k** `Users:` **1k** |\\n<details>\\n<summary><b>\\ud83d\\udcc4 bar.py (Click to Expand)</b></summary>\\n\\n| Issue  | Additional Info |\\n| :--------- | :-------- |\\n| \\u203c\\ufe0f [**issue 2**](http://testserver/organizations/foobar/issues/{self.group_ids[0]}/?referrer=github-open-pr-bot) issue2 | `Handled:` **True** `Event Count:` **2k** `Users:` **2k** |\\n| \\u203c\\ufe0f [**issue 1**](http://testserver/organizations/foo/issues/{self.group_ids[1]}/?referrer=github-open-pr-bot) issue1 | `Handled:` **True** `Event Count:` **1k** `Users:` **1k** |\\n</details>\\n---\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e or let us know in #proj-github-pr-comments</sub>"}}'.encode()
+        )
+
+        pull_request_comment_query = PullRequestComment.objects.all()
+        assert len(pull_request_comment_query) == 1
+        assert pull_request_comment_query[0].external_id == 1
+        assert pull_request_comment_query[0].comment_type == CommentType.OPEN_PR
+        mock_metrics.incr.assert_called_with("github_open_pr_comment.comment_created")
+
+    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_filenames")
+    @patch(
+        "sentry.tasks.integrations.github.open_pr_comment.get_projects_and_filenames_from_source_file"
+    )
+    @patch("sentry.tasks.integrations.github.open_pr_comment.get_top_5_issues_by_count_for_file")
+    @patch("sentry.tasks.integrations.github.open_pr_comment.safe_for_comment", return_value=True)
+    @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
+    @responses.activate
+    def test_comment_workflow_api_error(
+        self,
+        mock_metrics,
+        mock_safe_for_comment,
+        mock_issues,
+        mock_reverse_codemappings,
+        mock_pr_filenames,
+    ):
+        mock_pr_filenames.return_value = ["foo.py"]
+        mock_reverse_codemappings.return_value = ([self.project], ["foo.py"])
+
+        mock_issues.return_value = self.groups
+
+        responses.add(
+            responses.POST,
+            self.base_url + "/repos/getsentry/sentry/issues/1/comments",
+            status=400,
+            json={"id": 1},
+        )
+        responses.add(
+            responses.POST,
+            self.base_url + "/repos/getsentry/sentry/issues/2/comments",
+            status=400,
+            json={
+                "message": "Unable to create comment because issue is locked.",
+                "documentation_url": "https://docs.github.com/articles/locking-conversations/",
+            },
+        )
+        responses.add(
+            responses.POST,
+            self.base_url + "/repos/getsentry/sentry/issues/3/comments",
+            status=400,
+            json={
+                "message": "API rate limit exceeded",
+                "documentation_url": "https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting",
+            },
+        )
+
+        with pytest.raises(ApiError):
+            open_pr_comment_workflow(self.pr.id)
+            mock_metrics.incr.assert_called_with("github_open_pr_comment.api_error")
+
+        pr_2 = self.create_pr_issues()
+
+        # does not raise ApiError for locked issue
+        open_pr_comment_workflow(pr_2.id)
+        mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.error", tags={"type": "issue_locked_error"}
+        )
+
+        pr_3 = self.create_pr_issues()
+
+        # does not raise ApiError for rate limited error
+        open_pr_comment_workflow(pr_3.id)
+        mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.error", tags={"type": "rate_limited_error"}
+        )
+
+    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_filenames")
+    @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
+    def test_comment_workflow_missing_pr(self, mock_metrics, mock_pr_filenames):
+        PullRequest.objects.all().delete()
+
+        open_pr_comment_workflow(0)
+
+        assert not mock_pr_filenames.called
+        mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.error", tags={"type": "missing_pr"}
+        )
+
+    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_filenames")
+    @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
+    def test_comment_workflow_missing_org(self, mock_metrics, mock_pr_filenames):
+        self.pr.organization_id = 0
+        self.pr.save()
+
+        open_pr_comment_workflow(self.pr.id)
+
+        assert not mock_pr_filenames.called
+        mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.error", tags={"type": "missing_org"}
+        )
+
+    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_filenames")
+    def test_comment_workflow_missing_org_option(self, mock_pr_filenames):
+        OrganizationOption.objects.set_value(
+            organization=self.organization, key="sentry:github_open_pr_bot", value=False
+        )
+        open_pr_comment_workflow(self.pr.id)
+
+        assert not mock_pr_filenames.called
+
+    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_filenames")
+    @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
+    def test_comment_workflow_missing_repo(self, mock_metrics, mock_pr_filenames):
+        self.pr.repository_id = 0
+        self.pr.save()
+
+        open_pr_comment_workflow(self.pr.id)
+
+        assert not mock_pr_filenames.called
+        mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.error", tags={"type": "missing_repo"}
+        )
+
+    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_filenames")
+    @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
+    def test_comment_workflow_missing_integration(self, mock_metrics, mock_pr_filenames):
+        # invalid integration id
+        self.gh_repo.integration_id = 0
+        self.gh_repo.save()
+
+        open_pr_comment_workflow(self.pr.id)
+
+        assert not mock_pr_filenames.called
+        mock_metrics.incr.assert_called_with(
+            "github_open_pr_comment.error", tags={"type": "missing_integration"}
         )


### PR DESCRIPTION
The task for commenting on an open PR. Takes in an argument `pr_id` -- a `PullRequest` object will be created in the Github webhook when a PR is opened.

Checks (note that checking for the feature flag can occur before queuing the task):
- Check if the PR exists
- Check if the PR's org exists
- Check if the org has the open PR comment feature option enabled
- Check if the PR's repo exists
- Check if the repo's integration exists

Comment workflow
- Determine if the PR is safe to comment on (<= 7 files changes and <= 500 lines changed; these are adjustable)

For each file:
- Reverse codemap filenames from the PR into projects and filenames in Sentry. If a file has no reverse codemappings then we will not create a table for it.
- Get the top issues per PR file using the reverse codemappings. If a file has no issues then we will not create a table for it.

If there are no issues associated with the PR, then we will not comment on the PR.

Posting the comment
- Format the issues per PR file into a comment. After the first table, the other tables are tucked away into toggles
- Post the comment

For ER-1811