### PR TITLE
chore(alerts): Clean up rate limiting flag references

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -552,38 +552,35 @@ class SubscriptionProcessor:
         """
         self.trigger_alert_counts[trigger.id] += 1
 
-        if features.has(
-            "organizations:metric-alert-rate-limiting", self.subscription.project.organization
+        # If an incident was created for this rule, trigger type, and subscription
+        # within the last 10 minutes, don't make another one
+        last_it = (
+            IncidentTrigger.objects.filter(alert_rule_trigger=trigger)
+            .order_by("-incident_id")
+            .select_related("incident")
+            .first()
+        )
+        last_incident: Incident | None = last_it.incident if last_it else None
+        last_incident_projects = (
+            [project.id for project in last_incident.projects.all()] if last_incident else []
+        )
+        minutes_since_last_incident = (
+            (timezone.now() - last_incident.date_added).seconds / 60 if last_incident else None
+        )
+        if (
+            last_incident
+            and self.subscription.project.id in last_incident_projects
+            and minutes_since_last_incident <= 10
         ):
-            # If an incident was created for this rule, trigger type, and subscription
-            # within the last 10 minutes, don't make another one
-            last_it = (
-                IncidentTrigger.objects.filter(alert_rule_trigger=trigger)
-                .order_by("-incident_id")
-                .select_related("incident")
-                .first()
+            metrics.incr(
+                "incidents.alert_rules.hit_rate_limit",
+                tags={
+                    "last_incident_id": last_incident.id,
+                    "project_id": self.subscription.project.id,
+                    "trigger_id": trigger.id,
+                },
             )
-            last_incident: Incident | None = last_it.incident if last_it else None
-            last_incident_projects = (
-                [project.id for project in last_incident.projects.all()] if last_incident else []
-            )
-            minutes_since_last_incident = (
-                (timezone.now() - last_incident.date_added).seconds / 60 if last_incident else None
-            )
-            if (
-                last_incident
-                and self.subscription.project.id in last_incident_projects
-                and minutes_since_last_incident <= 10
-            ):
-                metrics.incr(
-                    "incidents.alert_rules.hit_rate_limit",
-                    tags={
-                        "last_incident_id": last_incident.id,
-                        "project_id": self.subscription.project.id,
-                        "trigger_id": trigger.id,
-                    },
-                )
-                return None
+            return None
         if self.trigger_alert_counts[trigger.id] >= self.alert_rule.threshold_period:
             metrics.incr("incidents.alert_rules.trigger", tags={"type": "fire"})
 

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -46,7 +46,6 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQueryEventType
 from sentry.testutils.cases import BaseMetricsTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time, iso_format
-from sentry.testutils.helpers.features import with_feature
 from sentry.utils import json
 from sentry.utils.dates import to_timestamp
 
@@ -2113,7 +2112,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             incident, [self.action], [(150.0, IncidentStatus.CLOSED, mock.ANY)]
         )
 
-    @with_feature("organizations:metric-alert-rate-limiting")
     def test_no_new_incidents_within_ten_minutes(self):
         # Verify that a new incident is not made for the same rule, trigger, and
         # subscription if an incident was already made within the last 10 minutes.
@@ -2152,7 +2150,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
             any_order=True,
         )
 
-    @with_feature("organizations:metric-alert-rate-limiting")
     def test_incident_made_after_ten_minutes(self):
         # Verify that a new incident will be made for the same rule, trigger, and
         # subscription if the last incident made for those was made more tha 10 minutes


### PR DESCRIPTION
The metric alert rate limiting flag has been turned on for all orgs for a couple of weeks now and is working as expected, so we can remove the flag. Part of #58648

Will follow up with a PR to remove the flag entirely