### PR TITLE
fix(metrics-extraction): Get topN extracted tag working

### DIFF
--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -168,7 +168,10 @@ function WidgetQueries({
         if (rawResult.isMetricsData !== undefined) {
           isSeriesMetricsDataResults.push(rawResult.isMetricsData);
         }
-        if (rawResult.isMetricsExtractedData !== undefined) {
+        if (
+          (rawResult.isMetricsExtractedData || rawResult.meta?.isMetricsExtractedData) !==
+          undefined
+        ) {
           isSeriesMetricsExtractedDataResults.push(
             rawResult.isMetricsExtractedData || rawResult.meta?.isMetricsExtractedData
           );


### PR DESCRIPTION
### Summary
Currently it's only look at the root of a group for the flag, but it's only in meta.

![Screenshot 2023-11-23 at 1 22 35 PM](https://github.com/getsentry/sentry/assets/6111995/881919b6-da86-420f-a58e-a456e65887d9)
