### PR TITLE
fix(hybridcloud) Don't assign user to socialauth model

### DIFF
--- a/src/social_auth/models.py
+++ b/src/social_auth/models.py
@@ -156,7 +156,6 @@ class UserSocialAuth(models.Model):
     def get_social_auth(cls, provider, uid, user):
         try:
             instance = cls.objects.get(provider=provider, uid=uid, user_id=user.id)
-            instance.user = user
             return instance
         except UserSocialAuth.DoesNotExist:
             return None


### PR DESCRIPTION
Setting RpcUser into the SocialAuth model results in a runtime error. We don't use `socialauth.user` anywhere and not having it should be safe.

Fixes SENTRY-17QC
Fixes HC-994