### PR TITLE
fix(discover): Fix errors dataset in discover to correctly be able to select columns

### DIFF
--- a/src/sentry/search/events/builder/errors.py
+++ b/src/sentry/search/events/builder/errors.py
@@ -85,6 +85,8 @@ class ErrorsQueryBuilderMixin:
         elif isinstance(aliased_col, Column):
             return self._apply_column_entity(aliased_col.name)
 
+        raise NotImplementedError(f"{type(aliased_col)} not implemented in aliased_column")
+
     def column(self, name: str) -> Column:
         """Given an unresolved sentry column name and return a snql column.
 

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -6149,17 +6149,18 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
         assert response.data["data"][0]["count()"] == 1
 
     def test_user_display(self):
-        group_1 = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "timestamp": self.ten_mins_ago_iso,
-                "fingerprint": ["group1"],
-                "user": {
-                    "email": "hellboy@bar.com",
+        with self.options({"issues.group_attributes.send_kafka": True}):
+            group_1 = self.store_event(
+                data={
+                    "event_id": "a" * 32,
+                    "timestamp": self.ten_mins_ago_iso,
+                    "fingerprint": ["group1"],
+                    "user": {
+                        "email": "hellboy@bar.com",
+                    },
                 },
-            },
-            project_id=self.project.id,
-        ).group
+                project_id=self.project.id,
+            ).group
 
         features = {
             "organizations:discover-basic": True,
@@ -6177,3 +6178,67 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
         assert len(data) == 1
         result = {r["user.display"] for r in data}
         assert result == {"hellboy@bar.com"}
+
+    def test_all_events_fields(self):
+        user_data = {
+            "id": self.user.id,
+            "username": "user",
+            "email": "hellboy@bar.com",
+            "ip_address": "127.0.0.1",
+        }
+        replay_id = str(uuid.uuid4())
+        with self.options({"issues.group_attributes.send_kafka": True}):
+            event = self.store_event(
+                data={
+                    "fingerprint": ["group1"],
+                    "contexts": {
+                        "trace": {
+                            "trace_id": str(uuid.uuid4().hex),
+                            "span_id": "933e5c9a8e464da9",
+                            "type": "trace",
+                        },
+                        "replay": {"replay_id": replay_id},
+                    },
+                    "tags": {"device": "Mac"},
+                    "user": user_data,
+                },
+                project_id=self.project.id,
+            )
+
+        query = {
+            "field": [
+                "id",
+                "transaction",
+                "title",
+                "release",
+                "environment",
+                "user.display",
+                "device",
+                "os",
+                "replayId",
+                "timestamp",
+            ],
+            "statsPeriod": "1h",
+            "query": "is:unresolved",
+            "dataset": "errors",
+            "sort": "-title",
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+
+        data = response.data["data"][0]
+
+        assert data == {
+            "id": event.event_id,
+            "events.transaction": "",
+            "project.name": event.project.name.lower(),
+            "events.title": event.group.title,
+            "release": event.release,
+            "events.environment": None,
+            "user.display": user_data["email"],
+            "device": "Mac",
+            "os": "",
+            "replayId": replay_id,
+            "events.timestamp": event.datetime.replace(microsecond=0).isoformat(),
+        }


### PR DESCRIPTION
The errors dataset wasn't thorough enough about aliasing columns and so fetching events in discover would fail when attempting to select some columns.
