### PR TITLE
fix(devserver) Add additional workers for devserver

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -210,6 +210,7 @@ def devserver(
         "thunder-lock": False,
         "timeout": 600,
         "harakiri": 600,
+        "workers": 1 if debug_server else 2,
     }
 
     if reload:
@@ -407,7 +408,6 @@ Alternatively, run without --workers.
     server = SentryHTTPServer(
         host=host,
         port=int(server_port),
-        workers=1,
         extra_options=uwsgi_overrides,
         debug=debug_server,
     )


### PR DESCRIPTION
Having even one more worker helps with devserver performance quite a bit. When the server is run in debug mode we'll still only run one worker.