### PR TITLE
feat(ui): Add usePrismTokens hook for custom rendering of syntax highlighted elements

### DIFF
--- a/static/app/utils/usePrismTokens.spec.tsx
+++ b/static/app/utils/usePrismTokens.spec.tsx
@@ -1,0 +1,111 @@
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import {loadPrismLanguage} from 'sentry/utils/loadPrismLanguage';
+import {usePrismTokens} from 'sentry/utils/usePrismTokens';
+
+const JS_CODE = `function foo() {
+  // Returns 'bar'
+  return 'bar';
+}`;
+
+const SINGLE_LINE_CODE = `const a='b'`;
+
+const NESTED_CODE = `<p class="hey">Test</p>`;
+
+describe('usePrismTokens', () => {
+  beforeAll(async () => {
+    // Loading all languagues up front makes tests run consistently
+    await loadPrismLanguage('javascript', {});
+    await loadPrismLanguage('html', {});
+  });
+
+  it('splits tokens by line', () => {
+    const {result} = reactHooks.renderHook(usePrismTokens, {
+      initialProps: {code: JS_CODE, language: 'javascript'},
+    });
+    const lines = result.current;
+    expect(lines).toHaveLength(4);
+
+    expect(lines[0]).toEqual([
+      {children: 'function', className: 'token keyword'},
+      {children: ' ', className: 'token'},
+      {children: 'foo', className: 'token function'},
+      {children: '(', className: 'token punctuation'},
+      {children: ')', className: 'token punctuation'},
+      {children: ' ', className: 'token'},
+      {children: '{', className: 'token punctuation'},
+    ]);
+
+    expect(lines[1]).toEqual([
+      {children: '  ', className: 'token'},
+      {children: "// Returns 'bar'", className: 'token comment'},
+    ]);
+
+    expect(lines[2]).toEqual([
+      {children: '  ', className: 'token'},
+      {children: 'return', className: 'token keyword'},
+      {children: ' ', className: 'token'},
+      {children: "'bar'", className: 'token string'},
+      {children: ';', className: 'token punctuation'},
+    ]);
+
+    expect(lines[3]).toEqual([{children: '}', className: 'token punctuation'}]);
+  });
+
+  it('works with single line of code', () => {
+    const {result} = reactHooks.renderHook(usePrismTokens, {
+      initialProps: {code: SINGLE_LINE_CODE, language: 'javascript'},
+    });
+    const lines = result.current;
+
+    expect(lines).toEqual([
+      [
+        {children: 'const', className: 'token keyword'},
+        {children: ' a', className: 'token'},
+        {children: '=', className: 'token operator'},
+        {children: "'b'", className: 'token string'},
+      ],
+    ]);
+  });
+
+  it('falls back when no grammar is available', () => {
+    jest.spyOn(console, 'warn').mockImplementation();
+
+    const {result} = reactHooks.renderHook(usePrismTokens, {
+      initialProps: {code: JS_CODE, language: 'not-a-language'},
+    });
+    const lines = result.current;
+
+    expect(lines).toEqual([
+      [{children: 'function foo() {', className: 'token'}],
+      [{children: "  // Returns 'bar'", className: 'token'}],
+      [{children: "  return 'bar';", className: 'token'}],
+      [{children: '}', className: 'token'}],
+    ]);
+  });
+
+  it('works with nested tokens', () => {
+    const {result} = reactHooks.renderHook(usePrismTokens, {
+      initialProps: {code: NESTED_CODE, language: 'html'},
+    });
+    const lines = result.current;
+
+    expect(lines).toEqual([
+      [
+        {children: '<', className: 'token tag punctuation'},
+        {children: 'p', className: 'token tag'},
+        {children: ' ', className: 'token tag'},
+        {children: 'class', className: 'token tag attr-name'},
+        {children: '=', className: 'token tag attr-value punctuation'},
+        {children: '"', className: 'token tag attr-value punctuation'},
+        {children: 'hey', className: 'token tag attr-value'},
+        {children: '"', className: 'token tag attr-value punctuation'},
+        {children: '>', className: 'token tag punctuation'},
+        {children: 'Test', className: 'token'},
+        {children: '</', className: 'token tag punctuation'},
+        {children: 'p', className: 'token tag'},
+        {children: '>', className: 'token tag punctuation'},
+      ],
+    ]);
+  });
+});

