### PR TITLE
fix(metrics-extraction): Fix group-by on transaction

### DIFF
--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -43,7 +43,11 @@ class MetricsDatasetConfig(DatasetConfig):
 
     @property
     def field_alias_converter(self) -> Mapping[str, Callable[[str], SelectType]]:
-        transaction_alias = self._resolve_transaction_alias_on_demand if self.builder.use_on_demand else self._resolve_transaction_alias
+        transaction_alias = (
+            self._resolve_transaction_alias_on_demand
+            if self.builder.use_on_demand
+            else self._resolve_transaction_alias
+        )
         return {
             constants.PROJECT_ALIAS: self._resolve_project_slug_alias,
             constants.PROJECT_NAME_ALIAS: self._resolve_project_slug_alias,
@@ -807,7 +811,7 @@ class MetricsDatasetConfig(DatasetConfig):
 
     def _resolve_transaction_alias_on_demand(self, _: str) -> SelectType:
         """On-demand doesn't need a transform for transaction in it's where clause
-        since conditions are saved on a per-metric basis. 
+        since conditions are saved on a per-metric basis.
         """
         return Column(self.builder.resolve_column_name("transaction"))
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1301,4 +1301,3 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             [{"count": 5.0}],
             [{"count": 10.0}],
         ]
-

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1252,3 +1252,53 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             expected_on_demand_query=True,
             dataset="metricsEnhanced",
         )
+
+    def test_group_by_transaction(self):
+        field = "count()"
+        groupbys = ["transaction"]
+        query = "transaction.duration:>=100"
+        spec = OnDemandMetricSpec(
+            field=field,
+            groupbys=groupbys,
+            query=query,
+            spec_type=MetricSpecType.DYNAMIC_QUERY,
+        )
+
+        for hour in range(0, 2):
+            self.store_on_demand_metric(
+                (hour + 1) * 5,
+                spec=spec,
+                additional_tags={
+                    "transaction": "/performance",
+                    "environment": "production",
+                },
+                timestamp=self.day_ago + timedelta(hours=hour),
+            )
+
+        response = self.do_request(
+            data={
+                "dataset": "metricsEnhanced",
+                "environment": "production",
+                "excludeOther": 1,
+                "field": [field, "transaction"],
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=2)),
+                "interval": "1h",
+                "orderby": f"-{field}",
+                "partial": 1,
+                "project": self.project.id,
+                "query": query,
+                "topEvents": 5,
+                "yAxis": field,
+                "onDemandType": "dynamic_query",
+                "useOnDemandMetrics": "true",
+            },
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["/performance"]["meta"]["isMetricsExtractedData"] is True
+        assert [attrs for time, attrs in response.data["/performance"]["data"]] == [
+            [{"count": 5.0}],
+            [{"count": 10.0}],
+        ]
+


### PR DESCRIPTION
### Summary
Currently group-by on transaction top-n will break since it tries to performance the alias transform statement for the top-event 'transaction' where condition, where it tries to coalesce all empty values ('', null, unparameterized).
