### PR TITLE
fix(open-pr-comments): use count_users_seen to get affected user count

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -120,7 +120,7 @@ def get_issue_table_contents(issue_list: List[Dict[str, int]]) -> List[PullReque
             title=issue.title,
             subtitle=issue.culprit,
             url=issue.get_absolute_url(),
-            affected_users=group_id_to_info[issue.id]["affected_users"],
+            affected_users=issue.count_users_seen(),
             event_count=group_id_to_info[issue.id]["event_count"],
             is_handled=bool(group_id_to_info[issue.id]["is_handled"]),
         )
@@ -237,7 +237,6 @@ def get_top_5_issues_by_count_for_file(
                 [
                     Column("group_id"),
                     Function("count", [], "event_count"),
-                    Function("uniq", [Column("user_hash")], "affected_users"),
                     Function("isHandled", [], "is_handled"),
                 ]
             )

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -19,13 +19,55 @@ from sentry.tasks.integrations.github.open_pr_comment import (
     safe_for_comment,
 )
 from sentry.tasks.integrations.github.pr_comment import PullRequestIssue
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
 from tests.sentry.tasks.integrations.github.test_pr_comment import GithubCommentTestCase
 
 pytestmark = [requires_snuba]
+
+
+class CreateEventTestCase(TestCase):
+    def _create_event(
+        self,
+        culprit=None,
+        timestamp=None,
+        filenames=None,
+        project_id=None,
+        user_id=None,
+        handled=True,
+    ):
+        if culprit is None:
+            culprit = "issue0"
+        if timestamp is None:
+            timestamp = iso_format(before_now(seconds=5))
+        if filenames is None:
+            filenames = ["foo.py", "baz.py"]
+        if project_id is None:
+            project_id = self.project.id
+
+        return self.store_event(
+            data={
+                "message": "hello!",
+                "culprit": culprit,
+                "platform": "python",
+                "timestamp": timestamp,
+                "exception": {
+                    "values": [
+                        {
+                            "type": "Error",
+                            "stacktrace": {
+                                "frames": [{"filename": filename} for filename in filenames],
+                            },
+                            "mechanism": {"handled": handled, "type": "generic"},
+                        },
+                    ]
+                },
+                "user": {"id": user_id},
+            },
+            project_id=project_id,
+        )
 
 
 @region_silo_test
@@ -235,59 +277,16 @@ class TestGetFilenames(GithubCommentTestCase):
 
 
 @region_silo_test
-class TestGetCommentIssues(TestCase):
+class TestGetCommentIssues(CreateEventTestCase):
     def setUp(self):
-        super().setUp()
-
         self.group_id = [self._create_event(user_id=str(i)) for i in range(6)][0].group.id
         self.another_org = self.create_organization()
         self.another_org_project = self.create_project(organization=self.another_org)
-
-    def _create_event(
-        self,
-        culprit=None,
-        timestamp=None,
-        filenames=None,
-        project_id=None,
-        user_id=None,
-        handled=True,
-    ):
-        if culprit is None:
-            culprit = "issue0"
-        if timestamp is None:
-            timestamp = iso_format(before_now(seconds=5))
-        if filenames is None:
-            filenames = ["foo.py", "baz.py"]
-        if project_id is None:
-            project_id = self.project.id
-
-        return self.store_event(
-            data={
-                "message": "hello!",
-                "culprit": culprit,
-                "platform": "python",
-                "timestamp": timestamp,
-                "exception": {
-                    "values": [
-                        {
-                            "type": "Error",
-                            "stacktrace": {
-                                "frames": [{"filename": filename} for filename in filenames],
-                            },
-                            "mechanism": {"handled": handled, "type": "generic"},
-                        },
-                    ]
-                },
-                "user": {"id": user_id},
-            },
-            project_id=project_id,
-        )
 
     def test_simple(self):
         top_5_issues = get_top_5_issues_by_count_for_file([self.project], ["baz.py"])
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
         assert top_5_issue_ids == [self.group_id]