--- a/static/app/utils/usePrismTokens.stories.tsx
+++ b/static/app/utils/usePrismTokens.stories.tsx
@@ -1,0 +1,91 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import JSXNode from 'sentry/components/stories/jsxNode';
+import SizingWindow from 'sentry/components/stories/sizingWindow';
+import storyBook from 'sentry/stories/storyBook';
+import {prismStyles} from 'sentry/styles/prism';
+import {space} from 'sentry/styles/space';
+import {SyntaxHighlightLine, usePrismTokens} from 'sentry/utils/usePrismTokens';
+
+const JS_CODE = `function foo() {
+  // Returns 'bar'
+  return 'bar';
+}`;
+
+function TestComponent({
+  languange,
+  lines,
+}: {
+  languange: string;
+  lines: SyntaxHighlightLine[];
+}) {
+  return (
+    <Wrapper>
+      <pre className={`language-${languange}`}>
+        <code>
+          {lines.map((line, i) => (
+            <Line key={i}>
+              <LineNumber>ln: {i + 1}</LineNumber>
+              <div>
+                {line.map((token, j) => (
+                  <span key={j} className={token.className}>
+                    {token.children}
+                  </span>
+                ))}
+              </div>
+            </Line>
+          ))}
+        </code>
+      </pre>
+    </Wrapper>
+  );
+}
+
+export default storyBook('usePrismTokens', story => {
+  story('Default', () => {
+    const lines = usePrismTokens({code: JS_CODE, language: 'js'});
+
+    return (
+      <Fragment>
+        <p>
+          The <code>usePrismTokens</code> hook is meant to be used for code blocks which
+          require custom UI or behavior, such as customizing line numbers of highlighting
+          parts of the code. If this is not required, use the{' '}
+          <JSXNode name="CodeSnippet" /> component or{' '}
+          <code>Prism.highlightElement()</code>.
+        </p>
+        <SizingWindow display="block">
+          <TestComponent languange="js" lines={lines} />
+        </SizingWindow>
+      </Fragment>
+    );
+  });
+});
+
+const Wrapper = styled('div')`
+  max-width: 400px;
+  background: var(--prism-block-background);
+  border-radius: ${p => p.theme.borderRadius};
+  border: 1px solid ${p => p.theme.border};
+
+  ${p => prismStyles(p.theme)}
+  pre {
+    margin: 0;
+  }
+`;
+
+const Line = styled('div')`
+  display: grid;
+  grid-template-columns: 58px 1fr;
+  gap: ${space(1)};
+  height: 22px;
+  line-height: 22px;
+  background-color: ${p => p.theme.background};
+`;
+
+const LineNumber = styled('div')`
+  background: ${p => p.theme.purple400};
+  color: ${p => p.theme.white};
+  padding: 0 ${space(1)};
+`;

