### PR TITLE
feat(ddm-alerts): Set chart granularity and period via url

### DIFF
--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -39,7 +39,7 @@ export type MetricsApiRequestQuery = MetricsApiRequestMetric & {
   orderBy?: string;
   per_page?: number;
   project?: number[];
-  star?: DateString;
+  start?: DateString;
   statsPeriod?: string;
   useNewMetricsLayer?: boolean;
 };

--- a/static/app/utils/metrics/index.spec.tsx
+++ b/static/app/utils/metrics/index.spec.tsx
@@ -140,15 +140,15 @@ describe('getMetricsInterval', () => {
 
 describe('formatMetricUsingFixedUnit', () => {
   it('should return the formatted value with the short form of the given unit', () => {
-    expect(formatMetricUsingFixedUnit(123456, 'millisecond')).toBe('123,456 ms');
-    expect(formatMetricUsingFixedUnit(2.1231245, 'kibibyte')).toBe('2.123 KiB');
-    expect(formatMetricUsingFixedUnit(1222.1231245, 'megabyte')).toBe('1,222.123 MB');
+    expect(formatMetricUsingFixedUnit(123456, 'millisecond')).toBe('123,456ms');
+    expect(formatMetricUsingFixedUnit(2.1231245, 'kibibyte')).toBe('2.123KiB');
+    expect(formatMetricUsingFixedUnit(1222.1231245, 'megabyte')).toBe('1,222.123MB');
   });
 
   it.each(formattingSupportedMetricUnits.filter(unit => unit !== 'none'))(
     'appends a unit for every supported one (except none)',
     unit => {
-      expect(formatMetricUsingFixedUnit(1234.56, unit)).toMatch(/1,234\.56 .+/);
+      expect(formatMetricUsingFixedUnit(1234.56, unit)).toMatch(/1,234\.56.+/);
     }
   );
 

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -314,7 +314,7 @@ const getShortMetricUnit = (unit: string): string => METRIC_UNIT_TO_SHORT[unit] 
 
 export function formatMetricUsingFixedUnit(value: number | null, unit: string) {
   return value !== null
-    ? `${round(value, 3).toLocaleString()} ${getShortMetricUnit(unit)}`.trim()
+    ? `${round(value, 3).toLocaleString()}${getShortMetricUnit(unit)}`.trim()
     : '\u2015';
 }
 

--- a/static/app/utils/metrics/useMetricsData.tsx
+++ b/static/app/utils/metrics/useMetricsData.tsx
@@ -1,7 +1,7 @@
 import {useEffect, useState} from 'react';
 
 import {ApiResult} from 'sentry/api';
-import {DateString, MetricsApiResponse} from 'sentry/types';
+import {DateString, MetricsApiRequestQuery, MetricsApiResponse} from 'sentry/types';
 import {getMetricsApiRequestQuery, MetricsQuery} from 'sentry/utils/metrics';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -22,15 +22,10 @@ function getRefetchInterval(
   return 60 * 1000;
 }
 
-export function useMetricsData({
-  mri,
-  op,
-  datetime,
-  projects,
-  environments,
-  query,
-  groupBy,
-}: MetricsQuery) {
+export function useMetricsData(
+  {mri, op, datetime, projects, environments, query, groupBy}: MetricsQuery,
+  overrides: Partial<MetricsApiRequestQuery> = {}
+) {
   const organization = useOrganization();
 
   const useNewMetricsLayer = organization.features.includes(
@@ -46,7 +41,7 @@ export function useMetricsData({
       groupBy,
     },
     {datetime, projects, environments},
-    {useNewMetricsLayer}
+    {...overrides, useNewMetricsLayer}
   );
 
   return useApiQuery<MetricsApiResponse>(

--- a/static/app/views/alerts/rules/metric/constants.tsx
+++ b/static/app/views/alerts/rules/metric/constants.tsx
@@ -177,7 +177,10 @@ function getAlertTimeWindow(period: string | undefined): TimeWindow | undefined 
     return undefined;
   }
 
-  const timeWindows = Object.values(TimeWindow).sort() as number[];
+  const timeWindows = Object.values(TimeWindow)
+    .filter((value): value is TimeWindow => typeof value === 'number')
+    .sort();
+
   for (let index = 0; index < timeWindows.length; index++) {
     const timeWindow = timeWindows[index];
     if (periodMinutes <= timeWindow) {

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -872,7 +872,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
   }
 
   renderTriggerChart() {
-    const {organization, ruleId, rule} = this.props;
+    const {organization, ruleId, rule, location} = this.props;
 
     const {
       query,
@@ -889,10 +889,9 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       dataset,
       alertType,
       isQueryValid,
-      location,
     } = this.state;
 
-    const isMigration = this.props.location?.query?.migration === '1';
+    const isMigration = location?.query?.migration === '1';
     // TODO(telemetry-experience): Remove this and all connected logic once the migration is complete
     const isTransactionMigration = isMigration && ruleNeedsMigration(rule);
     const isOnDemand = isOnDemandMetricAlert(dataset, aggregate, query);

--- a/static/app/views/ddm/createAlertModal.tsx
+++ b/static/app/views/ddm/createAlertModal.tsx
@@ -6,6 +6,7 @@ import {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Button} from 'sentry/components/button';
 import {AreaChart} from 'sentry/components/charts/areaChart';
 import {HeaderTitleLegend} from 'sentry/components/charts/styles';
+import {getInterval} from 'sentry/components/charts/utils';
 import CircleIndicator from 'sentry/components/circleIndicator';
 import SelectControl from 'sentry/components/forms/controls/selectControl';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
@@ -16,7 +17,8 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Project} from 'sentry/types';
+import {PageFilters, Project} from 'sentry/types';
+import {parsePeriodToHours, statsPeriodToDays} from 'sentry/utils/dates';
 import {
   formatMetricUsingFixedUnit,
   MetricDisplayType,
@@ -27,7 +29,13 @@ import {useMetricsData} from 'sentry/utils/metrics/useMetricsData';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
-import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
+import {AVAILABLE_TIME_PERIODS} from 'sentry/views/alerts/rules/metric/triggers/chart';
+import {
+  Dataset,
+  EventTypes,
+  TimePeriod,
+  TimeWindow,
+} from 'sentry/views/alerts/rules/metric/types';
 import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
 import {getChartSeries} from 'sentry/views/ddm/widget';
 
@@ -54,6 +62,56 @@ function getInitialFormState(metricsQuery: MetricsQuery): FormState {
   };
 }
 
+function getAlertPeriod(metricsQuery: MetricsQuery) {
+  const {period, start, end} = metricsQuery.datetime;
+  const inHours = statsPeriodToDays(period, start, end) * 24;
+
+  switch (true) {
+    case inHours <= 6:
+      return TimePeriod.SIX_HOURS;
+    case inHours <= 24:
+      return TimePeriod.ONE_DAY;
+    case inHours <= 3 * 24:
+      return TimePeriod.THREE_DAYS;
+    case inHours <= 7 * 24:
+      return TimePeriod.SEVEN_DAYS;
+    case inHours <= 14 * 24:
+      return TimePeriod.FOURTEEN_DAYS;
+    default:
+      return TimePeriod.SEVEN_DAYS;
+  }
+}
+
+const TIME_WINDOWS_TO_CHECK = [
+  TimeWindow.ONE_MINUTE,
+  TimeWindow.FIVE_MINUTES,
+  TimeWindow.TEN_MINUTES,
+  TimeWindow.FIFTEEN_MINUTES,
+  TimeWindow.THIRTY_MINUTES,
+  TimeWindow.ONE_HOUR,
+  TimeWindow.TWO_HOURS,
+  TimeWindow.FOUR_HOURS,
+  TimeWindow.ONE_DAY,
+];
+
+function getAlertInterval(metricsQuery, period: TimePeriod) {
+  const interval = getInterval(metricsQuery.datetime, 'metrics');
+  const inMinutes = parsePeriodToHours(interval) * 60;
+
+  function toInterval(timeWindow: TimeWindow) {
+    return `${timeWindow}m`;
+  }
+
+  for (let index = 0; index < TIME_WINDOWS_TO_CHECK.length; index++) {
+    const timeWindow = TIME_WINDOWS_TO_CHECK[index];
+    if (inMinutes <= timeWindow && AVAILABLE_TIME_PERIODS[timeWindow].includes(period)) {
+      return toInterval(timeWindow);
+    }
+  }
+
+  return toInterval(TimeWindow.ONE_HOUR);
+}
+
 export function CreateAlertModal({Header, Body, Footer, metricsQuery}: Props) {
   const router = useRouter();
   const organization = useOrganization();
@@ -65,14 +123,25 @@ export function CreateAlertModal({Header, Body, Footer, metricsQuery}: Props) {
   const selectedProject = projects.find(p => p.id === formState.project);
   const isFormValid = formState.project !== null;
 
-  const {data, isLoading, refetch, isError} = useMetricsData({
-    mri: metricsQuery.mri,
-    op: metricsQuery.op,
-    projects: formState.project ? [parseInt(formState.project, 10)] : [],
-    environments: formState.environment ? [formState.environment] : [],
-    datetime: metricsQuery.datetime,
-    query: metricsQuery.query,
-  });
+  const alertPeriod = useMemo(() => getAlertPeriod(metricsQuery), [metricsQuery]);
+  const alertInterval = useMemo(
+    () => getAlertInterval(metricsQuery, alertPeriod),
+    [metricsQuery, alertPeriod]
+  );
+
+  const {data, isLoading, refetch, isError} = useMetricsData(
+    {
+      mri: metricsQuery.mri,
+      op: metricsQuery.op,
+      projects: formState.project ? [parseInt(formState.project, 10)] : [],
+      environments: formState.environment ? [formState.environment] : [],
+      datetime: {period: alertPeriod} as PageFilters['datetime'],
+      query: metricsQuery.query,
+    },
+    {
+      interval: alertInterval,
+    }
+  );
 
   const chartSeries = useMemo(
     () =>
@@ -141,6 +210,8 @@ export function CreateAlertModal({Header, Body, Footer, metricsQuery}: Props) {
         dataset: Dataset.GENERIC_METRICS,
         eventTypes: EventTypes.TRANSACTION,
         aggregate: MRIToField(metricsQuery.mri, metricsQuery.op!),
+        interval: alertInterval,
+        statsPeriod: alertPeriod,
         referrer: 'ddm',
         // Event type also needs to be added to the query
         query: `${metricsQuery.query}  event.type:transaction`.trim(),
@@ -149,6 +220,8 @@ export function CreateAlertModal({Header, Body, Footer, metricsQuery}: Props) {
       })}`
     );
   }, [
+    alertInterval,
+    alertPeriod,
     formState.environment,
     metricsQuery.mri,
     metricsQuery.op,


### PR DESCRIPTION
Pass the interval and period to the alert creation page when creating an alert based on a DDM chart.

Alert create:
 - Collect `timeWindow` from `eventView`
 - Collect statsPeriod query param

DDM:
 - Calculate nearest matching alert `interval` & `statsPeriod`
 - Use it in preview chart and for creating the alert URL