### PR TITLE
feat(ddm-alerts): Handle custom metric alerts details

### DIFF
--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -49,7 +49,7 @@ export interface MetricWidgetQueryParams
   sort?: SortState;
 }
 
-export interface DdmQUeryParams {
+export interface DdmQueryParams {
   widgets: string; // stringified json representation of MetricWidgetQueryParams
   end?: DateString;
   environment?: string[];
@@ -78,12 +78,12 @@ export function getDdmUrl(
     statsPeriod,
     project,
     ...otherParams
-  }: Omit<DdmQUeryParams, 'project' | 'widgets'> & {
+  }: Omit<DdmQueryParams, 'project' | 'widgets'> & {
     widgets: MetricWidgetQueryParams[];
     project?: (string | number)[];
   }
 ) {
-  const urlParams: Partial<DdmQUeryParams> = {
+  const urlParams: Partial<DdmQueryParams> = {
     ...otherParams,
     project: project?.map(id => (typeof id === 'string' ? parseInt(id, 10) : id)),
     widgets: JSON.stringify(widgets),

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -33,8 +33,8 @@ export type MetricTag = {
   key: string;
 };
 
-export type SortState = {
-  name: 'name' | 'avg' | 'min' | 'max' | 'sum';
+type SortState = {
+  name: 'name' | 'avg' | 'min' | 'max' | 'sum' | undefined;
   order: 'asc' | 'desc';
 };
 

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -33,7 +33,7 @@ export type MetricTag = {
   key: string;
 };
 
-type SortState = {
+export type SortState = {
   name: 'name' | 'avg' | 'min' | 'max' | 'sum' | undefined;
   order: 'asc' | 'desc';
 };

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -1,6 +1,6 @@
 import {InjectedRouter} from 'react-router';
 import moment from 'moment';
-import qs from 'qs';
+import * as qs from 'query-string';
 
 import {
   DateTimeObject,
@@ -96,12 +96,7 @@ export function getDdmUrl(
     urlParams.end = end;
   }
 
-  return `/organizations/${orgSlug}/ddm/?${qs.stringify(
-    urlParams,
-    // Need to pass indices false, otherwise page filters will not be recognized
-    // as qs per adds the indices per default whereas react router does not
-    {indices: false}
-  )}`;
+  return `/organizations/${orgSlug}/ddm/?${qs.stringify(urlParams)}`;
 }
 
 export function getMetricsApiRequestQuery(

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -268,7 +268,7 @@ export function fieldToMri(field: string) {
 }
 
 // This is a workaround as the alert builder requires a valid aggregate to be set
-export const DEFAULT_METRIC_ALERT_AGGREGATE = 'sum(c:custom/my_metric@none)';
+export const DEFAULT_METRIC_ALERT_AGGREGATE = 'sum(c:custom/iolnqzyenoqugwm@none)';
 
 export const formatMriAggregate = (aggregate: string) => {
   if (aggregate === DEFAULT_METRIC_ALERT_AGGREGATE) {
@@ -278,6 +278,7 @@ export const formatMriAggregate = (aggregate: string) => {
   const {mri, op} = fieldToMri(aggregate);
   const parsed = parseMRI(mri);
 
+  // The field does not contain an MRI -> return the aggregate as is
   if (!parsed) {
     return aggregate;
   }

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -1,5 +1,6 @@
 import {InjectedRouter} from 'react-router';
 import moment from 'moment';
+import qs from 'qs';
 
 import {
   DateTimeObject,
@@ -68,20 +69,19 @@ export type MetricsQuery = {
   query?: string;
 };
 
-export function getDdmLocation(
+export function getDdmUrl(
   orgSlug: string,
   params: Omit<DdmQUeryParams, 'project'> & {project?: (string | number)[]}
 ) {
-  return {
-    pathname: `/organizations/${orgSlug}/ddm/`,
-    query: {
+  return `/organizations/${orgSlug}/ddm/?${qs.stringify(
+    {
       ...params,
-      project: params.project?.map(id =>
-        typeof id === 'string' ? parseInt(id, 10) : id
-      ),
       widgets: JSON.stringify(params.widgets),
     },
-  };
+    // Need to pass indices false, otherwise page filters will not be recognized
+    // as qs per adds the indices per default whereas react router does not
+    {indices: false}
+  )}`;
 }
 
 export function getMetricsApiRequestQuery(

--- a/static/app/utils/metrics/useMetricsMeta.tsx
+++ b/static/app/utils/metrics/useMetricsMeta.tsx
@@ -63,6 +63,9 @@ export function useMetricsMeta(
 
   return {
     data: combinedMeta,
-    isLoading: sessionsMeta.isLoading || txnsMeta.isLoading || customMeta.isLoading,
+    isLoading:
+      (sessionsMeta.isLoading, sessionsMeta.fetchStatus !== 'idle') ||
+      (txnsMeta.isLoading, txnsMeta.fetchStatus !== 'idle') ||
+      (customMeta.isLoading, customMeta.fetchStatus !== 'idle'),
   };
 }

--- a/static/app/utils/metrics/useMetricsMeta.tsx
+++ b/static/app/utils/metrics/useMetricsMeta.tsx
@@ -64,8 +64,8 @@ export function useMetricsMeta(
   return {
     data: combinedMeta,
     isLoading:
-      (sessionsMeta.isLoading, sessionsMeta.fetchStatus !== 'idle') ||
-      (txnsMeta.isLoading, txnsMeta.fetchStatus !== 'idle') ||
-      (customMeta.isLoading, customMeta.fetchStatus !== 'idle'),
+      (sessionsMeta.isLoading && sessionsMeta.fetchStatus !== 'idle') ||
+      (txnsMeta.isLoading && txnsMeta.fetchStatus !== 'idle') ||
+      (customMeta.isLoading && customMeta.fetchStatus !== 'idle'),
   };
 }

--- a/static/app/views/alerts/rules/metric/details/body.tsx
+++ b/static/app/views/alerts/rules/metric/details/body.tsx
@@ -32,6 +32,7 @@ import {
 } from 'sentry/views/alerts/utils/migrationUi';
 
 import {isCrashFreeAlert} from '../utils/isCrashFreeAlert';
+import {isCustomMetricAlert} from '../utils/isCustomMetricAlert';
 
 import {
   API_INTERVAL_POINTS_LIMIT,
@@ -89,9 +90,9 @@ export default function MetricDetailsBody({
       return null;
     }
 
-    const {dataset, query} = rule;
+    const {aggregate, dataset, query} = rule;
 
-    if (isCrashFreeAlert(dataset)) {
+    if (isCrashFreeAlert(dataset) || isCustomMetricAlert(aggregate)) {
       return query.trim().split(' ');
     }
 

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -45,6 +45,7 @@ import {ReactEchartsRef, Series} from 'sentry/types/echarts';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {getDuration} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import {formatMriAggregate} from 'sentry/utils/metrics';
 import {getForceMetricsLayerQueryExtras} from 'sentry/utils/metrics/features';
 import {shouldShowOnDemandMetricAlertUI} from 'sentry/utils/onDemandMetrics/features';
 import {MINUTES_THRESHOLD_TO_DISPLAY_SECONDS} from 'sentry/utils/sessions';
@@ -368,7 +369,7 @@ class MetricChart extends PureComponent<Props, State> {
           </ChartHeader>
           <ChartFilters>
             <StyledCircleIndicator size={8} />
-            <Filters>{rule.aggregate}</Filters>
+            <Filters>{formatMriAggregate(rule.aggregate)}</Filters>
             <Truncate value={queryFilter ?? ''} maxLength={truncateWidth} />
           </ChartFilters>
           {getDynamicText({

--- a/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
@@ -12,6 +12,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import type {SessionApiResponse} from 'sentry/types';
 import type {Series} from 'sentry/types/echarts';
+import {formatMriAggregate} from 'sentry/utils/metrics';
 import {getCrashFreeRateSeries} from 'sentry/utils/sessions';
 import {lightTheme as theme} from 'sentry/utils/theme';
 import {
@@ -170,7 +171,10 @@ export function getMetricAlertChartOption({
     ({label}) => label === AlertRuleTriggerType.WARNING
   );
 
-  const series: AreaChartSeries[] = [...timeseriesData];
+  const series: AreaChartSeries[] = timeseriesData.map(s => ({
+    ...s,
+    seriesName: s.seriesName && formatMriAggregate(s.seriesName),
+  }));
   const areaSeries: AreaChartSeries[] = [];
   // Ensure series data appears below incident/mark lines
   series[0].z = 1;

--- a/static/app/views/alerts/rules/metric/metricRulePresets.tsx
+++ b/static/app/views/alerts/rules/metric/metricRulePresets.tsx
@@ -2,7 +2,7 @@ import type {LinkProps} from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types';
 import {DisplayModes} from 'sentry/utils/discover/types';
-import {fieldToMri, getDdmLocation, MetricDisplayType} from 'sentry/utils/metrics';
+import {fieldToMri, getDdmUrl, MetricDisplayType} from 'sentry/utils/metrics';
 import type {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
 import type {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {isCustomMetricAggregate} from 'sentry/views/alerts/rules/metric/utils/isCustomMetricAggregate';
@@ -48,7 +48,7 @@ export function makeDefaultCta({
     const {mri, op} = fieldToMri(rule.aggregate);
     return {
       buttonText: t('Open in DDM'),
-      to: getDdmLocation(orgSlug, {
+      to: getDdmUrl(orgSlug, {
         start: timePeriod.start,
         end: timePeriod.end,
         utc: timePeriod.utc,

--- a/static/app/views/alerts/rules/metric/metricRulePresets.tsx
+++ b/static/app/views/alerts/rules/metric/metricRulePresets.tsx
@@ -54,7 +54,7 @@ export function makeDefaultCta({
         utc: timePeriod.utc,
         // 7 days are 9999m in alerts as of a rounding error in the `events-stats` endpoint
         // We need to round to 7d here to display it correctly in DDM
-        period: timePeriod.period === '9999m' ? '7d' : timePeriod.period,
+        statsPeriod: timePeriod.period === '9999m' ? '7d' : timePeriod.period,
         project: projects
           .filter(({slug}) => rule.projects.includes(slug))
           .map(project => project.id),

--- a/static/app/views/alerts/rules/metric/mriField.tsx
+++ b/static/app/views/alerts/rules/metric/mriField.tsx
@@ -25,7 +25,7 @@ function filterAndSortOperations(operations: string[]) {
 }
 
 function MriField({aggregate, project, onChange}: Props) {
-  const {data: meta} = useMetricsMeta([parseInt(project.id, 10)], {
+  const {data: meta, isLoading} = useMetricsMeta([parseInt(project.id, 10)], {
     useCases: ['custom'],
   });
   const metaArr = useMemo(() => {
@@ -44,7 +44,7 @@ function MriField({aggregate, project, onChange}: Props) {
         {}
       );
     }
-  }, [metaArr, onChange, selectedMriMeta]);
+  }, [metaArr, onChange, selectedMriMeta, isLoading]);
 
   const handleMriChange = useCallback(
     option => {
@@ -108,7 +108,7 @@ function MriField({aggregate, project, onChange}: Props) {
   );
 
   // When using the async variant of SelectControl, we need to pass in an option object instead of just the value
-  const selectedOption = selectedMriMeta && {
+  const selectedMriOption = selectedMriMeta && {
     label: selectedMriMeta.name,
     value: selectedMriMeta.mri,
   };
@@ -117,17 +117,21 @@ function MriField({aggregate, project, onChange}: Props) {
     <Wrapper>
       <StyledSelectControl
         searchable
+        isDisabled={isLoading}
         placeholder={t('Select a metric')}
+        noOptionsMessage={() =>
+          metaArr.length === 0 ? t('No metrics in this project') : t('No options')
+        }
         async
         defaultOptions={getMriOptions('')}
         loadOptions={searchText => Promise.resolve(getMriOptions(searchText))}
         filterOption={() => true}
-        value={selectedOption}
+        value={selectedMriOption}
         onChange={handleMriChange}
       />
       <StyledSelectControl
         searchable
-        disabled={!selectedValues.mri}
+        isDisabled={isLoading || !selectedMriMeta}
         placeholder={t('Select an operation')}
         options={operationOptions}
         value={selectedValues.op}

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -153,8 +153,10 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     const {alertType, query, eventTypes, dataset} = this.state;
     const eventTypeFilter = getEventTypeFilter(this.state.dataset, eventTypes);
     const queryWithTypeFilter = (
-      query && alertType !== 'custom_metrics'
-        ? `(${query}) AND (${eventTypeFilter})`
+      alertType !== 'custom_metrics'
+        ? query
+          ? `(${query}) AND (${eventTypeFilter})`
+          : eventTypeFilter
         : query
     ).trim();
     return isCrashFreeAlert(dataset) ? query : queryWithTypeFilter;

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -155,7 +155,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     const queryWithTypeFilter = (
       query && alertType !== 'custom_metrics'
         ? `(${query}) AND (${eventTypeFilter})`
-        : eventTypeFilter
+        : query
     ).trim();
     return isCrashFreeAlert(dataset) ? query : queryWithTypeFilter;
   }

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -150,10 +150,12 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
   }
 
   get chartQuery(): string {
-    const {query, eventTypes, dataset} = this.state;
+    const {alertType, query, eventTypes, dataset} = this.state;
     const eventTypeFilter = getEventTypeFilter(this.state.dataset, eventTypes);
     const queryWithTypeFilter = (
-      query ? `(${query}) AND (${eventTypeFilter})` : eventTypeFilter
+      query && alertType !== 'custom_metrics'
+        ? `(${query}) AND (${eventTypeFilter})`
+        : eventTypeFilter
     ).trim();
     return isCrashFreeAlert(dataset) ? query : queryWithTypeFilter;
   }
@@ -911,7 +913,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
               <AlertInfo>
                 <StyledCircleIndicator size={8} />
                 <Aggregate>{formatMriAggregate(aggregate)}</Aggregate>
-                {!(hasDdmAlertsSupport(organization) && alertType === 'custom_metrics')
+                {alertType !== 'custom_metrics'
                   ? `event.type:${eventTypes?.join(',')}`
                   : ''}
               </AlertInfo>

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -34,6 +34,7 @@ import type {
 } from 'sentry/types';
 import type {Series} from 'sentry/types/echarts';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {formatMriAggregate} from 'sentry/utils/metrics';
 import {getForceMetricsLayerQueryExtras} from 'sentry/utils/metrics/features';
 import {shouldShowOnDemandMetricAlertUI} from 'sentry/utils/onDemandMetrics/features';
 import {
@@ -505,7 +506,7 @@ class TriggersChart extends PureComponent<Props, State> {
         period={period}
         yAxis={aggregate}
         includePrevious={false}
-        currentSeriesNames={[aggregate]}
+        currentSeriesNames={[formatMriAggregate(aggregate)]}
         partial={false}
         queryExtras={queryExtras}
         dataLoadedCallback={onDataLoaded}

--- a/static/app/views/alerts/rules/metric/utils/isCustomMetricAlert.tsx
+++ b/static/app/views/alerts/rules/metric/utils/isCustomMetricAlert.tsx
@@ -1,0 +1,8 @@
+import {fieldToMri} from 'sentry/utils/metrics';
+
+/**
+ * Currently we can tell if an alert is a crash free alert by checking the aggregate for a MRI,
+ */
+export function isCustomMetricAlert(aggregate: string): boolean {
+  return fieldToMri(aggregate).mri !== undefined;
+}

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -44,7 +44,7 @@ import {DiscoverDatasets, DisplayModes} from 'sentry/utils/discover/types';
 import {getMeasurements} from 'sentry/utils/measurements/measurements';
 import {
   fieldToMri,
-  getDdmLocation,
+  getDdmUrl,
   MetricDisplayType,
   MetricWidgetQueryParams,
 } from 'sentry/utils/metrics';
@@ -413,7 +413,7 @@ export function getWidgetDDMUrl(
       ? {start: getUtcDateString(start), end: getUtcDateString(end), utc}
       : {statsPeriod: period};
 
-  const ddmLocation = getDdmLocation(organization.slug, {
+  const ddmLocation = getDdmUrl(organization.slug, {
     ...datetime,
     project: selection.projects,
     environment: selection.environments,
@@ -431,7 +431,7 @@ export function getWidgetDDMUrl(
     }),
   });
 
-  return `${ddmLocation.pathname}?${qs.stringify(ddmLocation.query)}`;
+  return ddmLocation;
 }
 
 export function flattenErrors(

--- a/static/app/views/ddm/queryBuilder.tsx
+++ b/static/app/views/ddm/queryBuilder.tsx
@@ -16,6 +16,7 @@ import {
   isAllowedOp,
   MetricDisplayType,
   MetricsQuery,
+  MetricWidgetQueryParams,
 } from 'sentry/utils/metrics';
 import {useMetricsMeta} from 'sentry/utils/metrics/useMetricsMeta';
 import {useMetricsTags} from 'sentry/utils/metrics/useMetricsTags';
@@ -23,12 +24,11 @@ import useApi from 'sentry/utils/useApi';
 import useKeyPress from 'sentry/utils/useKeyPress';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {MetricWidgetProps} from 'sentry/views/ddm/widget';
 
 type QueryBuilderProps = {
   displayType: MetricDisplayType; // TODO(ddm): move display type out of the query builder
   metricsQuery: Pick<MetricsQuery, 'mri' | 'op' | 'query' | 'groupBy'>;
-  onChange: (data: Partial<MetricWidgetProps>) => void;
+  onChange: (data: Partial<MetricWidgetQueryParams>) => void;
   projects: number[];
   powerUserMode?: boolean;
 };

--- a/static/app/views/ddm/summaryTable.tsx
+++ b/static/app/views/ddm/summaryTable.tsx
@@ -10,15 +10,13 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getUtcDateString} from 'sentry/utils/dates';
-import {formatMetricsUsingUnitAndOp, parseMRI} from 'sentry/utils/metrics';
+import {formatMetricsUsingUnitAndOp, parseMRI, SortState} from 'sentry/utils/metrics';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useRouter from 'sentry/utils/useRouter';
 import {DEFAULT_SORT_STATE} from 'sentry/views/ddm/constants';
-import {MetricWidgetDisplayConfig, Series} from 'sentry/views/ddm/widget';
+import {Series} from 'sentry/views/ddm/widget';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
-
-type SortState = MetricWidgetDisplayConfig['sort'];
 
 export function SummaryTable({
   series,

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -18,8 +18,7 @@ import {MetricsApiResponse, PageFilters} from 'sentry/types';
 import {
   defaultMetricDisplayType,
   getSeriesName,
-  MetricDisplayType,
-  MetricsQuery,
+  MetricWidgetQueryParams,
   parseMRI,
   updateQuery,
 } from 'sentry/utils/metrics';
@@ -34,11 +33,6 @@ import {SummaryTable} from 'sentry/views/ddm/summaryTable';
 
 import {DEFAULT_SORT_STATE, MIN_WIDGET_WIDTH} from './constants';
 
-type SortState = {
-  name: 'name' | 'avg' | 'min' | 'max' | 'sum';
-  order: 'asc' | 'desc';
-};
-
 const emptyWidget = {
   mri: '',
   op: undefined,
@@ -47,18 +41,10 @@ const emptyWidget = {
   sort: DEFAULT_SORT_STATE,
 };
 
-export type MetricWidgetDisplayConfig = {
-  displayType: MetricDisplayType;
+export interface MetricWidgetProps extends MetricWidgetQueryParams {
   onChange: (data: Partial<MetricWidgetProps>) => void;
   position: number;
-  sort: SortState;
-  focusedSeries?: string;
-  powerUserMode?: boolean;
-  showSummaryTable?: boolean;
-};
-
-export type MetricWidgetProps = Pick<MetricsQuery, 'mri' | 'op' | 'query' | 'groupBy'> &
-  MetricWidgetDisplayConfig;
+}
 
 export function useMetricWidgets() {
   const router = useRouter();
@@ -68,7 +54,7 @@ export function useMetricWidgets() {
   );
 
   const widgets: MetricWidgetProps[] = currentWidgets.map(
-    (widget: MetricWidgetProps, i) => {
+    (widget: MetricWidgetQueryParams, i) => {
       return {
         mri: widget.mri,
         op: widget.op,
@@ -84,7 +70,7 @@ export function useMetricWidgets() {
     }
   );
 
-  const onChange = (position: number, data: Partial<MetricWidgetProps>) => {
+  const onChange = (position: number, data: Partial<MetricWidgetQueryParams>) => {
     currentWidgets[position] = {...currentWidgets[position], ...data};
 
     updateQuery(router, {


### PR DESCRIPTION
Fix appearance of metric based alerts in metric details
Add typing for query params in ddm.
Add `Open in DDM` button to metric based alerts.

- closes https://github.com/getsentry/sentry/issues/60248
- closes https://github.com/getsentry/sentry/issues/60382