### PR TITLE
removes the v2 suffix from notification methods and does more cleanup

### DIFF
--- a/src/sentry/api/validators/integrations.py
+++ b/src/sentry/api/validators/integrations.py
@@ -19,7 +19,3 @@ def validate_provider(
             f'The provider "{provider}" is not supported. We currently accept {available_providers} identities.'
         )
     return provider_option
-
-
-def validate_provider_option(provider: Optional[str]) -> Optional[ExternalProviders]:
-    return validate_provider(provider) if provider else None

--- a/src/sentry/api/validators/notifications.py
+++ b/src/sentry/api/validators/notifications.py
@@ -1,9 +1,7 @@
-from typing import AbstractSet, Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
+from typing import List, Optional
 
 from sentry.api.exceptions import ParameterValidationError
-from sentry.api.validators.integrations import validate_provider
 from sentry.notifications.helpers import validate as helper_validate
-from sentry.notifications.helpers import validate_v2 as helper_validate_v2
 from sentry.notifications.types import (
     NOTIFICATION_SCOPE_TYPE,
     NOTIFICATION_SETTING_OPTION_VALUES,
@@ -12,17 +10,6 @@ from sentry.notifications.types import (
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
-from sentry.types.integrations import ExternalProviders
-
-
-def intersect_dict_set(d: Dict[int, Any], s: Set[int]) -> Dict[int, Any]:
-    """Get the sub-dictionary where the keys are in the intersections the original keys and the set."""
-    # TODO(mgaeta): Genericize the key type and move to sentry.utils.
-    return {k: v for k, v in d.items() if k in s}
-
-
-def validate_type_option(type: Optional[str]) -> Optional[NotificationSettingTypes]:
-    return validate_type(type) if type else None
 
 
 def validate_type(type: str, context: Optional[List[str]] = None) -> NotificationSettingTypes:
@@ -41,25 +28,6 @@ def validate_scope_type(
         raise ParameterValidationError(f"Unknown scope_type: {scope_type}", context)
 
 
-def validate_scope(
-    scope_id: Union[int, str],
-    scope_type: NotificationScopeType,
-    user: Optional[Any] = None,
-    context: Optional[List[str]] = None,
-) -> int:
-    if user and scope_type == NotificationScopeType.USER:
-        if scope_id == "me":
-            # Overwrite "me" with the current user's ID.
-            scope_id = user.id
-        elif scope_id != str(user.id):
-            raise ParameterValidationError(f"Incorrect user ID: {scope_id}", context)
-
-    try:
-        return int(scope_id)
-    except ValueError:
-        raise ParameterValidationError(f"Invalid ID: {scope_id}", context)
-
-
 def validate_value(
     type: NotificationSettingTypes, value_param: str, context: Optional[List[str]] = None
 ) -> NotificationSettingOptionValues:
@@ -71,88 +39,3 @@ def validate_value(
     if value != NotificationSettingOptionValues.DEFAULT and not helper_validate(type, value):
         raise ParameterValidationError(f"Invalid value for type {type}: {value}", context)
     return value
-
-
-def validate_value_v2(
-    type: NotificationSettingTypes, value_param: str, context: Optional[List[str]] = None
-) -> NotificationSettingOptionValues:
-    try:
-        value = {v: k for k, v in NOTIFICATION_SETTING_OPTION_VALUES.items()}[value_param]
-    except KeyError:
-        raise ParameterValidationError(f"Unknown value: {value_param}", context)
-
-    if value != NotificationSettingOptionValues.DEFAULT and not helper_validate_v2(type, value):
-        raise ParameterValidationError(f"Invalid value for type {type}: {value}", context)
-    return value
-
-
-def get_valid_items(
-    data: Mapping[Any, Any], context: Optional[List[str]] = None
-) -> AbstractSet[Any]:
-    try:
-        return data.items()
-    except AttributeError:
-        raise ParameterValidationError("Malformed JSON in payload", context)
-
-
-def validate(
-    data: Mapping[str, Mapping[str, Mapping[int, Mapping[str, str]]]],
-    user: Optional[Any] = None,
-) -> Iterable[
-    Tuple[
-        ExternalProviders,
-        NotificationSettingTypes,
-        NotificationScopeType,
-        int,
-        NotificationSettingOptionValues,
-    ],
-]:
-    """
-    Validate some serialized notification settings. If invalid, raise an
-    exception. Otherwise, return them as a list of tuples.
-    """
-
-    if not data:
-        raise ParameterValidationError("Payload required")
-
-    parent_context = ["notification_settings"]
-    context = parent_context
-    notification_settings_to_update: Dict[
-        Tuple[
-            NotificationSettingTypes,
-            NotificationScopeType,
-            int,
-            ExternalProviders,
-        ],
-        NotificationSettingOptionValues,
-    ] = {}
-    for type_key, notifications_by_type in get_valid_items(data, context):
-        type = validate_type(type_key, context)
-        context = parent_context + [type_key]
-
-        for scope_type_key, notifications_by_scope_type in get_valid_items(
-            notifications_by_type, context
-        ):
-            scope_type = validate_scope_type(scope_type_key, context)
-            context = parent_context + [type_key, scope_type_key]
-            for scope_id, notifications_by_scope_id in get_valid_items(
-                notifications_by_scope_type, context
-            ):
-                scope_id = validate_scope(scope_id, scope_type, user, context)
-
-                context = parent_context + [type_key, scope_type_key, str(scope_id)]
-                for provider_key, value_key in get_valid_items(notifications_by_scope_id, context):
-                    provider = validate_provider(provider_key, context=context)
-                    value = validate_value(type, value_key, context)
-
-                    notification_settings_to_update[(type, scope_type, scope_id, provider)] = value
-
-    return {
-        (provider, type, scope_type, scope_id, value)
-        for (
-            type,
-            scope_type,
-            scope_id,
-            provider,
-        ), value in notification_settings_to_update.items()
-    }

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -23,7 +23,7 @@ from sentry.incidents.models import (
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.models.user import User
 from sentry.notifications.types import NotificationSettingEnum
-from sentry.notifications.utils.participants import get_notification_recipients_v2
+from sentry.notifications.utils.participants import get_notification_recipients
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
@@ -130,7 +130,7 @@ class EmailActionHandler(ActionHandler):
 
         elif self.action.target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
             users = None
-            out = get_notification_recipients_v2(
+            out = get_notification_recipients(
                 recipients=list(
                     RpcActor(id=member.user_id, actor_type=ActorType.USER)
                     for member in target.member_set

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -17,7 +17,7 @@ from sentry.notifications.types import (
     FallthroughChoiceType,
     NotificationSettingEnum,
 )
-from sentry.notifications.utils.participants import get_notification_recipients_v2
+from sentry.notifications.utils.participants import get_notification_recipients
 from sentry.plugins.base.structs import Notification
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.tasks.digests import deliver_digest
@@ -108,7 +108,7 @@ class MailAdapter:
         """
         user_ids = project.member_set.values_list("user_id", flat=True)
         actors = [RpcActor(id=uid, actor_type=ActorType.USER) for uid in user_ids]
-        recipients = get_notification_recipients_v2(
+        recipients = get_notification_recipients(
             recipients=actors,
             type=NotificationSettingEnum.ISSUE_ALERTS,
             project_ids=[project.id],

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -19,7 +19,6 @@ from sentry.notifications.types import (
     NOTIFICATION_SETTING_TYPES,
     SUBSCRIPTION_REASON_MAP,
     VALID_VALUES_FOR_KEY,
-    VALID_VALUES_FOR_KEY_V2,
     GroupSubscriptionReason,
     NotificationSettingEnum,
     NotificationSettingOptionValues,
@@ -98,11 +97,6 @@ def get_type_defaults() -> Mapping[NotificationSettingEnum, NotificationSettings
 def validate(type: NotificationSettingTypes, value: NotificationSettingOptionValues) -> bool:
     """:returns boolean. True if the "value" is valid for the "type"."""
     return value in VALID_VALUES_FOR_KEY.get(type, {})
-
-
-def validate_v2(type: NotificationSettingTypes, value: NotificationSettingOptionValues) -> bool:
-    """:returns boolean. True if the "value" is valid for the "type"."""
-    return value in VALID_VALUES_FOR_KEY_V2.get(type, {})
 
 
 def get_subscription_from_attributes(

--- a/src/sentry/notifications/notifications/activity/new_processing_issues.py
+++ b/src/sentry/notifications/notifications/activity/new_processing_issues.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 from sentry.models.activity import Activity
 from sentry.notifications.types import GroupSubscriptionReason, NotificationSettingEnum
 from sentry.notifications.utils import summarize_issues
-from sentry.notifications.utils.participants import ParticipantMap, get_notification_recipients_v2
+from sentry.notifications.utils.participants import ParticipantMap, get_notification_recipients
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.types.integrations import ExternalProviders
 
@@ -25,7 +25,7 @@ class NewProcessingIssuesActivityNotification(ActivityNotification):
         participants_by_provider = None
         user_ids = list(self.project.member_set.values_list("user_id", flat=True))
         actors = [RpcActor(id=uid, actor_type=ActorType.USER) for uid in user_ids]
-        participants_by_provider = get_notification_recipients_v2(
+        participants_by_provider = get_notification_recipients(
             recipients=actors,
             type=NotificationSettingEnum.WORKFLOW,
             project_ids=[self.project.id],

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -231,14 +231,14 @@ class BaseNotification(abc.ABC):
     def filter_to_accepting_recipients(
         self, recipients: Iterable[RpcActor]
     ) -> Mapping[ExternalProviders, Iterable[RpcActor]]:
-        from sentry.notifications.utils.participants import get_notification_recipients_v2
+        from sentry.notifications.utils.participants import get_notification_recipients
 
         setting_type = (
             NotificationSettingEnum(NOTIFICATION_SETTING_TYPES[self.notification_setting_type])
             if self.notification_setting_type
             else NotificationSettingEnum.ISSUE_ALERTS
         )
-        return get_notification_recipients_v2(
+        return get_notification_recipients(
             recipients=recipients,
             type=setting_type,
             organization_id=self.organization.id,

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -154,7 +154,7 @@ NOTIFICATION_SETTING_OPTION_VALUES = {
 }
 
 # default is not a choice anymore, we just delete the row if we want to the default
-NOTIFICATION_SETTING_V2_CHOICES = [
+NOTIFICATION_SETTING_CHOICES = [
     NotificationSettingsOptionEnum.ALWAYS.value,
     NotificationSettingsOptionEnum.NEVER.value,
     NotificationSettingsOptionEnum.SUBSCRIBE_ONLY.value,
@@ -252,10 +252,6 @@ VALID_VALUES_FOR_KEY = {
         NotificationSettingOptionValues.ALWAYS,
         NotificationSettingOptionValues.NEVER,
     },
-}
-
-VALID_VALUES_FOR_KEY_V2 = {
-    **VALID_VALUES_FOR_KEY,
     NotificationSettingTypes.REPORTS: {
         NotificationSettingOptionValues.ALWAYS,
         NotificationSettingOptionValues.NEVER,

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -559,7 +559,7 @@ def get_notification_recipients(
     return out
 
 
-# TODO(Steve): Remove once reference is gone from sentry
+# TODO(Steve): Remove once reference is gone from getsentry
 def get_notification_recipients_v2(
     recipients: Iterable[RpcActor],
     type: NotificationSettingEnum,

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -537,7 +537,7 @@ def combine_recipients_by_provider(
     return recipients_by_provider
 
 
-def get_notification_recipients_v2(
+def get_notification_recipients(
     recipients: Iterable[RpcActor],
     type: NotificationSettingEnum,
     organization_id: Optional[int] = None,
@@ -559,6 +559,23 @@ def get_notification_recipients_v2(
     return out
 
 
+# TODO(Steve): Remove once reference is gone from sentry
+def get_notification_recipients_v2(
+    recipients: Iterable[RpcActor],
+    type: NotificationSettingEnum,
+    organization_id: Optional[int] = None,
+    project_ids: Optional[List[int]] = None,
+    actor_type: Optional[ActorType] = None,
+) -> Mapping[ExternalProviders, set[RpcActor]]:
+    return get_notification_recipients(
+        recipients=recipients,
+        type=type,
+        organization_id=organization_id,
+        project_ids=project_ids,
+        actor_type=actor_type,
+    )
+
+
 def get_recipients_by_provider(
     project: Project,
     recipients: Iterable[RpcActor],
@@ -577,7 +594,7 @@ def get_recipients_by_provider(
     teams_by_provider: Mapping[ExternalProviders, Iterable[RpcActor]] = {}
 
     # get by team
-    teams_by_provider = get_notification_recipients_v2(
+    teams_by_provider = get_notification_recipients(
         recipients=teams,
         type=setting_type,
         organization_id=project.organization_id,
@@ -598,7 +615,7 @@ def get_recipients_by_provider(
     # Repeat for users.
     users_by_provider: Mapping[ExternalProviders, Iterable[RpcActor]] = {}
     # convert from string to enum
-    users_by_provider = get_notification_recipients_v2(
+    users_by_provider = get_notification_recipients(
         recipients=users,
         type=setting_type,
         organization_id=project.organization_id,

--- a/src/sentry/notifications/validators.py
+++ b/src/sentry/notifications/validators.py
@@ -2,12 +2,8 @@ from rest_framework import serializers
 
 from sentry.api.exceptions import ParameterValidationError
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
-from sentry.api.validators.notifications import (
-    validate_scope_type,
-    validate_type,
-    validate_value_v2,
-)
-from sentry.notifications.types import NOTIFICATION_SETTING_V2_CHOICES, NotificationScopeEnum
+from sentry.api.validators.notifications import validate_scope_type, validate_type, validate_value
+from sentry.notifications.types import NOTIFICATION_SETTING_CHOICES, NotificationScopeEnum
 from sentry.types.integrations import PERSONAL_NOTIFICATION_PROVIDERS
 
 
@@ -37,14 +33,14 @@ class UserNotificationSettingOptionWithValueSerializer(
     value = serializers.CharField()
 
     def validate_value(self, value):
-        if value not in NOTIFICATION_SETTING_V2_CHOICES:
+        if value not in NOTIFICATION_SETTING_CHOICES:
             raise serializers.ValidationError("Invalid value")
         return value
 
     def validate(self, data):
         try:
             int_type = validate_type(data["type"])
-            validate_value_v2(int_type, data["value"])
+            validate_value(int_type, data["value"])
         except ParameterValidationError:
             raise serializers.ValidationError("Invalid type for value")
         return data

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -18,7 +18,7 @@ from sentry.models.scheduledeletion import RegionScheduledDeletion
 from sentry.models.user import User
 from sentry.monitors.models import Monitor, MonitorType, ScheduleType
 from sentry.notifications.types import NotificationSettingEnum
-from sentry.notifications.utils.participants import get_notification_recipients_v2
+from sentry.notifications.utils.participants import get_notification_recipients
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.silo.base import SiloMode
 from sentry.snuba.models import SnubaQuery
@@ -424,7 +424,7 @@ class CopyProjectSettingsTest(TestCase):
 
 class FilterToSubscribedUsersTest(TestCase):
     def run_test(self, users: Iterable[User], expected_users: Iterable[User]):
-        recipients = get_notification_recipients_v2(
+        recipients = get_notification_recipients(
             recipients=RpcActor.many_from_object(users),
             type=NotificationSettingEnum.ISSUE_ALERTS,
             project_ids=[self.project.id],


### PR DESCRIPTION
This PR removes the `v2` suffix for a lot of notification methods/constants and removes old functions that we don't need anymore. No underlying logic should be changing.