### PR TITLE
fix(metrics_extraction): Support http.referer

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -176,14 +176,6 @@ class MetricsQueryBuilder(QueryBuilder):
             # Replace with proper table code later
             if fields.is_function(col) and self._get_on_demand_metric_spec(col)
         }
-        # {'count()': OnDemandMetricSpec(
-        #   field='count()',
-        #   query='http.url:https://sentry.io/*/foo/bar/* http.referer:"https://sentry.io/*/bar/*" event.type:transaction',
-        #   groupbys=['networkId'],
-        #   spec_type=<MetricSpecType.DYNAMIC_QUERY: 'dynamic_query'>,
-        #   op='sum',
-        #   _metric_type='c',
-        #   _arguments=[])}
         return map
 
     def _get_metrics_query_from_on_demand_spec(

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -176,6 +176,14 @@ class MetricsQueryBuilder(QueryBuilder):
             # Replace with proper table code later
             if fields.is_function(col) and self._get_on_demand_metric_spec(col)
         }
+        # {'count()': OnDemandMetricSpec(
+        #   field='count()',
+        #   query='http.url:https://sentry.io/*/foo/bar/* http.referer:"https://sentry.io/*/bar/*" event.type:transaction',
+        #   groupbys=['networkId'],
+        #   spec_type=<MetricSpecType.DYNAMIC_QUERY: 'dynamic_query'>,
+        #   op='sum',
+        #   _metric_type='c',
+        #   _arguments=[])}
         return map
 
     def _get_metrics_query_from_on_demand_spec(

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -81,6 +81,7 @@ _SEARCH_TO_PROTOCOL_FIELDS = {
     "geo.subdivision": "user.geo.subdivision",
     "http.method": "request.method",
     "http.url": "request.url",
+    "http.referer": "request.referer",
     # url is a tag extracted by Sentry itself, on Relay it's received as `request.url`
     "url": "request.url",
     "sdk.name": "sdk.name",

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -81,7 +81,7 @@ _SEARCH_TO_PROTOCOL_FIELDS = {
     "geo.subdivision": "user.geo.subdivision",
     "http.method": "request.method",
     "http.url": "request.url",
-    "http.referer": "request.referer",
+    "http.referer": "request.headers.Referer",
     # url is a tag extracted by Sentry itself, on Relay it's received as `request.url`
     "url": "request.url",
     "sdk.name": "sdk.name",

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -999,6 +999,11 @@ class OnDemandMetricSpec:
 
         return self._arguments[0]
 
+    @property
+    def metric_type(self) -> str:
+        """Returns c, d or s representing if it's a counter, distribution or set."""
+        return self._metric_type
+
     @cached_property
     def mri(self) -> str:
         """The unique identifier of the on-demand metric."""

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 from datetime import timedelta
-from typing import Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 import sentry_sdk
 
 from sentry.discover.arithmetic import categorize_columns
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
+from sentry.models.organization import Organization
 from sentry.snuba import discover
 from sentry.snuba.metrics_performance import histogram_query as metrics_histogram_query
 from sentry.snuba.metrics_performance import query as metrics_query
@@ -180,26 +183,26 @@ def timeseries_query(
 
 
 def top_events_timeseries(
-    timeseries_columns,
-    selected_columns,
-    user_query,
-    params,
-    orderby,
-    rollup,
-    limit,
-    organization,
-    equations=None,
-    referrer=None,
+    timeseries_columns: Sequence[str],
+    selected_columns: Sequence[str],
+    user_query: str,
+    params: dict[str, str],
+    orderby: Sequence[str],
+    rollup: int,
+    limit: int,
+    organization: Organization,
+    equations: Optional[Sequence[Any]] = None,
+    referrer: Optional[str] = None,
     top_events=None,
-    allow_empty=True,
-    zerofill_results=True,
-    include_other=False,
-    functions_acl=None,
-    on_demand_metrics_enabled: bool = False,
-    on_demand_metrics_type=None,
+    allow_empty: Optional[bool] = True,
+    zerofill_results: Optional[bool] = True,
+    include_other: Optional[bool] = False,
+    functions_acl: Optional[List[str]] = None,
+    on_demand_metrics_enabled: Optional[bool] = False,
+    on_demand_metrics_type: Optional[str] = None,
 ):
     metrics_compatible = False
-    equations, columns = categorize_columns(selected_columns)
+    equations, _ = categorize_columns(selected_columns)
     if not equations:
         metrics_compatible = True
 

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -201,7 +201,7 @@ def top_events_timeseries(
     functions_acl: Optional[List[str]] = None,
     on_demand_metrics_enabled: Optional[bool] = False,
     on_demand_metrics_type: Optional[MetricSpecType] = None,
-) -> Optional[SnubaTSResult]:
+) -> SnubaTSResult | dict[str, Any]:
     metrics_compatible = False
     equations, _ = categorize_columns(selected_columns)
     if not equations:

--- a/src/sentry/snuba/metrics_enhanced_performance.py
+++ b/src/sentry/snuba/metrics_enhanced_performance.py
@@ -9,6 +9,7 @@ from sentry.discover.arithmetic import categorize_columns
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.snuba import discover
+from sentry.snuba.metrics.extraction import MetricSpecType
 from sentry.snuba.metrics_performance import histogram_query as metrics_histogram_query
 from sentry.snuba.metrics_performance import query as metrics_query
 from sentry.snuba.metrics_performance import timeseries_query as metrics_timeseries_query
@@ -199,8 +200,8 @@ def top_events_timeseries(
     include_other: Optional[bool] = False,
     functions_acl: Optional[List[str]] = None,
     on_demand_metrics_enabled: Optional[bool] = False,
-    on_demand_metrics_type: Optional[str] = None,
-):
+    on_demand_metrics_type: Optional[MetricSpecType] = None,
+) -> Optional[SnubaTSResult]:
     metrics_compatible = False
     equations, _ = categorize_columns(selected_columns)
     if not equations:

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -344,7 +344,7 @@ def top_events_timeseries(
     functions_acl=None,
     on_demand_metrics_enabled=False,
     on_demand_metrics_type: Optional[MetricSpecType] = None,
-) -> SnubaTSResult:
+) -> SnubaTSResult | dict[str, Any]:
     if top_events is None:
         top_events = query(
             selected_columns,

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -344,7 +344,7 @@ def top_events_timeseries(
     functions_acl=None,
     on_demand_metrics_enabled=False,
     on_demand_metrics_type: Optional[MetricSpecType] = None,
-):
+) -> SnubaTSResult:
     if top_events is None:
         top_events = query(
             selected_columns,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1899,7 +1899,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
 
     def store_on_demand_metric(
         self,
-        value: int,
+        value: int | float,
         spec: OnDemandMetricSpec,
         additional_tags: Optional[Dict[str, str]] = None,
         timestamp: Optional[datetime] = None,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1866,7 +1866,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
         project: Optional[int] = None,
         use_case_id: UseCaseID = UseCaseID.TRANSACTIONS,
         aggregation_option: Optional[AggregationOption] = None,
-    ):
+    ) -> None:
         internal_metric = METRICS_MAP[metric] if internal_metric is None else internal_metric
         entity = self.ENTITY_MAP[metric] if entity is None else entity
         org_id = self.organization.id
@@ -1899,16 +1899,16 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
 
     def store_on_demand_metric(
         self,
-        value: list[Any] | Any,
+        value: int,
         spec: OnDemandMetricSpec,
         additional_tags: Optional[Dict[str, str]] = None,
         timestamp: Optional[datetime] = None,
-    ):
-        metric_spec = spec.to_metric_spec(self.project)
-        metric_spec_tags = metric_spec["tags"] or [] if metric_spec else []
+    ) -> None:
+        relay_metric_spec = spec.to_metric_spec(self.project)
+        metric_spec_tags = relay_metric_spec["tags"] if relay_metric_spec else []
         tags = {i["key"]: i.get("value") or i.get("field") for i in metric_spec_tags}
 
