### PR TITLE
feat(spans): Cluster full description for resource spans

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -191,20 +191,14 @@ def record_span_descriptions(
             continue
         safe_execute(_record_sample, ClustererNamespace.SPANS, project, description)
 
-        update_rule_rate = options.get("span_descs.bump-lifetime-sample-rate")
-        if update_rule_rate and random.random() < update_rule_rate:
-            safe_execute(
-                _update_span_description_rule_lifetime, project, event_data, _with_transaction=False
-            )
-
 
 def _get_span_description_to_store(span: Mapping[str, Any]) -> Optional[str]:
-    if not span.get("op") in ("resource.css", "resource.script"):
+    if not span.get("op") in ("resource.css", "resource.script", "resource.img"):
         return None
 
-    sentry_tags = span.get("sentry_tags") or {}
-    if url := sentry_tags.get("description"):
-        return urlparse(url).path
+    if url := span.get("description"):
+        parsed = urlparse(url)
+        return f"{parsed.netloc}{parsed.path}"
 
     return None
 

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -167,7 +167,7 @@ def cluster_projects_span_descs(projects: Sequence[Project]) -> None:
                     # the clusterer to avoid scrubbing other tokens. The prefix
                     # `**` in the glob ensures we match the prefix but we don't
                     # scrub it.
-                    new_rules = [ReplacementRule(f"**{r}") for r in new_rules]
+                    new_rules = [ReplacementRule(r) for r in new_rules]
 
                 track_clusterer_run(ClustererNamespace.SPANS, project)
 


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/58689 was a quick shot at leveraging the clusterer to discover patterns in third-party web APIs. It did not work well because it used the scrubbed description, where domain name and path were already gone.

This PR uses the raw description instead. Note that the discovered rules are not applied in production, we only use them to learn & eventually convert common patterns to hard-coded rules.

ref: https://github.com/getsentry/team-ingest/issues/249