### PR TITLE
feat(metrics_extraction): Track widget conditions & skip error only widgets

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -318,7 +318,7 @@ def _is_widget_query_low_cardinality(widget_query: DashboardWidgetQuery, project
         return False
 
     # No columns or only errors means no high-cardinality tags.
-    if not widget_query.columns or "conditions=event.type:error" in widget_query.conditions:
+    if not widget_query.columns or "event.type:error" in widget_query.conditions:
         return True
 
     max_cardinality_allowed = options.get("on_demand.max_widget_cardinality.count")

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -318,7 +318,7 @@ def _is_widget_query_low_cardinality(widget_query: DashboardWidgetQuery, project
         return False
 
     # No columns or only errors means no high-cardinality tags.
-    if not widget_query.columns or widget_query.conditions == "conditions=event.type:error":
+    if not widget_query.columns or "conditions=event.type:error" in widget_query.conditions:
         return True
 
     max_cardinality_allowed = options.get("on_demand.max_widget_cardinality.count")


### PR DESCRIPTION
We do not need to calculate the cardinality for widgets that are only for errors.

We want to slice the events for `HighCardinalityWidgetException` by the `conditions` of the widget queries in order to determine if there are more cases we need to skip.