### PR TITLE
fix(hybridcloud) Assign newestissue view to region silo

### DIFF
--- a/src/sentry/web/frontend/newest_issue.py
+++ b/src/sentry/web/frontend/newest_issue.py
@@ -3,9 +3,10 @@ from django.urls import reverse
 from rest_framework.request import Request
 
 from sentry.models.group import Group, GroupStatus
-from sentry.web.frontend.base import OrganizationView
+from sentry.web.frontend.base import OrganizationView, region_silo_view
 
 
+@region_silo_view
 class NewestIssueView(OrganizationView):
     def handle(self, request: Request, organization, issue_type="error", **kwargs) -> HttpResponse:
         issue_list_url = organization.absolute_url(

--- a/tests/sentry/web/frontend/test_newest_performance_issue.py
+++ b/tests/sentry/web/frontend/test_newest_performance_issue.py
@@ -11,6 +11,7 @@ from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.performance_issues.event_generators import get_event
+from sentry.testutils.silo import region_silo_test
 
 
 def make_event(**kwargs):
@@ -28,6 +29,7 @@ nplus_one_no_timestamp = {**get_event("n-plus-one-in-django-index-view")}
 del nplus_one_no_timestamp["timestamp"]
 
 
+@region_silo_test(stable=True)
 class NewestIssueViewTest(TestCase, PerformanceIssueTestCase):
     @cached_property
     def path(self):


### PR DESCRIPTION
I left this out of my previous set of view silo assignments as I thought it would be more complex than this.