### PR TITLE
fix(hybrid-cloud): Handle Discord PINGs prior to Region fetching

### DIFF
--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -59,6 +59,24 @@ class DiscordRequestParserTest(TestCase):
             assert response.data == {"type": 1}
             assert not get_response_from_first_region.called
 
+    def test_interactions_endpoint_routing_ping_no_integration(self):
+        # Discord PING without an identifier linking to an integration
+        data = {"type": DiscordRequestTypes.PING}
+        parser = self.get_parser(reverse("sentry-integration-discord-interactions"), data=data)
+        assert parser.get_integration_from_request() is None
+        with patch.object(parser, "get_regions_from_organizations", return_value=[]), patch.object(
+            parser, "get_response_from_first_region"
+        ) as get_response_from_first_region, patch.object(
+            parser, "get_response_from_control_silo"
+        ) as mock_response_from_control, assume_test_silo_mode(
+            SiloMode.CONTROL, can_be_monolith=False
+        ):
+            response = parser.get_response()
+            assert response.status_code == 200
+            assert response.data == {"type": 1}
+            assert not mock_response_from_control.called
+            assert not get_response_from_first_region.called
+
     def test_interactions_endpoint_routing_command(self):
         data = {"guild_id": self.integration.external_id, "type": int(DiscordRequestTypes.COMMAND)}
         parser = self.get_parser(reverse("sentry-integration-discord-interactions"), data=data)


### PR DESCRIPTION
Handling the Discord PINGs at the request parser needs to happen prior to Integration/Organization payload checks.

This is because Discord PINGs does not send any identifier(s) associating the PING to an Integration/Organization. This is verified from my testing with ngrok (acting as a an Interaction endpoint) and the Discord server.