### PR TITLE
fix(perf): Allow `null` size fields in span waterfall

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.spec.tsx
@@ -66,6 +66,31 @@ describe('SpanDetail', function () {
     );
   }
 
+  describe('resource spans', function () {
+    it('shows size fields', function () {
+      render(
+        renderSpanDetail({
+          span: Span({
+            op: 'resource.link',
+            description: 'static.assets/content.js',
+            data: {
+              'http.response_content_length': 132,
+              'http.response_transfer_size': 0,
+              'http.decoded_response_content_length': null,
+            },
+          }),
+        })
+      );
+
+      expect(
+        screen.queryByText('http.decoded_response_content_length')
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('http.response_transfer_size')).toBeInTheDocument();
+      expect(screen.getByText('http.response_content_length')).toBeInTheDocument();
+      expect(screen.getByText('132.0 B')).toBeInTheDocument();
+    });
+  });
+
   describe('db spans', function () {
     it('renders "Similar Span" button but no Query Details button by default', function () {
       render(

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -372,9 +372,12 @@ function SpanDetail(props: Props) {
     );
   }
 
-  function partitionSizes(data) {
+  function partitionSizes(data): {
+    nonSizeKeys: {[key: string]: unknown};
+    sizeKeys: {[key: string]: number};
+  } {
     const sizeKeys = SIZE_DATA_KEYS.reduce((keys, key) => {
-      if (data.hasOwnProperty(key)) {
+      if (data.hasOwnProperty(key) && defined(data[key])) {
         keys[key] = data[key];
       }
       return keys;


### PR DESCRIPTION
Sometimes this happens, and the span waterfall completely crashes.

- Add spec for resource spans
- Check for null or undefined size fields

Fixes JAVASCRIPT-2PCW
