### PR TITLE
fix(alerts): Hide total count for custom metrics and on-demand

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -895,6 +895,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     const isMigration = this.props.location?.query?.migration === '1';
     // TODO(telemetry-experience): Remove this and all connected logic once the migration is complete
     const isTransactionMigration = isMigration && ruleNeedsMigration(rule);
+    const isOnDemand = isOnDemandMetricAlert(dataset, aggregate, query);
 
     const chartProps = {
       organization,
@@ -913,7 +914,8 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       comparisonDelta,
       comparisonType,
       isQueryValid,
-      isOnDemandMetricAlert: isOnDemandMetricAlert(dataset, aggregate, query),
+      isOnDemandMetricAlert: isOnDemand,
+      showTotalCount: alertType !== 'custom_metrics' && !isOnDemand,
       onDataLoaded: this.handleTimeSeriesDataFetched,
     };
 

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.spec.tsx
@@ -51,10 +51,12 @@ describe('Incident Rules Create', () => {
         newAlertOrQuery
         onDataLoaded={() => {}}
         isQueryValid
+        showTotalCount
       />
     );
 
     expect(await screen.findByTestId('area-chart')).toBeInTheDocument();
+    expect(await screen.findByTestId('alert-total-events')).toBeInTheDocument();
 
     expect(eventStatsMock).toHaveBeenCalledWith(
       expect.anything(),
@@ -71,6 +73,60 @@ describe('Incident Rules Create', () => {
     );
 
     expect(eventCountsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {
+          project: ['2'],
+          query: 'event.type:error',
+          statsPeriod: '9999m',
+          environment: [],
+        },
+      })
+    );
+  });
+
+  it('does not show & query total count if showTotalCount === false', async () => {
+    const {organization, project, router} = initializeOrg();
+
+    render(
+      <TriggersChart
+        api={api}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        query="event.type:error"
+        timeWindow={1}
+        aggregate="count()"
+        dataset={Dataset.ERRORS}
+        triggers={[]}
+        environment={null}
+        comparisonType={AlertRuleComparisonType.COUNT}
+        resolveThreshold={null}
+        thresholdType={AlertRuleThresholdType.BELOW}
+        newAlertOrQuery
+        onDataLoaded={() => {}}
+        isQueryValid
+      />
+    );
+
+    expect(await screen.findByTestId('area-chart')).toBeInTheDocument();
+    expect(screen.queryByTestId('alert-total-events')).not.toBeInTheDocument();
+
+    expect(eventStatsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {
+          interval: '1m',
+          project: [2],
+          query: 'event.type:error',
+          statsPeriod: '9999m',
+          yAxis: 'count()',
+          referrer: 'api.organization-event-stats',
+        },
+      })
+    );
+
+    expect(eventCountsMock).not.toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         query: {

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -82,6 +82,7 @@ type Props = {
   header?: React.ReactNode;
   isOnDemandMetricAlert?: boolean;
   onDataLoaded?: (data: EventsStats | MultiSeriesEventsStats | null) => void;
+  showTotalCount?: boolean;
 };
 
 const TIME_PERIOD_MAP: Record<TimePeriod, string> = {
@@ -158,15 +159,18 @@ class TriggersChart extends PureComponent<Props, State> {
   };
 
   componentDidMount() {
-    if (!isSessionAggregate(this.props.aggregate)) {
+    const {aggregate, showTotalCount} = this.props;
+    if (showTotalCount && !isSessionAggregate(aggregate)) {
       this.fetchTotalCount();
     }
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    const {query, environment, timeWindow, aggregate, projects} = this.props;
+    const {query, environment, timeWindow, aggregate, projects, showTotalCount} =
+      this.props;
     const {statsPeriod} = this.state;
     if (
+      showTotalCount &&
       !isSessionAggregate(aggregate) &&
       (!isEqual(prevProps.projects, projects) ||
         prevProps.environment !== environment ||
@@ -243,6 +247,7 @@ class TriggersChart extends PureComponent<Props, State> {
         statsPeriod,
         environment: environment ? [environment] : [],
         dataset: queryDataset,
+        ...getForceMetricsLayerQueryExtras(organization, dataset),
       });
       this.setState({totalCount});
     } catch (e) {
@@ -284,6 +289,7 @@ class TriggersChart extends PureComponent<Props, State> {
       aggregate,
       comparisonType,
       organization,
+      showTotalCount,
     } = this.props;
     const {statsPeriod, totalCount} = this.state;
     const statsPeriodOptions = this.availableTimePeriods[timeWindow];
@@ -335,12 +341,16 @@ class TriggersChart extends PureComponent<Props, State> {
         )}
 
         <ChartControls>
-          <InlineContainer data-test-id="alert-total-events">
-            <SectionHeading>{totalCountLabel}</SectionHeading>
-            <SectionValue>
-              {totalCount !== null ? totalCount.toLocaleString() : '\u2014'}
-            </SectionValue>
-          </InlineContainer>
+          {showTotalCount ? (
+            <InlineContainer data-test-id="alert-total-events">
+              <SectionHeading>{totalCountLabel}</SectionHeading>
+              <SectionValue>
+                {totalCount !== null ? totalCount.toLocaleString() : '\u2014'}
+              </SectionValue>
+            </InlineContainer>
+          ) : (
+            <InlineContainer />
+          )}
           <InlineContainer>
             <CompactSelect
               size="sm"


### PR DESCRIPTION
Querying the total count is broken for custom metrics and on-demand metrics.
For now, we decided to hide it for those as it does not offer a lot of value in the alert creation context.

- closes https://github.com/getsentry/sentry/issues/60578