### PR TITLE
ref(ui): Split out modals, prevent api.tsx from importing everything

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -2,9 +2,9 @@ import type {ModalTypes} from 'sentry/components/globalModal';
 import type {CreateNewIntegrationModalOptions} from 'sentry/components/modals/createNewIntegrationModal';
 import type {CreateReleaseIntegrationModalOptions} from 'sentry/components/modals/createReleaseIntegrationModal';
 import type {DashboardWidgetQuerySelectorModalOptions} from 'sentry/components/modals/dashboardWidgetQuerySelectorModal';
-import {InviteRow} from 'sentry/components/modals/inviteMembersModal/types';
+import type {InviteRow} from 'sentry/components/modals/inviteMembersModal/types';
 import type {ReprocessEventModalOptions} from 'sentry/components/modals/reprocessEventModal';
-import {OverwriteWidgetModalProps} from 'sentry/components/modals/widgetBuilder/overwriteWidgetModal';
+import type {OverwriteWidgetModalProps} from 'sentry/components/modals/widgetBuilder/overwriteWidgetModal';
 import type {WidgetViewerModalOptions} from 'sentry/components/modals/widgetViewerModal';
 import ModalStore from 'sentry/stores/modalStore';
 import type {
@@ -18,7 +18,7 @@ import type {
   SentryApp,
   Team,
 } from 'sentry/types';
-import {AppStoreConnectStatusData, CustomRepoType} from 'sentry/types/debugFiles';
+import type {AppStoreConnectStatusData, CustomRepoType} from 'sentry/types/debugFiles';
 
 export type ModalOptions = ModalTypes['options'];
 export type ModalRenderProps = ModalTypes['renderProps'];
@@ -40,14 +40,6 @@ export function closeModal() {
   ModalStore.closeModal();
 }
 
-type OpenSudoModalOptions = {
-  isSuperuser?: boolean;
-  needsReload?: boolean;
-  onClose?: () => void;
-  retryRequest?: () => Promise<any>;
-  sudo?: boolean;
-};
-
 type EmailVerificationModalOptions = {
   actionMessage?: string;
   emailVerified?: boolean;
@@ -59,13 +51,6 @@ type InviteMembersModalOptions = {
   onClose?: () => void;
   source?: string;
 };
-
-export async function openSudo({onClose, ...args}: OpenSudoModalOptions = {}) {
-  const mod = await import('sentry/components/modals/sudoModal');
-  const {default: Modal} = mod;
-
-  openModal(deps => <Modal {...deps} {...args} />, {onClose});
-}
 
 export async function openEmailVerification({
   onClose,
@@ -186,13 +171,6 @@ export async function openTeamAccessRequestModal(options: TeamAccessRequestModal
   const {default: Modal} = mod;
 
   openModal(deps => <Modal {...deps} {...options} />);
-}
-
-export async function redirectToProject(newProjectSlug: string) {
-  const mod = await import('sentry/components/modals/redirectToProject');
-  const {default: Modal} = mod;
-
-  openModal(deps => <Modal {...deps} slug={newProjectSlug} />, {});
 }
 
 type HelpSearchModalOptions = {

--- a/static/app/actionCreators/redirectToProject.tsx
+++ b/static/app/actionCreators/redirectToProject.tsx
@@ -1,0 +1,8 @@
+import ModalStore from 'sentry/stores/modalStore';
+
+export async function redirectToProject(newProjectSlug: string) {
+  const mod = await import('sentry/components/modals/redirectToProject');
+  const {default: Modal} = mod;
+
+  ModalStore.openModal(deps => <Modal {...deps} slug={newProjectSlug} />, {});
+}

--- a/static/app/actionCreators/sudoModal.tsx
+++ b/static/app/actionCreators/sudoModal.tsx
@@ -1,0 +1,16 @@
+import ModalStore from 'sentry/stores/modalStore';
+
+type OpenSudoModalOptions = {
+  isSuperuser?: boolean;
+  needsReload?: boolean;
+  onClose?: () => void;
+  retryRequest?: () => Promise<any>;
+  sudo?: boolean;
+};
+
+export async function openSudo({onClose, ...args}: OpenSudoModalOptions = {}) {
+  const mod = await import('sentry/components/modals/sudoModal');
+  const {default: Modal} = mod;
+
+  ModalStore.openModal(deps => <Modal {...deps} {...args} />, {onClose});
+}

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -3,7 +3,8 @@ import * as Sentry from '@sentry/react';
 import Cookies from 'js-cookie';
 import * as qs from 'query-string';
 
-import {openSudo, redirectToProject} from 'sentry/actionCreators/modal';
+import {redirectToProject} from 'sentry/actionCreators/redirectToProject';
+import {openSudo} from 'sentry/actionCreators/sudoModal';
 import {EXPERIMENTAL_SPA} from 'sentry/constants';
 import {
   PROJECT_MOVED,

--- a/static/app/components/search/sources/commandSource.tsx
+++ b/static/app/components/search/sources/commandSource.tsx
@@ -1,7 +1,8 @@
 import {Component} from 'react';
 import {PlainRoute} from 'react-router';
 
-import {openHelpSearchModal, openSudo} from 'sentry/actionCreators/modal';
+import {openHelpSearchModal} from 'sentry/actionCreators/modal';
+import {openSudo} from 'sentry/actionCreators/sudoModal';
 import Access from 'sentry/components/acl/access';
 import {NODE_ENV, usingCustomerDomain} from 'sentry/constants';
 import {t, toggleLocaleDebug} from 'sentry/locale';

--- a/static/app/stores/modalStore.tsx
+++ b/static/app/stores/modalStore.tsx
@@ -1,6 +1,6 @@
 import {createStore} from 'reflux';
 
-import {ModalOptions, ModalRenderProps} from 'sentry/actionCreators/modal';
+import type {ModalOptions, ModalRenderProps} from 'sentry/actionCreators/modal';
 
 import {CommonStoreDefinition} from './types';
 

--- a/static/app/views/alerts/utils/migrationUi.ts
+++ b/static/app/views/alerts/utils/migrationUi.ts
@@ -2,7 +2,7 @@ import {Organization} from 'sentry/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Dataset, MetricRule} from 'sentry/views/alerts/rules/metric/types';
-import {CombinedMetricIssueAlerts} from 'sentry/views/alerts/types';
+import type {CombinedMetricIssueAlerts} from 'sentry/views/alerts/types';
 
 // TODO(telemetry-experience): remove when the migration is complete
 export const hasMigrationFeatureFlag = (organization: Organization): boolean =>

--- a/static/app/views/organizationContextContainer.spec.tsx
+++ b/static/app/views/organizationContextContainer.spec.tsx
@@ -3,8 +3,8 @@ import {Organization} from 'sentry-fixture/organization';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {openSudo} from 'sentry/actionCreators/modal';
 import * as OrganizationActionCreator from 'sentry/actionCreators/organization';
+import {openSudo} from 'sentry/actionCreators/sudoModal';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';

--- a/static/app/views/organizationContextContainer.spec.tsx
+++ b/static/app/views/organizationContextContainer.spec.tsx
@@ -4,7 +4,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import * as OrganizationActionCreator from 'sentry/actionCreators/organization';
-import {openSudo} from 'sentry/actionCreators/sudoModal';
+import * as openSudo from 'sentry/actionCreators/sudoModal';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -14,9 +14,6 @@ import {OrganizationLegacyContext} from 'sentry/views/organizationContextContain
 
 jest.mock('sentry/stores/configStore', () => ({
   get: jest.fn(),
-}));
-jest.mock('sentry/actionCreators/modal', () => ({
-  openSudo: jest.fn(),
 }));
 
 describe('OrganizationContextContainer', function () {
@@ -156,6 +153,7 @@ describe('OrganizationContextContainer', function () {
   });
 
   it('opens sudo modal for superusers on 403s', async function () {
+    const openSudoSpy = jest.spyOn(openSudo, 'openSudo');
     jest
       .mocked(ConfigStore.get)
       .mockImplementation(() => TestStubs.Config({isSuperuser: true}));
@@ -166,7 +164,7 @@ describe('OrganizationContextContainer', function () {
 
     renderComponent();
 
-    await waitFor(() => expect(openSudo).toHaveBeenCalled());
+    await waitFor(() => expect(openSudoSpy).toHaveBeenCalled());
   });
 
   it('uses last organization from ConfigStore', function () {

--- a/static/app/views/organizationContextContainer.tsx
+++ b/static/app/views/organizationContextContainer.tsx
@@ -3,8 +3,8 @@ import {PlainRoute, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
-import {openSudo} from 'sentry/actionCreators/modal';
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organization';
+import {openSudo} from 'sentry/actionCreators/sudoModal';
 import {Client} from 'sentry/api';
 import {Alert} from 'sentry/components/alert';
 import LoadingError from 'sentry/components/loadingError';


### PR DESCRIPTION
Importing certain files drags in a ton of the app with it. By splitting these two modals out of the modal file we can prevent a lot of the app from being imported from `app/api.tsx`

see the following chain where the file we wanted was `app/chartcuterie/config.tsx` but got tons of components
```
 @ ../node_modules/platformicons/svg/ sync ^\.\/.*\.svg$ ./HTML5.svg
 @ ../node_modules/platformicons/build/index.js 1:4490-4517
 @ ./app/data/forms/projectGeneralSettings.tsx 5:0-45 52:48-60
 @ ./app/data/forms/ sync \.tsx?$ ./projectGeneralSettings.tsx
 @ ./app/actionCreators/formSearch.tsx 33:18-67
 @ ./app/components/search/sources/formSource.tsx 3:0-65 82:4-17
 @ ./app/components/search/index.tsx 11:0-69 110:42-52
 @ ./app/components/modals/commandPalette.tsx
 @ ./app/actionCreators/modal.tsx 103:20-69
 -- > @ ./app/api.tsx 7:0-74 164:2-19 230:6-14
 @ ./app/utils/useApi.tsx
 @ ./app/utils/queryClient.tsx 4:0-41 31:14-20 119:14-20
 @ ./app/views/alerts/utils/migrationUi.ts
 @ ./app/views/alerts/wizard/options.tsx 9:0-85 140:22-50
 @ ./app/views/alerts/rules/metric/details/metricChartOption.tsx 17:0-75 305:16-37
 @ ./app/chartcuterie/metricAlert.tsx 5:0-137 71:8-33 100:8-33 103:22-54
 @ ./app/chartcuterie/config.tsx 13:0-50 32:0-25
```
