### PR TITLE
fix(hybrid-cloud): Updates org auth token minting to include the correct region URL

### DIFF
--- a/src/sentry/api/endpoints/org_auth_tokens.py
+++ b/src/sentry/api/endpoints/org_auth_tokens.py
@@ -16,6 +16,7 @@ from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrgAuthTokenPermission
 from sentry.api.serializers import serialize
 from sentry.api.utils import generate_region_url
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.orgauthtoken import MAX_NAME_LENGTH, OrgAuthToken
 from sentry.models.user import User
@@ -67,7 +68,10 @@ class OrgAuthTokensEndpoint(ControlSiloOrganizationEndpoint):
         organization: RpcOrganization,
     ) -> Response:
         try:
-            token_str = generate_token(organization.slug, generate_region_url())
+            org_mapping = OrganizationMapping.objects.get(organization_id=organization.id)
+            token_str = generate_token(
+                organization.slug, generate_region_url(region_name=org_mapping.region_name)
+            )
         except SystemUrlPrefixMissingException:
             return Response(
                 {


### PR DESCRIPTION
Updates the org auth token code to pull the org mapping + region_name before minting a new token. Previously this was seeding the token with the control silo URL, but we need this to match the region the organization exists in.
