### PR TITLE
fix(starfish): Screens widget loading jank

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/slowScreens.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/slowScreens.tsx
@@ -385,7 +385,15 @@ function SlowScreensByTTID(props: PerformanceWidgetProps) {
       InteractiveTitle={
         InteractiveTitle ? () => <InteractiveTitle isLoading={false} /> : null
       }
-      EmptyComponent={WidgetEmptyStateWarning}
+      EmptyComponent={
+        isLoadingReleases
+          ? () => (
+              <LoadingWrapper height={TOTAL_EXPANDABLE_ROWS_HEIGHT + props.chartHeight}>
+                <StyledLoadingIndicator size={40} />
+              </LoadingWrapper>
+            )
+          : WidgetEmptyStateWarning
+      }
       Queries={Queries}
       Visualizations={Visualizations}
     />
@@ -396,4 +404,15 @@ export default SlowScreensByTTID;
 
 const StyledDurationWrapper = styled('div')`
   padding: 0 ${space(1)};
+`;
+
+const LoadingWrapper = styled('div')<{height?: number}>`
+  height: ${p => p.height}px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  margin: 0;
 `;


### PR DESCRIPTION
Since we delay the list items request until we've loaded the releases, we initially see the empty state. This overrides the empty state so we'll see a loader until the request is fired and completes