### PR TITLE
ref(feature): support single feature signature

### DIFF
--- a/static/app/components/acl/feature.spec.tsx
+++ b/static/app/components/acl/feature.spec.tsx
@@ -62,7 +62,7 @@ describe('Feature', function () {
     });
 
     it('has no features', function () {
-      render(<Feature features={['org-baz']}>{childrenMock}</Feature>, {
+      render(<Feature features="org-baz">{childrenMock}</Feature>, {
         context: routerContext,
       });
 
@@ -78,7 +78,7 @@ describe('Feature', function () {
     it('calls render function when no features', function () {
       const noFeatureRenderer = jest.fn(() => null);
       render(
-        <Feature features={['org-baz']} renderDisabled={noFeatureRenderer}>
+        <Feature features="org-baz" renderDisabled={noFeatureRenderer}>
           {childrenMock}
         </Feature>,
         {context: routerContext}
@@ -97,7 +97,7 @@ describe('Feature', function () {
     it('can specify org from props', function () {
       const customOrg = Organization({features: ['org-bazar']});
       render(
-        <Feature organization={customOrg} features={['org-bazar']}>
+        <Feature organization={customOrg} features="org-bazar">
           {childrenMock}
         </Feature>,
         {context: routerContext}
@@ -115,7 +115,7 @@ describe('Feature', function () {
     it('can specify project from props', function () {
       const customProject = TestStubs.Project({features: ['project-baz']});
       render(
-        <Feature project={customProject} features={['project-baz']}>
+        <Feature project={customProject} features="project-baz">
           {childrenMock}
         </Feature>,
         {context: routerContext}
@@ -148,7 +148,7 @@ describe('Feature', function () {
     });
 
     it('handles features prefixed with org/project', function () {
-      render(<Feature features={['organizations:org-bar']}>{childrenMock}</Feature>, {
+      render(<Feature features="organizations:org-bar">{childrenMock}</Feature>, {
         context: routerContext,
       });
 
@@ -160,7 +160,7 @@ describe('Feature', function () {
         renderDisabled: false,
       });
 
-      render(<Feature features={['projects:bar']}>{childrenMock}</Feature>, {
+      render(<Feature features="projects:bar">{childrenMock}</Feature>, {
         context: routerContext,
       });
 
@@ -178,7 +178,7 @@ describe('Feature', function () {
         features: new Set(['organizations:create']),
       });
 
-      render(<Feature features={['organizations:create']}>{childrenMock}</Feature>, {
+      render(<Feature features="organizations:create">{childrenMock}</Feature>, {
         context: routerContext,
       });
 
@@ -195,7 +195,7 @@ describe('Feature', function () {
   describe('no children', function () {
     it('should display renderDisabled with no feature', function () {
       render(
-        <Feature features={['nope']} renderDisabled={() => <span>disabled</span>}>
+        <Feature features="nope" renderDisabled={() => <span>disabled</span>}>
           <div>The Child</div>
         </Feature>,
         {context: routerContext}
@@ -205,7 +205,7 @@ describe('Feature', function () {
 
     it('should display be empty when on', function () {
       render(
-        <Feature features={['org-bar']} renderDisabled={() => <span>disabled</span>}>
+        <Feature features="org-bar" renderDisabled={() => <span>disabled</span>}>
           <div>The Child</div>
         </Feature>,
         {context: routerContext}
@@ -217,7 +217,7 @@ describe('Feature', function () {
   describe('as React node', function () {
     it('has features', function () {
       render(
-        <Feature features={['org-bar']}>
+        <Feature features="org-bar">
           <div>The Child</div>
         </Feature>,
         {context: routerContext}
@@ -228,7 +228,7 @@ describe('Feature', function () {
 
     it('has no features', function () {
       render(
-        <Feature features={['org-baz']}>
+        <Feature features="org-baz">
           <div>The Child</div>
         </Feature>,
         {context: routerContext}
@@ -239,7 +239,7 @@ describe('Feature', function () {
 
     it('renders a default disabled component', function () {
       render(
-        <Feature features={['org-baz']} renderDisabled>
+        <Feature features="org-baz" renderDisabled>
           <div>The Child</div>
         </Feature>,
         {context: routerContext}
@@ -253,7 +253,7 @@ describe('Feature', function () {
       const noFeatureRenderer = jest.fn(() => null);
       const children = <div>The Child</div>;
       render(
-        <Feature features={['org-baz']} renderDisabled={noFeatureRenderer}>
+        <Feature features="org-baz" renderDisabled={noFeatureRenderer}>
           {children}
         </Feature>,
         {context: routerContext}
@@ -286,7 +286,7 @@ describe('Feature', function () {
     it('uses hookName if provided', function () {
       const children = <div>The Child</div>;
       render(
-        <Feature features={['org-bazar']} hookName="feature-disabled:sso-basic">
+        <Feature features="org-bazar" hookName="feature-disabled:sso-basic">
           {children}
         </Feature>,
         {context: routerContext}

--- a/static/app/components/acl/feature.tsx
+++ b/static/app/components/acl/feature.tsx
@@ -10,6 +10,8 @@ import withProject from 'sentry/utils/withProject';
 
 import ComingSoon from './comingSoon';
 
+const renderComingSoon = () => <ComingSoon />;
+
 type Props = {
   /**
    * If children is a function then will be treated as a render prop and
@@ -167,7 +169,7 @@ class Feature extends Component<Props> {
         ? false
         : typeof renderDisabled === 'function'
         ? renderDisabled
-        : () => <ComingSoon />;
+        : renderComingSoon;
 
     // Override the renderDisabled function with a hook store function if there
     // is one registered for the feature.

--- a/static/app/components/acl/featureDisabled.spec.tsx
+++ b/static/app/components/acl/featureDisabled.spec.tsx
@@ -5,8 +5,19 @@ import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 describe('FeatureDisabled', function () {
   it('renders', function () {
     render(
+      <FeatureDisabled features="organization:my-features" featureName="Some Feature" />
+    );
+
+    expect(
+      screen.getByText('This feature is not enabled on your Sentry installation.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Help')).toBeInTheDocument();
+  });
+
+  it('supports a list of disabled features', function () {
+    render(
       <FeatureDisabled
-        features={['organization:my-features']}
+        features={['organization:my-features', 'organization:other-feature']}
         featureName="Some Feature"
       />
     );
@@ -22,7 +33,7 @@ describe('FeatureDisabled', function () {
     render(
       <FeatureDisabled
         message={customMessage}
-        features={['organization:my-features']}
+        features="organization:my-features"
         featureName="Some Feature"
       />
     );
@@ -35,7 +46,7 @@ describe('FeatureDisabled', function () {
     render(
       <FeatureDisabled
         alert={customAlert}
-        features={['organization:my-features']}
+        features="organization:my-features"
         featureName="Some Feature"
       />
     );
@@ -46,7 +57,7 @@ describe('FeatureDisabled', function () {
     render(
       <FeatureDisabled
         alert
-        features={['organization:my-features']}
+        features="organization:my-features"
         featureName="Some Feature"
       />
     );

--- a/static/app/components/acl/featureDisabled.tsx
+++ b/static/app/components/acl/featureDisabled.tsx
@@ -11,10 +11,13 @@ import {space} from 'sentry/styles/space';
 import {selectText} from 'sentry/utils/selectText';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 
-const installText = (features: string[], featureName: string): string =>
-  `# ${t('Enables the %s feature', featureName)}\n${features
+const installText = (features: Props['features'], featureName: string): string => {
+  const featuresList = Array.isArray(features) ? features : [features];
+
+  return `# ${t('Enables the %s feature', featureName)}\n${featuresList
     .map(f => `SENTRY_FEATURES['${f}'] = True`)
     .join('\n')}`;
+};
 
 type Props = {
   /**
@@ -26,7 +29,7 @@ type Props = {
    * The feature flag keys that should be displayed in the code example for
    * enabling the feature.
    */
-  features: string[];
+  features: string | string[];
   /**
    * Render the disabled message within a warning Alert. A custom Alert
    * component may be provided.

--- a/static/app/components/acl/featureDisabledModal.spec.tsx
+++ b/static/app/components/acl/featureDisabledModal.spec.tsx
@@ -20,7 +20,7 @@ describe('FeatureTourModal', function () {
         closeModal={onCloseModal}
         CloseButton={() => <button>Close</button>}
         featureName="Default Feature"
-        features={['organization:test-feature']}
+        features="organization:test-feature"
         {...props}
       />
     );

--- a/static/app/components/acl/featureDisabledModal.tsx
+++ b/static/app/components/acl/featureDisabledModal.tsx
@@ -7,7 +7,7 @@ import {t} from 'sentry/locale';
 
 type Props = ModalRenderProps & {
   featureName: string;
-  features: string[];
+  features: string | string[];
   message?: string;
 };
 

--- a/static/app/components/dataExport.tsx
+++ b/static/app/components/dataExport.tsx
@@ -105,7 +105,7 @@ function DataExport({
   }, [payload.queryInfo, payload.queryType, organization.slug, api]);
 
   return (
-    <Feature features={['organizations:discover-query']}>
+    <Feature features="organizations:discover-query">
       {inProgress ? (
         <Button
           size="sm"

--- a/static/app/components/discover/discoverFeature.tsx
+++ b/static/app/components/discover/discoverFeature.tsx
@@ -32,7 +32,7 @@ function DiscoverFeature({children}: Props) {
   return (
     <Feature
       hookName="feature-disabled:open-discover"
-      features={['organizations:discover-basic']}
+      features="organizations:discover-basic"
       renderDisabled={renderDisabled}
     >
       {({hasFeature}) => children({hasFeature})}

--- a/static/app/components/dynamicSampling/investigationRule.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.tsx
@@ -277,7 +277,7 @@ function InvestigationRuleCreationInternal(props: PropsInternal) {
 export function InvestigationRuleCreation(props: Props) {
   const organization = useOrganization();
   return (
-    <Feature features={['investigation-bias']}>
+    <Feature features="investigation-bias">
       <InvestigationRuleCreationInternal {...props} organization={organization} />
     </Feature>
   );

--- a/static/app/components/events/contexts/profile/index.tsx
+++ b/static/app/components/events/contexts/profile/index.tsx
@@ -26,7 +26,7 @@ export function ProfileEventContext({event, data}: ProfileContextProps) {
   const meta = event._meta?.contexts?.profile ?? {};
 
   return (
-    <Feature organization={organization} features={['profiling']}>
+    <Feature organization={organization} features="profiling">
       <ErrorBoundary mini>
         <KeyValueList
           data={getKnownData<ProfileContext, ProfileContextKey>({

--- a/static/app/components/modals/debugFileCustomRepository/index.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/index.tsx
@@ -84,7 +84,7 @@ function DebugFileCustomRepository({
 
   if (sourceType === CustomRepoType.APP_STORE_CONNECT) {
     return (
-      <Feature organization={organization} features={['app-store-connect-multiple']}>
+      <Feature organization={organization} features="app-store-connect-multiple">
         {({hasFeature, features}) => {
           if (
             hasFeature ||
@@ -123,7 +123,7 @@ function DebugFileCustomRepository({
   }
 
   return (
-    <Feature organization={organization} features={['custom-symbol-sources']}>
+    <Feature organization={organization} features="custom-symbol-sources">
       {({hasFeature, features}) => {
         if (hasFeature) {
           if (sourceType === CustomRepoType.HTTP) {

--- a/static/app/components/organizations/projectPageFilter/index.tsx
+++ b/static/app/components/organizations/projectPageFilter/index.tsx
@@ -427,7 +427,7 @@ function checkboxWrapper(
 ) {
   return (
     <Feature
-      features={['organizations:global-views']}
+      features="organizations:global-views"
       hookName="feature-disabled:project-selector-checkbox"
       renderDisabled={props => (
         <Hovercard

--- a/static/app/components/organizations/projectPageFilter/menuFooter.tsx
+++ b/static/app/components/organizations/projectPageFilter/menuFooter.tsx
@@ -31,7 +31,7 @@ function ProjectPageFilterMenuFooter({
     <Fragment>
       <Feature
         organization={organization}
-        features={['organizations:global-views']}
+        features="organizations:global-views"
         hookName="feature-disabled:project-selector-all-projects"
         renderDisabled={false}
       >

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -109,8 +109,7 @@ function useOpenOnboardingSidebar(organization?: Organization) {
   }, [openOnboardingSidebar]);
 }
 
-function Sidebar({organization}: Props) {
-  const location = useLocation();
+function Sidebar({location, organization}: Props) {
   const config = useLegacyStore(ConfigStore);
   const preferences = useLegacyStore(PreferencesStore);
   const activePanel = useLegacyStore(SidebarPanelStore);

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useContext, useEffect} from 'react';
+import {Fragment, useCallback, useContext, useEffect} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -109,7 +109,8 @@ function useOpenOnboardingSidebar(organization?: Organization) {
   }, [openOnboardingSidebar]);
 }
 
-function Sidebar({location, organization}: Props) {
+function Sidebar({organization}: Props) {
+  const location = useLocation();
   const config = useLegacyStore(ConfigStore);
   const preferences = useLegacyStore(PreferencesStore);
   const activePanel = useLegacyStore(SidebarPanelStore);
@@ -119,10 +120,13 @@ function Sidebar({location, organization}: Props) {
 
   useOpenOnboardingSidebar();
 
-  const toggleCollapse = () => {
-    const action = collapsed ? showSidebar : hideSidebar;
-    action();
-  };
+  const toggleCollapse = useCallback(() => {
+    if (collapsed) {
+      showSidebar();
+    } else {
+      hideSidebar();
+    }
+  }, [collapsed]);
 
   // Close panel on any navigation
   useEffect(() => void hidePanel(), [location?.pathname]);
@@ -200,7 +204,7 @@ function Sidebar({location, organization}: Props) {
   const discover2 = hasOrganization && (
     <Feature
       hookName="feature-disabled:discover2-sidebar-item"
-      features={['discover-basic']}
+      features="discover-basic"
       organization={organization}
     >
       <SidebarItem
@@ -216,7 +220,7 @@ function Sidebar({location, organization}: Props) {
   const performance = hasOrganization && (
     <Feature
       hookName="feature-disabled:performance-sidebar-item"
-      features={['performance-view']}
+      features="performance-view"
       organization={organization}
     >
       {(() => {
@@ -234,10 +238,7 @@ function Sidebar({location, organization}: Props) {
               to={`/organizations/${organization.slug}/performance/`}
               id="performance"
             >
-              <Feature
-                features={['performance-database-view']}
-                organization={organization}
-              >
+              <Feature features="performance-database-view" organization={organization}>
                 <SidebarItem
                   {...sidebarItemProps}
                   label={
@@ -252,10 +253,7 @@ function Sidebar({location, organization}: Props) {
                   icon={<SubitemDot collapsed />}
                 />
               </Feature>
-              <Feature
-                features={['starfish-browser-webvitals']}
-                organization={organization}
-              >
+              <Feature features="starfish-browser-webvitals" organization={organization}>
                 <SidebarItem
                   {...sidebarItemProps}
                   isAlpha={WEBVITALS_RELEASE_LEVEL === 'alpha'}
@@ -271,10 +269,7 @@ function Sidebar({location, organization}: Props) {
                   icon={<SubitemDot collapsed />}
                 />
               </Feature>
-              <Feature
-                features={['performance-screens-view']}
-                organization={organization}
-              >
+              <Feature features="performance-screens-view" organization={organization}>
                 <SidebarItem
                   {...sidebarItemProps}
                   isAlpha={SCREENS_RELEASE_LEVEL === 'alpha'}
@@ -286,7 +281,7 @@ function Sidebar({location, organization}: Props) {
                   icon={<SubitemDot collapsed />}
                 />
               </Feature>
-              <Feature features={['starfish-browser-resource-module-ui']}>
+              <Feature features="starfish-browser-resource-module-ui">
                 <SidebarItem
                   {...sidebarItemProps}
                   isNew
@@ -317,7 +312,7 @@ function Sidebar({location, organization}: Props) {
   const starfish = hasOrganization && (
     <Feature
       hookName="feature-disabled:starfish-view"
-      features={['starfish-view']}
+      features="starfish-view"
       organization={organization}
     >
       <SidebarAccordion
@@ -358,7 +353,7 @@ function Sidebar({location, organization}: Props) {
   );
 
   const userFeedback = hasOrganization && (
-    <Feature features={['old-user-feedback']} organization={organization}>
+    <Feature features="old-user-feedback" organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
         icon={<IconSupport />}
@@ -370,7 +365,7 @@ function Sidebar({location, organization}: Props) {
   );
 
   const feedback = hasOrganization && (
-    <Feature features={['user-feedback-ui']} organization={organization}>
+    <Feature features="user-feedback-ui" organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
         icon={<IconMegaphone />}
@@ -394,7 +389,7 @@ function Sidebar({location, organization}: Props) {
   );
 
   const monitors = hasOrganization && (
-    <Feature features={['monitors']} organization={organization}>
+    <Feature features="monitors" organization={organization}>
       <SidebarItem
         {...sidebarItemProps}
         icon={<IconTimer />}
@@ -409,7 +404,7 @@ function Sidebar({location, organization}: Props) {
   const replays = hasOrganization && (
     <Feature
       hookName="feature-disabled:replay-sidebar-item"
-      features={['session-replay-ui']}
+      features="session-replay-ui"
       organization={organization}
       requireAll={false}
     >
@@ -461,7 +456,7 @@ function Sidebar({location, organization}: Props) {
   const profiling = hasOrganization && (
     <Feature
       hookName="feature-disabled:profiling-sidebar-item"
-      features={['profiling']}
+      features="profiling"
       organization={organization}
       requireAll={false}
     >

--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -130,7 +130,7 @@ export default class AdminSettings extends DeprecatedAsyncView<{}, State> {
             {fields['beacon.anonymous']}
           </Panel>
 
-          <Feature features={['organizations:performance-issues-dev']}>
+          <Feature features="organizations:performance-issues-dev">
             <Panel>
               <PanelHeader>Performance Issues - All</PanelHeader>
               {fields['performance.issues.all.problem-detection']}
@@ -219,7 +219,7 @@ export default class AdminSettings extends DeprecatedAsyncView<{}, State> {
               {fields['profile.issues.blocked_main_thread-ppg.ga-rollout']}
             </Panel>
           </Feature>
-          <Feature features={['organizations:view-hierarchies-options-dev']}>
+          <Feature features="organizations:view-hierarchies-options-dev">
             <Panel>
               <PanelHeader>View Hierarchy</PanelHeader>
             </Panel>

--- a/static/app/views/alerts/list/incidents/index.tsx
+++ b/static/app/views/alerts/list/incidents/index.tsx
@@ -307,7 +307,7 @@ function IncidentsListContainer(props: Props) {
 
   return (
     <Feature
-      features={['incidents']}
+      features="incidents"
       hookName="feature-disabled:alerts-page"
       renderDisabled={renderDisabled}
     >

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -226,7 +226,7 @@ class MetricChart extends PureComponent<Props, State> {
           </Fragment>
         </StyledInlineContainer>
         {!isSessionAggregate(rule.aggregate) && (
-          <Feature features={['discover-basic']}>
+          <Feature features="discover-basic">
             <Button size="sm" {...props}>
               {buttonText}
             </Button>

--- a/static/app/views/alerts/rules/metric/details/relatedIssuesNotAvailable.tsx
+++ b/static/app/views/alerts/rules/metric/details/relatedIssuesNotAvailable.tsx
@@ -23,7 +23,7 @@ export function RelatedIssuesNotAvailable({buttonTo, buttonText}: Props) {
       type="info"
       showIcon
       trailingItems={
-        <Feature features={['discover-basic']}>
+        <Feature features="discover-basic">
           <Button priority="default" size="xs" to={buttonTo}>
             {buttonText}
           </Button>

--- a/static/app/views/alerts/rules/metric/thresholdTypeForm.tsx
+++ b/static/app/views/alerts/rules/metric/thresholdTypeForm.tsx
@@ -35,7 +35,7 @@ function ThresholdTypeForm({
   }
 
   return (
-    <Feature features={['organizations:change-alerts']} organization={organization}>
+    <Feature features="organizations:change-alerts" organization={organization}>
       <FormRow>
         <StyledRadioGroup
           disabled={disabled}

--- a/static/app/views/alerts/rules/metric/triggers/thresholdControl.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/thresholdControl.tsx
@@ -196,7 +196,7 @@ class ThresholdControl extends Component<Props, State> {
           )}
         </Container>
         {!hideControl && (
-          <Feature features={['metric-alert-threshold-period']}>
+          <Feature features="metric-alert-threshold-period">
             <SelectContainer>
               <SelectControl
                 isDisabled={disabled}

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -130,7 +130,7 @@ function Controls({
       <DashboardEditFeature>
         {hasFeature => (
           <Fragment>
-            <Feature features={['dashboards-import']}>
+            <Feature features="dashboards-import">
               <Button
                 data-test-id="dashboard-export"
                 onClick={e => {
@@ -211,7 +211,7 @@ function DashboardEditFeature({
   return (
     <Feature
       hookName="feature-disabled:dashboards-edit"
-      features={['organizations:dashboards-edit']}
+      features="organizations:dashboards-edit"
       renderDisabled={renderDisabled}
     >
       {({hasFeature}) => children(hasFeature)}

--- a/static/app/views/dashboards/create.tsx
+++ b/static/app/views/dashboards/create.tsx
@@ -46,7 +46,7 @@ function CreateDashboard(props: Props) {
 
   return (
     <Feature
-      features={['dashboards-edit']}
+      features="dashboards-edit"
       organization={props.organization}
       renderDisabled={renderDisabled}
     >

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -285,7 +285,7 @@ class ManageDashboards extends DeprecatedAsyncView<Props, State> {
     return (
       <Feature
         organization={organization}
-        features={['dashboards-edit']}
+        features="dashboards-edit"
         renderDisabled={this.renderNoAccess}
       >
         <SentryDocumentTitle title={t('Dashboards')} orgSlug={organization.slug}>
@@ -325,7 +325,7 @@ class ManageDashboards extends DeprecatedAsyncView<Props, State> {
                     >
                       {t('Create Dashboard')}
                     </Button>
-                    <Feature features={['dashboards-import']}>
+                    <Feature features="dashboards-import">
                       <Button
                         onClick={() => {
                           openImportDashboardFromFileModal({

--- a/static/app/views/dashboards/view.tsx
+++ b/static/app/views/dashboards/view.tsx
@@ -114,7 +114,7 @@ export function DashboardBasicFeature({organization, children}: FeatureProps) {
   return (
     <Feature
       hookName="feature-disabled:dashboards-page"
-      features={['organizations:dashboards-basic']}
+      features="organizations:dashboards-basic"
       organization={organization}
       renderDisabled={renderDisabled}
     >

--- a/static/app/views/dashboards/widgetBuilder/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/index.tsx
@@ -14,7 +14,7 @@ function WidgetBuilderContainer(props: WidgetBuilderProps) {
 
   return (
     <Feature
-      features={['dashboards-edit']}
+      features="dashboards-edit"
       organization={organization}
       renderDisabled={() => (
         <Layout.Page withPadding>

--- a/static/app/views/discover/eventDetails/content.tsx
+++ b/static/app/views/discover/eventDetails/content.tsx
@@ -194,7 +194,7 @@ class EventDetailsContent extends DeprecatedAsyncComponent<Props, State> {
                 <TransactionToProfileButton projectSlug={this.projectId} />
               )}
               {transactionSummaryTarget && (
-                <Feature organization={organization} features={['performance-view']}>
+                <Feature organization={organization} features="performance-view">
                   {({hasFeature}) => (
                     <Button
                       size="sm"

--- a/static/app/views/discover/index.tsx
+++ b/static/app/views/discover/index.tsx
@@ -22,7 +22,7 @@ function DiscoverContainer({organization, children}: Props) {
 
   return (
     <Feature
-      features={['discover-basic']}
+      features="discover-basic"
       organization={organization}
       hookName="feature-disabled:discover2-page"
       renderDisabled={renderNoAccess}

--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -269,7 +269,7 @@ class DiscoverLanding extends DeprecatedAsyncComponent<Props, State> {
     return (
       <Feature
         organization={organization}
-        features={['discover-query']}
+        features="discover-query"
         renderDisabled={this.renderNoAccess}
       >
         <SentryDocumentTitle title={t('Discover')} orgSlug={organization.slug}>

--- a/static/app/views/discover/queryList.tsx
+++ b/static/app/views/discover/queryList.tsx
@@ -211,7 +211,7 @@ class QueryList extends Component<Props> {
             });
           }}
           renderContextMenu={() => (
-            <Feature organization={organization} features={['dashboards-edit']}>
+            <Feature organization={organization} features="dashboards-edit">
               {({hasFeature}) => {
                 return hasFeature && this.renderDropdownMenu(menuItems);
               }}
@@ -313,7 +313,7 @@ class QueryList extends Component<Props> {
             />
           )}
           renderContextMenu={() => (
-            <Feature organization={organization} features={['dashboards-edit']}>
+            <Feature organization={organization} features="dashboards-edit">
               {({hasFeature}) => this.renderDropdownMenu(menuItems(hasFeature))}
             </Feature>
           )}

--- a/static/app/views/discover/resultsHeader.tsx
+++ b/static/app/views/discover/resultsHeader.tsx
@@ -158,7 +158,7 @@ class ResultsHeader extends Component<Props, State> {
             </GuideAnchor>
           ) : (
             <Fragment>
-              <Feature features={['organizations:discover-query']}>
+              <Feature features="organizations:discover-query">
                 <DiscoverBreadcrumb
                   eventView={eventView}
                   organization={organization}

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -509,7 +509,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
     return (
       <Feature
         organization={organization}
-        features={['discover-query']}
+        features="discover-query"
         hookName="feature-disabled:discover-saved-query-create"
         renderDisabled={renderDisabled}
       >
@@ -575,7 +575,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
       <ResponsiveButtonBar gap={1}>
         {this.renderQueryButton(disabled => this.renderSaveAsHomepage(disabled))}
         {this.renderQueryButton(disabled => this.renderButtonSave(disabled))}
-        <Feature organization={organization} features={['incidents']}>
+        <Feature organization={organization} features="incidents">
           {({hasFeature}) => hasFeature && this.renderButtonCreateAlert()}
         </Feature>
 

--- a/static/app/views/discover/table/tableActions.tsx
+++ b/static/app/views/discover/table/tableActions.tsx
@@ -44,7 +44,7 @@ function renderDownloadButton(canEdit: boolean, props: Props) {
   const {tableData} = props;
   return (
     <Feature
-      features={['organizations:discover-query']}
+      features="organizations:discover-query"
       renderDisabled={() => renderBrowserExportButton(canEdit, props)}
     >
       {tableData?.data && tableData.data.length < 50

--- a/static/app/views/feedback/index.tsx
+++ b/static/app/views/feedback/index.tsx
@@ -17,7 +17,7 @@ export default function FeedbackContainer({children}: Props) {
 
   return (
     <Feature
-      features={['user-feedback-ui']}
+      features="user-feedback-ui"
       organization={organization}
       renderDisabled={NoAccess}
     >

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -276,7 +276,7 @@ export function Actions(props: Props) {
 
     return (
       <Feature
-        features={['projects:discard-groups']}
+        features="projects:discard-groups"
         hookName="feature-disabled:discard-groups"
         organization={organization}
         project={project}
@@ -473,7 +473,7 @@ export function Actions(props: Props) {
       {discoverCap.enabled && (
         <Feature
           hookName="feature-disabled:open-in-discover"
-          features={['discover-basic']}
+          features="discover-basic"
           organization={organization}
         >
           <ActionButton

--- a/static/app/views/issueDetails/groupEventAttachments/index.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/index.tsx
@@ -16,7 +16,7 @@ type Props = RouteComponentProps<{groupId: string}, {}> & {
 function GroupEventAttachmentsContainer({organization, group}: Props) {
   return (
     <Feature
-      features={['event-attachments']}
+      features="event-attachments"
       organization={organization}
       renderDisabled={props => (
         <FeatureDisabled {...props} featureName={t('Event Attachments')} />

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -221,10 +221,7 @@ function ProfilingDurationRegressionIssueDetailsContent({
         <ErrorBoundary mini>
           <EventFunctionBreakpointChart event={event} />
         </ErrorBoundary>
-        <Feature
-          features={['profiling-differential-flamegraph']}
-          organization={organization}
-        >
+        <Feature features="profiling-differential-flamegraph" organization={organization}>
           <ErrorBoundary mini>
             <EventDifferenialFlamegraph event={event} />
           </ErrorBoundary>

--- a/static/app/views/issueDetails/groupReplays/index.tsx
+++ b/static/app/views/issueDetails/groupReplays/index.tsx
@@ -23,7 +23,7 @@ function GroupReplaysContainer(props: Props) {
 
   return (
     <Feature
-      features={['session-replay']}
+      features="session-replay"
       organization={organization}
       renderDisabled={renderNoAccess}
     >

--- a/static/app/views/issueDetails/groupSimilarIssues/index.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/index.tsx
@@ -6,7 +6,7 @@ type Props = React.ComponentProps<typeof SimilarStackTrace>;
 
 function GroupSimilarIssues({project, ...props}: Props) {
   return (
-    <Feature features={['similarity-view']} project={project}>
+    <Feature features="similarity-view" project={project}>
       <SimilarStackTrace project={project} {...props} />
     </Feature>
   );

--- a/static/app/views/monitors/index.tsx
+++ b/static/app/views/monitors/index.tsx
@@ -7,7 +7,7 @@ function MonitorsContainer({children}: {children?: React.ReactNode}) {
   const organization = useOrganization();
 
   return (
-    <Feature features={['monitors']} renderDisabled>
+    <Feature features="monitors" renderDisabled>
       <NoProjectMessage organization={organization}>
         <PageFiltersContainer>{children}</PageFiltersContainer>
       </NoProjectMessage>

--- a/static/app/views/organizationStats/teamInsights/index.tsx
+++ b/static/app/views/organizationStats/teamInsights/index.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 function TeamInsightsContainer({children, organization}: Props) {
   return (
-    <Feature organization={organization} features={['team-insights']}>
+    <Feature organization={organization} features="team-insights">
       <NoProjectMessage organization={organization}>
         {children && isValidElement(children)
           ? cloneElement<any>(children, {

--- a/static/app/views/performance/database/modulePageProviders.tsx
+++ b/static/app/views/performance/database/modulePageProviders.tsx
@@ -21,7 +21,7 @@ export function ModulePageProviders({title, children, baseURL}: Props) {
         <SentryDocumentTitle title={title} orgSlug={organization.slug}>
           <Layout.Page>
             <Feature
-              features={['performance-database-view']}
+              features="performance-database-view"
               organization={organization}
               renderDisabled={NoAccess}
             >

--- a/static/app/views/performance/index.tsx
+++ b/static/app/views/performance/index.tsx
@@ -31,7 +31,7 @@ function PerformanceContainer({organization, location, children}: Props) {
   return (
     <Feature
       hookName="feature-disabled:performance-page"
-      features={['performance-view']}
+      features="performance-view"
       organization={organization}
       renderDisabled={renderNoAccess}
     >

--- a/static/app/views/performance/transactionSummary/aggregateSpanWaterfall/index.tsx
+++ b/static/app/views/performance/transactionSummary/aggregateSpanWaterfall/index.tsx
@@ -30,7 +30,7 @@ function AggregateSpanWaterfall(): React.ReactElement {
   const httpMethod = decodeScalar(location.query['http.method']);
   return (
     <Feature
-      features={['starfish-aggregate-span-waterfall']}
+      features="starfish-aggregate-span-waterfall"
       organization={organization}
       renderDisabled={renderNoAccess}
     >

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -143,7 +143,7 @@ function TransactionHeader({
       </Layout.HeaderContent>
       <Layout.HeaderActions>
         <ButtonBar gap={1}>
-          <Feature organization={organization} features={['incidents']}>
+          <Feature organization={organization} features="incidents">
             {({hasFeature}) =>
               hasFeature && !metricsCardinality?.isLoading ? (
                 <CreateAlertFromViewButton

--- a/static/app/views/performance/transactionSummary/transactionOverview/metricEvents/metricsEventsDropdown.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/metricEvents/metricsEventsDropdown.tsx
@@ -48,7 +48,7 @@ function getOptions(mepContext: MetricsEnhancedSettingContext): MetricsEventsOpt
 
 export function MetricsEventsDropdown() {
   return (
-    <Feature features={['performance-use-metrics']}>
+    <Feature features="performance-use-metrics">
       <InnerDropdown />
     </Feature>
   );

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.tsx
@@ -19,7 +19,7 @@ function TransactionReplaysContainer() {
 
   return (
     <Feature
-      features={['session-replay']}
+      features="session-replay"
       organization={organization}
       renderDisabled={renderNoAccess}
     >

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/chart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/chart.tsx
@@ -65,7 +65,7 @@ function Chart(props: Props) {
   return (
     <Panel>
       <ChartContainer>
-        <Feature features={['performance-span-histogram-view']}>
+        <Feature features="performance-span-histogram-view">
           {({hasFeature}) => {
             if (hasFeature) {
               if (display === DisplayModes.TIMESERIES) {
@@ -77,7 +77,7 @@ function Chart(props: Props) {
           }}
         </Feature>
       </ChartContainer>
-      <Feature features={['performance-span-histogram-view']}>
+      <Feature features="performance-span-histogram-view">
         <ChartControls>
           <InlineContainer>
             <SectionHeading>{t('Total Events')}</SectionHeading>

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -179,7 +179,7 @@ function SpanDetailsContent(props: ContentProps) {
 
   return (
     <Fragment>
-      <Feature features={['performance-span-histogram-view']}>
+      <Feature features="performance-span-histogram-view">
         <SpanDetailsControls
           organization={organization}
           location={location}

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.tsx
@@ -45,7 +45,7 @@ export default function SpanDetails(props: Props) {
       projectSlug={project?.slug}
     >
       <Feature
-        features={['performance-view']}
+        features="performance-view"
         organization={organization}
         renderDisabled={NoAccess}
       >

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -544,7 +544,7 @@ function TrendsListItem(props: TrendsListItemProps) {
           <ValueDelta {...props} />
         </ItemTransactionStatus>
       </ListItemContainer>
-      <Feature features={['performance-change-explorer']}>
+      <Feature features="performance-change-explorer">
         <PerformanceChangeExplorer
           collapsed={openedTransaction === null}
           onClose={() => setOpenedTransaction(null)}

--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -317,7 +317,7 @@ class TrendsContent extends Component<Props, State> {
                   )}
                 />
               </ListContainer>
-              <Feature features={['organizations:performance-trendsv2-dev-only']}>
+              <Feature features="organizations:performance-trendsv2-dev-only">
                 <ListContainer>
                   <ChangedTransactions
                     trendChangeType={TrendChangeType.IMPROVED}

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -267,7 +267,7 @@ function VitalDetailContent(props: Props) {
         <Layout.HeaderActions>
           <ButtonBar gap={1}>
             {renderVitalSwitcher()}
-            <Feature organization={organization} features={['incidents']}>
+            <Feature organization={organization} features="incidents">
               {({hasFeature}) => hasFeature && renderCreateAlertButton()}
             </Feature>
           </ButtonBar>

--- a/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
+++ b/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
@@ -37,7 +37,7 @@ function MissingPerformanceButtons({organization}: Props) {
   return (
     <Feature
       hookName="feature-disabled:project-performance-score-card"
-      features={['performance-view']}
+      features="performance-view"
       organization={organization}
     >
       <ButtonBar gap={1}>

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -320,7 +320,7 @@ class ProjectDetail extends DeprecatedAsyncView<Props, State> {
               </Layout.Main>
               <Layout.Side>
                 <ProjectTeamAccess organization={organization} project={project} />
-                <Feature features={['incidents']} organization={organization}>
+                <Feature features="incidents" organization={organization}>
                   <ProjectLatestAlerts
                     organization={organization}
                     projectSlug={params.projectId}

--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -203,7 +203,7 @@ export function ProjectInstallPlatform({location, params}: Props) {
       <div>
         {isGettingStarted && showPerformancePrompt && (
           <Feature
-            features={['performance-view']}
+            features="performance-view"
             hookName="feature-disabled:performance-new-project"
           >
             {({hasFeature}) => {

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -550,7 +550,7 @@ class ReleaseOverview extends DeprecatedAsyncView<Props> {
                             withChart
                           />
 
-                          <Feature features={['performance-view']}>
+                          <Feature features="performance-view">
                             {hasReleaseComparisonPerformance ? (
                               <PerformanceCardTable
                                 organization={organization}

--- a/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
@@ -151,7 +151,7 @@ function SentryFunctionDetails(props: Props) {
 
   return (
     <div>
-      <Feature features={['organizations:sentry-functions']}>
+      <Feature features="organizations:sentry-functions">
         <h2>
           {sentryFunction ? t('Editing Sentry Function') : t('Create Sentry Function')}
         </h2>

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -74,7 +74,7 @@ function OrganizationSettingsForm({initialData, onSave}: Props) {
                   </Tag>
                 </Hovercard>
               )}
-              features={['organizations:codecov-integration']}
+              features="organizations:codecov-integration"
             >
               {() => null}
             </Feature>

--- a/static/app/views/settings/organizationMembers/organizationMembersWrapper.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersWrapper.tsx
@@ -165,7 +165,7 @@ function renderInviteMembersButton({
       body={
         <FeatureDisabled
           featureName={t('Invite Members')}
-          features={['organizations:invite-members']}
+          features="organizations:invite-members"
           hideHelpToggle
         />
       }

--- a/static/app/views/settings/organizationRelay/index.tsx
+++ b/static/app/views/settings/organizationRelay/index.tsx
@@ -12,7 +12,7 @@ function OrganizationRelay(props: Omit<RelayWrapper['props'], 'organization'>) {
   return (
     <Feature
       organization={organization}
-      features={['relay']}
+      features="relay"
       hookName="feature-disabled:relay"
       renderDisabled={p => (
         <Panel>

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -239,7 +239,7 @@ class LegacyBrowserFilterRow extends Component<RowProps, RowState> {
 function CustomFilters({project, disabled}: {disabled: boolean; project: Project}) {
   return (
     <Feature
-      features={['projects:custom-inbound-filters']}
+      features="projects:custom-inbound-filters"
       hookName="feature-disabled:custom-inbound-filters"
       project={project}
       renderDisabled={({children, ...props}) => {

--- a/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
@@ -105,7 +105,7 @@ function KeyRateLimitsForm({data, disabled, organization, params}: Props) {
   return (
     <Form saveOnBlur apiEndpoint={apiEndpoint} apiMethod="PUT" initialData={data}>
       <Feature
-        features={['projects:rate-limits']}
+        features="projects:rate-limits"
         hookName="feature-disabled:rate-limits"
         renderDisabled={({children, ...props}) =>
           typeof children === 'function' &&

--- a/static/app/views/settings/projectDataForwarding/index.tsx
+++ b/static/app/views/settings/projectDataForwarding/index.tsx
@@ -146,7 +146,7 @@ class ProjectDataForwarding extends DeprecatedAsyncComponent<Props, State> {
     return (
       <div data-test-id="data-forwarding-settings">
         <Feature
-          features={['projects:data-forwarding']}
+          features="projects:data-forwarding"
           hookName="feature-disabled:data-forwarding"
         >
           {({hasFeature, features}) => (

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.tsx
@@ -208,7 +208,7 @@ function CustomRepositories({
   }
 
   return (
-    <Feature features={['custom-symbol-sources']} organization={organization}>
+    <Feature features="custom-symbol-sources" organization={organization}>
       {({hasFeature}) => (
         <Access access={['project:write']} project={project}>
           {({hasAccess}) => {

--- a/static/app/views/settings/projectIssueGrouping/index.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.tsx
@@ -111,7 +111,7 @@ class ProjectIssueGrouping extends DeprecatedAsyncView<Props, State> {
             fields={[fields.groupingEnhancements]}
           />
 
-          <Feature features={['set-grouping-config']} organization={organization}>
+          <Feature features="set-grouping-config" organization={organization}>
             <JsonForm
               {...jsonFormProps}
               title={t('Change defaults')}

--- a/static/app/views/settings/projectPerformance/index.tsx
+++ b/static/app/views/settings/projectPerformance/index.tsx
@@ -12,7 +12,7 @@ type Props = RouteComponentProps<{projectId: string}, {}> & {
 
 function ProjectPerformanceContainer(props: Props) {
   return (
-    <Feature features={['performance-view']}>
+    <Feature features="performance-view">
       <ProjectPerformance {...props} />
     </Feature>
   );

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -862,7 +862,7 @@ class ProjectPerformance extends DeprecatedAsyncView<Props, State> {
             )}
           </Access>
         </Form>
-        <Feature features={['organizations:dynamic-sampling']}>
+        <Feature features="organizations:dynamic-sampling">
           <Form
             saveOnBlur
             allowUndo
@@ -910,7 +910,7 @@ class ProjectPerformance extends DeprecatedAsyncView<Props, State> {
           </Form>
         </Feature>
         <Fragment>
-          <Feature features={['organizations:performance-issues-dev']}>
+          <Feature features="organizations:performance-issues-dev">
             <Form
               saveOnBlur
               allowUndo

--- a/static/app/views/starfish/index.tsx
+++ b/static/app/views/starfish/index.tsx
@@ -18,7 +18,7 @@ function StarfishContainer({organization, children}: Props) {
   return (
     <Feature
       hookName="feature-disabled:starfish-view"
-      features={['starfish-view']}
+      features="starfish-view"
       organization={organization}
       renderDisabled={NoAccess}
     >


### PR DESCRIPTION
Refactors feature and feature disabled components to support a single feature via string signature (I'm open to adding a feature prop instead of overloading features if someone has strong opinions). With the changes here we can avoid inlining the array each time + save a couple of rerenders here and there.

Apologies to everyone getting tagged, you can ignore this. Someone from @getsentry/app-frontend is probably best suitable to review the changes.