### PR TITLE
feat(browser-starfish): add span sample in resource summary

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
@@ -23,7 +23,7 @@ import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/render
 import ResourceSizeCell from 'sentry/views/starfish/components/tableCells/resourceSizeCell';
 import {WiderHovercard} from 'sentry/views/starfish/components/tableCells/spanDescriptionCell';
 import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {SpanIndexedField, SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 
@@ -123,7 +123,11 @@ function ResourceSummaryTable() {
                 <FullSpanDescription
                   group={groupId}
                   language="http"
-                  transaction={row[TRANSACTION]}
+                  filters={{
+                    [SpanIndexedField.RESOURCE_RENDER_BLOCKING_STATUS]:
+                      row[RESOURCE_RENDER_BLOCKING_STATUS],
+                    [SpanIndexedField.TRANSACTION]: row[TRANSACTION],
+                  }}
                 />
               </Fragment>
             }

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import {browserHistory, Link} from 'react-router';
+import styled from '@emotion/styled';
 
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
@@ -8,6 +9,7 @@ import GridEditable, {
 } from 'sentry/components/gridEditable';
 import Pagination, {CursorHandler} from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
@@ -15,16 +17,22 @@ import {RESOURCE_THROUGHPUT_UNIT} from 'sentry/views/performance/browser/resourc
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {useResourcePagesQuery} from 'sentry/views/performance/browser/resources/utils/useResourcePageQuery';
 import {useResourceSummarySort} from 'sentry/views/performance/browser/resources/utils/useResourceSummarySort';
+import {FullSpanDescription} from 'sentry/views/starfish/components/fullSpanDescription';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
 import {renderHeadCell} from 'sentry/views/starfish/components/tableCells/renderHeadCell';
 import ResourceSizeCell from 'sentry/views/starfish/components/tableCells/resourceSizeCell';
+import {WiderHovercard} from 'sentry/views/starfish/components/tableCells/spanDescriptionCell';
 import {ThroughputCell} from 'sentry/views/starfish/components/tableCells/throughputCell';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {DataTitles, getThroughputTitle} from 'sentry/views/starfish/views/spans/types';
 
-const {RESOURCE_RENDER_BLOCKING_STATUS, SPAN_SELF_TIME, HTTP_RESPONSE_CONTENT_LENGTH} =
-  SpanMetricsField;
+const {
+  RESOURCE_RENDER_BLOCKING_STATUS,
+  SPAN_SELF_TIME,
+  HTTP_RESPONSE_CONTENT_LENGTH,
+  TRANSACTION,
+} = SpanMetricsField;
 
 type Row = {
   'avg(http.response_content_length)': number;
@@ -90,7 +98,7 @@ function ResourceSummaryTable() {
         query = `${RESOURCE_RENDER_BLOCKING_STATUS}:${blockingStatus}`;
       }
 
-      return (
+      const link = (
         <Link
           to={{
             pathname: location.pathname,
@@ -103,6 +111,26 @@ function ResourceSummaryTable() {
         >
           {row[key]}
         </Link>
+      );
+
+      return (
+        <DescriptionWrapper>
+          <WiderHovercard
+            position="right"
+            body={
+              <Fragment>
+                <TitleWrapper>{t('Example')}</TitleWrapper>
+                <FullSpanDescription
+                  group={groupId}
+                  language="http"
+                  transaction={row[TRANSACTION]}
+                />
+              </Fragment>
+            }
+          >
+            {link}
+          </WiderHovercard>
+        </DescriptionWrapper>
       );
     }
     if (key === RESOURCE_RENDER_BLOCKING_STATUS) {
@@ -161,5 +189,15 @@ export const getActionName = (transactionOp: string) => {
       return transactionOp;
   }
 };
+
+const TitleWrapper = styled('div')`
+  margin-bottom: ${space(1)};
+`;
+
+const DescriptionWrapper = styled('div')`
+  .inline-flex {
+    display: inline-flex;
+  }
+`;
 
 export default ResourceSummaryTable;

--- a/static/app/views/starfish/components/fullSpanDescription.tsx
+++ b/static/app/views/starfish/components/fullSpanDescription.tsx
@@ -9,23 +9,14 @@ import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatte
 
 const formatter = new SQLishFormatter();
 
-export function FullSpanDescription({
-  group,
-  shortDescription,
-  language,
-  transaction,
-}: Props) {
+export function FullSpanDescription({group, shortDescription, language, filters}: Props) {
   const {
     data: fullSpan,
     isLoading,
     isFetching,
-  } = useFullSpanFromTrace(group, undefined, Boolean(group), transaction);
+  } = useFullSpanFromTrace(group, undefined, Boolean(group), filters);
 
   const description = fullSpan?.description ?? shortDescription;
-
-  if (!description && shortDescription) {
-    return null;
-  }
 
   if (isLoading && isFetching) {
     return (
@@ -33,6 +24,10 @@ export function FullSpanDescription({
         <LoadingIndicator mini hideMessage relative />
       </PaddedSpinner>
     );
+  }
+
+  if (!description) {
+    return null;
   }
 
   if (language === 'sql') {
@@ -51,10 +46,10 @@ export function FullSpanDescription({
 }
 
 interface Props {
+  filters?: Record<string, string>;
   group?: string;
   language?: 'sql' | 'http';
   shortDescription?: string;
-  transaction?: string;
 }
 
 const LINE_LENGTH = 60;

--- a/static/app/views/starfish/components/fullSpanDescription.tsx
+++ b/static/app/views/starfish/components/fullSpanDescription.tsx
@@ -9,16 +9,21 @@ import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatte
 
 const formatter = new SQLishFormatter();
 
-export function FullSpanDescription({group, shortDescription, language}: Props) {
+export function FullSpanDescription({
+  group,
+  shortDescription,
+  language,
+  transaction,
+}: Props) {
   const {
     data: fullSpan,
     isLoading,
     isFetching,
-  } = useFullSpanFromTrace(group, undefined, Boolean(group));
+  } = useFullSpanFromTrace(group, undefined, Boolean(group), transaction);
 
   const description = fullSpan?.description ?? shortDescription;
 
-  if (!description) {
+  if (!description && shortDescription) {
     return null;
   }
 
@@ -49,6 +54,7 @@ interface Props {
   group?: string;
   language?: 'sql' | 'http';
   shortDescription?: string;
+  transaction?: string;
 }
 
 const LINE_LENGTH = 60;

--- a/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
+++ b/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
@@ -9,12 +9,17 @@ import {SpanIndexedField} from 'sentry/views/starfish/types';
 export function useFullSpanFromTrace(
   group?: string,
   sorts?: Sort[],
-  enabled: boolean = true
+  enabled: boolean = true,
+  transaction?: string
 ) {
   const filters: {[key: string]: string} = {};
 
   if (group) {
     filters[SpanIndexedField.SPAN_GROUP] = group;
+  }
+
+  if (transaction) {
+    filters[SpanIndexedField.TRANSACTION] = transaction ?? '';
   }
 
   const indexedSpansResponse = useIndexedSpans(filters, sorts, 1, enabled);

--- a/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
+++ b/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
@@ -10,16 +10,12 @@ export function useFullSpanFromTrace(
   group?: string,
   sorts?: Sort[],
   enabled: boolean = true,
-  extraFilters?: Record<string, string>
+  extraFilters: Record<string, string> = {}
 ) {
-  let filters: {[key: string]: string} = {};
+  const filters = {...extraFilters};
 
   if (group) {
     filters[SpanIndexedField.SPAN_GROUP] = group;
-  }
-
-  if (extraFilters) {
-    filters = {...filters, ...extraFilters};
   }
 
   const indexedSpansResponse = useIndexedSpans(filters, sorts, 1, enabled);

--- a/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
+++ b/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
@@ -10,16 +10,16 @@ export function useFullSpanFromTrace(
   group?: string,
   sorts?: Sort[],
   enabled: boolean = true,
-  transaction?: string
+  extraFilters?: Record<string, string>
 ) {
-  const filters: {[key: string]: string} = {};
+  let filters: {[key: string]: string} = {};
 
   if (group) {
     filters[SpanIndexedField.SPAN_GROUP] = group;
   }
 
-  if (transaction) {
-    filters[SpanIndexedField.TRANSACTION] = transaction ?? '';
+  if (extraFilters) {
+    filters = {...filters, ...extraFilters};
   }
 
   const indexedSpansResponse = useIndexedSpans(filters, sorts, 1, enabled);

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -114,6 +114,7 @@ export enum SpanIndexedField {
   PROJECT = 'project',
   PROJECT_ID = 'project_id',
   PROFILE_ID = 'profile_id',
+  TRANSACTION = 'transaction',
 }
 
 export type SpanIndexedFieldTypes = {


### PR DESCRIPTION
Work for #60482 

See an example of a span from the resource summary page (same as hover dropdown), when hovering over a page
<img width="691" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/cbcc9390-590a-4d04-99a5-919f79c3565a">
