### PR TITLE
ref(feedback): fix capitalization and mapping of integration names

### DIFF
--- a/static/app/components/feedback/list/issueTrackingSignals.tsx
+++ b/static/app/components/feedback/list/issueTrackingSignals.tsx
@@ -27,6 +27,20 @@ function filterLinkedPlugins(actions: ExternalIssueComponent[]) {
   return plugins.concat(nonPlugins);
 }
 
+function getPluginNames(pluginIssue) {
+  return {
+    name: pluginIssue.props.plugin.name ?? '',
+    icon: pluginIssue.props.plugin.slug ?? '',
+  };
+}
+
+function getIntegrationNames(integrationIssue) {
+  return {
+    name: integrationIssue.props.configurations[0].provider.name ?? '',
+    icon: integrationIssue.key ?? '',
+  };
+}
+
 export default function IssueTrackingSignals({group}: Props) {
   const {actions} = useExternalIssueData({
     group,
@@ -49,15 +63,17 @@ export default function IssueTrackingSignals({group}: Props) {
     );
   }
 
-  const name =
-    linkedIssues[0].type === 'plugin-issue' || linkedIssues[0].type === 'plugin-action'
-      ? linkedIssues[0].props.plugin.slug ?? ''
-      : linkedIssues[0].key;
+  const issue = linkedIssues[0];
+
+  const {name, icon} =
+    issue.type === 'plugin-issue' || issue.type === 'plugin-action'
+      ? getPluginNames(issue)
+      : getIntegrationNames(issue);
 
   return (
     <FeedbackIcon
       tooltipText={t('Linked %s Issue', name)}
-      icon={getIntegrationIcon(name, 'xs')}
+      icon={getIntegrationIcon(icon, 'xs')}
     />
   );
 }


### PR DESCRIPTION
Fixes the casing of linked integration issue names, and improves the mapping of plugin to icon/name:

<img width="149" alt="SCR-20231204-ixmo" src="https://github.com/getsentry/sentry/assets/56095982/b2afb8ea-f533-4379-aa38-c62ac6c78377">
