### PR TITLE
fix(hybridcloud) Add organization list to US pin list

### DIFF
--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -37,6 +37,7 @@ REGION_PINNED_URL_NAMES = (
     # New usage of these is region scoped.
     "sentry-error-page-embed",
     "sentry-release-hook",
+    "sentry-api-0-organizations",
     "sentry-api-0-projects",
     "sentry-api-0-accept-project-transfer",
     "sentry-account-email-unsubscribe-incident",


### PR DESCRIPTION
If a request to the organization list endpoints is received on control silo, it should be forwarded to the US region.