### PR TITLE
ref(notifications): remove default value and default field name for notification settings

### DIFF
--- a/static/app/views/settings/account/accountNotificationFineTuning.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuning.tsx
@@ -5,13 +5,11 @@ import styled from '@emotion/styled';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import SelectField from 'sentry/components/forms/fields/selectField';
 import Form from 'sentry/components/forms/form';
-import JsonForm from 'sentry/components/forms/jsonForm';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Pagination from 'sentry/components/pagination';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
-import {fields} from 'sentry/data/forms/accountNotificationSettings';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
@@ -244,20 +242,6 @@ class AccountNotificationFineTuning extends DeprecatedAsyncView<Props, State> {
       <div>
         <SettingsPageHeader title={title} />
         {description && <TextBlock>{description}</TextBlock>}
-
-        {field && field.defaultFieldName && (
-          <Form
-            saveOnBlur
-            apiMethod="PUT"
-            apiEndpoint="/users/me/notifications/"
-            initialData={notifications}
-          >
-            <JsonForm
-              title={`Default ${title}`}
-              fields={[fields[field.defaultFieldName]]}
-            />
-          </Form>
-        )}
         <Panel>
           <StyledPanelHeader hasButtons={isProject}>
             {isProject ? (

--- a/static/app/views/settings/account/notifications/fields.tsx
+++ b/static/app/views/settings/account/notifications/fields.tsx
@@ -5,7 +5,6 @@ export type FineTuneField = {
   description: string;
   title: string;
   type: 'select';
-  defaultFieldName?: string;
   defaultValue?: string;
   options?: SelectValue<string>[];
 };

--- a/static/app/views/settings/account/notifications/fields.tsx
+++ b/static/app/views/settings/account/notifications/fields.tsx
@@ -15,15 +15,13 @@ export const ACCOUNT_NOTIFICATION_FIELDS: Record<string, FineTuneField> = {
   alerts: {
     title: t('Issue Alert Notifications'),
     description: t(
-      'Notifications from Alert Rules that your team has setup. You’ll always receive notifications from Alerts configured to be sent directly to you.'
+      "Notifications from Alert Rules that your team has setup. You'll always receive notifications from Alerts configured to be sent directly to you."
     ),
     type: 'select',
     options: [
       {value: '1', label: t('On')},
       {value: '0', label: t('Off')},
     ],
-    defaultValue: '-1',
-    defaultFieldName: 'subscribeByDefault',
   },
   workflow: {
     title: t('Workflow Notifications'),
@@ -36,8 +34,6 @@ export const ACCOUNT_NOTIFICATION_FIELDS: Record<string, FineTuneField> = {
       {value: '1', label: t('Only on issues I subscribe to')},
       {value: '2', label: t('Never')},
     ],
-    defaultValue: '-1',
-    defaultFieldName: 'workflowNotifications',
   },
   deploy: {
     title: t('Deploy Notifications'),
@@ -50,8 +46,6 @@ export const ACCOUNT_NOTIFICATION_FIELDS: Record<string, FineTuneField> = {
       {value: '3', label: t('Only on deploys with my commits')},
       {value: '4', label: t('Never')},
     ],
-    defaultValue: '-1',
-    defaultFieldName: 'deployNotifications',
   },
   reports: {
     title: t('Weekly Reports'),
@@ -65,7 +59,6 @@ export const ACCOUNT_NOTIFICATION_FIELDS: Record<string, FineTuneField> = {
       {value: '1', label: t('On')},
       {value: '0', label: t('Off')},
     ],
-    defaultFieldName: 'weeklyReports',
   },
   approval: {
     title: t('Nudges'),
@@ -94,7 +87,6 @@ export const ACCOUNT_NOTIFICATION_FIELDS: Record<string, FineTuneField> = {
       {value: '1', label: t('On')},
       {value: '0', label: t('Off')},
     ],
-    defaultFieldName: 'spikeProtection',
   },
   email: {
     title: t('Email Routing'),


### PR DESCRIPTION
We shouldn't use a default value in the settings because we want the default to actually reflect the backend settings. Additionally, I'm removing the `defaultFieldName` which was used for some weird logic that mapped from legacy fields we don't need to maintain anymore.