### PR TITLE
fix(metrics-extraction): Use widget ids instead of object references

### DIFF
--- a/static/app/utils/performance/contexts/metricsEnhancedPerformanceDataContext.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedPerformanceDataContext.tsx
@@ -12,7 +12,7 @@ import {useOnDemandControl} from './onDemandControl';
 import {createDefinedContext} from './utils';
 
 export type MetricsResultsMetaMapKey = Widget;
-type ExtractedDataMap = Map<MetricsResultsMetaMapKey, boolean | undefined>;
+type ExtractedDataMap = Map<string, boolean | undefined>;
 
 export interface MetricsEnhancedPerformanceDataContext {
   setIsMetricsData: (value?: boolean) => void;
@@ -85,7 +85,9 @@ export function MetricsResultsMetaProvider({children}: {children: ReactNode}) {
 
   const setIsMetricsExtractedData = useCallback(
     (mapKey: MetricsResultsMetaMapKey, value?: boolean) => {
-      metricsExtractedDataMap.set(mapKey, value);
+      if (mapKey.id) {
+        metricsExtractedDataMap.set(mapKey.id, value);
+      }
     },
     [metricsExtractedDataMap]
   );
@@ -141,7 +143,7 @@ export function ExtractedMetricsTag(props: {queryKey: MetricsResultsMetaMapKey})
   const {forceOnDemand} = _onDemandControl;
 
   const isMetricsExtractedData =
-    resultsMeta?.metricsExtractedDataMap.get(props.queryKey) || undefined;
+    resultsMeta?.metricsExtractedDataMap.get(props.queryKey.id ?? '') || undefined;
 
   if (!organization.features.includes('on-demand-metrics-extraction-experimental')) {
     // Separate if for easier flag deletion

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -159,7 +159,9 @@ function WidgetQueries({
       if (rawResults.isMetricsExtractedData !== undefined) {
         isSeriesMetricsExtractedDataResults.push(rawResults.isMetricsExtractedData);
       }
-      isSeriesMetricsExtractedDataResults.push(rawResults.isMetricsExtractedData);
+      isSeriesMetricsExtractedDataResults.push(
+        rawResults.isMetricsExtractedData || rawResults.meta?.isMetricsExtractedData
+      );
     } else {
       Object.keys(rawResults).forEach(key => {
         const rawResult: EventsStats = rawResults[key];
@@ -167,7 +169,9 @@ function WidgetQueries({
           isSeriesMetricsDataResults.push(rawResult.isMetricsData);
         }
         if (rawResult.isMetricsExtractedData !== undefined) {
-          isSeriesMetricsExtractedDataResults.push(rawResult.isMetricsExtractedData);
+          isSeriesMetricsExtractedDataResults.push(
+            rawResults.isMetricsExtractedData || rawResult.meta.isMetricsExtractedData
+          );
         }
       });
     }

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -170,7 +170,7 @@ function WidgetQueries({
         }
         if (rawResult.isMetricsExtractedData !== undefined) {
           isSeriesMetricsExtractedDataResults.push(
-            rawResults.isMetricsExtractedData || rawResult.meta.isMetricsExtractedData
+            rawResult.isMetricsExtractedData || rawResult.meta?.isMetricsExtractedData
           );
         }
       });


### PR DESCRIPTION
### Summary
It should be fine if instances are stale metrics data since a new widget object should override that map value if the widget 
has refetched data, we don't need to use objects as keys here.
