### PR TITLE
fix(browser-starfish): typo

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceInfo.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceInfo.tsx
@@ -110,7 +110,7 @@ function ResourceInfo(props: Props) {
       {hasNoData && (
         <Alert style={{width: '100%'}} type="warning" showIcon>
           {t(
-            "We couldn't find any size information for this resource, this is likely because the `allow-timing-origin` header is not set"
+            "We couldn't find any size information for this resource, this is likely because the `timing-allow-origin` header is not set."
           )}
         </Alert>
       )}


### PR DESCRIPTION
Typo in resource info when no resource size found