### PR TITLE
feat(database): Show query source

### DIFF
--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -24,6 +24,10 @@ interface CodeSnippetProps {
   filename?: string;
   hideCopyButton?: boolean;
   /**
+   * Controls whether the snippet wrapper has rounded corners.
+   */
+  isRounded?: boolean;
+  /**
    * Fires after the code snippet is highlighted and all DOM nodes are available
    * @param element The root element of the code snippet
    */
@@ -50,6 +54,7 @@ export function CodeSnippet({
   filename,
   hideCopyButton,
   language,
+  isRounded = true,
   onAfterHighlight,
   onCopy,
   onSelectAndCopy,
@@ -102,6 +107,7 @@ export function CodeSnippet({
 
   return (
     <Wrapper
+      isRounded={isRounded}
       className={`${dark ? 'prism-dark ' : ''}${className ?? ''}`}
       data-render-inline={dataRenderInline}
     >
@@ -156,10 +162,10 @@ export function CodeSnippet({
   );
 }
 
-const Wrapper = styled('div')`
+const Wrapper = styled('div')<{isRounded: boolean}>`
   position: relative;
   background: var(--prism-block-background);
-  border-radius: ${p => p.theme.borderRadius};
+  border-radius: ${p => (p.isRounded ? p.theme.borderRadius : '0px')};
 
   ${p => prismStyles(p.theme)}
   pre {

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -13,6 +13,7 @@ import {space} from 'sentry/styles/space';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {DurationChart} from 'sentry/views/performance/database/durationChart';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
@@ -21,6 +22,7 @@ import {useSelectedDurationAggregate} from 'sentry/views/performance/database/us
 import {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
 import {SpanDescription} from 'sentry/views/starfish/components/spanDescription';
 import {useFullSpanFromTrace} from 'sentry/views/starfish/queries/useFullSpanFromTrace';
+import {useIndexedSpans} from 'sentry/views/starfish/queries/useIndexedSpans';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import {
@@ -60,6 +62,11 @@ function SpanSummaryPage({params}: Props) {
   const filters: SpanMetricsQueryFilters = {
     'span.group': groupId,
   };
+
+  const {data: indexedSpans} = useIndexedSpans({'span.group': groupId}, 1);
+
+  const {projects} = useProjects();
+  const project = projects.find(p => p.id === String(indexedSpans?.[0]?.project_id));
 
   if (endpoint) {
     filters.transaction = endpoint;
@@ -158,6 +165,7 @@ function SpanSummaryPage({params}: Props) {
           {span?.[SpanMetricsField.SPAN_DESCRIPTION] && (
             <DescriptionContainer>
               <SpanDescription
+                project={project}
                 span={{
                   ...span,
                   ...fullSpan,

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -160,6 +160,7 @@ function SpanSummaryPage({params}: Props) {
               <SpanDescription
                 span={{
                   ...span,
+                  ...fullSpan,
                   [SpanMetricsField.SPAN_DESCRIPTION]:
                     fullSpan?.description ??
                     spanMetrics?.[SpanMetricsField.SPAN_DESCRIPTION],

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -63,7 +63,11 @@ function SpanSummaryPage({params}: Props) {
     'span.group': groupId,
   };
 
-  const {data: indexedSpans} = useIndexedSpans({'span.group': groupId}, 1);
+  const {data: indexedSpans} = useIndexedSpans(
+    {'span.group': groupId},
+    [INDEXED_SPAN_SORT],
+    1
+  );
 
   const {projects} = useProjects();
   const project = projects.find(p => p.id === String(indexedSpans?.[0]?.project_id));
@@ -75,7 +79,7 @@ function SpanSummaryPage({params}: Props) {
 
   const sort = useModuleSort(QueryParameterNames.ENDPOINTS_SORT, DEFAULT_SORT);
 
-  const {data: fullSpan} = useFullSpanFromTrace(groupId);
+  const {data: fullSpan} = useFullSpanFromTrace(groupId, [INDEXED_SPAN_SORT]);
 
   const {data: spanMetrics} = useSpanMetrics(
     filters,
@@ -218,6 +222,11 @@ function SpanSummaryPage({params}: Props) {
 const DEFAULT_SORT: Sort = {
   kind: 'desc',
   field: 'time_spent_percentage()',
+};
+
+const INDEXED_SPAN_SORT = {
+  field: 'span.self_time',
+  kind: 'desc' as const,
 };
 
 const PaddedContainer = styled('div')`

--- a/static/app/views/starfish/components/fullSpanDescription.tsx
+++ b/static/app/views/starfish/components/fullSpanDescription.tsx
@@ -14,7 +14,7 @@ export function FullSpanDescription({group, shortDescription, language}: Props) 
     data: fullSpan,
     isLoading,
     isFetching,
-  } = useFullSpanFromTrace(group, Boolean(group));
+  } = useFullSpanFromTrace(group, undefined, Boolean(group));
 
   const description = fullSpan?.description ?? shortDescription;
 

--- a/static/app/views/starfish/components/spanDescription.tsx
+++ b/static/app/views/starfish/components/spanDescription.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import Feature from 'sentry/components/acl/feature';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {Project} from 'sentry/types';
 import {StackTraceMiniFrame} from 'sentry/views/starfish/components/stackTraceMiniFrame';
@@ -38,17 +39,18 @@ function DatabaseSpanDescription({span, project}: Props) {
         {formatter.toString(span[SpanMetricsField.SPAN_DESCRIPTION])}
       </CodeSnippet>
 
-      {/* TODO: Feature flag gate */}
-      {span?.data?.['code.filepath'] && (
-        <StackTraceMiniFrame
-          project={project}
-          frame={{
-            absPath: span?.data?.['code.filepath'],
-            lineNo: span?.data?.['code.lineno'],
-            function: span?.data?.['code.function'],
-          }}
-        />
-      )}
+      <Feature features={['organizations:performance-database-view-query-source']}>
+        {span?.data?.['code.filepath'] && (
+          <StackTraceMiniFrame
+            project={project}
+            frame={{
+              absPath: span?.data?.['code.filepath'],
+              lineNo: span?.data?.['code.lineno'],
+              function: span?.data?.['code.function'],
+            }}
+          />
+        )}
+      </Feature>
     </React.Fragment>
   );
 }

--- a/static/app/views/starfish/components/spanDescription.tsx
+++ b/static/app/views/starfish/components/spanDescription.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';

--- a/static/app/views/starfish/components/spanDescription.tsx
+++ b/static/app/views/starfish/components/spanDescription.tsx
@@ -1,6 +1,8 @@
+import React from 'react';
 import styled from '@emotion/styled';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {StackTraceMiniFrame} from 'sentry/views/starfish/components/stackTraceMiniFrame';
 import {MetricsResponse, SpanMetricsField} from 'sentry/views/starfish/types';
 import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatter';
 
@@ -8,7 +10,13 @@ type Props = {
   span: Pick<
     MetricsResponse,
     SpanMetricsField.SPAN_OP | SpanMetricsField.SPAN_DESCRIPTION
-  >;
+  > & {
+    data: {
+      'code.filepath': string;
+      'code.function': string;
+      'code.lineno': number;
+    };
+  };
 };
 
 export function SpanDescription({span}: Props) {
@@ -23,9 +31,22 @@ function DatabaseSpanDescription({span}: Props) {
   const formatter = new SQLishFormatter();
 
   return (
-    <CodeSnippet language="sql">
-      {formatter.toString(span[SpanMetricsField.SPAN_DESCRIPTION])}
-    </CodeSnippet>
+    <React.Fragment>
+      <CodeSnippet language="sql">
+        {formatter.toString(span[SpanMetricsField.SPAN_DESCRIPTION])}
+      </CodeSnippet>
+
+      {/* TODO: Feature flag gate */}
+      {span?.data?.['code.filepath'] && (
+        <StackTraceMiniFrame
+          frame={{
+            absPath: span?.data?.['code.filepath'],
+            lineNo: span?.data?.['code.lineno'],
+            function: span?.data?.['code.function'],
+          }}
+        />
+      )}
+    </React.Fragment>
   );
 }
 

--- a/static/app/views/starfish/components/spanDescription.tsx
+++ b/static/app/views/starfish/components/spanDescription.tsx
@@ -34,8 +34,8 @@ function DatabaseSpanDescription({span, project}: Props) {
   const formatter = new SQLishFormatter();
 
   return (
-    <React.Fragment>
-      <CodeSnippet language="sql">
+    <Frame>
+      <CodeSnippet language="sql" isRounded={false}>
         {formatter.toString(span[SpanMetricsField.SPAN_DESCRIPTION])}
       </CodeSnippet>
 
@@ -51,9 +51,15 @@ function DatabaseSpanDescription({span, project}: Props) {
           />
         )}
       </Feature>
-    </React.Fragment>
+    </Frame>
   );
 }
+
+const Frame = styled('div')`
+  border: solid 1px ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  overflow: hidden;
+`;
 
 const WordBreak = styled('div')`
   word-break: break-word;

--- a/static/app/views/starfish/components/spanDescription.tsx
+++ b/static/app/views/starfish/components/spanDescription.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {Project} from 'sentry/types';
 import {StackTraceMiniFrame} from 'sentry/views/starfish/components/stackTraceMiniFrame';
 import {MetricsResponse, SpanMetricsField} from 'sentry/views/starfish/types';
 import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatter';
@@ -11,23 +12,24 @@ type Props = {
     MetricsResponse,
     SpanMetricsField.SPAN_OP | SpanMetricsField.SPAN_DESCRIPTION
   > & {
-    data: {
-      'code.filepath': string;
-      'code.function': string;
-      'code.lineno': number;
+    data?: {
+      'code.filepath'?: string;
+      'code.function'?: string;
+      'code.lineno'?: number;
     };
   };
+  project?: Project;
 };
 
-export function SpanDescription({span}: Props) {
+export function SpanDescription({span, project}: Props) {
   if (span[SpanMetricsField.SPAN_OP]?.startsWith('db')) {
-    return <DatabaseSpanDescription span={span} />;
+    return <DatabaseSpanDescription span={span} project={project} />;
   }
 
   return <WordBreak>{span[SpanMetricsField.SPAN_DESCRIPTION]}</WordBreak>;
 }
 
-function DatabaseSpanDescription({span}: Props) {
+function DatabaseSpanDescription({span, project}: Props) {
   const formatter = new SQLishFormatter();
 
   return (
@@ -39,6 +41,7 @@ function DatabaseSpanDescription({span}: Props) {
       {/* TODO: Feature flag gate */}
       {span?.data?.['code.filepath'] && (
         <StackTraceMiniFrame
+          project={project}
           frame={{
             absPath: span?.data?.['code.filepath'],
             lineNo: span?.data?.['code.lineno'],

--- a/static/app/views/starfish/components/stackTraceMiniFrame.tsx
+++ b/static/app/views/starfish/components/stackTraceMiniFrame.tsx
@@ -1,0 +1,52 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {Frame} from 'sentry/types';
+
+interface Props {
+  frame: Partial<Pick<Frame, 'absPath' | 'colNo' | 'function' | 'lineNo'>>;
+}
+
+export function StackTraceMiniFrame({frame}: Props) {
+  return (
+    <FrameContainer>
+      {frame.absPath && <Emphasize>{frame?.absPath}</Emphasize>}
+      {frame.function && (
+        <Fragment>
+          <Deemphasize> {t('in')} </Deemphasize>
+          <Emphasize>{frame?.function}</Emphasize>
+        </Fragment>
+      )}
+      {frame.lineNo && (
+        <Fragment>
+          <Deemphasize> {t('at line')} </Deemphasize>
+          <Emphasize>{frame?.lineNo}</Emphasize>
+        </Fragment>
+      )}
+    </FrameContainer>
+  );
+}
+
+const FrameContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+  padding: ${space(1.5)} ${space(2)};
+
+  font-family: ${p => p.theme.text.family};
+  font-size: ${p => p.theme.fontSizeMedium};
+
+  border-top: 1px solid ${p => p.theme.border};
+
+  background: ${p => p.theme.surface200};
+`;
+
+const Emphasize = styled('span')`
+  color: ${p => p.theme.gray500};
+`;
+
+const Deemphasize = styled('span')`
+  color: ${p => p.theme.gray300};
+`;

--- a/static/app/views/starfish/components/stackTraceMiniFrame.tsx
+++ b/static/app/views/starfish/components/stackTraceMiniFrame.tsx
@@ -1,17 +1,24 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Frame} from 'sentry/types';
+import {Frame, Project} from 'sentry/types';
 
 interface Props {
   frame: Partial<Pick<Frame, 'absPath' | 'colNo' | 'function' | 'lineNo'>>;
+  project?: Project;
 }
 
-export function StackTraceMiniFrame({frame}: Props) {
+export function StackTraceMiniFrame({frame, project}: Props) {
   return (
     <FrameContainer>
+      {project && (
+        <ProjectAvatarContainer>
+          <ProjectAvatar project={project} size={16} />
+        </ProjectAvatarContainer>
+      )}
       {frame.absPath && <Emphasize>{frame?.absPath}</Emphasize>}
       {frame.function && (
         <Fragment>
@@ -41,6 +48,10 @@ const FrameContainer = styled('div')`
   border-top: 1px solid ${p => p.theme.border};
 
   background: ${p => p.theme.surface200};
+`;
+
+const ProjectAvatarContainer = styled('div')`
+  margin-right: ${space(1)};
 `;
 
 const Emphasize = styled('span')`

--- a/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
+++ b/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
@@ -1,3 +1,4 @@
+import {Sort} from 'sentry/utils/discover/fields';
 import {useEventJSON} from 'sentry/views/starfish/queries/useEventJSON';
 import {useIndexedSpans} from 'sentry/views/starfish/queries/useIndexedSpans';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
@@ -5,14 +6,18 @@ import {SpanIndexedField} from 'sentry/views/starfish/types';
 // NOTE: Fetching the top one is a bit naive, but works for now. A better
 // approach might be to fetch several at a time, and let the hook consumer
 // decide how to display them
-export function useFullSpanFromTrace(group?: string, enabled: boolean = true) {
+export function useFullSpanFromTrace(
+  group?: string,
+  sorts?: Sort[],
+  enabled: boolean = true
+) {
   const filters: {[key: string]: string} = {};
 
   if (group) {
     filters[SpanIndexedField.SPAN_GROUP] = group;
   }
 
-  const indexedSpansResponse = useIndexedSpans(filters, 1, enabled);
+  const indexedSpansResponse = useIndexedSpans(filters, sorts, 1, enabled);
 
   const firstIndexedSpan = indexedSpansResponse.data?.[0];
 

--- a/static/app/views/starfish/queries/useIndexedSpans.tsx
+++ b/static/app/views/starfish/queries/useIndexedSpans.tsx
@@ -1,6 +1,7 @@
 import {Location} from 'history';
 
 import EventView from 'sentry/utils/discover/eventView';
+import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -15,14 +16,13 @@ interface Filters {
 
 export const useIndexedSpans = (
   filters: Filters,
+  sorts: Sort[] = [{field: 'timestamp', kind: 'desc'}],
   limit: number = DEFAULT_LIMIT,
   enabled: boolean = true,
   referrer: string = 'use-indexed-spans'
 ) => {
   const location = useLocation();
-  const eventView = getEventView(filters, location);
-
-  eventView.sorts = [{field: 'timestamp', kind: 'desc'}];
+  const eventView = getEventView(filters, location, sorts);
 
   return useSpansQuery<SpanIndexedFieldTypes[]>({
     eventView,
@@ -33,7 +33,7 @@ export const useIndexedSpans = (
   });
 };
 
-function getEventView(filters: Filters, location: Location) {
+function getEventView(filters: Filters, location: Location, sorts?: Sort[]) {
   // TODO: Add a `MutableSearch` constructor that accept a key-value mapping
   const search = new MutableSearch([]);
 
@@ -41,7 +41,7 @@ function getEventView(filters: Filters, location: Location) {
     search.addFilterValue(filterName, filters[filterName]);
   }
 
-  return EventView.fromNewQueryWithLocation(
+  const eventView = EventView.fromNewQueryWithLocation(
     {
       name: '',
       query: search.formatString(),
@@ -51,4 +51,10 @@ function getEventView(filters: Filters, location: Location) {
     },
     location
   );
+
+  if (sorts) {
+    eventView.sorts = sorts;
+  }
+
+  return eventView;
 }

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -112,6 +112,7 @@ export enum SpanIndexedField {
   SPAN_DOMAIN = 'span.domain',
   TIMESTAMP = 'timestamp',
   PROJECT = 'project',
+  PROJECT_ID = 'project_id',
   PROFILE_ID = 'profile_id',
 }
 
@@ -130,6 +131,7 @@ export type SpanIndexedFieldTypes = {
   [SpanIndexedField.SPAN_DOMAIN]: string[];
   [SpanIndexedField.TIMESTAMP]: string;
   [SpanIndexedField.PROJECT]: string;
+  [SpanIndexedField.PROJECT_ID]: number;
   [SpanIndexedField.PROFILE_ID]: string;
   [SpanIndexedField.RESOURCE_RENDER_BLOCKING_STATUS]: '' | 'non-blocking' | 'blocking';
   [SpanIndexedField.HTTP_RESPONSE_CONTENT_LENGTH]: string;


### PR DESCRIPTION
That's right, it's happening. This PR shows the code query source if it's available in span info. Hidden behind a flag for now while I continue to work on the UI, but this is a start for us to dog food on!

**e.g.,**
![Screenshot 2023-11-28 at 6 18 17 PM](https://github.com/getsentry/sentry/assets/989898/438ded34-e138-4eef-bfd8-f509fe1caa54)

## Other Changes

- Add `project_id` to known indexed span fields
- Allow unrounded code snippets
- Wrap in a frame
- Fetch the slowest span when getting a query sample
