### PR TITLE
fix(hybrid-cloud): Fix cross-silo access on issue creation

### DIFF
--- a/src/sentry/integrations/jira/actions/form.py
+++ b/src/sentry/integrations/jira/actions/form.py
@@ -5,17 +5,21 @@ from typing import Any
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
-from sentry.models.integrations.integration import Integration
 from sentry.rules.actions import IntegrationNotifyServiceForm
+from sentry.services.hybrid_cloud.integration.service import integration_service
 
 
 class JiraNotifyServiceForm(IntegrationNotifyServiceForm):
+    provider = "jira"
+
     def clean(self) -> dict[str, Any] | None:
         cleaned_data = super().clean()
 
-        integration = cleaned_data.get("integration")
-        try:
-            Integration.objects.get(id=integration)
-        except Integration.DoesNotExist:
+        integration_id = cleaned_data.get("integration")
+        integration = integration_service.get_integration(
+            integration_id=integration_id, provider=self.provider
+        )
+
+        if not integration:
             raise forms.ValidationError(_("Jira integration is a required field."), code="invalid")
         return cleaned_data

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -10,14 +10,17 @@ from sentry.eventstore.models import GroupEvent
 from sentry.integrations import IntegrationInstallation
 from sentry.models.grouplink import GroupLink
 from sentry.models.integrations.external_issue import ExternalIssue
-from sentry.models.integrations.integration import Integration
+from sentry.services.hybrid_cloud.integration.model import RpcIntegration
+from sentry.services.hybrid_cloud.integration.service import integration_service
+from sentry.services.hybrid_cloud.util import region_silo_function
 from sentry.types.rules import RuleFuture
 
 logger = logging.getLogger("sentry.rules")
 
 
+@region_silo_function
 def create_link(
-    integration: Integration,
+    integration: RpcIntegration,
     installation: IntegrationInstallation,
     event: GroupEvent,
     response: Response,
@@ -79,14 +82,13 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
         integration_id = future.kwargs.get("integration_id")
         generate_footer = future.kwargs.get("generate_footer")
 
-        try:
-            integration = Integration.objects.get(
-                id=integration_id,
-                provider=provider,
-                organizationintegration__organization_id=organization.id,
-                status=ObjectStatus.ACTIVE,
-            )
-        except Integration.DoesNotExist:
+        integration = integration_service.get_integration(
+            integration_id=integration_id,
+            provider=provider,
+            organization_id=organization.id,
+            status=ObjectStatus.ACTIVE,
+        )
+        if not integration:
             # Integration removed, rule still active.
             return
 

--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -138,6 +138,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         external_id: str | None = None,
         organization_id: int | None = None,
         organization_integration_id: Optional[int] = None,
+        status: int | None = None,
     ) -> RpcIntegration | None:
         integration_kwargs: Dict[str, Any] = {}
         if integration_id is not None:
@@ -150,7 +151,8 @@ class DatabaseBackedIntegrationService(IntegrationService):
             integration_kwargs["organizationintegration__organization_id"] = organization_id
         if organization_integration_id is not None:
             integration_kwargs["organizationintegration__id"] = organization_integration_id
-
+        if status is not None:
+            integration_kwargs["status"] = status
         if not integration_kwargs:
             return None
 

--- a/src/sentry/services/hybrid_cloud/integration/service.py
+++ b/src/sentry/services/hybrid_cloud/integration/service.py
@@ -92,6 +92,7 @@ class IntegrationService(RpcService):
         external_id: Optional[str] = None,
         organization_id: Optional[int] = None,
         organization_integration_id: Optional[int] = None,
+        status: Optional[int] = None,
     ) -> Optional[RpcIntegration]:
         """
         Returns an RpcIntegration using either the id or a combination of the provider and external_id

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -6,12 +6,13 @@ from sentry.models.integrations.integration import Integration
 from sentry.rules.actions.notify_event import NotifyEventAction
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import assume_test_silo_mode
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba]
 
 
+@region_silo_test(stable=True)
 class ProjectRuleActionsEndpointTest(APITestCase):
     endpoint = "sentry-api-0-project-rule-actions"
     method = "POST"


### PR DESCRIPTION
Fixes [HC-TEST-REGION-PK](https://sentry-st.sentry.io/issues/4587597166/)

This was found to be preventing MS Team actions from being created, but it looked like it also applied to all other issue actions. It wasn't caught by tests since that endpoint wasn't stabilized. I believe only Jira had a bad form that needed to be rewritten, as I've manually checked the other action forms and haven't found any control silo models accessed.

Hopefully this lets us perform actions to integrations properly.