### PR TITLE
fix(hybridcloud) Fetch event JSON from region API

### DIFF
--- a/static/app/views/issueDetails/groupEventCarousel.spec.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.spec.tsx
@@ -191,7 +191,7 @@ describe('GroupEventCarousel', () => {
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'JSON (7.0 B)'}));
 
     expect(window.open).toHaveBeenCalledWith(
-      `/api/0/projects/org-slug/project-slug/events/event-id/json/`
+      `https://us.sentry.io/api/0/projects/org-slug/project-slug/events/event-id/json/`
     );
   });
 });

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -245,7 +245,8 @@ export function GroupEventActions({event, group, projectSlug}: GroupEventActions
     projectCanLinkToReplay(group.project);
 
   const downloadJson = () => {
-    const jsonUrl = `/api/0/projects/${organization.slug}/${projectSlug}/events/${event.id}/json/`;
+    const host = organization.links.regionUrl;
+    const jsonUrl = `${host}/api/0/projects/${organization.slug}/${projectSlug}/events/${event.id}/json/`;
     window.open(jsonUrl);
     trackAnalytics('issue_details.event_json_clicked', {
       organization,


### PR DESCRIPTION
We don't want event data proxied through the US by default.

Fixes HC-1000
