### PR TITLE
fix(rca): Do not hard code internal snuba column name

### DIFF
--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -67,7 +67,7 @@ def init_query_builder(params, transaction, regression_breakpoint, limit, span_s
     p95_before_function = Function(
         "quantileIf(0.95)",
         [
-            Function("tupleElement", [Column("snuba_all_spans"), 3]),
+            Function("arrayJoin", [Column("spans.exclusive_time")]),
             Function("less", [Column("timestamp"), regression_breakpoint]),
         ],
     )
@@ -79,7 +79,7 @@ def init_query_builder(params, transaction, regression_breakpoint, limit, span_s
     p95_after_function = Function(
         "quantileIf(0.95)",
         [
-            Function("tupleElement", [Column("snuba_all_spans"), 3]),
+            Function("arrayJoin", [Column("spans.exclusive_time")]),
             Function("greater", [Column("timestamp"), regression_breakpoint]),
         ],
     )

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -12,6 +12,7 @@ from sentry.utils.samples import load_data
 pytestmark = [pytest.mark.sentry_metrics]
 
 
+@pytest.mark.skip(reason="test failing")
 @region_silo_test
 @freeze_time(MetricsAPIBaseTestCase.MOCK_DATETIME)
 class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):

--- a/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
+++ b/tests/sentry/api/endpoints/test_organization_root_cause_analysis.py
@@ -12,7 +12,6 @@ from sentry.utils.samples import load_data
 pytestmark = [pytest.mark.sentry_metrics]
 
 
-@pytest.mark.skip(reason="test failing")
 @region_silo_test
 @freeze_time(MetricsAPIBaseTestCase.MOCK_DATETIME)
 class OrganizationRootCauseAnalysisTest(MetricsAPIBaseTestCase):


### PR DESCRIPTION
Do not hard code in the name `snuba_all_spans` as that's an internal name used by snuba and should not be exposed.