### PR TITLE
fix(issues): optimize query to run only for new queries

### DIFF
--- a/static/app/views/issueList/groupStatsProvider.tsx
+++ b/static/app/views/issueList/groupStatsProvider.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useEffect, useState} from 'react';
+import {createContext, useContext, useEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 import {dropUndefinedKeys} from '@sentry/utils';
 import * as reactQuery from '@tanstack/react-query';
@@ -80,6 +80,10 @@ export function GroupStatsProvider(props: GroupStatsProviderProps) {
   const api = useApi();
   const [groupStats, setGroupStats] = useState<Record<string, GroupStats>>({});
 
+  const groupIds = useMemo(() => {
+    return props.groupIds.filter(id => !groupStats[id]);
+  }, [props.groupIds, groupStats]);
+
   const queryFn = (): Promise<Record<string, GroupStats>> => {
     const promise = api
       .requestPromise<true>(`/organizations/${props.organization.slug}/issues-stats/`, {
@@ -88,7 +92,7 @@ export function GroupStatsProvider(props: GroupStatsProviderProps) {
           selection: props.selection,
           period: props.period,
           query: props.query,
-          groupIds: props.groupIds,
+          groupIds,
         }),
         includeAllArgs: true,
       })
@@ -117,11 +121,11 @@ export function GroupStatsProvider(props: GroupStatsProviderProps) {
       props.selection,
       props.period,
       props.query,
-      props.groupIds,
+      groupIds,
     ],
     queryFn,
     {
-      enabled: props.groupIds.length > 0,
+      enabled: groupIds.length > 0,
       staleTime: Infinity,
     }
   );


### PR DESCRIPTION
Request stats only for the groups that we have not already fetched stats for.