### PR TITLE
fix(sdk-updates): filter out empty sdk names / versions before serializing

### DIFF
--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -27,6 +27,9 @@ def by_project_id(sdk):
 
 
 def serialize(data, projects):
+    # filter out SDKs with empty sdk.name or sdk.version
+    nonempty_sdks = [sdk for sdk in data if sdk["sdk.name"] != "" and sdk["sdk.version"] != ""]
+
     # Build datastructure of the latest version of each SDK in use for each
     # project we have events for.
     latest_sdks = chain.from_iterable(
@@ -38,7 +41,7 @@ def serialize(data, projects):
             }
             for sdk_name, sdks in groupby(sorted(sdks_used, key=by_sdk_name), key=by_sdk_name)
         ]
-        for project_id, sdks_used in groupby(data, key=by_project_id)
+        for project_id, sdks_used in groupby(nonempty_sdks, key=by_project_id)
     )
 
     # Determine suggested upgrades for each project

--- a/tests/sentry/api/endpoints/test_organization_sdk_updates.py
+++ b/tests/sentry/api/endpoints/test_organization_sdk_updates.py
@@ -199,6 +199,40 @@ class OrganizationSdkUpdates(APITestCase, SnubaTestCase):
             == "Creating a LegacyVersion has been deprecated and will be removed in the next major release"
         )
 
+    @mock.patch(
+        "sentry.api.endpoints.organization_sdk_updates.SdkIndexState",
+        return_value=SdkIndexState(sdk_versions={"example.sdk": "2.0.0"}),
+    )
+    def test_empty_version_sdk_name(self, mock_index_state):
+        min_ago = iso_format(before_now(minutes=1))
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "oh no",
+                "timestamp": min_ago,
+                "fingerprint": ["group-1"],
+                "sdk": {"name": "", "version": "1.0.0"},
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "b",
+                "timestamp": min_ago,
+                "fingerprint": ["group-2"],
+                "sdk": {"name": "example.sdk", "version": ""},
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+
+        response = self.client.get(self.url)
+
+        update_suggestions = response.data
+        assert len(update_suggestions) == 0
+
 
 @region_silo_test
 class OrganizationSdks(APITestCase):


### PR DESCRIPTION
Fixes SENTRY-YCY

- Discover can't seem to filter out [empty strings](https://sentry.sentry.io/discover/homepage/?field=sdk.name&field=sdk.version&field=count%28%29&name=All+Events&project=1&query=%21sdk.name%3A%22%22&sort=-sdk.name&statsPeriod=24h&yAxis=count%28%29) correctly, so doing this filtering in the serialization process instead of adding a discover filter. Test fails on master but passes with my change. Still need to figure out upstream how empty sdk names / versions are making it in but this will stop the endpoint from 500ing.
