### PR TITLE
ref(crons): message_type is always available

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -571,13 +571,6 @@ def _process_message(
     partition: int,
     wrapper: CheckinMessage | ClockPulseMessage,
 ) -> None:
-
-    # XXX: Relay does not attach a message type, to properly discriminate the
-    # message_type we add it by default here. This can be removed once the
-    # message_type is guaranteed
-    if "message_type" not in wrapper:
-        wrapper["message_type"] = "check_in"
-
     try:
         try_monitor_tasks_trigger(ts, partition)
     except Exception:

--- a/src/sentry/monitors/types.py
+++ b/src/sentry/monitors/types.py
@@ -5,9 +5,7 @@ from typing_extensions import NotRequired
 
 
 class CheckinMessage(TypedDict):
-    # TODO(epurkhiser): We should make this required and ensure the message
-    # produced by relay includes this message type
-    message_type: NotRequired[Literal["check_in"]]
+    message_type: Literal["check_in"]
     payload: str
     start_time: float
     project_id: str

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -70,6 +70,7 @@ class MonitorConsumerTest(TestCase):
         payload.update(overrides)
 
         wrapper = {
+            "message_type": "check_in",
             "start_time": ts.timestamp(),
             "project_id": self.project.id,
             "payload": json.dumps(payload),


### PR DESCRIPTION
After https://github.com/getsentry/relay/pull/2723 this field is
guaranteed to exist in the CheckinMessage. We no longer need to add this
in and have it marked as NotRequired.