### PR TITLE
fix(hybridcloud) Add timeout to RPC requests

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -671,6 +671,9 @@ SENTRY_REGION_CONFIG: Any = ()
 # Shared secret used to sign cross-region RPC requests.
 RPC_SHARED_SECRET = None
 
+# Timeout for RPC requests between regions
+RPC_TIMEOUT = 5.0
+
 # The protocol, host and port for control silo
 # Usecases include sending requests to the Integration Proxy Endpoint and RPC requests.
 SENTRY_CONTROL_ADDRESS = os.environ.get("SENTRY_CONTROL_ADDRESS", None)

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -584,7 +584,10 @@ class _RemoteSiloCall:
     def _fire_request(self, headers: Mapping[str, str], data: bytes) -> requests.Response:
         # TODO: Performance considerations (persistent connections, pooling, etc.)?
         url = self.address + self.path
-        return requests.post(url, headers=headers, data=data)
+        try:
+            return requests.post(url, headers=headers, data=data, timeout=settings.RPC_TIMEOUT)
+        except requests.Timeout as e:
+            raise self._remote_exception(f"Timeout of {settings.RPC_TIMEOUT} exceeded") from e
 
 
 class RpcAuthenticationSetupException(Exception):


### PR DESCRIPTION
I arbitrarily chose 5 seconds. We'll adapt this in the pre-production environment if necessary, but having a timeout ensure we won't hang indefinitely in workers or until we hit request timeouts in web requests.
