### PR TITLE
fix(github): Natural sort labels

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from operator import attrgetter
 from typing import Any, Dict, List, Mapping, Sequence
 
@@ -264,9 +265,12 @@ class GitHubIssueBasic(IssueBasicMixin):
         except Exception as e:
             self.raise_error(e)
 
+        def natural_sort_pair(pair: Sequence[str, str]) -> tuple[str, str]:
+            return [int(text) if text.isdigit() else text for text in re.split("([0-9]+)", pair[0])]
+
         # sort alphabetically
         labels = tuple(
-            sorted([(label["name"], label["name"]) for label in response], key=lambda pair: pair[0])
+            sorted([(label["name"], label["name"]) for label in response], key=natural_sort_pair)
         )
 
         return labels

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -265,7 +265,7 @@ class GitHubIssueBasic(IssueBasicMixin):
         except Exception as e:
             self.raise_error(e)
 
-        def natural_sort_pair(pair: Sequence[str, str]) -> tuple[str, str]:
+        def natural_sort_pair(pair: tuple[str, str]) -> str | int:
             return [int(text) if text.isdigit() else text for text in re.split("([0-9]+)", pair[0])]
 
         # sort alphabetically

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -87,13 +87,23 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         responses.add(
             responses.GET,
             "https://api.github.com/repos/getsentry/sentry/labels",
-            json=[{"name": "bug"}, {"name": "enhancement"}, {"name": "duplicate"}],
+            json=[
+                {"name": "bug"},
+                {"name": "enhancement"},
+                {"name": "duplicate"},
+                {"name": "1"},
+                {"name": "2"},
+                {"name": "10"},
+            ],
         )
 
         repo = "getsentry/sentry"
 
         # results should be sorted alphabetically
         assert self.integration.get_repo_labels(repo) == (
+            ("1", "1"),
+            ("2", "2"),
+            ("10", "10"),
             ("bug", "bug"),
             ("duplicate", "duplicate"),
             ("enhancement", "enhancement"),

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -92,8 +92,8 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
                 {"name": "enhancement"},
                 {"name": "duplicate"},
                 {"name": "1"},
-                {"name": "2"},
                 {"name": "10"},
+                {"name": "2"},
             ],
         )
 


### PR DESCRIPTION
Labels would originally sort lexicographically, which would put numerical string labels like `1, 10, 2, 20, 3`.

We now sort naturally which correct this problem.

![Screenshot 2023-11-30 at 1 41 51 PM](https://github.com/getsentry/sentry/assets/67301797/fd8f83b8-db45-49e0-9b5e-6cf3605bc7a5)
