### PR TITLE
chore(profiling): Disable profiling deobfuscation v2

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -71,7 +71,7 @@ simplejson>=3.17.6
 sqlparse>=0.4.4
 statsd>=3.3
 structlog>=22
-symbolic>=12.7.0
+symbolic==12.3.0
 toronado>=0.1.0
 typing-extensions>=4.0.0
 ua-parser>=0.10.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -188,7 +188,7 @@ sqlparse==0.4.4
 statsd==3.3
 stripe==3.1.0
 structlog==22.1.0
-symbolic==12.7.0
+symbolic==12.3.0
 time-machine==2.13.0
 tokenize-rt==5.0.0
 tomli==2.0.1

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -127,7 +127,7 @@ sqlparse==0.4.4
 statsd==3.3
 stripe==3.1.0
 structlog==22.1.0
-symbolic==12.7.0
+symbolic==12.3.0
 toronado==0.1.0
 tqdm==4.64.1
 typing-extensions==4.5.0

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import random
 from copy import deepcopy
 from datetime import datetime, timezone
 from time import time
@@ -11,7 +10,7 @@ import sentry_sdk
 from django.conf import settings
 from symbolic.proguard import ProguardMapper
 
-from sentry import options, quotas
+from sentry import quotas
 from sentry.constants import DataCategory
 from sentry.lang.javascript.processing import _handles_frame as is_valid_javascript_frame
 from sentry.lang.native.processing import _merge_image
@@ -240,12 +239,18 @@ def _deobfuscate_profile(profile: Profile, project: Project) -> bool:
                 )
                 return True
 
-            if project.organization_id in options.get(
-                "profiling.android.deobfuscation_v2_org_ids"
-            ) or random.random() < options.get("profiling.android.deobfuscation_v2_sample_rate"):
-                _deobfuscate_v2(profile=profile, project=project)
-            else:
-                _deobfuscate(profile=profile, project=project)
+            _deobfuscate(profile=profile, project=project)
+
+            # V2 depends on a newer version of symbolic that is causing
+            # OOMs in the save transaction workers.
+            #
+            # if project.organization_id in options.get(
+            #     "profiling.android.deobfuscation_v2_org_ids"
+            # ) or random.random() < options.get("profiling.android.deobfuscation_v2_sample_rate"):
+            #     _deobfuscate_v2(profile=profile, project=project)
+            # else:
+            #     _deobfuscate(profile=profile, project=project)
+
             profile["deobfuscated"] = True
             return True
         except Exception as e:
@@ -775,6 +780,7 @@ def _deobfuscate(profile: Profile, project: Project) -> None:
                     method["data"]["deobfuscation_status"] = "missing"
 
 
+""" disabled as this requires a newer version of symbolic that is causing OOMs
 @metrics.wraps("process_profile.deobfuscate")
 def _deobfuscate_v2(profile: Profile, project: Project) -> None:
     debug_file_id = profile.get("build_id")
@@ -871,6 +877,7 @@ def _deobfuscate_v2(profile: Profile, project: Project) -> None:
                     method["data"]["deobfuscation_status"] = "partial"
                 else:
                     method["data"]["deobfuscation_status"] = "missing"
+"""
 
 
 @metrics.wraps("process_profile.track_outcome")


### PR DESCRIPTION
This depends on a new version of symbolic/rust-proguard that is causing OOMs elsewhere in sentry. So we're disabling this and followed by a library downgrade.