### PR TITLE
feat(first-severity-escalation): Add post process step for detecting new escalating issues

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1910,6 +1910,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "projects:first-event-severity-alerting": False,
     # Enable calculating a severity score for events which create a new group
     "projects:first-event-severity-calculation": False,
+    # Enable escalation detection for new issues
+    "projects:first-event-severity-new-escalation": False,
     # Enable functionality for attaching  minidumps to events and displaying
     # then in the group UI.
     "projects:minidump": True,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -280,6 +280,7 @@ default_manager.add("organizations:metric-meta", OrganizationFeature, FeatureHan
 default_manager.add("projects:alert-filters", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:first-event-severity-alerting", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:first-event-severity-calculation", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("projects:first-event-severity-new-escalation", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:minidump", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:race-free-group-creation", ProjectFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("projects:similarity-indexing", ProjectFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1350,9 +1350,11 @@ def detect_new_escalation(job: PostProcessJob):
     """
     from sentry.models.groupinbox import GroupInboxReason, add_group_to_inbox
 
-    if not features.has("projects:first-event-severity-new-escalation", job["event"].project):
-        return
     group = job["event"].group
+    if not group or not features.has(
+        "projects:first-event-severity-new-escalation", job["event"].project
+    ):
+        return
     group_age_hours = (datetime.now() - group.first_seen).total_seconds() / 3600
     if group_age_hours >= MAX_NEW_ESCALATION_AGE_HOURS or group.substatus != GroupSubStatus.NEW:
         return

--- a/tests/sentry/api/endpoints/test_user_notification_email.py
+++ b/tests/sentry/api/endpoints/test_user_notification_email.py
@@ -16,7 +16,7 @@ class UserNotificationEmailTestBase(APITestCase):
         self.login_as(user=self.user)
 
 
-@control_silo_test()
+@control_silo_test
 class UserNotificationEmailGetTest(UserNotificationEmailTestBase):
     def test_populates_useroptions_for_email(self):
         UserEmail.objects.create(user=self.user, email="alias@example.com", is_verified=True).save()

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -58,8 +58,10 @@ from sentry.tasks.merge import merge_groups
 from sentry.tasks.post_process import (
     ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT,
     feedback_filter_decorator,
+    locks,
     post_process_group,
     process_event,
+    run_post_process_job,
 )
 from sentry.testutils.cases import BaseTestCase, PerformanceIssueTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers import with_feature
@@ -1970,6 +1972,89 @@ class ReplayLinkageTestMixin(BasePostProgressGroupMixin):
                 self.assertNotEqual(args, ("post_process.process_replay_link.id_sampled"))
 
 
+class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
+    @patch("sentry.tasks.post_process.run_post_process_job", side_effect=run_post_process_job)
+    def test_has_escalated(self, mock_run_post_process_job):
+        event = self.create_event(data={}, project_id=self.project.id)
+        group = event.group
+        group.first_seen = datetime.now() - timedelta(hours=1)
+        group.times_seen = 10000
+
+        with self.feature("projects:first-event-severity-new-escalation"):
+            self.call_post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                event=event,
+            )
+        job = mock_run_post_process_job.call_args[0][0]
+        assert job["has_escalated"]
+
+    @patch("sentry.tasks.post_process.run_post_process_job", side_effect=run_post_process_job)
+    def test_has_escalated_no_flag(self, mock_run_post_process_job):
+        event = self.create_event(data={}, project_id=self.project.id)
+        group = event.group
+        group.update(first_seen=datetime.now() - timedelta(hours=1), times_seen=10000)
+
+        self.call_post_process_group(
+            is_new=True,
+            is_regression=False,
+            is_new_group_environment=True,
+            event=event,
+        )
+        job = mock_run_post_process_job.call_args[0][0]
+        assert not job["has_escalated"]
+
+    @patch("sentry.tasks.post_process.run_post_process_job", side_effect=run_post_process_job)
+    def test_has_escalated_old(self, mock_run_post_process_job):
+        event = self.create_event(data={}, project_id=self.project.id)
+        group = event.group
+        group.update(first_seen=datetime.now() - timedelta(days=2), times_seen=10000)
+
+        with self.feature("projects:first-event-severity-new-escalation"):
+            self.call_post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                event=event,
+            )
+        job = mock_run_post_process_job.call_args[0][0]
+        assert not job["has_escalated"]
+
+    @patch("sentry.tasks.post_process.run_post_process_job", side_effect=run_post_process_job)
+    def test_has_escalated_low_rate(self, mock_run_post_process_job):
+        event = self.create_event(data={}, project_id=self.project.id)
+        group = event.group
+        group.update(first_seen=datetime.now() - timedelta(hours=1), times_seen=1)
+
+        with self.feature("projects:first-event-severity-new-escalation"):
+            self.call_post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                event=event,
+            )
+        job = mock_run_post_process_job.call_args[0][0]
+        assert not job["has_escalated"]
+
+    @patch("sentry.tasks.post_process.run_post_process_job", side_effect=run_post_process_job)
+    def test_has_escalated_locked(self, mock_run_post_process_job):
+        event = self.create_event(data={}, project_id=self.project.id)
+        group = event.group
+        group.first_seen = datetime.now() - timedelta(hours=1)
+        group.times_seen = 10000
+        lock = locks.get(f"detect_escalation:{group.id}", duration=10, name="detect_escalation")
+        with self.feature("projects:first-event-severity-new-escalation"), lock.acquire():
+            self.call_post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                event=event,
+            )
+        job = mock_run_post_process_job.call_args[0][0]
+        assert not job["has_escalated"]
+
+
 @region_silo_test
 class PostProcessGroupErrorTest(
     TestCase,
@@ -1985,6 +2070,7 @@ class PostProcessGroupErrorTest(
     SnoozeTestSkipSnoozeMixin,
     SDKCrashMonitoringTestMixin,
     ReplayLinkageTestMixin,
+    DetectNewEscalationTestMixin,
 ):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
This adds a `detect_new_escalation` step to post process group for errors. This is feature gated at the moment and so won't run for any customers.

Resolves https://github.com/getsentry/sentry/issues/60413