### PR TITLE
ref(stats-detectors): Unify endpoint detector logic

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -4,7 +4,7 @@ import heapq
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Any, DefaultDict, Dict, Generator, List, Optional, Set, Tuple, Union
+from typing import Any, DefaultDict, Dict, Generator, List, Optional, Tuple, Union
 
 import sentry_sdk
 from django.utils import timezone as django_timezone
@@ -166,6 +166,56 @@ def run_detection() -> None:
     )
 
 
+class EndpointRegressionDetector(RegressionDetector):
+    kind = "endpoint"
+    config = MovingAverageRelativeChangeDetectorConfig(
+        change_metric="statistical_detectors.rel_change.transactions",
+        min_data_points=6,
+        short_moving_avg_factory=lambda: ExponentialMovingAverage(2 / 21),
+        long_moving_avg_factory=lambda: ExponentialMovingAverage(2 / 41),
+        threshold=0.2,
+    )
+    store = RedisDetectorStore(detector_type=DetectorType.ENDPOINT)  # e for endpoint
+    state_cls = MovingAverageDetectorState
+    detector_cls = MovingAverageRelativeChangeDetector
+
+    @classmethod
+    def query_payloads(
+        cls,
+        projects: List[Project],
+        start: datetime,
+    ) -> List[DetectorPayload]:
+        return query_transactions(projects, start)
+
+    @classmethod
+    def update_metrics(cls, projects, total, regressed, improved):
+        metrics.incr(
+            "statistical_detectors.performance.projects.active",
+            amount=projects,
+            sample_rate=1.0,
+        )
+
+        metrics.incr(
+            "statistical_detectors.total.transactions",
+            amount=total,
+            sample_rate=1.0,
+        )
+
+        # This is the number of regressed functions found in this iteration
+        metrics.incr(
+            "statistical_detectors.regressed.transactions",
+            amount=regressed,
+            sample_rate=1.0,
+        )
+
+        # This is the number of improved functions found in this iteration
+        metrics.incr(
+            "statistical_detectors.improved.transactions",
+            amount=improved,
+            sample_rate=1.0,
+        )
+
+
 class FunctionRegressionDetector(RegressionDetector):
     kind = "function"
     config = MovingAverageRelativeChangeDetectorConfig(
@@ -186,6 +236,34 @@ class FunctionRegressionDetector(RegressionDetector):
         start: datetime,
     ) -> List[DetectorPayload]:
         return query_functions(projects, start)
