### PR TITLE
test(prism): Mock Prism in test env to prevent act warnings

### DIFF
--- a/static/app/__mocks__/prismjs.tsx
+++ b/static/app/__mocks__/prismjs.tsx
@@ -1,0 +1,13 @@
+import prismComponents from 'prismjs/components';
+
+const Prism = {
+  manual: false,
+  languages: Object.keys(prismComponents.languages).reduce(
+    (acc, language) => ({...acc, [language]: {}}),
+    {}
+  ),
+  tokenize: (code: string) => [code],
+  highlightElement: () => {},
+};
+
+export default Prism;

--- a/static/app/components/events/interfaces/request/index.spec.tsx
+++ b/static/app/components/events/interfaces/request/index.spec.tsx
@@ -6,6 +6,8 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {Request} from 'sentry/components/events/interfaces/request';
 import {EntryRequest, EntryType} from 'sentry/types/event';
 
+jest.unmock('prismjs');
+
 describe('Request entry', function () {
   it('display redacted data', async function () {
     const event = {

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
@@ -3,7 +3,6 @@ import {createPortal} from 'react-dom';
 
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {AuthTokenGenerator} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
-import {NODE_ENV} from 'sentry/constants';
 
 interface OnboardingCodeSnippetProps
   extends Omit<React.ComponentProps<typeof CodeSnippet>, 'onAfterHighlight'> {}
@@ -32,11 +31,7 @@ export function OnboardingCodeSnippet(props: OnboardingCodeSnippetProps) {
   const [authTokenNodes, setAuthTokenNodes] = useState<HTMLSpanElement[]>([]);
 
   const handleAfterHighlight = useCallback((element: HTMLElement) => {
-    // Don't execute this code in tests as it will throw an error
-    // code snippet calls the onAfterHighlight callback too late, so it triggers the "updates should be wrapped into act(...)" error
-    if (NODE_ENV !== 'test') {
-      setAuthTokenNodes(replaceTokensWithSpan(element));
-    }
+    setAuthTokenNodes(replaceTokensWithSpan(element));
   }, []);
 
   return (

--- a/static/app/utils/prism.tsx
+++ b/static/app/utils/prism.tsx
@@ -52,6 +52,12 @@ export async function loadPrismLanguage(
   try {
     const language: string | undefined = prismLanguageMap[lang.toLowerCase()];
 
+    // Short-circuit if language already loaded
+    if (Prism.languages[language]) {
+      onLoad?.();
+      return;
+    }
+
     // If Prism doesn't have any grammar file available for the language
     if (!language) {
       if (!suppressExistenceWarning) {

--- a/static/app/utils/usePrismTokens.spec.tsx
+++ b/static/app/utils/usePrismTokens.spec.tsx
@@ -3,6 +3,8 @@ import {reactHooks} from 'sentry-test/reactTestingLibrary';
 import {loadPrismLanguage} from 'sentry/utils/prism';
 import {usePrismTokens} from 'sentry/utils/usePrismTokens';
 
+jest.unmock('prismjs');
+
 const JS_CODE = `function foo() {
   // Returns 'bar'
   return 'bar';

--- a/static/app/utils/usePrismTokens.tsx
+++ b/static/app/utils/usePrismTokens.tsx
@@ -1,6 +1,6 @@
 import {useEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
-import * as Prism from 'prismjs';
+import Prism from 'prismjs';
 
 import {loadPrismLanguage, prismLanguageMap} from 'sentry/utils/prism';
 

--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -201,8 +201,9 @@ describe('Onboarding Setup Docs', function () {
         await screen.findByRole('heading', {name: 'Configure React SDK'})
       ).toBeInTheDocument();
 
-      expect(await screen.findByText('// Performance Monitoring')).toBeInTheDocument();
-      expect(screen.getByText('// Session Replay')).toBeInTheDocument();
+      const codeBlock = await screen.findByText(/import \* as Sentry/);
+      expect(codeBlock).toHaveTextContent(/Performance Monitoring/);
+      expect(codeBlock).toHaveTextContent(/Session Replay/);
     });
 
     it('only performance checked', async function () {
@@ -250,8 +251,9 @@ describe('Onboarding Setup Docs', function () {
         }
       );
 
-      expect(await screen.findByText('// Performance Monitoring')).toBeInTheDocument();
-      expect(screen.queryByText('// Session Replay')).not.toBeInTheDocument();
+      const codeBlock = await screen.findByText(/import \* as Sentry/);
+      expect(codeBlock).toHaveTextContent(/Performance Monitoring/);
+      expect(codeBlock).not.toHaveTextContent(/Session Replay/);
     });
 
     it('only session replay checked', async function () {
@@ -299,8 +301,9 @@ describe('Onboarding Setup Docs', function () {
         }
       );
 
-      expect(await screen.findByText('// Session Replay')).toBeInTheDocument();
-      expect(screen.queryByText('// Performance Monitoring')).not.toBeInTheDocument();
+      const codeBlock = await screen.findByText(/import \* as Sentry/);
+      expect(codeBlock).toHaveTextContent(/Session Replay/);
+      expect(codeBlock).not.toHaveTextContent(/Performance Monitoring/);
     });
 
     it('only error monitoring checked', async function () {
@@ -350,8 +353,9 @@ describe('Onboarding Setup Docs', function () {
 
       await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
-      expect(screen.queryByText('// Session Replay')).not.toBeInTheDocument();
-      expect(screen.queryByText('// Performance Monitoring')).not.toBeInTheDocument();
+      const codeBlock = await screen.findByText(/import \* as Sentry/);
+      expect(codeBlock).not.toHaveTextContent(/Performance Monitoring/);
+      expect(codeBlock).not.toHaveTextContent(/Session Replay/);
     });
   });
 


### PR DESCRIPTION
This is needed for https://github.com/getsentry/sentry/pull/60807 which has many tests failing due to act warnings. Once Prism loads a language grammar, the onLoad will trigger a state change which is annoying to deal with for every component that renders a stack trace.

By mocking Prism, we avoid all the overhead of loading language grammars and having to deal with the async nature of it. The vast majority of tests do not need Prism to test their behavior, and for the ones that do I've unmocked it.