### PR TITLE
fix(hybridcloud) Fix silo isolation in local development and prod.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -895,6 +895,7 @@ CELERY_QUEUES_REGION = [
     Queue("merge", routing_key="merge"),
     Queue("notifications", routing_key="notifications"),
     Queue("options", routing_key="options"),
+    Queue("outbox", routing_key="outbox"),
     Queue("post_process_errors", routing_key="post_process_errors"),
     Queue("post_process_issue_platform", routing_key="post_process_issue_platform"),
     Queue("post_process_transactions", routing_key="post_process_transactions"),

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3995,3 +3995,5 @@ if SILO_DEVSERVER:
 
     control_port = os.environ.get("SENTRY_CONTROL_SILO_PORT", "8000")
     SENTRY_CONTROL_ADDRESS = f"http://127.0.0.1:{control_port}"
+
+    CELERYBEAT_SCHEDULE_FILENAME = f"celerybeat-schedule-{SILO_MODE}"

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -401,7 +401,7 @@ Alternatively, run without --workers.
         os.environ["SENTRY_CONTROL_SILO_PORT"] = str(ports["server"] + 1)
         os.environ["SENTRY_DEVSERVER_BIND"] = f"127.0.0.1:{server_port}"
         os.environ["UWSGI_HTTP_SOCKET"] = f"127.0.0.1:{ports['region.server']}"
-        os.environ["UWSGI_WORKERS"] = "5"
+        os.environ["UWSGI_WORKERS"] = "8"
         os.environ["UWSGI_THREADS"] = "2"
 
     server = SentryHTTPServer(
@@ -461,7 +461,7 @@ Alternatively, run without --workers.
             "SENTRY_REGION_SILO_PORT": str(ports["region.server"]),
             "SENTRY_DEVSERVER_BIND": f"127.0.0.1:{server_port}",
             "UWSGI_HTTP_SOCKET": f"127.0.0.1:{ports['server']}",
-            "UWSGI_WORKERS": "5",
+            "UWSGI_WORKERS": "8",
             "UWSGI_THREADS": "2",
         }
         merged_env = os.environ.copy()


### PR DESCRIPTION
- Separate the celerybeat shelf files in local development.
- Assign queue names to the region outbox flushing tasks so there is no chance of cross task bleed in local dev.
- Increase number of web workers to 8 so that issue details loads in a reasonable timeframe. This view does 27 requests which saturate all our workers and can lead to timeouts.