### PR TITLE
fix filter spelling 'safe' not 'save'

### DIFF
--- a/src/sentry/templates/sentry/emails/dyn-sampling-custom-rule-fulfilled.html
+++ b/src/sentry/templates/sentry/emails/dyn-sampling-custom-rule-fulfilled.html
@@ -14,6 +14,6 @@
     We'll stop collecting once we reach 100 or 48 hours after rule creation.
     </p>
 
-  <a href="{{ discover_link | save }}" class="btn">View Samples</a>
+  <a href="{{ discover_link|safe }}" class="btn">View Samples</a>
 
 {% endblock %}


### PR DESCRIPTION
Fix template for dynamic sampling custom rule notification fulfilment.
Was using a misspelled filter 'save' instead of 'safe'