--- a/static/app/utils/usePrismTokens.tsx
+++ b/static/app/utils/usePrismTokens.tsx
@@ -1,0 +1,151 @@
+import {useEffect, useMemo, useState} from 'react';
+import * as Sentry from '@sentry/react';
+import * as Prism from 'prismjs';
+
+import {loadPrismLanguage, prismLanguageMap} from 'sentry/utils/loadPrismLanguage';
+
+type PrismHighlightParams = {
+  code: string;
+  language: string;
+};
+
+export type SyntaxHighlightToken = {
+  children: string;
+  className: string;
+};
+
+export type SyntaxHighlightLine = SyntaxHighlightToken[];
+
+type IntermediateToken = {
+  children: string;
+  types: Set<string>;
+};
+
+const useLoadPrismLanguage = (language: string, {onLoad}: {onLoad: () => void}) => {
+  useEffect(() => {
+    if (!language) {
+      return;
+    }
+
+    loadPrismLanguage(language, {
+      onLoad,
+      onError: () => {
+        Sentry.withScope(scope => {
+          scope.setTag('prism_language', language);
+          Sentry.captureException(
+            new Error('Prism.js failed to load language for stack trace')
+          );
+        });
+      },
+    });
+  }, [language, onLoad]);
+};
+
+const getPrismGrammar = (language: string) => {
+  const fullLanguage = prismLanguageMap[language];
+  return Prism.languages[fullLanguage] ?? null;
+};
+
+const splitMultipleTokensByLine = (
+  tokens: Array<string | Prism.Token>,
+  types: Set<string> = new Set(['token'])
+) => {
+  const lines: IntermediateToken[][] = [];
+  let currentLine: IntermediateToken[] = [];
+
+  for (const token of tokens) {
+    const tokenLines = splitTokenContentByLine(token, new Set(types));
+    if (tokenLines.length === 0) {
+      continue;
+    }
+
+    currentLine.push(...tokenLines[0]);
+    if (tokenLines.length > 1) {
+      for (let i = 1; i < tokenLines.length; i++) {
+        lines.push(currentLine);
+        currentLine = tokenLines[i];
+      }
+    }
+  }
+
+  if (currentLine.length > 0) {
+    lines.push(currentLine);
+  }
+
+  return lines;
+};
+
+// Splits a token by newlines encounted inside of its content.
+// Returns an array of lines. If the returned array only has a single
+// line, no newlines were found.
+const splitTokenContentByLine = (
+  token: string | Prism.Token,
+  types: Set<string> = new Set(['token'])
+): IntermediateToken[][] => {
+  if (typeof token === 'string') {
+    const lines: IntermediateToken[][] = [];
+    token.split(/\r?\n/).forEach(line => {
+      if (line) {
+        lines.push([{types: new Set(types), children: line}]);
+      } else {
+        // If empty string, new line was at the end of the token
+        lines.push([]);
+      }
+    });
+    return lines;
+  }
+
+  types.add(token.type);
+
+  if (Array.isArray(token.content)) {
+    return splitMultipleTokensByLine(token.content, new Set(types));
+  }
+
+  return splitTokenContentByLine(token.content, types);
+};
+
+const breakTokensByLine = (
+  tokens: Array<string | Prism.Token>
+): SyntaxHighlightLine[] => {
+  const lines = splitMultipleTokensByLine(tokens);
+
+  return lines.map(line =>
+    line.map(token => ({
+      children: token.children,
+      className: [...token.types].join(' '),
+    }))
+  );
+};
+
+/**
+ * Returns a list of tokens broken up by line for syntax highlighting.
+ *
+ * Meant to be used for code blocks which require custom UI and cannot rely
+ * on Prism.highlightElement().
+ *
+ * Each token contains a `className` and `children` which can be used for
+ * rendering like so: <span className={token.className}>{token.children}</span>
+ *
+ * Automatically handles importing of the language grammar.
+ */
+export const usePrismTokens = ({
+  code,
+  language,
+}: PrismHighlightParams): SyntaxHighlightLine[] => {
+  const [grammar, setGrammar] = useState<Prism.Grammar | null>(() =>
+    getPrismGrammar(language)
+  );
+  useLoadPrismLanguage(language, {
+    onLoad: () => {
+      setGrammar(getPrismGrammar(language));
+    },
+  });
+  const tokens = useMemo(() => {
+    if (!grammar) {
+      return [code];
+    }
+    return Prism.tokenize(code, grammar);
+  }, [grammar, code]);
+
+  return breakTokensByLine(tokens);
+};

--- a/static/app/utils/usePrismTokens.tsx
+++ b/static/app/utils/usePrismTokens.tsx
@@ -30,12 +30,10 @@ const useLoadPrismLanguage = (language: string, {onLoad}: {onLoad: () => void}) 
     loadPrismLanguage(language, {
       onLoad,
       onError: () => {
-        Sentry.withScope(scope => {
-          scope.setTag('prism_language', language);
-          Sentry.captureException(
-            new Error('Prism.js failed to load language for stack trace')
-          );
-        });
+        Sentry.captureException(
+          new Error('Prism.js failed to load language for stack trace'),
+          {extra: {language}}
+        );
       },
     });
   }, [language, onLoad]);
@@ -140,12 +138,13 @@ export const usePrismTokens = ({
       setGrammar(getPrismGrammar(language));
     },
   });
-  const tokens = useMemo(() => {
+  const lines = useMemo(() => {
     if (!grammar) {
-      return [code];
+      return breakTokensByLine([code]);
     }
-    return Prism.tokenize(code, grammar);
+    const tokens = Prism.tokenize(code, grammar);
+    return breakTokensByLine(tokens);
   }, [grammar, code]);
 
-  return breakTokensByLine(tokens);
+  return lines;
 };


### PR DESCRIPTION
I'm adding this utility hook to allow for more custom rendering of code blocks. `Prims.highlightElement` works well for just normal syntax highlighting, but there are situations where we want to customize line numbers or render elements inline (such as the stacktrace links in the stack trace). Using Prism.tokenize() allows us to do this all in React which allows for a lot more flexibility than having to deal with Prism plugins.

I initially tried using the library https://github.com/FormidableLabs/prism-react-renderer, but found that it brought in [30kb (gzipped)](https://bundlejs.com/?q=prism-react-renderer%402.3.0&treeshake=%5B%7B+Highlight+%7D%5D) which seemed unnecessary for what we required. So I decided to just implement the necessary functionality, which is the part where we break the prism tokens up by line to more easily customize the rendering.

While this isn't yet implemented anywhere, there are tests and you can see an example in the stories:

<img width="683" alt="CleanShot 2023-11-29 at 10 01 36@2x" src="https://github.com/getsentry/sentry/assets/10888943/4cbc85d5-2a3e-454f-8f10-dcd09957487d">
