### PR TITLE
feat(crons): Switch default behavior to thresholds

### DIFF
--- a/src/sentry/monitors/logic/mark_ok.py
+++ b/src/sentry/monitors/logic/mark_ok.py
@@ -27,10 +27,12 @@ def mark_ok(checkin: MonitorCheckIn, ts: datetime):
         and monitor_env.status != MonitorStatus.OK
     ):
         params["status"] = MonitorStatus.OK
-        recovery_threshold = monitor_env.monitor.config.get("recovery_threshold")
+        recovery_threshold = monitor_env.monitor.config.get("recovery_threshold", 1)
+        if not recovery_threshold:
+            recovery_threshold = 1
 
         # Run incident logic if recovery threshold is set
-        if recovery_threshold:
+        if recovery_threshold > 1:
             # Check if our incident is recovering
             previous_checkins = (
                 MonitorCheckIn.objects.filter(monitor_environment=monitor_env)

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -242,7 +242,7 @@ class MarkFailedTestCase(TestCase):
         monitor_environment = MonitorEnvironment.objects.create(
             monitor=monitor,
             environment=self.environment,
-            status=monitor.status,
+            status=MonitorStatus.OK,
         )
 
         successful_check_in = MonitorCheckIn.objects.create(
@@ -585,6 +585,7 @@ class MarkFailedTestCase(TestCase):
         monitor_incidents = MonitorIncident.objects.filter(monitor_environment=monitor_environment)
         assert len(monitor_incidents) == 0
 
+    @with_feature("organizations:issue-platform")
     @patch("sentry.issues.producer.produce_occurrence_to_kafka")
     def test_mark_failed_issue_threshold(self, mock_produce_occurrence_to_kafka):
         failure_issue_threshold = 8


### PR DESCRIPTION
Changes default behavior for crons issues to create one issue per monitor incident. The default threshold is 1 for issue creation + recovery.

Includes solution to https://github.com/getsentry/sentry/issues/60123