### PR TITLE
fix(ddm): Rework logic for aggregate translation in alerts

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -4,6 +4,7 @@ from typing import Any, List, Mapping, Optional
 
 from django.utils import timezone
 
+from sentry import features
 from sentry.api import client
 from sentry.api.base import logger
 from sentry.api.serializers import serialize
@@ -191,7 +192,12 @@ def build_metric_alert_chart(
         ),
     }
 
-    aggregate = translate_aggregate_field(snuba_query.aggregate, reverse=True)
+    allow_mri = features.has(
+        "organizations:ddm-experimental",
+        organization,
+        actor=user,
+    )
+    aggregate = translate_aggregate_field(snuba_query.aggregate, reverse=True, allow_mri=allow_mri)
     # If we allow alerts to be across multiple orgs this will break
     first_subscription_or_none = snuba_query.subscriptions.first()
     if first_subscription_or_none is None:

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1546,15 +1546,14 @@ def get_column_from_aggregate_with_mri(aggregate):
 
 
 def check_aggregate_column_support(aggregate, allow_mri=False):
+    # TODO(ddm): remove `allow_mri` once the experimental feature flag is removed.
     column = get_column_from_aggregate(aggregate, allow_mri)
-    if is_mri(column) and allow_mri:
-        return True
-
     return (
         column is None
         or is_measurement(column)
         or column in SUPPORTED_COLUMNS
         or column in TRANSLATABLE_COLUMNS
+        or (is_mri(column) and allow_mri)
     )
 
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -43,7 +43,7 @@ from sentry.models.notificationaction import ActionService, ActionTarget
 from sentry.models.project import Project
 from sentry.relay.config.metric_extraction import on_demand_metrics_feature_flags
 from sentry.search.events.builder import QueryBuilder
-from sentry.search.events.fields import resolve_field
+from sentry.search.events.fields import is_function, resolve_field
 from sentry.services.hybrid_cloud.app import RpcSentryAppInstallation, app_service
 from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
 from sentry.services.hybrid_cloud.integration.model import RpcOrganizationIntegration
@@ -61,7 +61,7 @@ from sentry.snuba.entity_subscription import (
     get_entity_subscription_from_snuba_query,
 )
 from sentry.snuba.metrics.extraction import should_use_on_demand_metrics
-from sentry.snuba.metrics.naming_layer.mri import is_mri
+from sentry.snuba.metrics.naming_layer.mri import get_available_operations, is_mri, parse_mri
 from sentry.snuba.models import SnubaQuery
 from sentry.snuba.subscriptions import (
     bulk_create_snuba_subscriptions,
@@ -1512,26 +1512,54 @@ TRANSLATABLE_COLUMNS = {
 }
 
 
-def get_column_from_aggregate(aggregate):
+def get_column_from_aggregate(aggregate, allow_mri):
+    if allow_mri:
+        mri_column = get_column_from_aggregate_with_mri(aggregate)
+        # Only if the column was allowed, we return it, otherwise we fallback to the old logic.
+        if mri_column:
+            return mri_column
+
     function = resolve_field(aggregate)
     if function.aggregate is not None:
         return function.aggregate[1]
+
     return None
 
 
+def get_column_from_aggregate_with_mri(aggregate):
+    match = is_function(aggregate)
+    if match is None:
+        return None
+
+    function = match.group("function")
+    columns = match.group("columns")
+
+    parsed_mri = parse_mri(columns)
+    if parsed_mri is None:
+        return None
+
+    available_ops = set(get_available_operations(parsed_mri))
+    if function not in available_ops:
+        return None
+
+    return columns
+
+
 def check_aggregate_column_support(aggregate, allow_mri=False):
-    column = get_column_from_aggregate(aggregate)
+    column = get_column_from_aggregate(aggregate, allow_mri)
+    if is_mri(column) and allow_mri:
+        return True
+
     return (
         column is None
         or is_measurement(column)
-        or (is_mri(column) and allow_mri)
         or column in SUPPORTED_COLUMNS
         or column in TRANSLATABLE_COLUMNS
     )
 
 
-def translate_aggregate_field(aggregate, reverse=False):
-    column = get_column_from_aggregate(aggregate)
+def translate_aggregate_field(aggregate, reverse=False, allow_mri=False):
+    column = get_column_from_aggregate(aggregate, allow_mri)
     if not reverse:
         if column in TRANSLATABLE_COLUMNS:
             return aggregate.replace(column, TRANSLATABLE_COLUMNS[column])

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -135,13 +135,13 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         return query
 
     def validate_aggregate(self, aggregate):
-        try:
-            allow_mri = features.has(
-                "organizations:ddm-experimental",
-                self.context["organization"],
-                actor=self.context.get("user", None),
-            )
+        allow_mri = features.has(
+            "organizations:ddm-experimental",
+            self.context["organization"],
+            actor=self.context.get("user", None),
+        )
 
+        try:
             if not check_aggregate_column_support(
                 aggregate,
                 allow_mri=allow_mri,
@@ -151,7 +151,8 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                 )
         except InvalidSearchQuery as e:
             raise serializers.ValidationError(f"Invalid Metric: {e}")
-        return translate_aggregate_field(aggregate)
+
+        return translate_aggregate_field(aggregate, allow_mri=True)
 
     def validate_query_type(self, query_type):
         try:
@@ -259,7 +260,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             self.context["organization"],
             actor=self.context.get("user", None),
         ):
