### PR TITLE
fix(generic-metrics): Modify schema validation sampler

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/schema_validator.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/schema_validator.py
@@ -44,5 +44,5 @@ class MetricsSchemaValidator:
             return None
 
         validation_sample_rate = self.schema_validation_rules.get(use_case_id, 1.0)
-        if random.random() <= validation_sample_rate:
+        if random.random() < validation_sample_rate:
             return self.input_codec.validate(message)


### PR DESCRIPTION
`random.random()` generates a number within the bounds of [0.0, 1.0) -- inclusive of 0.0 and not inclusive of 1.0. This means that with the current sampler, a schema validation rate of 0.0 means that we could still be performing schema validation, since 0.0 <= 0.0
