### PR TITLE
fix(prism): Set manual=true to stop highlightAll() on page load

### DIFF
--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -7,7 +7,7 @@ import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {prismStyles} from 'sentry/styles/prism';
 import {space} from 'sentry/styles/space';
-import {loadPrismLanguage} from 'sentry/utils/loadPrismLanguage';
+import {loadPrismLanguage} from 'sentry/utils/prism';
 
 interface CodeSnippetProps {
   children: string;

--- a/static/app/components/events/interfaces/request/graphQlRequestBody.tsx
+++ b/static/app/components/events/interfaces/request/graphQlRequestBody.tsx
@@ -12,7 +12,7 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {EntryRequestDataGraphQl, Event} from 'sentry/types';
 import {defined} from 'sentry/utils';
-import {loadPrismLanguage} from 'sentry/utils/loadPrismLanguage';
+import {loadPrismLanguage} from 'sentry/utils/prism';
 
 type GraphQlBodyProps = {data: EntryRequestDataGraphQl['data']; event: Event};
 

--- a/static/app/utils/marked.tsx
+++ b/static/app/utils/marked.tsx
@@ -3,7 +3,7 @@ import marked from 'marked'; // eslint-disable-line no-restricted-imports
 import Prism from 'prismjs';
 
 import {NODE_ENV} from 'sentry/constants';
-import {loadPrismLanguage} from 'sentry/utils/loadPrismLanguage';
+import {loadPrismLanguage} from 'sentry/utils/prism';
 
 // Only https and mailto, (e.g. no javascript, vbscript, data protocols)
 const safeLinkPattern = /^(https?:|mailto:)/i;

--- a/static/app/utils/prism.tsx
+++ b/static/app/utils/prism.tsx
@@ -1,4 +1,14 @@
+import Prism from 'prismjs';
 import prismComponents from 'prismjs/components';
+
+/**
+ * Without this, Prism will call highlightAll() automatically on page load.
+ * We call highlightElement() when necessary so this is both unnecessary and
+ * can lead to issues when loading a page in a background tab.
+ *
+ * See https://prismjs.com/docs/Prism.html#.manual
+ */
+Prism.manual = true;
 
 /**
  * A mapping object containing all Prism languages/aliases that can be loaded using

--- a/static/app/utils/usePrismTokens.spec.tsx
+++ b/static/app/utils/usePrismTokens.spec.tsx
@@ -1,6 +1,6 @@
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
-import {loadPrismLanguage} from 'sentry/utils/loadPrismLanguage';
+import {loadPrismLanguage} from 'sentry/utils/prism';
 import {usePrismTokens} from 'sentry/utils/usePrismTokens';
 
 const JS_CODE = `function foo() {

--- a/static/app/utils/usePrismTokens.tsx
+++ b/static/app/utils/usePrismTokens.tsx
@@ -2,7 +2,7 @@ import {useEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 import * as Prism from 'prismjs';
 
-import {loadPrismLanguage, prismLanguageMap} from 'sentry/utils/loadPrismLanguage';
+import {loadPrismLanguage, prismLanguageMap} from 'sentry/utils/prism';
 
 type PrismHighlightParams = {
   code: string;


### PR DESCRIPTION
So I found an issue with using the new `usePrismTokens` hook, which is that if you loaded a component using it in a background tab and switched to it after the page had rendered, Prism would call `highlightAll()` and mess up the already highlighted code. This is because Prism calls that function on the `DOMContentLoaded` event: https://github.com/PrismJS/prism/blob/59e5a3471377057de1f401ba38337aca27b80e03/components/prism-core.js#L1184-L1201

In order to stop that from happening, we need to set `manual=false` which is fine for our usage because we always manually call highlightElement(). AFAICT, this is the only way to do this: https://prismjs.com/docs/Prism.html#.manual

I wasn't sure the best place to add this, so I added it to the prism util file that all usages of Prism are already importing from. I renamed it from  `loadPrismLanguage` to just `utils/prism` to make it more of a general file to put prism helpers. If you have a better suggestion for where to put this, I'm all ears.