### PR TITLE
fix(perf): Re-enable React profiler

### DIFF
--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, ReactNode, useEffect, useRef} from 'react';
+import {Fragment, Profiler, ReactNode, useEffect, useRef} from 'react';
 import {captureMessage, setExtra, setTag} from '@sentry/react';
 import * as Sentry from '@sentry/react';
 import {IdleTransaction} from '@sentry/tracing';
@@ -24,9 +24,8 @@ const ASSET_OUTLIER_VALUE = 1_000_000_000; // Assets over 1GB are ignored since 
 const VCD_START = 'vcd-start';
 const VCD_END = 'vcd-end';
 
-export function Profiler(props: {children: React.ReactNode; id: string; onRender: any}) {
-  return <Fragment>{props.children}</Fragment>;
-}
+// This re-export makes it possible to stub out the Profiler globally if required
+export {Profiler};
 
 /**
  * It depends on where it is called but the way we fetch transactions can be empty despite an ongoing transaction existing.


### PR DESCRIPTION
Replace the no-op stub with the real profiler from React. We stubbed this out in https://github.com/getsentry/sentry/pull/60712/ because we thought this might be causing `RangeError` in Chrome 120.0.0, but that wasn't the case.
