### PR TITLE
ref(grouping): adding sdk to group merge/unmerge metrics

### DIFF
--- a/src/sentry/api/endpoints/group_hashes.py
+++ b/src/sentry/api/endpoints/group_hashes.py
@@ -73,7 +73,7 @@ class GroupHashesEndpoint(GroupEndpoint):
             "grouping.unmerge_issues",
             sample_rate=1.0,
             # We assume that if someone's merged groups, they were all from the same platform
-            tags={"platform": group.platform or "unknown"},
+            tags={"platform": group.platform or "unknown", "sdk": group.sdk or "unknown"},
         )
 
         unmerge.delay(

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -245,7 +245,6 @@ def update_groups(
 
     discard = result.get("discard")
     if discard:
-
         return handle_discard(request, list(queryset), projects, acting_user)
 
     status_details = result.pop("statusDetails", result)
@@ -655,6 +654,7 @@ def update_groups(
             tags={
                 # We assume that if someone's merging groups, they're from the same platform
                 "platform": group_list[0].platform or "unknown",
+                "sdk": group_list[0].sdk or "unknown",
                 # TODO: It's probably cleaner to just send this value from the front end
                 "referer": (
                     "issue stream"

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -799,7 +799,7 @@ class Group(Model):
         """
         return self.data.get("type", "default")
 
-    def get_event_metadata(self) -> Mapping[str, str]:
+    def get_event_metadata(self) -> Mapping[str, Any]:
         """
         Return the metadata of this issue.
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -826,6 +826,15 @@ class Group(Model):
         return self.project.organization
 
     @property
+    def sdk(self) -> str | None:
+        """returns normalized SDK name"""
+
+        try:
+            return self.get_event_metadata()["sdk"]["name_normalized"]
+        except KeyError:
+            return None
+
+    @property
     def checksum(self):
         warnings.warn("Group.checksum is no longer used", DeprecationWarning)
         return ""

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -874,6 +874,9 @@ class Factories:
             kwargs["data"].update({"type": "default", "metadata": {"title": kwargs["message"]}})
         if "short_id" not in kwargs:
             kwargs["short_id"] = project.next_short_id()
+        if "metadata" in kwargs:
+            metadata = kwargs.pop("metadata")
+            kwargs["data"].setdefault("metadata", {}).update(metadata)
         return Group.objects.create(project=project, **kwargs)
 
     @staticmethod

--- a/tests/sentry/api/endpoints/test_group_hashes.py
+++ b/tests/sentry/api/endpoints/test_group_hashes.py
@@ -96,7 +96,10 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
     def test_unmerge(self):
         self.login_as(user=self.user)
 
-        group = self.create_group(platform="javascript")
+        group = self.create_group(
+            platform="javascript",
+            metadata={"sdk": {"name_normalized": "sentry.javascript.nextjs"}},
+        )
 
         hashes = [
             GroupHash.objects.create(project=group.project, group=group, hash=hash)
@@ -117,7 +120,7 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
             mock_metrics_incr.assert_any_call(
                 "grouping.unmerge_issues",
                 sample_rate=1.0,
-                tags={"platform": "javascript"},
+                tags={"platform": "javascript", "sdk": "sentry.javascript.nextjs"},
             )
 
     def test_unmerge_conflict(self):

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -335,9 +335,11 @@ class MergeGroupsTest(TestCase):
                 "unknown",
             ),
         ]:
-
             group_ids = [
-                self.create_group(platform="javascript").id,
+                self.create_group(
+                    platform="javascript",
+                    metadata={"sdk": {"name_normalized": "sentry.javascript.nextjs"}},
+                ).id,
                 self.create_group(platform="javascript").id,
             ]
             project = self.project
@@ -357,6 +359,7 @@ class MergeGroupsTest(TestCase):
                     tags={
                         "platform": "javascript",
                         "referer": expected_referer_tag,
+                        "sdk": "sentry.javascript.nextjs",
                     },
                 )
 


### PR DESCRIPTION
Implements #59748

Injects SDK name created in #59763 as a metric tag into group merge/unmerge metrics. 