### PR TITLE
fix(ddm): Quick fix to always take the last code location instead of the first

### DIFF
--- a/static/app/views/ddm/codeLocations.tsx
+++ b/static/app/views/ddm/codeLocations.tsx
@@ -30,8 +30,13 @@ export function CodeLocations({
     return null;
   }
 
-  const frameToShow = data?.codeLocations[0].frames[0];
-  const otherFrames = data?.codeLocations[0].frames.slice(1) ?? [];
+  const codeLocations = data?.codeLocations;
+  if (!codeLocations) {
+    return null;
+  }
+
+  const frameToShow = codeLocations[codeLocations.length - 1].frames[0];
+  const otherFrames = codeLocations[codeLocations.length - 1].frames.slice(1) ?? [];
 
   if (!frameToShow) {
     return null;


### PR DESCRIPTION
This is not a proper fix, currently the endpoint returns the latest items last, so we should use this to display for now. But the correct solution is to query by timeframe and aggregate all locations.