-        metric_type = spec._metric_type
+        metric_type = spec.metric_type
         if additional_tags:
             # Additional tags might be needed to override field values from the spec.
             tags.update(additional_tags)
@@ -1921,8 +1921,6 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
             tags=tags,
             timestamp=timestamp,
         )
-
-        return spec
 
     def store_span_metric(
         self,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1904,8 +1904,9 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsLayerTestCase, TestCase):
         additional_tags: Optional[Dict[str, str]] = None,
         timestamp: Optional[datetime] = None,
     ) -> None:
+        """Convert on-demand metric and store it"""
         relay_metric_spec = spec.to_metric_spec(self.project)
-        metric_spec_tags = relay_metric_spec["tags"] if relay_metric_spec else []
+        metric_spec_tags = relay_metric_spec["tags"] or [] if relay_metric_spec else []
         tags = {i["key"]: i.get("value") or i.get("field") for i in metric_spec_tags}
 
         metric_type = spec.metric_type

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1280,7 +1280,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             [{"count": 0.5}],
         ]
 
-    def test_bar_chart_group_bys_on_demand(self):
+    def test_glob_http_referer_on_demand(self):
         agg = "count()"
         network_id_tag = "networkId"
         url = "https://sentry.io"
@@ -1327,7 +1327,6 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             self.store_on_demand_metric(
                 1,
                 spec=spec,
-                # Becase we're using topEvents=1 this will fall under Other
                 additional_tags={network_id_tag: "5678"},
                 timestamp=self.day_ago + timedelta(hours=hour),
             )
