### PR TITLE
Threshold status releases index

### DIFF
--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -592,7 +592,9 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
 
           <Layout.Body>
             <Layout.Main fullWidth>
-              <ReleaseFeedbackBanner />
+              {organization.features.includes('releases-v2-banner') && (
+                <ReleaseFeedbackBanner />
+              )}
               {JSON.stringify(this.state.thresholdStatuses)}
 
               {this.renderHealthCta()}

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -77,7 +77,7 @@ type Props = RouteComponentProps<RouteParams, {}> & {
 
 type State = {
   releases: Release[];
-  thresholdStatuses?: ThresholdStatus[];
+  thresholdStatuses?: {[key: string]: ThresholdStatus[]};
 } & DeprecatedAsyncView['state'];
 
 class ReleasesList extends DeprecatedAsyncView<Props, State> {
@@ -176,13 +176,6 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
       this.setState({thresholdStatuses});
     });
   }
-
-  getThresholdsByProject = () => {
-    const thresholdStatuses = this.state.thresholdStatuses;
-    // Key by project + release version
-    // Then filter by environment
-    // threshold statuses already key'd by proj-env-release
-  };
 
   getQuery() {
     const {query} = this.props.location.query;
@@ -549,28 +542,22 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
                 />
               )}
 
-              {releases.map((release, index) => {
-                console.log('release: ', release);
-                // const thresholds = Object.values(thresholdStatuses).filter(threshold => threshold.)
-                // threshold statuses - if multiple thresholds, they'll be bucketed under proj-env-release
-                //
-                return (
-                  <ReleaseCard
-                    key={`${release.version}-${release.projects[0].slug}`}
-                    activeDisplay={activeDisplay}
-                    release={release}
-                    organization={organization}
-                    location={location}
-                    selection={selection}
-                    reloading={reloading}
-                    showHealthPlaceholders={isHealthLoading}
-                    isTopRelease={index === 0}
-                    getHealthData={getHealthData}
-                    showReleaseAdoptionStages={showReleaseAdoptionStages}
-                    thresholdStatuses={thresholdStatuses}
-                  />
-                );
-              })}
+              {releases.map((release, index) => (
+                <ReleaseCard
+                  key={`${release.projects[0].slug}-${release.version}`}
+                  activeDisplay={activeDisplay}
+                  release={release}
+                  organization={organization}
+                  location={location}
+                  selection={selection}
+                  reloading={reloading}
+                  showHealthPlaceholders={isHealthLoading}
+                  isTopRelease={index === 0}
+                  getHealthData={getHealthData}
+                  showReleaseAdoptionStages={showReleaseAdoptionStages}
+                  thresholdStatuses={thresholdStatuses || {}}
+                />
+              ))}
               <Pagination pageLinks={releasesPageLinks} />
             </Fragment>
           );
@@ -609,7 +596,7 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
               {organization.features.includes('releases-v2-banner') && (
                 <ReleaseFeedbackBanner />
               )}
-              {/* TODO remove */}
+              {/* TODO: REMOVE THIS */}
               {JSON.stringify(this.state.thresholdStatuses)}
 
               {this.renderHealthCta()}

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -596,8 +596,6 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
               {organization.features.includes('releases-v2-banner') && (
                 <ReleaseFeedbackBanner />
               )}
-              {/* TODO: REMOVE THIS */}
-              {JSON.stringify(this.state.thresholdStatuses)}
 
               {this.renderHealthCta()}
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -177,6 +177,13 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
     });
   }
 
+  getThresholdsByProject = () => {
+    const thresholdStatuses = this.state.thresholdStatuses;
+    // Key by project + release version
+    // Then filter by environment
+    // threshold statuses already key'd by proj-env-release
+  };
+
   getQuery() {
     const {query} = this.props.location.query;
 
@@ -494,7 +501,7 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
     showReleaseAdoptionStages: boolean
   ) {
     const {location, selection, organization, router} = this.props;
-    const {releases, reloading, releasesPageLinks} = this.state;
+    const {releases, reloading, releasesPageLinks, thresholdStatuses} = this.state;
 
     const selectedProject = this.getSelectedProject();
     const hasReleasesSetup = selectedProject?.features.includes('releases');
@@ -542,21 +549,28 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
                 />
               )}
 
