### PR TITLE
feat(stacktrace): Add syntax highlighting to stack trace

### DIFF
--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -161,7 +161,7 @@ function Context({
       className={`${className} context ${isExpanded ? 'expanded' : ''}`}
       data-test-id="frame-context"
     >
-      {frame.context && hasSyntaxHighlighting ? (
+      {frame.context && hasSyntaxHighlighting && lines.length > 0 ? (
         <CodeWrapper className={prismClassName}>
           <pre className={prismClassName}>
             <code className={prismClassName}>

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -8,7 +8,6 @@ import ContextLine from 'sentry/components/events/interfaces/frame/contextLine';
 import {StacktraceLink} from 'sentry/components/events/interfaces/frame/stacktraceLink';
 import {IconFlag} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {prismStyles} from 'sentry/styles/prism';
 import {space} from 'sentry/styles/space';
 import {
   CodecovStatusCode,
@@ -136,8 +135,8 @@ function Context({
   );
 
   const fileExtension = getFileExtension(frame.filename || '') ?? '';
-  const tokens = usePrismTokens({
-    code: contextLines.map(([, code]) => code).join('\n'),
+  const lines = usePrismTokens({
+    code: contextLines?.map(([, code]) => code).join('\n') ?? '',
     language: fileExtension,
   });
 
@@ -166,7 +165,7 @@ function Context({
         <CodeWrapper className={prismClassName}>
           <pre className={prismClassName}>
             <code className={prismClassName}>
-              {tokens.map((line, i) => {
+              {lines.map((line, i) => {
                 const contextLine = contextLines[i];
                 const isActive = activeLineNumber === contextLine[0];
                 const hasComponents = isActive && components.length > 0;
@@ -295,7 +294,6 @@ const CodeWrapper = styled('div')`
   position: relative;
   padding: 0;
 
-  ${p => prismStyles(p.theme)}
   && pre {
     white-space: pre-wrap;
     margin: 0;

--- a/static/app/components/events/interfaces/frame/contextLineNumber.tsx
+++ b/static/app/components/events/interfaces/frame/contextLineNumber.tsx
@@ -1,0 +1,101 @@
+import styled from '@emotion/styled';
+import classNames from 'classnames';
+
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {Coverage} from 'sentry/types';
+
+interface Props {
+  isActive: boolean;
+  lineNumber: number;
+  children?: React.ReactNode;
+  coverage?: Coverage | '';
+}
+
+const coverageText: Record<Coverage, string | undefined> = {
+  [Coverage.NOT_COVERED]: t('Uncovered'),
+  [Coverage.COVERED]: t('Covered'),
+  [Coverage.PARTIAL]: t('Partially Covered'),
+  [Coverage.NOT_APPLICABLE]: undefined,
+};
+const coverageClass: Record<Coverage, string | undefined> = {
+  [Coverage.NOT_COVERED]: 'uncovered',
+  [Coverage.COVERED]: 'covered',
+  [Coverage.PARTIAL]: 'partial',
+  [Coverage.NOT_APPLICABLE]: undefined,
+};
+
+function ContextLineNumber({lineNumber, isActive, coverage = ''}: Props) {
+  return (
+    <Wrapper className={classNames(coverageClass[coverage], isActive ? 'active' : '')}>
+      <Tooltip skipWrapper title={coverageText[coverage]} delay={200}>
+        <div className="line-number">{lineNumber}</div>
+      </Tooltip>
+    </Wrapper>
+  );
+}
+
+export default ContextLineNumber;
+
+const Wrapper = styled('div')`
+  background: inherit;
+  height: 24px;
+  width: 58px;
+  display: inline-block;
+  color: ${p => p.theme.textColor};
+  font-size: ${p => p.theme.fontSizeSmall};
+  margin-right: ${space(1)};
+
+  .line-number {
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: end;
+    height: 100%;
+    text-align: right;
+    padding-right: ${space(2)};
+    margin-right: ${space(1.5)};
+    background: transparent;
+    min-width: 58px;
+    border-right-style: solid;
+    border-right-color: transparent;
+    user-select: none;
+  }
+
+  &.covered .line-number {
+    background: ${p => p.theme.green100};
+  }
+
+  &.uncovered .line-number {
+    background: ${p => p.theme.red100};
+    border-right-color: ${p => p.theme.red300};
+  }
+
+  &.partial .line-number {
+    background: ${p => p.theme.yellow100};
+    border-right-style: dashed;
+    border-right-color: ${p => p.theme.yellow300};
+  }
+
+  &.active {
+    background: none;
+  }
+
+  &.active.partial .line-number {
+    mix-blend-mode: screen;
+    background: ${p => p.theme.yellow200};
+  }
+
+  &.active.covered .line-number {
+    mix-blend-mode: screen;
+    background: ${p => p.theme.green200};
+  }
+
+  &.active.uncovered .line-number {
+    color: ${p => p.theme.stacktraceActiveText};
+    mix-blend-mode: screen;
+    background: ${p => p.theme.red300};
+  }
+`;


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/47598

Uses `usePrismTokens` to add syntax highlighting to the stack trace when the `issue-details-stacktrace-syntax-highlighting` flag is enabled. 

Before:

![CleanShot 2023-11-29 at 10 55 42](https://github.com/getsentry/sentry/assets/10888943/25f38151-0fa0-447c-a3c6-d52a00c7c63f)

Affter:

![CleanShot 2023-11-29 at 10 43 02](https://github.com/getsentry/sentry/assets/10888943/89f73bcd-782f-4ceb-bac2-709eb19385c1)

![CleanShot 2023-11-29 at 10 44 00](https://github.com/getsentry/sentry/assets/10888943/5034d188-9e23-4766-8c3e-70a240d1d4c3)
