### PR TITLE
feat(relay): Introduce options to global config

### DIFF
--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -64,6 +64,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
 
         if version == "3" and request.relay_request_data.get("global"):
             response["global"] = get_global_config()
+            response["global_status"] = "ready"
 
         if self._should_post_or_schedule(version, request):
             # Always compute the full config. It's invalid to send partial

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -23,9 +23,8 @@ def get_global_config():
 
     options = dict()
     for option in RELAY_OPTIONS:
-        value = sentry.options.get(option)
-        if value is not None:
-            options[option] = value
+        if (value := sentry.options.get(option)) is not None:
+                options[option] = value
 
     if options:
         global_config["options"] = options

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -24,7 +24,7 @@ def get_global_config():
     options = dict()
     for option in RELAY_OPTIONS:
         if (value := sentry.options.get(option)) is not None:
-                options[option] = value
+            options[option] = value
 
     if options:
         global_config["options"] = options

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -1,10 +1,20 @@
+import sentry.options
 from sentry.relay.config.measurements import get_measurements_config
 from sentry.utils import metrics
+
+# List of options to include in the global config.
+RELAY_OPTIONS = []
 
 
 @metrics.wraps("relay.globalconfig.get")
 def get_global_config():
     """Return the global configuration for Relay."""
+
+    options = dict()
+    for option in RELAY_OPTIONS:
+        options[option] = sentry.options.get(option)
+
     return {
         "measurements": get_measurements_config(),
+        "options": options,
     }

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -24,7 +24,7 @@ def get_global_config():
     options = dict()
     for option in RELAY_OPTIONS:
         value = sentry.options.get(option)
-        if value:
+        if value is not None:
             options[option] = value
 
     if options:

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v3.py
@@ -189,4 +189,5 @@ def test_return_project_and_global_config(
         "configs": {default_projectkey.public_key: {"is_mock_config": True}},
         "pending": [],
         "global": {"global_mock_config": True},
+        "global_status": "ready",
     }


### PR DESCRIPTION
Setup infrastructure to add options to the global config, also update the global config endpoint to signal relay the global config is fully ready.

Relay PR: https://github.com/getsentry/relay/pull/2813