### PR TITLE
fix(devserver): Install mkcert root cert into python-certifi

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "build": "NODE_OPTIONS=--max-old-space-size=4096 yarn webpack",
     "build-js-loader": "ts-node scripts/build-js-loader.ts",
     "validate-api-examples": "cd api-docs && yarn openapi-examples-validator ../tests/apidocs/openapi-derefed.json --no-additional-properties",
-    "mkcert-localhost": "mkcert -key-file config/localhost-key.pem -cert-file config/localhost.pem localhost 127.0.0.1 dev.getsentry.net *.dev.getsentry.net && mkcert -install"
+    "mkcert-localhost": "scripts/mkcert.sh"
   },
   "browserslist": {
     "production": [

--- a/scripts/mkcert.sh
+++ b/scripts/mkcert.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eu
+
+# Install mkcert's root certificate
+mkcert -install
+
+# Add mkcert's root certificate into the local python certificate store
+cat $(mkcert -CAROOT)/rootCA.pem >>$(python -m certifi)
+
+# Geneate local certificates for dev
+mkcert -key-file config/localhost-key.pem -cert-file config/localhost.pem localhost 127.0.0.1 dev.getsentry.net *.dev.getsentry.net


### PR DESCRIPTION
This allows python requests to verify requests through the HTTPS webpack
devserver proxy.

This is a follow up to #60673 to allow the devserver to correctly be able to talk back to itself.