### PR TITLE
fix(hybrid-cloud): Fix Discord PING response

### DIFF
--- a/src/sentry/integrations/discord/webhooks/base.py
+++ b/src/sentry/integrations/discord/webhooks/base.py
@@ -5,7 +5,6 @@ import logging
 from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
-from rest_framework.response import Response
 
 from sentry import analytics
 from sentry.api.api_publish_status import ApiPublishStatus

--- a/src/sentry/integrations/discord/webhooks/base.py
+++ b/src/sentry/integrations/discord/webhooks/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -39,13 +40,13 @@ class DiscordInteractionsEndpoint(Endpoint):
         super().__init__()
 
     @classmethod
-    def respond_ping(cls) -> Response:
+    def respond_ping(cls) -> JsonResponse:
         # https://discord.com/developers/docs/tutorials/upgrading-to-application-commands#adding-an-interactions-endpoint-url
-        return Response({"type": DiscordResponseTypes.PONG}, status=200)
+        return JsonResponse({"type": DiscordResponseTypes.PONG})
 
     @csrf_exempt
     @transaction_start("DiscordInteractionsEndpoint")
-    def post(self, request: Request) -> Response:
+    def post(self, request: Request) -> HttpResponse:
         try:
             discord_request = self.discord_request_class(request)
             discord_request.validate()

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -4,15 +4,20 @@ from typing import Any, Mapping
 from unittest.mock import MagicMock, patch
 
 import pytest
-from django.test import RequestFactory
-from django.urls import reverse
+from django.http import JsonResponse
+from django.test import RequestFactory, override_settings
+from django.urls import re_path, reverse
+from rest_framework.permissions import AllowAny
 
+from sentry.api.base import Endpoint
 from sentry.integrations.discord.requests.base import DiscordRequestTypes
+from sentry.integrations.discord.webhooks.base import DiscordInteractionsEndpoint
 from sentry.middleware.integrations.parsers.discord import DiscordRequestParser
 from sentry.silo.base import SiloMode
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.types.region import Region, RegionCategory
+from sentry.utils import json
 from sentry.utils.signing import sign
 
 
@@ -54,7 +59,8 @@ class DiscordRequestParserTest(TestCase):
         ):
             response = parser.get_response()
             assert response.status_code == 200
-            assert response.data == {"type": 1}
+            data = json.loads(response.content)
+            assert data == {"type": 1}
             assert not get_response_from_first_region.called
         integration = parser.get_integration_from_request()
         assert integration == self.integration
@@ -73,7 +79,8 @@ class DiscordRequestParserTest(TestCase):
         ):
             response = parser.get_response()
             assert response.status_code == 200
-            assert response.data == {"type": 1}
+            data = json.loads(response.content)
+            assert data == {"type": 1}
             assert not mock_response_from_control.called
             assert not get_response_from_first_region.called
             assert parser.get_integration_from_request() is None
@@ -132,3 +139,43 @@ class DiscordRequestParserTest(TestCase):
 
             parser_integration = parser.get_integration_from_request()
             assert parser_integration.id == self.integration.id
+
+
+class DiscordTestEndpoint(Endpoint):
+    permission_classes = (AllowAny,)
+
+    def post(self, request):
+        return JsonResponse({"foo": "bar"})
+
+
+urlpatterns = [
+    re_path(
+        r"^extensions/discord/interactions/$",
+        DiscordTestEndpoint.as_view(),
+        name="discord-test-endpoint",
+    ),
+]
+
+
+@control_silo_test
+# @override_settings(ROOT_URLCONF=__name__)
+class End2EndTest(APITestCase):
+    def test_discord_request_parser(self):
+        response = self.client.post(
+            reverse("sentry-integration-discord-interactions"),
+            data={"type": DiscordRequestTypes.PING},
+        )
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data == {"foo": "bar"}
+
+    # def test_discord_request_parser2(self):
+    #     with patch.object(
+    #         DiscordInteractionsEndpoint, "respond_ping", return_value=JsonResponse({"type": 2})
+    #     ):
+    #         response = self.client.post(
+    #             reverse("discord-test-endpoint"), data={"type": DiscordRequestTypes.PING}
+    #         )
+    #         assert response.status_code == 200
+    #         data = json.loads(response.content)
+    #         assert data == {"foo": "bar"}

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -140,42 +140,12 @@ class DiscordRequestParserTest(TestCase):
             parser_integration = parser.get_integration_from_request()
             assert parser_integration.id == self.integration.id
 
-
-class DiscordTestEndpoint(Endpoint):
-    permission_classes = (AllowAny,)
-
-    def post(self, request):
-        return JsonResponse({"foo": "bar"})
-
-
-urlpatterns = [
-    re_path(
-        r"^extensions/discord/interactions/$",
-        DiscordTestEndpoint.as_view(),
-        name="discord-test-endpoint",
-    ),
-]
-
-
-@control_silo_test
-# @override_settings(ROOT_URLCONF=__name__)
-class End2EndTest(APITestCase):
-    def test_discord_request_parser(self):
-        response = self.client.post(
-            reverse("sentry-integration-discord-interactions"),
-            data={"type": DiscordRequestTypes.PING},
-        )
-        assert response.status_code == 200
-        data = json.loads(response.content)
-        assert data == {"foo": "bar"}
-
-    # def test_discord_request_parser2(self):
-    #     with patch.object(
-    #         DiscordInteractionsEndpoint, "respond_ping", return_value=JsonResponse({"type": 2})
-    #     ):
-    #         response = self.client.post(
-    #             reverse("discord-test-endpoint"), data={"type": DiscordRequestTypes.PING}
-    #         )
-    #         assert response.status_code == 200
-    #         data = json.loads(response.content)
-    #         assert data == {"foo": "bar"}
+    def test_discord_interaction_endpoint(self):
+        with assume_test_silo_mode(SiloMode.CONTROL, can_be_monolith=False):
+            response = self.client.post(
+                reverse("sentry-integration-discord-interactions"),
+                data={"type": DiscordRequestTypes.PING},
+            )
+            assert response.status_code == 200
+            data = json.loads(response.content)
+            assert data == {"type": 1}

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -4,14 +4,10 @@ from typing import Any, Mapping
 from unittest.mock import MagicMock, patch
 
 import pytest
-from django.http import JsonResponse
-from django.test import RequestFactory, override_settings
-from django.urls import re_path, reverse
-from rest_framework.permissions import AllowAny
+from django.test import RequestFactory
+from django.urls import reverse
 
-from sentry.api.base import Endpoint
 from sentry.integrations.discord.requests.base import DiscordRequestTypes
-from sentry.integrations.discord.webhooks.base import DiscordInteractionsEndpoint
 from sentry.middleware.integrations.parsers.discord import DiscordRequestParser
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, TestCase
@@ -140,6 +136,9 @@ class DiscordRequestParserTest(TestCase):
             parser_integration = parser.get_integration_from_request()
             assert parser_integration.id == self.integration.id
 
+
+@control_silo_test
+class End2EndTest(APITestCase):
     def test_discord_interaction_endpoint(self):
         with assume_test_silo_mode(SiloMode.CONTROL, can_be_monolith=False):
             response = self.client.post(


### PR DESCRIPTION
Fixes [HC-TEST-CONTROL-MG](https://sentry-st.sentry.io/issues/4682895882/?project=4505211735834624).

Using `rest_framework`'s `Response` to do a trivial JSON response requires some post-processing work. I've instead opted for Django's `JsonResponse`.

I've updated the tests, and included an end-to-end test of the Discord request parser. This let's us factor in the middleware layers for the request-response flow.