### PR TITLE
doc(snuba): document datasets in Sentry

### DIFF
--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -4,19 +4,53 @@ from enum import Enum, unique
 @unique
 class Dataset(Enum):
     Events = "events"
+    "The events dataset contains all ingested errors."
+
     Transactions = "transactions"
+    "The transactions dataset contains all ingested transactions."
+
     Discover = "discover"
+    "The discover dataset is a combination of both the events and transactions datasets."
+
     Outcomes = "outcomes"
+    """
+    The outcomes dataset contains materialized views of raw outcomes.
+    Outcomes are used to track usage of the product, i.e. how many errors has the
+    project ingested, etc.
+    """
+
     OutcomesRaw = "outcomes_raw"
+    "The raw, non materialized version of the above"
+
     Sessions = "sessions"
-    # Actually Release Health
+    "The sessions dataset is deprecated I think?"
+
     Metrics = "metrics"
+    "Not sure what this is, is it also release health?"
+
     PerformanceMetrics = "generic_metrics"
+    """
+    PerformanceMetrics contains all generic metrics platform metrics.
+    """
+
     Replays = "replays"
+    "Indexed data for the Session Replays feature"
+
     Profiles = "profiles"
+    "Indexed data for the Profiling feature"
+
     IssuePlatform = "search_issues"
+    "Issues made via the issue platform will be searchable via the IssuePlatform dataset"
+
     Functions = "functions"
+    "The functions dataset is built on top of profiling and contains more granular data about profiling functions"
+
     SpansIndexed = "spans"
+    """
+    Contains span data which is searchable.
+    This is different from metrics,
+    indexed spans are similar to indexed transactions in the fields available to search
+    """
 
 
 @unique

--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -23,10 +23,10 @@ class Dataset(Enum):
     "The raw, non materialized version of the above"
 
     Sessions = "sessions"
-    "The sessions dataset is deprecated I think?"
+    "The sessions dataset is deprecated."
 
     Metrics = "metrics"
-    "Not sure what this is, is it also release health?"
+    "this 'metrics' dataset is only used for release health."
 
     PerformanceMetrics = "generic_metrics"
     """


### PR DESCRIPTION
We have a lot of datasets and it is a bit overwhelming now. Added some comments which may or may not be correct for each dataset. Will tag some teams and we can iterate on the descriptions.