### PR TITLE
dev: opt-in to `devenv` with SENTRY_DEVENV_BETA

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -189,6 +189,8 @@ make setup-git-config
 
 ### Python ###
 
+venv_name=".venv"
+
 # Use requirements-dev.txt to decide when to cut over to `devenv` tooling.
 # This also provides us with a clean-cut rollback procedure.
 if [ -n "$SENTRY_DEVENV_BETA" ] || grep -Eq "^devenv($|>)" requirements-dev.txt; then
@@ -196,18 +198,14 @@ if [ -n "$SENTRY_DEVENV_BETA" ] || grep -Eq "^devenv($|>)" requirements-dev.txt;
     echo "Using devenv."
     export SENTRY_DEVENV_HOME="${SENTRY_DEVENV_HOME:-$XDG_DATA_HOME/sentry-devenv}"
     PATH_add "${SENTRY_DEVENV_HOME}/bin"
-    venv_name="${SENTRY_DEVENV_HOME}/virtualenvs/sentry"
     if ! command -v devenv >/dev/null; then
       die '
 Please install the `devenv` tool:
     https://github.com/getsentry/devenv#install
 '
-    elif [ ! -f "${venv_name}/bin/activate" ]; then
-        devenv sync
-    fi
+    devenv sync
 else
     # Old and busted. (but currently working)
-    venv_name=".venv"
     if [ ! -f "${venv_name}/bin/activate" ]; then
         prompt_python_venv_creation
         # This is time consuming but it has to be done

--- a/.envrc
+++ b/.envrc
@@ -191,16 +191,9 @@ make setup-git-config
 
 # Use requirements-dev.txt to decide when to cut over to `devenv` tooling.
 # This also provides us with a clean-cut rollback procedure.
-if ! grep -Eq "^devenv($|>)" requirements-dev.txt; then
-    # Old and busted. (but currently working)
-    venv_name=".venv"
-    if [ ! -f "${venv_name}/bin/activate" ]; then
-        prompt_python_venv_creation
-        # This is time consuming but it has to be done
-        source "${SENTRY_ROOT}/scripts/bootstrap-py3-venv"
-    fi
-else
+if [ -n "$SENTRY_DEVENV_BETA" ] || grep -Eq "^devenv($|>)" requirements-dev.txt; then
     # The new hotness. (but not ready yet)
+    echo "Using devenv."
     export SENTRY_DEVENV_HOME="${SENTRY_DEVENV_HOME:-$XDG_DATA_HOME/sentry-devenv}"
     PATH_add "${SENTRY_DEVENV_HOME}/bin"
     venv_name="${SENTRY_DEVENV_HOME}/virtualenvs/sentry"
@@ -211,6 +204,14 @@ Please install the `devenv` tool:
 '
     elif [ ! -f "${venv_name}/bin/activate" ]; then
         devenv sync
+    fi
+else
+    # Old and busted. (but currently working)
+    venv_name=".venv"
+    if [ ! -f "${venv_name}/bin/activate" ]; then
+        prompt_python_venv_creation
+        # This is time consuming but it has to be done
+        source "${SENTRY_ROOT}/scripts/bootstrap-py3-venv"
     fi
 fi
 


### PR DESCRIPTION
Gonna be beta testing with a select few - they'll toggle opt-in status with SENTRY_DEVENV_BETA.

For release we'll put it in requirements-dev.txt.