### PR TITLE
fix(metric-alerts): Fix bug where `is:unresolved` doesn't validate correctly.

### DIFF
--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -192,7 +192,7 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
         query_builder_cls = QueryBuilder
         # TODO: Remove this query when we remove the feature check
         organization = Organization.objects.filter(project__id__in=project_ids)[0]
-        parser_config_overrides = {"blocked_keys": ALERT_BLOCKED_FIELDS}
+        parser_config_overrides: MutableMapping[str, Any] = {"blocked_keys": ALERT_BLOCKED_FIELDS}
         if self.dataset == Dataset.Events and features.has(
             "organizations:metric-alert-ignore-archived", organization
         ):

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -192,10 +192,14 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
         query_builder_cls = QueryBuilder
         # TODO: Remove this query when we remove the feature check
         organization = Organization.objects.filter(project__id__in=project_ids)[0]
+        parser_config_overrides = {"blocked_keys": ALERT_BLOCKED_FIELDS}
         if self.dataset == Dataset.Events and features.has(
             "organizations:metric-alert-ignore-archived", organization
         ):
+            from sentry.snuba.errors import PARSER_CONFIG_OVERRIDES
+
             query_builder_cls = ErrorsQueryBuilder
+            parser_config_overrides.update(PARSER_CONFIG_OVERRIDES)
 
         return query_builder_cls(
             dataset=Dataset(self.dataset.value),
@@ -206,7 +210,7 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
             limit=None,
             config=QueryBuilderConfig(
                 skip_time_conditions=True,
-                parser_config_overrides={"blocked_keys": ALERT_BLOCKED_FIELDS},
+                parser_config_overrides=parser_config_overrides,
                 skip_field_validation_for_entity_subscription_deletion=skip_field_validation_for_entity_subscription_deletion,
             ),
         )

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -133,7 +133,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
             ]
         ):
             data = deepcopy(self.valid_alert_rule)
-            data["query"] = "status:unresolved"
+            data["query"] = "is:unresolved"
             resp = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
@@ -143,7 +143,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
         assert resp.data == serialize(alert_rule, self.user)
-        assert alert_rule.snuba_query.query == "status:unresolved"
+        assert alert_rule.snuba_query.query == "is:unresolved"
 
     def test_project_not_in_request(self):
         """Test that if you don't provide the project data in the request, we grab it from the URL"""


### PR DESCRIPTION
When we switched to using `is:unresolved` I missed updating some tests, and so validating `is:` queries on metric alerts failed.
