### PR TITLE
fix(browser-starfish): resource pages selector search sometimes inaccurate

### DIFF
--- a/static/app/views/performance/browser/resources/jsCssView/index.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/index.tsx
@@ -49,11 +49,7 @@ function JSCSSView() {
     ...(filters[SPAN_DOMAIN] ? {[SPAN_DOMAIN]: filters[SPAN_DOMAIN]} : {}),
   };
 
-  const extraQuery = [
-    'AND (',
-    ...getResourceTypeFilter(undefined, DEFAULT_RESOURCE_TYPES),
-    ')',
-  ];
+  const extraQuery = getResourceTypeFilter(undefined, DEFAULT_RESOURCE_TYPES);
 
   return (
     <Fragment>

--- a/static/app/views/performance/browser/resources/utils/useResourcePagesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcePagesQuery.ts
@@ -31,7 +31,9 @@ export const useResourcePagesQuery = (
 
   const queryConditions = [
     ...DEFAULT_RESOURCE_FILTERS,
+    'AND (',
     ...getResourceTypeFilter(resourceFilters[SPAN_OP], defaultResourceTypes),
+    ')',
     ...getDomainFilter(spanDomain),
     ...(search && search.length > 0
       ? [`${SpanMetricsField.TRANSACTION}:*${[search]}*`]

--- a/static/app/views/performance/browser/resources/utils/useResourcePagesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcePagesQuery.ts
@@ -31,9 +31,7 @@ export const useResourcePagesQuery = (
 
   const queryConditions = [
     ...DEFAULT_RESOURCE_FILTERS,
-    'AND (',
     ...getResourceTypeFilter(resourceFilters[SPAN_OP], defaultResourceTypes),
-    ')',
     ...getDomainFilter(spanDomain),
     ...(search && search.length > 0
       ? [`${SpanMetricsField.TRANSACTION}:*${[search]}*`]

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -52,9 +52,7 @@ export const getResourcesEventViewQuery = (
           `${RESOURCE_RENDER_BLOCKING_STATUS}:${resourceFilters[RESOURCE_RENDER_BLOCKING_STATUS]}`,
         ]
       : [`!${RESOURCE_RENDER_BLOCKING_STATUS}:blocking`]),
-    'AND (',
     ...getResourceTypeFilter(resourceFilters[SPAN_OP], defaultResourceTypes),
-    ')',
   ];
 };
 
@@ -169,5 +167,5 @@ export const getResourceTypeFilter = (
       defaultResourceTypes.map(type => SPAN_OP_FILTER[type]).join(' OR '),
     ];
   }
-  return resourceFilter;
+  return ['(', ...resourceFilter, ')'];
 };

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -925,7 +925,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
           per_page: QUERY_LIMIT_PARAM,
           project: ['-42'],
           query:
-            '!span.description:browser-extension://* resource.render_blocking_status:blocking AND ( span.op:resource.script OR file_extension:css OR file_extension:[woff,woff2,ttf,otf,eot] ) transaction.op:pageload',
+            '!span.description:browser-extension://* resource.render_blocking_status:blocking ( span.op:resource.script OR file_extension:css OR file_extension:[woff,woff2,ttf,otf,eot] ) transaction.op:pageload',
           sort: '-time_spent_percentage()',
           statsPeriod: '7d',
         }),


### PR DESCRIPTION
We need to add brackets around the OR conditions in the page selector, otherwise the search is incorrect and we don't get all results

Before Query
![image](https://github.com/getsentry/sentry/assets/44422760/849b0b8a-dc37-4dcb-8458-746d84d2fdab)


After Query
![image](https://github.com/getsentry/sentry/assets/44422760/b8f29807-835d-4ee2-a98b-5cf90b0b32b8)