-              {releases.map((release, index) => (
-                <ReleaseCard
-                  key={`${release.version}-${release.projects[0].slug}`}
-                  activeDisplay={activeDisplay}
-                  release={release}
-                  organization={organization}
-                  location={location}
-                  selection={selection}
-                  reloading={reloading}
-                  showHealthPlaceholders={isHealthLoading}
-                  isTopRelease={index === 0}
-                  getHealthData={getHealthData}
-                  showReleaseAdoptionStages={showReleaseAdoptionStages}
-                />
-              ))}
+              {releases.map((release, index) => {
+                console.log('release: ', release);
+                // const thresholds = Object.values(thresholdStatuses).filter(threshold => threshold.)
+                // threshold statuses - if multiple thresholds, they'll be bucketed under proj-env-release
+                //
+                return (
+                  <ReleaseCard
+                    key={`${release.version}-${release.projects[0].slug}`}
+                    activeDisplay={activeDisplay}
+                    release={release}
+                    organization={organization}
+                    location={location}
+                    selection={selection}
+                    reloading={reloading}
+                    showHealthPlaceholders={isHealthLoading}
+                    isTopRelease={index === 0}
+                    getHealthData={getHealthData}
+                    showReleaseAdoptionStages={showReleaseAdoptionStages}
+                    thresholdStatuses={thresholdStatuses}
+                  />
+                );
+              })}
               <Pagination pageLinks={releasesPageLinks} />
             </Fragment>
           );
@@ -595,6 +609,7 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
               {organization.features.includes('releases-v2-banner') && (
                 <ReleaseFeedbackBanner />
               )}
+              {/* TODO remove */}
               {JSON.stringify(this.state.thresholdStatuses)}
 
               {this.renderHealthCta()}

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -56,7 +56,6 @@ type Props = {
   showReleaseAdoptionStages: boolean;
 };
 
