### PR TITLE
fix(hybrid-cloud): Mark DiscordInteractionsEndpoint as an all silo endpoint

### DIFF
--- a/src/sentry/integrations/discord/webhooks/base.py
+++ b/src/sentry/integrations/discord/webhooks/base.py
@@ -8,7 +8,7 @@ from rest_framework.request import Request
 
 from sentry import analytics
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.integrations.discord.requests.base import DiscordRequest, DiscordRequestError
 from sentry.integrations.discord.webhooks.command import DiscordCommandHandler
 from sentry.integrations.discord.webhooks.message_component import DiscordMessageComponentHandler
@@ -19,7 +19,7 @@ from .types import DiscordResponseTypes
 logger = logging.getLogger(__name__)
 
 
-@region_silo_endpoint
+@all_silo_endpoint
 class DiscordInteractionsEndpoint(Endpoint):
     publish_status = {
         "POST": ApiPublishStatus.UNKNOWN,

--- a/src/sentry/integrations/discord/webhooks/message_component.py
+++ b/src/sentry/integrations/discord/webhooks/message_component.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from functools import cached_property
 
 from rest_framework.response import Response
 
@@ -40,6 +41,7 @@ RESOLVED_IN_CURRENT_RELEASE = "The issue will be resolved in the current release
 UNRESOLVED = "The issue has been unresolved."
 MARKED_ONGOING = "The issue has been marked as ongoing."
 ARCHIVE_UNTIL_ESCALATES = "The issue will be archived until it escalates."
+INVALID_GROUP_ID = "Invalid group ID."
 
 
 class DiscordMessageComponentHandler(DiscordInteractionHandler):
@@ -54,8 +56,16 @@ class DiscordMessageComponentHandler(DiscordInteractionHandler):
         self.custom_id: str = request.get_component_custom_id()
         self.user: RpcUser
         # Everything after the colon is the group id in a custom_id
-        self.group_id: str = self.custom_id.split(":")[1]
-        self.group: Group = Group.objects.get(id=self.group_id)
+        custom_id_parts = self.custom_id.split(":")
+        self.group_id: str = custom_id_parts[1] if len(custom_id_parts) > 1 else ""
+
+    @cached_property
+    def group(self) -> Group | None:
+        try:
+            group_id = int(self.group_id)
+            return Group.objects.filter(id=group_id).first()
+        except Exception:
+            return None
 
     def handle(self) -> Response:
         logging_data = self.request.logging_data
@@ -64,6 +74,12 @@ class DiscordMessageComponentHandler(DiscordInteractionHandler):
             logger.warning("discord.interaction.component.not_linked", extra={**logging_data})
             return self.send_message(NO_IDENTITY)
         self.user = self.request.user
+
+        if not self.group_id:
+            return self.send_message(INVALID_GROUP_ID)
+
+        if not self.group:
+            return self.send_message(INVALID_GROUP_ID)
 
         if not self.group.organization.has_access(self.user):
             logger.warning(
@@ -104,9 +120,12 @@ class DiscordMessageComponentHandler(DiscordInteractionHandler):
             return self.archive()
 
         logger.warning("discord.interaction.component.unknown_custom_id", extra={**logging_data})
-        return Response(status=404)
+        return self.send_message(INVALID_GROUP_ID)
 
     def assign_dialog(self) -> Response:
+        if (not self.group_id) or (not self.group):
+            return self.send_message(INVALID_GROUP_ID)
+
         assign_selector = DiscordSelectMenu(
             custom_id=f"{CustomIds.ASSIGN}:{self.group_id}",
             placeholder="Select Assignee...",
@@ -203,21 +222,22 @@ class DiscordMessageComponentHandler(DiscordInteractionHandler):
         return self.send_message(ARCHIVE_UNTIL_ESCALATES)
 
     def update_group(self, data: Mapping[str, object]) -> None:
-        analytics.record(
-            "integrations.discord.status",
-            organization_id=self.group.organization.id,
-            user_id=self.user.id,
-            status=data,
-        )
-        update_groups(
-            request=self.request.request,
-            group_ids=[self.group.id],
-            projects=[self.group.project],
-            organization_id=self.group.organization.id,
-            search_fn=None,
-            user=self.user,  # type: ignore
-            data=data,
-        )
+        if self.group:
+            analytics.record(
+                "integrations.discord.status",
+                organization_id=self.group.organization.id,
+                user_id=self.user.id,
+                status=data,
+            )
+            update_groups(
+                request=self.request.request,
+                group_ids=[self.group.id],
+                projects=[self.group.project],
+                organization_id=self.group.organization.id,
+                search_fn=None,
+                user=self.user,  # type: ignore
+                data=data,
+            )
 
 
 def get_assign_selector_options(group: Group) -> list[DiscordSelectMenuOption]:

--- a/src/sentry/integrations/discord/webhooks/message_component.py
+++ b/src/sentry/integrations/discord/webhooks/message_component.py
@@ -75,10 +75,7 @@ class DiscordMessageComponentHandler(DiscordInteractionHandler):
             return self.send_message(NO_IDENTITY)
         self.user = self.request.user
 
-        if not self.group_id:
-            return self.send_message(INVALID_GROUP_ID)
-
-        if not self.group:
+        if (not self.group_id) or (not self.group):
             return self.send_message(INVALID_GROUP_ID)
 
         if not self.group.organization.has_access(self.user):

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -172,6 +172,7 @@ const patterns: RegExp[] = [
   new RegExp('^extensions/msteams/configure/$'),
   new RegExp('^extensions/msteams/link-identity/[^/]+/$'),
   new RegExp('^extensions/msteams/unlink-identity/[^/]+/$'),
+  new RegExp('^extensions/discord/interactions/$'),
   new RegExp('^extensions/discord/link-identity/[^/]+/$'),
   new RegExp('^extensions/discord/unlink-identity/[^/]+/$'),
   new RegExp('^share/(?:group|issue)/[^/]+/$'),

--- a/tests/sentry/integrations/discord/webhooks/test_message_component.py
+++ b/tests/sentry/integrations/discord/webhooks/test_message_component.py
@@ -13,6 +13,7 @@ from sentry.integrations.discord.requests.base import (
 from sentry.integrations.discord.webhooks.message_component import (
     ARCHIVE_UNTIL_ESCALATES,
     ASSIGNEE_UPDATED,
+    INVALID_GROUP_ID,
     MARKED_ONGOING,
     NO_IDENTITY,
     NOT_IN_ORG,
@@ -23,11 +24,14 @@ from sentry.integrations.discord.webhooks.message_component import (
     UNRESOLVED,
 )
 from sentry.models.release import Release
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 WEBHOOK_URL = "/extensions/discord/interactions/"
 
 
+@region_silo_test
 class DiscordMessageComponentInteractionTest(APITestCase):
     def setUp(self):
         patcher = mock.patch(
@@ -79,25 +83,61 @@ class DiscordMessageComponentInteractionTest(APITestCase):
     def get_select_options(self, response: Any) -> Any:
         return self.get_message_components(response)[0]["components"][0]["options"]
 
-    def test_unknown_id_interaction(self):
+    def test_unknown_custom_id_interaction(self):
         response = self.send_interaction({"custom_id": f"unknown:{self.group.id}"})
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert self.get_message_content(response) == INVALID_GROUP_ID
+
+    def test_empty_custom_id_interaction(self):
+        response = self.send_interaction({"custom_id": ""})
+        assert response.status_code == 200
+        assert self.get_message_content(response) == INVALID_GROUP_ID
 
     def test_no_user(self):
         response = self.send_interaction(member={"user": {"id": "not-our-user"}})
+        assert response.status_code == 200
+        assert self.get_message_content(response) == NO_IDENTITY
+
+    def test_no_guild_id(self):
+        response = self.client.post(
+            path=WEBHOOK_URL,
+            data={
+                "type": DiscordRequestTypes.MESSAGE_COMPONENT,
+            },
+            format="json",
+            HTTP_X_SIGNATURE_ED25519="signature",
+            HTTP_X_SIGNATURE_TIMESTAMP="timestamp",
+        )
+        assert response.status_code == 200
+        assert self.get_message_content(response) == NO_IDENTITY
+
+    def test_invalid_guild_id(self):
+        response = self.client.post(
+            path=WEBHOOK_URL,
+            data={
+                "type": DiscordRequestTypes.MESSAGE_COMPONENT,
+                "guild_id": "invalid_guild_id",
+            },
+            format="json",
+            HTTP_X_SIGNATURE_ED25519="signature",
+            HTTP_X_SIGNATURE_TIMESTAMP="timestamp",
+        )
+        assert response.status_code == 200
         assert self.get_message_content(response) == NO_IDENTITY
 
     def test_not_in_org(self):
         other_user = self.create_user()
         other_user_discord_id = "other-user1234"
         other_org = self.create_organization()
-        self.discord_integration.add_organization(other_org)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.discord_integration.add_organization(other_org)
         self.create_identity(
             user=other_user, identity_provider=self.provider, external_id=other_user_discord_id
         )
 
         response = self.send_interaction(member={"user": {"id": other_user_discord_id}})
 
+        assert response.status_code == 200
         assert self.get_message_content(response) == NOT_IN_ORG
 
     def test_assign_dialog(self):
@@ -107,10 +147,21 @@ class DiscordMessageComponentInteractionTest(APITestCase):
                 "custom_id": f"{CustomIds.ASSIGN_DIALOG}:{self.group.id}",
             }
         )
+        assert response.status_code == 200
         assert self.get_select_options(response) == [
             {"label": f"#{self.team.slug}", "value": f"team:{self.team.id}", "default": False},
             {"label": self.user.email, "value": f"user:{self.user.id}", "default": False},
         ]
+
+    def test_assign_dialog_invalid_group_id(self):
+        response = self.send_interaction(
+            {
+                "component_type": DiscordMessageComponentTypes.BUTTON,
+                "custom_id": f"{CustomIds.ASSIGN_DIALOG}:invalid",
+            }
+        )
+        assert response.status_code == 200
+        assert self.get_message_content(response) == INVALID_GROUP_ID
 
     def test_assign(self):
         response = self.send_interaction(
@@ -120,6 +171,7 @@ class DiscordMessageComponentInteractionTest(APITestCase):
                 "values": [f"user:{self.user.id}"],
             }
         )
+        assert response.status_code == 200
         assert self.get_message_content(response) == ASSIGNEE_UPDATED
 
     def test_resolve_dialog(self):
@@ -129,6 +181,7 @@ class DiscordMessageComponentInteractionTest(APITestCase):
                 "custom_id": f"{CustomIds.RESOLVE_DIALOG}:{self.group.id}",
             }
         )
+        assert response.status_code == 200
         assert self.get_select_options(response) == [
             option.build() for option in RESOLVE_DIALOG_OPTIONS
         ]
@@ -140,6 +193,7 @@ class DiscordMessageComponentInteractionTest(APITestCase):
                 "custom_id": f"{CustomIds.RESOLVE}:{self.group.id}",
             }
         )
