### PR TITLE
fix(security): allow to connect to Algolia

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -466,6 +466,9 @@ CSP_FONT_SRC = [
 ]
 CSP_CONNECT_SRC = [
     "'self'",
+    "*.algolia.net",
+    "*.algolianet.com",
+    "*.algolia.io",
 ]
 CSP_FRAME_ANCESTORS = [
     "'none'",


### PR DESCRIPTION
Algolia-backend snippet is used by _Help -> Search Support, Docs and More_

We import `@sentry-internal/global-search` npm package here:
https://github.com/getsentry/sentry/blob/master/static/app/components/search/sources/helpSource.tsx#L7

The constants are defined here in the package:
https://github.com/getsentry/sentry-global-search/blob/master/src/sentry-global-search/sentry-global-search.ts#L48-L51