### PR TITLE
chore(hybrid-cloud): Delete ControlSiloClient

### DIFF
--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Iterable, Mapping
 
-from django.conf import settings
 from django.http import HttpResponse
 from django.http.request import HttpRequest
 from requests import Request
@@ -122,20 +121,3 @@ class RegionSiloClient(BaseSiloClient):
         # Ensure the region is registered
         self.region = get_region_by_name(region.name)
         self.base_url = self.region.address
-
-
-class ControlSiloClient(BaseSiloClient):
-    access_modes = [SiloMode.REGION]
-
-    metrics_prefix = "silo_client.control"
-    log_path = "sentry.silo.client.control"
-    silo_client_name = "control"
-
-    def __init__(self) -> None:
-        super().__init__()
-
-        self.base_url = getattr(settings, "SENTRY_CONTROL_ADDRESS")
-        if not self.base_url:
-            raise AttributeError(
-                "Configure 'SENTRY_CONTROL_ADDRESS' in sentry configuration settings to use the ControlSiloClient"
-            )

--- a/tests/sentry/silo/test_client.py
+++ b/tests/sentry/silo/test_client.py
@@ -4,7 +4,7 @@ from pytest import raises
 
 from sentry.shared_integrations.response.base import BaseApiResponse
 from sentry.silo import SiloMode
-from sentry.silo.client import ControlSiloClient, RegionSiloClient, SiloClientError
+from sentry.silo.client import RegionSiloClient, SiloClientError
 from sentry.silo.util import PROXY_DIRECT_LOCATION_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import TestCase
 from sentry.testutils.region import override_regions
@@ -23,17 +23,11 @@ class SiloClientTest(TestCase):
     @override_settings(SILO_MODE=SiloMode.MONOLITH)
     def test_init_clients_from_monolith(self):
         with raises(SiloClientError):
-            ControlSiloClient()
-
-        with raises(SiloClientError):
             RegionSiloClient(self.region)
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_init_clients_from_control(self):
         with override_regions(self.region_config):
-            with raises(SiloClientError):
-                ControlSiloClient()
-
             with raises(SiloClientError):
                 RegionSiloClient("atlantis")  # type: ignore[arg-type]
 
@@ -50,10 +44,6 @@ class SiloClientTest(TestCase):
     def test_init_clients_from_region(self):
         with raises(SiloClientError):
             RegionSiloClient(self.region)
-
-        client = ControlSiloClient()
-        assert client.base_url is not None
-        assert self.dummy_address in client.base_url
 
     @responses.activate
     @override_settings(SILO_MODE=SiloMode.CONTROL)


### PR DESCRIPTION
The `ControlSiloClient` API client was introduced [a while ago](https://github.com/getsentry/sentry/pull/40544), and hasn't been used since. It's been replaced by [`IntegrationProxyClient`](https://github.com/getsentry/sentry/blob/27718e84d31983ef5620a63da49ac562db9178c7/src/sentry/shared_integrations/client/proxy.py#L62-L70).

So we can just delete `ControlSiloClient`.
