### PR TITLE
fix(discover): Fix a bug in the errors dataset in discover when we don't pass a query that causes a join

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -14,6 +14,7 @@ from sentry.constants import MAX_TOP_EVENTS
 from sentry.models.organization import Organization
 from sentry.snuba import (
     discover,
+    errors,
     functions,
     metrics_enhanced_performance,
     metrics_performance,
@@ -189,6 +190,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                     if dataset
                     in [
                         discover,
+                        errors,
                         functions,
                         metrics_performance,
                         metrics_enhanced_performance,

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -143,7 +143,7 @@ def zerofill(data, start, end, rollup, orderby, time_col_name=None):
     data_by_time = {}
 
     for obj in data:
-        if time_col_name:
+        if time_col_name and time_col_name in obj:
             obj["time"] = obj.pop(time_col_name)
         # This is needed for SnQL, and was originally done in utils.snuba.get_snuba_translators
         if isinstance(obj["time"], str):

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -189,6 +189,18 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         assert response.status_code == 200, response.content
         assert [attrs for time, attrs in response.data["data"]] == [[{"count": 1}], [{"count": 2}]]
 
+    def test_errors_dataset_no_query(self):
+        response = self.do_request(
+            {
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=2)),
+                "interval": "1h",
+                "dataset": "errors",
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert [attrs for time, attrs in response.data["data"]] == [[{"count": 1}], [{"count": 2}]]
+
     def test_misaligned_last_bucket(self):
         response = self.do_request(
             data={


### PR DESCRIPTION
The errors dataset in discover was erroring out when we included a query that doesn't perform a join. Added a fix + test to handle this case
