### PR TITLE
fix(database): Prevent errors related to negative chart intervals

### DIFF
--- a/static/app/components/charts/utils.spec.tsx
+++ b/static/app/components/charts/utils.spec.tsx
@@ -110,6 +110,10 @@ describe('Chart Utils', function () {
       [0, '15m'],
     ]);
 
+    it('handles negative intervals', function () {
+      expect(ladder.getInterval(-1)).toEqual('15m');
+    });
+
     it('finds granularity at lower bound', function () {
       expect(ladder.getInterval(getDiffInMinutes({period: '2m'}))).toEqual('15m');
     });

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -203,11 +203,9 @@ export class GranularityLadder {
   getInterval(minutes: number): string {
     if (minutes < 0) {
       // Sometimes this happens, in unknown circumstances. See the `getIntervalForMetricFunction` function span in Sentry for more info, the reason might appear there. For now, a reasonable fallback in these rare cases is to return the finest granularity, since it'll either fulfill the request or time out.
-      Sentry.withScope(() => {
-        Sentry.captureException(
-          new Error('Invalid duration supplied to interval function')
-        );
-      });
+      Sentry.captureException(
+        new Error('Invalid duration supplied to interval function')
+      );
 
       return (this.steps.at(-1) as GranularityStep)[1];
     }

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import type {EChartsOption, LegendComponentOption, LineSeriesOption} from 'echarts';
 import type {Location} from 'history';
 import orderBy from 'lodash/orderBy';
@@ -202,6 +203,12 @@ export class GranularityLadder {
   getInterval(minutes: number): string {
     if (minutes < 0) {
       // Sometimes this happens, in unknown circumstances. See the `getIntervalForMetricFunction` function span in Sentry for more info, the reason might appear there. For now, a reasonable fallback in these rare cases is to return the finest granularity, since it'll either fulfill the request or time out.
+      Sentry.withScope(() => {
+        Sentry.captureException(
+          new Error('Invalid duration supplied to interval function')
+        );
+      });
+
       return (this.steps.at(-1) as GranularityStep)[1];
     }
 

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -200,9 +200,14 @@ export class GranularityLadder {
   }
 
   getInterval(minutes: number): string {
+    if (minutes < 0) {
+      // Sometimes this happens, in unknown circumstances. See the `getIntervalForMetricFunction` function span in Sentry for more info, the reason might appear there. For now, a reasonable fallback in these rare cases is to return the finest granularity, since it'll either fulfill the request or time out.
+      return (this.steps.at(-1) as GranularityStep)[1];
+    }
+
     const step = this.steps.find(([threshold]) => {
       return minutes >= threshold;
-    }) as GranularityStep; // This can never be undefined, because the constructor ensures that an invalid ladder cannot be created
+    }) as GranularityStep;
 
     return step[1];
   }

--- a/static/app/views/performance/database/getIntervalForMetricFunction.tsx
+++ b/static/app/views/performance/database/getIntervalForMetricFunction.tsx
@@ -21,19 +21,13 @@ export function getIntervalForMetricFunction(
   metricFunction: Aggregate | SpanFunctions | string,
   datetimeObj: DateTimeObject
 ) {
-  const sentryTransaction = Sentry.getCurrentHub().getScope()?.getTransaction();
-
-  const sentrySpan = sentryTransaction?.startChild({
-    op: 'function',
-    description: 'getIntervalForMetricFunction',
-    data: {
-      ...datetimeObj,
-    },
-  });
-
-  const ladder = GRANULARITIES[metricFunction] ?? COUNTER_GRANULARITIES;
-  const interval = ladder.getInterval(getDiffInMinutes(datetimeObj));
-  sentrySpan?.finish();
+  const interval = Sentry.startSpan(
+    {op: 'function', name: 'getIntervalForMetricFunction', data: {...datetimeObj}},
+    () => {
+      const ladder = GRANULARITIES[metricFunction] ?? COUNTER_GRANULARITIES;
+      return ladder.getInterval(getDiffInMinutes(datetimeObj));
+    }
+  );
 
   return interval;
 }

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -103,6 +103,7 @@ jest.mock('echarts-for-react/lib/core', function echartsMockFactory() {
 
 jest.mock('@sentry/react', function sentryReact() {
   const SentryReact = jest.requireActual('@sentry/react');
+  const SentryReactCore = jest.requireActual('@sentry/core');
   return {
     init: jest.fn(),
     configureScope: jest.fn(),
@@ -115,7 +116,11 @@ jest.mock('@sentry/react', function sentryReact() {
     captureMessage: jest.fn(),
     captureException: jest.fn(),
     showReportDialog: jest.fn(),
-    startSpan: jest.fn(),
+    startSpan: jest
+      .fn()
+      .mockImplementation((context, callback) =>
+        callback(new SentryReactCore.Span(context))
+      ),
     finishSpan: jest.fn(),
     lastEventId: jest.fn(),
     getCurrentHub: jest.spyOn(SentryReact, 'getCurrentHub'),

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -103,7 +103,6 @@ jest.mock('echarts-for-react/lib/core', function echartsMockFactory() {
 
 jest.mock('@sentry/react', function sentryReact() {
   const SentryReact = jest.requireActual('@sentry/react');
-  const SentryReactCore = jest.requireActual('@sentry/core');
   return {
     init: jest.fn(),
     configureScope: jest.fn(),
@@ -116,11 +115,7 @@ jest.mock('@sentry/react', function sentryReact() {
     captureMessage: jest.fn(),
     captureException: jest.fn(),
     showReportDialog: jest.fn(),
-    startSpan: jest
-      .fn()
-      .mockImplementation((context, callback) =>
-        callback(new SentryReactCore.Span(context))
-      ),
+    startSpan: jest.spyOn(SentryReact, 'startSpan'),
     finishSpan: jest.fn(),
     lastEventId: jest.fn(),
     getCurrentHub: jest.spyOn(SentryReact, 'getCurrentHub'),


### PR DESCRIPTION
This is a bit of a mysterious error. Apparently sometimes the interval functions gets a _negative_ duration. It's unclear why, so I'm adding a custom span to keep track of the parameters. In the meantime, the `< 0` check prevents the error.

Fixes JAVASCRIPT-2PS1
