### PR TITLE
fix(hybridcloud) Fix AttributeError when member is missing

### DIFF
--- a/src/sentry/web/frontend/disabled_member_view.py
+++ b/src/sentry/web/frontend/disabled_member_view.py
@@ -21,7 +21,7 @@ class DisabledMemberView(ReactPageView):
             member = organization_service.check_membership_by_id(
                 user_id=user.id, organization_id=organization.id
             )
-            if not member or member.flags["member-limit:restricted"]:
+            if member and not member.flags["member-limit:restricted"]:
                 return self.redirect(
                     reverse("sentry-organization-issue-list", args=[organization.slug])
                 )

--- a/src/sentry/web/frontend/disabled_member_view.py
+++ b/src/sentry/web/frontend/disabled_member_view.py
@@ -21,7 +21,7 @@ class DisabledMemberView(ReactPageView):
             member = organization_service.check_membership_by_id(
                 user_id=user.id, organization_id=organization.id
             )
-            if not member.flags["member-limit:restricted"]:
+            if not member or member.flags["member-limit:restricted"]:
                 return self.redirect(
                     reverse("sentry-organization-issue-list", args=[organization.slug])
                 )

--- a/tests/sentry/web/frontend/test_disabled_member_view.py
+++ b/tests/sentry/web/frontend/test_disabled_member_view.py
@@ -22,6 +22,10 @@ class DisabledMemberViewTest(TestCase):
     def create_one_member(self, flags=None):
         self.create_member(user=self.user, organization=self.org, role="member", flags=flags)
 
+    def test_member_missing(self):
+        resp = self.client.get("/disabled-member/")
+        assert resp.status_code == 302
+
     def test_member_disabled_can_load(self):
         self.create_one_member(
             flags=OrganizationMember.flags["member-limit:restricted"],


### PR DESCRIPTION
check_membership_by_id can return None and we need to account for that.

Fixes SENTRY-18YX