+        assert response.status_code == 200
         assert self.get_message_content(response) == RESOLVED
 
     def test_resolve_now_from_dialog(self):
@@ -150,6 +204,7 @@ class DiscordMessageComponentInteractionTest(APITestCase):
                 "values": [""],
             }
         )
+        assert response.status_code == 200
         assert self.get_message_content(response) == RESOLVED
 
     def test_resolve_in_next_release(self):
@@ -165,6 +220,7 @@ class DiscordMessageComponentInteractionTest(APITestCase):
                 "values": ["inNextRelease"],
             }
         )
+        assert response.status_code == 200
         assert self.get_message_content(response) == RESOLVED_IN_NEXT_RELEASE
 
     def test_resolve_in_current_release(self):
@@ -180,6 +236,7 @@ class DiscordMessageComponentInteractionTest(APITestCase):
                 "values": ["inCurrentRelease"],
             }
         )
+        assert response.status_code == 200
         assert self.get_message_content(response) == RESOLVED_IN_CURRENT_RELEASE
 
     def test_unresolve(self):
@@ -189,6 +246,7 @@ class DiscordMessageComponentInteractionTest(APITestCase):
                 "custom_id": f"{CustomIds.UNRESOLVE}:{self.group.id}",
             }
         )
+        assert response.status_code == 200
         assert self.get_message_content(response) == UNRESOLVED
 
     def test_mark_ongoing(self):
