### PR TITLE
fix(perf): Fix broken transaction details routes

### DIFF
--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/index.tsx
@@ -69,7 +69,7 @@ export function ScreenLoadSpanSamples({
       : transactionName;
 
   const link = normalizeUrl(
-    `/organizations/${organization.slug}/${transactionRoute}?${qs.stringify({
+    `/organizations/${organization.slug}${transactionRoute}?${qs.stringify({
       project: query.project,
       transaction: transactionName,
     })}`

--- a/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/sampleList/index.tsx
@@ -87,7 +87,7 @@ export function SampleList({
       : transactionName;
 
   const link = normalizeUrl(
-    `/organizations/${organization.slug}/${transactionRoute}?${qs.stringify({
+    `/organizations/${organization.slug}${transactionRoute}?${qs.stringify({
       project: query.project,
       transaction: transactionName,
     })}`


### PR DESCRIPTION
This slipped in during a refactor, the slash is not needed, and breaks the link. See https://sentry.sentry.io/feedback/?alert_rule_id=14756941&alert_type=issue&feedbackSlug=javascript%3A4678050882&notification_uuid=92b109d7-19cb-46a6-9420-cc796cd69eee&referrer=feedback_list_page&statsPeriod=7d
