### PR TITLE
fix(hybrid-cloud): Fix AwsLambdaIntegration

### DIFF
--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -94,6 +94,9 @@ class AwsLambdaIntegration(IntegrationInstallation, ServerlessMixin):
             )
         return self._client
 
+    def get_client(self) -> AwsLambdaProxyClient:
+        return self.client
+
     def get_one_lambda_function(self, name):
         # https://boto3.amazonaws.com/v1/documentation/api/1.22.12/reference/services/lambda.html
         return self.client.get_function(FunctionName=name)["Configuration"]


### PR DESCRIPTION
Apply similar fix in https://github.com/getsentry/sentry/pull/60912 for the `AwsLambdaIntegration` class.

We need to implement `AwsLambdaIntegration.get_client` since we make use of this in the Integration Proxy flow in the Hybrid Cloud world.