### PR TITLE
chore(open-pr-comments): throw more loggers

### DIFF
--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -190,8 +190,9 @@ def create_or_update_comment(
 
     # TODO(cathy): Figure out a way to track average rate limit left for GH client
 
+    logger_event = metrics_base.format(key="create_or_update_comment")
     logger.info(
-        "github.pr_comment.create_or_update_comment",
+        logger_event,
         extra={"new_comment": pr_comment is None, "pr_key": pr_key, "repo": repo.name},
     )
 


### PR DESCRIPTION
Debugging testing in prod. The workflow task is being queued, but there is no comment and none of the existing loggers are logged, so adding more here.