### PR TITLE
fix(weekly-reports): Don't send analytics if using an email override

### DIFF
--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -1105,6 +1105,8 @@ def send_email(ctx, user_id, dry_run=False, email_override=None):
     )
     if dry_run:
         return
+    if email_override:
+        message.send(to=(email_override,))
     else:
         analytics.record(
             "weekly_report.sent",
@@ -1113,8 +1115,5 @@ def send_email(ctx, user_id, dry_run=False, email_override=None):
             notification_uuid=template_ctx["notification_uuid"],
             user_project_count=template_ctx["user_project_count"],
         )
-    if email_override:
-        message.send(to=(email_override,))
-    else:
         message.add_users((user_id,))
         message.send_async()

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -2,6 +2,7 @@ import copy
 from datetime import datetime, timedelta, timezone
 from unittest import mock
 
+import pytest
 from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
 from django.db import router
@@ -665,13 +666,14 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
             assert context["user_project_count"] == 1
             assert f"Weekly Report for {self.organization.name}" in message_params["subject"]
 
-        record.assert_any_call(
-            "weekly_report.sent",
-            user_id=user.id,
-            organization_id=self.organization.id,
-            notification_uuid=mock.ANY,
-            user_project_count=1,
-        )
+        with pytest.raises(AssertionError):
+            record.assert_any_call(
+                "weekly_report.sent",
+                user_id=user.id,
+                organization_id=self.organization.id,
+                notification_uuid=mock.ANY,
+                user_project_count=1,
+            )
 
         message_builder.return_value.send.assert_called_with(to=("joseph@speedwagon.org",))
 
@@ -715,13 +717,14 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase):
             assert context["organization"] == self.organization
             assert context["user_project_count"] == 3
 
-        record.assert_any_call(
-            "weekly_report.sent",
-            user_id=None,
-            organization_id=self.organization.id,
-            notification_uuid=mock.ANY,
-            user_project_count=3,
-        )
+        with pytest.raises(AssertionError):
+            record.assert_any_call(
+                "weekly_report.sent",
+                user_id=None,
+                organization_id=self.organization.id,
+                notification_uuid=mock.ANY,
+                user_project_count=1,
+            )
 
         message_builder.return_value.send.assert_called_with(to=("jonathan@speedwagon.org",))
 


### PR DESCRIPTION
Originally, when triggering a non-dry run of weekly reports, we still recorded in analytics. However, because we allow the triggering of non-dry runs without a target user (thus generating a report for a user who'd have access to all projects), the analytics would cause an error, as it requires a valid user. 

We shouldn't need to record analytics for manual triggers of the weekly reports anyway (we already didn't for dry runs), they should only be recorded for the real weekly reports.

Resolves SENTRY-195W