### PR TITLE
ref: upgrade stripe to 3.1.0

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -186,7 +186,7 @@ sortedcontainers==2.4.0
 soupsieve==2.3.2.post1
 sqlparse==0.4.4
 statsd==3.3
-stripe==2.61.0
+stripe==3.1.0
 structlog==22.1.0
 symbolic==12.7.0
 time-machine==2.13.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -125,7 +125,7 @@ snuba-sdk==2.0.9
 soupsieve==2.3.2.post1
 sqlparse==0.4.4
 statsd==3.3
-stripe==2.61.0
+stripe==3.1.0
 structlog==22.1.0
 symbolic==12.7.0
 toronado==0.1.0

--- a/requirements-getsentry.txt
+++ b/requirements-getsentry.txt
@@ -11,4 +11,4 @@ PlanOut==0.6.0
 pycountry==17.5.14
 pyvat==1.3.15
 reportlab==3.6.13
-stripe==2.61.0
+stripe==3.1.0


### PR DESCRIPTION
this fixes python 3.10 support (vendored broken version of six)

<!-- Describe your PR here. -->