### PR TITLE
fix(devserver): Have relay talk directly to the devserver

### DIFF
--- a/config/relay/config.yml
+++ b/config/relay/config.yml
@@ -1,6 +1,6 @@
 ---
 relay:
-  upstream: 'http://host.docker.internal:8000/'
+  upstream: 'http://host.docker.internal:8001/'
   host: 0.0.0.0
   port: 7899
 logging:


### PR DESCRIPTION
This avoids proxying through the webpack proxy, which may or may not be
running with HTTPS.

This is a follow up to https://github.com/getsentry/sentry/pull/60673