### PR TITLE
fix(hybridcloud) Consolidate region pinned route names

### DIFF
--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -15,36 +15,6 @@ from sentry.silo import SiloMode
 from sentry.silo.base import SiloLimit
 from sentry.types.region import get_region_by_name
 
-# Backwards compatibility for URLs that don't
-# have enough context to route via organization.
-# New usage of these endpoints uses region domains,
-# but existing customers have been using these routes
-# on the main domain for a long time.
-REGION_PINNED_URL_NAMES = (
-    # These paths have organization scoped aliases
-    "sentry-api-0-builtin-symbol-sources",
-    "sentry-api-0-grouping-configs",
-    # These paths are used by relay which is implicitly region scoped
-    "sentry-api-0-relays-index",
-    "sentry-api-0-relay-register-challenge",
-    "sentry-api-0-relay-register-response",
-    "sentry-api-0-relay-projectconfigs",
-    "sentry-api-0-relay-projectids",
-    "sentry-api-0-relay-publickeys",
-    "sentry-api-0-relays-healthcheck",
-    "sentry-api-0-relays-details",
-    # Backwards compatibility for US customers.
-    # New usage of these is region scoped.
-    "sentry-error-page-embed",
-    "sentry-release-hook",
-    "sentry-api-0-organizations",
-    "sentry-api-0-projects",
-    "sentry-api-0-accept-project-transfer",
-    "sentry-account-email-unsubscribe-incident",
-    "sentry-account-email-unsubscribe-issue",
-    "sentry-account-email-unsubscribe-project",
-)
-
 SENTRY_APP_REGION_URL_NAMES = (
     "sentry-api-0-sentry-app-installation-external-requests",
     "sentry-api-0-sentry-app-installation-external-issue-actions",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3942,7 +3942,7 @@ SENTRY_SDK_UPSTREAM_METRICS_ENABLED = False
 
 # Backwards compatibility for URLs that don't
 # have enough context to route via organization.
-# New usage of these endpoints uses region domains,
+# New usage of these endpoints should use the region domains,
 # but existing customers have been using these routes
 # on the main domain for a long time.
 REGION_PINNED_URL_NAMES = {
@@ -3962,10 +3962,9 @@ REGION_PINNED_URL_NAMES = {
     # New usage of these is region scoped.
     "sentry-error-page-embed",
     "sentry-release-hook",
+    "sentry-api-0-organizations",
     "sentry-api-0-projects",
-    "sentry-account-email-unsubscribe-incident",
-    "sentry-account-email-unsubscribe-issue",
-    "sentry-account-email-unsubscribe-project",
+    "sentry-api-0-accept-project-transfer",
 }
 
 # Shared resource ids for accounting


### PR DESCRIPTION
Remove the unused copy of this data. I had to move the list of views pinned to the US region to settings so that getsentry could augment it and forgot to remove the copy in api_gateway.

I've removed the unsubscribe links as they no longer exist.