### PR TITLE
ref(testing): UserEmail factory can generate fake emails

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -775,7 +775,7 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)
-    def create_useremail(user, email, **kwargs):
+    def create_useremail(user, email=None, **kwargs):
         if not email:
             email = uuid4().hex + "@example.com"
 


### PR DESCRIPTION
Minor change that supports easier `UserEmail` tests.