### PR TITLE
feat(open-pr-comments): queue task in webhook

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -14,7 +14,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 
-from sentry import analytics, options
+from sentry import analytics, features, options
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.constants import EXTENSION_LANGUAGE_MAP, ObjectStatus
@@ -40,6 +40,7 @@ from sentry.services.hybrid_cloud.organization.serial import serialize_rpc_organ
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo import SiloMode
+from sentry.tasks.integrations.github.open_pr_comment import open_pr_comment_workflow
 from sentry.utils import json, metrics
 from sentry.utils.json import JSONData
 
@@ -450,6 +451,7 @@ class PullRequestEventWebhook(Webhook):
         title = pull_request["title"]
         body = pull_request["body"]
         user = pull_request["user"]
+        action = event["action"]
 
         """
         The value of the merge_commit_sha attribute changes depending on the
@@ -503,7 +505,7 @@ class PullRequestEventWebhook(Webhook):
 
         author.preload_users()
         try:
-            PullRequest.objects.update_or_create(
+            pr, created = PullRequest.objects.update_or_create(
                 organization_id=organization.id,
                 repository_id=repo.id,
                 key=number,
@@ -515,6 +517,22 @@ class PullRequestEventWebhook(Webhook):
                     "merge_commit_sha": merge_commit_sha,
                 },
             )
+
+            if action == "opened" and created:
+                if not features.has("organizations:integrations-open-pr-comment", organization):
+                    logger.info(
+                        "github.open_pr_comment.flag_missing",
+                        extra={"organization_id": organization.id},
+                    )
+                    return
+
+                metrics.incr("github.open_pr_comment.queue_task")
+                logger.info(
+                    "github.open_pr_comment.queue_task",
+                    extra={"pr_id": pr.id},
+                )
+                open_pr_comment_workflow.delay(pr_id=pr.id)
+
         except IntegrityError:
             pass
 

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -31,6 +31,7 @@ from sentry.tasks.integrations.github.pr_comment import (
     PullRequestIssue,
     create_or_update_comment,
     format_comment_url,
+    get_pr_comment,
 )
 from sentry.templatetags.sentry_helpers import small_count
 from sentry.types.referrer_ids import GITHUB_OPEN_PR_BOT_REFERRER
@@ -363,9 +364,11 @@ def open_pr_comment_workflow(pr_id: int) -> None:
     issue_list: List[Dict[str, Any]] = list(itertools.chain.from_iterable(top_issues_per_file))
     issue_id_list: List[int] = [issue["group_id"] for issue in issue_list]
 
+    pr_comment = get_pr_comment(pr_id, comment_type=CommentType.OPEN_PR)
+
     try:
         create_or_update_comment(
-            pr_comment=None,
+            pr_comment=pr_comment,
             client=client,
             repo=repo,
             pr_key=pull_request.key,

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -148,14 +148,10 @@ def get_comment_contents(issue_list: List[int]) -> List[PullRequestIssue]:
 
 
 def get_pr_comment(pr_id: int, comment_type: int) -> PullRequestComment | None:
-    pr_comment = None
     pr_comment_query = PullRequestComment.objects.filter(
         pull_request__id=pr_id, comment_type=comment_type
     )
-    if pr_comment_query.exists():
-        pr_comment = pr_comment_query[0]
-
-    return pr_comment
+    return pr_comment_query[0] if pr_comment_query.exists() else None
 
 
 def create_or_update_comment(

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -147,6 +147,17 @@ def get_comment_contents(issue_list: List[int]) -> List[PullRequestIssue]:
     ]
 
 
+def get_pr_comment(pr_id: int, comment_type: int) -> PullRequestComment | None:
+    pr_comment = None
+    pr_comment_query = PullRequestComment.objects.filter(
+        pull_request__id=pr_id, comment_type=comment_type
+    )
+    if pr_comment_query.exists():
+        pr_comment = pr_comment_query[0]
+
+    return pr_comment
+
+
 def create_or_update_comment(
     pr_comment: PullRequestComment | None,
     client: GitHubAppsClient,
@@ -213,12 +224,7 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
         logger.info("github.pr_comment.option_missing", extra={"organization_id": org_id})
         return
 
-    pr_comment = None
-    pr_comment_query = PullRequestComment.objects.filter(
-        pull_request__id=pullrequest_id, comment_type=CommentType.MERGED_PR
-    )
-    if pr_comment_query.exists():
-        pr_comment = pr_comment_query[0]
+    pr_comment = get_pr_comment(pr_id=pullrequest_id, comment_type=CommentType.MERGED_PR)
 
     try:
         project = Project.objects.get_from_cache(id=project_id)

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 import responses
+from django.utils import timezone
 
 from sentry.models.group import Group
 from sentry.models.options.organization_option import OrganizationOption
@@ -459,7 +460,7 @@ You modified these files in this pull request and we noticed these issues associ
         )
 
 
-@region_silo_test(stable=True)
+@region_silo_test
 class TestOpenPRCommentWorkflow(GithubCommentTestCase):
     def setUp(self):
         super().setUp()
@@ -519,6 +520,55 @@ class TestOpenPRCommentWorkflow(GithubCommentTestCase):
         assert pull_request_comment_query[0].external_id == 1
         assert pull_request_comment_query[0].comment_type == CommentType.OPEN_PR
         mock_metrics.incr.assert_called_with("github_open_pr_comment.comment_created")
+
+    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_filenames")
+    @patch(
+        "sentry.tasks.integrations.github.open_pr_comment.get_projects_and_filenames_from_source_file"
+    )
+    @patch("sentry.tasks.integrations.github.open_pr_comment.get_top_5_issues_by_count_for_file")
+    @patch("sentry.tasks.integrations.github.open_pr_comment.safe_for_comment", return_value=True)
+    @patch("sentry.tasks.integrations.github.pr_comment.metrics")
+    @responses.activate
+    def test_comment_workflow_comment_exists(
+        self,
+        mock_metrics,
+        mock_safe_for_comment,
+        mock_issues,
+        mock_reverse_codemappings,
+        mock_pr_filenames,
+    ):
+        # two filenames, the second one has a toggle table
+        mock_pr_filenames.return_value = ["foo.py", "bar.py"]
+        mock_reverse_codemappings.return_value = ([self.project], ["foo.py"])
+
+        mock_issues.return_value = self.groups
+
+        now = timezone.now()
+        PullRequestComment.objects.create(
+            external_id=1,
+            pull_request=self.pr,
+            created_at=now,
+            updated_at=now,
+            group_ids=[0, 1],
+            comment_type=CommentType.OPEN_PR,
+        )
+
+        responses.add(
+            responses.PATCH,
+            self.base_url + "/repos/getsentry/sentry/issues/comments/1",
+            json={"id": 1},
+            headers={"X-Ratelimit-Limit": "60", "X-Ratelimit-Remaining": "59"},
+        )
+
+        open_pr_comment_workflow(self.pr.id)
+
+        pull_request_comment_query = PullRequestComment.objects.all()
+        pr_comment = pull_request_comment_query[0]
+        assert len(pull_request_comment_query) == 1
+        assert pr_comment.external_id == 1
+        assert pr_comment.comment_type == CommentType.OPEN_PR
+        assert pr_comment.created_at != pr_comment.updated_at
+        mock_metrics.incr.assert_called_with("github_open_pr_comment.comment_updated")
 
     @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_filenames")
     @patch(


### PR DESCRIPTION
Queue the open PR comment workflow task in the Github webhook if a PR has been opened and a `PullRequest` object was newly created.

This PR also includes a small fix to check for an existing comment in the open PR comment workflow.

For ER-1812