@@ -1337,7 +1336,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                 "dataset": "metricsEnhanced",
                 "field": [network_id_tag, agg],
                 "start": iso_format(self.day_ago),
-                "end": iso_format(self.day_ago + timedelta(hours=2)),
+                "end": iso_format(self.day_ago + timedelta(hours=5)),
                 "onDemandType": "dynamic_query",
                 "orderby": f"-{agg}",
                 "interval": "1d",
@@ -1345,7 +1344,6 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                 "query": query,
                 "referrer": "api.dashboards.widget.bar-chart",
                 "project": self.project.id,
-                "statsPeriod": "24h",
                 "topEvents": 1,
                 "useOnDemandMetrics": "true",
                 "yAxis": agg,
@@ -1355,8 +1353,8 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
         assert response.status_code == 200, response.content
         assert response.data == {
             "1234": {
-                "data": [(1701561600, [{"count": 5.0}]), (1701648000, [{"count": 0}])],
-                "end": 1701648001,
+                "data": [(1701561600, [{"count": 5.0}])],
+                "end": 1701561600,
                 "isMetricsData": False,
                 "meta": {
                     "dataset": "metricsEnhanced",
@@ -1371,8 +1369,8 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                 "start": 1701561600,
             },
             "Other": {
-                "data": [(1701561600, [{"count": 5.0}]), (1701648000, [{"count": 0}])],
-                "end": 1701648001,
+                "data": [(1701561600, [{"count": 5.0}])],
+                "end": 1701561600,
                 "isMetricsData": False,
                 "meta": {
                     "dataset": "metricsEnhanced",

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1296,7 +1296,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             "mri": "c:transactions/on_demand@none",
             "field": None,
             "tags": [
-                {"key": "query_hash", "value": "fc0c932e"},
+                {"key": "query_hash", "value": "ac241f56"},
                 {"key": "networkId", "field": "event.tags.networkId"},
                 {"key": "environment", "field": "event.environment"},
             ],
@@ -1310,7 +1310,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                     },
                     {
                         "op": "glob",
-                        "name": "event.request.referer",
+                        "name": "event.request.headers.Referer",
                         "value": ["https://sentry.io/*/bar/*"],
                     },
                 ],

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1291,6 +1291,31 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
             query=query,
             spec_type=MetricSpecType.DYNAMIC_QUERY,
         )
+        assert spec.to_metric_spec(self.project) == {
+            "category": "transaction",
+            "mri": "c:transactions/on_demand@none",
+            "field": None,
+            "tags": [
+                {"key": "query_hash", "value": "fc0c932e"},
+                {"key": "networkId", "field": "event.tags.networkId"},
+                {"key": "environment", "field": "event.environment"},
+            ],
+            "condition": {
+                "op": "and",
+                "inner": [
+                    {
+                        "op": "glob",
+                        "name": "event.request.url",
+                        "value": ["https://sentry.io/*/foo/bar/*"],
+                    },
+                    {
+                        "op": "glob",
+                        "name": "event.request.referer",
+                        "value": ["https://sentry.io/*/bar/*"],
+                    },
+                ],
+            },
+        }
 
         for hour in range(0, 5):
             self.store_on_demand_metric(

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1351,56 +1351,16 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
         )
 
         assert response.status_code == 200, response.content
-        assert response.data == {
-            "1234": {
-                "data": [(1701561600, [{"count": 5.0}])],
-                "end": 1701561600,
+        for datum in response.data.values():
+            assert datum["meta"] == {
+                "dataset": "metricsEnhanced",
+                "datasetReason": "unchanged",
+                "fields": {},
                 "isMetricsData": False,
-                "meta": {
-                    "dataset": "metricsEnhanced",
-                    "datasetReason": "unchanged",
-                    "fields": {},
-                    "isMetricsData": False,
-                    "isMetricsExtractedData": True,
-                    "tips": {},
-                    "units": {},
-                },
-                "order": 0,
-                "start": 1701561600,
-            },
-            "5678": {
-                "data": [(1701561600, [{"count": 5.0}])],
-                "end": 1701561600,
-                "isMetricsData": False,
-                "meta": {
-                    "dataset": "metricsEnhanced",
-                    "datasetReason": "unchanged",
-                    "fields": {},
-                    "isMetricsData": False,
-                    "isMetricsExtractedData": True,
-                    "tips": {},
-                    "units": {},
-                },
-                "order": 1,
-                "start": 1701561600,
-            },
-            "Other": {
-                "data": [(1701561600, [{"count": 5.0}, {"count": 5.0}])],
-                "end": 1701561600,
-                "isMetricsData": False,
-                "meta": {
-                    "dataset": "metricsEnhanced",
-                    "datasetReason": "unchanged",
-                    "fields": {},
-                    "isMetricsData": False,
-                    "isMetricsExtractedData": True,
-                    "tips": {},
-                    "units": {},
-                },
-                "order": 2,
-                "start": 1701561600,
-            },
-        }
+                "isMetricsExtractedData": True,
+                "tips": {},
+                "units": {},
+            }
 
     def _test_is_metrics_extracted_data(
         self, params: dict[str, Any], expected_on_demand_query: bool, dataset: str

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1283,7 +1283,9 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
     def test_bar_chart_group_bys_on_demand(self):
         agg = "count()"
         network_id_tag = "networkId"
-        query = "transaction.duration:>=100"
+        url = "https://sentry.io"
+        query = f'http.url:{url}/*/foo/bar/* http.referer:"{url}/*/bar/*" event.type:transaction'
+        # query = "transaction.duration:>=100"
         spec = OnDemandMetricSpec(
             field=agg,
             groupbys=[network_id_tag],
@@ -1305,7 +1307,6 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                 timestamp=self.day_ago + timedelta(hours=hour),
             )
 
-        url = "https://sentry.io"
         response = self.do_request(
             data={
                 "dataset": "metricsEnhanced",
@@ -1316,8 +1317,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                 "orderby": f"-{agg}",
                 "interval": "1d",
                 "partial": 1,
-                "query": f'http.url:{url}/*/foo/bar/* http.referer:"{url}/*/bar/*" '
-                + "event.type:transaction",
+                "query": query,
                 "referrer": "api.dashboards.widget.bar-chart",
                 "project": self.project.id,
                 "statsPeriod": "24h",
@@ -1328,12 +1328,14 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
         )
 
         assert response.status_code == 200, response.content
+        # XXX: Fix this
+        assert response.data == {}
         # breakpoint()
-        assert response.data[network_id_tag]["meta"]["isMetricsExtractedData"] is True
-        assert [attrs for _, attrs in response.data[network_id_tag]["data"]] == [
-            [{"count": 0.5}],
-            [{"count": 0.5}],
-        ]
+        # assert response.data[network_id_tag]["meta"]["isMetricsExtractedData"] is True
+        # assert [attrs for _, attrs in response.data[network_id_tag]["data"]] == [
+        #     [{"count": 0.5}],
+        #     [{"count": 0.5}],
+        # ]
 
     def _test_is_metrics_extracted_data(
         self, params: dict[str, Any], expected_on_demand_query: bool, dataset: str

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -1344,7 +1344,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                 "query": query,
                 "referrer": "api.dashboards.widget.bar-chart",
                 "project": self.project.id,
-                "topEvents": 1,
+                "topEvents": 2,
                 "useOnDemandMetrics": "true",
                 "yAxis": agg,
             },
@@ -1368,7 +1368,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                 "order": 0,
                 "start": 1701561600,
             },
-            "Other": {
+            "5678": {
                 "data": [(1701561600, [{"count": 5.0}])],
                 "end": 1701561600,
                 "isMetricsData": False,
@@ -1382,6 +1382,22 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTestWithOnDemandW
                     "units": {},
                 },
                 "order": 1,
+                "start": 1701561600,
+            },
+            "Other": {
+                "data": [(1701561600, [{"count": 5.0}, {"count": 5.0}])],
+                "end": 1701561600,
+                "isMetricsData": False,
+                "meta": {
+                    "dataset": "metricsEnhanced",
+                    "datasetReason": "unchanged",
+                    "fields": {},
+                    "isMetricsData": False,
+                    "isMetricsExtractedData": True,
+                    "tips": {},
+                    "units": {},
+                },
+                "order": 2,
                 "start": 1701561600,
             },
         }


### PR DESCRIPTION
A customer widget was falling back to Discover because the `http.referer` field was not supported by on-demand.
This change adds support for it and does some typing changes.