### PR TITLE
chore(hybridcloud) Tweak old invite logging

### DIFF
--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Mapping, Optional
 
+from django.http import HttpRequest
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.request import Request
@@ -33,7 +34,7 @@ def get_invite_state(
     member_id: int,
     organization_slug: Optional[str],
     user_id: int,
-    request: Request,
+    request: HttpRequest,
 ) -> Optional[RpcUserInviteContext]:
     if organization_slug is None:
         member_mapping: OrganizationMemberMapping | None = None

--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -33,6 +33,7 @@ def get_invite_state(
     member_id: int,
     organization_slug: Optional[str],
     user_id: int,
+    request: Request,
 ) -> Optional[RpcUserInviteContext]:
     if organization_slug is None:
         member_mapping: OrganizationMemberMapping | None = None
@@ -66,9 +67,8 @@ def get_invite_state(
             extra={
                 "member_id": member_id,
                 "org_id": member_mapping.organization_id,
-                "token_expired": invite_context.member.token_expired
-                if invite_context and invite_context.member
-                else -1,
+                "url": request.path,
+                "method": request.method,
             },
         )
     else:
@@ -103,7 +103,10 @@ class AcceptOrganizationInvite(Endpoint):
         self, request: Request, member_id: int, token: str, organization_slug: Optional[str] = None
     ) -> Response:
         invite_context = get_invite_state(
-            member_id=int(member_id), organization_slug=organization_slug, user_id=request.user.id
+            member_id=int(member_id),
+            organization_slug=organization_slug,
+            user_id=request.user.id,
+            request=request,
         )
         if invite_context is None:
             return self.respond_invalid()
@@ -197,6 +200,7 @@ class AcceptOrganizationInvite(Endpoint):
             member_id=int(member_id),
             organization_slug=organization_slug,
             user_id=request.user.id,
+            request=request,
         )
         if invite_context is None:
             return self.respond_invalid()

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -75,7 +75,7 @@ class OrganizationMemberSerializerTest(TestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             UserEmail.objects.filter(user=user, email=user.email).update(is_verified=False)
 
-            invite_state = get_invite_state(member.id, org.slug, user.id)
+            invite_state = get_invite_state(member.id, org.slug, user.id, request)
             assert invite_state, "Expected invite state, logic bug?"
             invite_helper = ApiInviteHelper(
                 request=request, invite_context=invite_state, token=None


### PR DESCRIPTION
Tweak this logging again to try and learn more about how customers are interacting with invitations in deprecated ways.