### PR TITLE
fix(ddm): Fixes projects and show more in code locations widget

### DIFF
--- a/static/app/views/ddm/codeLocations.tsx
+++ b/static/app/views/ddm/codeLocations.tsx
@@ -6,13 +6,19 @@ import {Button} from 'sentry/components/button';
 import DefaultTitle from 'sentry/components/events/interfaces/frame/defaultTitle';
 import {tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Frame} from 'sentry/types';
+import {Frame, PageFilters} from 'sentry/types';
 import {hasDdmAlertsSupport} from 'sentry/utils/metrics/features';
 import {useMetricsCodeLocations} from 'sentry/utils/metrics/useMetricsCodeLocations';
 import useOrganization from 'sentry/utils/useOrganization';
 
-export function CodeLocations({mri}: {mri: string}) {
-  const {data} = useMetricsCodeLocations(mri);
+export function CodeLocations({
+  mri,
+  projects,
+}: {
+  mri: string;
+  projects?: PageFilters['projects'];
+}) {
+  const {data} = useMetricsCodeLocations(mri, projects);
   const [isExpanded, setIsExpanded] = useState(false);
   const organization = useOrganization();
 
@@ -43,19 +49,21 @@ export function CodeLocations({mri}: {mri: string}) {
             />
           </LeftLineTitle>
         </DefaultLineTitleWrapper>
-        <ToggleButton size="xs" borderless onClick={() => setIsExpanded(curr => !curr)}>
-          {isExpanded
-            ? tn(
-                'Hide %s more code location',
-                'Hide %s more code locations',
-                otherFrames.length
-              )
-            : tn(
-                'Show %s more code location',
-                'Show %s more code locations',
-                otherFrames.length
-              )}
-        </ToggleButton>
+        {otherFrames.length > 0 && (
+          <ToggleButton size="xs" borderless onClick={() => setIsExpanded(curr => !curr)}>
+            {isExpanded
+              ? tn(
+                  'Hide %s more code location',
+                  'Hide %s more code locations',
+                  otherFrames.length
+                )
+              : tn(
+                  'Show %s more code location',
+                  'Show %s more code locations',
+                  otherFrames.length
+                )}
+          </ToggleButton>
+        )}
       </DefaultLine>
       {isExpanded &&
         otherFrames.map(frame => (

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -248,7 +248,7 @@ function MetricWidgetBody({
           setHoveredLegend={focusedSeries ? undefined : setHoveredLegend}
         />
       )}
-      <CodeLocations mri={metricsQuery.mri} />
+      <CodeLocations mri={metricsQuery.mri} projects={projects} />
     </StyledMetricWidgetBody>
   );
 }


### PR DESCRIPTION
Hides `show more code locations` when there are no other code locations and correctly passes projects to code locations hook.