### PR TITLE
fix(metrics-extraction): Fix percentiles test timestamps

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1209,16 +1209,10 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
 
         assert response.data["p75(measurements.fcp)"]["meta"]["isMetricsExtractedData"]
         assert response.data["p75(measurements.lcp)"]["meta"]["isMetricsData"]
-        assert response.data["p75(measurements.fcp)"]["data"] == [
-            (1700474400, [{"count": 0}]),
-            (1700478000, [{"count": 225.0}]),
-        ]
+        assert [attrs for time, attrs in response.data["p75(measurements.fcp)"]["data"]] == [[{"count": 0}], [{"count": 225.0}]]
         assert response.data["p75(measurements.lcp)"]["meta"]["isMetricsExtractedData"]
         assert response.data["p75(measurements.lcp)"]["meta"]["isMetricsData"]
-        assert response.data["p75(measurements.lcp)"]["data"] == [
-            (1700474400, [{"count": 0}]),
-            (1700478000, [{"count": 450.0}]),
-        ]
+        assert [attrs for time, attrs in response.data["p75(measurements.lcp)"]["data"]] == [[{"count": 0}], [{"count": 450.0}]]
 
     def _test_is_metrics_extracted_data(
         self, params: dict[str, Any], expected_on_demand_query: bool, dataset: str

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1209,10 +1209,16 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
 
         assert response.data["p75(measurements.fcp)"]["meta"]["isMetricsExtractedData"]
         assert response.data["p75(measurements.lcp)"]["meta"]["isMetricsData"]
-        assert [attrs for time, attrs in response.data["p75(measurements.fcp)"]["data"]] == [[{"count": 0}], [{"count": 225.0}]]
+        assert [attrs for time, attrs in response.data["p75(measurements.fcp)"]["data"]] == [
+            [{"count": 0}],
+            [{"count": 225.0}],
+        ]
         assert response.data["p75(measurements.lcp)"]["meta"]["isMetricsExtractedData"]
         assert response.data["p75(measurements.lcp)"]["meta"]["isMetricsData"]
-        assert [attrs for time, attrs in response.data["p75(measurements.lcp)"]["data"]] == [[{"count": 0}], [{"count": 450.0}]]
+        assert [attrs for time, attrs in response.data["p75(measurements.lcp)"]["data"]] == [
+            [{"count": 0}],
+            [{"count": 450.0}],
+        ]
 
     def _test_is_metrics_extracted_data(
         self, params: dict[str, Any], expected_on_demand_query: bool, dataset: str


### PR DESCRIPTION
We should never test static timestamps unless we want pain, deferred to the future :)
