### PR TITLE
feat(profiling): use fallback 2d canvas renderer for flamechart

### DIFF
--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -2,6 +2,7 @@ import {ReactElement, useEffect, useLayoutEffect, useMemo, useState} from 'react
 import * as Sentry from '@sentry/react';
 import {mat3, vec2} from 'gl-matrix';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {FlamegraphZoomView} from 'sentry/components/profiling/flamegraph/flamegraphZoomView';
 import {defined} from 'sentry/utils';
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
@@ -187,6 +188,7 @@ export function AggregateFlamegraph(props: AggregateFlamegraphProps): ReactEleme
 
     if (renderer === null) {
       Sentry.captureException('Failed to initialize a flamegraph renderer');
+      addErrorMessage('Failed to initialize renderer');
       return null;
     }
 

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -1,4 +1,5 @@
 import {ReactElement, useEffect, useLayoutEffect, useMemo, useState} from 'react';
+import * as Sentry from '@sentry/react';
 import {mat3, vec2} from 'gl-matrix';
 
 import {FlamegraphZoomView} from 'sentry/components/profiling/flamegraph/flamegraphZoomView';
@@ -14,8 +15,10 @@ import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {
   computeConfigViewWithStrategy,
+  initializeFlamegraphRenderer,
   useResizeCanvasObserver,
 } from 'sentry/utils/profiling/gl/utils';
+import {FlamegraphRenderer2D} from 'sentry/utils/profiling/renderers/flamegraphRenderer2D';
 import {FlamegraphRendererWebGL} from 'sentry/utils/profiling/renderers/flamegraphRendererWebGL';
 import {Rect} from 'sentry/utils/profiling/speedscope';
 import {useFlamegraph} from 'sentry/views/profiling/flamegraphProvider';
@@ -169,10 +172,25 @@ export function AggregateFlamegraph(props: AggregateFlamegraphProps): ReactEleme
       return null;
     }
 
