### PR TITLE
chore(hybridcloud) Move email reply tasks to a dedicated queue

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -836,6 +836,7 @@ CELERY_QUEUES_REGION = [
     Queue("digests.delivery", routing_key="digests.delivery"),
     Queue("digests.scheduling", routing_key="digests.scheduling"),
     Queue("email", routing_key="email"),
+    Queue("email.inbound", routing_key="email.inbound"),
     Queue("events.preprocess_event", routing_key="events.preprocess_event"),
     Queue("events.process_event", routing_key="events.process_event"),
     Queue("events.reprocess_events", routing_key="events.reprocess_events"),

--- a/src/sentry/tasks/email.py
+++ b/src/sentry/tasks/email.py
@@ -26,7 +26,7 @@ def _get_user_from_email(group: Group, email: str) -> Optional[RpcUser]:
 
 @instrumented_task(
     name="sentry.tasks.email.process_inbound_email",
-    queue="email",
+    queue="email.inbound",
     default_retry_delay=60 * 5,
     max_retries=None,
     silo_mode=SiloMode.REGION,


### PR DESCRIPTION
This workload isn't high volume but we need it to not be in the `email` queue. The `email` queue is unique in that it is shared by control and region silos, so all messages in that queue need to be silo safe.