### PR TITLE
ref(stats-detectors): Start unifying detector logic

### DIFF
--- a/src/sentry/statistical_detectors/detector.py
+++ b/src/sentry/statistical_detectors/detector.py
@@ -4,7 +4,14 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Generic, List, Mapping, Optional, Tuple, TypeVar
+from typing import Any, Generator, Generic, List, Mapping, Optional, Set, Tuple, TypeVar
+
+import sentry_sdk
+
+from sentry import options
+from sentry.models.project import Project
+from sentry.utils import metrics
+from sentry.utils.iterators import chunked
 
 
 class TrendType(Enum):
@@ -34,6 +41,11 @@ class DetectorState(ABC):
     def to_redis_dict(self) -> Mapping[str | bytes, bytes | float | int | str]:
         ...
 
+    @classmethod
+    @abstractmethod
+    def empty(cls) -> DetectorState:
+        ...
+
 
 @dataclass(frozen=True)
 class DetectorConfig(ABC):
@@ -56,5 +68,126 @@ class DetectorStore(ABC, Generic[T]):
 
 class DetectorAlgorithm(ABC, Generic[T]):
     @abstractmethod
+    def __init__(
+        self,
+        state: DetectorState,
+        config: DetectorConfig,
+    ):
+        ...
+
+    @abstractmethod
     def update(self, payload: DetectorPayload) -> Tuple[Optional[TrendType], float]:
         ...
+
+    @property
+    @abstractmethod
+    def state(self) -> DetectorState:
+        ...
+
+
+@dataclass(frozen=True)
+class RegressionDetector(ABC):
+    kind: str
+    config: DetectorConfig
+    store: DetectorStore
+    state_cls: type[DetectorState]
+    detector_cls: type[DetectorAlgorithm]
+
+    @classmethod
+    def all_payloads(
+        cls,
+        projects: List[Project],
+        start: datetime,
+    ) -> Generator[DetectorPayload, None, None]:
+        projects_per_query = options.get("statistical_detectors.query.batch_size")
+        assert projects_per_query > 0
+
+        for projects in chunked(projects, projects_per_query):
+            try:
+                yield from cls.query_payloads(projects, start)
+            except Exception as e:
+                sentry_sdk.capture_exception(e)
+                continue
+
+    @classmethod
+    @abstractmethod
+    def query_payloads(
+        cls,
+        projects: List[Project],
+        start: datetime,
+    ) -> List[DetectorPayload]:
+        ...
+
+    @classmethod
+    def detect_trends(
+        cls, projects: List[Project], start: datetime
+    ) -> Generator[Tuple[Optional[TrendType], float, DetectorPayload], None, None]:
+        unique_project_ids: Set[int] = set()
+
+        total_count = 0
+        regressed_count = 0
+        improved_count = 0
+
+        for payloads in chunked(cls.all_payloads(projects, start), 100):
+            total_count += len(payloads)
+
+            raw_states = cls.store.bulk_read_states(payloads)
+
+            states = []
+
+            for raw_state, payload in zip(raw_states, payloads):
+                try:
+                    state = cls.state_cls.from_redis_dict(raw_state)
+                except Exception as e:
+                    state = cls.state_cls.empty()
+
+                    if raw_state:
+                        # empty raw state implies that there was no
+                        # previous state so no need to capture an exception
+                        sentry_sdk.capture_exception(e)
+
+                algorithm = cls.detector_cls(state, cls.config)
+                trend_type, score = algorithm.update(payload)
+
+                states.append(None if trend_type is None else algorithm.state.to_redis_dict())
+
+                if trend_type == TrendType.Regressed:
+                    regressed_count += 1
+                elif trend_type == TrendType.Improved:
+                    improved_count += 1
+
+                unique_project_ids.add(payload.project_id)
+
+                yield (trend_type, score, payload)
+
+            cls.store.bulk_write_states(payloads, states)
+
+        # TODO: These metrics are function specific. Refactor so that it handles
+        # various detector types.
+
+        # This is the total number of functions examined in this iteration
+        metrics.incr(
+            "statistical_detectors.total.functions",
+            amount=total_count,
+            sample_rate=1.0,
+        )
+
+        # This is the number of regressed functions found in this iteration
+        metrics.incr(
+            "statistical_detectors.regressed.functions",
+            amount=regressed_count,
+            sample_rate=1.0,
+        )
+
+        # This is the number of improved functions found in this iteration
+        metrics.incr(
+            "statistical_detectors.improved.functions",
+            amount=improved_count,
+            sample_rate=1.0,
+        )
+
+        metrics.incr(
+            "statistical_detectors.profiling.projects.active",
+            amount=len(unique_project_ids),
+            sample_rate=1.0,
+        )


### PR DESCRIPTION
Going to be taking a incremental approach to unify the EMA detector logic between functions and transactions as they're almost identical. To keep the changes small, this starts by lifting the logic for functions into a unified interface. Next up will be refactoring transactions to use the same interface.