### PR TITLE
fix(metrics-extraction): Fix apdex resolution in on-demand

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -1642,7 +1642,11 @@ class TopMetricsQueryBuilder(TimeseriesMetricQueryBuilder):
     ) -> Optional[WhereType]:
         """Given a list of top events construct the conditions"""
         conditions = []
+
         for field in self.fields:
+            if fields.is_function(field):
+                # A function will never be in a top_events dict.
+                continue
             resolved_field = self.resolve_column(field)
 
             values: Set[Any] = set()

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -117,7 +117,6 @@ from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import install_slack
-from sentry.testutils.pytest.fixtures import default_project
 from sentry.testutils.pytest.selenium import Browser
 from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
 from sentry.types.integrations import ExternalProviders
@@ -1893,8 +1892,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
         additional_tags: Optional[Dict[str, str]] = None,
         timestamp: Optional[datetime] = None,
     ):
-        project: Project = default_project
-        metric_spec = spec.to_metric_spec(project)
+        metric_spec = spec.to_metric_spec(self.project)
         metric_spec_tags = metric_spec["tags"] or [] if metric_spec else []
         tags = {i["key"]: i.get("value") or i.get("field") for i in metric_spec_tags}
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1220,6 +1220,66 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             [{"count": 450.0}],
         ]
 
+    def test_apdex_issue(self):
+        field = "apdex(300)"
+        groupbys = ["group_tag"]
+        query = "transaction.duration:>=100"
+        spec = OnDemandMetricSpec(
+            field=field,
+            groupbys=groupbys,
+            query=query,
+            spec_type=MetricSpecType.DYNAMIC_QUERY,
+        )
+
+        for hour in range(0, 5):
+            self.store_on_demand_metric(
+                1,
+                spec=spec,
+                additional_tags={
+                    "group_tag": "group_one",
+                    "environment": "production",
+                    "satisfaction": "tolerable",
+                },
+                timestamp=self.day_ago + timedelta(hours=hour),
+            )
+            self.store_on_demand_metric(
+                1,
+                spec=spec,
+                additional_tags={
+                    "group_tag": "group_two",
+                    "environment": "production",
+                    "satisfaction": "satisfactory",
+                },
+                timestamp=self.day_ago + timedelta(hours=hour),
+            )
+
+        response = self.do_request(
+            data={
+                "dataset": "metricsEnhanced",
+                "environment": "production",
+                "excludeOther": 1,
+                "field": [field, "group_tag"],
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=2)),
+                "interval": "1h",
+                "orderby": f"-{field}",
+                "partial": 1,
+                "project": self.project.id,
+                "query": query,
+                "topEvents": 5,
+                "yAxis": field,
+                "onDemandType": "dynamic_query",
+                "useOnDemandMetrics": "true",
+            },
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["group_one"]["meta"]["isMetricsExtractedData"] is True
+        assert [attrs for time, attrs in response.data["group_one"]["data"]] == [
+            [{"count": 0.5}],
+            [{"count": 0.5}],
+        ]
+
     def _test_is_metrics_extracted_data(
         self, params: dict[str, Any], expected_on_demand_query: bool, dataset: str
     ) -> None:


### PR DESCRIPTION
### Summary
Apdex was failing in Top N because it tries to build out top event conditions by resolving all fields. It's not necessary to check function fields since the data from top_events is a string -> data map, so a function will always fail regardless, and we don't want to build out conditions for functions regardless.
