### PR TITLE
ref: make mock target unambiguous between module and attribute

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_projects_experiment.py
+++ b/tests/sentry/api/endpoints/test_organization_projects_experiment.py
@@ -9,6 +9,7 @@ from sentry.api.endpoints.organization_projects_experiment import (
     OrganizationProjectsExperimentEndpoint,
     fetch_slugifed_email_username,
 )
+from sentry.experiments.manager import ExperimentManager
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
@@ -31,7 +32,7 @@ class OrganizationProjectsExperimentCreateTest(APITestCase):
         self.login_as(user=self.user)
         self.email_username = fetch_slugifed_email_username(self.user.email)
         self.t1 = f"team-{self.email_username}"
-        self.mock_experiment_get = patch("sentry.experiments.manager.get", return_value=1).start()
+        self.mock_experiment_get = patch.object(ExperimentManager, "get", return_value=1).start()
 
     @cached_property
     def path(self):

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -14,6 +14,7 @@ from sentry.models.environment import Environment
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
 from sentry.models.user import User
 from sentry.silo import SiloMode
+from sentry.tasks.integrations.slack.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
@@ -620,7 +621,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         "sentry.integrations.slack.actions.notification.get_channel_id",
         return_value=("#", None, True),
     )
-    @patch("sentry.tasks.integrations.slack.find_channel_id_for_rule.apply_async")
+    @patch.object(find_channel_id_for_rule, "apply_async")
     @patch("sentry.integrations.slack.utils.rule_status.uuid4")
     def test_kicks_off_slack_async_job(
         self,

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -31,6 +31,9 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.services.hybrid_cloud.app import app_service
 from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.silo import SiloMode
+from sentry.tasks.integrations.slack.find_channel_id_for_alert_rule import (
+    find_channel_id_for_alert_rule,
+)
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
@@ -655,7 +658,7 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
         "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
         return_value=("#", None, True),
     )
-    @patch("sentry.tasks.integrations.slack.find_channel_id_for_alert_rule.apply_async")
+    @patch.object(find_channel_id_for_alert_rule, "apply_async")
     @patch("sentry.integrations.slack.utils.rule_status.uuid4")
     def test_kicks_off_slack_async_job(
         self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id
@@ -780,7 +783,7 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
             ]
         }
 
-    @patch("sentry.tasks.integrations.slack.find_channel_id_for_alert_rule.apply_async")
+    @patch.object(find_channel_id_for_alert_rule, "apply_async")
     @patch("sentry.integrations.slack.utils.rule_status.uuid4")
     @responses.activate
     def test_create_slack_alert_with_empty_channel_id(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -24,6 +24,9 @@ from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.silo import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
+from sentry.tasks.integrations.slack.find_channel_id_for_alert_rule import (
+    find_channel_id_for_alert_rule,
+)
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
@@ -556,7 +559,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
         "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
         return_value=("#", None, True),
     )
-    @patch("sentry.tasks.integrations.slack.find_channel_id_for_alert_rule.apply_async")
+    @patch.object(find_channel_id_for_alert_rule, "apply_async")
     @patch("sentry.integrations.slack.utils.rule_status.uuid4")
     def test_kicks_off_slack_async_job(
         self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id
@@ -908,7 +911,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(AlertRuleIndexBase):
         "sentry.integrations.slack.utils.channel.get_channel_id_with_timeout",
         return_value=("#", None, True),
     )
-    @patch("sentry.tasks.integrations.slack.find_channel_id_for_alert_rule.apply_async")
+    @patch.object(find_channel_id_for_alert_rule, "apply_async")
     @patch("sentry.integrations.slack.utils.rule_status.uuid4")
     def test_crash_rate_alerts_kicks_off_slack_async_job(
         self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import responses
 from django.http import HttpResponse
 
+from sentry.api.client import ApiClient
 from sentry.integrations.msteams.card_builder.identity import build_linking_card
 from sentry.integrations.msteams.link_identity import build_linking_url
 from sentry.integrations.msteams.utils import ACTION_TYPE
@@ -200,7 +201,7 @@ class StatusActionTest(APITestCase):
         assert self.group1.get_status() == GroupStatus.IGNORED
 
     @responses.activate
-    @patch("sentry.api.client.put")
+    @patch.object(ApiClient, "put")
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
     def test_ignore_with_params(self, verify, client_put):
         client_put.return_value = HttpResponse(status=200)
@@ -339,7 +340,7 @@ class StatusActionTest(APITestCase):
         assert b"Assign" in responses.calls[0].request.body
 
     @responses.activate
-    @patch("sentry.api.client.put")
+    @patch.object(ApiClient, "put")
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
     def test_resolve_with_params(self, verify, client_put):
         client_put.return_value = HttpResponse(status=200)

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -6,7 +6,7 @@ from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.groupmeta import GroupMeta
 from sentry.models.groupredirect import GroupRedirect
 from sentry.models.userreport import UserReport
-from sentry.similarity import _make_index_backend
+from sentry.similarity import _make_index_backend, features
 from sentry.tasks.merge import merge_groups
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -17,7 +17,7 @@ from sentry.utils import redis
 index = _make_index_backend(redis.clusters.get("default").get_local_client(0))
 
 
-@patch("sentry.similarity.features.index", new=index)
+@patch.object(features, "index", new=index)
 @region_silo_test
 class MergeGroupTest(TestCase, SnubaTestCase):
     @patch("sentry.eventstream.backend")

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -40,7 +40,7 @@ from sentry.utils.dates import to_timestamp
 index = _make_index_backend(redis.clusters.get("default").get_local_client(0))
 
 
-@patch("sentry.similarity.features.index", new=index)
+@patch.object(features, "index", new=index)
 class UnmergeTestCase(TestCase, SnubaTestCase):
     def test_get_fingerprint(self):
         assert (


### PR DESCRIPTION
3.11 prefers the module over the attribute breaking these patches

<!-- Describe your PR here. -->