### PR TITLE
fix(prism): Finish loading language deps before attempting to original language

### DIFF
--- a/static/app/utils/loadPrismLanguage.ts
+++ b/static/app/utils/loadPrismLanguage.ts
@@ -57,8 +57,15 @@ export async function loadPrismLanguage(
     // Check for dependencies (e.g. `php` requires `markup-templating`) & download them
     const deps: string[] | string | undefined =
       prismComponents.languages[language].require;
-    (Array.isArray(deps) ? deps : [deps]).forEach(
-      async dep => dep && (await import(`prismjs/components/prism-${dep}.min`))
+    const depsArray = Array.isArray(deps) ? deps : [deps];
+    await Promise.all(
+      depsArray.map(dep => {
+        if (!dep) {
+          return Promise.resolve();
+        }
+
+        return import(`prismjs/components/prism-${dep}.min`);
+      })
     );
 
     // Download language grammar file


### PR DESCRIPTION
This fixes a bug that is most present in Firefox, but can also be repro'd in Chrome occasionally. When a language has dependencies (such as tsx, which requires both typescript and javascript), the previous behavior would not wait for the original imports to complete before importing the original language (tsx in this example). If the previous requests were not finished, the imported code would fail.