### PR TITLE
ref(notifications): adds new notification_setting_type_enum field to notifications

### DIFF
--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -11,7 +11,11 @@ from django.utils.safestring import SafeString
 from sentry.db.models import Model
 from sentry.notifications.helpers import get_reason_context
 from sentry.notifications.notifications.base import ProjectNotification
-from sentry.notifications.types import NotificationSettingTypes, UnsubscribeContext
+from sentry.notifications.types import (
+    NotificationSettingEnum,
+    NotificationSettingTypes,
+    UnsubscribeContext,
+)
 from sentry.notifications.utils import send_activity_notification
 from sentry.notifications.utils.avatar import avatar_as_html
 from sentry.notifications.utils.participants import ParticipantMap, get_participants_for_group
@@ -27,6 +31,7 @@ if TYPE_CHECKING:
 class ActivityNotification(ProjectNotification, abc.ABC):
     metrics_key = "activity"
     notification_setting_type = NotificationSettingTypes.WORKFLOW
+    notification_setting_type_enum = NotificationSettingEnum.WORKFLOW
     template_path = "sentry/emails/activity/generic"
 
     def __init__(self, activity: Activity) -> None:

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -10,7 +10,7 @@ from sentry.models.commit import Commit
 from sentry.models.commitfilechange import CommitFileChange
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
-from sentry.notifications.types import NotificationSettingTypes
+from sentry.notifications.types import NotificationSettingEnum, NotificationSettingTypes
 from sentry.notifications.utils import (
     get_deploy,
     get_environment_for_deploy,
@@ -30,7 +30,7 @@ from .base import ActivityNotification
 class ReleaseActivityNotification(ActivityNotification):
     metrics_key = "release_activity"
     notification_setting_type = NotificationSettingTypes.DEPLOY
-    notification_setting_type_enum = NotificationSettingTypes.DEPLOY
+    notification_setting_type_enum = NotificationSettingEnum.DEPLOY
     template_path = "sentry/emails/activity/release"
 
     def __init__(self, activity: Activity) -> None:

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -30,6 +30,7 @@ from .base import ActivityNotification
 class ReleaseActivityNotification(ActivityNotification):
     metrics_key = "release_activity"
     notification_setting_type = NotificationSettingTypes.DEPLOY
+    notification_setting_type_enum = NotificationSettingTypes.DEPLOY
     template_path = "sentry/emails/activity/release"
 
     def __init__(self, activity: Activity) -> None:

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -35,8 +35,10 @@ class BaseNotification(abc.ABC):
         ExternalProviders.DISCORD: "[{text}]({url})",
     }
     message_builder = "SlackNotificationsMessageBuilder"
-    # some notifications have no settings for it
+    # some notifications have no settings for it which is why it is optional
+    # TODO(steve): Replace notification_setting_type with notification_setting_type_enum
     notification_setting_type: NotificationSettingTypes | None = None
+    notification_setting_type_enum: NotificationSettingEnum | None = None
     analytics_event: str = ""
 
     def __init__(self, organization: Organization, notification_uuid: str | None = None):

--- a/src/sentry/notifications/notifications/codeowners_auto_sync.py
+++ b/src/sentry/notifications/notifications/codeowners_auto_sync.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping
 
 from sentry.notifications.notifications.base import ProjectNotification
-from sentry.notifications.types import NotificationSettingTypes
+from sentry.notifications.types import NotificationSettingEnum, NotificationSettingTypes
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.types.integrations import ExternalProviders
 
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 class AutoSyncNotification(ProjectNotification):
     metrics_key = "auto_sync"
     notification_setting_type = NotificationSettingTypes.DEPLOY
+    notification_setting_type_enum = NotificationSettingEnum.DEPLOY
     template_path = "sentry/emails/codeowners-auto-sync-failure"
 
     def determine_recipients(self) -> list[RpcActor]:

--- a/src/sentry/notifications/notifications/missing_members_nudge.py
+++ b/src/sentry/notifications/notifications/missing_members_nudge.py
@@ -8,7 +8,7 @@ from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notifications.strategies.member_write_role_recipient_strategy import (
     MemberWriteRoleRecipientStrategy,
 )
-from sentry.notifications.types import NotificationSettingTypes
+from sentry.notifications.types import NotificationSettingEnum, NotificationSettingTypes
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.types.integrations import ExternalProviders
 
@@ -22,6 +22,7 @@ class MissingMembersNudgeNotification(BaseNotification):
 
     RoleBasedRecipientStrategyClass = MemberWriteRoleRecipientStrategy
     notification_setting_type = NotificationSettingTypes.APPROVAL
+    notification_setting_type_enum = NotificationSettingEnum.APPROVAL
 
     def __init__(
         self,

--- a/src/sentry/notifications/notifications/organization_request/base.py
+++ b/src/sentry/notifications/notifications/organization_request/base.py
@@ -9,7 +9,7 @@ from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notifications.strategies.role_based_recipient_strategy import (
     RoleBasedRecipientStrategy,
 )
-from sentry.notifications.types import NotificationSettingTypes
+from sentry.notifications.types import NotificationSettingEnum, NotificationSettingTypes
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.types.integrations import ExternalProviders
 
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 class OrganizationRequestNotification(BaseNotification, abc.ABC):
     notification_setting_type = NotificationSettingTypes.APPROVAL
+    notification_setting_type_enum = NotificationSettingEnum.APPROVAL
     RoleBasedRecipientStrategyClass: Type[RoleBasedRecipientStrategy]
 
     def __init__(self, organization: Organization, requester: User) -> None:

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -16,6 +16,7 @@ from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.types import (
     ActionTargetType,
     FallthroughChoiceType,
+    NotificationSettingEnum,
     NotificationSettingTypes,
 )
 from sentry.notifications.utils import (
@@ -62,6 +63,7 @@ class AlertRuleNotification(ProjectNotification):
     message_builder = "IssueNotificationMessageBuilder"
     metrics_key = "issue_alert"
     notification_setting_type = NotificationSettingTypes.ISSUE_ALERTS
+    notification_setting_type_enum = NotificationSettingEnum.ISSUE_ALERTS
     template_path = "sentry/emails/error"
 
     def __init__(


### PR DESCRIPTION
We want to remove `NotificationSettingTypes` and replace it with `NotificationSettingEnum`. This step starts swapping it over in notifications.