### PR TITLE
feat: Added metrics summary sample rates as options

### DIFF
--- a/src/sentry/metrics/minimetrics.py
+++ b/src/sentry/metrics/minimetrics.py
@@ -88,6 +88,10 @@ def before_emit_metric(key: str, tags: Dict[str, Any]) -> bool:
     return True
 
 
+def should_summarize_metric(key: str, tags: Dict[str, Any]) -> bool:
+    return random.random() < options.get("delightful_metrics.metrics_summary_sample_rate")
+
+
 class MiniMetricsMetricsBackend(MetricsBackend):
     @staticmethod
     def _keep_metric(sample_rate: float) -> bool:

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -97,7 +97,6 @@ def is_current_event_safe():
     """
 
     with configure_scope() as scope:
-
         # Scope was explicitly marked as unsafe
         if scope._tags.get(UNSAFE_TAG):
             return False
@@ -432,6 +431,9 @@ def configure_sdk():
     sdk_options.setdefault("_experiments", {}).update(
         enable_metrics=True,
         before_emit_metric=minimetrics.before_emit_metric,
+        # turn summaries on, but filter them dynamically in the callback
+        metrics_summary_sample_rate=1.0,
+        should_summarize_metric=minimetrics.should_summarize_metric,
     )
 
     sentry_sdk.init(


### PR DESCRIPTION
This lands a callback which controls the sample rate of span local metric summaries dynamically.

Refs https://github.com/getsentry/sentry-python/pull/2522