### PR TITLE
fix(metrics): Pass stacklevel through all backends

### DIFF
--- a/src/sentry/metrics/base.py
+++ b/src/sentry/metrics/base.py
@@ -39,6 +39,7 @@ class MetricsBackend(local):
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         raise NotImplementedError
 
@@ -49,6 +50,7 @@ class MetricsBackend(local):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        stacklevel: int = 0,
     ) -> None:
         raise NotImplementedError
 
@@ -60,6 +62,7 @@ class MetricsBackend(local):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         raise NotImplementedError
 
@@ -71,5 +74,6 @@ class MetricsBackend(local):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         raise NotImplementedError

--- a/src/sentry/metrics/datadog.py
+++ b/src/sentry/metrics/datadog.py
@@ -42,6 +42,7 @@ class DatadogMetricsBackend(MetricsBackend):
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         tags = dict(tags or ())
 
@@ -62,6 +63,7 @@ class DatadogMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        stacklevel: int = 0,
     ) -> None:
         tags = dict(tags or ())
 
@@ -83,6 +85,7 @@ class DatadogMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         tags = dict(tags or ())
 
@@ -104,6 +107,7 @@ class DatadogMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         # We keep the same implementation for Datadog.
         self.timing(key, value, instance, tags, sample_rate)

--- a/src/sentry/metrics/dogstatsd.py
+++ b/src/sentry/metrics/dogstatsd.py
@@ -22,6 +22,7 @@ class DogStatsdMetricsBackend(MetricsBackend):
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         tags = dict(tags or ())
 
@@ -40,6 +41,7 @@ class DogStatsdMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        stacklevel: int = 0,
     ) -> None:
         tags = dict(tags or ())
 
@@ -59,6 +61,7 @@ class DogStatsdMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         tags = dict(tags or ())
 
@@ -78,6 +81,7 @@ class DogStatsdMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         # We keep the same implementation for Datadog.
         self.timing(key, value, instance, tags, sample_rate)

--- a/src/sentry/metrics/dummy.py
+++ b/src/sentry/metrics/dummy.py
@@ -14,6 +14,7 @@ class DummyMetricsBackend(MetricsBackend):
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         pass
 
@@ -24,6 +25,7 @@ class DummyMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        stacklevel: int = 0,
     ) -> None:
         pass
 
@@ -35,6 +37,7 @@ class DummyMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         pass
 
@@ -46,5 +49,6 @@ class DummyMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         pass

--- a/src/sentry/metrics/logging.py
+++ b/src/sentry/metrics/logging.py
@@ -15,6 +15,7 @@ class LoggingBackend(MetricsBackend):
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         logger.debug("%r: %+g", key, amount, extra={"instance": instance, "tags": tags or {}})
 
