### PR TITLE
feat(hybrid-cloud): Implement IP Address Resolution and Validation for RegionSiloClient API Requests

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -116,6 +116,10 @@ INTERNAL_IPS = ()
 # List of IP subnets which should not be accessible
 SENTRY_DISALLOWED_IPS = ()
 
+# List of Region silo IP addresses which are accessible from the control silo.
+# These are individual IP addresses, not subnets (CIDR notation).
+SENTRY_REGION_SILO_IPS = ()
+
 # When resolving DNS for external sources (source map fetching, webhooks, etc),
 # ensure that domains are fully resolved first to avoid poking internal
 # search domains.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -116,10 +116,6 @@ INTERNAL_IPS = ()
 # List of IP subnets which should not be accessible
 SENTRY_DISALLOWED_IPS = ()
 
-# List of Region silo IP addresses which are accessible from the control silo.
-# These are individual IP addresses, not subnets (CIDR notation).
-SENTRY_REGION_SILO_IPS = ()
-
 # When resolving DNS for external sources (source map fetching, webhooks, etc),
 # ensure that domains are fully resolved first to avoid poking internal
 # search domains.

--- a/src/sentry/net/socket.py
+++ b/src/sentry/net/socket.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import ipaddress
 import socket
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -11,7 +12,9 @@ from urllib3.exceptions import LocationParseError
 from urllib3.util.connection import _set_socket_options, allowed_gai_family
 
 from sentry.exceptions import RestrictedIPAddress
