### PR TITLE
feat(ddm): Add feature flag for metrics metadata

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1568,6 +1568,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:metrics-extraction": False,
     # Enables the usage of the new metrics layer in the metrics API.
     "organizations:metrics-api-new-metrics-layer": False,
+    # Enables the metrics metadata.
+    "organizations:metric-meta": False,
     # Enables higher limit for alert rules
     "organizations:more-slow-alerts": False,
     # Extract on demand metrics

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -269,6 +269,7 @@ default_manager.add("organizations:source-maps-debugger-blue-thunder-edition", O
 default_manager.add("organizations:suspect-commits-all-frames", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:weekly-report-logs", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:metrics-api-new-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:metric-meta", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.
 

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -269,7 +269,7 @@ default_manager.add("organizations:source-maps-debugger-blue-thunder-edition", O
 default_manager.add("organizations:suspect-commits-all-frames", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:weekly-report-logs", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:metrics-api-new-metrics-layer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:metric-meta", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:metric-meta", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.
 

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -64,6 +64,7 @@ EXPOSABLE_FEATURES = [
     "organizations:session-replay-recording-scrubbing",
     "organizations:device-class-synthesis",
     "organizations:custom-metrics",
+    "organizations:metric-meta",
 ]
 
 EXTRACT_METRICS_VERSION = 1


### PR DESCRIPTION
This PR adds a new feature flag used to control the enabling of the new metrics metadata feature.

Epic: https://github.com/getsentry/sentry/issues/60260