### PR TITLE
fix(alerts): transaction metrics being available

### DIFF
--- a/static/app/utils/metrics/useMetricsMeta.tsx
+++ b/static/app/utils/metrics/useMetricsMeta.tsx
@@ -34,32 +34,43 @@ export function useMetricsMeta(
     ];
   };
 
+  const hasSessions = enabledUseCases.includes('sessions');
+  const hasTransactions = enabledUseCases.includes('transactions');
+  const hasCustom = enabledUseCases.includes('custom');
+
   const commonOptions = {
     staleTime: Infinity,
   };
 
   const sessionsMeta = useApiQuery<MetricMeta[]>(getKey('sessions'), {
     ...commonOptions,
-    enabled: enabledUseCases.includes('sessions'),
+    enabled: hasSessions,
   });
   const txnsMeta = useApiQuery<MetricMeta[]>(getKey('transactions'), {
     ...commonOptions,
-    enabled: enabledUseCases.includes('transactions'),
+    enabled: hasTransactions,
   });
   const customMeta = useApiQuery<MetricMeta[]>(getKey('custom'), {
     ...commonOptions,
-    enabled: enabledUseCases.includes('custom'),
+    enabled: hasCustom,
   });
 
   const combinedMeta = useMemo<Record<string, MetricMeta>>(() => {
     return [
-      ...(sessionsMeta.data ?? []),
-      ...(txnsMeta.data ?? []),
-      ...(customMeta.data ?? []),
+      ...(hasSessions ? sessionsMeta.data ?? [] : []),
+      ...(hasTransactions ? txnsMeta.data ?? [] : []),
+      ...(hasCustom ? customMeta.data ?? [] : []),
     ].reduce((acc, metricMeta) => {
       return {...acc, [metricMeta.mri]: metricMeta};
     }, {});
-  }, [sessionsMeta.data, txnsMeta.data, customMeta.data]);
+  }, [
+    hasSessions,
+    sessionsMeta.data,
+    hasTransactions,
+    txnsMeta.data,
+    hasCustom,
+    customMeta.data,
+  ]);
 
   return {
     data: combinedMeta,

--- a/static/app/views/alerts/rules/metric/mriField.tsx
+++ b/static/app/views/alerts/rules/metric/mriField.tsx
@@ -7,6 +7,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Project} from 'sentry/types';
 import {
+  DEFAULT_METRIC_ALERT_AGGREGATE,
   fieldToMri,
   getReadableMetricType,
   isAllowedOp,
@@ -37,14 +38,21 @@ function MriField({aggregate, project, onChange}: Props) {
 
   useEffect(() => {
     // Auto-select the first mri if none of the available ones is selected
-    if (!selectedMriMeta && metaArr.length > 0) {
+    if (!selectedMriMeta) {
       const newSelection = metaArr[0];
-      onChange(
-        mriToField(newSelection.mri, filterAndSortOperations(newSelection.operations)[0]),
-        {}
-      );
+      if (newSelection) {
+        onChange(
+          mriToField(
+            newSelection.mri,
+            filterAndSortOperations(newSelection.operations)[0]
+          ),
+          {}
+        );
+      } else if (aggregate !== DEFAULT_METRIC_ALERT_AGGREGATE) {
+        onChange(DEFAULT_METRIC_ALERT_AGGREGATE, {});
+      }
     }
-  }, [metaArr, onChange, selectedMriMeta, isLoading]);
+  }, [metaArr, onChange, selectedMriMeta, isLoading, aggregate]);
 
   const handleMriChange = useCallback(
     option => {

--- a/static/app/views/alerts/rules/metric/utils/isCustomMetricAlert.tsx
+++ b/static/app/views/alerts/rules/metric/utils/isCustomMetricAlert.tsx
@@ -1,7 +1,7 @@
 import {fieldToMri} from 'sentry/utils/metrics';
 
 /**
- * Currently we can tell if an alert is a crash free alert by checking the aggregate for a MRI,
+ * Currently we can tell if an alert is a custom metric alert by checking the aggregate for a MRI,
  */
 export function isCustomMetricAlert(aggregate: string): boolean {
   return fieldToMri(aggregate).mri !== undefined;


### PR DESCRIPTION
Fix `useMetricsMeta` returning wrong use cases
Fix `MriField` to reset to `DEFAULT_METRIC_ALERT_AGGREGATE` if no metrics are available.