### PR TITLE
fix(browser-starfish): fix query main graphs on resource module

### DIFF
--- a/static/app/views/performance/browser/resources/jsCssView/index.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/index.tsx
@@ -43,16 +43,17 @@ type Option = {
 function JSCSSView() {
   const filters = useResourceModuleFilters();
   const sort = useResourceSort();
-  const extraQuery = [
-    'AND (',
-    ...getResourceTypeFilter(undefined, DEFAULT_RESOURCE_TYPES),
-    ')',
-  ];
 
   const spanTimeChartsFilters: ModuleFilters = {
     'span.op': `[${DEFAULT_RESOURCE_TYPES.join(',')}]`,
     ...(filters[SPAN_DOMAIN] ? {[SPAN_DOMAIN]: filters[SPAN_DOMAIN]} : {}),
   };
+
+  const extraQuery = [
+    'AND (',
+    ...getResourceTypeFilter(undefined, DEFAULT_RESOURCE_TYPES),
+    ')',
+  ];
 
   return (
     <Fragment>

--- a/static/app/views/performance/browser/resources/jsCssView/index.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/index.tsx
@@ -16,6 +16,7 @@ import {
 } from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {useResourcePagesQuery} from 'sentry/views/performance/browser/resources/utils/useResourcePagesQuery';
 import {useResourceSort} from 'sentry/views/performance/browser/resources/utils/useResourceSort';
+import {getResourceTypeFilter} from 'sentry/views/performance/browser/resources/utils/useResourcesQuery';
 import {ModuleName} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {SpanTimeCharts} from 'sentry/views/starfish/views/spans/spanTimeCharts';
@@ -42,6 +43,11 @@ type Option = {
 function JSCSSView() {
   const filters = useResourceModuleFilters();
   const sort = useResourceSort();
+  const extraQuery = [
+    'AND (',
+    ...getResourceTypeFilter(undefined, DEFAULT_RESOURCE_TYPES),
+    ')',
+  ];
 
   const spanTimeChartsFilters: ModuleFilters = {
     'span.op': `[${DEFAULT_RESOURCE_TYPES.join(',')}]`,
@@ -54,6 +60,7 @@ function JSCSSView() {
         moduleName={ModuleName.OTHER}
         appliedFilters={spanTimeChartsFilters}
         throughputUnit={RESOURCE_THROUGHPUT_UNIT}
+        extraQuery={extraQuery}
       />
 
       <FilterOptionsContainer>

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -32,6 +32,8 @@ const CHART_HEIGHT = 140;
 type Props = {
   appliedFilters: ModuleFilters;
   moduleName: ModuleName;
+  eventView?: EventView;
+  extraQuery?: string[];
   spanCategory?: string;
   throughputUnit?: RateUnits;
 };
@@ -51,10 +53,14 @@ export function SpanTimeCharts({
   appliedFilters,
   spanCategory,
   throughputUnit = RateUnits.PER_MINUTE,
+  extraQuery,
 }: Props) {
   const {selection} = usePageFilters();
 
   const eventView = getEventView(moduleName, selection, appliedFilters, spanCategory);
+  if (extraQuery) {
+    eventView.query += ` ${extraQuery.join(' ')}`;
+  }
 
   const {isLoading} = useSpansQuery({
     eventView,


### PR DESCRIPTION
new query, resource spans are under `span.module:other`
![image](https://github.com/getsentry/sentry/assets/44422760/9a762569-cd21-4de6-b1b1-df93834eea9a)
