### PR TITLE
feat(grouping): Exclude sentry-java sdk frames from group and inapp

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -449,6 +449,7 @@ module:org.glassfish.* -app
 module:org.jboss.* -app
 module:feign.* -app
 module:io.opentelemetry.* -app
+module:io.sentry.* -app -group
 
 ## kotlin
 module:kotlin.* -app

--- a/tests/sentry/grouping/grouping_inputs/stacktrace-collapse-recursion.json
+++ b/tests/sentry/grouping/grouping_inputs/stacktrace-collapse-recursion.json
@@ -4,7 +4,7 @@
       {
         "function": "main",
         "abs_path": "Application.java",
-        "module": "io.sentry.example.Application",
+        "module": "com.example.Application",
         "filename": "Application.java",
         "lineno": 13,
         "in_app": false
@@ -12,7 +12,7 @@
       {
         "function": "normalFunc",
         "abs_path": "Application.java",
-        "module": "io.sentry.example.Application",
+        "module": "com.example.Application",
         "filename": "Application.java",
         "lineno": 20,
         "in_app": false
@@ -20,7 +20,7 @@
       {
         "function": "recurFunc",
         "abs_path": "Application.java",
-        "module": "io.sentry.example.Application",
+        "module": "com.example.Application",
         "filename": "Application.java",
         "lineno": 27,
         "in_app": false
@@ -28,7 +28,7 @@
       {
         "function": "recurFunc",
         "abs_path": "Application.java",
-        "module": "io.sentry.example.Application",
+        "module": "com.example.Application",
         "filename": "Application.java",
         "lineno": 27,
         "in_app": false
@@ -36,7 +36,7 @@
       {
         "function": "recurFunc",
         "abs_path": "Application.java",
-        "module": "io.sentry.example.Application",
+        "module": "com.example.Application",
         "filename": "Application.java",
         "lineno": 27,
         "in_app": false
@@ -44,7 +44,7 @@
       {
         "function": "recurFunc",
         "abs_path": "Application.java",
-        "module": "io.sentry.example.Application",
+        "module": "com.example.Application",
         "filename": "Application.java",
         "lineno": 25,
         "in_app": false
@@ -52,7 +52,7 @@
       {
         "function": "throwError",
         "abs_path": "Application.java",
-        "module": "io.sentry.example.Application",
+        "module": "com.example.Application",
         "filename": "Application.java",
         "lineno": 32,
         "in_app": false

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:28.809960Z'
+created: '2023-11-28T16:31:35.546537Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
       stacktrace (ignored because hash matches system variant)
         frame* (frame considered in-app because no frame is in-app)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*
@@ -19,7 +19,7 @@ app:
             13
         frame* (frame considered in-app because no frame is in-app)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*
@@ -28,7 +28,7 @@ app:
             20
         frame* (frame considered in-app because no frame is in-app)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*
@@ -37,7 +37,7 @@ app:
             27
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*
@@ -46,7 +46,7 @@ app:
             27
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*
@@ -55,7 +55,7 @@ app:
             27
         frame* (frame considered in-app because no frame is in-app)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*
@@ -64,7 +64,7 @@ app:
             25
         frame* (frame considered in-app because no frame is in-app)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*
@@ -73,13 +73,13 @@ app:
             32
 --------------------------------------------------------------------------
 system:
-  hash: "894c3489e2ade384dc107bca6829d134"
+  hash: "9bdadae4fa003cef6cf460ff1325e54b"
   component:
     system*
       stacktrace*
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*
@@ -88,7 +88,7 @@ system:
             13
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*
@@ -97,7 +97,7 @@ system:
             20
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*
@@ -106,7 +106,7 @@ system:
             27
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*
@@ -115,7 +115,7 @@ system:
             27
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*
@@ -124,7 +124,7 @@ system:
             27
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*
@@ -133,7 +133,7 @@ system:
             25
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "Application.java"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_collapse_recursion.pysnap
@@ -1,241 +1,241 @@
 ---
-created: '2021-08-04T15:53:48.979617Z'
+created: '2023-11-28T16:31:44.412695Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "b7e1e5ef711f75f419c749ffb19efb39"
+  hash: "bd53ce6ba0864834150964b0f6089eff"
   tree_label: "throwError"
   component:
     app-depth-1*
       stacktrace*
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "throwError"
 --------------------------------------------------------------------------
 app-depth-2:
-  hash: "9840fdc749627fbfacae7e58f325326a"
+  hash: "937d42d999fd58698bbecfd38420277d"
   tree_label: "throwError | recurFunc"
   component:
     app-depth-2*
       stacktrace*
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "throwError"
 --------------------------------------------------------------------------
 app-depth-3:
-  hash: "e40eae807d6005ad95f045fcccaeb0a4"
+  hash: "06954690264f9745166373289a01ea64"
   tree_label: "throwError | recurFunc | recurFunc"
   component:
     app-depth-3*
       stacktrace*
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "throwError"
 --------------------------------------------------------------------------
 app-depth-4:
-  hash: "3fb69ce71efee7c559762478ce1981bc"
+  hash: "319f9ce02504182ef024834948b06556"
   tree_label: "throwError | recurFunc | recurFunc | normalFunc"
   component:
     app-depth-4*
       stacktrace*
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "throwError"
 --------------------------------------------------------------------------
 app-depth-5:
-  hash: "894c3489e2ade384dc107bca6829d134"
+  hash: "9bdadae4fa003cef6cf460ff1325e54b"
   tree_label: "throwError | recurFunc | recurFunc | normalFunc | main"
   component:
     app-depth-5*
       stacktrace*
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "throwError"
 --------------------------------------------------------------------------
 app-depth-max:
-  hash: "894c3489e2ade384dc107bca6829d134"
+  hash: "9bdadae4fa003cef6cf460ff1325e54b"
   tree_label: "throwError | recurFunc | recurFunc | normalFunc | main"
   component:
     app-depth-max*
       stacktrace*
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "throwError"
 --------------------------------------------------------------------------
 system:
-  hash: "894c3489e2ade384dc107bca6829d134"
+  hash: "9bdadae4fa003cef6cf460ff1325e54b"
   tree_label: "throwError | recurFunc | recurFunc | normalFunc | main"
   component:
     system*
       stacktrace*
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:32.394999Z'
+created: '2023-11-28T16:31:54.180041Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,104 +10,104 @@ app:
       stacktrace
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "throwError"
 --------------------------------------------------------------------------
 system:
-  hash: "894c3489e2ade384dc107bca6829d134"
+  hash: "9bdadae4fa003cef6cf460ff1325e54b"
   component:
     system*
       stacktrace*
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:36.377022Z'
+created: '2023-11-28T16:31:59.273571Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,104 +10,104 @@ app:
       stacktrace
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "throwError"
 --------------------------------------------------------------------------
 system:
-  hash: "894c3489e2ade384dc107bca6829d134"
+  hash: "9bdadae4fa003cef6cf460ff1325e54b"
   component:
     system*
       stacktrace*
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:39.823461Z'
+created: '2023-11-28T16:31:38.255775Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,104 +10,104 @@ app:
       stacktrace
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "throwError"
 --------------------------------------------------------------------------
 system:
-  hash: "894c3489e2ade384dc107bca6829d134"
+  hash: "9bdadae4fa003cef6cf460ff1325e54b"
   component:
     system*
       stacktrace*
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:43.190432Z'
+created: '2023-11-28T16:31:41.147500Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,104 +10,104 @@ app:
       stacktrace
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "throwError"
 --------------------------------------------------------------------------
 system:
-  hash: "894c3489e2ade384dc107bca6829d134"
+  hash: "9bdadae4fa003cef6cf460ff1325e54b"
   component:
     system*
       stacktrace*
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
         frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_chained.pysnap
@@ -1,14 +1,16 @@
 ---
+created: '2023-11-28T16:01:07.159219Z'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "750486b8d8c51500fa0dfbb6f1577af0"
+  hash: null
   component:
-    app*
-      chained-exception*
+    app (exception of system takes precedence)
+      chained-exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
         exception*
           stacktrace
-            frame (non app frame)
+            frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
               module*
                 "io.sentry.example.Application"
               filename (module takes precedence)
@@ -175,7 +177,7 @@ app:
             "Address already in use"
         exception*
           stacktrace
-            frame (non app frame)
+            frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
               module*
                 "io.sentry.example.Application"
               filename (module takes precedence)
@@ -285,8 +287,8 @@ app:
           value*
             "service.getName(): \"Tomcat\";  Protocol handler start failed"
         exception*
-          stacktrace*
-            frame*
+          stacktrace
+            frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
               module*
                 "io.sentry.example.Application"
               filename (module takes precedence)
@@ -386,24 +388,24 @@ app:
                 "start"
           type*
             "LifecycleException"
-          value (ignored because stacktrace takes precedence)
+          value* (stripped event-specific values)
             "Failed to start component [Connector[HTTP/<float><int>]]"
 --------------------------------------------------------------------------
 default:
   hash: null
   component:
-    default (exception of app/system takes precedence)
-      message (exception of app/system takes precedence)
+    default (exception of system takes precedence)
+      message (exception of system takes precedence)
         "Failed to start connector [Connector[HTTP/<float><int>]]"
 --------------------------------------------------------------------------
 system:
-  hash: "8924849495809d42431719c2b9ab65c8"
+  hash: "1959b227a7cf6acf7f3fd401b5d9f09b"
   component:
     system*
       chained-exception*
         exception*
           stacktrace*
-            frame*
+            frame (ignored by stack trace rule (module:io.sentry.* -app -group))
               module*
                 "io.sentry.example.Application"
               filename (module takes precedence)
@@ -570,7 +572,7 @@ system:
             "Address already in use"
         exception*
           stacktrace*
-            frame*
+            frame (ignored by stack trace rule (module:io.sentry.* -app -group))
               module*
                 "io.sentry.example.Application"
               filename (module takes precedence)
@@ -681,7 +683,7 @@ system:
             "service.getName(): \"Tomcat\";  Protocol handler start failed"
         exception*
           stacktrace*
-            frame*
+            frame (ignored by stack trace rule (module:io.sentry.* -app -group))
               module*
                 "io.sentry.example.Application"
               filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2023-11-28T16:01:06.243244Z'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -385,7 +387,7 @@ app:
               "nativemethodaccessorimpl.java"
             function*
               "invoke0"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
             module*
               "io.sentry.example.Application"
             filename (module takes precedence)
@@ -405,7 +407,7 @@ default:
         "Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.ArithmeticException: / by zero] with root cause"
 --------------------------------------------------------------------------
 system:
-  hash: "12f3d3df2e7804af98f4b56c602d17b0"
+  hash: "ef2555bf7958ada8eefafbfdaed1c409"
   component:
     system*
       exception*
@@ -788,7 +790,7 @@ system:
               "nativemethodaccessorimpl.java"
             function*
               "invoke0"
-          frame*
+          frame (ignored by stack trace rule (module:io.sentry.* -app -group))
             module*
               "io.sentry.example.Application"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,116 +1,113 @@
 ---
-created: '2023-11-28T16:01:08.782196Z'
+created: '2023-11-28T16:31:48.761745Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
-    app
+    app (stacktrace of system takes precedence)
       stacktrace
-        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
+        frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
-        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
+        frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
-        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
+        frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
+        frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
+        frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
+        frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
+        frame (non app frame)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "throwError"
 --------------------------------------------------------------------------
-fallback:
-  hash: "d41d8cd98f00b204e9800998ecf8427e"
---------------------------------------------------------------------------
 system:
-  hash: null
+  hash: "9bdadae4fa003cef6cf460ff1325e54b"
   component:
-    system
-      stacktrace
-        frame (ignored by stack trace rule (module:io.sentry.* -app -group))
+    system*
+      stacktrace*
+        frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
-        frame (ignored by stack trace rule (module:io.sentry.* -app -group))
+        frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
-        frame (ignored by stack trace rule (module:io.sentry.* -app -group))
+        frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
+        frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
+        frame (ignored due to recursion)
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (ignored by stack trace rule (module:io.sentry.* -app -group))
+        frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (ignored by stack trace rule (module:io.sentry.* -app -group))
+        frame*
           module*
-            "io.sentry.example.Application"
+            "com.example.Application"
           filename (module takes precedence)
             "application.java"
           function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,56 +1,56 @@
 ---
-created: '2023-01-11T11:41:29.165976Z'
+created: '2023-11-28T16:01:08.782196Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
-    app (stacktrace of system takes precedence)
+    app
       stacktrace
-        frame (non app frame)
+        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
-        frame (non app frame)
+        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
-        frame (non app frame)
+        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (non app frame)
+        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (non app frame)
+        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (non app frame)
+        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (non app frame)
+        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)
@@ -58,54 +58,57 @@ app:
           function*
             "throwError"
 --------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
 system:
-  hash: "894c3489e2ade384dc107bca6829d134"
+  hash: null
   component:
-    system*
-      stacktrace*
-        frame*
+    system
+      stacktrace
+        frame (ignored by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "main"
-        frame*
+        frame (ignored by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "normalFunc"
-        frame*
+        frame (ignored by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (ignored due to recursion)
+        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame (ignored due to recursion)
+        frame (marked out of app by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame*
+        frame (ignored by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)
             "application.java"
           function*
             "recurFunc"
-        frame*
+        frame (ignored by stack trace rule (module:io.sentry.* -app -group))
           module*
             "io.sentry.example.Application"
           filename (module takes precedence)


### PR DESCRIPTION
This is necessary for the sentry-java sdk to not mess up grouping, because we'll start sending sdk frames for fatals from the next major version (relevant pr: https://github.com/getsentry/sentry-java/pull/3021)

Also changed `io.sentry` to `com.example` in `stacktrace-collapse-recursion` snapshot so it's not affected by this change