### PR TITLE
fix(crons): Allow empty timezone in monitor config

### DIFF
--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -129,6 +129,7 @@ class ConfigValidator(serializers.Serializer):
     timezone = serializers.ChoiceField(
         choices=pytz.all_timezones,
         required=False,
+        allow_blank=True,
         help_text="tz database style timezone string",
     )
 
@@ -169,6 +170,10 @@ class ConfigValidator(serializers.Serializer):
             schedule_type = self.instance.get("schedule_type")
         else:
             schedule_type = None
+
+        # Remove blank timezone values
+        if attrs.get("timezone") == "":
+            del attrs["timezone"]
 
         schedule = attrs.get("schedule")
         if not schedule:

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -458,6 +458,23 @@ class MonitorConsumerTest(TestCase):
         )
         assert monitor_environment is not None
 
+    def test_monitor_upsert_empty_timezone(self):
+        self.send_checkin(
+            "my-monitor",
+            monitor_config={
+                "schedule": {"type": "crontab", "value": "13 * * * *"},
+                "timezone": "",
+            },
+            environment="my-environment",
+        )
+
+        checkin = MonitorCheckIn.objects.get(guid=self.guid)
+        assert checkin.status == CheckInStatus.OK
+
+        monitor = Monitor.objects.get(slug="my-monitor")
+        assert monitor is not None
+        assert "timezone" not in monitor.config
+
     def test_monitor_upsert_invalid_slug(self):
         self.send_checkin(
             "some/slug@with-weird|stuff",


### PR DESCRIPTION
Some SDKs are passing through blank timezones. Currently we're failing validation for these monitors, we can instead allow these monitors through but remove the invalid blank timezone. This will default to UTC (likely what they want) for the monitor.