### PR TITLE
ref(issues): bump stats endpoint limit

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -88,7 +88,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
             )
             if not groups:
                 raise ParseError(detail="No matching groups found")
-            elif len(groups) > 25:
+            elif len(groups) > 100:
                 raise ParseError(detail="Too many groups requested.")
             elif not all(request.access.has_project_access(g.project) for g in groups):
                 raise PermissionDenied


### PR DESCRIPTION
Bump stats endpoint limit so that we can take the same provider approach as replay counts provider