### PR TITLE
chore(feedback): Keep feedback type definitions up to date with what the server sends

### DIFF
--- a/static/app/utils/feedback/types.tsx
+++ b/static/app/utils/feedback/types.tsx
@@ -13,6 +13,10 @@ export type FeedbackIssue = Overwrite<
       name: string;
       title: string;
       value: string;
+      sdk?: {
+        name: string;
+        name_normalized: string;
+      };
       source?: null | string;
     };
     owners: null | unknown;
@@ -32,6 +36,11 @@ export type FeedbackIssueList = Overwrite<
       name: string;
       title: string;
       value: string;
+      sdk?: {
+        name: string;
+        name_normalized: string;
+      };
+      source?: null | string;
     };
     owners: null | unknown;
   }


### PR DESCRIPTION
The server sends something like this in the list response:

<img width="451" alt="SCR-20231127-marw" src="https://github.com/getsentry/sentry/assets/187460/97017ed3-66a7-40e2-8638-e7ab8289a208">


And in the details response:
<img width="581" alt="SCR-20231127-mbcr" src="https://github.com/getsentry/sentry/assets/187460/273718cd-00de-4d7d-8e7a-83d951be5416">
