### PR TITLE
fix(starfish): Skip querying for chart if all charts minimized

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/slowScreens.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/slowScreens.tsx
@@ -172,6 +172,10 @@ function SlowScreensByTTID(props: PerformanceWidgetProps) {
         },
         fields: field,
         component: provided => {
+          if (selectedListIndex < 0) {
+            return null;
+          }
+
           const eventView = props.eventView.clone();
           let extraQueryParams = getMEPParamsIfApplicable(mepSetting, props.chartSetting);
           const pageFilterDatetime = {


### PR DESCRIPTION
There's a downstream lookup for the transaction name for the chart query that errors out if we minimize the charts (i.e. selectedListIndex is -1). This avoids the query if there's nothing to fetch.

Fixes JAVASCRIPT-2PYZ
