### PR TITLE
fix(profiling): use correct sample tick view

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
@@ -208,7 +208,7 @@ function FlamegraphZoomView({
       }
       sampleTickRenderer.draw(
         flamegraphView.fromTransformedConfigView(flamegraphCanvas.physicalSpace),
-        flamegraphView.configView
+        flamegraphView.toOriginConfigView(flamegraphView.configView)
       );
     };
 


### PR DESCRIPTION
JS timelines are sometimes offset and it breaks the tick rendering