### PR TITLE
fix(alerts): Add date period to tags query

### DIFF
--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -65,7 +65,8 @@ export function fetchOrganizationTags(
   TagStore.reset();
 
   const url = `/organizations/${orgId}/tags/`;
-  const query: Query = {use_cache: '1'};
+  // Default fetching the last 7 days of tags
+  const query: Query = {use_cache: '1', statsPeriod: '7d'};
   if (projectIds) {
     query.project = projectIds;
   }


### PR DESCRIPTION
## Objective:

Related to https://github.com/getsentry/sentry/issues/60320

The Snuba query to fetch the tags for a project is timing out. We will need a more involved fix storing the tags in another datastore like Redis and periodically updating it from Clickhouse. 

This PR is a short term fix. I added a date period of 7 days so that the query does not time out.
