### PR TITLE
fix(metrics): Refine text contents for investigation rule notification  

### DIFF
--- a/src/sentry/templates/sentry/emails/dyn-sampling-custom-rule-fulfilled.html
+++ b/src/sentry/templates/sentry/emails/dyn-sampling-custom-rule-fulfilled.html
@@ -7,11 +7,11 @@
 
     <p>We've collected {{ num_samples }} samples for the following search query:</p>
     <pre>
-    {{ query }}
+{{ query }}
     </pre>
 
     <p>
-    We'll stop collecting once we reach 100 or 48 hours after rule creation.
+    We'll stop giving special priority to samples for your query once we collected 100 samples matching your query or 48 hours have passed from rule creation.
     </p>
 
   <a href="{{ discover_link|safe }}" class="btn">View Samples</a>

--- a/src/sentry/templates/sentry/emails/dyn-sampling-custom-rule-fulfilled.txt
+++ b/src/sentry/templates/sentry/emails/dyn-sampling-custom-rule-fulfilled.txt
@@ -3,7 +3,7 @@ We have samples!
 We've collected {{ num_samples }} samples for the following search query:
 `{{ query }}`
 
-We'll stop collecting once we reach 100 or 48 hours after rule creation.
+We'll stop giving special priority to samples for your query once we collected 100 samples matching your query or 48 hours have passed from rule creation.
 
 View samples here:
 {{ discover_link|safe }}


### PR DESCRIPTION
This PR refines the contents of the email notification for investigation rule to clearly
specify the conditions under which samples are being collected.

It also fixes the indentation of the query in the html version of the email

The message used is:

```
We'll stop giving special priority to samples for your query once we collected 100 samples matching your query or 48 hours have passed from rule creation.
```