### PR TITLE
fix(hybrid-cloud): Validate Discord requests in request parser

### DIFF
--- a/src/sentry/integrations/discord/requests/base.py
+++ b/src/sentry/integrations/discord/requests/base.py
@@ -13,6 +13,7 @@ from sentry.services.hybrid_cloud.identity.service import identity_service
 from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
 from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.utils import json
 
 from ..utils import logger, verify_signature
 
@@ -54,7 +55,8 @@ class DiscordRequest:
     def __init__(self, request: Request):
         self.request = request
         self._integration: RpcIntegration | None = None
-        self._data: Mapping[str, object] = self.request.data
+        self._body = self.request.body.decode("utf-8")
+        self._data: Mapping[str, object] = json.loads(self._body)
         self._identity: RpcIdentity | None = None
         self.user: RpcUser | None = None
 
@@ -65,7 +67,11 @@ class DiscordRequest:
     @property
     def data(self) -> Mapping[str, object]:
         """This is the data object nested within request.data"""
-        return self._data.get("data") or {}  # type: ignore
+        data = self._data.get("data")
+        if isinstance(data, dict):
+            return data
+        else:
+            return {}
 
     @property
     def guild_id(self) -> str | None:
@@ -119,7 +125,7 @@ class DiscordRequest:
         public_key: str = options.get("discord.public-key")
         signature: str | None = self.request.META.get("HTTP_X_SIGNATURE_ED25519")
         timestamp: str | None = self.request.META.get("HTTP_X_SIGNATURE_TIMESTAMP")
-        body: str = self.request.body.decode("utf-8")
+        body: str = self._body
         if not signature or not timestamp:
             self._info(
                 "discord.authorize.auth.missing.data",
@@ -211,22 +217,23 @@ class DiscordRequest:
     def get_command_name(self) -> str:
         if not self.is_command():
             return ""
-        return self.data["name"]  # type: ignore
+        return str(self.data.get("name", ""))
 
     def get_component_custom_id(self) -> str:
         if not self.is_message_component():
             return ""
-        return self.data["custom_id"]  # type: ignore
+        return str(self.data.get("custom_id", ""))
 
     def is_select_component(self) -> bool:
-        return self.data["component_type"] == DiscordMessageComponentTypes.SELECT
+        return self.data.get("component_type", None) == DiscordMessageComponentTypes.SELECT
 
     def get_selected_options(self) -> list[str]:
         if not self.is_select_component():
             logger.info("discord.interaction.component.not.is_select_component")
             return []
+        values = self.data.get("values", [])
         logger.info(
             "discord.interaction.component.get_selected_options",
-            extra={"data": self.data, "values": self.data["values"]},
+            extra={"data": self.data, "values": values},
         )
-        return self.data["values"]  # type: ignore
+        return values  # type: ignore

--- a/tests/sentry/integrations/discord/test_requests.py
+++ b/tests/sentry/integrations/discord/test_requests.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from unittest import mock
-from urllib.parse import urlencode
 
 from sentry.integrations.discord.requests.base import DiscordRequest
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.utils import json
 
 
 @control_silo_test
@@ -27,7 +27,7 @@ class DiscordRequestTest(TestCase):
             if request_data is None
             else request_data
         )
-        self.request.body = urlencode(self.request.data).encode()
+        self.request.body = json.dumps(self.request.data).encode()
         self.request.META = {
             "HTTP_X_SIGNATURE_ED25519": "signature",
             "HTTP_X_SIGNATURE_TIMESTAMP": "timestamp",

--- a/tests/sentry/integrations/discord/webhooks/test_endpoint.py
+++ b/tests/sentry/integrations/discord/webhooks/test_endpoint.py
@@ -13,7 +13,7 @@ WEBHOOK_URL = "/extensions/discord/interactions/"
 class DiscordWebhookTest(APITestCase):
     @mock.patch("sentry.integrations.discord.requests.base.verify_signature")
     def test_ping_interaction(self, mock_verify_signature):
-        mock_verify_signature.return_value = True
+        mock_verify_signature.return_value = None
         resp = self.client.post(
             path=WEBHOOK_URL,
             data={


### PR DESCRIPTION
According to the Discord documentation on building the Interactions endpoint, we need to validate the signature headers they send: https://discord.com/developers/docs/interactions/receiving-and-responding#security-and-authorization

Discord will intentionally send invalid signature headers to check that they're validated by verifying that we respond with the `401` HTTP status code.

I've updated the Discord request parser to perform this validation, and respond accordingly.