### PR TITLE
feat(browser-starfish): ui updates to resource module

### DIFF
--- a/static/app/utils/performance/contexts/pageError.tsx
+++ b/static/app/utils/performance/contexts/pageError.tsx
@@ -1,17 +1,23 @@
 import {createContext, useContext, useState} from 'react';
+import {Theme} from '@emotion/react';
 
 import {Alert} from 'sentry/components/alert';
 
+export type PageAlert = {
+  message: string;
+  type: keyof Theme['alert'];
+};
+
 const pageErrorContext = createContext<{
-  setPageError: (error: string | undefined) => void;
-  pageError?: string;
+  setPageError: (error: PageAlert | string | undefined) => void;
+  pageError?: PageAlert | string;
 }>({
   pageError: undefined,
-  setPageError: (_: string | undefined) => {},
+  setPageError: (_: PageAlert | string | undefined) => {},
 });
 
 export function PageErrorProvider({children}: {children: React.ReactNode}) {
-  const [pageError, setPageError] = useState<string | undefined>();
+  const [pageError, setPageError] = useState<PageAlert | string | undefined>();
   return (
     <pageErrorContext.Provider
       value={{
@@ -30,9 +36,12 @@ export function PageErrorAlert() {
     return null;
   }
 
+  const type = typeof pageError === 'string' ? 'error' : pageError.type;
+  const message = typeof pageError === 'string' ? pageError : pageError.message;
+
   return (
-    <Alert type="error" data-test-id="page-error-alert" showIcon>
-      {pageError}
+    <Alert type={type} data-test-id="page-error-alert" showIcon>
+      {message}
     </Alert>
   );
 }

--- a/static/app/views/performance/browser/resources/index.tsx
+++ b/static/app/views/performance/browser/resources/index.tsx
@@ -10,6 +10,10 @@ import {ProjectPageFilter} from 'sentry/components/organizations/projectPageFilt
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {RateUnits} from 'sentry/utils/discover/fields';
+import {
+  PageErrorAlert,
+  PageErrorProvider,
+} from 'sentry/utils/performance/contexts/pageError';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import ImageView from 'sentry/views/performance/browser/resources/imageView';
@@ -38,52 +42,54 @@ function ResourcesLandingPage() {
       title={[t('Performance'), t('Resources')].join(' — ')}
       baseURL="/performance/browser/resources"
     >
-      <Layout.Header>
-        <Layout.HeaderContent>
-          <Breadcrumbs
-            crumbs={[
-              {
-                label: 'Performance',
-                to: normalizeUrl(`/organizations/${organization.slug}/performance/`),
-                preservePageFilters: true,
-              },
-              {
-                label: 'Resources',
-              },
-            ]}
-          />
-
-          <Layout.Title>{t('Resources')}</Layout.Title>
-        </Layout.HeaderContent>
-      </Layout.Header>
-
-      <Layout.Body>
-        <Layout.Main fullWidth>
-          <FeedbackWidget />
-          <FilterOptionsContainer columnCount={2}>
-            <PageFilterBar condensed>
-              <ProjectPageFilter />
-              <EnvironmentPageFilter />
-              <DatePageFilter />
-            </PageFilterBar>
-            <DomainSelector
-              emptyOptionLocation="top"
-              value={filters[SPAN_DOMAIN] || ''}
-              additionalQuery={[
-                ...DEFAULT_RESOURCE_FILTERS,
-                `${SPAN_OP}:[${DEFAULT_RESOURCE_TYPES.join(',')}]`,
+      <PageErrorProvider>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Breadcrumbs
+              crumbs={[
+                {
+                  label: 'Performance',
+                  to: normalizeUrl(`/organizations/${organization.slug}/performance/`),
+                  preservePageFilters: true,
+                },
+                {
+                  label: 'Resources',
+                },
               ]}
             />
-          </FilterOptionsContainer>
 
-          {(!filters[SPAN_OP] ||
-            filters[SPAN_OP] === 'resource.script' ||
-            filters[SPAN_OP] === 'resource.css' ||
-            filters[SPAN_OP] === 'resource.font') && <JSCSSView />}
+            <Layout.Title>{t('Resources')}</Layout.Title>
+          </Layout.HeaderContent>
+        </Layout.Header>
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <FeedbackWidget />
+            <PageErrorAlert />
+            <FilterOptionsContainer columnCount={2}>
+              <PageFilterBar condensed>
+                <ProjectPageFilter />
+                <EnvironmentPageFilter />
+                <DatePageFilter />
+              </PageFilterBar>
+              <DomainSelector
+                emptyOptionLocation="top"
+                value={filters[SPAN_DOMAIN] || ''}
+                additionalQuery={[
+                  ...DEFAULT_RESOURCE_FILTERS,
+                  `${SPAN_OP}:[${DEFAULT_RESOURCE_TYPES.join(',')}]`,
+                ]}
+              />
+            </FilterOptionsContainer>
 
-          {filters[SPAN_OP] === 'resource.img' && <ImageView />}
-        </Layout.Main>
-      </Layout.Body>
+            {(!filters[SPAN_OP] ||
+              filters[SPAN_OP] === 'resource.script' ||
+              filters[SPAN_OP] === 'resource.css' ||
+              filters[SPAN_OP] === 'resource.font') && <JSCSSView />}
+
+            {filters[SPAN_OP] === 'resource.img' && <ImageView />}
+          </Layout.Main>
+        </Layout.Body>
+      </PageErrorProvider>
     </ModulePageProviders>
   );
 }

--- a/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
@@ -45,7 +45,7 @@ const {SPM} = SpanFunction;
 const RESOURCE_SIZE_ALERT: PageAlert = {
   type: 'info',
   message: t(
-    `If you're noticing unusually large resource sizes, try updating to SDK version 3.82.0 or higher.`
+    `If you're noticing unusually large resource sizes, try updating to SDK version 7.82.0 or higher.`
   ),
 };
 

--- a/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/jsCssView/resourceTable.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
@@ -12,6 +12,7 @@ import GridEditable, {
 import Pagination, {CursorHandler} from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {PageAlert, usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {RESOURCE_THROUGHPUT_UNIT} from 'sentry/views/performance/browser/resources';
@@ -41,10 +42,16 @@ const {TIME_SPENT_PERCENTAGE} = SpanFunction;
 
 const {SPM} = SpanFunction;
 
+const RESOURCE_SIZE_ALERT: PageAlert = {
+  type: 'info',
+  message: t(
+    `If you're noticing unusually large resource sizes, try updating to SDK version 3.82.0 or higher.`
+  ),
+};
+
 type Row = {
   'avg(http.response_content_length)': number;
   'avg(span.self_time)': number;
-  'http.decoded_response_content_length': number;
   'project.id': number;
   'resource.render_blocking_status': string;
   'span.description': string;
@@ -66,6 +73,7 @@ type Props = {
 function ResourceTable({sort, defaultResourceTypes}: Props) {
   const location = useLocation();
   const cursor = decodeScalar(location.query?.[QueryParameterNames.SPANS_CURSOR]);
+  const {setPageError, pageError} = usePageError();
 
   const {data, isLoading, pageLinks} = useResourcesQuery({
     sort,
@@ -76,7 +84,6 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
 
   const columnOrder: GridColumnOrder<keyof Row>[] = [
     {key: SPAN_DESCRIPTION, width: COL_WIDTH_UNDEFINED, name: t('Resource Description')},
-    {key: SPAN_OP, width: COL_WIDTH_UNDEFINED, name: t('Type')},
     {
       key: `${SPM}()`,
       width: COL_WIDTH_UNDEFINED,
@@ -94,14 +101,19 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
       name: DataTitles['avg(http.response_content_length)'],
     },
   ];
-  const tableData: Row[] = data.length
-    ? data.map(span => ({
-        ...span,
-        'http.decoded_response_content_length': Math.floor(
-          Math.random() * (1000 - 500) + 500
-        ),
-      }))
-    : [];
+  const tableData: Row[] = data;
+
+  useEffect(() => {
+    if (pageError !== RESOURCE_SIZE_ALERT) {
+      for (const row of tableData) {
+        const encodedSize = row[`avg(${HTTP_RESPONSE_CONTENT_LENGTH})`];
+        if (encodedSize >= 2147483647) {
+          setPageError(RESOURCE_SIZE_ALERT);
+          break;
+        }
+      }
+    }
+  }, [tableData, setPageError, pageError]);
 
   const renderBodyCell = (col: Column, row: Row) => {
     const {key} = col;
@@ -158,12 +170,6 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
         return <span>{t('Font')}</span>;
       }
       return <span>{spanOp}</span>;
-    }
-    if (key === 'http.decoded_response_content_length') {
-      const isUncompressed =
-        row['http.response_content_length'] ===
-        row['http.decoded_response_content_length'];
-      return <span>{isUncompressed ? t('true') : t('false')}</span>;
     }
     if (key === 'time_spent_percentage()') {
       return (


### PR DESCRIPTION
Fixes #60553 
And more work towards #60482 

1. Remove type column in resource module
2. Adds CTA to update SDK if resource sizes look off
![image](https://github.com/getsentry/sentry/assets/44422760/8eaa1311-ec24-463a-bc3a-6f694e26e73b)

3. remove some unused code for when we had decoded body size
