### PR TITLE
feat(browser-starfish): add min throughput value to resource pages

### DIFF
--- a/static/app/views/starfish/components/tableCells/throughputCell.tsx
+++ b/static/app/views/starfish/components/tableCells/throughputCell.tsx
@@ -14,7 +14,7 @@ type Props = {
 export function ThroughputCell({rate, unit, containerProps}: Props) {
   return (
     <NumberContainer {...containerProps}>
-      {rate ? formatRate(rate, unit, {minimumValue: 0.01}) : '--'}
+      {rate ? formatRate(rate, unit, {minimumValue: 0.001}) : '--'}
     </NumberContainer>
   );
 }

--- a/static/app/views/starfish/components/tableCells/throughputCell.tsx
+++ b/static/app/views/starfish/components/tableCells/throughputCell.tsx
@@ -14,7 +14,7 @@ type Props = {
 export function ThroughputCell({rate, unit, containerProps}: Props) {
   return (
     <NumberContainer {...containerProps}>
-      {rate ? formatRate(rate, unit, {minimumValue: 0.001}) : '--'}
+      {rate ? formatRate(rate, unit, {minimumValue: 0.01}) : '--'}
     </NumberContainer>
   );
 }

--- a/static/app/views/starfish/components/tableCells/throughputCell.tsx
+++ b/static/app/views/starfish/components/tableCells/throughputCell.tsx
@@ -14,7 +14,7 @@ type Props = {
 export function ThroughputCell({rate, unit, containerProps}: Props) {
   return (
     <NumberContainer {...containerProps}>
-      {rate ? formatRate(rate, unit) : '--'}
+      {rate ? formatRate(rate, unit, {minimumValue: 0.001}) : '--'}
     </NumberContainer>
   );
 }


### PR DESCRIPTION
Work for #60482 

Before
<img width="803" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/f3445399-7bc1-43af-adec-9001293a45bf">


After
<img width="582" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/1d297149-7c47-418f-a187-464b3e449d30">
