### PR TITLE
fix(perf): Correctly parse successful time ranges

### DIFF
--- a/static/app/components/charts/utils.spec.tsx
+++ b/static/app/components/charts/utils.spec.tsx
@@ -144,6 +144,9 @@ describe('Chart Utils', function () {
       it('can parse a period string in weeks', function () {
         expect(getDiffInMinutes({period: '1w'})).toBe(10080);
       });
+      it('can parse a period string with an upsell suffix', function () {
+        expect(getDiffInMinutes({period: '90d-trial'})).toBe(129600);
+      });
     });
 
     // This uses moment so we probably don't need to test it too extensively

--- a/static/app/components/organizations/pageFilters/parse.tsx
+++ b/static/app/components/organizations/pageFilters/parse.tsx
@@ -15,7 +15,7 @@ export type StatsPeriodType = 'h' | 'd' | 's' | 'm' | 'w';
 type SingleParamValue = string | undefined | null;
 type ParamValue = string[] | SingleParamValue;
 
-const STATS_PERIOD_PATTERN = '^(\\d+)([hdmsw])?$';
+const STATS_PERIOD_PATTERN = '^(\\d+)([hdmsw])?(-\\w+)?$';
 
 /**
  * Parses a stats period into `period` and `periodLength`


### PR DESCRIPTION
When users are going through onboarding, `TimeRangeSelector` adds a special dropdown value: `90d-trial`. When selected, this value makes it into the URL. The UI then fails to parse this date range, and ends up spitting out a negative number, which causes unusual behaviour.

I considered removing the `-trial` suffix behaviour, but I decided to do it on the parsing side instead, in the name of permissive parsing. This is a simpler and more robust change, IMO, but you tell me. I also don't want to remove an onboarding functionality that's currently in use, or make a major change to it.

- Add test for upsell ranges
- Parse upsell ranges

Fixes JAVASCRIPT-2PYT
