### PR TITLE
feat(nel): add subtitle to NEL events

### DIFF
--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -260,6 +260,7 @@ export enum EventOrGroupType {
   HPKP = 'hpkp',
   EXPECTCT = 'expectct',
   EXPECTSTAPLE = 'expectstaple',
+  NEL = 'nel',
   DEFAULT = 'default',
   TRANSACTION = 'transaction',
   AGGREGATE_TRANSACTION = 'aggregateTransaction',

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -157,6 +157,7 @@ export function getTitle(
       };
     }
     case EventOrGroupType.CSP:
+    case EventOrGroupType.NEL:
       return {
         title: customTitle ?? metadata.directive ?? '',
         subtitle: metadata.uri ?? '',


### PR DESCRIPTION
Reduced version of https://github.com/getsentry/sentry/pull/57564

Just add the subtitle to make NEL events look like familiar CSP events:
<img width="627" alt="image" src="https://github.com/getsentry/sentry/assets/1127549/94d1c2f4-2f52-453a-8791-3980cffce5d8">