-            column = get_column_from_aggregate(data["aggregate"])
+            column = get_column_from_aggregate(data["aggregate"], allow_mri=True)
             if is_mri(column) and dataset != Dataset.PerformanceMetrics:
                 raise serializers.ValidationError(
                     "You can use an MRI only on alerts on performance metrics"

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -152,7 +152,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         except InvalidSearchQuery as e:
             raise serializers.ValidationError(f"Invalid Metric: {e}")
 
-        return translate_aggregate_field(aggregate, allow_mri=True)
+        return translate_aggregate_field(aggregate, allow_mri=allow_mri)
 
     def validate_query_type(self, query_type):
         try:

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -780,10 +780,11 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
             ]
         ):
             for mri in (
-                # "sum(c:transactions/count_per_root_project@none)",
+                "sum(c:transactions/count_per_root_project@none)",
                 "p90(d:transactions/duration@millisecond)",
-                # "count_unique(s:transactions/user@none)",
-                # "avg(d:custom/sentry.process_profile.symbolicate.process@second)",
+                "p95(d:transactions/duration@millisecond)",
+                "count_unique(s:transactions/user@none)",
+                "avg(d:custom/sentry.process_profile.symbolicate.process@second)",
             ):
                 test_params = {
                     **self.alert_rule_dict,

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -780,10 +780,10 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
             ]
         ):
             for mri in (
-                "sum(c:transactions/count_per_root_project@none)",
-                "p95(d:transactions/duration@millisecond)",
-                "count_unique(s:transactions/user@none)",
-                "avg(d:custom/sentry.process_profile.symbolicate.process@second)",
+                # "sum(c:transactions/count_per_root_project@none)",
+                "p90(d:transactions/duration@millisecond)",
+                # "count_unique(s:transactions/user@none)",
+                # "avg(d:custom/sentry.process_profile.symbolicate.process@second)",
             ):
                 test_params = {
                     **self.alert_rule_dict,


### PR DESCRIPTION
This PR improves the implementation of the aggregate translations and checks which are used in alerts to validate queries.

The only small problem with the PR is that the feature flag check inside `build_metric_alert_chart` is not always getting `user` thus it might not behave correctly when testing new custom alerts when scoped to users. However, the translation code in `translate_aggregate_field` which requires the boolean flag, is not doing anything special for mri-based aggregates, so we should not have any problems.