### PR TITLE
feat(feedback): Move contact-email and message fields outside the contexts object

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -101,6 +101,15 @@ def fix_for_issue_platform(event_data):
     if event_data.get("user", {}).get("id") is not None:
         event_data["user"]["id"] = str(event_data["user"]["id"])
 
+    # If no user email was provided specify the contact-email as the user-email.
+    feedback_obj = event_data.get("contexts", {}).get("feedback", {})
+    contact_email = feedback_obj.get("contact_email")
+    if not event_data.get("user", {}).get("email", ""):
+        ret_event["user"]["email"] = contact_email
+
+    # Set the event message to the feedback message.
+    ret_event["extra"] = {"message": feedback_obj.get("message")}
+
     return ret_event
 
 

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -108,7 +108,7 @@ def fix_for_issue_platform(event_data):
         ret_event["user"]["email"] = contact_email
 
     # Set the event message to the feedback message.
-    ret_event["extra"] = {"message": feedback_obj.get("message")}
+    ret_event["logentry"] = {"message": feedback_obj.get("message")}
 
     return ret_event
 

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -104,7 +104,7 @@ def fix_for_issue_platform(event_data):
     # If no user email was provided specify the contact-email as the user-email.
     feedback_obj = event_data.get("contexts", {}).get("feedback", {})
     contact_email = feedback_obj.get("contact_email")
-    if not event_data.get("user", {}).get("email", ""):
+    if not ret_event["user"].get("email", ""):
         ret_event["user"]["email"] = contact_email
 
     # Set the event message to the feedback message.

--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -110,6 +110,12 @@ def test_fix_for_issue_platform():
         "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
         "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
     }
+    assert fixed_event["extra"]["message"] == event["contexts"]["feedback"]["message"]
+
+    # Assert the contact-email is set as the user-email when no user-email exists.
+    event["user"].pop("email")
+    fixed_event = fix_for_issue_platform(event)
+    assert fixed_event["user"]["email"] == event["contexts"]["feedback"]["contact_email"]
 
 
 def test_corrected_still_works():

--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -110,7 +110,7 @@ def test_fix_for_issue_platform():
         "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
         "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
     }
-    assert fixed_event["extra"]["message"] == event["contexts"]["feedback"]["message"]
+    assert fixed_event["logentry"]["message"] == event["contexts"]["feedback"]["message"]
 
     # Assert the contact-email is set as the user-email when no user-email exists.
     event["user"].pop("email")


### PR DESCRIPTION
@JoshFerge There's no `message` field in `event.schema.json`.  So I just put in the extra object for now just to have a code path to change later.  Consider it a todo.

I'm not entirely sure where this should live.  Without changing the schema, it feels like a tag is the best place at the moment...  That or a top-level contexts field e.g. `"feedback_message": message`.  I'm not sure what the etiquette is around adding fields to contexts.  Do you have any thoughts?

Closes: https://github.com/getsentry/sentry/issues/59928