### PR TITLE
feat(profiling): upgrade symbolic dependency to 12.8.0 and re-enable android deobfuscation v2

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -71,7 +71,7 @@ simplejson>=3.17.6
 sqlparse>=0.4.4
 statsd>=3.3
 structlog>=22
-symbolic==12.3.0
+symbolic==12.8.0
 toronado>=0.1.0
 typing-extensions>=4.0.0
 ua-parser>=0.10.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -187,7 +187,7 @@ sqlparse==0.4.4
 statsd==3.3
 stripe==3.1.0
 structlog==22.1.0
-symbolic==12.3.0
+symbolic==12.8.0
 time-machine==2.13.0
 tokenize-rt==5.0.0
 tomli==2.0.1

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -129,7 +129,7 @@ sqlparse==0.4.4
 statsd==3.3
 stripe==3.1.0
 structlog==22.1.0
-symbolic==12.3.0
+symbolic==12.8.0
 toronado==0.1.0
 tqdm==4.64.1
 typing-extensions==4.5.0


### PR DESCRIPTION
_Symbolic_ `12.8.0` _ProguardMapper_ has the following improvements:

1. it allows for optional param_mapping initialization so that we don't take extra memory in services where deobfuscation without line numbers is not necessary

2. some minor optimization that let us save some memory even when we need param_mapping for deobfuscation without line numbers