-        assert top_5_issues[0]["affected_users"] == 6
 
     def test_filters_resolved_issue(self):
         group = Group.objects.all()[0]
@@ -350,11 +349,9 @@ class TestGetCommentIssues(TestCase):
 
         top_5_issues = get_top_5_issues_by_count_for_file([self.project], ["baz.py"])
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
-        users_affected = [issue["affected_users"] for issue in top_5_issues]
         is_handled = [issue["is_handled"] for issue in top_5_issues]
 
         assert top_5_issue_ids == [self.group_id, group_id_1, group_id_2, group_id_3, group_id_4]
-        assert users_affected == [6, 5, 4, 3, 2]
         assert is_handled == [1, 0, 1, 0, 1]
 
     def test_get_issue_table_contents(self):
@@ -384,7 +381,7 @@ class TestGetCommentIssues(TestCase):
         ][0].group.id
 
         top_5_issues = get_top_5_issues_by_count_for_file([self.project], ["baz.py"])
-        affected_users = [issue["affected_users"] for issue in top_5_issues]
+        affected_users = [6, 5, 4, 3, 2]
         event_count = [issue["event_count"] for issue in top_5_issues]
         is_handled = [bool(issue["is_handled"]) for issue in top_5_issues]
 
@@ -471,24 +468,42 @@ You modified these files in this pull request and we noticed these issues associ
         )
 
 
-@region_silo_test
-class TestOpenPRCommentWorkflow(GithubCommentTestCase):
+class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
+    base_url = "https://api.github.com"
+
     def setUp(self):
-        super().setUp()
         self.user_id = "user_1"
         self.app_id = "app_1"
-        self.pr = self.create_pr_issues()
+
+        self.group_id_1 = [self._create_event(culprit="issue1", user_id=str(i)) for i in range(5)][
+            0
+        ].group.id
+        self.group_id_2 = [
+            self._create_event(culprit="issue2", filenames=["foo.py", "bar.py"], user_id=str(i))
+            for i in range(6)
+        ][0].group.id
+
+        self.gh_repo = self.create_repo(
+            name="getsentry/sentry",
+            provider="integrations:github",
+            integration_id=self.integration.id,
+            project=self.project,
+            url="https://github.com/getsentry/sentry",
+        )
+        self.pr = PullRequest.objects.create(
+            organization_id=self.organization.id,
+            repository_id=self.gh_repo.id,
+            key=str(1),
+        )
         self.groups = [
             {
                 "group_id": g.id,
                 "event_count": 1000 * (i + 1),
-                "affected_users": 1000 * (i + 1),
                 "is_handled": True,
             }
             for i, g in enumerate(Group.objects.all())
         ]
         self.groups.reverse()
