### PR TITLE
feat(ddm): enable DDM in dashboards

### DIFF
--- a/static/app/utils/metrics/features.tsx
+++ b/static/app/utils/metrics/features.tsx
@@ -1,9 +1,12 @@
 import type {Organization} from 'sentry/types';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 
-// TODO(ddm): rename this since dashboards and code locations are also behind it
-export function hasDdmAlertsSupport(organization: Organization) {
+export function hasDDMExperimentalFeature(organization: Organization) {
   return organization.features.includes('ddm-experimental');
+}
+
+export function hasDDMFeature(organization: Organization) {
+  return organization.features.includes('ddm-ui');
 }
 
 /**
@@ -16,7 +19,8 @@ export function getForceMetricsLayerQueryExtras(
   organization: Organization,
   alertDataset: Dataset
 ): {forceMetricsLayer: 'true'} | Record<string, never> {
-  return hasDdmAlertsSupport(organization) && alertDataset === Dataset.GENERIC_METRICS
+  return hasDDMExperimentalFeature(organization) &&
+    alertDataset === Dataset.GENERIC_METRICS
     ? {forceMetricsLayer: 'true'}
     : {};
 }

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -25,7 +25,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Environment, Organization, Project, SelectValue} from 'sentry/types';
 import {getDisplayName} from 'sentry/utils/environment';
-import {hasDdmAlertsSupport} from 'sentry/utils/metrics/features';
+import {hasDDMExperimentalFeature} from 'sentry/utils/metrics/features';
 import {getMRI} from 'sentry/utils/metrics/mri';
 import {getOnDemandKeys, isOnDemandQueryString} from 'sentry/utils/onDemandMetrics';
 import {hasOnDemandMetricAlertFeature} from 'sentry/utils/onDemandMetrics/features';
@@ -460,7 +460,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                 flexibleControlStateSize
               >
                 {({onChange, onBlur, onKeyDown, initialData, value}) => {
-                  return hasDdmAlertsSupport(organization) ? (
+                  return hasDDMExperimentalFeature(organization) ? (
                     <MetricSearchBar
                       mri={getMRI(aggregate)}
                       projectIds={[project.id]}

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -32,7 +32,7 @@ import {metric, trackAnalytics} from 'sentry/utils/analytics';
 import type EventView from 'sentry/utils/discover/eventView';
 import {
   getForceMetricsLayerQueryExtras,
-  hasDdmAlertsSupport,
+  hasDDMExperimentalFeature,
 } from 'sentry/utils/metrics/features';
 import {DEFAULT_METRIC_ALERT_FIELD, formatMRIField} from 'sentry/utils/metrics/mri';
 import {isOnDemandQueryString} from 'sentry/utils/onDemandMetrics';
@@ -1091,7 +1091,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
               thresholdChart={wizardBuilderChart}
               onFilterSearch={this.handleFilterUpdate}
               allowChangeEventTypes={
-                hasDdmAlertsSupport(organization)
+                hasDDMExperimentalFeature(organization)
                   ? dataset === Dataset.ERRORS
                   : dataset === Dataset.ERRORS || alertType === 'custom_transactions'
               }

--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -7,7 +7,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {explodeFieldString, generateFieldAsString} from 'sentry/utils/discover/fields';
-import {hasDdmAlertsSupport} from 'sentry/utils/metrics/features';
+import {hasDDMExperimentalFeature} from 'sentry/utils/metrics/features';
 import MriField from 'sentry/views/alerts/rules/metric/mriField';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {
@@ -105,7 +105,7 @@ export default function WizardField({
           label: AlertWizardAlertNames.cls,
           value: 'cls',
         },
-        ...(hasDdmAlertsSupport(organization)
+        ...(hasDDMExperimentalFeature(organization)
           ? [
               {
                 label: AlertWizardAlertNames.custom_transactions,
@@ -116,9 +116,9 @@ export default function WizardField({
       ],
     },
     {
-      label: hasDdmAlertsSupport(organization) ? t('METRICS') : t('CUSTOM'),
+      label: hasDDMExperimentalFeature(organization) ? t('METRICS') : t('CUSTOM'),
       options: [
-        hasDdmAlertsSupport(organization)
+        hasDDMExperimentalFeature(organization)
           ? {
               label: AlertWizardAlertNames.custom_metrics,
               value: 'custom_metrics',
@@ -179,7 +179,7 @@ export default function WizardField({
                 model.setValue('alertType', option.value);
               }}
             />
-            {hasDdmAlertsSupport(organization) && alertType === 'custom_metrics' ? (
+            {hasDDMExperimentalFeature(organization) && alertType === 'custom_metrics' ? (
               <MriField
                 project={project}
                 aggregate={aggregate}

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -11,7 +11,7 @@ import {
   SpanOpBreakdown,
   WebVital,
 } from 'sentry/utils/fields';
-import {hasDdmAlertsSupport} from 'sentry/utils/metrics/features';
+import {hasDDMExperimentalFeature} from 'sentry/utils/metrics/features';
 import {DEFAULT_METRIC_ALERT_FIELD} from 'sentry/utils/metrics/mri';
 import {ON_DEMAND_METRICS_UNSUPPORTED_TAGS} from 'sentry/utils/onDemandMetrics/constants';
 import {shouldShowOnDemandMetricAlertUI} from 'sentry/utils/onDemandMetrics/features';
@@ -103,14 +103,14 @@ export const getAlertWizardCategories = (org: Organization): AlertWizardCategory
       'lcp',
       'fid',
       'cls',
-      ...(hasDdmAlertsSupport(org)
+      ...(hasDDMExperimentalFeature(org)
         ? (['custom_transactions'] satisfies AlertType[])
         : []),
     ],
   },
   {
-    categoryHeading: hasDdmAlertsSupport(org) ? t('Metrics') : t('Custom'),
-    options: [hasDdmAlertsSupport(org) ? 'custom_metrics' : 'custom_transactions'],
+    categoryHeading: hasDDMExperimentalFeature(org) ? t('Metrics') : t('Custom'),
+    options: [hasDDMExperimentalFeature(org) ? 'custom_metrics' : 'custom_transactions'],
   },
 ];
 

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.tsx
@@ -34,6 +34,7 @@ import {
   getColumnsAndAggregatesAsStrings,
   QueryFieldValue,
 } from 'sentry/utils/discover/fields';
+import {hasDDMFeature} from 'sentry/utils/metrics/features';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -180,7 +181,6 @@ function WidgetBuilder({
   }
 
   const hasReleaseHealthFeature = organization.features.includes('dashboards-rh-widget');
-  const hasCustomMetricsFeature = organization.features.includes('ddm-experimental');
 
   const filteredDashboardWidgets = dashboard.widgets.filter(({widgetType}) => {
     if (widgetType === WidgetType.RELEASE) {
@@ -1132,7 +1132,7 @@ function WidgetBuilder({
                                     displayType={state.displayType}
                                     onChange={handleDataSetChange}
                                     hasReleaseHealthFeature={hasReleaseHealthFeature}
-                                    hasCustomMetricsFeature={hasCustomMetricsFeature}
+                                    hasCustomMetricsFeature={hasDDMFeature(organization)}
                                   />
                                   {isTabularChart && (
                                     <DashboardsMEPConsumer>

--- a/static/app/views/ddm/codeLocations.tsx
+++ b/static/app/views/ddm/codeLocations.tsx
@@ -7,7 +7,7 @@ import DefaultTitle from 'sentry/components/events/interfaces/frame/defaultTitle
 import {tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Frame, PageFilters} from 'sentry/types';
-import {hasDdmAlertsSupport} from 'sentry/utils/metrics/features';
+import {hasDDMExperimentalFeature} from 'sentry/utils/metrics/features';
 import {useMetricsCodeLocations} from 'sentry/utils/metrics/useMetricsCodeLocations';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -22,7 +22,7 @@ export function CodeLocations({
   const [isExpanded, setIsExpanded] = useState(false);
   const organization = useOrganization();
 
-  if (!hasDdmAlertsSupport(organization)) {
+  if (!hasDDMExperimentalFeature(organization)) {
     return null;
   }
 

--- a/static/app/views/ddm/contextMenu.tsx
+++ b/static/app/views/ddm/contextMenu.tsx
@@ -9,6 +9,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {MetricDisplayType, MetricsQuery} from 'sentry/utils/metrics';
+import {hasDDMFeature} from 'sentry/utils/metrics/features';
 import {MRIToField, parseMRI} from 'sentry/utils/metrics/mri';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -31,7 +32,7 @@ export function MetricWidgetContextMenu({metricsQuery, displayType}: ContextMenu
     displayType
   );
 
-  if (!organization.features.includes('ddm-experimental')) {
+  if (!hasDDMFeature(organization)) {
     return null;
   }
 


### PR DESCRIPTION
Moves DDM dashboard features from `ddm-experimental` to `ddm-ui`