@@ -25,6 +26,7 @@ class LoggingBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        stacklevel: int = 0,
     ) -> None:
         logger.debug(
             "%r: %g ms", key, value * 1000, extra={"instance": instance, "tags": tags or {}}
@@ -38,6 +40,7 @@ class LoggingBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         logger.debug("%r: %+g", key, value, extra={"instance": instance, "tags": tags or {}})
 
@@ -49,5 +52,6 @@ class LoggingBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         logger.debug("%r: %+g", key, value, extra={"instance": instance, "tags": tags or {}})

--- a/src/sentry/metrics/middleware.py
+++ b/src/sentry/metrics/middleware.py
@@ -125,13 +125,16 @@ class MiddlewareWrapper(MetricsBackend):
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         current_tags = get_current_global_tags()
         if tags is not None:
             current_tags.update(tags)
         current_tags = _filter_tags(key, current_tags)
 
-        return self.inner.incr(key, instance, current_tags, amount, sample_rate, unit)
+        return self.inner.incr(
+            key, instance, current_tags, amount, sample_rate, unit, stacklevel + 1
+        )
 
     def timing(
         self,
@@ -140,13 +143,14 @@ class MiddlewareWrapper(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        stacklevel: int = 0,
     ) -> None:
         current_tags = get_current_global_tags()
         if tags is not None:
             current_tags.update(tags)
         current_tags = _filter_tags(key, current_tags)
 
-        return self.inner.timing(key, value, instance, current_tags, sample_rate)
+        return self.inner.timing(key, value, instance, current_tags, sample_rate, stacklevel + 1)
 
     def gauge(
         self,
@@ -156,13 +160,16 @@ class MiddlewareWrapper(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         current_tags = get_current_global_tags()
         if tags is not None:
             current_tags.update(tags)
         current_tags = _filter_tags(key, current_tags)
 
-        return self.inner.gauge(key, value, instance, current_tags, sample_rate, unit)
+        return self.inner.gauge(
+            key, value, instance, current_tags, sample_rate, unit, stacklevel + 1
+        )
 
     def distribution(
         self,
@@ -172,10 +179,13 @@ class MiddlewareWrapper(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         current_tags = get_current_global_tags()
         if tags is not None:
             current_tags.update(tags)
         current_tags = _filter_tags(key, current_tags)
 
-        return self.inner.distribution(key, value, instance, current_tags, sample_rate, unit)
+        return self.inner.distribution(
+            key, value, instance, current_tags, sample_rate, unit, stacklevel + 1
+        )

--- a/src/sentry/metrics/statsd.py
+++ b/src/sentry/metrics/statsd.py
@@ -25,6 +25,7 @@ class StatsdMetricsBackend(MetricsBackend):
         amount: Union[float, int] = 1,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         self.client.incr(self._full_key(self._get_key(key)), amount, sample_rate)
 
@@ -35,6 +36,7 @@ class StatsdMetricsBackend(MetricsBackend):
         instance: Optional[str] = None,
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
+        stacklevel: int = 0,
     ) -> None:
         self.client.timing(self._full_key(self._get_key(key)), value, sample_rate)
 
@@ -46,6 +48,7 @@ class StatsdMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         self.client.gauge(self._full_key(self._get_key(key)), value, sample_rate)
 
@@ -57,5 +60,6 @@ class StatsdMetricsBackend(MetricsBackend):
         tags: Optional[Tags] = None,
         sample_rate: float = 1,
         unit: Optional[str] = None,
+        stacklevel: int = 0,
     ) -> None:
         self.timing(key, value, instance, tags, sample_rate)

--- a/src/sentry/utils/arroyo.py
+++ b/src/sentry/utils/arroyo.py
@@ -48,17 +48,46 @@ class MetricsWrapper(Metrics):
             return {**self.__tags, **tags}
 
     def increment(
-        self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float] = 1,
+        tags: Optional[Tags] = None,
+        stacklevel: int = 0,
     ) -> None:
         # sentry metrics backend uses `incr` instead of `increment`
-        self.__backend.incr(key=self.__merge_name(name), amount=value, tags=self.__merge_tags(tags))
+        self.__backend.incr(
+            key=self.__merge_name(name),
+            amount=value,
+            tags=self.__merge_tags(tags),
+            stacklevel=stacklevel + 1,
+        )
 
-    def gauge(self, name: str, value: Union[int, float], tags: Optional[Tags] = None) -> None:
-        self.__backend.gauge(key=self.__merge_name(name), value=value, tags=self.__merge_tags(tags))
+    def gauge(
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        stacklevel: int = 0,
+    ) -> None:
+        self.__backend.gauge(
+            key=self.__merge_name(name),
+            value=value,
+            tags=self.__merge_tags(tags),
+            stacklevel=stacklevel + 1,
+        )
 
-    def timing(self, name: str, value: Union[int, float], tags: Optional[Tags] = None) -> None:
+    def timing(
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+        stacklevel: int = 0,
+    ) -> None:
         self.__backend.timing(
-            key=self.__merge_name(name), value=value, tags=self.__merge_tags(tags)
+            key=self.__merge_name(name),
+            value=value,
+            tags=self.__merge_tags(tags),
+            stacklevel=stacklevel + 1,
         )
 
 
@@ -110,7 +139,6 @@ class RunTaskWithMultiprocessing(ArroyoRunTaskWithMultiprocessing[TStrategyPaylo
         initializer: Optional[Callable[[], None]] = None,
         **kwargs: Any,
     ) -> RunTaskWithMultiprocessing:
-
         from django.conf import settings
 
         if settings.KAFKA_CONSUMER_FORCE_DISABLE_MULTIPROCESSING:

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -204,7 +204,8 @@ def timer(
     else:
         current_tags["result"] = "success"
     finally:
-        timing(key, time.monotonic() - start, instance, current_tags, sample_rate, stacklevel + 1)
+        # stacklevel must be increased by 2 because of the contextmanager indirection
+        timing(key, time.monotonic() - start, instance, current_tags, sample_rate, stacklevel + 2)
 
 
 def wraps(

--- a/src/sentry/utils/redis_metrics.py
+++ b/src/sentry/utils/redis_metrics.py
@@ -31,14 +31,40 @@ class RedisToolsMetricsBackend(Metrics):
             return {**self.__tags, **tags}
 
     def increment(
-        self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
+        self,
+        name: str,
+        value: Union[int, float] = 1,
+        tags: Optional[Tags] = None,
     ) -> None:
-        self.__backend.incr(key=self.__merge_name(name), amount=value, tags=self.__merge_tags(tags))
+        self.__backend.incr(
+            key=self.__merge_name(name),
+            amount=value,
+            tags=self.__merge_tags(tags),
+            stacklevel=1,
+        )
 
-    def gauge(self, name: str, value: Union[int, float], tags: Optional[Tags] = None) -> None:
-        self.__backend.gauge(key=self.__merge_name(name), value=value, tags=self.__merge_tags(tags))
+    def gauge(
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+    ) -> None:
+        self.__backend.gauge(
+            key=self.__merge_name(name),
+            value=value,
+            tags=self.__merge_tags(tags),
+            stacklevel=1,
+        )
 
-    def timing(self, name: str, value: Union[int, float], tags: Optional[Tags] = None) -> None:
+    def timing(
+        self,
+        name: str,
+        value: Union[int, float],
+        tags: Optional[Tags] = None,
+    ) -> None:
         self.__backend.timing(
-            key=self.__merge_name(name), value=value, tags=self.__merge_tags(tags)
+            key=self.__merge_name(name),
+            value=value,
+            tags=self.__merge_tags(tags),
+            stacklevel=1,
         )


### PR DESCRIPTION
Adds an optional `stacklevel` argument to the base `MetricsBackend` class and all implementations. This allows users of the `sentry.utils.metrics` abstraction to specify their own stack offset for code locations in DDM. 

This also fixes wrong code locations reported through the metrics middleware that is used in Sentry to inject common tags.

There is no subclass in `getsentry`.