### PR TITLE
fix(relocation): Include org list in claim user email for relocation

### DIFF
--- a/src/sentry/models/lostpasswordhash.py
+++ b/src/sentry/models/lostpasswordhash.py
@@ -48,8 +48,8 @@ class LostPasswordHash(Model):
         cls._send_email("recover_password", user, hash, extra)
 
     @classmethod
-    def send_relocate_account_email(cls, user, hash) -> None:
-        cls._send_email("relocate_account", user, hash, {})
+    def send_relocate_account_email(cls, user, hash, orgs) -> None:
+        cls._send_email("relocate_account", user, hash, {"orgs": orgs})
 
     @classmethod
     def _send_email(cls, mode, user, hash, extra) -> None:

--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -1106,7 +1106,7 @@ def notifying_users(uuid: str) -> None:
         # Okay, everything seems fine - go ahead and send those emails.
         for user in imported_users:
             hash = lost_password_hash_service.get_or_create(user_id=user.id).hash
-            LostPasswordHash.send_relocate_account_email(user, hash)
+            LostPasswordHash.send_relocate_account_email(user, hash, relocation.want_org_slugs)
 
         notifying_owner.delay(uuid)
 

--- a/tests/sentry/models/test_lostpasswordhash.py
+++ b/tests/sentry/models/test_lostpasswordhash.py
@@ -28,7 +28,7 @@ class LostPasswordTest(TestCase):
         password_hash = LostPasswordHash.objects.create(user=self.user)
 
         with self.options({"system.url-prefix": "http://testserver"}), self.tasks():
-            LostPasswordHash.send_relocate_account_email(self.user, password_hash.hash)
+            LostPasswordHash.send_relocate_account_email(self.user, password_hash.hash, ["testorg"])
 
         assert len(mail.outbox) == 1
         msg = mail.outbox[0]
@@ -41,6 +41,6 @@ class LostPasswordTest(TestCase):
             args=[password_hash.user_id, password_hash.hash],
         )
         assert msg.body.startswith(
-            "The following Sentry organizations that you are a member of have been migrated onto sentry.io:\n\n\nTo continue with using these accounts at their new location, please claim your account with sentry.io.\n\nClaim Account"
+            "The following Sentry organizations that you are a member of have been migrated onto sentry.io:\n\n* testorg\n\n\nTo continue with using these accounts at their new location, please claim your account with sentry.io.\n\nClaim Account"
         )
         assert url in msg.body

--- a/tests/sentry/tasks/test_relocation.py
+++ b/tests/sentry/tasks/test_relocation.py
@@ -1626,6 +1626,8 @@ class NotifyingUsersTest(RelocationTaskTestCase):
                 mock_relocation_email.call_args_list[0][0][0].username,
                 mock_relocation_email.call_args_list[1][0][0].username,
             ]
+            assert mock_relocation_email.call_args_list[0][0][2] == ["testing"]
+            assert mock_relocation_email.call_args_list[1][0][2] == ["testing"]
             assert "admin@example.com" in email_targets
             assert "member@example.com" in email_targets
 


### PR DESCRIPTION
This adds the list of org slugs to the claim user email for relocation