### PR TITLE
fix(functions): use same function names

### DIFF
--- a/static/app/utils/profiling/frame.tsx
+++ b/static/app/utils/profiling/frame.tsx
@@ -35,7 +35,10 @@ export class Frame {
 
   constructor(
     frameInfo: Profiling.FrameInfo,
-    type?: 'mobile' | 'javascript' | 'node' | string
+    type?: 'mobile' | 'javascript' | 'node' | string,
+    // In aggregate mode, we miss certain info like lineno/col and so
+    // we need to make sure we don't try to use it or infer data based on it
+    mode?: 'detailed' | 'aggregate'
   ) {
     this.key = frameInfo.key;
     this.file = frameInfo.file;
@@ -78,7 +81,7 @@ export class Frame {
       }
 
       // If the frame had no line or column, it was part of the native code, (e.g. calling String.fromCharCode)
-      if (this.line === undefined && this.column === undefined) {
+      if (this.line === undefined && this.column === undefined && mode !== 'aggregate') {
         this.name += ` ${t('[native code]')}`;
         this.is_application = false;
       }

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -200,7 +200,8 @@ function SlowestFunctionEntry({
       },
       project?.platform && /node|javascript/.test(project.platform)
         ? project.platform
-        : undefined
+        : undefined,
+      'aggregate'
     );
   }, [func, project]);
 

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -18,6 +18,7 @@ import {IconChevron, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {Frame} from 'sentry/utils/profiling/frame';
 import {EventsResultsDataRow} from 'sentry/utils/profiling/hooks/types';
 import {useProfileFunctions} from 'sentry/utils/profiling/hooks/useProfileFunctions';
 import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
@@ -190,6 +191,19 @@ function SlowestFunctionEntry({
   const score = Math.ceil((((func['sum()'] as number) ?? 0) / totalDuration) * BARS);
   const palette = new Array(BARS).fill([CHART_PALETTE[0][0]]);
 
+  const frame = useMemo(() => {
+    return new Frame(
+      {
+        key: 0,
+        name: func.function as string,
+        package: func.package as string,
+      },
+      project?.platform && /node|javascript/.test(project.platform)
+        ? project.platform
+        : undefined
+    );
+  }, [func, project]);
+
   const userQuery = useMemo(() => {
     const conditions = new MutableSearch(query);
 
@@ -222,7 +236,7 @@ function SlowestFunctionEntry({
           </Tooltip>
         )}
         <FunctionName>
-          <Tooltip title={func.package}>{func.function}</Tooltip>
+          <Tooltip title={frame.package}>{frame.name}</Tooltip>
         </FunctionName>
         <Tooltip
           title={tct('Appeared [count] times for a total time spent of [totalSelfTime]', {
@@ -279,8 +293,8 @@ function SlowestFunctionEntry({
                     projectSlug: project.slug,
                     profileId: examples[0],
                     query: {
-                      frameName: func.function as string,
-                      framePackage: func.package as string,
+                      frameName: frame.name,
+                      framePackage: frame.package,
                     },
                   });
                   transactionCol = (

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -198,6 +198,7 @@ function SlowestFunctionEntry({
         name: func.function as string,
         package: func.package as string,
       },
+      // Ensures that the frame runs through the normalization code path
       project?.platform && /node|javascript/.test(project.platform)
         ? project.platform
         : undefined,

--- a/static/app/views/profiling/profileSummary/slowestProfileFunctions.tsx
+++ b/static/app/views/profiling/profileSummary/slowestProfileFunctions.tsx
@@ -163,6 +163,7 @@ function SlowestFunctionEntry(props: SlowestFunctionEntryProps) {
         name: props.func.function as string,
         package: props.func.package as string,
       },
+      // Ensures that the frame runs through the normalization code path
       props.project?.platform && /node|javascript/.test(props.project.platform)
         ? props.project.platform
         : undefined,

--- a/static/app/views/profiling/profileSummary/slowestProfileFunctions.tsx
+++ b/static/app/views/profiling/profileSummary/slowestProfileFunctions.tsx
@@ -165,7 +165,8 @@ function SlowestFunctionEntry(props: SlowestFunctionEntryProps) {
       },
       props.project?.platform && /node|javascript/.test(props.project.platform)
         ? props.project.platform
-        : undefined
+        : undefined,
+      'aggregate'
     );
   }, [props.func, props.project]);
 


### PR DESCRIPTION
I reverted https://github.com/getsentry/sentry/pull/60273 as we started displaying native_code for aggregate frames in JS projects (which we don't have the lineno/colno for). Instead add a mode so we skip inferring some fields in this case