### PR TITLE
feat(hybrid-cloud): Adds user gated region selection feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1422,8 +1422,6 @@ SENTRY_EARLY_FEATURES = {
 SENTRY_FEATURES: dict[str, bool | None] = {
     # Enables user registration.
     "auth:register": True,
-    # Enables region provisioning for individual users
-    "hybrid-cloud:region-provisioning-allow-list": False,
     # Enables alert creation on indexed events in UI (use for PoC/testing only)
     "organizations:alert-allow-indexed": False,
     # Enables transaction to metric dataset migration UI for alert rules
@@ -1934,6 +1932,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:investigation-bias": False,
     # Controls whether or not the relocation endpoints can be used.
     "relocation:enabled": False,
+    # Enables region provisioning for individual users
+    "user:region-provisioning-allow-list": False,
     # Don't add feature defaults down here! Please add them in their associated
     # group sorted alphabetically.
 }

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1422,6 +1422,8 @@ SENTRY_EARLY_FEATURES = {
 SENTRY_FEATURES: dict[str, bool | None] = {
     # Enables user registration.
     "auth:register": True,
+    # Enables region provisioning for individual users
+    "hybrid-cloud:region-provisioning-allow-list": False,
     # Enables alert creation on indexed events in UI (use for PoC/testing only)
     "organizations:alert-allow-indexed": False,
     # Enables transaction to metric dataset migration UI for alert rules

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1897,6 +1897,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:suspect-commits-all-frames": False,
     # Enable logs for debugging weekly reports
     "organizations:weekly-report-logs": False,
+    # Enables region provisioning for individual users
+    "organizations:multi-region-selector": False,
     # Enable data forwarding functionality for projects.
     "projects:data-forwarding": True,
     # Enable functionality to discard groups.
@@ -1932,8 +1934,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:investigation-bias": False,
     # Controls whether or not the relocation endpoints can be used.
     "relocation:enabled": False,
-    # Enables region provisioning for individual users
-    "user:region-provisioning-allow-list": False,
     # Don't add feature defaults down here! Please add them in their associated
     # group sorted alphabetically.
 }

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -63,6 +63,7 @@ register_permanent_features(default_manager)
 default_manager.add("auth:register", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:create", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("relocation:enabled", SystemFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:multi-region-selector", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 
 # Organization scoped features that are in development or in customer trials.
 default_manager.add("organizations:javascript-console-error-tag", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
@@ -287,9 +288,6 @@ default_manager.add("projects:span-metrics-extraction", ProjectFeature, FeatureH
 default_manager.add("projects:span-metrics-extraction-ga-modules", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:span-metrics-extraction-all-modules", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:span-metrics-extraction-resource", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
-
-# User scoped features
-default_manager.add("user:region-provisioning-allow-list", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 
 # Project plugin features
 default_manager.add("projects:plugins", ProjectPluginFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -289,7 +289,7 @@ default_manager.add("projects:span-metrics-extraction-all-modules", ProjectFeatu
 default_manager.add("projects:span-metrics-extraction-resource", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 
 # User scoped features
-default_manager.add("user:region-provisioning-allow-list", SystemFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("user:region-provisioning-allow-list", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 
 # Project plugin features
 default_manager.add("projects:plugins", ProjectPluginFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -63,7 +63,6 @@ register_permanent_features(default_manager)
 default_manager.add("auth:register", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:create", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("relocation:enabled", SystemFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("hybrid-cloud:region-provisioning-allow-list", SystemFeature, FeatureHandlerStrategy.REMOTE)
 
 # Organization scoped features that are in development or in customer trials.
 default_manager.add("organizations:javascript-console-error-tag", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
@@ -288,6 +287,9 @@ default_manager.add("projects:span-metrics-extraction", ProjectFeature, FeatureH
 default_manager.add("projects:span-metrics-extraction-ga-modules", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:span-metrics-extraction-all-modules", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:span-metrics-extraction-resource", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
+
+# User scoped features
+default_manager.add("user:region-provisioning-allow-list", SystemFeature, FeatureHandlerStrategy.REMOTE)
 
 # Project plugin features
 default_manager.add("projects:plugins", ProjectPluginFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -63,6 +63,7 @@ register_permanent_features(default_manager)
 default_manager.add("auth:register", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:create", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("relocation:enabled", SystemFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("hybrid-cloud:region-provisioning-allow-list", SystemFeature, FeatureHandlerStrategy.REMOTE)
 
 # Organization scoped features that are in development or in customer trials.
 default_manager.add("organizations:javascript-console-error-tag", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1466,6 +1466,7 @@ register(
 
 register("hybrid_cloud.outbox_rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("hybrid_cloud.multi-region-selector", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("hybrid_cloud.region-user-allow-list", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Decides whether an incoming transaction triggers an update of the clustering rule applied to it.
 register("txnames.bump-lifetime-sample-rate", default=0.1, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -306,3 +306,12 @@ def find_all_multitenant_region_names() -> List[str]:
         for region in load_global_regions().regions
         if region.category == RegionCategory.MULTI_TENANT
     ]
+
+
+def get_region_display_name(region_name: str) -> str:
+    if region_name == "us":
+        return "🇺🇸 United States of America (US)"
+    if region_name == "de":
+        return "🇪🇺 European Union (EU)"
+
+    return region_name

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -169,7 +169,7 @@ class _ClientConfig:
         ):
             yield "organizations:customer-domains"
         if options.get("hybrid_cloud.multi-region-selector") or features.has(
-            "hybrid-cloud:region-provisioning-allow-list", actor=self.user
+            "user:region-provisioning-allow-list", actor=self.user
         ):
             yield "organizations:multi-region-selector"
 

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -168,8 +168,9 @@ class _ClientConfig:
             self.last_org and features.has("organizations:customer-domains", self.last_org)
         ):
             yield "organizations:customer-domains"
+        # TODO (Gabe): Remove selector option check once GetSentry side lands
         if options.get("hybrid_cloud.multi-region-selector") or features.has(
-            "user:region-provisioning-allow-list", actor=self.user
+            "organizations:multi-region-selector", actor=self.user
         ):
             yield "organizations:multi-region-selector"
 

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -168,7 +168,9 @@ class _ClientConfig:
             self.last_org and features.has("organizations:customer-domains", self.last_org)
         ):
             yield "organizations:customer-domains"
-        if options.get("hybrid_cloud.multi-region-selector"):
+        if options.get("hybrid_cloud.multi-region-selector") or features.has(
+            "hybrid-cloud:region-provisioning-allow-list", actor=self.user
+        ):
             yield "organizations:multi-region-selector"
 
     @property


### PR DESCRIPTION
We are adding a new feature flag that will gate region-selection via a user allow-list in flagr. This adds the feature flag itself and modifies the region selector flag check to include this new feature flag check.

This PR also adds a display name method to region module in order to support an upcoming GetSentry change allowing region selection in our SSO pipeline flow.
