### PR TITLE
ref: Replace `TestStubs.Event()` calls with imports from `sentry-fixture/event`

### DIFF
--- a/static/app/components/eventOrGroupHeader.spec.tsx
+++ b/static/app/components/eventOrGroupHeader.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -17,7 +19,7 @@ const group = TestStubs.Group({
   culprit: 'culprit',
 });
 
-const event = TestStubs.Event({
+const event = EventFixture({
   id: 'id',
   eventID: 'eventID',
   groupID: 'groupID',
@@ -111,10 +113,10 @@ describe('EventOrGroupHeader', function () {
       render(
         <EventOrGroupHeader
           organization={organization}
-          data={{
+          data={EventFixture({
             ...event,
             type: EventOrGroupType.ERROR,
-          }}
+          })}
           {...router}
         />
       );

--- a/static/app/components/events/contextSummary/index.spec.tsx
+++ b/static/app/components/events/contextSummary/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -49,56 +51,51 @@ const CONTEXT_BROWSER = {
 describe('ContextSummary', function () {
   describe('render()', function () {
     it('renders nothing without contexts', function () {
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         id: '',
         contexts: {},
-      };
+      });
 
       render(<ContextSummary event={event} />);
     });
 
     it('renders nothing with a single user context', function () {
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         id: '',
         user: CONTEXT_USER,
         contexts: {},
-      };
+      });
 
       render(<ContextSummary event={event} />);
     });
 
     it('should bail out with empty contexts', function () {
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         id: '',
         user: CONTEXT_USER,
         contexts: {
           device: {},
           os: {},
         },
-      };
+      });
 
       render(<ContextSummary event={event} />);
     });
 
     it('renders at least three contexts', function () {
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         id: '',
         user: CONTEXT_USER,
         contexts: {
           device: CONTEXT_DEVICE,
         },
-      };
+      });
 
       render(<ContextSummary event={event} />);
     });
 
     it('renders up to four contexts', function () {
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         id: '',
         user: CONTEXT_USER,
         contexts: {
@@ -107,14 +104,13 @@ describe('ContextSummary', function () {
           runtime: CONTEXT_RUNTIME,
           device: CONTEXT_DEVICE, // must be omitted
         },
-      };
+      });
 
       render(<ContextSummary event={event} />);
     });
 
     it('should prefer client_os over os', function () {
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         id: '',
         user: CONTEXT_USER,
         contexts: {
@@ -123,14 +119,13 @@ describe('ContextSummary', function () {
           browser: CONTEXT_BROWSER,
           runtime: CONTEXT_RUNTIME,
         },
-      };
+      });
 
       render(<ContextSummary event={event} />);
     });
 
     it('renders client_os too', function () {
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         id: '',
         user: CONTEXT_USER,
         contexts: {
@@ -138,14 +133,13 @@ describe('ContextSummary', function () {
           browser: CONTEXT_BROWSER,
           runtime: CONTEXT_RUNTIME,
         },
-      };
+      });
 
       render(<ContextSummary event={event} />);
     });
 
     it('should skip non-default named contexts', function () {
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         id: '',
         user: CONTEXT_USER,
         contexts: {
@@ -154,14 +148,13 @@ describe('ContextSummary', function () {
           runtime: CONTEXT_RUNTIME,
           device: CONTEXT_DEVICE,
         },
-      };
+      });
 
       render(<ContextSummary event={event} />);
     });
 
     it('should skip a missing user context', function () {
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         id: '',
         contexts: {
           os: CONTEXT_OS,
@@ -169,7 +162,7 @@ describe('ContextSummary', function () {
           runtime: CONTEXT_RUNTIME,
           device: CONTEXT_DEVICE,
         },
-      };
+      });
 
       render(<ContextSummary event={event} />);
     });

--- a/static/app/components/events/contexts/app/getAppKnownDataDetails.spec.tsx
+++ b/static/app/components/events/contexts/app/getAppKnownDataDetails.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {appKnownDataValues} from 'sentry/components/events/contexts/app';
 import {getAppKnownDataDetails} from 'sentry/components/events/contexts/app/getAppKnownDataDetails';
 
