### PR TITLE
feat(alerts): Skip snuba query on frequency filters for new issues

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -124,6 +124,10 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         if not (interval and value is not None):
             return False
 
+        # Assumes that the first event in a group will always be below the threshold.
+        if state.is_new and value > 1:
+            return False
+
         # TODO(mgaeta): Bug: Rule is optional.
         current_value = self.get_rate(event, interval, self.rule.environment_id)  # type: ignore
         logging.info(f"event_frequency_rule current: {current_value}, threshold: {value}")

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -220,7 +220,8 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase):
         rule = self.get_rule(data=data, rule=Rule(environment_id=None))
         self.assertDoesNotPass(rule, event, is_new=False)
 
-    def test_is_new_issue_skips_snuba(self):
+    @patch("sentry.rules.conditions.event_frequency.BaseEventFrequencyCondition.get_rate")
+    def test_is_new_issue_skips_snuba(self, mock_get_rate):
         # Looking for more than 1 event
         data = {"interval": "1m", "value": 6}
         minutes = 1
@@ -238,6 +239,7 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase):
         # Issue is new and is the first event
         self.assertDoesNotPass(rule, event, is_new=True)
         self.assertDoesNotPass(environment_rule, event, is_new=True)
+        assert mock_get_rate.call_count == 0
 
 
 class EventFrequencyConditionTestCase(StandardIntervalTestBase):

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -106,11 +106,11 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase):
             )
 
         if passes:
-            self.assertPasses(rule, event)
-            self.assertPasses(environment_rule, event)
+            self.assertPasses(rule, event, is_new=False)
+            self.assertPasses(environment_rule, event, is_new=False)
         else:
-            self.assertDoesNotPass(rule, event)
-            self.assertDoesNotPass(environment_rule, event)
+            self.assertDoesNotPass(rule, event, is_new=False)
+            self.assertDoesNotPass(environment_rule, event, is_new=False)
 
     def test_one_minute_with_events(self):
         data = {"interval": "1m", "value": 6}
@@ -180,7 +180,7 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase):
             "comparisonInterval": "1d",
         }
         rule = self.get_rule(data=data, rule=Rule(environment_id=None))
-        self.assertPasses(rule, event)
+        self.assertPasses(rule, event, is_new=False)
 
         data = {
             "interval": "1h",
@@ -189,7 +189,7 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase):
             "comparisonInterval": "1d",
         }
         rule = self.get_rule(data=data, rule=Rule(environment_id=None))
-        self.assertDoesNotPass(rule, event)
+        self.assertDoesNotPass(rule, event, is_new=False)
 
     def test_comparison_empty_comparison_period(self):
         # Test data is 1 event in the current period and 0 events in the comparison period. This
@@ -209,7 +209,7 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase):
             "comparisonInterval": "1d",
         }
         rule = self.get_rule(data=data, rule=Rule(environment_id=None))
-        self.assertDoesNotPass(rule, event)
+        self.assertDoesNotPass(rule, event, is_new=False)
 
         data = {
             "interval": "1h",
@@ -218,7 +218,26 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase):
             "comparisonInterval": "1d",
         }
         rule = self.get_rule(data=data, rule=Rule(environment_id=None))
-        self.assertDoesNotPass(rule, event)
+        self.assertDoesNotPass(rule, event, is_new=False)
+
+    def test_is_new_issue_skips_snuba(self):
+        # Looking for more than 1 event
+        data = {"interval": "1m", "value": 6}
+        minutes = 1
+        rule = self.get_rule(data=data, rule=Rule(environment_id=None))
+        environment_rule = self.get_rule(data=data, rule=Rule(environment_id=self.environment.id))
+
+        event = self.add_event(
+            data={
+                "fingerprint": ["something_random"],
+                "user": {"id": uuid4().hex},
+            },
+            project_id=self.project.id,
+            timestamp=before_now(minutes=minutes),
+        )
+        # Issue is new and is the first event
+        self.assertDoesNotPass(rule, event, is_new=True)
+        self.assertDoesNotPass(environment_rule, event, is_new=True)
 
 
 class EventFrequencyConditionTestCase(StandardIntervalTestBase):
@@ -315,8 +334,8 @@ class EventFrequencyPercentConditionTestCase(SnubaTestCase, RuleTestCase):
         rule = self.get_rule(data=data, rule=Rule(environment_id=None))
         environment_rule = self.get_rule(data=data, rule=Rule(environment_id=self.environment.id))
         if passes:
-            self.assertPasses(rule, self.test_event)
-            self.assertPasses(environment_rule, self.test_event)
+            self.assertPasses(rule, self.test_event, is_new=False)
+            self.assertPasses(environment_rule, self.test_event, is_new=False)
         else:
             self.assertDoesNotPass(rule, self.test_event)
             self.assertDoesNotPass(environment_rule, self.test_event)
@@ -425,7 +444,7 @@ class EventFrequencyPercentConditionTestCase(SnubaTestCase, RuleTestCase):
             "comparisonInterval": "1d",
         }
         rule = self.get_rule(data=data, rule=Rule(environment_id=None))
-        self.assertPasses(rule, event)
+        self.assertPasses(rule, event, is_new=False)
 
         data = {
             "interval": "1h",
@@ -434,7 +453,7 @@ class EventFrequencyPercentConditionTestCase(SnubaTestCase, RuleTestCase):
             "comparisonInterval": "1d",
         }
         rule = self.get_rule(data=data, rule=Rule(environment_id=None))
-        self.assertDoesNotPass(rule, event)
+        self.assertDoesNotPass(rule, event, is_new=False)
 
 
 @freeze_time((now() - timedelta(days=2)).replace(hour=12, minute=40, second=0, microsecond=0))


### PR DESCRIPTION
Skips running the snuba query for issue alerts with a frequency filter "more than x in 1 hour" when the issue alert is new/first seen.

The assumption here is that new issues can't have 5 events in the last hour because this is the first time we're seeing it.
