### PR TITLE
fix(ci): Fix incorrect usage of `control_silo_test`

### DIFF
--- a/tests/sentry/api/endpoints/test_user_notification_email.py
+++ b/tests/sentry/api/endpoints/test_user_notification_email.py
@@ -16,7 +16,7 @@ class UserNotificationEmailTestBase(APITestCase):
         self.login_as(user=self.user)
 
 
-@control_silo_test(stable=True)
+@control_silo_test
 class UserNotificationEmailGetTest(UserNotificationEmailTestBase):
     def test_populates_useroptions_for_email(self):
         UserEmail.objects.create(user=self.user, email="alias@example.com", is_verified=True).save()


### PR DESCRIPTION
Incorrect merge passes the `stable` parameter to this decorator, just putting up a quick fix to unbreak ci
