### PR TITLE
feat(replays): Add options automator backed accessibility issues killswitch

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -380,6 +380,12 @@ register(
     default=None,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "organizations:session-replay-accessibility-issues-enabled",
+    type=Bool,
+    default=True,
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Analytics
 register("analytics.backend", default="noop", flags=FLAG_NOSTORE)

--- a/src/sentry/replays/endpoints/project_replay_accessibility_issues.py
+++ b/src/sentry/replays/endpoints/project_replay_accessibility_issues.py
@@ -44,6 +44,9 @@ class ProjectReplayAccessibilityIssuesEndpoint(ProjectEndpoint):
         ):
             return Response(status=404)
 
+        if options.get("organizations:session-replay-accessibility-issues-enabled") is False:
+            return Response(status=404)
+
         try:
             replay_id = str(uuid.UUID(replay_id)).replace("-", "")
         except ValueError:


### PR DESCRIPTION
`organizations:session-replay-accessibility-issues-enabled` can be set to false to disable accessibility issues.

We'll manage rollout with flagr and then remove the flag once we're GA (unless we can manage rollout with options automator?  no idea).

Relates to: https://github.com/getsentry/session-replay-analyzer/issues/22