### PR TITLE
fix(metrics-extraction): Fix extraction iterating over widget columns

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -378,7 +378,7 @@ def _is_widget_query_low_cardinality(widget_query: DashboardWidgetQuery, project
             return False
 
         try:
-            for index, column in enumerate(widget_query.columns):
+            for index, column in enumerate(unique_columns):
                 count = processed_results["data"][0][unique_columns[index]]
                 if count > max_cardinality_allowed:
                     cache.set(cache_key, False, timeout=_get_widget_cardinality_query_ttl())

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -756,12 +756,29 @@ def test_get_metric_extraction_config_with_high_cardinality(default_project):
             ["epm()"],
             f"transaction.duration:>={duration}",
             default_project,
-            columns=["user.id", "release"],
+            columns=["user.id", "release", "count()"],
         )
 
         config = get_metric_extraction_config(default_project)
 
         assert not config
+
+
+@django_db_all
+@override_options({"on_demand.max_widget_cardinality.count": 1})
+def test_get_metric_extraction_config_with_low_cardinality(default_project):
+    duration = 1000
+    with Feature({ON_DEMAND_METRICS_WIDGETS: True}):
+        create_widget(
+            ["epm()"],
+            f"transaction.duration:>={duration}",
+            default_project,
+            columns=["user.id", "release", "count()"],
+        )
+
+        config = get_metric_extraction_config(default_project)
+
+        assert config
 
 
 @django_db_all


### PR DESCRIPTION
### Summary
We split up the iteration over the columns to only iterate over unique columns, we shouldn't be iterating the widget columns since we get index out of range
