### PR TITLE
fix(dashboards): metric tag label

### DIFF
--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -593,8 +593,11 @@ class QueryField extends Component<Props> {
         tagType = 'success';
         break;
       case FieldValueKind.FIELD:
+        text = DEPRECATED_FIELDS.includes(label) ? 'deprecated' : 'field';
+        tagType = 'highlight';
+        break;
       case FieldValueKind.METRICS:
-        text = DEPRECATED_FIELDS.includes(label) ? 'deprecated' : 'metric';
+        text = 'metric';
         tagType = 'highlight';
         break;
       default:


### PR DESCRIPTION
Fixes a case where certain fields in widget builder dropdowns were labeled as metrics.

Before
![image](https://github.com/getsentry/sentry/assets/86684834/b7f89c1e-1823-4d92-a96e-c394c1497bb8)
After
![image](https://github.com/getsentry/sentry/assets/86684834/7a5890a2-758d-4dba-8ec7-2c46010d3e1d)
