### PR TITLE
ref: remove django 1.9 pickle compat

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -4,19 +4,17 @@ import importlib.metadata
 import logging
 import os
 import sys
-from typing import Any, TypeVar
+from typing import Any
 
 import click
 from django.conf import settings
 
 from sentry.silo.patches.silo_aware_transaction_patch import patch_silo_aware_atomic
-from sentry.utils import metrics, warnings
+from sentry.utils import warnings
 from sentry.utils.sdk import configure_sdk
 from sentry.utils.warnings import DeprecatedSettingWarning
 
 logger = logging.getLogger("sentry.runner.initializer")
-
-T = TypeVar("T")
 
 
 def register_plugins(settings: Any, raise_on_plugin_load_failure: bool = False) -> None:
@@ -367,8 +365,6 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
 
     monkeypatch_drf_listfield_serializer_errors()
 
-    monkeypatch_model_unpickle()
-
     import django
 
     django.setup()
@@ -467,39 +463,6 @@ def validate_regions(settings: Any) -> None:
         return
 
     load_from_config(region_config).validate_all()
-
-
-import django.db.models.base
-
-model_unpickle = django.db.models.base.model_unpickle
-
-
-def __model_unpickle_compat(
-    model_id: str, attrs: Any | None = None, factory: Any | None = None
-) -> object:
-    if attrs is not None or factory is not None:
-        metrics.incr("django.pickle.loaded_19_pickle.__model_unpickle_compat", sample_rate=1)
-        logger.error(
-            "django.compat.model-unpickle-compat",
-            extra={"model_id": model_id, "attrs": attrs, "factory": factory},
-            exc_info=True,
-        )
-    return model_unpickle(model_id)
-
-
-def __simple_class_factory_compat(model: T, attrs: Any) -> T:
-    return model
-
-
-def monkeypatch_model_unpickle() -> None:
-    # https://code.djangoproject.com/ticket/27187
-    # Django 1.10 breaks pickle compat with 1.9 models.
-    django.db.models.base.model_unpickle = __model_unpickle_compat
-
-    # Django 1.10 needs this to unpickle 1.9 models, but we can't branch while
-    # monkeypatching else our monkeypatched funcs won't be pickleable.
-    # So just vendor simple_class_factory from 1.9.
-    django.db.models.base.simple_class_factory = __simple_class_factory_compat
 
 
 def monkeypatch_django_migrations() -> None:


### PR DESCRIPTION
this was breaking mypy -- we haven't run django 1.x in years so this should be fairly safe.  I also checked datadog and did not find any hits on the metric listed here