-        self.group_ids = [g["group_id"] for g in self.groups]
 
     @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_filenames")
     @patch(
@@ -523,7 +538,7 @@ class TestOpenPRCommentWorkflow(GithubCommentTestCase):
 
         assert (
             responses.calls[0].request.body
-            == f'{{"body": "## \\ud83d\\ude80 Sentry Issue Report\\nYou modified these files in this pull request and we noticed these issues associated with them.\\n\\n\\ud83d\\udcc4 **foo.py**\\n\\n| Issue  | Additional Info |\\n| :--------- | :-------- |\\n| \\u203c\\ufe0f [**issue 2**](http://testserver/organizations/foobar/issues/{self.group_ids[0]}/?referrer=github-open-pr-bot) issue2 | `Handled:` **True** `Event Count:` **2k** `Users:` **2k** |\\n| \\u203c\\ufe0f [**issue 1**](http://testserver/organizations/foo/issues/{self.group_ids[1]}/?referrer=github-open-pr-bot) issue1 | `Handled:` **True** `Event Count:` **1k** `Users:` **1k** |\\n<details>\\n<summary><b>\\ud83d\\udcc4 bar.py (Click to Expand)</b></summary>\\n\\n| Issue  | Additional Info |\\n| :--------- | :-------- |\\n| \\u203c\\ufe0f [**issue 2**](http://testserver/organizations/foobar/issues/{self.group_ids[0]}/?referrer=github-open-pr-bot) issue2 | `Handled:` **True** `Event Count:` **2k** `Users:` **2k** |\\n| \\u203c\\ufe0f [**issue 1**](http://testserver/organizations/foo/issues/{self.group_ids[1]}/?referrer=github-open-pr-bot) issue1 | `Handled:` **True** `Event Count:` **1k** `Users:` **1k** |\\n</details>\\n---\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e or let us know in #proj-github-pr-comments</sub>"}}'.encode()
+            == f'{{"body": "## \\ud83d\\ude80 Sentry Issue Report\\nYou modified these files in this pull request and we noticed these issues associated with them.\\n\\n\\ud83d\\udcc4 **foo.py**\\n\\n| Issue  | Additional Info |\\n| :--------- | :-------- |\\n| \\u203c\\ufe0f [**Error**](http://testserver/organizations/baz/issues/{self.group_id_2}/?referrer=github-open-pr-bot) issue2 | `Handled:` **True** `Event Count:` **2k** `Users:` **6** |\\n| \\u203c\\ufe0f [**Error**](http://testserver/organizations/baz/issues/{self.group_id_1}/?referrer=github-open-pr-bot) issue1 | `Handled:` **True** `Event Count:` **1k** `Users:` **5** |\\n<details>\\n<summary><b>\\ud83d\\udcc4 bar.py (Click to Expand)</b></summary>\\n\\n| Issue  | Additional Info |\\n| :--------- | :-------- |\\n| \\u203c\\ufe0f [**Error**](http://testserver/organizations/baz/issues/{self.group_id_2}/?referrer=github-open-pr-bot) issue2 | `Handled:` **True** `Event Count:` **2k** `Users:` **6** |\\n| \\u203c\\ufe0f [**Error**](http://testserver/organizations/baz/issues/{self.group_id_1}/?referrer=github-open-pr-bot) issue1 | `Handled:` **True** `Event Count:` **1k** `Users:` **5** |\\n</details>\\n---\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e or let us know in #proj-github-pr-comments</sub>"}}'.encode()
         )
 
         pull_request_comment_query = PullRequestComment.objects.all()
@@ -667,7 +682,11 @@ class TestOpenPRCommentWorkflow(GithubCommentTestCase):
             open_pr_comment_workflow(self.pr.id)
             mock_metrics.incr.assert_called_with("github_open_pr_comment.api_error")
 
-        pr_2 = self.create_pr_issues()
+        pr_2 = PullRequest.objects.create(
+            organization_id=self.organization.id,
+            repository_id=self.gh_repo.id,
+            key=str(2),
+        )
 
         # does not raise ApiError for locked issue
         open_pr_comment_workflow(pr_2.id)
@@ -675,7 +694,11 @@ class TestOpenPRCommentWorkflow(GithubCommentTestCase):
             "github_open_pr_comment.error", tags={"type": "issue_locked_error"}
         )
 
-        pr_3 = self.create_pr_issues()
+        pr_3 = PullRequest.objects.create(
+            organization_id=self.organization.id,
+            repository_id=self.gh_repo.id,
+            key=str(3),
+        )
 
         # does not raise ApiError for rate limited error
         open_pr_comment_workflow(pr_3.id)


### PR DESCRIPTION
Calling the `count_users_seen` function on the `Group` model is how the user count is calculated on issues today. I was previously trying to do it within a Snuba query by getting the count of unique values in the `user_hash` column, but this appears to be inaccurate. It's possible that a `user_hash` is still stored for events that technically were not experienced by any user.