### PR TITLE
fix(hybridcloud) Add missing silo annotation to view

### DIFF
--- a/src/sentry/web/frontend/project_event.py
+++ b/src/sentry/web/frontend/project_event.py
@@ -4,9 +4,10 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import eventstore
-from sentry.web.frontend.base import ProjectView
+from sentry.web.frontend.base import ProjectView, region_silo_view
 
 
+@region_silo_view
 class ProjectEventRedirect(ProjectView):
     required_scope = "event:read"
 

--- a/src/sentry/web/frontend/project_event.py
+++ b/src/sentry/web/frontend/project_event.py
@@ -1,7 +1,6 @@
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
 from rest_framework.request import Request
-from rest_framework.response import Response
 
 from sentry import eventstore
 from sentry.web.frontend.base import ProjectView, region_silo_view
@@ -11,7 +10,9 @@ from sentry.web.frontend.base import ProjectView, region_silo_view
 class ProjectEventRedirect(ProjectView):
     required_scope = "event:read"
 
-    def handle(self, request: Request, organization, project, client_event_id) -> Response:
+    def handle(
+        self, request: Request, organization, project, client_event_id
+    ) -> HttpResponseRedirect:
         """
         Given a client event id and project, redirects to the event page
         """
@@ -23,9 +24,8 @@ class ProjectEventRedirect(ProjectView):
         if not event.group_id:
             raise Http404
 
-        return HttpResponseRedirect(
-            reverse(
-                "sentry-organization-event-detail",
-                args=[organization.slug, event.group_id, event.event_id],
-            )
+        path = reverse(
+            "sentry-organization-event-detail",
+            args=[organization.slug, event.group_id, event.event_id],
         )
+        return HttpResponseRedirect(organization.absolute_url(path))

--- a/tests/sentry/web/frontend/test_project_event.py
+++ b/tests/sentry/web/frontend/test_project_event.py
@@ -2,6 +2,7 @@ from django.urls import reverse
 
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 
 
@@ -30,6 +31,19 @@ class ProjectEventTest(SnubaTestCase, TestCase):
         self.assertRedirects(
             resp,
             f"/organizations/{self.org.slug}/issues/{self.event.group_id}/events/{self.event.event_id}/",
+        )
+
+    @with_feature("organizations:customer-domains")
+    def test_redirect_to_event_customer_domain(self):
+        resp = self.client.get(
+            reverse(
+                "sentry-project-event-redirect",
+                args=[self.org.slug, self.project.slug, self.event.event_id],
+            )
+        )
+        assert (
+            resp["Location"]
+            == f"http://{self.org.slug}.testserver/issues/{self.event.group_id}/events/{self.event.event_id}/"
         )
 
     def test_event_not_found(self):

--- a/tests/sentry/web/frontend/test_project_event.py
+++ b/tests/sentry/web/frontend/test_project_event.py
@@ -30,20 +30,7 @@ class ProjectEventTest(SnubaTestCase, TestCase):
         )
         self.assertRedirects(
             resp,
-            f"/organizations/{self.org.slug}/issues/{self.event.group_id}/events/{self.event.event_id}/",
-        )
-
-    @with_feature("organizations:customer-domains")
-    def test_redirect_to_event_customer_domain(self):
-        resp = self.client.get(
-            reverse(
-                "sentry-project-event-redirect",
-                args=[self.org.slug, self.project.slug, self.event.event_id],
-            )
-        )
-        assert (
-            resp["Location"]
-            == f"http://{self.org.slug}.testserver/issues/{self.event.group_id}/events/{self.event.event_id}/"
+            f"http://testserver/organizations/{self.org.slug}/issues/{self.event.group_id}/events/{self.event.event_id}/",
         )
 
     def test_event_not_found(self):
@@ -73,3 +60,34 @@ class ProjectEventTest(SnubaTestCase, TestCase):
         )
         resp = self.client.get(url)
         assert resp.status_code == 404
+
+
+@region_silo_test
+class ProjectEventCustomerDomainTest(SnubaTestCase, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.login_as(self.user)
+        self.org = self.create_organization()
+        self.team = self.create_team(organization=self.org, name="Mariachi Band")
+        self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
+        self.project = self.create_project(organization=self.org, teams=[self.team])
+        min_ago = iso_format(before_now(minutes=1))
+        self.event = self.store_event(
+            data={"fingerprint": ["group1"], "timestamp": min_ago}, project_id=self.project.id
+        )
+
+    @with_feature("organizations:customer-domains")
+    def test_redirect_to_event_customer_domain(self):
+        self.org.refresh_from_db()
+        with self.feature("organizations:customer-domains"):
+            resp = self.client.get(
+                reverse(
+                    "sentry-project-event-redirect",
+                    args=[self.org.slug, self.project.slug, self.event.event_id],
+                )
+            )
+        assert (
+            resp["Location"]
+            == f"http://{self.org.slug}.testserver/issues/{self.event.group_id}/events/{self.event.event_id}/"
+        )


### PR DESCRIPTION
The project event redirect view needs a silo annotation in order to be proxied through the api gateway

Fixes HC-999