-// TODO: change to functional component
 function ReleaseCard({
   release,
   organization,

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -18,6 +18,7 @@ import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization, PageFilters, Release} from 'sentry/types';
 
+import {ThresholdStatus} from '../../utils/types';
 import {ReleasesDisplayOption} from '../releasesDisplayOptions';
 import {ReleasesRequestRenderProps} from '../releasesRequest';
 
@@ -54,6 +55,7 @@ type Props = {
   selection: PageFilters;
   showHealthPlaceholders: boolean;
   showReleaseAdoptionStages: boolean;
+  thresholdStatuses: ThresholdStatus[];
 };
 
 function ReleaseCard({
@@ -67,12 +69,9 @@ function ReleaseCard({
   isTopRelease,
   getHealthData,
   showReleaseAdoptionStages,
+  thresholdStatuses,
 }: Props) {
   const {version, commitCount, lastDeploy, dateCreated, versionInfo} = release;
-
-  // TODO: fetch release threshold status
-  // Query for every release card??
-  // Query a full batch and match via card?
 
   const [projectsToShow, projectsToHide] = useMemo(() => {
     // sort health rows inside release card alphabetically by project name,

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -71,31 +71,39 @@ function ReleaseCard({
   showReleaseAdoptionStages,
   thresholdStatuses,
 }: Props) {
-  const {version, commitCount, lastDeploy, dateCreated, versionInfo} = release;
+  const {
+    version,
+    commitCount,
+    lastDeploy,
+    dateCreated,
+    versionInfo,
+    adoptionStages,
+    projects,
+  } = release;
 
   const [projectsToShow, projectsToHide] = useMemo(() => {
     // sort health rows inside release card alphabetically by project name,
     // show only the ones that are selected in global header
     return partition(
-      release.projects.sort((a, b) => a.slug.localeCompare(b.slug)),
+      projects.sort((a, b) => a.slug.localeCompare(b.slug)),
       p =>
         // do not filter for My Projects & All Projects
         selection.projects.length > 0 && !selection.projects.includes(-1)
           ? selection.projects.includes(p.id)
           : true
     );
-  }, [release, selection.projects]);
+  }, [projects, selection.projects]);
 
   const hasThresholds = useMemo(() => {
-    const project_slugs = release.projects.map(proj => proj.slug);
+    const project_slugs = projects.map(proj => proj.slug);
     let has = false;
     project_slugs.forEach(slug => {
-      if (`${slug}-${release.version}` in thresholdStatuses) {
-        has = thresholdStatuses[`${slug}-${release.version}`].length > 0;
+      if (`${slug}-${version}` in thresholdStatuses) {
+        has = thresholdStatuses[`${slug}-${version}`].length > 0;
       }
     });
     return has;
-  }, [thresholdStatuses, release]);
+  }, [thresholdStatuses, version, projects]);
 
   const getHiddenProjectsTooltip = () => {
     const limitedProjects = projectsToHide.map(p => p.slug).slice(0, 5);
@@ -185,12 +193,12 @@ function ReleaseCard({
             )}
           >
             {projectsToShow.map((project, index) => {
-              const key = `${project.slug}-${release.version}`;
+              const key = `${project.slug}-${version}`;
               return (
                 <ReleaseCardProjectRow
                   key={`${key}-row`}
                   activeDisplay={activeDisplay}
-                  adoptionStages={release.adoptionStages}
+                  adoptionStages={adoptionStages}
                   getHealthData={getHealthData}
                   hasThresholds={hasThresholds}
                   index={index}
@@ -198,7 +206,8 @@ function ReleaseCard({
                   location={location}
                   organization={organization}
                   project={project}
-                  releaseVersion={release.version}
+                  releaseVersion={version}
+                  lastDeploy={lastDeploy}
                   showPlaceholders={showHealthPlaceholders}
                   showReleaseAdoptionStages={showReleaseAdoptionStages}
                   thresholdStatuses={hasThresholds ? thresholdStatuses[`${key}`] : []}

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -115,7 +115,7 @@ function ReleaseCardProjectRow({
   });
 
   const pendingThresholds = thresholds.filter(status => {
-    return new Date(status.end) > new Date();
+    return new Date(status.end || '') > new Date();
   });
 
   const crashFreeRate = getHealthData.getCrashFreeRate(releaseVersion, id, activeDisplay);

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -30,14 +30,15 @@ import {
   getReleaseUnhandledIssuesUrl,
   isMobileRelease,
 } from '../../utils';
+import {ThresholdStatus} from '../../utils/types';
 import {ReleasesDisplayOption} from '../releasesDisplayOptions';
 import {ReleasesRequestRenderProps} from '../releasesRequest';
 
 import {
   AdoptionColumn,
   AdoptionStageColumn,
-  CrashesColumn,
   CrashFreeRateColumn,
+  DisplaySmallCol,
   NewIssuesColumn,
   ReleaseProjectColumn,
   ReleaseProjectsLayout,
@@ -61,6 +62,7 @@ function getCrashFreeIcon(crashFreePercent: number, iconSize: IconSize = 'sm') {
 type Props = {
   activeDisplay: ReleasesDisplayOption;
   getHealthData: ReleasesRequestRenderProps['getHealthData'];
+  hasThresholds: boolean;
   index: number;
   isTopRelease: boolean;
   location: Location;
@@ -69,21 +71,24 @@ type Props = {
   releaseVersion: string;
   showPlaceholders: boolean;
   showReleaseAdoptionStages: boolean;
+  thresholdStatuses: ThresholdStatus[];
   adoptionStages?: Release['adoptionStages'];
 };
 
 function ReleaseCardProjectRow({
-  index,
-  project,
-  organization,
-  location,
-  getHealthData,
-  releaseVersion,
   activeDisplay,
+  adoptionStages,
+  getHealthData,
+  hasThresholds,
+  index,
+  isTopRelease,
+  location,
+  organization,
+  project,
+  releaseVersion,
   showPlaceholders,
   showReleaseAdoptionStages,
-  isTopRelease,
-  adoptionStages,
+  thresholdStatuses,
 }: Props) {
   const theme = useTheme();
   const {id, newGroups} = project;
@@ -110,7 +115,10 @@ function ReleaseCardProjectRow({
 
   return (
     <ProjectRow data-test-id="release-card-project-row">
-      <ReleaseProjectsLayout showReleaseAdoptionStages={showReleaseAdoptionStages}>
+      <ReleaseProjectsLayout
+        showReleaseAdoptionStages={showReleaseAdoptionStages}
+        hasThresholds={hasThresholds}
+      >
         <ReleaseProjectColumn>
           <ProjectBadge project={project} avatarSize={16} />
         </ReleaseProjectColumn>
@@ -178,7 +186,7 @@ function ReleaseCardProjectRow({
           )}
         </CrashFreeRateColumn>
 
-        <CrashesColumn>
+        <DisplaySmallCol>
           {showPlaceholders ? (
             <StyledPlaceholder width="30px" />
           ) : defined(crashCount) ? (
@@ -196,7 +204,7 @@ function ReleaseCardProjectRow({
           ) : (
             <NotAvailable />
           )}
-        </CrashesColumn>
+        </DisplaySmallCol>
 
         <NewIssuesColumn>
           <Tooltip title={t('Open in Issues')}>
@@ -207,6 +215,12 @@ function ReleaseCardProjectRow({
             </GlobalSelectionLink>
           </Tooltip>
         </NewIssuesColumn>
+
+        {hasThresholds && (
+          <DisplaySmallCol>
+            {thresholdStatuses && thresholdStatuses.length}
+          </DisplaySmallCol>
+        )}
 
         <ViewColumn>
           <GuideAnchor disabled={!isTopRelease || index !== 0} target="view_release">

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -238,6 +238,7 @@ function ReleaseCardProjectRow({
 
         {hasThresholds && (
           <DisplaySmallCol>
+            {/* TODO: link to release details page */}
             {thresholds && thresholds.length > 0 && (
               <Tooltip
                 title={
@@ -252,6 +253,7 @@ function ReleaseCardProjectRow({
                           t('still pending')}
                       </div>
                     )}
+                    {t('Open in Release Details')}
                   </div>
                 }
               >

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import LazyLoad from 'react-lazyload';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -19,7 +20,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconCheckmark, IconFire, IconWarning} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Organization, Release, ReleaseProject} from 'sentry/types';
+import {Deploy, Organization, Release, ReleaseProject} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import type {IconSize} from 'sentry/utils/theme';
 
@@ -73,6 +74,7 @@ type Props = {
   showReleaseAdoptionStages: boolean;
   thresholdStatuses: ThresholdStatus[];
   adoptionStages?: Release['adoptionStages'];
+  lastDeploy?: Deploy | undefined;
 };
 
 function ReleaseCardProjectRow({
@@ -82,6 +84,7 @@ function ReleaseCardProjectRow({
   hasThresholds,
   index,
   isTopRelease,
+  lastDeploy,
   location,
   organization,
   project,
@@ -98,6 +101,23 @@ function ReleaseCardProjectRow({
     id,
     ReleasesDisplayOption.SESSIONS
   );
+
+  const thresholds = useMemo(() => {
+    return (
+      thresholdStatuses?.filter(status => {
+        return status.environment?.name === lastDeploy?.environment;
+      }) || []
+    );
+  }, [thresholdStatuses, lastDeploy]);
+
+  const healthyThresholds = thresholds.filter(status => {
+    return status.is_healthy;
+  });
+
+  const pendingThresholds = thresholds.filter(status => {
+    return new Date(status.end) > new Date();
+  });
+
   const crashFreeRate = getHealthData.getCrashFreeRate(releaseVersion, id, activeDisplay);
   const get24hCountByProject = getHealthData.get24hCountByProject(id, activeDisplay);
   const timeSeries = getHealthData.getTimeSeries(releaseVersion, id, activeDisplay);
@@ -218,7 +238,31 @@ function ReleaseCardProjectRow({
 
         {hasThresholds && (
           <DisplaySmallCol>
-            {thresholdStatuses && thresholdStatuses.length}
+            {thresholds && thresholds.length > 0 && (
+              <Tooltip
+                title={
+                  <div>
+                    <div>
+                      {`${healthyThresholds.length} / ${thresholds.length} ` +
+                        t('thresholds succeeded')}
+                    </div>
+                    {pendingThresholds.length > 0 && (
+                      <div>
+                        {`${pendingThresholds.length} / ${thresholds.length} ` +
+                          t('still pending')}
+                      </div>
+                    )}
+                  </div>
+                }
+              >
+                <ThresholdHealth
+                  allHealthy={healthyThresholds.length === thresholds.length}
+                  allThresholdsFinished={pendingThresholds.length === 0}
+                >
+                  {healthyThresholds.length} / {thresholds && thresholds.length}
+                </ThresholdHealth>
+              </Tooltip>
+            )}
           </DisplaySmallCol>
         )}
 
@@ -285,4 +329,19 @@ const ViewColumn = styled('div')`
   ${p => p.theme.overflowEllipsis};
   line-height: 20px;
   text-align: right;
+`;
+
+const ThresholdHealth = styled('div')<{
+  allHealthy?: boolean;
+  allThresholdsFinished?: boolean;
+}>`
+  color: ${p => {
+    if (!p.allHealthy) {
+      return p.theme.errorText;
+    }
+    if (p.allThresholdsFinished) {
+      return p.theme.successText;
+    }
+    return p.theme.activeText;
+  }};
 `;

--- a/static/app/views/releases/utils/fetchThresholdStatus.tsx
+++ b/static/app/views/releases/utils/fetchThresholdStatus.tsx
@@ -1,0 +1,18 @@
+import {Client} from 'sentry/api';
+import {Organization} from 'sentry/types';
+
+import {ThresholdStatus, ThresholdStatusesQuery} from './types';
+
+export function fetchThresholdStatuses(
+  organization: Organization,
+  api: Client,
+  query: ThresholdStatusesQuery
+): Promise<ThresholdStatus[]> {
+  return api.requestPromise(
+    `/organizations/${organization.slug}/release-threshold-statuses/`,
+    {
+      method: 'GET',
+      query,
+    }
+  );
+}

--- a/static/app/views/releases/utils/fetchThresholdStatus.tsx
+++ b/static/app/views/releases/utils/fetchThresholdStatus.tsx
@@ -7,7 +7,7 @@ export function fetchThresholdStatuses(
   organization: Organization,
   api: Client,
   query: ThresholdStatusesQuery
-): Promise<ThresholdStatus[]> {
+): Promise<{[key: string]: ThresholdStatus[]}> {
   return api.requestPromise(
     `/organizations/${organization.slug}/release-threshold-statuses/`,
     {

--- a/static/app/views/releases/utils/types.tsx
+++ b/static/app/views/releases/utils/types.tsx
@@ -3,10 +3,20 @@ import moment from 'moment';
 import {Environment, Project} from 'sentry/types';
 
 export type ThresholdQuery = {
-  environment?: string[] | undefined;
-  project?: number[] | undefined;
+  environment?: string[] | undefined; // list of environment names
+  project?: number[] | undefined; // list of project ids
 };
 
+export type ThresholdStatusesQuery = Omit<ThresholdQuery, 'project'> & {
+  end: string;
+  release: string[]; // list of release versions
+  start: string;
+  project?: string[]; // list of project slugs
+};
+
+export type ThresholdStatus = Threshold & {
+  is_healthy: boolean;
+};
 export type Threshold = {
   environment: Environment;
   id: string;

--- a/static/app/views/releases/utils/types.tsx
+++ b/static/app/views/releases/utils/types.tsx
@@ -18,9 +18,11 @@ export type ThresholdStatus = Threshold & {
   is_healthy: boolean;
 };
 export type Threshold = {
+  end: string;
   environment: Environment;
   id: string;
   project: Project;
+  start: string;
   threshold_type: string;
   trigger_type: 'over' | 'under';
   value: number;

--- a/static/app/views/releases/utils/types.tsx
+++ b/static/app/views/releases/utils/types.tsx
@@ -18,16 +18,16 @@ export type ThresholdStatus = Threshold & {
   is_healthy: boolean;
 };
 export type Threshold = {
-  end: string;
   environment: Environment;
   id: string;
   project: Project;
-  start: string;
   threshold_type: string;
   trigger_type: 'over' | 'under';
   value: number;
   window_in_seconds: number;
   date_added?: string;
+  end?: string;
+  start?: string;
 };
 
 export type EditingThreshold = Omit<Threshold, 'environment' | 'window_in_seconds'> & {


### PR DESCRIPTION
Adds a thresholds health column to relevant releases that have thresholds set.

Filters thresholds by environment if listed

highlights threshold health in `Success`/`Active`/`Error`

<img width="420" alt="Screenshot 2023-12-04 at 4 26 55 PM" src="https://github.com/getsentry/sentry/assets/6186377/42a838ad-f73f-4f1a-9f7d-73732652d20b">
