### PR TITLE
ref: Remove TestStubs.Organization in favor of importing sentry-fixture/organization

### DIFF
--- a/fixtures/js-stubs/types.tsx
+++ b/fixtures/js-stubs/types.tsx
@@ -35,7 +35,6 @@ type TestStubFixtures = {
   Members: OverridableStubList;
   MetricRule: OverridableStub;
   OrgRoleList: OverridableStub;
-  Organization: OverridableStub;
   PageFilters: OverridableStub;
   PlatformExternalIssue: OverridableStub;
   Plugin: OverridableStub;

--- a/static/app/components/forms/fields/sentryMemberTeamSelectorField.spec.tsx
+++ b/static/app/components/forms/fields/sentryMemberTeamSelectorField.spec.tsx
@@ -1,4 +1,5 @@
 import selectEvent from 'react-select-event';
+import {Organization} from 'sentry-fixture/organization';
 import {Project} from 'sentry-fixture/project';
 import {Team} from 'sentry-fixture/team';
 import {User} from 'sentry-fixture/user';
@@ -12,7 +13,7 @@ import TeamStore from 'sentry/stores/teamStore';
 import SentryMemberTeamSelectorField from './sentryMemberTeamSelectorField';
 
 describe('SentryMemberTeamSelectorField', () => {
-  const org = TestStubs.Organization();
+  const org = Organization();
   const mockUsers = [User()];
   const mockTeams = [Team()];
   const mockProjects = [Project()];

--- a/static/app/utils/withDomainRedirect.spec.tsx
+++ b/static/app/utils/withDomainRedirect.spec.tsx
@@ -241,7 +241,7 @@ describe('withDomainRedirect', function () {
   });
 
   it('updates path when :orgId is present in the routes and there is no subdomain', function () {
-    const organization = TestStubs.Organization({
+    const organization = Organization({
       slug: 'albertos-apples',
       features: ['customer-domains'],
     });


### PR DESCRIPTION
We're trying to kill the TestStubs.* imports, this moves things along.

See: https://github.com/getsentry/frontend-tsc/issues/49
Depends on: https://github.com/getsentry/getsentry/pull/12236