### PR TITLE
fix(hybridcloud) Move async_send_notification out of email queue

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -885,6 +885,7 @@ CELERY_QUEUES_REGION = [
     Queue("incident_snapshots", routing_key="incident_snapshots"),
     Queue("incidents", routing_key="incidents"),
     Queue("merge", routing_key="merge"),
+    Queue("notifications", routing_key="notifications"),
     Queue("options", routing_key="options"),
     Queue("post_process_errors", routing_key="post_process_errors"),
     Queue("post_process_issue_platform", routing_key="post_process_issue_platform"),


### PR DESCRIPTION
The email queue is common between control and region roles. This queue is used by the silo naive MessageBuilder.send_async method to deliver email messages.

The `async_send_notification` task contains queries for region resources, and needs to be moved out of the shared queue so that we don't have silo cross talk once roles are separated.