@@ -11,7 +13,7 @@ describe('getAppKnownDataDetails', function () {
       const appKnownDataDetails = getAppKnownDataDetails({
         type: appKnownDataValues[type],
         data: appMockData,
-        event: TestStubs.Event(),
+        event: EventFixture(),
       });
 
       if (!appKnownDataDetails) {

--- a/static/app/components/events/contexts/app/index.spec.tsx
+++ b/static/app/components/events/contexts/app/index.spec.tsx
@@ -1,4 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -35,14 +36,13 @@ export const appMetaMockData = {
   },
 };
 
-const event = {
-  ...TestStubs.Event(),
+const event = EventFixture({
   _meta: {
     contexts: {
       app: appMetaMockData,
     },
   },
-};
+});
 
 describe('app event context', function () {
   it('display redacted data', async function () {

--- a/static/app/components/events/contexts/browser/index.spec.tsx
+++ b/static/app/components/events/contexts/browser/index.spec.tsx
@@ -1,4 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -28,14 +29,13 @@ export const browserMetaMockData = {
   },
 };
 
-const event = {
-  ...TestStubs.Event(),
+const event = EventFixture({
   _meta: {
     contexts: {
       browser: browserMetaMockData,
     },
   },
-};
+});
 
 describe('browser event context', function () {
   it('display redacted data', async function () {

--- a/static/app/components/events/contexts/device/getDeviceKnownDataDetails.spec.tsx
+++ b/static/app/components/events/contexts/device/getDeviceKnownDataDetails.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {
   deviceKnownDataValues,
   getDeviceKnownDataDetails,
@@ -13,7 +15,7 @@ describe('getDeviceKnownDataDetails', function () {
       const deviceKnownData = getDeviceKnownDataDetails({
         type: deviceKnownDataValues[type],
         data: deviceMockData,
-        event: TestStubs.Event(),
+        event: EventFixture(),
       });
 
       if (!deviceKnownData) {

--- a/static/app/components/events/contexts/device/index.spec.tsx
+++ b/static/app/components/events/contexts/device/index.spec.tsx
@@ -1,4 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -45,14 +46,13 @@ export const deviceContextMetaMockData = {
   },
 };
 
-const event = {
-  ...TestStubs.Event(),
+const event = EventFixture({
   _meta: {
     contexts: {
       device: deviceContextMetaMockData,
     },
   },
-};
+});
 
 describe('device event context', function () {
   it('display redacted data', async function () {

--- a/static/app/components/events/contexts/gpu/index.spec.tsx
+++ b/static/app/components/events/contexts/gpu/index.spec.tsx
@@ -1,4 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -33,14 +34,13 @@ export const gpuMetaMockData = {
   },
 };
 
-const event = {
-  ...TestStubs.Event(),
+const event = EventFixture({
   _meta: {
     contexts: {
       gpu: gpuMetaMockData,
     },
   },
-};
+});
 
 // Flaky test https://github.com/getsentry/sentry/actions/runs/4465585304/jobs/7842795315?pr=45984
 // eslint-disable-next-line

--- a/static/app/components/events/contexts/memoryInfo/getMemoryInfoKnownDataDetails.spec.tsx
+++ b/static/app/components/events/contexts/memoryInfo/getMemoryInfoKnownDataDetails.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {
   getMemoryInfoKnownDataDetails,
   memoryInfoKnownDataValues,
@@ -13,7 +15,7 @@ describe('getMemoryInfoKnownDataDetails', function () {
       const memoryInfoKnownData = getMemoryInfoKnownDataDetails({
         type: memoryInfoKnownDataValues[type],
         data: memoryInfoMockData,
-        event: TestStubs.Event(),
+        event: EventFixture(),
       });
 
       if (!memoryInfoKnownData) {

--- a/static/app/components/events/contexts/memoryInfo/index.spec.tsx
+++ b/static/app/components/events/contexts/memoryInfo/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {MemoryInfoEventContext} from 'sentry/components/events/contexts/memoryInfo';
@@ -20,14 +22,13 @@ export const memoryInfoMetaMockData = {
   },
 };
 
-const event = {
-  ...TestStubs.Event(),
+const event = EventFixture({
   _meta: {
     contexts: {
       memory_info: memoryInfoMetaMockData,
     },
   },
-};
+});
 
 describe('memory info event context', function () {
   it('display redacted data', function () {

--- a/static/app/components/events/contexts/operatingSystem/index.spec.tsx
+++ b/static/app/components/events/contexts/operatingSystem/index.spec.tsx
@@ -1,4 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -30,14 +31,13 @@ export const operatingSystemMetaMockData = {
   },
 };
 
-const event = {
-  ...TestStubs.Event(),
+const event = EventFixture({
   _meta: {
     contexts: {
       os: operatingSystemMetaMockData,
     },
   },
-};
+});
 
 describe('operating system event context', function () {
   it('display redacted data', async function () {

--- a/static/app/components/events/contexts/profile/index.spec.tsx
+++ b/static/app/components/events/contexts/profile/index.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
@@ -15,7 +16,7 @@ const profileContext = {
   profile_id: profileId,
 };
 
-const event = TestStubs.Event();
+const event = EventFixture();
 const project = TestStubs.Project();
 
 describe('profile event context', function () {

--- a/static/app/components/events/contexts/runtime/index.spec.tsx
+++ b/static/app/components/events/contexts/runtime/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -27,14 +29,13 @@ export const runtimeMetaMockData = {
   },
 };
 
-const event = {
-  ...TestStubs.Event(),
+const event = EventFixture({
   _meta: {
     contexts: {
       runtime: runtimeMetaMockData,
     },
   },
-};
+});
 
 describe('runtime event context', function () {
   it('display redacted data', async function () {

--- a/static/app/components/events/contexts/state/index.spec.tsx
+++ b/static/app/components/events/contexts/state/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -20,7 +22,7 @@ describe('StateContext', function () {
             },
           },
         }}
-        event={TestStubs.Event()}
+        event={EventFixture()}
       />
     );
 
@@ -32,8 +34,7 @@ describe('StateContext', function () {
   });
 
   it('display redacted data', async function () {
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       _meta: {
         contexts: {
           state: {
@@ -48,7 +49,7 @@ describe('StateContext', function () {
           },
         },
       },
-    };
+    });
 
     render(
       <StateEventContext

--- a/static/app/components/events/contexts/threadPoolInfo/getThreadPoolInfoKnownDataDetails.spec.tsx
+++ b/static/app/components/events/contexts/threadPoolInfo/getThreadPoolInfoKnownDataDetails.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {
   getThreadPoolInfoKnownDataDetails,
   threadPoolInfoKnownDataValues,
@@ -13,7 +15,7 @@ describe('getThreadPoolInfoKnownDataDetails', function () {
       const threadPoolInfoKnownData = getThreadPoolInfoKnownDataDetails({
         type: threadPoolInfoKnownDataValues[type],
         data: threadPoolInfoMockData,
-        event: TestStubs.Event(),
+        event: EventFixture(),
       });
 
       if (!threadPoolInfoKnownData) {

--- a/static/app/components/events/contexts/threadPoolInfo/index.spec.tsx
+++ b/static/app/components/events/contexts/threadPoolInfo/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {ThreadPoolInfoEventContext} from 'sentry/components/events/contexts/threadPoolInfo';
@@ -19,14 +21,13 @@ export const threadPoolInfoMetaMockData = {
   },
 };
 
-const event = {
-  ...TestStubs.Event(),
+const event = EventFixture({
   _meta: {
     contexts: {
       threadpool_info: threadPoolInfoMetaMockData,
     },
   },
-};
+});
 
 describe('thread pool info event context', function () {
   it('display redacted data', function () {

--- a/static/app/components/events/contexts/trace/getTraceKnownDataDetails.spec.tsx
+++ b/static/app/components/events/contexts/trace/getTraceKnownDataDetails.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {traceKnownDataValues} from 'sentry/components/events/contexts/trace';
@@ -14,7 +15,7 @@ describe('getTraceKnownDataDetails', function () {
         type: traceKnownDataValues[type],
         data: traceMockData,
         organization: Organization(),
-        event: TestStubs.Event(),
+        event: EventFixture(),
       });
 
       if (!traceKnownData) {

--- a/static/app/components/events/contexts/trace/index.spec.tsx
+++ b/static/app/components/events/contexts/trace/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -21,14 +23,13 @@ export const traceContextMetaMockData = {
   },
 };
 
-const event = {
-  ...TestStubs.Event(),
+const event = EventFixture({
   _meta: {
     contexts: {
       trace: traceContextMetaMockData,
     },
   },
-};
+});
 
 describe('trace event context', function () {
   const data = {

--- a/static/app/components/events/contexts/unity/index.spec.tsx
+++ b/static/app/components/events/contexts/unity/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {UnityEventContext} from 'sentry/components/events/contexts/unity';
@@ -18,14 +20,13 @@ export const unityMetaMockData = {
   },
 };
 
-const event = {
-  ...TestStubs.Event(),
+const event = EventFixture({
   _meta: {
     contexts: {
       unity: unityMetaMockData,
     },
   },
-};
+});
 
 describe('unity event context', function () {
   it('display redacted data', function () {

--- a/static/app/components/events/eventAttachments.spec.tsx
+++ b/static/app/components/events/eventAttachments.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {EventAttachment} from 'sentry-fixture/eventAttachment';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -20,7 +21,7 @@ describe('EventAttachments', function () {
       attachmentsRole: 'member',
     },
   } as any);
-  const event = TestStubs.Event({metadata: {stripped_crash: false}});
+  const event = EventFixture({metadata: {stripped_crash: false}});
 
   const props = {
     projectSlug: project.slug,

--- a/static/app/components/events/eventCustomPerformanceMetrics.spec.tsx
+++ b/static/app/components/events/eventCustomPerformanceMetrics.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -24,7 +25,7 @@ describe('EventCustomPerformanceMetrics', function () {
 
   it('should not render non custom performance metrics', function () {
     const {router, organization} = initializeOrg();
-    const event = TestStubs.Event({
+    const event = EventFixture({
       measurements: {lcp: {value: 10, unit: 'millisecond'}},
     });
     render(
@@ -40,7 +41,7 @@ describe('EventCustomPerformanceMetrics', function () {
 
   it('should render custom performance metrics', function () {
     const {router, organization} = initializeOrg();
-    const event = TestStubs.Event({
+    const event = EventFixture({
       measurements: {
         'custom.count': {unit: 'none', value: 10},
         'custom.duration': {unit: 'millisecond', value: 123},
@@ -71,7 +72,7 @@ describe('EventCustomPerformanceMetrics', function () {
 
   it('should render custom performance metrics context menu', async function () {
     const {router, organization} = initializeOrg();
-    const event = TestStubs.Event({
+    const event = EventFixture({
       measurements: {
         'custom.size': {unit: 'kibibyte', value: 456},
       },
@@ -94,7 +95,7 @@ describe('EventCustomPerformanceMetrics', function () {
 
   it('should render custom performance metrics custom unit', function () {
     const {router, organization} = initializeOrg();
-    const event = TestStubs.Event({
+    const event = EventFixture({
       measurements: {
         'custom.unit': {unit: 'customunit', value: 456},
       },

--- a/static/app/components/events/eventEntries.spec.tsx
+++ b/static/app/components/events/eventEntries.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -8,7 +9,7 @@ describe('EventEntries', function () {
   const defaultProps = {
     organization: Organization(),
     project: TestStubs.Project(),
-    event: TestStubs.Event(),
+    event: EventFixture(),
     location: TestStubs.location(),
   };
 
@@ -32,7 +33,7 @@ describe('EventEntries', function () {
     render(
       <EventEntries
         {...defaultProps}
-        event={TestStubs.Event({
+        event={EventFixture({
           entries: [TestStubs.EventEntry(), TestStubs.EventEntryDebugMeta()],
           contexts: {
             replay_id: 1,

--- a/static/app/components/events/eventErrors.spec.tsx
+++ b/static/app/components/events/eventErrors.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -11,7 +13,7 @@ import {EntryType} from 'sentry/types';
 describe('EventErrors', () => {
   const defaultProps = {
     project: TestStubs.Project(),
-    event: TestStubs.Event(),
+    event: EventFixture(),
     isShare: false,
   };
 
@@ -27,7 +29,7 @@ describe('EventErrors', () => {
   });
 
   it('renders with errors in event', async () => {
-    const eventWithErrors = TestStubs.Event({
+    const eventWithErrors = EventFixture({
       errors: [
         {
           type: 'invalid_data',
@@ -60,7 +62,7 @@ describe('EventErrors', () => {
   });
 
   it('does not render hidden cocoa errors', async () => {
-    const eventWithErrors = TestStubs.Event({
+    const eventWithErrors = EventFixture({
       errors: [
         {
           type: 'not_invalid_data',
@@ -92,7 +94,7 @@ describe('EventErrors', () => {
   });
 
   it('hides source map not found error', () => {
-    const eventWithDifferentDist = TestStubs.Event({
+    const eventWithDifferentDist = EventFixture({
       errors: [
         {
           type: JavascriptProcessingErrors.JS_MISSING_SOURCE,
@@ -105,7 +107,7 @@ describe('EventErrors', () => {
   });
 
   it('hides event error that is hidden', () => {
-    const eventWithUnknownError = TestStubs.Event({
+    const eventWithUnknownError = EventFixture({
       errors: [
         {
           type: GenericSchemaErrors.UNKNOWN_ERROR,
@@ -128,7 +130,7 @@ describe('EventErrors', () => {
     const proGuardUuid = 'a59c8fcc-2f27-49f8-af9e-02661fc3e8d7';
 
     it('displays missing mapping file with debugmeta but no event error', async () => {
-      const eventWithDebugMeta = TestStubs.Event({
+      const eventWithDebugMeta = EventFixture({
         platform: 'java',
         entries: [
           {
@@ -153,7 +155,7 @@ describe('EventErrors', () => {
     });
 
     it('displays missing mapping file with debugmeta and matching event error', async () => {
-      const eventWithDebugMeta = TestStubs.Event({
+      const eventWithDebugMeta = EventFixture({
         platform: 'java',
         entries: [
           {
@@ -186,7 +188,7 @@ describe('EventErrors', () => {
 
     describe('ProGuard Plugin seems to not be correctly configured', function () {
       it('find minified data in the exception entry', async function () {
-        const newEvent = TestStubs.Event({
+        const newEvent = EventFixture({
           platform: 'java',
           entries: [
             {
@@ -240,7 +242,7 @@ describe('EventErrors', () => {
       });
 
       it('find minified data in the threads entry', async function () {
-        const newEvent = TestStubs.Event({
+        const newEvent = EventFixture({
           platform: 'java',
           entries: [
             {

--- a/static/app/components/events/eventEvidence.spec.tsx
+++ b/static/app/components/events/eventEvidence.spec.tsx
@@ -1,9 +1,11 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {EventEvidence} from 'sentry/components/events/eventEvidence';
 
 describe('EventEvidence', () => {
-  const event = TestStubs.Event({
+  const event = EventFixture({
     occurrence: {
       evidenceData: {},
       evidenceDisplay: [
@@ -33,7 +35,7 @@ describe('EventEvidence', () => {
     const {container} = render(
       <EventEvidence
         {...defaultProps}
-        event={TestStubs.Event({occurrence: {evidenceDisplay: []}})}
+        event={EventFixture({occurrence: {evidenceDisplay: []}})}
       />
     );
 

--- a/static/app/components/events/eventExtraData/index.spec.tsx
+++ b/static/app/components/events/eventExtraData/index.spec.tsx
@@ -1,4 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -7,8 +8,7 @@ import {EventExtraData} from 'sentry/components/events/eventExtraData';
 
 describe('EventExtraData', function () {
   it('display redacted data', async function () {
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       context: {
         'sys.argv': ['', '', '', '', '', '', '', '', '', ''],
         sdk: {
@@ -170,7 +170,7 @@ describe('EventExtraData', function () {
           },
         },
       },
-    };
+    });
 
     render(<EventExtraData event={event} />, {
       organization: {

--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 import {RRWebInitFrameEvents} from 'sentry-fixture/replay/rrweb';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
@@ -52,7 +53,7 @@ describe('EventReplay', function () {
   });
 
   const defaultProps = {
-    event: TestStubs.Event({
+    event: EventFixture({
       entries: [],
       tags: [],
       platform: 'javascript',
@@ -105,7 +106,7 @@ describe('EventReplay', function () {
     render(
       <EventReplay
         {...defaultProps}
-        event={TestStubs.Event({
+        event={EventFixture({
           entries: [],
           tags: [],
         })}
@@ -128,7 +129,7 @@ describe('EventReplay', function () {
     render(
       <EventReplay
         {...defaultProps}
-        event={TestStubs.Event({
+        event={EventFixture({
           entries: [],
           tags: [{key: 'replayId', value: '761104e184c64d439ee1014b72b4d83b'}],
           platform: 'javascript',
@@ -151,7 +152,7 @@ describe('EventReplay', function () {
     render(
       <EventReplay
         {...defaultProps}
-        event={TestStubs.Event({
+        event={EventFixture({
           entries: [],
           tags: [],
           contexts: {

--- a/static/app/components/events/eventSdk.spec.tsx
+++ b/static/app/components/events/eventSdk.spec.tsx
@@ -1,4 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -7,8 +8,7 @@ import {EventSdk} from 'sentry/components/events/eventSdk';
 
 describe('event sdk', function () {
   it('display redacted tags', async function () {
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       sdk: {
         name: 'sentry.cocoa',
         version: '',
@@ -18,9 +18,9 @@ describe('event sdk', function () {
           version: {'': {rem: [['organization:0', 'x']]}},
         },
       },
-    };
+    });
 
-    render(<EventSdk sdk={event.sdk} meta={event._meta.sdk} />, {
+    render(<EventSdk sdk={event.sdk} meta={event._meta?.sdk} />, {
       organization: {
         relayPiiConfig: JSON.stringify(DataScrubbingRelayPiiConfig()),
       },

--- a/static/app/components/events/eventTags/index.spec.tsx
+++ b/static/app/components/events/eventTags/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -6,13 +8,12 @@ import {EventTags} from 'sentry/components/events/eventTags';
 
 describe('event tags', function () {
   it('display redacted tags', async function () {
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       tags: null,
       _meta: {
         tags: {'': {rem: [['project:2', 'x']]}},
       },
-    };
+    });
 
     const {organization, project, router} = initializeOrg({
       organization: {
@@ -46,8 +47,7 @@ describe('event tags', function () {
       {key: 'device.family', value: 'iOS'},
     ];
 
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       tags,
       _meta: {
         tags: {
@@ -58,7 +58,7 @@ describe('event tags', function () {
           },
         },
       },
-    };
+    });
 
     const {organization, project, router} = initializeOrg({
       organization: {
@@ -93,10 +93,9 @@ describe('event tags', function () {
   it('transacation tag links to transaction overview', function () {
     const tags = [{key: 'transaction', value: 'mytransaction'}];
 
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       tags,
-    };
+    });
 
     const {organization, project, router} = initializeOrg({
       organization: {

--- a/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -115,7 +116,7 @@ describe('EventTagsAndScreenshot', function () {
     },
   ];
 
-  const event = TestStubs.Event({user});
+  const event = EventFixture({user});
 
   const {organization, project, router} = initializeOrg({
     organization: {
@@ -187,7 +188,7 @@ describe('EventTagsAndScreenshot', function () {
     it('not shared event - without attachments', function () {
       render(
         <EventTagsAndScreenshot
-          event={{...event, tags, contexts}}
+          event={EventFixture({...event, tags, contexts})}
           organization={organization}
           projectSlug={project.slug}
           location={router.location}
@@ -234,7 +235,7 @@ describe('EventTagsAndScreenshot', function () {
     it('shared event - without attachments', function () {
       render(
         <EventTagsAndScreenshot
-          event={{...event, tags, contexts}}
+          event={EventFixture({...event, tags, contexts})}
           organization={organization}
           projectSlug={project.slug}
           location={router.location}
@@ -253,7 +254,7 @@ describe('EventTagsAndScreenshot', function () {
     it('shared event - with attachments', function () {
       render(
         <EventTagsAndScreenshot
-          event={{...event, tags, contexts}}
+          event={EventFixture({...event, tags, contexts})}
           organization={organization}
           projectSlug={project.slug}
           location={router.location}
@@ -282,7 +283,7 @@ describe('EventTagsAndScreenshot', function () {
         <Fragment>
           <GlobalModal />
           <EventTagsAndScreenshot
-            event={TestStubs.Event({user: {}, contexts: {}})}
+            event={EventFixture({user: {}, contexts: {}})}
             organization={organization}
             projectSlug={project.slug}
             location={router.location}
@@ -337,7 +338,7 @@ describe('EventTagsAndScreenshot', function () {
     it('has context, async tags and attachments', async function () {
       render(
         <EventTagsAndScreenshot
-          event={{...event, tags, contexts}}
+          event={EventFixture({...event, tags, contexts})}
           organization={organization}
           projectSlug={project.slug}
           location={router.location}
@@ -394,7 +395,7 @@ describe('EventTagsAndScreenshot', function () {
       });
       render(
         <EventTagsAndScreenshot
-          event={{...event, tags, contexts}}
+          event={EventFixture({...event, tags, contexts})}
           organization={organization}
           projectSlug={project.slug}
           location={router.location}
@@ -437,7 +438,7 @@ describe('EventTagsAndScreenshot', function () {
       });
       render(
         <EventTagsAndScreenshot
-          event={{...event, tags, contexts}}
+          event={EventFixture({...event, tags, contexts})}
           organization={organization}
           projectSlug={project.slug}
           location={router.location}
@@ -471,7 +472,7 @@ describe('EventTagsAndScreenshot', function () {
     it('has context and attachments only', async function () {
       render(
         <EventTagsAndScreenshot
-          event={{...event, contexts}}
+          event={EventFixture({...event, contexts})}
           organization={organization}
           projectSlug={project.slug}
           location={router.location}

--- a/static/app/components/events/eventViewHierarchy.spec.tsx
+++ b/static/app/components/events/eventViewHierarchy.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {EventAttachment} from 'sentry-fixture/eventAttachment';
 import {Organization} from 'sentry-fixture/organization';
 
@@ -48,7 +49,7 @@ const MOCK_DATA = JSON.stringify({
 const organization = Organization({
   features: ['event-attachments'],
 });
-const event = TestStubs.Event();
+const event = EventFixture();
 
 describe('Event View Hierarchy', function () {
   let mockAttachment;

--- a/static/app/components/events/eventVitals.spec.tsx
+++ b/static/app/components/events/eventVitals.spec.tsx
@@ -1,46 +1,38 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import EventVitals from 'sentry/components/events/eventVitals';
-import {Event} from 'sentry/types';
-
-function makeEvent(measurements = {}, sdk = {version: '5.27.3'}): Event {
-  const formattedMeasurements = {};
-  for (const [name, value] of Object.entries(measurements)) {
-    formattedMeasurements[name] = {value};
-  }
-  const event = TestStubs.Event({measurements: formattedMeasurements});
-  if (sdk !== null) {
-    event.sdk = sdk;
-  }
-
-  return event;
-}
 
 describe('EventVitals', function () {
   it('should not render anything', function () {
-    const event = makeEvent({});
+    const event = EventFixture();
     const {container} = render(<EventVitals event={event} />);
     expect(container).toBeEmptyDOMElement();
   });
 
   it('should not render non web vitals', function () {
-    const event = makeEvent({
-      'mark.stuff': 123,
-      'op.more.stuff': 123,
+    const event = EventFixture({
+      measurements: {
+        'mark.stuff': {value: 123},
+        'op.more.stuff': {value: 123},
+      },
     });
     const {container} = render(<EventVitals event={event} />);
     expect(container).toBeEmptyDOMElement();
   });
 
   it('should render some web vitals with a header', function () {
-    const event = makeEvent({
-      fp: 1,
-      fcp: 2,
-      lcp: 3,
-      fid: 4,
-      cls: 0.1,
-      ttfb: 5,
-      'ttfb.requesttime': 6,
+    const event = EventFixture({
+      measurements: {
+        fp: {value: 1},
+        fcp: {value: 2},
+        lcp: {value: 3},
+        fid: {value: 4},
+        cls: {value: 0.1},
+        ttfb: {value: 5},
+        'ttfb.requesttime': {value: 6},
+      },
     });
     render(<EventVitals event={event} />);
 
@@ -58,7 +50,12 @@ describe('EventVitals', function () {
   });
 
   it('should render some web vitals with a heading and a sdk warning', function () {
-    const event = makeEvent({fp: 1}, {version: '5.26.0'});
+    const event = EventFixture({
+      measurements: {
+        fp: {value: 1},
+      },
+      sdk: {version: '5.26.0'},
+    });
     render(<EventVitals event={event} />);
 
     [
@@ -74,14 +71,16 @@ describe('EventVitals', function () {
   });
 
   it('should show fire icon if vital failed threshold', function () {
-    const event = makeEvent({
-      fp: 5000,
-      fcp: 5000,
-      lcp: 5000,
-      fid: 4,
-      cls: 0.1,
-      ttfb: 5,
-      'ttfb.requesttime': 6,
+    const event = EventFixture({
+      measurements: {
+        fp: {value: 5000},
+        fcp: {value: 5000},
+        lcp: {value: 5000},
+        fid: {value: 4},
+        cls: {value: 0.1},
+        ttfb: {value: 5},
+        'ttfb.requesttime': {value: 6},
+      },
     });
     render(<EventVitals event={event} />);
 

--- a/static/app/components/events/groupingInfo/groupingVariant.spec.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
 
 import {EventGroupVariantType} from 'sentry/types';
@@ -5,8 +7,7 @@ import {EventGroupVariantType} from 'sentry/types';
 import GroupingVariant from './groupingVariant';
 
 describe('Grouping Variant', () => {
-  const event = {
-    ...TestStubs.Event(),
+  const event = EventFixture({
     entries: [
       {
         type: 'spans',
@@ -22,8 +23,8 @@ describe('Grouping Variant', () => {
         ],
       },
     ],
-  };
-  const occurrenceEvent = {
+  });
+  const occurrenceEvent = EventFixture({
     ...event,
     occurrence: {
       fingerprint: ['test-fingerprint'],
@@ -34,7 +35,7 @@ describe('Grouping Variant', () => {
         parentSpanIds: [],
       },
     },
-  };
+  });
   const performanceIssueVariant = {
     type: EventGroupVariantType.PERFORMANCE_PROBLEM,
     description: 'performance issue',

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.spec.tsx
@@ -1,4 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Project} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -52,7 +53,7 @@ describe('Breadcrumb Data Default', function () {
             },
           },
         }}
-        event={TestStubs.Event()}
+        event={EventFixture()}
         orgSlug="org-slug"
         searchTerm=""
         breadcrumb={{
@@ -96,7 +97,7 @@ describe('Breadcrumb Data Default', function () {
             },
           },
         }}
-        event={TestStubs.Event()}
+        event={EventFixture()}
         orgSlug="org-slug"
         searchTerm=""
         breadcrumb={{

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -40,7 +41,7 @@ describe('Breadcrumbs', () => {
 
     props = {
       organization: Organization(),
-      event: TestStubs.Event({entries: [], projectID: project.id}),
+      event: EventFixture({entries: [], projectID: project.id}),
       data: {
         values: [
           {

--- a/static/app/components/events/interfaces/crashContent/exception/actionableItems.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItems.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -13,7 +14,7 @@ describe('Actionable Items', () => {
 
   const defaultProps = {
     project: TestStubs.Project(),
-    event: TestStubs.Event(),
+    event: EventFixture(),
     isShare: false,
   };
 
@@ -61,7 +62,7 @@ describe('Actionable Items', () => {
       method: 'GET',
     });
 
-    const eventWithErrors = TestStubs.Event({
+    const eventWithErrors = EventFixture({
       errors: eventErrors,
     });
 
@@ -97,7 +98,7 @@ describe('Actionable Items', () => {
       method: 'GET',
     });
 
-    const eventWithErrors = TestStubs.Event({
+    const eventWithErrors = EventFixture({
       errors: eventErrors,
       sdk: {
         name: 'sentry.cocoa',
@@ -121,7 +122,7 @@ describe('Actionable Items', () => {
         data: {mapping_uuid: 'a59c8fcc-2f27-49f8-af9e-02661fc3e8d7'},
       },
     ];
-    const eventWithDebugMeta = TestStubs.Event({
+    const eventWithDebugMeta = EventFixture({
       platform: 'java',
       entries: [
         {

--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -1,5 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
-import {Event} from 'sentry-fixture/event';
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Project} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -31,7 +31,7 @@ describe('Exception Content', function () {
       projects: [project],
     });
 
-    const event = Event({
+    const event = EventFixture({
       _meta: {
         entries: {
           0: {
@@ -151,7 +151,7 @@ describe('Exception Content', function () {
   });
 
   describe('exception groups', function () {
-    const event = TestStubs.Event({entries: [TestStubs.EventEntryExceptionGroup()]});
+    const event = EventFixture({entries: [TestStubs.EventEntryExceptionGroup()]});
     const project = TestStubs.Project();
     beforeEach(() => {
       const promptResponse = {

--- a/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/sourceMapDebug.spec.tsx
@@ -1,9 +1,10 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {Event, ExceptionValue} from 'sentry/types';
+import {ExceptionValue} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
 import {SourceMapDebug} from './sourceMapDebug';
@@ -65,13 +66,12 @@ describe('SourceMapDebug', () => {
     projectSlug: project.slug,
     eventId,
   });
-  const event: Event = {
-    ...TestStubs.Event(),
+  const event = EventFixture({
     id: eventId,
     sdk: {
       name: sdkName,
     },
-  } as Event;
+  });
 
   it('should use unqiue in app frames', () => {
     expect(debugFrames).toHaveLength(1);

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -57,8 +59,7 @@ const props: React.ComponentProps<typeof ExceptionStacktraceContent> = {
   newestFirst: true,
   chainedException: false,
   stackType: StackType.ORIGINAL,
-  event: {
-    ...TestStubs.Event(),
+  event: EventFixture({
     entries: [],
     crashFile: {
       sha1: 'sha1',
@@ -81,7 +82,7 @@ const props: React.ComponentProps<typeof ExceptionStacktraceContent> = {
     projectID: '123',
     tags: [{value: 'production', key: 'production'}],
     title: 'TestException',
-  },
+  }),
   data: stacktrace,
   stacktrace,
   hasHierarchicalGrouping: false,

--- a/static/app/components/events/interfaces/crashContent/index.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render} from 'sentry-test/reactTestingLibrary';
 
 import {CrashContent} from 'sentry/components/events/interfaces/crashContent';
@@ -47,7 +49,7 @@ describe('CrashContent', function () {
       <CrashContent
         stackView={StackView.FULL}
         stackType={StackType.ORIGINAL}
-        event={TestStubs.Event()}
+        event={EventFixture()}
         newestFirst
         exception={(proxiedExc as any).exception}
         projectSlug={TestStubs.Project().slug}

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {EventEntryStacktrace} from 'sentry-fixture/eventEntryStacktrace';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -7,7 +8,7 @@ import {EventOrGroupType} from 'sentry/types';
 import {StacktraceType} from 'sentry/types/stacktrace';
 
 const eventEntryStacktrace = EventEntryStacktrace();
-const event = TestStubs.Event({
+const event = EventFixture({
   entries: [eventEntryStacktrace],
   type: EventOrGroupType.ERROR,
 });
@@ -255,7 +256,10 @@ describe('StackTrace', function () {
 
       renderedComponent({
         data: newData,
-        event: {...event, entries: [{...event.entries[0], stacktrace: newData.frames}]},
+        event: EventFixture({
+          ...event,
+          entries: [{...event.entries[0], stacktace: newData.frames}],
+        }),
         includeSystemFrames: false,
       });
 
@@ -286,7 +290,10 @@ describe('StackTrace', function () {
 
       renderedComponent({
         data: newData,
-        event: {...event, entries: [{...event.entries[0], stacktrace: newData.frames}]},
+        event: EventFixture({
+          ...event,
+          entries: [{...event.entries[0], stacktrace: newData.frames}],
+        }),
         includeSystemFrames: false,
       });
 
@@ -319,7 +326,10 @@ describe('StackTrace', function () {
 
       renderedComponent({
         data: newData,
-        event: {...event, entries: [{...event.entries[0], stacktrace: newData.frames}]},
+        event: EventFixture({
+          ...event,
+          entries: [{...event.entries[0], stacktrace: newData.frames}],
+        }),
         includeSystemFrames: false,
       });
 
@@ -352,11 +362,11 @@ describe('StackTrace', function () {
 
       renderedComponent({
         data: newData,
-        event: {
+        event: EventFixture({
           ...event,
           entries: [{...event.entries[0], stacktrace: newData.frames}],
           type: EventOrGroupType.TRANSACTION,
-        },
+        }),
         includeSystemFrames: false,
       });
 
@@ -386,12 +396,12 @@ describe('StackTrace', function () {
 
       renderedComponent({
         data: newData,
-        event: {
+        event: EventFixture({
           ...event,
           entries: [{...event.entries[0], stacktrace: newData.frames}],
           type: EventOrGroupType.ERROR,
           tags: [{key: 'mechanism', value: 'ANR'}],
-        },
+        }),
         includeSystemFrames: false,
       });
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {EventEntryStacktrace} from 'sentry-fixture/eventEntryStacktrace';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -7,7 +8,7 @@ import {EventOrGroupType} from 'sentry/types';
 import {StacktraceType} from 'sentry/types/stacktrace';
 
 const eventEntryStacktrace = EventEntryStacktrace();
-const event = TestStubs.Event({
+const event = EventFixture({
   entries: [eventEntryStacktrace],
   type: EventOrGroupType.ERROR,
 });

--- a/static/app/components/events/interfaces/csp/index.spec.tsx
+++ b/static/app/components/events/interfaces/csp/index.spec.tsx
@@ -1,4 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -8,8 +9,7 @@ import {EntryType} from 'sentry/types/event';
 
 describe('Csp report entry', function () {
   it('display redacted data', async function () {
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       entries: [{type: EntryType.CSP, data: {effective_directive: ''}}],
       _meta: {
         entries: {
@@ -20,7 +20,7 @@ describe('Csp report entry', function () {
           },
         },
       },
-    };
+    });
     render(<Csp data={event.entries[0].data} event={event} />, {
       organization: {
         relayPiiConfig: JSON.stringify(DataScrubbingRelayPiiConfig()),

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, renderGlobalModal, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -6,7 +8,7 @@ import {DebugImageDetails} from 'sentry/components/events/interfaces/debugMeta/d
 
 describe('Debug Meta - Image Details', function () {
   const eventEntryDebugMeta = TestStubs.EventEntryDebugMeta();
-  const event = TestStubs.Event({entries: [eventEntryDebugMeta]});
+  const event = EventFixture({entries: [eventEntryDebugMeta]});
   const {organization, project} = initializeOrg();
 
   beforeEach(function () {

--- a/static/app/components/events/interfaces/debugMeta/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -10,7 +11,7 @@ import GlobalModal from 'sentry/components/globalModal';
 describe('DebugMeta', function () {
   it('opens details modal', async function () {
     const eventEntryDebugMeta = TestStubs.EventEntryDebugMeta();
-    const event = TestStubs.Event({entries: [eventEntryDebugMeta]});
+    const event = EventFixture({entries: [eventEntryDebugMeta]});
     const {organization, project, router} = initializeOrg();
     const routerProps = {router, location: router.location};
 

--- a/static/app/components/events/interfaces/frame/context.spec.tsx
+++ b/static/app/components/events/interfaces/frame/context.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 import {Repository} from 'sentry-fixture/repository';
 import {RepositoryProjectPathConfig} from 'sentry-fixture/repositoryProjectPathConfig';
@@ -12,7 +13,7 @@ import Context, {getLineCoverage} from './context';
 describe('Frame - Context', function () {
   const org = Organization();
   const project = TestStubs.Project({});
-  const event = TestStubs.Event({projectID: project.id});
+  const event = EventFixture({projectID: project.id});
   const integration = TestStubs.GitHubIntegration();
   const repo = Repository({integrationId: integration.id});
   const frame = {filename: '/sentry/app.py', lineNo: 233} as Frame;

--- a/static/app/components/events/interfaces/frame/contexts.spec.tsx
+++ b/static/app/components/events/interfaces/frame/contexts.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {DeviceEventContext} from 'sentry/components/events/contexts/device';
@@ -18,7 +20,7 @@ describe('User', function () {
           ip_address: '',
           data: {},
         }}
-        event={TestStubs.Event()}
+        event={EventFixture()}
       />
     );
 
@@ -35,7 +37,7 @@ describe('User', function () {
           ip_address: '',
           data: {},
         }}
-        event={TestStubs.Event()}
+        event={EventFixture()}
       />
     );
 
@@ -52,7 +54,7 @@ describe('User', function () {
           ip_address: '',
           data: {},
         }}
-        event={TestStubs.Event()}
+        event={EventFixture()}
       />
     );
 
@@ -75,14 +77,14 @@ describe('Device', function () {
 
   describe('getInferredData', function () {
     it('renders', function () {
-      render(<DeviceEventContext data={device} event={TestStubs.Event()} />);
+      render(<DeviceEventContext data={device} event={EventFixture()} />);
     });
 
     it('renders screen_resolution inferred from screen_width_pixels and screen_height_pixels', function () {
       render(
         <DeviceEventContext
           data={{...device, screen_resolution: undefined}}
-          event={TestStubs.Event()}
+          event={EventFixture()}
         />
       );
 
@@ -111,7 +113,7 @@ describe('Device', function () {
             screen_width_pixels: undefined,
             screen_height_pixels: undefined,
           }}
-          event={TestStubs.Event()}
+          event={EventFixture()}
         />
       );
 

--- a/static/app/components/events/interfaces/frame/deprecatedLine.spec.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
@@ -6,7 +7,7 @@ import DeprecatedLine from 'sentry/components/events/interfaces/frame/deprecated
 import {EntryType, Frame} from 'sentry/types';
 
 describe('Frame - Line', function () {
-  const event = TestStubs.Event();
+  const event = EventFixture();
 
   const data: Frame = {
     absPath: null,
@@ -158,8 +159,7 @@ describe('Frame - Line', function () {
   describe('ANR suspect frame', () => {
     it('should render suspect frame', () => {
       const org = {...Organization(), features: ['anr-analyze-frames']};
-      const eventWithThreads = {
-        ...event,
+      const eventWithThreads = EventFixture({
         entries: [
           {
             data: {
@@ -178,7 +178,7 @@ describe('Frame - Line', function () {
             type: EntryType.THREADS,
           },
         ],
-      };
+      });
       const suspectFrame: Frame = {
         filename: 'Instrumentation.java',
         absPath: 'Instrumentation.java',

--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -1,4 +1,5 @@
 import {Commit} from 'sentry-fixture/commit';
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 import {Repository} from 'sentry-fixture/repository';
 import {RepositoryProjectPathConfig} from 'sentry-fixture/repositoryProjectPathConfig';
@@ -16,7 +17,7 @@ describe('StacktraceLink', function () {
   const org = Organization();
   const platform = 'python';
   const project = TestStubs.Project({});
-  const event = TestStubs.Event({
+  const event = EventFixture({
     projectID: project.id,
     release: TestStubs.Release({lastCommit: Commit()}),
     platform,

--- a/static/app/components/events/interfaces/generic.spec.tsx
+++ b/static/app/components/events/interfaces/generic.spec.tsx
@@ -1,4 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -7,13 +8,12 @@ import {Generic} from 'sentry/components/events/interfaces/generic';
 
 describe('Generic entry', function () {
   it('display redacted data', async function () {
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       _meta: {
         hpkp: {'': {rem: [['organization:1', 'x']]}},
       },
-    };
-    render(<Generic type="hpkp" data={null} meta={event._meta.hpkp} />, {
+    });
+    render(<Generic type="hpkp" data={null} meta={event._meta?.hpkp} />, {
       organization: {
         relayPiiConfig: JSON.stringify(DataScrubbingRelayPiiConfig()),
       },

--- a/static/app/components/events/interfaces/message.spec.tsx
+++ b/static/app/components/events/interfaces/message.spec.tsx
@@ -1,4 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -8,8 +9,7 @@ import {Message} from 'sentry/components/events/interfaces/message';
 describe('Message entry', function () {
   const routerContext = TestStubs.routerContext();
   it('display redacted data', async function () {
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       entries: [
         {
           type: 'message',
@@ -27,7 +27,7 @@ describe('Message entry', function () {
           },
         },
       },
-    };
+    });
     render(<Message data={{formatted: null}} event={event} />, {
       context: routerContext,
       organization: {

--- a/static/app/components/events/interfaces/performance/spanEvidence.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {initializeData} from 'sentry-test/performance/initializePerformanceData';
 import {
   MockSpan,
@@ -6,7 +8,7 @@ import {
 } from 'sentry-test/performance/utils';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {EntryType, IssueTitle, IssueType} from 'sentry/types';
+import {EntryType, EventTransaction, IssueTitle, IssueType} from 'sentry/types';
 import {sanitizeQuerySelector} from 'sentry/utils/sanitizeQuerySelector';
 
 import {SpanEvidenceSection} from './spanEvidence';
@@ -88,7 +90,7 @@ describe('spanEvidence', () => {
   });
 
   it('renders settings button for issue with configurable thresholds', () => {
-    const event = TestStubs.Event({
+    const event = EventFixture({
       occurrence: {
         type: 1001,
         issueTitle: IssueTitle.PERFORMANCE_SLOW_DB_QUERY,
@@ -103,7 +105,7 @@ describe('spanEvidence', () => {
 
     render(
       <SpanEvidenceSection
-        event={event}
+        event={event as EventTransaction}
         organization={organization}
         projectSlug={project.slug}
       />,
@@ -123,7 +125,7 @@ describe('spanEvidence', () => {
   });
 
   it('does not render settings button for issue without configurable thresholds', () => {
-    const event = TestStubs.Event({
+    const event = EventFixture({
       occurrence: {
         type: 2003, // profile_json_decode_main_thread
       },
@@ -137,7 +139,7 @@ describe('spanEvidence', () => {
 
     render(
       <SpanEvidenceSection
-        event={event}
+        event={event as EventTransaction}
         organization={organization}
         projectSlug={project.slug}
       />,

--- a/static/app/components/events/interfaces/request/index.spec.tsx
+++ b/static/app/components/events/interfaces/request/index.spec.tsx
@@ -1,4 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -8,8 +9,7 @@ import {EntryRequest, EntryType} from 'sentry/types/event';
 
 describe('Request entry', function () {
   it('display redacted data', async function () {
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       entries: [
         {
           type: 'request',
@@ -159,7 +159,7 @@ describe('Request entry', function () {
           },
         },
       },
-    };
+    });
 
     render(<Request event={event} data={event.entries[0].data} />, {
       organization: {
@@ -199,15 +199,14 @@ describe('Request entry', function () {
         fragment: null,
       };
 
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         entries: [
           {
             type: EntryType.REQUEST,
             data,
           },
         ],
-      };
+      });
 
       render(<Request event={event} data={event.entries[0].data} />, {
         organization: {
@@ -234,15 +233,14 @@ describe('Request entry', function () {
         fragment: null,
       };
 
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         entries: [
           {
             type: EntryType.REQUEST,
             data,
           },
         ],
-      };
+      });
 
       render(<Request event={event} data={event.entries[0].data} />, {
         organization: {
@@ -269,15 +267,14 @@ describe('Request entry', function () {
         fragment: null,
       };
 
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         entries: [
           {
             type: EntryType.REQUEST,
             data,
           },
         ],
-      };
+      });
 
       render(<Request event={event} data={event.entries[0].data} />, {
         organization: {
@@ -305,15 +302,14 @@ describe('Request entry', function () {
         fragment: null,
       };
 
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         entries: [
           {
             type: EntryType.REQUEST,
             data,
           },
         ],
-      };
+      });
 
       expect(() =>
         render(<Request event={event} data={event.entries[0].data} />, {
@@ -337,15 +333,14 @@ describe('Request entry', function () {
         fragment: null,
       };
 
-      const event = {
-        ...TestStubs.Event(),
+      const event = EventFixture({
         entries: [
           {
             type: EntryType.REQUEST,
             data,
           },
         ],
-      };
+      });
 
       expect(() =>
         render(<Request event={event} data={event.entries[0].data} />, {
@@ -369,15 +364,14 @@ describe('Request entry', function () {
           },
         };
 
-        const event = {
-          ...TestStubs.Event(),
+        const event = EventFixture({
           entries: [
             {
               type: EntryType.REQUEST,
               data,
             },
           ],
-        };
+        });
 
         render(<Request event={event} data={event.entries[0].data} />);
 
@@ -400,8 +394,7 @@ describe('Request entry', function () {
           },
         };
 
-        const event = {
-          ...TestStubs.Event(),
+        const event = EventFixture({
           entries: [
             {
               type: EntryType.REQUEST,
@@ -415,7 +408,7 @@ describe('Request entry', function () {
               },
             },
           },
-        };
+        });
 
         const {container} = render(
           <Request event={event} data={event.entries[0].data} />

--- a/static/app/components/events/interfaces/utils.spec.tsx
+++ b/static/app/components/events/interfaces/utils.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {
   getCurlCommand,
   getCurrentThread,
@@ -300,7 +302,7 @@ describe('components/interfaces/utils', function () {
   describe('getCurrentThread()', function () {
     it('should return current thread if available', function () {
       const thread = getCurrentThread(
-        TestStubs.Event({
+        EventFixture({
           entries: [
             {
               data: {
@@ -328,7 +330,7 @@ describe('components/interfaces/utils', function () {
   describe('getThreadById()', function () {
     it('should return thread by given id if available', function () {
       const thread = getThreadById(
-        TestStubs.Event({
+        EventFixture({
           entries: [
             {
               data: {

--- a/static/app/components/events/packageData.spec.tsx
+++ b/static/app/components/events/packageData.spec.tsx
@@ -1,4 +1,5 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -7,8 +8,7 @@ import {EventPackageData} from 'sentry/components/events/packageData';
 
 describe('EventPackageData', function () {
   it('display redacted data', async function () {
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       packages: {
         certifi: '',
         pip: '18.0',
@@ -24,7 +24,7 @@ describe('EventPackageData', function () {
           certifi: {'': {rem: [['organization:1', 'x']]}},
         },
       },
-    };
+    });
 
     render(<EventPackageData event={event} />, {
       organization: {

--- a/static/app/components/events/profileEventEvidence.spec.tsx
+++ b/static/app/components/events/profileEventEvidence.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {ProfileEventEvidence} from 'sentry/components/events/profileEventEvidence';
@@ -5,7 +7,7 @@ import {IssueCategory, IssueType} from 'sentry/types';
 
 describe('ProfileEventEvidence', function () {
   const defaultProps = {
-    event: TestStubs.Event({
+    event: EventFixture({
       id: 'event-id',
       occurrence: {
         evidenceDisplay: [{name: 'Evidence name', value: 'Evidence value'}],

--- a/static/app/components/events/sdkUpdates/index.spec.tsx
+++ b/static/app/components/events/sdkUpdates/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render} from 'sentry-test/reactTestingLibrary';
 
@@ -7,7 +9,7 @@ describe('EventSdkUpdates', function () {
   const {routerContext} = initializeOrg();
 
   it('renders a suggestion to update the sdk and then enable an integration', function () {
-    const event = TestStubs.Event({
+    const event = EventFixture({
       id: '123',
       sdk: {
         name: 'sentry.python',

--- a/static/app/components/group/assignedTo.spec.tsx
+++ b/static/app/components/group/assignedTo.spec.tsx
@@ -1,5 +1,6 @@
 import {Commit} from 'sentry-fixture/commit';
 import {CommitAuthor} from 'sentry-fixture/commitAuthor';
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -58,7 +59,7 @@ describe('Group > AssignedTo', () => {
         slug: PROJECT_1.slug,
       },
     });
-    event = TestStubs.Event();
+    event = EventFixture();
 
     TeamStore.loadInitialData([TEAM_1]);
     ProjectsStore.loadInitialData([PROJECT_1]);

--- a/static/app/components/group/sentryAppExternalIssueActions.spec.tsx
+++ b/static/app/components/group/sentryAppExternalIssueActions.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 import {SentryApp} from 'sentry-fixture/sentryApp';
 import {SentryAppInstallation} from 'sentry-fixture/sentryAppInstallation';
@@ -45,7 +46,7 @@ describe('SentryAppExternalIssueActions', () => {
   it('renders without an external issue linked', async () => {
     render(
       <SentryAppExternalIssueActions
-        event={TestStubs.Event()}
+        event={EventFixture()}
         organization={Organization()}
         group={group}
         sentryAppInstallation={install}
@@ -89,7 +90,7 @@ describe('SentryAppExternalIssueActions', () => {
     });
     render(
       <SentryAppExternalIssueActions
-        event={TestStubs.Event()}
+        event={EventFixture()}
         organization={Organization()}
         group={group}
         sentryAppInstallation={install}
@@ -131,7 +132,7 @@ describe('SentryAppExternalIssueActions', () => {
     });
     render(
       <SentryAppExternalIssueActions
-        event={TestStubs.Event()}
+        event={EventFixture()}
         organization={Organization()}
         group={group}
         sentryAppInstallation={install}
@@ -171,7 +172,7 @@ describe('SentryAppExternalIssueActions', () => {
   it('renders with an external issue linked', () => {
     render(
       <SentryAppExternalIssueActions
-        event={TestStubs.Event()}
+        event={EventFixture()}
         organization={Organization()}
         group={group}
         sentryAppComponent={component}
@@ -196,7 +197,7 @@ describe('SentryAppExternalIssueActions', () => {
     });
     render(
       <SentryAppExternalIssueActions
-        event={TestStubs.Event()}
+        event={EventFixture()}
         organization={Organization()}
         group={group}
         sentryAppComponent={component}

--- a/static/app/components/group/sentryAppExternalIssueForm.spec.tsx
+++ b/static/app/components/group/sentryAppExternalIssueForm.spec.tsx
@@ -1,4 +1,5 @@
 import selectEvent from 'react-select-event';
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {SentryApp} from 'sentry-fixture/sentryApp';
 import {SentryAppInstallation} from 'sentry-fixture/sentryAppInstallation';
 
@@ -35,7 +36,7 @@ describe('SentryAppExternalIssueForm', () => {
     it('can create a new issue', async () => {
       render(
         <SentryAppExternalIssueForm
-          event={TestStubs.Event()}
+          event={EventFixture()}
           onSubmitSuccess={jest.fn()}
           group={group}
           sentryAppInstallation={sentryAppInstallation}
@@ -87,7 +88,7 @@ describe('SentryAppExternalIssueForm', () => {
     it('renders prepopulated defaults', () => {
       render(
         <SentryAppExternalIssueForm
-          event={TestStubs.Event()}
+          event={EventFixture()}
           onSubmitSuccess={jest.fn()}
           group={group}
           sentryAppInstallation={sentryAppInstallation}
@@ -111,7 +112,7 @@ describe('SentryAppExternalIssueForm', () => {
     it('can link an issue', async () => {
       render(
         <SentryAppExternalIssueForm
-          event={TestStubs.Event()}
+          event={EventFixture()}
           onSubmitSuccess={jest.fn()}
           group={group}
           sentryAppInstallation={sentryAppInstallation}
@@ -174,7 +175,7 @@ describe('SentryAppExternalIssueForm Async Field', () => {
 
     render(
       <SentryAppExternalIssueForm
-        event={TestStubs.Event()}
+        event={EventFixture()}
         onSubmitSuccess={jest.fn()}
         group={group}
         sentryAppInstallation={sentryAppInstallation}
@@ -240,7 +241,7 @@ describe('SentryAppExternalIssueForm Dependent fields', () => {
 
     render(
       <SentryAppExternalIssueForm
-        event={TestStubs.Event()}
+        event={EventFixture()}
         onSubmitSuccess={jest.fn()}
         group={group}
         sentryAppInstallation={sentryAppInstallation}

--- a/static/app/components/groupPreviewTooltip/evidencePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/evidencePreview.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import * as useApi from 'sentry/utils/useApi';
@@ -39,7 +41,7 @@ describe('EvidencePreview', () => {
   });
 
   it('renders the span evidence correctly when request succeeds', async () => {
-    const event = TestStubs.Event({
+    const event = EventFixture({
       occurrence: {
         evidenceDisplay: [
           {name: 'Transaction', value: '/api/0/transaction-test-endpoint/'},

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
@@ -1,18 +1,11 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {EventError} from 'sentry/types';
-import {EntryType, Event, ExceptionType, ExceptionValue, Frame} from 'sentry/types/event';
+import {EntryType, ExceptionType, ExceptionValue, Frame} from 'sentry/types/event';
 
 import {StackTracePreview} from './stackTracePreview';
-
-const makeEvent = (event: Partial<Event> = {}): Event => {
-  const evt: Event = {
-    ...TestStubs.Event(),
-    ...event,
-  };
-
-  return evt;
-};
 
 beforeEach(() => {
   MockApiClient.clearMockResponses();
@@ -38,7 +31,7 @@ describe('StackTracePreview', () => {
   it('warns about no stacktrace', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/123/events/recommended/`,
-      body: makeEvent({id: '456', entries: []}),
+      body: EventFixture({id: '456', entries: []}),
     });
 
     render(<StackTracePreview groupId="123">Preview Trigger</StackTracePreview>);
@@ -105,7 +98,7 @@ describe('StackTracePreview', () => {
 
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/123/events/recommended/`,
-      body: makeEvent(errorEvent),
+      body: EventFixture(errorEvent),
     });
 
     render(<StackTracePreview groupId="123">Preview Trigger</StackTracePreview>, {

--- a/static/app/components/tagsTable.spec.tsx
+++ b/static/app/components/tagsTable.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -10,8 +12,7 @@ describe('tags table', function () {
       {key: 'device.family', value: 'iOS'},
     ];
 
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       tags,
       _meta: {
         tags: {
@@ -22,7 +23,7 @@ describe('tags table', function () {
           },
         },
       },
-    };
+    });
 
     render(
       <TagsTable
@@ -49,8 +50,7 @@ describe('tags table', function () {
       {key: null, value: 'iOS'},
     ];
 
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       tags,
       _meta: {
         tags: {
@@ -61,7 +61,7 @@ describe('tags table', function () {
           },
         },
       },
-    };
+    });
 
     render(
       <TagsTable

--- a/static/app/utils/getStacktraceBody.spec.tsx
+++ b/static/app/utils/getStacktraceBody.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {EventStacktraceMessage} from 'sentry-fixture/eventStacktraceException';
 
 import getStacktraceBody from 'sentry/utils/getStacktraceBody';
@@ -21,7 +22,7 @@ describe('getStacktraceBody', function () {
   });
 
   it('returns empty array for empty event entries', function () {
-    const result = getStacktraceBody(TestStubs.Event({entries: []}));
+    const result = getStacktraceBody(EventFixture({entries: []}));
     expect(result).toEqual([]);
   });
 });

--- a/static/app/views/discover/table/quickContext/eventContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/eventContext.spec.tsx
@@ -1,4 +1,5 @@
 import type {Location} from 'history';
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
@@ -18,15 +19,6 @@ import EventView, {EventData} from 'sentry/utils/discover/eventView';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 
 import EventContext from './eventContext';
-
-const makeEvent = (event: Partial<Event> = {}): Event => {
-  const evt: Event = {
-    ...TestStubs.Event(),
-    ...event,
-  };
-
-  return evt;
-};
 
 const mockedLocation = TestStubs.location({
   query: {
@@ -67,7 +59,7 @@ describe('Quick Context Content: Event ID Column', function () {
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/sentry:6b43e285de834ec5b5fe30d62d549b20/',
-      body: makeEvent({
+      body: EventFixture({
         type: EventOrGroupType.TRANSACTION,
         entries: [],
         endTimestamp: currentTime,
@@ -85,7 +77,7 @@ describe('Quick Context Content: Event ID Column', function () {
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/sentry:6b43e285de834ec5b5fe30d62d549b20/',
-      body: makeEvent({
+      body: EventFixture({
         type: EventOrGroupType.TRANSACTION,
         entries: [],
         endTimestamp: currentTime,
@@ -114,7 +106,7 @@ describe('Quick Context Content: Event ID Column', function () {
     jest.spyOn(ConfigStore, 'get').mockImplementation(() => null);
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/sentry:6b43e285de834ec5b5fe30d62d549b20/',
-      body: makeEvent({type: EventOrGroupType.ERROR, entries: []}),
+      body: EventFixture({type: EventOrGroupType.ERROR, entries: []}),
     });
 
     renderEventContext();
@@ -178,7 +170,7 @@ describe('Quick Context Content: Event ID Column', function () {
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/sentry:6b43e285de834ec5b5fe30d62d549b20/',
-      body: makeEvent(errorEvent),
+      body: EventFixture(errorEvent),
     });
 
     renderEventContext(mockedLocation);

--- a/static/app/views/discover/table/quickContext/quickContextHovercard.spec.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextHovercard.spec.tsx
@@ -1,10 +1,11 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
-import {Event, EventOrGroupType} from 'sentry/types/event';
+import {EventOrGroupType} from 'sentry/types/event';
 import EventView, {EventData} from 'sentry/utils/discover/eventView';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -32,15 +33,6 @@ const renderQuickContextContent = (
     </QueryClientProvider>,
     {organization}
   );
-};
-
-const makeEvent = (event: Partial<Event> = {}): Event => {
-  const evt: Event = {
-    ...TestStubs.Event(),
-    ...event,
-  };
-
-  return evt;
 };
 
 jest.mock('sentry/utils/useLocation');
@@ -170,7 +162,7 @@ describe('Quick Context', function () {
       jest.spyOn(ConfigStore, 'get').mockImplementation(() => null);
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/events/sentry:6b43e285de834ec5b5fe30d62d549b20/',
-        body: makeEvent({type: EventOrGroupType.ERROR, entries: []}),
+        body: EventFixture({type: EventOrGroupType.ERROR, entries: []}),
       });
 
       renderQuickContextContent(defaultRow, ContextType.EVENT);

--- a/static/app/views/discover/utils.spec.tsx
+++ b/static/app/views/discover/utils.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import {Event as EventFixture} from 'sentry-fixture/event';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
@@ -337,7 +338,7 @@ describe('getExpandedResults()', function () {
       fields: [{field: 'count()'}, {field: 'epm()'}, {field: 'eps()'}],
     });
 
-    const result = getExpandedResults(view, {}, TestStubs.Event());
+    const result = getExpandedResults(view, {}, EventFixture());
 
     expect(result.fields).toEqual([{field: 'id', width: -1}]);
   });
@@ -345,7 +346,7 @@ describe('getExpandedResults()', function () {
   it('preserves aggregated fields', () => {
     let view = new EventView(state);
 
-    let result = getExpandedResults(view, {}, TestStubs.Event());
+    let result = getExpandedResults(view, {}, EventFixture());
     // id should be omitted as it is an implicit property on unaggregated results.
     expect(result.fields).toEqual([
       {field: 'timestamp', width: -1},
@@ -367,7 +368,7 @@ describe('getExpandedResults()', function () {
       ],
     });
 
-    result = getExpandedResults(view, {}, TestStubs.Event());
+    result = getExpandedResults(view, {}, EventFixture());
     // id should be omitted as it is an implicit property on unaggregated results.
     expect(result.fields).toEqual([
       {field: 'timestamp', width: -1},
@@ -400,7 +401,7 @@ describe('getExpandedResults()', function () {
       ],
     });
 
-    result = getExpandedResults(view, {}, TestStubs.Event());
+    result = getExpandedResults(view, {}, EventFixture());
     expect(result.fields).toEqual([
       {field: 'timestamp', width: -1},
       {field: 'title'},
@@ -422,7 +423,7 @@ describe('getExpandedResults()', function () {
       ],
     });
 
-    result = getExpandedResults(view, {}, TestStubs.Event());
+    result = getExpandedResults(view, {}, EventFixture());
     expect(result.fields).toEqual([
       {field: 'transaction.duration', width: -1},
       {field: 'measurements.foo', width: -1},
@@ -438,33 +439,33 @@ describe('getExpandedResults()', function () {
       ...state,
       fields: [...state.fields, {field: 'measurements.lcp'}, {field: 'measurements.fcp'}],
     });
-    let result = getExpandedResults(view, {extra: 'condition'}, TestStubs.Event());
+    let result = getExpandedResults(view, {extra: 'condition'}, EventFixture());
     expect(result.query).toEqual('event.type:error extra:condition title:ApiException');
 
     // handles user tag values.
-    result = getExpandedResults(view, {user: 'id:12735'}, TestStubs.Event());
+    result = getExpandedResults(view, {user: 'id:12735'}, EventFixture());
     expect(result.query).toEqual('event.type:error user:id:12735 title:ApiException');
-    result = getExpandedResults(view, {user: 'name:uhoh'}, TestStubs.Event());
+    result = getExpandedResults(view, {user: 'name:uhoh'}, EventFixture());
     expect(result.query).toEqual('event.type:error user:name:uhoh title:ApiException');
 
     // quotes value
-    result = getExpandedResults(view, {extra: 'has space'}, TestStubs.Event());
+    result = getExpandedResults(view, {extra: 'has space'}, EventFixture());
     expect(result.query).toEqual('event.type:error extra:"has space" title:ApiException');
 
     // appends to existing conditions
-    result = getExpandedResults(view, {'event.type': 'csp'}, TestStubs.Event());
+    result = getExpandedResults(view, {'event.type': 'csp'}, EventFixture());
     expect(result.query).toEqual('event.type:csp title:ApiException');
 
     // Includes empty strings
-    result = getExpandedResults(view, {}, TestStubs.Event({id: '0', custom_tag: ''}));
+    result = getExpandedResults(view, {}, EventFixture({id: '0', custom_tag: ''}));
     expect(result.query).toEqual('event.type:error title:ApiException custom_tag:""');
 
     // Includes 0
-    result = getExpandedResults(view, {}, TestStubs.Event({id: '0', custom_tag: 0}));
+    result = getExpandedResults(view, {}, EventFixture({id: '0', custom_tag: 0}));
     expect(result.query).toEqual('event.type:error title:ApiException custom_tag:0');
 
     // Includes null
-    result = getExpandedResults(view, {}, TestStubs.Event({id: '0', custom_tag: null}));
+    result = getExpandedResults(view, {}, EventFixture({id: '0', custom_tag: null}));
     expect(result.query).toEqual('event.type:error title:ApiException custom_tag:""');
 
     // Handles measurements while ignoring null values
@@ -481,7 +482,7 @@ describe('getExpandedResults()', function () {
 
   it('removes any aggregates in either search conditions or extra conditions', () => {
     const view = new EventView({...state, query: 'event.type:error count(id):<10'});
-    const result = getExpandedResults(view, {'count(id)': '>2'}, TestStubs.Event());
+    const result = getExpandedResults(view, {'count(id)': '>2'}, EventFixture());
     expect(result.query).toEqual('event.type:error title:ApiException');
   });
 
@@ -490,14 +491,14 @@ describe('getExpandedResults()', function () {
     const result = getExpandedResults(
       view,
       {extra: 'condition'},
-      TestStubs.Event({title: 'Event title'})
+      EventFixture({title: 'Event title'})
     );
     expect(result.query).toEqual('event.type:error extra:condition title:"Event title"');
   });
 
   it('applies tag key conditions from event data', () => {
     const view = new EventView(state);
-    const event = TestStubs.Event({
+    const event = EventFixture({
       type: 'error',
       tags: [
         {key: 'nope', value: 'nope'},
@@ -512,7 +513,7 @@ describe('getExpandedResults()', function () {
 
   it('generate eventview from an empty eventview', () => {
     const view = EventView.fromLocation(TestStubs.location());
-    const result = getExpandedResults(view, {some_tag: 'value'}, TestStubs.Event());
+    const result = getExpandedResults(view, {some_tag: 'value'}, EventFixture());
     expect(result.fields).toEqual([]);
     expect(result.query).toEqual('some_tag:value');
   });
@@ -557,7 +558,7 @@ describe('getExpandedResults()', function () {
       ...state,
       fields: [...state.fields, {field: 'error.type'}],
     });
-    const event = TestStubs.Event({
+    const event = EventFixture({
       type: 'error',
       tags: [
         {key: 'nope', value: 'nope'},
@@ -592,7 +593,7 @@ describe('getExpandedResults()', function () {
       ...state,
       fields: [{field: 'project'}, {field: 'environment'}, {field: 'title'}],
     });
-    const event = TestStubs.Event({
+    const event = EventFixture({
       title: 'something bad',
       timestamp: '2020-02-13T17:05:46+00:00',
       tags: [
@@ -614,7 +615,7 @@ describe('getExpandedResults()', function () {
       ...state,
       fields: [{field: 'user'}, {field: 'title'}],
     });
-    let event = TestStubs.Event({
+    let event = EventFixture({
       title: 'something bad',
       // user context should be ignored.
       user: {
@@ -626,7 +627,7 @@ describe('getExpandedResults()', function () {
     let result = getExpandedResults(view, {}, event);
     expect(result.query).toEqual('event.type:error user:id:1234 title:"something bad"');
 
-    event = TestStubs.Event({
+    event = EventFixture({
       title: 'something bad',
       tags: [{key: 'user', value: '1234'}],
     });
@@ -639,7 +640,7 @@ describe('getExpandedResults()', function () {
       ...state,
       fields: [{field: 'user'}, {field: 'title'}],
     });
-    const event = TestStubs.Event({
+    const event = EventFixture({
       title: 'something bad',
       user: 'id:1234',
     });
@@ -653,7 +654,7 @@ describe('getExpandedResults()', function () {
       fields: [{field: 'timestamp'}],
       sorts: [{field: 'timestamp', kind: 'desc'}],
     });
-    const event = TestStubs.Event({
+    const event = EventFixture({
       type: 'error',
       timestamp: '2020-02-13T17:05:46+00:00',
     });
@@ -667,7 +668,7 @@ describe('getExpandedResults()', function () {
       ...state,
       query: 'event.type:error title:bogus',
     });
-    const event = TestStubs.Event({
+    const event = EventFixture({
       title: 'bogus',
     });
     const result = getExpandedResults(view, {trace: 'abc123'}, event);
@@ -681,7 +682,7 @@ describe('getExpandedResults()', function () {
       query: '',
       fields: [{field: 'project'}],
     });
-    const event = TestStubs.Event({project: 'whoosh'});
+    const event = EventFixture({project: 'whoosh'});
     const result = getExpandedResults(view, {}, event);
     expect(result.query).toEqual('project:whoosh');
   });
@@ -693,7 +694,7 @@ describe('getExpandedResults()', function () {
       query: '',
       fields: [{field: 'project.name'}],
     });
-    const event = TestStubs.Event({'project.name': 'whoosh'});
+    const event = EventFixture({'project.name': 'whoosh'});
     const result = getExpandedResults(view, {}, event);
     expect(result.query).toEqual('project.name:whoosh');
   });
@@ -706,7 +707,7 @@ describe('getExpandedResults()', function () {
       fields: [{field: 'title'}],
     });
     // needs to be quoted because of whitespace in middle
-    const event = TestStubs.Event({title: 'hello there '});
+    const event = EventFixture({title: 'hello there '});
     const result = getExpandedResults(view, {}, event);
     expect(result.query).toEqual('title:"hello there "');
   });
@@ -720,7 +721,7 @@ describe('getExpandedResults()', function () {
       fields: [{field: 'environment'}],
     });
     expect(view.environment).toEqual([]);
-    const event = TestStubs.Event({environment: 'staging'});
+    const event = EventFixture({environment: 'staging'});
     const result = getExpandedResults(view, {}, event);
     expect(result.environment).toEqual(['staging']);
   });
@@ -733,7 +734,7 @@ describe('getExpandedResults()', function () {
       fields: [{field: 'environment'}],
     });
     expect(view.environment).toEqual(['staging']);
-    const event = TestStubs.Event({environment: 'staging'});
+    const event = EventFixture({environment: 'staging'});
     const result = getExpandedResults(view, {}, event);
     expect(result.environment).toEqual(['staging']);
   });

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -16,7 +18,7 @@ const SAMPLE_EVENT_ALERT_TEXT =
 
 describe('groupDetails', () => {
   const group = TestStubs.Group({issueCategory: IssueCategory.ERROR});
-  const event = TestStubs.Event();
+  const event = EventFixture();
   const project = TestStubs.Project({teams: [TestStubs.Team()]});
 
   const routes = [

--- a/static/app/views/issueDetails/groupEventCarousel.spec.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
@@ -8,7 +9,7 @@ import * as useMedia from 'sentry/utils/useMedia';
 import {GroupEventCarousel} from 'sentry/views/issueDetails/groupEventCarousel';
 
 describe('GroupEventCarousel', () => {
-  const testEvent = TestStubs.Event({
+  const testEvent = EventFixture({
     id: 'event-id',
     size: 7,
     dateCreated: '2019-03-20T00:00:00.000Z',

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -2,6 +2,7 @@ import {browserHistory, InjectedRouter} from 'react-router';
 import {Location} from 'history';
 import {Commit} from 'sentry-fixture/commit';
 import {CommitAuthor} from 'sentry-fixture/commitAuthor';
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {SentryApp} from 'sentry-fixture/sentryApp';
 import {SentryAppComponent} from 'sentry-fixture/sentryAppComponent';
 
@@ -42,7 +43,7 @@ const makeDefaultMockData = (
         },
       }),
     }),
-    event: TestStubs.Event({
+    event: EventFixture({
       size: 1,
       dateCreated: '2019-03-20T00:00:00.000Z',
       errors: [],
@@ -335,7 +336,7 @@ describe('groupEventDetails', () => {
       props.organization,
       props.project,
       props.group,
-      TestStubs.Event({
+      EventFixture({
         size: 1,
         dateCreated: '2019-03-20T00:00:00.000Z',
         errors: [],
@@ -361,7 +362,7 @@ describe('groupEventDetails', () => {
       issueCategory: IssueCategory.PERFORMANCE,
       issueType: IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
     });
-    const transaction = TestStubs.Event({
+    const transaction = EventFixture({
       entries: [{type: EntryType.SPANS, data: []}],
     });
 
@@ -369,7 +370,7 @@ describe('groupEventDetails', () => {
       props.organization,
       props.project,
       props.group,
-      TestStubs.Event({
+      EventFixture({
         size: 1,
         dateCreated: '2019-03-20T00:00:00.000Z',
         errors: [],
@@ -404,7 +405,7 @@ describe('groupEventDetails', () => {
       issueCategory: IssueCategory.PERFORMANCE,
       issueType: IssueType.PROFILE_FILE_IO_MAIN_THREAD,
     });
-    const transaction = TestStubs.Event({
+    const transaction = EventFixture({
       entries: [],
       occurrence: {
         evidenceDisplay: [],
@@ -419,7 +420,7 @@ describe('groupEventDetails', () => {
       props.organization,
       props.project,
       props.group,
-      TestStubs.Event({
+      EventFixture({
         size: 1,
         dateCreated: '2019-03-20T00:00:00.000Z',
         errors: [],
@@ -462,14 +463,14 @@ describe('EventCause', () => {
   it('renders suspect commit', async function () {
     const props = makeDefaultMockData(
       undefined,
-      TestStubs.Project({firstEvent: TestStubs.Event()})
+      TestStubs.Project({firstEvent: EventFixture()})
     );
 
     mockGroupApis(
       props.organization,
       props.project,
       props.group,
-      TestStubs.Event({
+      EventFixture({
         size: 1,
         dateCreated: '2019-03-20T00:00:00.000Z',
         errors: [],
@@ -529,7 +530,7 @@ describe('Platform Integrations', () => {
       props.organization,
       props.project,
       props.group,
-      TestStubs.Event({
+      EventFixture({
         size: 1,
         dateCreated: '2019-03-20T00:00:00.000Z',
         errors: [],

--- a/static/app/views/issueDetails/groupSidebar.spec.tsx
+++ b/static/app/views/issueDetails/groupSidebar.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Tags} from 'sentry-fixture/tags';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -92,7 +93,7 @@ describe('GroupSidebar', function () {
           group={group}
           project={project}
           organization={organization}
-          event={TestStubs.Event()}
+          event={EventFixture()}
           environments={[environment]}
         />
       );
@@ -109,7 +110,7 @@ describe('GroupSidebar', function () {
           group={group}
           project={project}
           organization={organization}
-          event={TestStubs.Event()}
+          event={EventFixture()}
           environments={[environment]}
         />
       );
@@ -129,7 +130,7 @@ describe('GroupSidebar', function () {
           group={group}
           project={project}
           organization={organization}
-          event={TestStubs.Event()}
+          event={EventFixture()}
           environments={[environment]}
         />
       );
@@ -140,7 +141,7 @@ describe('GroupSidebar', function () {
           group={group}
           project={project}
           organization={organization}
-          event={TestStubs.Event()}
+          event={EventFixture()}
           environments={[stagingEnv]}
         />
       );
@@ -177,7 +178,7 @@ describe('GroupSidebar', function () {
           group={group}
           project={project}
           organization={organization}
-          event={TestStubs.Event()}
+          event={EventFixture()}
           environments={[environment]}
         />
       );
@@ -215,7 +216,7 @@ describe('GroupSidebar', function () {
         }}
         project={project}
         organization={org}
-        event={TestStubs.Event()}
+        event={EventFixture()}
         environments={[]}
       />,
       {
@@ -254,7 +255,7 @@ describe('GroupSidebar', function () {
             ...organization,
             features: [...organization.features, 'issue-details-tag-improvements'],
           }}
-          event={TestStubs.Event()}
+          event={EventFixture()}
           environments={[environment]}
         />
       );
@@ -273,7 +274,7 @@ describe('GroupSidebar', function () {
             ...organization,
             features: [...organization.features, 'issue-details-tag-improvements'],
           }}
-          event={TestStubs.Event()}
+          event={EventFixture()}
           environments={[environment]}
         />
       );

--- a/static/app/views/issueDetails/quickTrace/index.spec.tsx
+++ b/static/app/views/issueDetails/quickTrace/index.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render} from 'sentry-test/reactTestingLibrary';
@@ -7,7 +8,7 @@ import QuickTrace from 'sentry/views/issueDetails/quickTrace';
 describe('IssueQuickTrace', () => {
   const defaultProps = {
     organization: Organization({features: ['performance-view']}),
-    event: TestStubs.Event({contexts: {trace: {trace_id: 100}}}),
+    event: EventFixture({contexts: {trace: {trace_id: 100}}}),
     group: TestStubs.Group(),
     location: TestStubs.location(),
   };
@@ -22,7 +23,7 @@ describe('IssueQuickTrace', () => {
 
   it('renders nothing if event does not have a trace context', () => {
     const {container} = render(
-      <QuickTrace {...defaultProps} event={TestStubs.Event({contexts: {}})} />
+      <QuickTrace {...defaultProps} event={EventFixture({contexts: {}})} />
     );
 
     expect(container).toBeEmptyDOMElement();

--- a/static/app/views/monitors/utils/getTimeRangeFromEvent.spec.tsx
+++ b/static/app/views/monitors/utils/getTimeRangeFromEvent.spec.tsx
@@ -1,8 +1,10 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {getTimeRangeFromEvent} from './getTimeRangeFromEvent';
 
 describe('getTimeRangeFromEvent', function () {
   it('correctly creates a centered 24h time window', function () {
-    const event = TestStubs.Event({dateReceived: '2023-07-26T09:00:00Z'});
+    const event = EventFixture({dateReceived: '2023-07-26T09:00:00Z'});
     const now = new Date('2023-07-27T11:00:00Z');
 
     const {start, end} = getTimeRangeFromEvent(event, now, '24h');
@@ -12,7 +14,7 @@ describe('getTimeRangeFromEvent', function () {
   });
 
   it('falls back to last 24h if the event cannot be centered', function () {
-    const event = TestStubs.Event({dateReceived: '2023-07-27T09:00:00Z'});
+    const event = EventFixture({dateReceived: '2023-07-27T09:00:00Z'});
     const now = new Date('2023-07-27T11:00:00Z');
 
     const {start, end} = getTimeRangeFromEvent(event, now, '24h');

--- a/static/app/views/performance/transactionDetails/eventMetas.spec.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -6,11 +7,10 @@ import EventMetas from './eventMetas';
 
 describe('EventMetas', () => {
   it('Displays event created and received dates when hovering', async () => {
-    const event = {
-      ...TestStubs.Event(),
+    const event = EventFixture({
       dateReceived: '2017-05-21T18:01:48.762Z',
       dateCreated: '2017-05-21T18:02:48.762Z',
-    };
+    });
     const routerContext = TestStubs.routerContext([]);
     const organization = Organization({});
     MockApiClient.addMockResponse({

--- a/static/app/views/performance/transactionDetails/index.spec.tsx
+++ b/static/app/views/performance/transactionDetails/index.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
@@ -40,7 +41,7 @@ describe('EventDetails', () => {
   });
 
   it('renders alert for sample transaction', async () => {
-    const event = TestStubs.Event();
+    const event = EventFixture();
     event.tags.push({key: 'sample_event', value: 'yes'});
 
     MockApiClient.addMockResponse({
@@ -64,7 +65,7 @@ describe('EventDetails', () => {
   });
 
   it('does not reender alert if already received transaction', async () => {
-    const event = TestStubs.Event();
+    const event = EventFixture();
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/latest/`,

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.spec.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
@@ -11,7 +13,7 @@ describe('QuickTraceMeta', function () {
   const routerContext = TestStubs.routerContext();
   const location = routerContext.context.location;
   const project = TestStubs.Project({platform: 'javascript'});
-  const event = TestStubs.Event({contexts: {trace: {trace_id: 'a'.repeat(32)}}});
+  const event = EventFixture({contexts: {trace: {trace_id: 'a'.repeat(32)}}});
   const emptyQuickTrace: QuickTraceQueryChildrenProps = {
     isLoading: false,
     error: null,
@@ -132,7 +134,7 @@ describe('QuickTraceMeta', function () {
   });
 
   it('renders missing trace when trace id is not present', function () {
-    const newEvent = TestStubs.Event();
+    const newEvent = EventFixture();
     render(
       <QuickTraceMeta
         event={newEvent}
@@ -152,7 +154,7 @@ describe('QuickTraceMeta', function () {
   });
 
   it('renders missing trace with hover card when feature disabled', async function () {
-    const newEvent = TestStubs.Event();
+    const newEvent = EventFixture();
     render(
       <QuickTraceMeta
         event={newEvent}
@@ -184,7 +186,7 @@ describe('QuickTraceMeta', function () {
 
   it('does not render when platform does not support tracing', function () {
     const newProject = TestStubs.Project();
-    const newEvent = TestStubs.Event();
+    const newEvent = EventFixture();
     const result = render(
       <QuickTraceMeta
         event={newEvent}

--- a/static/app/views/settings/project/projectOwnership/modal.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/modal.spec.tsx
@@ -1,3 +1,4 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
 import {EventEntryStacktrace} from 'sentry-fixture/eventEntryStacktrace';
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
@@ -13,7 +14,7 @@ describe('Project Ownership', () => {
   const project = TestStubs.Project();
   const issueId = '1234';
   const stacktrace = EventEntryStacktrace();
-  const event = TestStubs.Event({
+  const event = EventFixture({
     entries: [stacktrace],
   });
   const user = TestStubs.User();

--- a/static/app/views/sharedGroupDetails/index.spec.tsx
+++ b/static/app/views/sharedGroupDetails/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Event as EventFixture} from 'sentry-fixture/event';
+
 import {render} from 'sentry-test/reactTestingLibrary';
 
 import {RouteContext} from 'sentry/views/routeContext';
@@ -14,7 +16,7 @@ describe('SharedGroupDetails', function () {
       url: '/organizations/org-slug/shared/issues/a/',
       body: TestStubs.Group({
         title: 'ZeroDivisionError',
-        latestEvent: TestStubs.Event({
+        latestEvent: EventFixture({
           entries: [eventEntry, exception],
         }),
         project: TestStubs.Project({organization: {slug: 'test-org'}}),
@@ -24,7 +26,7 @@ describe('SharedGroupDetails', function () {
       url: '/shared/issues/a/',
       body: TestStubs.Group({
         title: 'ZeroDivisionError',
-        latestEvent: TestStubs.Event({
+        latestEvent: EventFixture({
           entries: [eventEntry, exception],
         }),
         project: TestStubs.Project({organization: {slug: 'test-org'}}),


### PR DESCRIPTION
We're trying to kill the TestStubs.* imports, this moves things along.

See: https://github.com/getsentry/frontend-tsc/issues/49