### PR TITLE
feat(severity): Auto-mark info-level events or lower with 0 severity

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2125,13 +2125,13 @@ severity_connection_pool = connection_from_url(
 
 
 def _get_severity_score(event: Event) -> float | None:
+    # If the event is info-level or lower, auto-mark as low severity
+    if LOG_LEVELS_MAP[event.data["level"]] <= logging.INFO:
+        return 0
+
     op = "event_manager._get_severity_score"
     logger_data = {"event_id": event.data["event_id"], "op": op}
     severity = None
-
-    # If the event is info-level, auto-mark as low severity
-    if LOG_LEVELS_MAP[event.data["level"]] <= logging.INFO:
-        return 0
 
     # We're using the title (which truncates the error message) rather than the full error type and
     # message here because the `exception` property in event data (where they live) isn't mirrored

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2129,6 +2129,10 @@ def _get_severity_score(event: Event) -> float | None:
     logger_data = {"event_id": event.data["event_id"], "op": op}
     severity = None
 
+    # If the event is info-level, auto-mark as low severity
+    if LOG_LEVELS_MAP[event.data["level"]] <= logging.INFO:
+        return 0
+
     # We're using the title (which truncates the error message) rather than the full error type and
     # message here because the `exception` property in event data (where they live) isn't mirrored
     # to BigQuery for storage space reasons (stacktraces can be enormous). Since the ML model is

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -92,7 +92,7 @@ class TestGetEventSeverity(TestCase):
             {"logentry": {"message": "Dogs are great!"}},
         ]
         for case in cases:
-            manager = EventManager(make_event(level="info", **case))
+            manager = EventManager(make_event(**case))
             event = manager.save(self.project.id)
 
             severity = _get_severity_score(event)
@@ -100,7 +100,7 @@ class TestGetEventSeverity(TestCase):
             payload = {
                 "message": "Dogs are great!",
                 "has_stacktrace": 0,
-                "log_level": "info",
+                "log_level": "error",
                 "handled": 1,
             }
 
@@ -239,6 +239,29 @@ class TestGetEventSeverity(TestCase):
             },
         )
         assert severity is None
+
+    @patch(
+        "sentry.event_manager.severity_connection_pool.urlopen",
+    )
+    @patch("sentry.event_manager.logger.info")
+    def test_info_events_yield_zero_severity(
+        self,
+        mock_logger_info: MagicMock,
+        mock_urlopen: MagicMock,
+    ) -> None:
+        manager = EventManager(
+            make_event(
+                level="info",
+                exception={"values": [{"type": "InfoEvent", "value": "Super Cool Info"}]},
+            )
+        )
+        event = manager.save(self.project.id)
+
+        severity = _get_severity_score(event)
+        assert severity == 0
+
+        mock_urlopen.assert_not_called()
+        mock_logger_info.assert_not_called()
 
 
 @region_silo_test(stable=True)


### PR DESCRIPTION
When an issue is of info-level or lower, we automatically mark them as low severity (hardcoded score of 0) so that we don't need to call the severity endpoint.

Closes #60057