### PR TITLE
fix(ddm-alerts): Trim metric names in select control

### DIFF
--- a/static/app/utils/middleEllipsis.spec.tsx
+++ b/static/app/utils/middleEllipsis.spec.tsx
@@ -1,0 +1,38 @@
+import {middleEllipsis} from 'sentry/utils/middleEllipsis';
+
+describe('middleEllipsis', function () {
+  it('returns slug if it is already short enough', function () {
+    expect(middleEllipsis('javascript', 20, ' ')).toBe('javascript');
+  });
+
+  it('trims long but unhyphenated slug', function () {
+    expect(middleEllipsis('javascriptfrontendproject', 20, ' ')).toBe(
+      'javascriptfrontendp…'
+    );
+  });
+
+  it('trims slug from the middle, preserves whole words', function () {
+    expect(middleEllipsis('symbol collector console', 20, ' ')).toBe('symbol…console');
+    expect(middleEllipsis('symbol collector mobile', 20, ' ')).toBe('symbol…mobile');
+    expect(middleEllipsis('visual snapshot cloud run', 20, ' ')).toBe('visual…cloud run');
+    expect(middleEllipsis('visual snapshot.cloud-run', 20, / |\./)).toBe(
+      'visual…cloud-run'
+    );
+    expect(
+      middleEllipsis(
+        'visual collector.console-running on_cloud.technology-task.with_luck',
+        50,
+        / |\.|-|_|\s/
+      )
+    ).toBe('visual collector.console…technology-task.with_luck');
+  });
+
+  it('trims slug from the middle, cuts whole words', function () {
+    expect(middleEllipsis('sourcemapsio javascript', 20, ' ')).toBe(
+      'sourcemaps…javascript'
+    );
+    expect(middleEllipsis('armcknight ios.ephemeraldemo', 20, /\.| /)).toBe(
+      'armcknig…phemeraldemo'
+    );
+  });
+});

--- a/static/app/utils/middleEllipsis.tsx
+++ b/static/app/utils/middleEllipsis.tsx
@@ -1,0 +1,83 @@
+/**
+ * Trim strings with a preference for preserving whole words. Only cut up
+ * whole words if the last remaining words are still too long.
+ *
+ * @param value The string to trim
+ * @param maxLength The maximum length of the string
+ * @param delimiter The delimiter to split the string by. If passing a regex be aware that the algorithm only supports single-character delimiters.
+ *
+ * **Examples:**
+ *
+ * - javascript project backend  -> javascript…backend
+ * - my long sentry project name -> my long…project name
+ * - javascriptproject backend   -> javascriptproj…ackend
+ */
+export function middleEllipsis(
+  value: string,
+  maxLength: number,
+  delimiter: string | RegExp = ' '
+) {
+  // Return the original slug if it's already shorter than maxLength
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  /**
+   * Array of words inside the string.
+   * E.g. "my project name" becomes ["my", "project", "name"]
+   */
+  const words: string[] = value.split(delimiter);
+  const delimiters = Array.from(value.match(new RegExp(delimiter, 'g')) || []);
+
+  // If the string is too long but not hyphenated, return an end-trimmed
+  // string. E.g. "javascriptfrontendproject" --> "javascriptfrontendp…"
+  if (words.length === 1) {
+    return `${value.slice(0, maxLength - 1)}\u2026`;
+  }
+
+  /**
+   * Returns the length (total number of letters plus hyphens in between
+   * words) of the current words array.
+   */
+  function getLength(arr: string[]): number {
+    return arr.reduce((acc, cur) => acc + cur.length + 1, 0) - 1;
+  }
+
+  // Progressively remove words and delimiters in the middle until we're below maxLength,
+  // or when only two words are left
+  while (getLength(words) > maxLength && words.length > 2) {
+    words.splice(Math.floor(words.length / 2 - 0.5), 1);
+  }
+
+  // If the remaining words array satisfies the maxLength requirement,
+  // return the trimmed result.
+  if (getLength(words) <= maxLength) {
+    const divider = Math.floor(words.length / 2);
+    const firstHalf = words.slice(0, divider);
+    const firstHalfWithDelimiters = firstHalf
+      .map((word, i) => (i === divider - 1 ? [word] : [word, delimiters[i]]))
+      .flat();
+
+    const secondHalf = words.slice(divider);
+    const secondHalfWithDelimiters = secondHalf
+      .map((word, i) =>
+        i === 0 ? [word] : [delimiters[delimiters.length - secondHalf.length + i], word]
+      )
+      .flat();
+
+    return `${firstHalfWithDelimiters.join('')}\u2026${secondHalfWithDelimiters.join(
+      ''
+    )}`;
+  }
+
+  // If the remaining 2 words are still too long, trim those words starting
+  // from the middle.
+  const debt = getLength(words) - maxLength;
+  const toTrimFromLeftWord = Math.ceil(debt / 2);
+  const leftWordLength = Math.max(words[0].length - toTrimFromLeftWord, 3);
+  const leftWord = words[0].slice(0, leftWordLength);
+  const rightWordLength = maxLength - leftWord.length;
+  const rightWord = words[1].slice(-rightWordLength);
+
+  return `${leftWord}\u2026${rightWord}`;
+}

