### PR TITLE
ref(feedback): Call `getIntegration` directly on hub

### DIFF
--- a/static/app/components/feedback/widget/feedbackWidget.tsx
+++ b/static/app/components/feedback/widget/feedbackWidget.tsx
@@ -1,6 +1,6 @@
 import {useEffect} from 'react';
 import {css, Global} from '@emotion/react';
-import {BrowserClient, getCurrentHub} from '@sentry/react';
+import {getCurrentHub} from '@sentry/react';
 import {Feedback} from '@sentry-internal/feedback';
 
 import ConfigStore from 'sentry/stores/configStore';
@@ -16,8 +16,7 @@ export default function FeedbackWidget() {
 
   useEffect(() => {
     const hub = getCurrentHub();
-    const client = hub && hub.getClient<BrowserClient>();
-    const feedback = client?.getIntegration(Feedback);
+    const feedback = hub.getIntegration(Feedback);
     const widget = feedback?.createWidget({
       colorScheme: widgetTheme,
       buttonLabel: 'Give Feedback',

--- a/static/app/components/profiling/profilingFeedbackButton.tsx
+++ b/static/app/components/profiling/profilingFeedbackButton.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useRef} from 'react';
-import {BrowserClient, getCurrentHub} from '@sentry/react';
+import {getCurrentHub} from '@sentry/react';
 import {Feedback} from '@sentry-internal/feedback';
 
 import {Button} from 'sentry/components/button';
@@ -12,8 +12,7 @@ function ProfilingFeedbackButton() {
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const config = useLegacyStore(ConfigStore);
   const hub = getCurrentHub();
-  const client = hub.getClient<BrowserClient>();
-  const feedback = client?.getIntegration(Feedback);
+  const feedback = hub.getIntegration(Feedback);
 
   useEffect(() => {
     if (!buttonRef.current || !feedback) {

--- a/static/app/views/monitors/components/cronsFeedbackButton.tsx
+++ b/static/app/views/monitors/components/cronsFeedbackButton.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useRef} from 'react';
-import {BrowserClient, getCurrentHub} from '@sentry/react';
+import {getCurrentHub} from '@sentry/react';
 import {Feedback} from '@sentry-internal/feedback';
 
 import {Button} from 'sentry/components/button';
@@ -13,8 +13,7 @@ function CronsFeedbackButton() {
   const title = 'Give Feedback';
   const widgetTheme = config.theme === 'dark' ? 'dark' : 'light';
   const hub = getCurrentHub();
-  const client = hub && hub.getClient<BrowserClient>();
-  const feedback = client?.getIntegration(Feedback);
+  const feedback = hub.getIntegration(Feedback);
 
   useEffect(() => {
     const widget =


### PR DESCRIPTION
...instead of on client
