### PR TITLE
fix(projects) Don't 500 when there are no sdks loaded

### DIFF
--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -4,6 +4,7 @@ from itertools import chain, groupby
 import sentry_sdk
 from django.utils import timezone
 from packaging import version
+from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -114,12 +115,10 @@ class OrganizationSdksEndpoint(OrganizationEndpoint):
     def get(self, request: Request, organization) -> Response:
         try:
             sdks = get_sdk_index()
-
-            if len(sdks) == 0:
-                raise Exception("No SDKs found in index")
-
-            return Response(sdks)
-
         except Exception as e:
             sentry_sdk.capture_exception(e)
             return Response({"detail": "Error occurred while fetching SDKs"}, status=500)
+
+        if len(sdks) == 0:
+            raise NotFound(detail="No SDKs found in index")
+        return Response(sdks)

--- a/tests/sentry/api/endpoints/test_organization_sdk_updates.py
+++ b/tests/sentry/api/endpoints/test_organization_sdk_updates.py
@@ -213,7 +213,8 @@ class OrganizationSdks(APITestCase):
         response = self.get_error_response(self.organization.slug)
 
         assert mocked_sdk_index.call_count == 1
-        assert response.data == {"detail": "Error occurred while fetching SDKs"}
+        assert response.status_code == 404
+        assert response.data == {"detail": "No SDKs found in index"}
 
     @mock.patch(
         "sentry.api.endpoints.organization_sdk_updates.get_sdk_index",
@@ -241,4 +242,5 @@ class OrganizationSdks(APITestCase):
         response = self.get_error_response(self.organization.slug, status_code=500)
 
         assert mocked_sdk_index.call_count == 1
+        assert response.status_code == 500
         assert response.data == {"detail": "Error occurred while fetching SDKs"}


### PR DESCRIPTION
We should return 40x response code for not found errors instead of a 500.
