### PR TITLE
fix(hybrid-cloud): Properly generate discord_request in Discord request parser

### DIFF
--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -31,7 +31,7 @@ class DiscordRequestParser(BaseRequestParser):
     _discord_request: DiscordRequest | None = None
 
     @property
-    def discord_request(self) -> DiscordRequest | None:
+    def discord_request(self) -> DiscordRequest:
         if self._discord_request is not None:
             return self._discord_request
         drf_request: Request = DiscordInteractionsEndpoint().initialize_request(self.request)

--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -31,7 +31,7 @@ class DiscordRequestParser(BaseRequestParser):
     _discord_request: DiscordRequest | None = None
 
     @property
-    def discord_request(self) -> DiscordRequest:
+    def discord_request(self) -> DiscordRequest | None:
         if self._discord_request is not None:
             return self._discord_request
         if self.view_class != DiscordInteractionsEndpoint:
@@ -51,17 +51,18 @@ class DiscordRequestParser(BaseRequestParser):
             )
             return Integration.objects.filter(id=integration_id).first()
 
-        if self.view_class == DiscordInteractionsEndpoint:
+        discord_request = self.discord_request
+        if self.view_class == DiscordInteractionsEndpoint and discord_request:
             with sentry_sdk.push_scope() as scope:
                 scope.set_extra("path", self.request.path)
-                scope.set_extra("guild_id", self.discord_request.guild_id)
+                scope.set_extra("guild_id", discord_request.guild_id)
                 sentry_sdk.capture_message(
                     f"{self.provider}.get_integration_from_request.discord_interactions_endpoint"
                 )
 
             return Integration.objects.filter(
                 provider=self.provider,
-                external_id=self.discord_request.guild_id,
+                external_id=discord_request.guild_id,
             ).first()
 
         logger.info(

--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -34,6 +34,8 @@ class DiscordRequestParser(BaseRequestParser):
     def discord_request(self) -> DiscordRequest:
         if self._discord_request is not None:
             return self._discord_request
+        if self.view_class != DiscordInteractionsEndpoint:
+            return None
         drf_request: Request = DiscordInteractionsEndpoint().initialize_request(self.request)
         self._discord_request: DiscordRequest = self.view_class.discord_request_class(drf_request)
         return self._discord_request

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -47,8 +47,6 @@ class DiscordRequestParserTest(TestCase):
     def test_interactions_endpoint_routing_ping(self):
         data = {"guild_id": self.integration.external_id, "type": DiscordRequestTypes.PING}
         parser = self.get_parser(reverse("sentry-integration-discord-interactions"), data=data)
-        integration = parser.get_integration_from_request()
-        assert integration == self.integration
         with patch.object(
             parser, "get_response_from_first_region"
         ) as get_response_from_first_region, assume_test_silo_mode(
@@ -58,12 +56,14 @@ class DiscordRequestParserTest(TestCase):
             assert response.status_code == 200
             assert response.data == {"type": 1}
             assert not get_response_from_first_region.called
+        integration = parser.get_integration_from_request()
+        assert integration == self.integration
 
     def test_interactions_endpoint_routing_ping_no_integration(self):
         # Discord PING without an identifier linking to an integration
         data = {"type": DiscordRequestTypes.PING}
         parser = self.get_parser(reverse("sentry-integration-discord-interactions"), data=data)
-        assert parser.get_integration_from_request() is None
+
         with patch.object(parser, "get_regions_from_organizations", return_value=[]), patch.object(
             parser, "get_response_from_first_region"
         ) as get_response_from_first_region, patch.object(
@@ -76,12 +76,11 @@ class DiscordRequestParserTest(TestCase):
             assert response.data == {"type": 1}
             assert not mock_response_from_control.called
             assert not get_response_from_first_region.called
+            assert parser.get_integration_from_request() is None
 
     def test_interactions_endpoint_routing_command(self):
         data = {"guild_id": self.integration.external_id, "type": int(DiscordRequestTypes.COMMAND)}
         parser = self.get_parser(reverse("sentry-integration-discord-interactions"), data=data)
-        integration = parser.get_integration_from_request()
-        assert integration == self.integration
         with patch.object(
             parser, "get_response_from_first_region"
         ) as mock_respond_from_first, assume_test_silo_mode(
@@ -89,6 +88,8 @@ class DiscordRequestParserTest(TestCase):
         ):
             parser.get_response()
             assert mock_respond_from_first.called
+        integration = parser.get_integration_from_request()
+        assert integration == self.integration
 
     def test_interactions_endpoint_routing_message_component(self):
         data = {
@@ -96,13 +97,13 @@ class DiscordRequestParserTest(TestCase):
             "type": int(DiscordRequestTypes.MESSAGE_COMPONENT),
         }
         parser = self.get_parser(reverse("sentry-integration-discord-interactions"), data=data)
-        integration = parser.get_integration_from_request()
-        assert integration == self.integration
         with patch.object(
             parser, "get_response_from_all_regions"
         ) as mock_response_from_all, assume_test_silo_mode(SiloMode.CONTROL, can_be_monolith=False):
             parser.get_response()
             assert mock_response_from_all.called
+        integration = parser.get_integration_from_request()
+        assert integration == self.integration
 
     def test_control_classes(self):
         params = sign(integration_id=self.integration.id, discord_id=self.discord_id)
@@ -116,8 +117,6 @@ class DiscordRequestParserTest(TestCase):
         )
         for path in [link_path, unlink_path]:
             parser = self.get_parser(path)
-            parser_integration = parser.get_integration_from_request()
-            assert parser_integration.id == self.integration.id
 
             # Forwards to control silo
             with patch.object(
@@ -130,3 +129,6 @@ class DiscordRequestParserTest(TestCase):
                 parser.get_response()
                 assert mock_response_from_control.called
                 assert not get_response_from_outbox_creation.called
+
+            parser_integration = parser.get_integration_from_request()
+            assert parser_integration.id == self.integration.id


### PR DESCRIPTION
Fixes [HC-TEST-CONTROL-M7](https://sentry-st.sentry.io/issues/4681906125/?project=4505211735834624).

I've adjusted the tests to assert on `parser.get_integration_from_request()` after `parser.get_response()` to properly reflect the actual state that the parser will run with.