### PR TITLE
feat(alerts): Add `is:unresolved` to default errors metric alert

### DIFF
--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -98,12 +98,13 @@ class Create extends Component<Props, State> {
   render() {
     const {hasMetricAlerts, organization, project, location, members} = this.props;
     const {alertType} = this.state;
-    const {aggregate, dataset, eventTypes, createFromWizard, createFromDiscover} =
+    const {aggregate, dataset, eventTypes, createFromWizard, createFromDiscover, query} =
       location?.query ?? {};
     const wizardTemplate: WizardRuleTemplate = {
       aggregate: aggregate ?? DEFAULT_WIZARD_TEMPLATE.aggregate,
       dataset: dataset ?? DEFAULT_WIZARD_TEMPLATE.dataset,
       eventTypes: eventTypes ?? DEFAULT_WIZARD_TEMPLATE.eventTypes,
+      query: query ?? DEFAULT_WIZARD_TEMPLATE.query,
     };
     const eventView = createFromDiscover ? EventView.fromLocation(location) : undefined;
 

--- a/static/app/views/alerts/rules/metric/constants.tsx
+++ b/static/app/views/alerts/rules/metric/constants.tsx
@@ -196,7 +196,7 @@ export function createRuleFromEventView(eventView: EventView): UnsavedMetricRule
 export function createRuleFromWizardTemplate(
   wizardTemplate: WizardRuleTemplate
 ): UnsavedMetricRule {
-  const {eventTypes, aggregate, dataset} = wizardTemplate;
+  const {eventTypes, aggregate, dataset, query} = wizardTemplate;
   const defaultRuleOptions: Partial<UnsavedMetricRule> = {};
 
   if (isSessionAggregate(aggregate)) {
@@ -213,6 +213,7 @@ export function createRuleFromWizardTemplate(
     eventTypes: [eventTypes],
     aggregate,
     dataset,
+    query: query ?? '',
   };
 }
 

--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -68,6 +68,15 @@ function AlertWizard({organization, params, location, projectId}: AlertWizardPro
       metricRuleTemplate = {...metricRuleTemplate, dataset: Dataset.METRICS};
     }
 
+    if (
+      !organization.features.includes('metric-alert-ignore-archived') &&
+      metricRuleTemplate?.dataset === Dataset.ERRORS
+    ) {
+      // Pre-fill status:unresolved for error metric alerts
+      // Filters out events in issues that are archived or resolved
+      metricRuleTemplate = {...metricRuleTemplate, query: 'status:unresolved'};
+    }
+
     const renderNoAccess = p => (
       <Hovercard
         body={

--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -72,9 +72,9 @@ function AlertWizard({organization, params, location, projectId}: AlertWizardPro
       !organization.features.includes('metric-alert-ignore-archived') &&
       metricRuleTemplate?.dataset === Dataset.ERRORS
     ) {
-      // Pre-fill status:unresolved for error metric alerts
+      // Pre-fill is:unresolved for error metric alerts
       // Filters out events in issues that are archived or resolved
-      metricRuleTemplate = {...metricRuleTemplate, query: 'status:unresolved'};
+      metricRuleTemplate = {...metricRuleTemplate, query: 'is:unresolved'};
     }
 
     const renderNoAccess = p => (

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -111,6 +111,7 @@ export type WizardRuleTemplate = {
   aggregate: string;
   dataset: Dataset;
   eventTypes: EventTypes;
+  query?: string;
 };
 
 export const AlertWizardRuleTemplates: Record<


### PR DESCRIPTION
When creating a new metric alert, we'll pre-fill the query with `is:unresolved`.

![Screenshot 2023-11-21 at 2 53 49 PM](https://github.com/getsentry/sentry/assets/1400464/8ce15a27-6868-4368-9151-2145f25985fe)

edit: switched from status:unresolved to is:unresolved to be consistent