### PR TITLE
feat(issue-details): Add analytics tracking for resource link clicks

### DIFF
--- a/static/app/components/events/interfaces/performance/resources.tsx
+++ b/static/app/components/events/interfaces/performance/resources.tsx
@@ -16,10 +16,11 @@ export type ResourceLink = {
 type Props = {
   configResources: NonNullable<IssueTypeConfig['resources']>;
   eventPlatform: Event['platform'];
+  groupId: string;
 };
 
 // This section provides users with resources on how to resolve an issue
-export function Resources({configResources, eventPlatform}: Props) {
+export function Resources({configResources, eventPlatform, groupId}: Props) {
   const organization = useOrganization();
   const links = [
     ...configResources.links,
@@ -37,6 +38,7 @@ export function Resources({configResources, eventPlatform}: Props) {
               trackAnalytics('issue_details.resources_link_clicked', {
                 organization,
                 resource: text,
+                group_id: groupId,
               })
             }
             key={link}

--- a/static/app/components/events/interfaces/performance/resources.tsx
+++ b/static/app/components/events/interfaces/performance/resources.tsx
@@ -4,7 +4,9 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {IconDocs} from 'sentry/icons';
 import {space} from 'sentry/styles/space';
 import {Event} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {IssueTypeConfig} from 'sentry/utils/issueTypeConfig/types';
+import useOrganization from 'sentry/utils/useOrganization';
 
 export type ResourceLink = {
   link: string;
@@ -18,6 +20,7 @@ type Props = {
 
 // This section provides users with resources on how to resolve an issue
 export function Resources({configResources, eventPlatform}: Props) {
+  const organization = useOrganization();
   const links = [
     ...configResources.links,
     ...(configResources.linksByPlatform[eventPlatform ?? ''] ?? []),
@@ -29,7 +32,17 @@ export function Resources({configResources, eventPlatform}: Props) {
       <LinkSection>
         {links.map(({link, text}) => (
           // Please note that the UI will not fit a very long text and if we need to support that we will need to update the UI
-          <ExternalLink key={link} href={link} openInNewTab>
+          <ExternalLink
+            onClick={() =>
+              trackAnalytics('issue_details.resources_link_clicked', {
+                organization,
+                resource: text,
+              })
+            }
+            key={link}
+            href={link}
+            openInNewTab
+          >
             <IconDocs /> {text}
           </ExternalLink>
         ))}

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -110,6 +110,7 @@ export type TeamInsightsEventParameters = {
     group_id: string;
     total_unmerged: number;
   };
+  'issue_details.resources_link_clicked': {resource: string};
   'issue_details.suspect_commits.commit_clicked': IssueDetailsWithAlert & {
     has_pull_request: boolean;
     suspect_commit_calculation: string;
@@ -178,6 +179,7 @@ export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
     'Issue Details: Screenshot downloaded from modal',
   'issue_details.issue_tab.screenshot_modal_opened':
     'Issue Details: Screenshot modal opened',
+  'issue_details.resources_link_clicked': 'Issue Details: Resources Link Clicked',
   'issue_details.suspect_commits.commit_clicked': 'Issue Details: Suspect Commit Clicked',
   'issue_details.suspect_commits.pull_request_clicked':
     'Issue Details: Suspect Pull Request Clicked',

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -110,7 +110,10 @@ export type TeamInsightsEventParameters = {
     group_id: string;
     total_unmerged: number;
   };
-  'issue_details.resources_link_clicked': {resource: string};
+  'issue_details.resources_link_clicked': {
+    group_id: string | undefined;
+    resource: string;
+  };
   'issue_details.suspect_commits.commit_clicked': IssueDetailsWithAlert & {
     has_pull_request: boolean;
     suspect_commit_calculation: string;

--- a/static/app/views/issueDetails/resourcesAndMaybeSolutions.tsx
+++ b/static/app/views/issueDetails/resourcesAndMaybeSolutions.tsx
@@ -34,7 +34,11 @@ export function ResourcesAndMaybeSolutions({event, projectSlug, group}: Props) {
     >
       <Content>
         {config.resources && (
-          <Resources eventPlatform={event.platform} configResources={config.resources} />
+          <Resources
+            eventPlatform={event.platform}
+            groupId={group.id}
+            configResources={config.resources}
+          />
         )}
         {displayAiSuggestedSolution && (
           <AiSuggestedSolution event={event} projectSlug={projectSlug} />


### PR DESCRIPTION
this pr adds analytics for tracking clicks on the links in the resources section on the issue details page 