@@ -198,6 +256,7 @@ class DiscordMessageComponentInteractionTest(APITestCase):
                 "custom_id": f"{CustomIds.MARK_ONGOING}:{self.group.id}",
             }
         )
+        assert response.status_code == 200
         assert self.get_message_content(response) == MARKED_ONGOING
 
     def test_archive(self):
@@ -207,4 +266,5 @@ class DiscordMessageComponentInteractionTest(APITestCase):
                 "custom_id": f"{CustomIds.ARCHIVE}:{self.group.id}",
             }
         )
+        assert response.status_code == 200
         assert self.get_message_content(response) == ARCHIVE_UNTIL_ESCALATES


### PR DESCRIPTION
The `DiscordInteractionsEndpoint` endpoint needs to be marked as `@all_silo_endpoint`, as it contains code paths that needs to be handled at the control silo. An example would be responding to `/help` commands; as this interaction doesn't depend on the Organization nor the Integration.

The Discord request parser relies on a valid `guild_id` (Discord server's id) to fetch the `Integration` object. If the `guild_id`  is valid, then we route requests to the appropriate region silo. Otherwise they route to the control silo.

I've updated tests to ensure `DiscordInteractionsEndpoint` is resilient for invalid values of `guild_id`.

I've also updated `DiscordInteractionsEndpoint` to be resilient for invalid values of group ids.