### PR TITLE
fix(hybrid-cloud): Fix MS Teams Integration inference

### DIFF
--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Callable, Mapping
+from typing import Any, Callable, Mapping
 
 import sentry_sdk
 from django.http import HttpRequest, HttpResponse
@@ -142,9 +142,8 @@ def verify_signature(request):
 class MsTeamsWebhookMixin:
     provider = "msteams"
 
-    def infer_team_id_from_channel_data(self, request: HttpRequest) -> str | None:
+    def infer_team_id_from_channel_data(self, data: Mapping[str, Any]) -> str | None:
         try:
-            data = request.data
             channel_data = data["channelData"]
             team_id = channel_data["team"]["id"]
             return team_id
@@ -152,13 +151,13 @@ class MsTeamsWebhookMixin:
             sentry_sdk.capture_exception(err)
         return None
 
-    def get_integration_from_channel_data(self, request: HttpRequest) -> RpcIntegration | None:
-        team_id = self.infer_team_id_from_channel_data(request)
+    def get_integration_from_channel_data(self, data: Mapping[str, Any]) -> RpcIntegration | None:
+        team_id = self.infer_team_id_from_channel_data(data=data)
         if team_id is None:
             return None
         return integration_service.get_integration(provider=self.provider, external_id=team_id)
 
-    def infer_integration_id_from_card_action(self, request: HttpRequest) -> int | None:
+    def infer_integration_id_from_card_action(self, data: Mapping[str, Any]) -> int | None:
         # The bot builds and sends Adaptive Cards to the channel, and in it will include card actions and context.
         # The context will include the "integrationId".
         # Whenever a user interacts with the card, MS Teams will send the card action and the context to the bot.
@@ -166,7 +165,6 @@ class MsTeamsWebhookMixin:
         #
         # See: https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-actions?tabs=json#actionsubmit
         try:
-            data = request.data
             payload = data["value"]["payload"]
             integration_id = payload["integrationId"]
             return integration_id
@@ -174,16 +172,16 @@ class MsTeamsWebhookMixin:
             sentry_sdk.capture_exception(err)
         return None
 
-    def get_integration_from_card_action(self, request: HttpRequest) -> RpcIntegration | None:
-        integration_id = self.infer_integration_id_from_card_action(request)
+    def get_integration_from_card_action(self, data: Mapping[str, Any]) -> RpcIntegration | None:
+        integration_id = self.infer_integration_id_from_card_action(data=data)
         if integration_id is None:
             return None
         return integration_service.get_integration(integration_id=integration_id)
 
-    def can_infer_integration(self, request: HttpRequest) -> bool:
+    def can_infer_integration(self, data: Mapping[str, Any]) -> bool:
         return (
-            self.infer_integration_id_from_card_action(request) is not None
-            or self.infer_team_id_from_channel_data(request) is not None
+            self.infer_integration_id_from_card_action(data=data) is not None
+            or self.infer_team_id_from_channel_data(data=data) is not None
         )
 
 
@@ -311,7 +309,7 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
 
         team_id = channel_data["team"]["id"]
 
-        integration = self.get_integration_from_channel_data(request)
+        integration = self.get_integration_from_channel_data(data=data)
         if integration is None:
             logger.info(
                 "msteams.uninstall.missing-integration",
@@ -431,7 +429,7 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
         else:
             conversation_id = channel_data["channel"]["id"]
 
-        integration = self.get_integration_from_card_action(request)
+        integration = self.get_integration_from_card_action(data=data)
         if integration is None:
             logger.info(
                 "msteams.action.missing-integration", extra={"integration_id": integration_id}


### PR DESCRIPTION
Fixes [HC-TEST-CONTROL-NY](https://sentry-st.sentry.io/issues/4689760564/).

Apply similar fix that @leeandher did in https://github.com/getsentry/sentry/pull/60816 for MS Teams.

This should hopefully finally let users assign people/teams to Sentry Issues on the MS Teams app. Once I can confirm this fix, I'll clean up the debugging logs on the next pull request.