+
+    @classmethod
+    def update_metrics(cls, projects, total, regressed, improved):
+        metrics.incr(
+            "statistical_detectors.profiling.projects.active",
+            amount=projects,
+            sample_rate=1.0,
+        )
+
+        metrics.incr(
+            "statistical_detectors.total.functions",
+            amount=total,
+            sample_rate=1.0,
+        )
+
+        # This is the number of regressed functions found in this iteration
+        metrics.incr(
+            "statistical_detectors.regressed.functions",
+            amount=regressed,
+            sample_rate=1.0,
+        )
+
+        # This is the number of improved functions found in this iteration
+        metrics.incr(
+            "statistical_detectors.improved.functions",
+            amount=improved,
+            sample_rate=1.0,
+        )
 
 
 @instrumented_task(
@@ -212,7 +290,7 @@ def detect_transaction_trends(
     ]
 
     ratelimit = options.get("statistical_detectors.ratelimit.ema")
-    trends = _detect_transaction_trends(projects, start)
+    trends = EndpointRegressionDetector.detect_trends(projects, start)
     regressions = limit_regressions_by_project(trends, ratelimit)
 
     delay = 12  # hours
@@ -317,105 +395,6 @@ def _detect_transaction_change_points(
             sentry_sdk.capture_exception(e)
             metrics.incr("statistical_detectors.breakpoint.errors", tags={"type": "transactions"})
             continue
-
-
-def get_all_transaction_payloads(
-    projects: List[Project], start: datetime, end: datetime
-) -> Generator[DetectorPayload, None, None]:
-    projects_per_query = options.get("statistical_detectors.query.batch_size")
-    assert projects_per_query > 0
-
-    for chunked_projects in chunked(projects, projects_per_query):
-        try:
-            yield from query_transactions(chunked_projects, start, end, TRANSACTIONS_PER_PROJECT)
-        except Exception as e:
-            sentry_sdk.capture_exception(e)
-            continue
-
-
-def _detect_transaction_trends(
-    projects: List[Project], start: datetime
-) -> Generator[Tuple[Optional[TrendType], float, DetectorPayload], None, None]:
-    unique_project_ids: Set[int] = set()
-
-    transactions_count = 0
-    regressed_count = 0
-    improved_count = 0
-
-    detector_config = MovingAverageRelativeChangeDetectorConfig(
-        change_metric="statistical_detectors.rel_change.transactions",
-        min_data_points=6,
-        short_moving_avg_factory=lambda: ExponentialMovingAverage(2 / 21),
-        long_moving_avg_factory=lambda: ExponentialMovingAverage(2 / 41),
-        threshold=0.2,
-    )
-
-    detector_store = RedisDetectorStore(detector_type=DetectorType.ENDPOINT)  # e for endpoint
-
-    start = start - timedelta(hours=1)
-    start = start.replace(minute=0, second=0, microsecond=0)
-    end = start + timedelta(hours=1)
-    all_transaction_payloads = get_all_transaction_payloads(projects, start, end)
-
-    for payloads in chunked(all_transaction_payloads, 100):
-        transactions_count += len(payloads)
-
-        raw_states = detector_store.bulk_read_states(payloads)
-
-        states = []
-
-        for raw_state, payload in zip(raw_states, payloads):
-            try:
-                state = MovingAverageDetectorState.from_redis_dict(raw_state)
-            except Exception as e:
-                state = MovingAverageDetectorState.empty()
-
-                if raw_state:
-                    # empty raw state implies that there was no
-                    # previous state so no need to capture an exception
-                    sentry_sdk.capture_exception(e)
-
-            detector = MovingAverageRelativeChangeDetector(state, detector_config)
-            trend_type, score = detector.update(payload)
-            states.append(None if trend_type is None else detector.state.to_redis_dict())
-
-            if trend_type == TrendType.Regressed:
-                regressed_count += 1
-            elif trend_type == TrendType.Improved:
-                improved_count += 1
-
-            unique_project_ids.add(payload.project_id)
-
-            yield (trend_type, score, payload)
-
-        detector_store.bulk_write_states(payloads, states)
-
-    # This is the total number of functions examined in this iteration
-    metrics.incr(
-        "statistical_detectors.total.transactions",
-        amount=transactions_count,
-        sample_rate=1.0,
-    )
-
-    # This is the number of regressed functions found in this iteration
-    metrics.incr(
-        "statistical_detectors.regressed.transactions",
-        amount=regressed_count,
-        sample_rate=1.0,
-    )
-
-    # This is the number of improved functions found in this iteration
-    metrics.incr(
-        "statistical_detectors.improved.transactions",
-        amount=improved_count,
-        sample_rate=1.0,
-    )
-
-    metrics.incr(
-        "statistical_detectors.performance.projects.active",
-        amount=len(unique_project_ids),
-        sample_rate=1.0,
-    )
 
 
 def query_transactions_timeseries(
@@ -823,9 +802,12 @@ BACKEND_TRANSACTION_OPS = [
 def query_transactions(
     projects: List[Project],
     start: datetime,
-    end: datetime,
-    transactions_per_project: int,
+    transactions_per_project: int = TRANSACTIONS_PER_PROJECT,
 ) -> List[DetectorPayload]:
+    start = start - timedelta(hours=1)
+    start = start.replace(minute=0, second=0, microsecond=0)
+    end = start + timedelta(hours=1)
+
     org_ids = list({p.organization_id for p in projects})
     project_ids = list({p.id for p in projects})
 

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -755,7 +755,6 @@ class TestTransactionsQuery(MetricsAPIBaseTestCase):
     def test_transactions_query(self) -> None:
         res = query_transactions(
             self.projects,
-            self.hour_ago,
             self.now,
             self.num_transactions + 1,  # detect if any extra transactions are returned
         )


### PR DESCRIPTION
Time to remove the duplicate logic for the endpoint regression and use the unified interface.