### PR TITLE
fix(feedback): crash report issue links to correct event with user report

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -88,7 +88,7 @@ function EventOrGroupHeader({
 
   function getTitle() {
     const {id, status} = data as Group;
-    const {eventID, groupID} = data as Event;
+    const {eventID: latestEventId, groupID} = data as Event;
     const hasEscalatingIssues = organization.features.includes('escalating-issues');
 
     const commonEleProps = {
@@ -106,14 +106,14 @@ function EventOrGroupHeader({
     }
 
     // If we have passed in a custom event ID, use it; otherwise use default
-    const finalEventId = eventId ?? eventID;
+    const finalEventId = eventId ?? latestEventId;
 
     return (
       <TitleWithLink
         {...commonEleProps}
         to={{
           pathname: `/organizations/${organization.slug}/issues/${
-            eventID ? groupID : id
+            latestEventId ? groupID : id
           }/${finalEventId ? `events/${finalEventId}/` : ''}`,
           query: {
             referrer: source || 'event-or-group-header',

--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -23,6 +23,7 @@ type Size = 'small' | 'normal';
 interface EventOrGroupHeaderProps {
   data: Event | Group | GroupTombstoneHelper;
   organization: Organization;
+  eventId?: string;
   /* is issue breakdown? */
   grouping?: boolean;
   hideIcons?: boolean;
@@ -46,6 +47,7 @@ function EventOrGroupHeader({
   onClick,
   hideIcons,
   hideLevel,
+  eventId,
   size = 'normal',
   grouping = false,
   source,
@@ -103,13 +105,16 @@ function EventOrGroupHeader({
       );
     }
 
+    // If we have passed in a custom event ID, use it; otherwise use default
+    const finalEventId = eventId ?? eventID;
+
     return (
       <TitleWithLink
         {...commonEleProps}
         to={{
           pathname: `/organizations/${organization.slug}/issues/${
             eventID ? groupID : id
-          }/${eventID ? `events/${eventID}/` : ''}`,
+          }/${finalEventId ? `events/${finalEventId}/` : ''}`,
           query: {
             referrer: source || 'event-or-group-header',
             stream_index: index,

--- a/static/app/components/feedback/feedbackItem/crashReportSection.tsx
+++ b/static/app/components/feedback/feedbackItem/crashReportSection.tsx
@@ -17,6 +17,10 @@ export default function CrashReportSection({
   const {data: crashReportData} = useApiQuery<Event>([eventEndpoint], {staleTime: 0});
 
   return crashReportData?.groupID ? (
-    <LinkedIssue organization={organization} groupID={crashReportData.groupID} />
+    <LinkedIssue
+      organization={organization}
+      groupID={crashReportData.groupID}
+      crashReportId={crashReportId}
+    />
   ) : null;
 }

--- a/static/app/components/feedback/feedbackItem/linkedIssue.tsx
+++ b/static/app/components/feedback/feedbackItem/linkedIssue.tsx
@@ -12,11 +12,12 @@ import {Group, Organization} from 'sentry/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
 interface Props {
+  crashReportId: string;
   groupID: string;
   organization: Organization;
 }
 
-export default function LinkedIssue({groupID, organization}: Props) {
+export default function LinkedIssue({groupID, organization, crashReportId}: Props) {
   const issueEndpoint = `/organizations/${organization.slug}/issues/${groupID}/`;
   const {data: groupData, isLoading} = useApiQuery<Group>([issueEndpoint], {
     staleTime: 0,
@@ -30,6 +31,7 @@ export default function LinkedIssue({groupID, organization}: Props) {
         <ErrorBoundary mini>
           <IssueDetailsContainer>
             <EventOrGroupHeader
+              eventId={crashReportId}
               organization={organization}
               data={groupData}
               size="normal"


### PR DESCRIPTION
Before, we weren't linking to the correct event instance for the crash report issue. 

I'm modifying the linked issue component to manually pass in the crash report event ID, which forces the link to the correct event with the user report associated.

https://github.com/getsentry/sentry/assets/56095982/2165d127-7007-4b92-a10b-750839d1fa14

Fixes https://github.com/getsentry/sentry/issues/60872