### PR TITLE
chore(ggg): Reduce threshold for query source

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3031,7 +3031,6 @@ SENTRY_SDK_CONFIG: ServerSdkConfig = {
     "send_default_pii": True,
     "auto_enabling_integrations": False,
     "enable_db_query_source": True,
-    "db_query_source_threshold_ms": 500,
 }
 
 SENTRY_DEV_DSN = os.environ.get("SENTRY_DEV_DSN")


### PR DESCRIPTION
Query sources are only added for _slow_ queries. I conservatively set the threshold to 500ms just out of caution. This PR removes the threshold, which drops down to the default value of 100ms.
