### PR TITLE
ref: convert sentry settings import hook to a normal module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -527,7 +527,6 @@ module = [
     "sentry.rules.history.endpoints.project_rule_group_history",
     "sentry.rules.history.endpoints.project_rule_stats",
     "sentry.rules.history.preview",
-    "sentry.runner.importer",
     "sentry.runner.initializer",
     "sentry.scim.endpoints.members",
     "sentry.scim.endpoints.teams",

--- a/src/sentry/runner/default_settings.py
+++ b/src/sentry/runner/default_settings.py
@@ -1,0 +1,8 @@
+"""this module is lazily loaded -- it is ~/.sentry/sentry.conf.py overlayed on sentry.conf.server."""
+from __future__ import annotations
+
+import sys
+
+from sentry.runner.importer import populate_module
+
+populate_module(sys.modules[__name__])

--- a/src/sentry/runner/importer.py
+++ b/src/sentry/runner/importer.py
@@ -1,103 +1,34 @@
 import importlib.metadata
-import sys
+import os.path
 import types
 
-import click
+DEFAULT_SETTINGS_MODULE = "sentry.conf.server"
+SENTRY_CONF_PY = os.path.expanduser("~/.sentry/sentry.conf.py")
 
 
-def install(name, config_path, default_settings, callback=None):
-    sys.meta_path.append(Importer(name, config_path, default_settings, callback))
+def populate_module(settings_mod: types.ModuleType) -> None:
+    default_settings_mod = importlib.import_module(DEFAULT_SETTINGS_MODULE)
+
+    # install the default settings for this app
+    _add_settings(default_settings_mod, settings=settings_mod)
+
+    # install the custom settings for this app
+    _load_settings(SENTRY_CONF_PY, settings=settings_mod)
+
+    install_plugin_apps("sentry.apps", settings_mod)
 
 
-class ConfigurationError(ValueError, click.ClickException):
-    def show(self, file=None):
-        if file is None:
-            from click._compat import get_text_stderr
+def _load_settings(filename: str, settings: types.ModuleType) -> None:
+    conf = types.ModuleType("temp_config")
+    conf.__file__ = filename
 
-            file = get_text_stderr()
-        click.secho(f"!! Configuration error: {self!r}", file=file, fg="red")
+    try:
+        with open(filename, mode="rb") as source_file:
+            exec(source_file.read(), conf.__dict__)
+    except (FileNotFoundError, IsADirectoryError):
+        return
 
-
-class Importer:
-    def __init__(self, name, config_path, default_settings=None, callback=None):
-        self.name = name
-        self.config_path = config_path
-        self.default_settings = default_settings
-        self.callback = callback
-
-    def __repr__(self):
-        return f"<{type(self)} for '{self.name}' ({self.config_path})>"
-
-    def find_module(self, fullname, path=None):
-        if fullname != self.name:
-            return
-        return self
-
-    def load_module(self, fullname):
-        # Check to make sure it's not already in sys.modules in case of a reload()
-        if fullname in sys.modules:
-            return sys.modules[fullname]  # pragma: no cover
-
-        try:
-            mod = self._load_module(fullname)
-        except Exception as e:
-            msg = str(e)
-            if msg:
-                msg = f"{type(e).__name__}: {msg}"
-            else:
-                msg = type(e).__name__
-            raise ConfigurationError(msg).with_traceback(e.__traceback__)
-        else:
-            # Install into sys.modules explicitly
-            sys.modules[fullname] = mod
-            if self.callback is not None:
-                self.callback(mod)
-            return mod
-
-    def _load_module(self, fullname):
-        if self.default_settings:
-            from importlib import import_module
-
-            default_settings_mod = import_module(self.default_settings)
-        else:
-            default_settings_mod = None
-
-        settings_mod = types.ModuleType(self.name)
-
-        # Django doesn't play too nice without the config file living as a real
-        # file, so let's fake it.
-        settings_mod.__file__ = self.config_path
-
-        # install the default settings for this app
-        load_settings(default_settings_mod, settings=settings_mod)
-
-        # install the custom settings for this app
-        load_settings(self.config_path, settings=settings_mod, silent=True)
-
-        install_plugin_apps("sentry.apps", settings_mod)
-
-        return settings_mod
-
-
-def load_settings(mod_or_filename, settings, silent=False):
-    if isinstance(mod_or_filename, str):
-        conf = types.ModuleType("temp_config")
-        conf.__file__ = mod_or_filename
-
-        try:
-            with open(mod_or_filename, mode="rb") as source_file:
-                exec(source_file.read(), conf.__dict__)
-        except OSError as e:
-            import errno
-
-            if silent and e.errno in (errno.ENOENT, errno.EISDIR):
-                return settings
-            e.strerror = "Unable to load configuration file (%s)" % e.strerror
-            raise
-    else:
-        conf = mod_or_filename
-
-    add_settings(conf, settings=settings)
+    _add_settings(conf, settings=settings)
 
 
 def install_plugin_apps(entry_point, settings):
@@ -117,7 +48,7 @@ def install_plugin_apps(entry_point, settings):
     settings.INSTALLED_APPS = tuple(installed_apps)
 
 
-def add_settings(mod, settings):
+def _add_settings(mod: types.ModuleType, settings: types.ModuleType) -> None:
     """
     Adds all settings that are part of ``mod`` to the global settings object.
     Special cases ``EXTRA_APPS`` to append the specified applications to the
@@ -129,7 +60,7 @@ def add_settings(mod, settings):
             continue
 
         setting_value = getattr(mod, setting)
-        if setting in ("INSTALLED_APPS",) and isinstance(setting_value, str):
+        if setting == "INSTALLED_APPS" and isinstance(setting_value, str):
             setting_value = (setting_value,)  # In case the user forgot the comma.
 
         # Any setting that starts with EXTRA_ and matches a setting that is a list or tuple

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -3,7 +3,8 @@ import warnings
 
 import click
 
-DEFAULT_SETTINGS_MODULE = "sentry.conf.server"
+from sentry.runner import importer
+
 DEFAULT_SETTINGS_CONF = "config.yml"
 DEFAULT_SETTINGS_OVERRIDE = "sentry.conf.py"
 
@@ -109,8 +110,6 @@ def configure(ctx, py, yaml, skip_service_validation=False):
     ):
         mimetypes.add_type(type, "." + ext)
 
-    from .importer import install
-
     if yaml is None:
         # `yaml` will be None when SENTRY_CONF is pointed
         # directly to a file, in which case, this file must exist
@@ -135,9 +134,9 @@ def configure(ctx, py, yaml, skip_service_validation=False):
 
         reload_on_change(yaml)
 
-    os.environ["DJANGO_SETTINGS_MODULE"] = "sentry_config"
+    importer.SENTRY_CONF_PY = py
 
-    install("sentry_config", py, DEFAULT_SETTINGS_MODULE)
+    os.environ["DJANGO_SETTINGS_MODULE"] = "sentry.runner.default_settings"
 
     from django.conf import settings
 

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -2,8 +2,7 @@ import types
 
 import pytest
 
-from sentry.runner.importer import ConfigurationError
-from sentry.runner.initializer import apply_legacy_settings, bootstrap_options
+from sentry.runner.initializer import ConfigurationError, apply_legacy_settings, bootstrap_options
 from sentry.utils.warnings import DeprecatedSettingWarning
 
 


### PR DESCRIPTION
this speeds up test discovery by about 1% (discovery is import-heavy and every import went through the custom meta_path loader)

closes #60799

<!-- Describe your PR here. -->