### PR TITLE
ref: upgrade reportlab to 4.0.7

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -160,7 +160,7 @@ rb==1.10.0
 redis==3.4.1
 redis-py-cluster==2.1.0
 regex==2022.9.13
-reportlab==3.6.13
+reportlab==4.0.7
 requests==2.31.0
 requests-oauthlib==1.2.0
 responses==0.23.1

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -106,7 +106,7 @@ rb==1.10.0
 redis==3.4.1
 redis-py-cluster==2.1.0
 regex==2022.9.13
-reportlab==3.6.13
+reportlab==4.0.7
 requests==2.31.0
 requests-oauthlib==1.2.0
 rfc3339-validator==0.1.2

--- a/requirements-getsentry.txt
+++ b/requirements-getsentry.txt
@@ -10,5 +10,5 @@ Avalara==20.9.0
 PlanOut==0.6.0
 pycountry==17.5.14
 pyvat==1.3.15
-reportlab==3.6.13
+reportlab==4.0.7
 stripe==3.1.0


### PR DESCRIPTION
this is needed for 3.10 support

the changelog and 4.x breaking change is mostly about internals changing that we don't care about (xml library, speedups)