### PR TITLE
feat(starfish): Fetch better releases in the selector

### DIFF
--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -81,7 +81,7 @@ export function ReleaseSelector({selectorKey, selectorValue}: Props) {
       options={[
         {
           value: '_releases',
-          label: t('Sorted by date created'),
+          label: t('Sorted by adoption'),
           options,
         },
       ]}

--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -81,7 +81,7 @@ export function ReleaseSelector({selectorKey, selectorValue}: Props) {
       options={[
         {
           value: '_releases',
-          label: t('Sorted by adoption'),
+          label: t('Sorted by date created'),
           options,
         },
       ]}

--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -6,6 +6,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {ApiQueryKey, useApiQuery, useQueries} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {escapeFilterValue} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -44,7 +45,9 @@ export function useReleases(searchTerm?: string) {
       const newQuery: NewQuery = {
         name: '',
         fields: ['release', 'count()'],
-        query: `transaction.op:ui.load release:[${releases.map(r => r.version).join()}]`,
+        query: `transaction.op:ui.load ${escapeFilterValue(
+          `release:[${releases.map(r => `"${r.version}"`).join()}]`
+        )}`,
         dataset: DiscoverDatasets.METRICS,
         version: 2,
         projects: selection.projects,
@@ -103,6 +106,7 @@ export function useReleases(searchTerm?: string) {
   return {
     ...releaseResults,
     data: releaseStats,
+    isLoading: !metricsFetched || releaseResults.isLoading,
   };
 }
 

--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -22,7 +22,7 @@ export function useReleases(searchTerm?: string) {
           per_page: 100,
           environment: environments,
           query: searchTerm,
-          sort: 'date',
+          sort: 'adoption',
         },
       },
     ],
@@ -36,6 +36,7 @@ export function useReleases(searchTerm?: string) {
     dataset: DiscoverDatasets.METRICS,
     version: 2,
     projects: selection.projects,
+    orderby: '-count()',
   };
   const eventView = EventView.fromNewQueryWithPageFilters(newQuery, selection);
   const {data: metricsResult, isLoading: isMetricsStatsLoading} = useTableQuery({

--- a/static/app/views/starfish/queries/useReleases.tsx
+++ b/static/app/views/starfish/queries/useReleases.tsx
@@ -56,7 +56,10 @@ export function useReleases(searchTerm?: string) {
       const queryKey = [
         `/organizations/${organization.slug}/events/`,
         {
-          query: eventView.getEventsAPIPayload(location),
+          query: {
+            ...eventView.getEventsAPIPayload(location),
+            referrer: 'api.starfish.mobile-release-selector',
+          },
         },
       ] as ApiQueryKey;
       return {

--- a/static/app/views/starfish/views/screens/index.tsx
+++ b/static/app/views/starfish/views/screens/index.tsx
@@ -210,7 +210,7 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
     return (
       <Alert type="warning" showIcon>
         {t(
-          'No screens found on recent releases. Please try a single iOS or Android project or a smaller date range.'
+          'No screens found on recent releases. Please try a single iOS or Android project, a single environment or a smaller date range.'
         )}
       </Alert>
     );


### PR DESCRIPTION
The release selector is currently an intersection of results from the release endpoint and events endpoint.
This PR switches it to consecutive http requests, so that we fetch the top 50 releases and pass those
as filters to the events requests to ensure we get numbers for those releases. This is way better in
cases of large time periods or a large number of releases.