### PR TITLE
fix(slack): Respond to hybrid cloud slack verification from Control

### DIFF
--- a/src/sentry/integrations/slack/requests/event.py
+++ b/src/sentry/integrations/slack/requests/event.py
@@ -12,6 +12,10 @@ def has_discover_links(links: list[str]) -> bool:
     return any(match_link(link)[0] == LinkType.DISCOVER for link in links)
 
 
+def is_event_challenge(data: Mapping[str, Any]) -> bool:
+    return data and data.get("type", {}) == "url_verification"
+
+
 class SlackEventRequest(SlackDMRequest):
     """
     An Event request sent from Slack.
@@ -42,8 +46,7 @@ class SlackEventRequest(SlackDMRequest):
 
     def is_challenge(self) -> bool:
         """We need to call this before validation."""
-        _is_challenge: bool = self.request.data.get("type") == "url_verification"
-        return _is_challenge
+        return is_event_challenge(self.request.data)
 
     @property
     def dm_data(self) -> Mapping[str, Any]:

--- a/src/sentry/integrations/slack/requests/event.py
+++ b/src/sentry/integrations/slack/requests/event.py
@@ -13,7 +13,7 @@ def has_discover_links(links: list[str]) -> bool:
 
 
 def is_event_challenge(data: Mapping[str, Any]) -> bool:
-    return data and data.get("type", {}) == "url_verification"
+    return data.get("type", "") == "url_verification"
 
 
 class SlackEventRequest(SlackDMRequest):

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 
 from sentry import analytics, features
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import region_silo_endpoint
+from sentry.api.base import all_silo_endpoint
 from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.message_builder.help import SlackHelpMessageBuilder
 from sentry.integrations.slack.message_builder.prompt import SlackPromptLinkMessageBuilder
@@ -28,7 +28,7 @@ from .base import SlackDMEndpoint
 from .command import LINK_FROM_CHANNEL_MESSAGE
 
 
-@region_silo_endpoint
+@all_silo_endpoint  # Only challenge verification is handled at control
 class SlackEventEndpoint(SlackDMEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -5,6 +5,7 @@ import logging
 from rest_framework.request import Request
 
 from sentry.integrations.slack.requests.base import SlackRequestError
+from sentry.integrations.slack.requests.event import is_event_challenge
 from sentry.integrations.slack.views.link_identity import SlackLinkIdentityView
 from sentry.integrations.slack.views.link_team import SlackLinkTeamView
 from sentry.integrations.slack.views.unlink_identity import SlackUnlinkIdentityView
@@ -20,6 +21,7 @@ from sentry.integrations.slack.webhooks.event import SlackEventEndpoint
 from sentry.models.integrations.integration import Integration
 from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
+from sentry.utils import json
 from sentry.utils.signing import unsign
 
 from .base import BaseRequestParser
@@ -90,6 +92,11 @@ class SlackRequestParser(BaseRequestParser):
         Slack Webhook Requests all require synchronous responses.
         """
         if self.view_class in self.control_classes:
+            return self.get_response_from_control_silo()
+
+        # Handle event interactions challenge request
+        data = json.loads(self.request.body.decode(encoding="utf-8"))
+        if is_event_challenge(data):
             return self.get_response_from_control_silo()
 
         regions = self.get_regions_from_organizations()

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -95,8 +95,12 @@ class SlackRequestParser(BaseRequestParser):
             return self.get_response_from_control_silo()
 
         # Handle event interactions challenge request
-        data = json.loads(self.request.body.decode(encoding="utf-8"))
-        if is_event_challenge(data):
+        data = None
+        try:
+            data = json.loads(self.request.body.decode(encoding="utf-8"))
+        except Exception:
+            pass
+        if data and is_event_challenge(data):
             return self.get_response_from_control_silo()
 
         regions = self.get_regions_from_organizations()

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -146,6 +146,7 @@ const patterns: RegExp[] = [
   new RegExp('^extensions/jira/configure/$'),
   new RegExp('^extensions/jira-server/issue-updated/[^/]+/$'),
   new RegExp('^extensions/jira-server/search/[^/]+/[^/]+/$'),
+  new RegExp('^extensions/slack/event/$'),
   new RegExp('^extensions/slack/link-identity/[^/]+/$'),
   new RegExp('^extensions/slack/unlink-identity/[^/]+/$'),
   new RegExp('^extensions/github/webhook/$'),


### PR DESCRIPTION
Almost a useless PR since this is only gonna apply to self-hosted users with unverified slack interactions endpoints that are running sentry in silo modes (which is just us in our test-region)

SaaS's endpoint is already verified but the test Slack App can't test interactions until this validation passes. Tested locally and seems to work fine with verification as well as slash commands