-    return new FlamegraphRendererWebGL(flamegraphCanvasRef, flamegraph, flamegraphTheme, {
-      colorCoding,
-      draw_border: true,
-    });
+    const renderer = initializeFlamegraphRenderer(
+      [FlamegraphRendererWebGL, FlamegraphRenderer2D],
+      [
+        flamegraphCanvasRef,
+        flamegraph,
+        flamegraphTheme,
+        {
+          colorCoding,
+          draw_border: true,
+        },
+      ]
+    );
+
+    if (renderer === null) {
+      Sentry.captureException('Failed to initialize a flamegraph renderer');
+      return null;
+    }
+
+    return renderer;
   }, [colorCoding, flamegraph, flamegraphCanvasRef, flamegraphTheme]);
 
   useEffect(() => {

--- a/static/app/components/profiling/flamegraph/differentialFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/differentialFlamegraph.tsx
@@ -1,4 +1,5 @@
 import {ReactElement, useEffect, useLayoutEffect, useMemo, useState} from 'react';
+import * as Sentry from '@sentry/react';
 import {mat3, vec2} from 'gl-matrix';
 
 import {FlamegraphZoomView} from 'sentry/components/profiling/flamegraph/flamegraphZoomView';
@@ -15,8 +16,10 @@ import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {
   computeConfigViewWithStrategy,
+  initializeFlamegraphRenderer,
   useResizeCanvasObserver,
 } from 'sentry/utils/profiling/gl/utils';
+import {FlamegraphRenderer2D} from 'sentry/utils/profiling/renderers/flamegraphRenderer2D';
 import {FlamegraphRendererWebGL} from 'sentry/utils/profiling/renderers/flamegraphRendererWebGL';
 import {Rect} from 'sentry/utils/profiling/speedscope';
 import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
@@ -182,15 +185,25 @@ export function DifferentialFlamegraph(props: DifferentialFlamegraphProps): Reac
       return null;
     }
 
-    return new FlamegraphRendererWebGL(
-      flamegraphCanvasRef,
-      differentialFlamegraph,
-      flamegraphTheme,
-      {
-        colorCoding,
-        draw_border: true,
-      }
+    const renderer = initializeFlamegraphRenderer(
+      [FlamegraphRendererWebGL, FlamegraphRenderer2D],
+      [
+        flamegraphCanvasRef,
+        differentialFlamegraph,
+        flamegraphTheme,
+        {
+          colorCoding,
+          draw_border: true,
+        },
+      ]
     );
+
+    if (renderer === null) {
+      Sentry.captureException('Failed to initialize a flamegraph renderer');
+      return null;
+    }
+
+    return renderer;
   }, [colorCoding, differentialFlamegraph, flamegraphCanvasRef, flamegraphTheme]);
 
   useEffect(() => {

--- a/static/app/components/profiling/flamegraph/differentialFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/differentialFlamegraph.tsx
@@ -2,6 +2,7 @@ import {ReactElement, useEffect, useLayoutEffect, useMemo, useState} from 'react
 import * as Sentry from '@sentry/react';
 import {mat3, vec2} from 'gl-matrix';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {FlamegraphZoomView} from 'sentry/components/profiling/flamegraph/flamegraphZoomView';
 import {defined} from 'sentry/utils';
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
@@ -200,6 +201,7 @@ export function DifferentialFlamegraph(props: DifferentialFlamegraphProps): Reac
 
     if (renderer === null) {
       Sentry.captureException('Failed to initialize a flamegraph renderer');
+      addErrorMessage('Failed to initialize renderer');
       return null;
     }
 

--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -10,6 +10,7 @@ import {
 import * as Sentry from '@sentry/react';
 import {mat3, vec2} from 'gl-matrix';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {ProfileDragDropImport} from 'sentry/components/profiling/flamegraph/flamegraphOverlays/profileDragDropImport';
 import {FlamegraphOptionsMenu} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphOptionsMenu';
 import {FlamegraphSearch} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch';
@@ -1180,6 +1181,7 @@ function Flamegraph(): ReactElement {
 
     if (renderer === null) {
       Sentry.captureException('Failed to initialize a flamegraph renderer');
+      addErrorMessage('Failed to initialize renderer');
       return null;
     }
 

--- a/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {vec2} from 'gl-matrix';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {
   CanvasPoolManager,
   useCanvasScheduler,
@@ -91,6 +92,7 @@ function FlamegraphZoomViewMinimap({
 
     if (renderer === null) {
       Sentry.captureException('Failed to initialize a flamegraph renderer');
+      addErrorMessage('Failed to initialize renderer');
       return null;
     }
 

--- a/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import {vec2} from 'gl-matrix';
 
 import {
@@ -15,7 +16,9 @@ import {
   getConfigSpaceTranslationBetweenVectors,
   getMinimapCanvasCursor,
   getPhysicalSpacePositionFromOffset,
+  initializeFlamegraphRenderer,
 } from 'sentry/utils/profiling/gl/utils';
+import {FlamegraphRenderer2D} from 'sentry/utils/profiling/renderers/flamegraphRenderer2D';
 import {FlamegraphRendererWebGL} from 'sentry/utils/profiling/renderers/flamegraphRendererWebGL';
 import {PositionIndicatorRenderer} from 'sentry/utils/profiling/renderers/positionIndicatorRenderer';
 import {Rect} from 'sentry/utils/profiling/speedscope';
@@ -76,12 +79,22 @@ function FlamegraphZoomViewMinimap({
       return null;
     }
 
-    return new FlamegraphRendererWebGL(
-      flamegraphMiniMapCanvasRef,
-      flamegraph,
-      flamegraphTheme,
-      {colorCoding, draw_border: false}
+    const renderer = initializeFlamegraphRenderer(
+      [FlamegraphRendererWebGL, FlamegraphRenderer2D],
+      [
+        flamegraphMiniMapCanvasRef,
+        flamegraph,
+        flamegraphTheme,
+        {colorCoding, draw_border: false},
+      ]
     );
+
+    if (renderer === null) {
+      Sentry.captureException('Failed to initialize a flamegraph renderer');
+      return null;
+    }
+
+    return renderer;
   }, [flamegraph, flamegraphMiniMapCanvasRef, colorCoding, flamegraphTheme]);
 
   const positionIndicatorRenderer: PositionIndicatorRenderer | null = useMemo(() => {

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -5,7 +5,10 @@ import {mat3, vec2} from 'gl-matrix';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {ColorChannels} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
-import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
+import {
+  FlamegraphRenderer,
+  FlamegraphRendererConstructor,
+} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 
 import {CanvasPoolManager} from '../canvasScheduler';
 import {clamp, colorComponentsToRGBA} from '../colors/utils';
@@ -13,6 +16,22 @@ import {FlamegraphCanvas} from '../flamegraphCanvas';
 import {SpanChartRenderer2D} from '../renderers/spansRenderer';
 import {SpanChartNode} from '../spanChart';
 import {Rect} from '../speedscope';
+
+export function initializeFlamegraphRenderer(
+  renderers: FlamegraphRendererConstructor[],
+  constructorArgs: ConstructorParameters<FlamegraphRendererConstructor>
+): FlamegraphRenderer | null {
+  for (const renderer of renderers) {
+    const r = new renderer(...constructorArgs);
+
+    // A renderer should only fail if the rendering context was unavailable
+    if (r.ctx !== null) {
+      return r;
+    }
+  }
+
+  return null;
+}
 
 export function createShader(
   gl: WebGLRenderingContext,

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -238,9 +238,15 @@ export function transformMatrixBetweenRect(from: Rect, to: Rect): mat3 {
   );
 }
 
-function getContext(canvas: HTMLCanvasElement, context: '2d'): CanvasRenderingContext2D;
-function getContext(canvas: HTMLCanvasElement, context: 'webgl'): WebGLRenderingContext;
-function getContext(canvas: HTMLCanvasElement, context: string): RenderingContext {
+export function getContext(
+  canvas: HTMLCanvasElement,
+  context: '2d'
+): CanvasRenderingContext2D;
+export function getContext(
+  canvas: HTMLCanvasElement,
+  context: 'webgl'
+): WebGLRenderingContext;
+export function getContext(canvas: HTMLCanvasElement, context: string): RenderingContext {
   const ctx =
     context === 'webgl'
       ? canvas.getContext(context, {antialias: false})
@@ -251,9 +257,25 @@ function getContext(canvas: HTMLCanvasElement, context: string): RenderingContex
   return ctx;
 }
 
-// Exported separately as writing export function for each overload as
-// breaks the line width rules and makes it harder to read.
-export {getContext};
+export function safeGetContext(
+  canvas: HTMLCanvasElement,
+  context: '2d'
+): CanvasRenderingContext2D;
+export function safeGetContext(
+  canvas: HTMLCanvasElement,
+  context: 'webgl'
+): WebGLRenderingContext;
+export function safeGetContext(
+  canvas: HTMLCanvasElement,
+  context: string
+): RenderingContext | null {
+  const ctx =
+    context === 'webgl'
+      ? canvas.getContext(context, {antialias: false})
+      : canvas.getContext(context);
+  return ctx;
+}
+
 export const ELLIPSIS = '\u2026';
 export function measureText(string: string, ctx?: CanvasRenderingContext2D): Rect {
   if (!string) {

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -22,10 +22,14 @@ export function initializeFlamegraphRenderer(
   constructorArgs: ConstructorParameters<FlamegraphRendererConstructor>
 ): FlamegraphRenderer | null {
   for (const renderer of renderers) {
-    const r = new renderer(...constructorArgs);
+    let r: FlamegraphRenderer | null = null;
+    try {
+      r = new renderer(...constructorArgs);
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
 
     // A renderer should only fail if the rendering context was unavailable
-    if (r.ctx !== null) {
+    if (r && r.ctx !== null) {
       return r;
     }
   }

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -16,7 +16,17 @@ export const DEFAULT_FLAMEGRAPH_RENDERER_OPTIONS: FlamegraphRendererOptions = {
   draw_border: false,
 };
 
+export interface FlamegraphRendererConstructor {
+  new (
+    canvas: HTMLCanvasElement,
+    flamegraph: Flamegraph,
+    theme: FlamegraphTheme,
+    options?: FlamegraphRendererOptions
+  ): FlamegraphRenderer;
+}
+
 export abstract class FlamegraphRenderer {
+  ctx: CanvasRenderingContext2D | WebGLRenderingContext | null = null;
   canvas: HTMLCanvasElement;
   flamegraph: Flamegraph;
   theme: FlamegraphTheme;

--- a/static/app/utils/profiling/renderers/flamegraphRenderer2D.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer2D.tsx
@@ -1,24 +1,61 @@
 import {mat3} from 'gl-matrix';
 
 import {colorComponentsToRGBA} from 'sentry/utils/profiling/colors/utils';
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {FlamegraphSearch} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch';
+import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
-import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
+import {getContext, resizeCanvasToDisplaySize} from 'sentry/utils/profiling/gl/utils';
+import {
+  DEFAULT_FLAMEGRAPH_RENDERER_OPTIONS,
+  FlamegraphRenderer,
+  FlamegraphRendererOptions,
+} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 import {Rect} from 'sentry/utils/profiling/speedscope';
 
 export class FlamegraphRenderer2D extends FlamegraphRenderer {
+  ctx: CanvasRenderingContext2D | null = null;
+
+  constructor(
+    canvas: HTMLCanvasElement,
+    flamegraph: Flamegraph,
+    theme: FlamegraphTheme,
+    options: FlamegraphRendererOptions = DEFAULT_FLAMEGRAPH_RENDERER_OPTIONS
+  ) {
+    super(canvas, flamegraph, theme, options);
+
+    this.flamegraph = flamegraph;
+    this.theme = theme;
+    this.options = options;
+    this.canvas = canvas;
+
+    this.initCanvasContext();
+  }
+
+  initCanvasContext(): boolean {
+    if (!this.canvas) {
+      throw new Error('Cannot initialize context from null canvas');
+    }
+
+    this.ctx = getContext(this.canvas, '2d');
+    if (!this.ctx) {
+      throw new Error('Could not get canvas 2d context');
+    }
+
+    resizeCanvasToDisplaySize(this.canvas);
+    return true;
+  }
+
   draw(configViewToPhysicalSpace: mat3) {
     if (!this.canvas) {
       throw new Error('No canvas to draw on');
     }
 
-    const context = this.canvas.getContext('2d');
-
-    if (!context) {
-      throw new Error('Could not get canvas 2d context');
+    if (!this.ctx) {
+      throw new Error('No canvas context to draw with');
     }
 
-    context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     const border = window.devicePixelRatio;
 
     const queue: FlamegraphFrame[] = [...this.flamegraph.root.children];
@@ -36,8 +73,8 @@ export class FlamegraphRenderer2D extends FlamegraphRenderer {
         this.colorMap.get(frame.key) ?? this.theme.COLORS.FRAME_GRAYSCALE_COLOR;
       const color = colorComponentsToRGBA(colors);
 
-      context.fillStyle = color;
-      context.fillRect(
+      this.ctx.fillStyle = color;
+      this.ctx.fillRect(
         rect.x + border,
         rect.y + border,
         rect.width - border,

--- a/static/app/utils/profiling/renderers/flamegraphRendererDOM.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRendererDOM.tsx
@@ -19,6 +19,7 @@ function colorComponentsToRgba(color: number[]): string {
 }
 
 export class FlamegraphRendererDOM extends FlamegraphRenderer {
+  ctx: CanvasRenderingContext2D | null = null;
   container: HTMLElement;
 
   constructor(
@@ -28,6 +29,10 @@ export class FlamegraphRendererDOM extends FlamegraphRenderer {
     options: FlamegraphRendererOptions = DEFAULT_FLAMEGRAPH_RENDERER_OPTIONS
   ) {
     super(canvas, flamegraph, theme, options);
+
+    // @ts-expect-error we are mocking the ctx so that
+    // safe renderer initialization does not skip the renderer
+    this.ctx = {};
 
     const newContainer = document.createElement('div');
     canvas.parentElement?.appendChild(newContainer);

--- a/static/app/utils/profiling/renderers/flamegraphRendererWebGL.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRendererWebGL.tsx
@@ -39,7 +39,7 @@ const UNMATCHED_SEARCH_FRAME_ATTRIBUTES: Readonly<Float32Array> = new Float32Arr
 ).fill(0);
 
 export class FlamegraphRendererWebGL extends FlamegraphRenderer {
-  gl: WebGLRenderingContext | null = null;
+  ctx: WebGLRenderingContext | null = null;
   program: WebGLProgram | null = null;
 
   // Vertex and color buffer
@@ -158,25 +158,25 @@ export class FlamegraphRendererWebGL extends FlamegraphRenderer {
       throw new Error('Cannot initialize context from null canvas');
     }
     // Setup webgl canvas context
-    this.gl = safeGetContext(this.canvas, 'webgl');
+    this.ctx = safeGetContext(this.canvas, 'webgl');
 
-    if (!this.gl) {
+    if (!this.ctx) {
       return false;
     }
 
-    this.gl.enable(this.gl.BLEND);
-    this.gl.blendFuncSeparate(
-      this.gl.SRC_ALPHA,
-      this.gl.ONE_MINUS_SRC_ALPHA,
-      this.gl.ONE,
-      this.gl.ONE_MINUS_SRC_ALPHA
+    this.ctx.enable(this.ctx.BLEND);
+    this.ctx.blendFuncSeparate(
+      this.ctx.SRC_ALPHA,
+      this.ctx.ONE_MINUS_SRC_ALPHA,
+      this.ctx.ONE,
+      this.ctx.ONE_MINUS_SRC_ALPHA
     );
     resizeCanvasToDisplaySize(this.canvas);
     return true;
   }
 
   initShaders(): void {
-    if (!this.gl) {
+    if (!this.ctx) {
       return;
     }
 
@@ -194,84 +194,84 @@ export class FlamegraphRendererWebGL extends FlamegraphRenderer {
       a_position: null,
     };
 
-    const vertexShader = createShader(this.gl, this.gl.VERTEX_SHADER, vertex());
+    const vertexShader = createShader(this.ctx, this.ctx.VERTEX_SHADER, vertex());
     const fragmentShader = createShader(
-      this.gl,
-      this.gl.FRAGMENT_SHADER,
+      this.ctx,
+      this.ctx.FRAGMENT_SHADER,
       fragment(this.theme)
     );
 
     // create program
-    this.program = createProgram(this.gl, vertexShader, fragmentShader);
+    this.program = createProgram(this.ctx, vertexShader, fragmentShader);
 
     // initialize uniforms
     for (const uniform in this.uniforms) {
-      this.uniforms[uniform] = getUniform(this.gl, this.program, uniform);
+      this.uniforms[uniform] = getUniform(this.ctx, this.program, uniform);
     }
 
     // initialize and upload search results buffer data
     this.attributes.a_is_search_result = getAttribute(
-      this.gl,
+      this.ctx,
       this.program,
       'a_is_search_result'
     );
-    createAndBindBuffer(this.gl, this.searchResults, this.gl.STATIC_DRAW);
-    pointToAndEnableVertexAttribute(this.gl, this.attributes.a_is_search_result, {
+    createAndBindBuffer(this.ctx, this.searchResults, this.ctx.STATIC_DRAW);
+    pointToAndEnableVertexAttribute(this.ctx, this.attributes.a_is_search_result, {
       size: 1,
-      type: this.gl.FLOAT,
+      type: this.ctx.FLOAT,
       normalized: false,
       stride: 0,
       offset: 0,
     });
 
     // initialize and upload color buffer data
-    this.attributes.a_color = getAttribute(this.gl, this.program, 'a_color');
-    createAndBindBuffer(this.gl, this.colors, this.gl.STATIC_DRAW);
-    pointToAndEnableVertexAttribute(this.gl, this.attributes.a_color, {
+    this.attributes.a_color = getAttribute(this.ctx, this.program, 'a_color');
+    createAndBindBuffer(this.ctx, this.colors, this.ctx.STATIC_DRAW);
+    pointToAndEnableVertexAttribute(this.ctx, this.attributes.a_color, {
       size: 4,
-      type: this.gl.FLOAT,
+      type: this.ctx.FLOAT,
       normalized: false,
       stride: 0,
       offset: 0,
     });
 
     // initialize and upload positions buffer data
-    this.attributes.a_position = getAttribute(this.gl, this.program, 'a_position');
-    createAndBindBuffer(this.gl, this.positions, this.gl.STATIC_DRAW);
-    pointToAndEnableVertexAttribute(this.gl, this.attributes.a_position, {
+    this.attributes.a_position = getAttribute(this.ctx, this.program, 'a_position');
+    createAndBindBuffer(this.ctx, this.positions, this.ctx.STATIC_DRAW);
+    pointToAndEnableVertexAttribute(this.ctx, this.attributes.a_position, {
       size: 2,
-      type: this.gl.FLOAT,
+      type: this.ctx.FLOAT,
       normalized: false,
       stride: 0,
       offset: 0,
     });
 
     // initialize and upload bounds buffer data
-    this.attributes.a_bounds = getAttribute(this.gl, this.program, 'a_bounds');
-    createAndBindBuffer(this.gl, this.bounds, this.gl.STATIC_DRAW);
-    pointToAndEnableVertexAttribute(this.gl, this.attributes.a_bounds, {
+    this.attributes.a_bounds = getAttribute(this.ctx, this.program, 'a_bounds');
+    createAndBindBuffer(this.ctx, this.bounds, this.ctx.STATIC_DRAW);
+    pointToAndEnableVertexAttribute(this.ctx, this.attributes.a_bounds, {
       size: 4,
-      type: this.gl.FLOAT,
+      type: this.ctx.FLOAT,
       normalized: false,
       stride: 0,
       offset: 0,
     });
 
     // Use shader program
-    this.gl.useProgram(this.program);
+    this.ctx.useProgram(this.program);
 
     // Check if we should draw border - order matters here
     // https://stackoverflow.com/questions/60673970/uniform-value-not-stored-if-i-put-the-gluniform1f-call-before-the-render-loop
-    this.gl.uniform1i(this.uniforms.u_draw_border, this.options.draw_border ? 1 : 0);
-    this.gl.uniform1i(this.uniforms.u_grayscale, 0);
+    this.ctx.uniform1i(this.uniforms.u_draw_border, this.options.draw_border ? 1 : 0);
+    this.ctx.uniform1i(this.uniforms.u_grayscale, 0);
   }
 
   setSearchResults(query: string, searchResults: FlamegraphSearch['results']['frames']) {
-    if (!this.program || !this.gl) {
+    if (!this.program || !this.ctx) {
       return;
     }
 
-    this.gl.uniform1i(
+    this.ctx.uniform1i(
       this.uniforms.u_grayscale,
       query.length > 0 || searchResults.size > 0 ? 1 : 0
     );
@@ -281,7 +281,7 @@ export class FlamegraphRendererWebGL extends FlamegraphRenderer {
   private updateSearchResultsBuffer(
     searchResults: FlamegraphSearch['results']['frames']
   ) {
-    if (!this.program || !this.gl) {
+    if (!this.program || !this.ctx) {
       return;
     }
 
@@ -295,14 +295,14 @@ export class FlamegraphRendererWebGL extends FlamegraphRenderer {
     }
 
     this.attributes.a_is_search_result = getAttribute(
-      this.gl,
+      this.ctx,
       this.program,
       'a_is_search_result'
     );
-    createAndBindBuffer(this.gl, this.searchResults, this.gl.STATIC_DRAW);
-    pointToAndEnableVertexAttribute(this.gl, this.attributes.a_is_search_result, {
+    createAndBindBuffer(this.ctx, this.searchResults, this.ctx.STATIC_DRAW);
+    pointToAndEnableVertexAttribute(this.ctx, this.attributes.a_is_search_result, {
       size: 1,
-      type: this.gl.FLOAT,
+      type: this.ctx.FLOAT,
       normalized: false,
       stride: 0,
       offset: 0,
@@ -310,12 +310,12 @@ export class FlamegraphRendererWebGL extends FlamegraphRenderer {
   }
 
   draw(configViewToPhysicalSpace: mat3): void {
-    if (!this.gl) {
+    if (!this.ctx) {
       throw new Error('Uninitialized WebGL context');
     }
 
-    this.gl.clearColor(0, 0, 0, 0);
-    this.gl.clear(this.gl.COLOR_BUFFER_BIT);
+    this.ctx.clearColor(0, 0, 0, 0);
+    this.ctx.clear(this.ctx.COLOR_BUFFER_BIT);
 
     // We have no frames to draw
     if (!this.positions.length || !this.program) {
@@ -323,16 +323,16 @@ export class FlamegraphRendererWebGL extends FlamegraphRenderer {
     }
 
     const projectionMatrix = makeProjectionMatrix(
-      this.gl.canvas.width,
-      this.gl.canvas.height
+      this.ctx.canvas.width,
+      this.ctx.canvas.height
     );
 
     // Projection matrix
-    this.gl.uniformMatrix3fv(this.uniforms.u_projection, false, projectionMatrix);
+    this.ctx.uniformMatrix3fv(this.uniforms.u_projection, false, projectionMatrix);
     // Model to projection
-    this.gl.uniformMatrix3fv(this.uniforms.u_model, false, configViewToPhysicalSpace);
+    this.ctx.uniformMatrix3fv(this.uniforms.u_model, false, configViewToPhysicalSpace);
     // Tell webgl to convert clip space to px
-    this.gl.viewport(0, 0, this.gl.canvas.width, this.gl.canvas.height);
+    this.ctx.viewport(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
 
     const physicalToConfig = mat3.invert(
       CONFIG_TO_PHYSICAL_SPACE,
@@ -340,12 +340,12 @@ export class FlamegraphRendererWebGL extends FlamegraphRenderer {
     );
     const configSpacePixel = PHYSICAL_SPACE_PX.transformRect(physicalToConfig);
 
-    this.gl.uniform2f(
+    this.ctx.uniform2f(
       this.uniforms.u_border_width,
       configSpacePixel.width,
       configSpacePixel.height
     );
 
-    this.gl.drawArrays(this.gl.TRIANGLES, 0, this.frames.length * VERTICES_PER_FRAME);
+    this.ctx.drawArrays(this.ctx.TRIANGLES, 0, this.frames.length * VERTICES_PER_FRAME);
   }
 }

--- a/static/app/utils/profiling/renderers/uiFramesRenderer.tsx
+++ b/static/app/utils/profiling/renderers/uiFramesRenderer.tsx
@@ -29,7 +29,7 @@ class UIFramesRenderer {
   canvas: HTMLCanvasElement | null;
   uiFrames: UIFrames;
 
-  gl: WebGLRenderingContext | null = null;
+  ctx: WebGLRenderingContext | null = null;
   program: WebGLProgram | null = null;
 
   theme: FlamegraphTheme;
@@ -153,24 +153,24 @@ class UIFramesRenderer {
       throw new Error('Cannot initialize context from null canvas');
     }
 
-    this.gl = safeGetContext(this.canvas, 'webgl');
-    if (!this.gl) {
+    this.ctx = safeGetContext(this.canvas, 'webgl');
+    if (!this.ctx) {
       return false;
     }
 
-    this.gl.enable(this.gl.BLEND);
-    this.gl.blendFuncSeparate(
-      this.gl.SRC_ALPHA,
-      this.gl.ONE_MINUS_SRC_ALPHA,
-      this.gl.ONE,
-      this.gl.ONE_MINUS_SRC_ALPHA
+    this.ctx.enable(this.ctx.BLEND);
+    this.ctx.blendFuncSeparate(
+      this.ctx.SRC_ALPHA,
+      this.ctx.ONE_MINUS_SRC_ALPHA,
+      this.ctx.ONE,
+      this.ctx.ONE_MINUS_SRC_ALPHA
     );
     resizeCanvasToDisplaySize(this.canvas);
     return true;
   }
 
   initShaders(): void {
-    if (!this.gl) {
+    if (!this.ctx) {
       throw new Error('Uninitialized WebGL context');
     }
 
@@ -185,56 +185,60 @@ class UIFramesRenderer {
       a_frame_type: null,
     };
 
-    const vertexShader = createShader(this.gl, this.gl.VERTEX_SHADER, uiFramesVertext());
+    const vertexShader = createShader(
+      this.ctx,
+      this.ctx.VERTEX_SHADER,
+      uiFramesVertext()
+    );
     const fragmentShader = createShader(
-      this.gl,
-      this.gl.FRAGMENT_SHADER,
+      this.ctx,
+      this.ctx.FRAGMENT_SHADER,
       uiFramesFragment(this.theme)
     );
 
     // create program
-    this.program = createProgram(this.gl, vertexShader, fragmentShader);
+    this.program = createProgram(this.ctx, vertexShader, fragmentShader);
 
     // initialize uniforms
     for (const uniform in this.uniforms) {
-      this.uniforms[uniform] = getUniform(this.gl, this.program, uniform);
+      this.uniforms[uniform] = getUniform(this.ctx, this.program, uniform);
     }
 
     // initialize and upload frame type information
-    this.attributes.a_frame_type = getAttribute(this.gl, this.program, 'a_frame_type');
-    createAndBindBuffer(this.gl, this.frame_types, this.gl.STATIC_DRAW);
-    pointToAndEnableVertexAttribute(this.gl, this.attributes.a_frame_type, {
+    this.attributes.a_frame_type = getAttribute(this.ctx, this.program, 'a_frame_type');
+    createAndBindBuffer(this.ctx, this.frame_types, this.ctx.STATIC_DRAW);
+    pointToAndEnableVertexAttribute(this.ctx, this.attributes.a_frame_type, {
       size: 1,
-      type: this.gl.FLOAT,
+      type: this.ctx.FLOAT,
       normalized: false,
       stride: 0,
       offset: 0,
     });
 
     // initialize and upload positions buffer data
-    this.attributes.a_position = getAttribute(this.gl, this.program, 'a_position');
-    createAndBindBuffer(this.gl, this.positions, this.gl.STATIC_DRAW);
-    pointToAndEnableVertexAttribute(this.gl, this.attributes.a_position, {
+    this.attributes.a_position = getAttribute(this.ctx, this.program, 'a_position');
+    createAndBindBuffer(this.ctx, this.positions, this.ctx.STATIC_DRAW);
+    pointToAndEnableVertexAttribute(this.ctx, this.attributes.a_position, {
       size: 2,
-      type: this.gl.FLOAT,
+      type: this.ctx.FLOAT,
       normalized: false,
       stride: 0,
       offset: 0,
     });
 
     // initialize and upload bounds buffer data
-    this.attributes.a_bounds = getAttribute(this.gl, this.program, 'a_bounds');
-    createAndBindBuffer(this.gl, this.bounds, this.gl.STATIC_DRAW);
-    pointToAndEnableVertexAttribute(this.gl, this.attributes.a_bounds, {
+    this.attributes.a_bounds = getAttribute(this.ctx, this.program, 'a_bounds');
+    createAndBindBuffer(this.ctx, this.bounds, this.ctx.STATIC_DRAW);
+    pointToAndEnableVertexAttribute(this.ctx, this.attributes.a_bounds, {
       size: 4,
-      type: this.gl.FLOAT,
+      type: this.ctx.FLOAT,
       normalized: false,
       stride: 0,
       offset: 0,
     });
 
     // Use shader program
-    this.gl.useProgram(this.program);
+    this.ctx.useProgram(this.program);
   }
 
   getColorForFrame(type: 'frozen' | 'slow'): [number, number, number, number] {
@@ -282,33 +286,33 @@ class UIFramesRenderer {
   }
 
   draw(configViewToPhysicalSpace: mat3): void {
-    if (!this.gl) {
+    if (!this.ctx) {
       throw new Error('Uninitialized WebGL context');
     }
 
-    this.gl.clearColor(0, 0, 0, 0);
-    this.gl.clear(this.gl.COLOR_BUFFER_BIT);
+    this.ctx.clearColor(0, 0, 0, 0);
+    this.ctx.clear(this.ctx.COLOR_BUFFER_BIT);
 
     // We have no frames to draw
     if (!this.positions.length || !this.program) {
       return;
     }
 
-    this.gl.useProgram(this.program);
+    this.ctx.useProgram(this.program);
 
     const projectionMatrix = makeProjectionMatrix(
-      this.gl.canvas.width,
-      this.gl.canvas.height
+      this.ctx.canvas.width,
+      this.ctx.canvas.height
     );
 
     // Projection matrix
-    this.gl.uniformMatrix3fv(this.uniforms.u_projection, false, projectionMatrix);
+    this.ctx.uniformMatrix3fv(this.uniforms.u_projection, false, projectionMatrix);
 
     // Model to projection
-    this.gl.uniformMatrix3fv(this.uniforms.u_model, false, configViewToPhysicalSpace);
+    this.ctx.uniformMatrix3fv(this.uniforms.u_model, false, configViewToPhysicalSpace);
 
     // Tell webgl to convert clip space to px
-    this.gl.viewport(0, 0, this.gl.canvas.width, this.gl.canvas.height);
+    this.ctx.viewport(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
 
     const physicalToConfig = mat3.invert(
       CONFIG_TO_PHYSICAL_SPACE,
@@ -317,14 +321,14 @@ class UIFramesRenderer {
 
     const configSpacePixel = PHYSICAL_SPACE_PX.transformRect(physicalToConfig);
 
-    this.gl.uniform2f(
+    this.ctx.uniform2f(
       this.uniforms.u_border_width,
       configSpacePixel.width,
       configSpacePixel.height
     );
 
-    this.gl.drawArrays(
-      this.gl.TRIANGLES,
+    this.ctx.drawArrays(
+      this.ctx.TRIANGLES,
       0,
       this.uiFrames.frames.length * VERTICES_PER_FRAME
     );


### PR DESCRIPTION
The profiling UI has currently been unavailable when a WebGL canvas context could not be obtained, this change implements a fallback approach that uses a 2D canvas renderer. The downside of the 2D canvas renderer is that it is much slower than the GL version as we are bottlenecked by the limitation of making 1 draw call per rectangle we are rendering, making this a degraded experience (however still usable for most flamecharts/graphs). 

The 2D renderer is missing draw call optimizations and will currently draw everything regardless of the user fov (I will add this optimization later) and we also need to add a 2D renderer for UI frames (which currently uses GL) to have this work on all platforms.

I am debating whether to add a "your browser does not support WebGL, this is a degraded experience" type banner in the UI. Since users can't really do anything about this besides changing browsers or enabling/disabling security or privacy features (which like to break WebGL on purpose), I am tempted to just transparently fallback to the 2D renderer.

To summarize the next steps
- [ ] add a 2D UI frames renderer and fallback to it the same way as the flamegraph renderer
- [ ] add fov optimization to the 2d canvas renderer
- [ ] possibly add the "degraded experience banner"?
