### PR TITLE
feat(eventuser): Stop writes to EventUser in EventManger

### DIFF
--- a/tests/acceptance/test_issue_tag_values.py
+++ b/tests/acceptance/test_issue_tag_values.py
@@ -14,10 +14,13 @@ class IssueTagValuesTest(AcceptanceTestCase, SnubaTestCase):
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(organization=self.org, name="Mariachi Band")
-        self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
+        self.project = self.create_project(
+            organization=self.org, teams=[self.team], name="Bengal", date_added=before_now(hours=2)
+        )
         self.login_as(self.user)
         self.page = IssueDetailsPage(self.browser, self.client)
         self.dismiss_assistant()
+        self.event = self.create_issue()
 
     def create_issue(self):
         event_data = load_data("javascript")
@@ -26,13 +29,11 @@ class IssueTagValuesTest(AcceptanceTestCase, SnubaTestCase):
         return self.store_event(data=event_data, project_id=self.project.id)
 
     def test_user_tag(self):
-        event = self.create_issue()
-        self.page.visit_tag_values(self.org.slug, event.group_id, "user")
-
-        assert self.browser.element_exists_by_test_id("group-tag-mail")
+        with self.feature("organizations:eventuser-from-snuba"):
+            self.page.visit_tag_values(self.org.slug, self.event.group_id, "user")
+            assert self.browser.element_exists_by_test_id("group-tag-mail")
 
     def test_url_tag(self):
-        event = self.create_issue()
-        self.page.visit_tag_values(self.org.slug, event.group_id, "url")
+        self.page.visit_tag_values(self.org.slug, self.event.group_id, "url")
 
         assert self.browser.element_exists_by_test_id("group-tag-url")


### PR DESCRIPTION
## Objective:

PR for https://github.com/getsentry/sentry/issues/59398

We will stop writes to EventUser table and just return the EventUser dataclass.

This is ready for review. But will not be merged until Dec 6.