### PR TITLE
fix(security): loose CSP for replays on self-hosted

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -475,14 +475,16 @@ CSP_BASE_URI = [
     "'none'",
 ]
 CSP_STYLE_SRC = [
-    "'self'",
     "'unsafe-inline'",
+    "*",  # required for replays
 ]
 CSP_IMG_SRC = [
-    "'self'",
     "blob:",
     "data:",
-    "https://secure.gravatar.com",
+    "*",  # required for replays
+]
+CSP_MEDIA_SRC = [
+    "*",  # required for replays
 ]
 
 if ENVIRONMENT == "development":


### PR DESCRIPTION
Replays could use arbitrary img, media, and css sources, so we need to allow all.

* Currently, sentry.io has the same behavior anyway.
* `'self'` and `https://secure.gravatar.com` are being merged to `*` for short.
* `blob:` and `data:` has to be separate because:
> Note that '*' matches only URLs with network schemes ('http', 'https', 'ws', 'wss'), or URLs whose scheme matches `self`'s scheme. The scheme 'blob:' must be added explicitly.