### PR TITLE
ref(devserver): Support https via mkcert for devserver

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -535,7 +535,26 @@ if (
     }
   }
 
+  // Try and load certificates from mkcert if available. Use $ yarn mkcert-localhost
+  const certPath = path.join(__dirname, 'config');
+  const certsAvailable = fs.existsSync(path.join(certPath, 'localhost.pem'));
+
+  // Always use https in dev-ui. For devserver use https if the certificates
+  // have already been generated.
+  const useHttps = IS_UI_DEV_ONLY || certsAvailable;
+
+  const httpsOptions = !certsAvailable
+    ? {}
+    : {
+        key: fs.readFileSync(path.join(certPath, 'localhost-key.pem')),
+        cert: fs.readFileSync(path.join(certPath, 'localhost.pem')),
+      };
+
   appConfig.devServer = {
+    server: {
+      type: useHttps ? 'https' : 'http',
+      options: httpsOptions,
+    },
     headers: {
       'Document-Policy': 'js-profiling',
     },
@@ -645,22 +664,9 @@ if (IS_UI_DEV_ONLY) {
     return slug;
   };
 
-  // Try and load certificates from mkcert if available. Use $ yarn mkcert-localhost
-  const certPath = path.join(__dirname, 'config');
-  const httpsOptions = !fs.existsSync(path.join(certPath, 'localhost.pem'))
-    ? {}
-    : {
-        key: fs.readFileSync(path.join(certPath, 'localhost-key.pem')),
-        cert: fs.readFileSync(path.join(certPath, 'localhost.pem')),
-      };
-
   appConfig.devServer = {
     ...appConfig.devServer,
     compress: true,
-    server: {
-      type: 'https',
-      options: httpsOptions,
-    },
     headers: {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Credentials': 'true',


### PR DESCRIPTION
Prior to this change we would only enable https in dev-ui.

This allows `sentry devserver` to run with https when the localhost certs have been generated using `mkcert`.

For `yarn dev-ui` we will still __always__ use HTTPS, since this is required to talk to the production API.

---

The problem this is solving is for users of both `yarn dev-ui` and `sentry devserver`. We now recommend that `dev.getsentry.net` is used for both ways of running sentry locally. With chrome it will do HSTS pinning for the domain when running `yarn dev-ui`, then when you run `sentry devserver` without SSL it will fail to connect with a HSTS pinning error.

By using HTTPS for both servers this will no longer be a problem.