--- a/static/app/utils/trimSlug.tsx
+++ b/static/app/utils/trimSlug.tsx
@@ -1,3 +1,5 @@
+import {middleEllipsis} from 'sentry/utils/middleEllipsis';
+
 /**
  * Trim slug name with a preference for preserving whole words. Only cut up
  * whole words if the last remaining words are still too long.
@@ -9,52 +11,5 @@
  *   javascriptproject-backend   -> javascriptproj…ackend
  */
 export function trimSlug(slug: string, maxLength: number = 20) {
-  // Return the original slug if it's already shorter than maxLength
-  if (slug.length <= maxLength) {
-    return slug;
-  }
-
-  /**
-   * Array of words inside the slug.
-   * E.g. "my-project-name" becomes ["my", "project", "name"]
-   */
-  const words: string[] = slug.split('-');
-
-  // If the string is too long but not hyphenated, return an end-trimmed
-  // string. E.g. "javascriptfrontendproject" --> "javascriptfrontendp…"
-  if (words.length === 1) {
-    return `${slug.slice(0, maxLength - 1)}\u2026`;
-  }
-
-  /**
-   * Returns the length (total number of letters plus hyphens in between
-   * words) of the current words array.
-   */
-  function getLength(arr: string[]): number {
-    return arr.reduce((acc, cur) => acc + cur.length + 1, 0) - 1;
-  }
-
-  // Progressively remove words in the middle until we're below maxLength,
-  // or when only two words are left
-  while (getLength(words) > maxLength && words.length > 2) {
-    words.splice(Math.floor(words.length / 2 - 0.5), 1);
-  }
-
-  // If the remaining words array satisfies the maxLength requirement,
-  // return the trimmed result.
-  if (getLength(words) <= maxLength) {
-    const divider = Math.floor(words.length / 2);
-    return `${words.slice(0, divider).join('-')}\u2026${words.slice(divider).join('-')}`;
-  }
-
-  // If the remaining 2 words are still too long, trim those words starting
-  // from the middle.
-  const debt = getLength(words) - maxLength;
-  const toTrimFromLeftWord = Math.ceil(debt / 2);
-  const leftWordLength = Math.max(words[0].length - toTrimFromLeftWord, 3);
-  const leftWord = words[0].slice(0, leftWordLength);
-  const rightWordLength = maxLength - leftWord.length;
-  const rightWord = words[1].slice(-rightWordLength);
-
-  return `${leftWord}\u2026${rightWord}`;
+  return middleEllipsis(slug, maxLength, '-');
 }

--- a/static/app/views/alerts/rules/metric/mriField.tsx
+++ b/static/app/views/alerts/rules/metric/mriField.tsx
@@ -15,6 +15,7 @@ import {
   parseMRI,
 } from 'sentry/utils/metrics/mri';
 import {useMetricsMeta} from 'sentry/utils/metrics/useMetricsMeta';
+import {middleEllipsis} from 'sentry/utils/middleEllipsis';
 
 interface Props {
   aggregate: string;
@@ -101,7 +102,7 @@ function MriField({aggregate, project, onChange}: Props) {
         disabled?: boolean;
         trailingItems?: React.ReactNode;
       }>(metric => ({
-        label: metric.name,
+        label: middleEllipsis(metric.name, 50, /\.|-|_/),
         value: metric.mri,
         trailingItems: (
           <Fragment>


### PR DESCRIPTION
Trim metric names in the alert interface.
Add `middleEllipsis` util -> a more generic version of `trimSlug`.

<img width="585" alt="Screenshot 2023-11-30 at 13 30 15" src="https://github.com/getsentry/sentry/assets/7033940/30610d0e-d861-4121-a0c3-39bd2cb0eaa3">

- closes https://github.com/getsentry/sentry/issues/60572