### PR TITLE
fix(hybrid-cloud): Fix /settings/billing/* routes for customer domains

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -272,12 +272,15 @@ _path_patterns: List[Tuple[re.Pattern[str], str]] = [
     (re.compile(r"\/?organizations\/(?!new)[^\/]+\/(.*)"), r"/\1"),
     # For /settings/:orgId/ -> /settings/organization/
     (
-        re.compile(r"\/settings\/(?!account)(?!projects)(?!teams)[^\/]+\/?$"),
+        re.compile(r"\/settings\/(?!account)(?!billing)(?!projects)(?!teams)[^\/]+\/?$"),
         "/settings/organization/",
     ),
     # Move /settings/:orgId/:section -> /settings/:section
     # but not /settings/organization or /settings/projects which is a new URL
-    (re.compile(r"^\/?settings\/(?!account)(?!projects)(?!teams)[^\/]+\/(.*)"), r"/settings/\1"),
+    (
+        re.compile(r"^\/?settings\/(?!account)(?!billing)(?!projects)(?!teams)[^\/]+\/(.*)"),
+        r"/settings/\1",
+    ),
     (re.compile(r"^\/?join-request\/[^\/]+\/?.*"), r"/join-request/"),
     (re.compile(r"^\/?onboarding\/[^\/]+\/(.*)"), r"/onboarding/\1"),
     (

--- a/static/app/utils/withDomainRequired.spec.tsx
+++ b/static/app/utils/withDomainRequired.spec.tsx
@@ -84,6 +84,14 @@ describe('normalizeUrl', function () {
       ],
       // Team settings links in breadcrumbs can be pre-normalized from breadcrumbs
       ['/settings/teams/peeps/', '/settings/teams/peeps/'],
+      [
+        '/settings/billing/checkout/?_q=all#hash',
+        '/settings/billing/checkout/?_q=all#hash',
+      ],
+      [
+        '/settings/billing/bundle-checkout/?_q=all#hash',
+        '/settings/billing/bundle-checkout/?_q=all#hash',
+      ],
     ];
     for (const [input, expected] of cases) {
       result = normalizeUrl(input);

--- a/static/app/utils/withDomainRequired.tsx
+++ b/static/app/utils/withDomainRequired.tsx
@@ -8,10 +8,16 @@ const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
   // /organizations/slug/section, but not /organizations/new
   [/\/organizations\/(?!new)[^\/]+\/(.*)/, '/$1'],
   // For /settings/:orgId/ -> /settings/organization/
-  [/\/settings\/(?!account)(?!projects)(?!teams)[^\/]+\/?$/, '/settings/organization/'],
+  [
+    /\/settings\/(?!account)(?!billing)(?!projects)(?!teams)[^\/]+\/?$/,
+    '/settings/organization/',
+  ],
   // Move /settings/:orgId/:section -> /settings/:section
   // but not /settings/organization or /settings/projects which is a new URL
-  [/^\/?settings\/(?!account)(?!projects)(?!teams)[^\/]+\/(.*)/, '/settings/$1'],
+  [
+    /^\/?settings\/(?!account)(?!billing)(?!projects)(?!teams)[^\/]+\/(.*)/,
+    '/settings/$1',
+  ],
   [/^\/?join-request\/[^\/]+\/?.*/, '/join-request/'],
   [/^\/?onboarding\/[^\/]+\/(.*)/, '/onboarding/$1'],
   // Handles /org-slug/project-slug/getting-started/platform/ -> /getting-started/project-slug/platform/

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -192,6 +192,11 @@ def test_customer_domain_path():
             "/settings/projects/getting-started/abc123/",
         ],
         ["/settings/teams/peeps/", "/settings/teams/peeps/"],
+        ["/settings/billing/checkout/?_q=all#hash", "/settings/billing/checkout/?_q=all#hash"],
+        [
+            "/settings/billing/bundle-checkout/?_q=all#hash",
+            "/settings/billing/bundle-checkout/?_q=all#hash",
+        ],
     ]
     for input_path, expected in scenarios:
         assert expected == customer_domain_path(input_path)


### PR DESCRIPTION
This lets billing routes such as https://sentry.io/settings/billing/checkout/ to load properly.