### PR TITLE
feat(issue-platform): Provide a way to get multiple groups by their fingerprints

### DIFF
--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -9,7 +9,7 @@ from django.conf import settings
 
 from sentry import features
 from sentry.issues.issue_occurrence import IssueOccurrence
-from sentry.issues.status_change_consumer import get_group_from_fingerprint, update_status
+from sentry.issues.status_change_consumer import get_groups_from_fingerprints, update_status
 from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.project import Project
 from sentry.services.hybrid_cloud import ValueEqualityEnum
@@ -108,7 +108,11 @@ def _prepare_status_change_message(
         from sentry.issues.ingest import process_occurrence_data
 
         process_occurrence_data(status_change.to_dict())
-        group = get_group_from_fingerprint(status_change.to_dict())
+        fingerprint = status_change.fingerprint
+        groups_by_fingerprints = get_groups_from_fingerprints(
+            status_change.project_id, [fingerprint]
+        )
+        group = groups_by_fingerprints.get(fingerprint[0], None)
         if not group:
             return None
         update_status(group, status_change.to_dict())

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
 from sentry_sdk.tracing import NoOpSpan, Transaction
 
@@ -107,7 +107,7 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
 
 
 def get_groups_from_fingerprints(
-    project_id: int, fingerprints: list[list[str]]
+    project_id: int, fingerprints: Iterable[Iterable[str]]
 ) -> dict[str, Group]:
     """
     Returns the list of groups given a list of fingerprints.

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -109,6 +109,12 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
 def get_groups_from_fingerprints(
     project_id: int, fingerprints: list[list[str]]
 ) -> dict[str, Group]:
+    """
+    Returns the list of groups given a list of fingerprints.
+
+    Note that fingerprints for issue platform are expected to be
+    processed via `process_occurrence_data` prior to calling this function.
+    """
     fingerprints_set = {fingerprint[0] for fingerprint in fingerprints}
     grouphash = GroupHash.objects.filter(
         project=project_id,

--- a/tests/sentry/issues/test_producer.py
+++ b/tests/sentry/issues/test_producer.py
@@ -268,7 +268,7 @@ class TestProduceOccurrenceForStatusChange(TestCase, OccurrenceTestMixin):
             "grouphash.not_found",
             extra={
                 "project_id": group.project_id,
-                "fingerprint": ["wronghash"],
+                "fingerprint": "wronghash",
             },
         )
         assert group.status == initial_status

--- a/tests/sentry/issues/test_status_change_consumer.py
+++ b/tests/sentry/issues/test_status_change_consumer.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from typing import Any, Dict
+from unittest.mock import MagicMock, patch
 
 from sentry.issues.occurrence_consumer import _process_message
+from sentry.issues.status_change_consumer import bulk_get_groups_from_fingerprints
 from sentry.models.group import Group, GroupStatus
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -37,9 +39,8 @@ class StatusChangeProcessMessageTest(IssueOccurrenceTestBase):
             result = _process_message(message)
         assert result is not None
 
-        occurrence = result[0]
-        assert Group.objects.filter(grouphash__hash=occurrence.fingerprint[0]).exists()
-
+        self.occurrence = result[0]
+        self.group = Group.objects.get(grouphash__hash=self.occurrence.fingerprint[0])
         self.fingerprint = ["touch-id"]
 
     @django_db_all
@@ -88,3 +89,90 @@ class StatusChangeProcessMessageTest(IssueOccurrenceTestBase):
 
         assert group.status == GroupStatus.UNRESOLVED
         assert group.substatus == GroupSubStatus.ESCALATING
+
+    def test_bulk_get_single_project(self) -> None:
+        groups_by_fingerprint = bulk_get_groups_from_fingerprints(
+            [(self.project.id, self.occurrence.fingerprint)]
+        )
+        assert len(groups_by_fingerprint) == 1
+        group = groups_by_fingerprint[(self.project.id, self.occurrence.fingerprint[0])]
+        assert group.id == self.group.id
+
+    def test_bulk_get_multiple_projects(self) -> None:
+        # set up second project and occurrence
+        project2 = self.create_project(organization=self.organization)
+        message = get_test_message(project2.id, fingerprint="new-fingerprint")
+        with self.feature("organizations:profile-file-io-main-thread-ingest"):
+            result = _process_message(message)
+        assert result is not None
+        occurrence2 = result[0]
+        group2 = Group.objects.get(grouphash__hash=occurrence2.fingerprint[0])
+
+        # get groups by fingerprint
+        groups_by_fingerprint = bulk_get_groups_from_fingerprints(
+            [
+                (self.project.id, self.occurrence.fingerprint),
+                (project2.id, occurrence2.fingerprint),
+            ]
+        )
+        assert len(groups_by_fingerprint) == 2
+        group1 = groups_by_fingerprint[(self.project.id, self.occurrence.fingerprint[0])]
+        assert group1.id == self.group.id
+        group2 = groups_by_fingerprint[(project2.id, occurrence2.fingerprint[0])]
+        assert group2.id == group2.id
+
+    @patch("sentry.issues.status_change_consumer.logger.error")
+    def test_bulk_get_missing_hash(self, mock_logger_error: MagicMock) -> None:
+        # set up second project and occurrence
+        project2 = self.create_project(organization=self.organization)
+        message = get_test_message(project2.id, fingerprint="new-fingerprint")
+        with self.feature("organizations:profile-file-io-main-thread-ingest"):
+            result = _process_message(message)
+        assert result is not None
+        assert Group.objects.filter(grouphash__hash=result[0].fingerprint[0]).exists()
+
+        # get groups by fingerprint
+        groups_by_fingerprint = bulk_get_groups_from_fingerprints(
+            [
+                (self.project.id, self.occurrence.fingerprint),
+                (project2.id, self.occurrence.fingerprint),  # this one is missing
+            ]
+        )
+
+        assert len(groups_by_fingerprint) == 1
+        group = groups_by_fingerprint[(self.project.id, self.occurrence.fingerprint[0])]
+        assert group.id == self.group.id
+        mock_logger_error.assert_called_with(
+            "grouphash.not_found",
+            extra={
+                "project_id": project2.id,
+                "fingerprint": self.occurrence.fingerprint[0],
+            },
+        )
+
+    def test_bulk_get_same_fingerprint(self) -> None:
+        # Set up second project and occurrence with the same
+        # fingerprint as the occurrence from the first project.
+        project2 = self.create_project(organization=self.organization)
+        message = get_test_message(project2.id)
+        with self.feature("organizations:profile-file-io-main-thread-ingest"):
+            result = _process_message(message)
+        assert result is not None
+        occurrence2 = result[0]
+        group2 = Group.objects.get(grouphash__hash=result[0].fingerprint[0], project=project2)
+
+        assert occurrence2.fingerprint[0] == self.occurrence.fingerprint[0]
+
+        # get groups by fingerprint
+        groups_by_fingerprint = bulk_get_groups_from_fingerprints(
+            [
+                (self.project.id, self.occurrence.fingerprint),
+                (project2.id, self.occurrence.fingerprint),
+            ]
+        )
+        assert len(groups_by_fingerprint) == 2
+        group1 = groups_by_fingerprint[(self.project.id, self.occurrence.fingerprint[0])]
+        assert group1.id == self.group.id
+        group2 = groups_by_fingerprint[(project2.id, self.occurrence.fingerprint[0])]
+        assert group2.id == group2.id
+        assert group1.id != group2.id


### PR DESCRIPTION
Modifies the existing `get_group_by_fingerprint` method to get multiple groups without the StatusChangeMessage format, using the project_id and list of fingerprints instead. 

Note that fingerprints are parsed using [this logic](https://github.com/getsentry/sentry/blob/master/src/sentry/issues/ingest.py#L68), any callers of the method will need to parse fingerprints similarly. 

