### PR TITLE
fix(open-pr-comments): only replace source root

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -209,7 +209,7 @@ def get_projects_and_filenames_from_source_file(
         for code_mapping in code_mappings:
             project_list.add(code_mapping.project)
             sentry_filenames.add(
-                pr_filename.replace(code_mapping.source_root, code_mapping.stack_root)
+                pr_filename.replace(code_mapping.source_root, code_mapping.stack_root, 1)
             )
     return project_list, sentry_filenames
 

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -209,6 +209,7 @@ class TestGetFilenames(GithubCommentTestCase):
             ("/src/sentry", "sentry"),
             ("tests/", "tests/"),
             ("app/", "static/app"),
+            ("tasks/integrations", "tasks"),  # random match in the middle of the string
         ]
         for source_root, stack_root in source_stack_nonmatches:
             self.create_code_mapping(
@@ -221,8 +222,9 @@ class TestGetFilenames(GithubCommentTestCase):
 
         filename = "src/sentry/tasks/integrations/github/open_pr_comment.py"
         correct_filenames = [
-            filename.replace(source_root, stack_root)
-            for source_root, stack_root in source_stack_pairs
+            "./src/sentry/tasks/integrations/github/open_pr_comment.py",
+            "sentry//tasks/integrations/github/open_pr_comment.py",
+            "sentry/tasks/integrations/github/open_pr_comment.py",
         ]
 
         project_list, sentry_filenames = get_projects_and_filenames_from_source_file(


### PR DESCRIPTION
We want to replace the source root in the PR filename with the stack root. If there are multiple matches of the source root within the filename (e.g. if the source root is the empty string `""`) then we need to take care to only replace the first occurrence of the match.

We already filter for matches for the first occurrence of the source root in the PR filename is at index 0. This PR addresses the case where the first occurrence of the source root is at the beginning of the file AND there are multiple occurrences --> we replace only the first occurrence.