### PR TITLE
ref: upgrade the runtime version of setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ filterwarnings = [
     # Consider all warnings to be errors other than the ignored ones.
     "error",
 
+    # a bunch of google packages use legacy namespace packages
+    "ignore:pkg_resources is deprecated as an API",
+    "ignore:Deprecated call to `pkg_resources.declare_namespace\\('google.*'\\)`.",
+
     # The following warning filters are for pytest only.
     # This is so we don't have to wrap most datetime objects in testing code
     # with django.utils.timezone.

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -236,4 +236,4 @@ zstandard==0.18.0
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==22.1.2
-setuptools==56.0.0
+setuptools==68.2.2

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -148,4 +148,4 @@ xmlsec==1.3.13
 zstandard==0.18.0
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==56.0.0
+setuptools==68.2.2


### PR DESCRIPTION
build-time is still held back due to broken editable installs (used by getsentry)

this unblocks some 3.11 changes

<!-- Describe your PR here. -->