### PR TITLE
fix(notifications): fix bug where email was shown as off when actually available

### DIFF
--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -18,10 +18,12 @@ export const VALUE_MAPPING = {
   committed_only: 40,
 };
 
+export const SUPPORTED_PROVIDERS = ['email', 'slack', 'msteams'] as const;
+export type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
+
 export const MIN_PROJECTS_FOR_CONFIRMATION = 3;
 export const MIN_PROJECTS_FOR_SEARCH = 3;
 export const MIN_PROJECTS_FOR_PAGINATION = 100;
-export type SupportedProviders = 'email' | 'slack' | 'msteams';
 export type ProviderValue = 'always' | 'never';
 
 interface NotificationBaseObject {

--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -19,7 +19,7 @@ export const VALUE_MAPPING = {
 };
 
 export const SUPPORTED_PROVIDERS = ['email', 'slack', 'msteams'] as const;
-export type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
+export type SupportedProviders = (typeof SUPPORTED_PROVIDERS)[number];
 
 export const MIN_PROJECTS_FOR_CONFIRMATION = 3;
 export const MIN_PROJECTS_FOR_SEARCH = 3;

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -23,6 +23,7 @@ import {
   DefaultSettings,
   NotificationOptionsObject,
   NotificationProvidersObject,
+  SUPPORTED_PROVIDERS,
   SupportedProviders,
 } from './constants';
 import {ACCOUNT_NOTIFICATION_FIELDS} from './fields';
@@ -169,14 +170,15 @@ class NotificationSettingsByTypeV2 extends DeprecatedAsyncComponent<Props, State
       option => option.scopeType === 'user' && option.type === notificationType
     );
 
-    const providers =
-      // if user has no settings saved so use default
-      relevantProviderSettings.length === 0 && defaultSettings
-        ? defaultSettings?.providerDefaults
-        : relevantProviderSettings
-            .filter(option => option.value === 'always')
-            .map(option => option.provider);
-    return providers.filter(this.isProviderSupported);
+    return SUPPORTED_PROVIDERS.filter(this.isProviderSupported).filter(provider => {
+      const providerSetting = relevantProviderSettings.find(
+        option => option.provider === provider
+      );
+      // if there is a matched setting use that, otherwise check provider defaults
+      return providerSetting
+        ? providerSetting.value === 'always'
+        : defaultSettings?.providerDefaults.includes(provider);
+    });
   }
 
   getFields(): Field[] {


### PR DESCRIPTION
This PR fixes a bug where Slack is enabled but there are no other settings (including email). This can happen when we do the notification nudge to enable Slack notifications via a button click. 