### PR TITLE
fix(browser-starfish): resource widget should not say alpha

### DIFF
--- a/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
@@ -30,7 +30,7 @@ export function WidgetHeader<T extends WidgetDataConstraint>(
   const featureBadge = isWebVitalsWidget ? (
     <FeatureBadge type="new" />
   ) : isResourcesWidget ? (
-    <FeatureBadge type="alpha" />
+    <FeatureBadge type="new" />
   ) : null;
 
   return (

--- a/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
@@ -27,11 +27,8 @@ export function WidgetHeader<T extends WidgetDataConstraint>(
   const isResourcesWidget =
     chartSetting === PerformanceWidgetSetting.MOST_TIME_CONSUMING_RESOURCES;
 
-  const featureBadge = isWebVitalsWidget ? (
-    <FeatureBadge type="new" />
-  ) : isResourcesWidget ? (
-    <FeatureBadge type="new" />
-  ) : null;
+  const featureBadge =
+    isWebVitalsWidget || isResourcesWidget ? <FeatureBadge type="new" /> : null;
 
   return (
     <WidgetHeaderContainer>


### PR DESCRIPTION
This resource module is not in alpha, it should say new instead
![image](https://github.com/getsentry/sentry/assets/44422760/a0e00ee3-309a-48b0-907e-b29488369fb5)
