### PR TITLE
ref(feedback): update colors and icons on list

### DIFF
--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -166,15 +166,10 @@ const StyledCheckbox = styled('div')<{
 
   ${p =>
     p.invertColors
-      ? p.checked
-        ? css`
-            background: ${p.theme.background};
-            border: 1px solid ${p.theme.gray200};
-          `
-        : css`
-            background: ${p.theme.background};
-            border: 0;
-          `
+      ? css`
+          background: ${p.theme.white};
+          border: 0;
+        `
       : p.checked
       ? css`
           background: ${p.color ?? p.theme.active};


### PR DESCRIPTION
This PR updates the colors and icons on the feedback list

- Icons and tooltips for linked replay & linked issue (crash report) are updated
  - icons for linked GH/Jira/multiple issue tracking not added yet, will add after that functionality is available on the feedback details 

https://github.com/getsentry/sentry/assets/56095982/9f6d57f9-8358-4ae5-9617-23f12a673ec9

- Light & dark mode checkboxes and text updated
<img width="386" alt="SCR-20231121-mufj" src="https://github.com/getsentry/sentry/assets/56095982/867287c9-e28d-423e-89b9-03ff1d94f085">
<img width="387" alt="SCR-20231121-muda" src="https://github.com/getsentry/sentry/assets/56095982/7131cd55-17b7-4381-af63-d162cec87647">
<img width="387" alt="SCR-20231121-mwcl" src="https://github.com/getsentry/sentry/assets/56095982/e7513aaa-bf20-4a86-b2e3-1b14c59a1b25">
<img width="384" alt="SCR-20231121-mwdw" src="https://github.com/getsentry/sentry/assets/56095982/60c2b109-84d7-451f-90b8-b9b2003954f8">


Relates to https://github.com/getsentry/sentry/issues/60371
Relates to https://github.com/getsentry/sentry/issues/60367