### PR TITLE
fix(hc): Add sort order to regions endpoint

### DIFF
--- a/src/sentry/api/endpoints/user_regions.py
+++ b/src/sentry/api/endpoints/user_regions.py
@@ -32,6 +32,7 @@ class UserRegionsEndpoint(UserEndpoint):
         org_mappings = (
             OrganizationMapping.objects.filter(organization_id__in=organization_ids)
             .distinct("region_name")
+            .order_by("region_name")
             .values_list("region_name", flat=True)
         )
         regions = [get_region_by_name(region_name).api_serialize() for region_name in org_mappings]

--- a/tests/sentry/api/endpoints/test_user_regions.py
+++ b/tests/sentry/api/endpoints/test_user_regions.py
@@ -27,10 +27,11 @@ class UserUserRolesTest(APITestCase):
         response = self.get_response("me")
         assert response.status_code == 200
         assert "regions" in response.data
-        assert len(response.data["regions"]) == 3
-        assert us.api_serialize() in response.data["regions"]
-        assert de.api_serialize() in response.data["regions"]
-        assert st.api_serialize() in response.data["regions"]
+        assert response.data["regions"] == [
+            st.api_serialize(),
+            de.api_serialize(),
+            us.api_serialize(),
+        ]
 
     @override_regions(region_config)
     def test_get_only_memberships(self):
@@ -41,8 +42,7 @@ class UserUserRolesTest(APITestCase):
         response = self.get_response("me")
         assert response.status_code == 200
         assert "regions" in response.data
-        assert len(response.data["regions"]) == 1
-        assert response.data["regions"][0] == de.api_serialize()
+        assert response.data["regions"] == [de.api_serialize()]
 
     @override_regions(region_config)
     def test_get_other_user_error(self):


### PR DESCRIPTION
This ensures that the order regions are listed in is stable across requests.

Fixes HC-998