### PR TITLE
fix(hybrid-cloud): Fix MS Teams parser.

### DIFF
--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -178,6 +178,12 @@ class MsTeamsWebhookMixin:
             return None
         return integration_service.get_integration(integration_id=integration_id)
 
+    def can_infer_integration(self, request: HttpRequest) -> bool:
+        return (
+            self.infer_integration_id_from_card_action(request) is not None
+            or self.infer_team_id_from_channel_data(request) is not None
+        )
+
 
 @region_silo_endpoint
 class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -195,7 +195,7 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
     @transaction_start("MsTeamsWebhookEndpoint")
     def post(self, request: HttpRequest) -> HttpResponse:
         # verify_signature will raise the exception corresponding to the error
-        verify_signature(request)
+        self.verify_webhook_request(request)
 
         data = request.data
         conversation_type = data.get("conversation", {}).get("conversationType")
@@ -226,6 +226,9 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
                 return self.handle_personal_member_add(request)
 
         return self.respond(status=204)
+
+    def verify_webhook_request(self, request: HttpRequest) -> bool:
+        return verify_signature(request)
 
     def handle_personal_member_add(self, request: HttpRequest):
         data = request.data

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -150,7 +150,13 @@ class MsTeamsWebhookMixin:
             pass
         return None
 
-    def get_integration_from_payload(self, request: HttpRequest) -> RpcIntegration | None:
+    def get_integration_from_card_action(self, request: HttpRequest) -> RpcIntegration | None:
+        # The bot builds and sends Adaptive Cards to the channel, and in it will include card actions and context.
+        # The context will include the "integrationId".
+        # Whenever a user interacts with the card, MS Teams will send the card action and the context to the bot.
+        # Here we parse the "integrationId" from the context.
+        #
+        # See: https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-actions?tabs=json#actionsubmit
         try:
             data = request.data
             payload = data["value"]["payload"]
@@ -396,7 +402,7 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
         else:
             conversation_id = channel_data["channel"]["id"]
 
-        integration = self.get_integration_from_payload(request)
+        integration = self.get_integration_from_card_action(request)
         if integration is None:
             logger.info(
                 "msteams.action.missing-integration", extra={"integration_id": integration_id}

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -199,9 +199,10 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
 
         data = request.data
         conversation_type = data.get("conversation", {}).get("conversationType")
+        event_type = data["type"]
 
         # only care about conversationUpdate and message
-        if data["type"] == "message":
+        if event_type == "message":
             # the only message events we care about are those which
             # are from a user submitting an option on a card, which
             # will always contain an "payload.actionType" in the data.
@@ -211,7 +212,7 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
                 return self.handle_channel_message(request)
             else:
                 return self.handle_personal_message(request)
-        elif data["type"] == "conversationUpdate":
+        elif event_type == "conversationUpdate":
             channel_data = data["channelData"]
             event = channel_data.get("eventType")
             # TODO: Handle other events

--- a/src/sentry/middleware/integrations/parsers/msteams.py
+++ b/src/sentry/middleware/integrations/parsers/msteams.py
@@ -33,6 +33,9 @@ class MsTeamsRequestParser(BaseRequestParser, MsTeamsWebhookMixin):
         if self.view_class not in self.region_view_classes:
             return self.get_response_from_control_silo()
 
+        if not self.can_infer_integration(self.request):
+            return self.get_response_from_control_silo()
+
         regions = self.get_regions_from_organizations()
         if len(regions) == 0:
             logger.info(f"{self.provider}.no_regions", extra={"path": self.request.path})

--- a/src/sentry/middleware/integrations/parsers/msteams.py
+++ b/src/sentry/middleware/integrations/parsers/msteams.py
@@ -22,7 +22,7 @@ class MsTeamsRequestParser(BaseRequestParser, MsTeamsWebhookMixin):
 
     @control_silo_function
     def get_integration_from_request(self) -> Integration | None:
-        integration = self.get_integration_from_payload(self.request)
+        integration = self.get_integration_from_card_action(self.request)
         if integration is None:
             integration = self.get_integration_from_channel_data(self.request)
         if integration:

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -168,6 +168,7 @@ const patterns: RegExp[] = [
   new RegExp('^extensions/bitbucket/search/[^/]+/[^/]+/$'),
   new RegExp('^extensions/vercel/delete/$'),
   new RegExp('^extensions/vercel/webhook/$'),
+  new RegExp('^extensions/msteams/webhook/$'),
   new RegExp('^extensions/msteams/configure/$'),
   new RegExp('^extensions/msteams/link-identity/[^/]+/$'),
   new RegExp('^extensions/msteams/unlink-identity/[^/]+/$'),

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import responses
 from django.http import HttpResponse
+from django.urls import reverse
 
 from sentry.api.client import ApiClient
 from sentry.integrations.msteams.card_builder.identity import build_linking_card
@@ -82,7 +83,6 @@ class StatusActionTest(APITestCase):
         ignore_input=None,
         assign_input=None,
     ):
-
         replyToId = "12345"
 
         channel_data = {"tenant": {"id": tenant_id}}
@@ -120,7 +120,8 @@ class StatusActionTest(APITestCase):
             "replyToId": replyToId,
         }
 
-        return self.client.post("/extensions/msteams/webhook/", data=payload)
+        webhook_url = reverse("sentry-integration-msteams-webhooks")
+        return self.client.post(webhook_url, data=payload)
 
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_vaue=True)
     @patch("sentry.integrations.msteams.link_identity.sign")


### PR DESCRIPTION
Testing and validating the features of the MS Teams integration resulted in issues at the associated request parser.

I spun up the [MS Teams Bot Framework Emulator](https://github.com/microsoft/BotFramework-Emulator) to understand the kinds of payloads MS Teams will send to the MS Teams webhook endpoint. 

As a result, I've marked MS Teams webhook endpoint to be `@all_silo_endpoint`, since there are code paths that doesn't depend on the Integration/Organization, and can be run at the control silo.

I've adjusted tests, the request parser, and the webhook endpoint to handle these cases. 