### PR TITLE
ci: Add a command to run https://knip.dev/ against the js code

### DIFF
--- a/.knip.json
+++ b/.knip.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://unpkg.com/knip@canary/schema.json",
+  "entry": [
+    "static/app/index.tsx",
+    "static/app/utils/statics-setup.tsx",
+    "static/app/views/integrationPipeline/index.tsx",
+    "static/app/chartcuterie/config.tsx",
+    "tests/js/sentry-test/index.tsx",
+    "static/app/**/__mocks__/*.{ts,tsx}",
+    "static/app/**/*.stories.{ts,tsx}"
+  ],
+  "project": ["static/**/*.{ts,tsx}", "tests/js/**/*.{ts,tsx}"],
+  "rules": {
+    "dependencies": "off",
+    "unlisted": "off",
+    "binaries": "off",
+    "exports": "warn",
+    "types": "warn"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
     "test-debug": "node --inspect-brk scripts/test.js --runInBand",
     "test-precommit": "yarn test-wrap --bail --findRelatedTests -u",
     "test-staged": "yarn test-wrap --findRelatedTests $(git diff --name-only --cached)",
+    "list-js-orphans": "npx knip --config ./.knip.json",
     "lint": "yarn eslint static/app tests/js  --ext .js,.jsx,.ts,.tsx",
     "lint:css": "yarn stylelint 'static/app/**/*.[jt]sx'",
     "dev": "(yarn check --verify-tree || yarn install --check-files) && sentry devserver",


### PR DESCRIPTION
Configured to list a) orphan files, and b) any modules that are exporting the same thing twice

Adding automation around this is something we should BE VERY CAREFUL ABOUT because `getsentry` repo might be importing something.

Therefore the correct action to take is not always 'delete files in the orphan list'... first check if it's used in `getsentry`. If it is used there, then maybe move the file into that repo. But it'll depend!

---

The current output is: https://gist.github.com/ryan953/f2656aeda27a7185afa8336212de67dd