-from sentry.net.http import IsIpAddressPermitted
+
+if TYPE_CHECKING:
+    from sentry.net.http import IsIpAddressPermitted
 
 DISALLOWED_IPS = frozenset(
     ipaddress.ip_network(str(i), strict=False) for i in settings.SENTRY_DISALLOWED_IPS

--- a/src/sentry/net/socket.py
+++ b/src/sentry/net/socket.py
@@ -105,7 +105,7 @@ def safe_create_connection(
     timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
     source_address=None,
     socket_options=None,
-    is_ipaddress_permitted: Callable[[str], bool] | None = is_ipaddress_allowed,
+    is_ipaddress_permitted: Callable[[str], bool] | None = None,
 ):
     if is_ipaddress_permitted is None:
         is_ipaddress_permitted = is_ipaddress_allowed

--- a/src/sentry/net/socket.py
+++ b/src/sentry/net/socket.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 import ipaddress
 import socket
-from typing import Callable
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -12,6 +11,7 @@ from urllib3.exceptions import LocationParseError
 from urllib3.util.connection import _set_socket_options, allowed_gai_family
 
 from sentry.exceptions import RestrictedIPAddress
+from sentry.net.http import IsIpAddressPermitted
 
 DISALLOWED_IPS = frozenset(
     ipaddress.ip_network(str(i), strict=False) for i in settings.SENTRY_DISALLOWED_IPS
@@ -105,7 +105,7 @@ def safe_create_connection(
     timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
     source_address=None,
     socket_options=None,
-    is_ipaddress_permitted: Callable[[str], bool] | None = None,
+    is_ipaddress_permitted: IsIpAddressPermitted = None,
 ):
     if is_ipaddress_permitted is None:
         is_ipaddress_permitted = is_ipaddress_allowed

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -18,6 +18,7 @@ from sentry.integrations.request_buffer import IntegrationRequestBuffer
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.integrations.utils import is_response_error, is_response_success
 from sentry.models.organization import Organization
+from sentry.net.http import SafeSession
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.utils import json, metrics
 from sentry.utils.audit import create_system_audit_entry
@@ -118,6 +119,12 @@ class BaseApiClient(TrackResponseMixin):
 
     def is_error_fatal(self, error: Exception) -> bool:
         return False
+
+    def build_session(self) -> SafeSession:
+        """
+        Generates a safe Requests session for the API client to use.
+        """
+        return build_session()
 
     @overload
     def _request(
@@ -250,7 +257,7 @@ class BaseApiClient(TrackResponseMixin):
                 extra[self.integration_type] = self.name
 
             try:
-                with build_session() as session:
+                with self.build_session() as session:
                     finalized_request = self.finalize_request(_prepared_request)
                     environment_settings = session.merge_environment_settings(
                         url=finalized_request.url,

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -144,6 +144,6 @@ class RegionSiloClient(BaseSiloClient):
     def build_session(self) -> SafeSession:
         """
         Generates a safe Requests session for the API client to use.
-        This injects a customer
+        This injects a custom is_ipaddress_permitted function to allow only connections to Region Silo IP addresses.
         """
         return build_session(is_ipaddress_permitted=validate_region_ip_address)

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ipaddress
-from typing import Any, Iterable, Mapping
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, cast
 
 from django.conf import settings
 from django.http import HttpResponse
@@ -20,8 +20,12 @@ from sentry.silo.util import (
 )
 from sentry.types.region import Region, get_region_by_name
 
-ALLOWED_REGION_IP_ADDRESSES = frozenset(
-    ipaddress.ip_address(force_str(ip, strings_only=True)) for ip in settings.SENTRY_REGION_SILO_IPS
+if TYPE_CHECKING:
+    from typing import FrozenSet
+
+ALLOWED_REGION_IP_ADDRESSES: FrozenSet[ipaddress.IPv4Address | ipaddress.IPv6Address] = frozenset(
+    ipaddress.ip_address(force_str(ip, strings_only=True))
+    for ip in cast(Iterable[str], settings.SENTRY_REGION_SILO_IPS)
 )
 
 

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -125,9 +125,14 @@ def validate_region_ip_address(ip: str) -> bool:
     Checks if the provided IP address is a Region Silo IP address.
     """
     if not ALLOWED_REGION_IP_ADDRESSES:
+        sentry_sdk.capture_exception(
+            RegionResolutionError(f"Disallowed Region Silo IP address: {ip}")
+        )
         return False
+
     ip_address = ipaddress.ip_address(force_str(ip, strings_only=True))
     result = ip_address in ALLOWED_REGION_IP_ADDRESSES
+
     if not result:
         sentry_sdk.capture_exception(
             RegionResolutionError(f"Disallowed Region Silo IP address: {ip}")

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -151,7 +151,9 @@ def validate_region_ip_address(ip: str) -> bool:
     """
     allowed_region_ip_addresses = get_region_ip_addresses()
     if not allowed_region_ip_addresses:
-        sentry_sdk.capture_exception(RegionResolutionError("allowed_region_ip_addresses is empty."))
+        sentry_sdk.capture_exception(
+            RegionResolutionError(f"allowed_region_ip_addresses is empty for: {ip}")
+        )
         return False
 
     ip_address = ipaddress.ip_address(force_str(ip, strings_only=True))

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -151,9 +151,7 @@ def validate_region_ip_address(ip: str) -> bool:
     """
     allowed_region_ip_addresses = get_region_ip_addresses()
     if not allowed_region_ip_addresses:
-        sentry_sdk.capture_exception(
-            RegionResolutionError(f"Disallowed Region Silo IP address: {ip}")
-        )
+        sentry_sdk.capture_exception(RegionResolutionError("allowed_region_ip_addresses is empty."))
         return False
 
     ip_address = ipaddress.ip_address(force_str(ip, strings_only=True))

--- a/tests/sentry/silo/test_client.py
+++ b/tests/sentry/silo/test_client.py
@@ -176,7 +176,7 @@ def test_validate_region_ip_address():
         assert mock_capture_exception.call_count == 1
         err = mock_capture_exception.call_args.args[0]
         assert isinstance(err, RegionResolutionError)
-        assert err.args == ("Disallowed Region Silo IP address: 172.31.255.255",)
+        assert err.args == ("allowed_region_ip_addresses is empty for: 172.31.255.255",)
 
     with patch(
         "sentry_sdk.capture_exception"


### PR DESCRIPTION
This pull request resolves the IP addresses from `SENTRY_REGION_CONFIG`, and to only allow API requests from the Control silo to a Region silo (`RegionSiloClient`) only if the IP address matches to those resolved from `SENTRY_REGION_CONFIG`.

I've also refactored the custom `urllib3` that we have to be able to leverage any injected `is_ipaddress_permitted` function to validate against a given ip addressed inferred from the `Request` object.

If a `is_ipaddress_permitted` function is not given, then we fallback to `is_ipaddress_allowed`, which leverages `SENTRY_DISALLOWED_IPS `.

This lets `RegionSiloClient` API clients to use a custom `is_ipaddress_permitted` function to only allow `Request` connections to any IP addresses resolved from `SENTRY_REGION_CONFIG`.

Previously, we've been relying on removing Region Silo IP addresses from `SENTRY_DISALLOWED_IPS`. This isn't ideal, as `SENTRY_DISALLOWED_IPS` is only meant for matching against user provided URLs.

By default, if `SENTRY_REGION_CONFIG` is empty, then `RegionSiloClient` will reject any and all requests.