### PR TITLE
fix(traces): Perf issues render with 2 column grid

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -323,9 +323,12 @@ function SpanDetail(props: Props) {
             relatedErrors.length
           )}
         </ErrorMessageTitle>
-        <ErrorMessageContent>
+        <Fragment>
           {visibleErrors.map(error => (
-            <Fragment key={error.event_id}>
+            <ErrorMessageContent
+              key={error.event_id}
+              excludeLevel={isErrorPerformanceError(error)}
+            >
               {isErrorPerformanceError(error) ? (
                 <ErrorDot level="error" />
               ) : (
@@ -340,9 +343,9 @@ function SpanDetail(props: Props) {
                   {error.title}
                 </Link>
               </ErrorTitle>
-            </Fragment>
+            </ErrorMessageContent>
           ))}
-        </ErrorMessageContent>
+        </Fragment>
         {relatedErrors.length > DEFAULT_ERRORS_VISIBLE && (
           <ErrorToggle size="xs" onClick={toggleErrors}>
             {errorsOpened ? t('Show less') : t('Show more')}

--- a/static/app/components/performance/waterfall/rowDetails.tsx
+++ b/static/app/components/performance/waterfall/rowDetails.tsx
@@ -8,10 +8,10 @@ export const ErrorMessageTitle = styled('div')`
   justify-content: space-between;
 `;
 
-export const ErrorMessageContent = styled('div')`
+export const ErrorMessageContent = styled('div')<{excludeLevel?: boolean}>`
   display: grid;
   align-items: center;
-  grid-template-columns: 16px 72px auto;
+  grid-template-columns: ${p => (p.excludeLevel ? '16px auto' : '16px 72px auto')};
   gap: ${space(0.75)};
   margin-top: ${space(0.75)};
 `;


### PR DESCRIPTION
We were seeing truncation issues with the perf issue name in the error message for a span. This is because we reserved 72px for the error message, but perf issues doesn't supply one. This forced the error title into this small 72px area and the next error badge to render up in the wrong row.

Now, for every row that renders, determine if we're going to have 2 or 3 children and provide the correct grid styling.

Before: 
<img width="531" alt="Screenshot 2023-11-29 at 5 29 09 PM" src="https://github.com/getsentry/sentry/assets/22846452/347d8f2c-7ef8-4256-b383-f8270f695f89">

After:
<img width="544" alt="Screenshot 2023-11-29 at 5 29 14 PM" src="https://github.com/getsentry/sentry/assets/22846452/b413a079-5118-4fde-bc7c-698c347f4d56">
