### PR TITLE
chore(hybridcloud) Add logging for early return cases in jira

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -945,6 +945,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
 
         # don't bother updating if it's already the status we'd change it to
         if jira_issue["fields"]["status"]["id"] == jira_status:
+            logger.info("jira.sync_status_outbound.unchanged")
             return
         try:
             transitions = client.get_transitions(external_issue.key)

--- a/src/sentry/integrations/jira/utils/api.py
+++ b/src/sentry/integrations/jira/utils/api.py
@@ -78,6 +78,7 @@ def handle_assignee_change(
 def handle_status_change(integration, data):
     status_changed = any(item for item in data["changelog"]["items"] if item["field"] == "status")
     if not status_changed:
+        logger.info("jira.handle_status_change.unchanged")
         return
 
     issue_key = data["issue"]["key"]


### PR DESCRIPTION
A few early returns in jira workflows were missing logging, and I think they might be getting hit in test-silos