### PR TITLE
feat(issue-details): Add analytics for replay preview status

### DIFF
--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -17,9 +17,12 @@ import {space} from 'sentry/styles/space';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import RequestError from 'sentry/utils/requestError/requestError';
+import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
+import {ReplayRecord} from 'sentry/views/replays/types';
 
 type Props = {
   eventTimestampMs: number;
@@ -28,6 +31,28 @@ type Props = {
   buttonProps?: Partial<ComponentProps<typeof LinkButton>>;
   focusTab?: TabKey;
 };
+
+function getReplayAnalyticsStatus({
+  fetchError,
+  replayRecord,
+}: {
+  fetchError?: RequestError;
+  replayRecord?: ReplayRecord;
+}) {
+  if (fetchError) {
+    return 'error';
+  }
+
+  if (replayRecord?.is_archived) {
+    return 'archived';
+  }
+
+  if (replayRecord) {
+    return 'success';
+  }
+
+  return 'none';
+}
 
 function ReplayPreview({
   buttonProps,
@@ -50,6 +75,10 @@ function ReplayPreview({
 
     return 0;
   }, [eventTimestampMs, startTimestampMs]);
+
+  useRouteAnalyticsParams({
+    event_replay_status: getReplayAnalyticsStatus({fetchError, replayRecord}),
+  });
 
   if (replayRecord?.is_archived) {
     return (

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -624,6 +624,8 @@ function useTrackView({
     trace_status: 'none',
     // Will be updated in GroupDetailsHeader if there are replays
     group_has_replay: false,
+    // Will be updated in ReplayPreview if there is a replay
+    event_replay_status: 'none',
     // Will be updated in SuspectCommits if there are suspect commits
     num_suspect_commits: 0,
     suspect_commit_calculation: 'no suspect commit',


### PR DESCRIPTION
We want to know how often the blue "replay not found" message is shown on issue details, so this adds `event_replay_status` to the `issue_details.viewed` analytics event.