### PR TITLE
ref(crons): Track relay -> kafka delay

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -544,6 +544,14 @@ def _process_checkin(
             else:
                 mark_ok(check_in, ts=start_time)
 
+            # track how much time it took for the message to make it through
+            # relay into kafka. This should help us understand when missed
+            # check-ins may be slipping in, since we use the `item.ts` to click
+            # the clock forward, if that is delayed it's possible for the
+            # check-in to come in late
+            kafka_delay = start_time.replace(tzinfo=None) - message_ts
+            metrics.gauge("monitors.checkin.relay_kafka_delay", kafka_delay.total_seconds())
+
             # how long in wall-clock time did it take for us to process this
             # check-in. This records from when the message was first appended
             # into the Kafka topic until we just completed processing.


### PR DESCRIPTION
This metric should help us understand if a message is taking too long to make it through relay, thus causing missed check-ins to be produced for messages that actually were recieved earlier than they were processed.

This can happen because we use the LogAppendTime of the kafka message as the driver to tick the clock forward. If a check-in is delayed to make it into kafka, it's possible that even when a check-in was received on-time, it may not have been produced into kafka fast enough.