### PR TITLE
ref(notifications): start removing notification_setting_type from code

### DIFF
--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -11,11 +11,7 @@ from django.utils.safestring import SafeString
 from sentry.db.models import Model
 from sentry.notifications.helpers import get_reason_context
 from sentry.notifications.notifications.base import ProjectNotification
-from sentry.notifications.types import (
-    NotificationSettingEnum,
-    NotificationSettingTypes,
-    UnsubscribeContext,
-)
+from sentry.notifications.types import NotificationSettingEnum, UnsubscribeContext
 from sentry.notifications.utils import send_activity_notification
 from sentry.notifications.utils.avatar import avatar_as_html
 from sentry.notifications.utils.participants import ParticipantMap, get_participants_for_group
@@ -30,7 +26,6 @@ if TYPE_CHECKING:
 
 class ActivityNotification(ProjectNotification, abc.ABC):
     metrics_key = "activity"
-    notification_setting_type = NotificationSettingTypes.WORKFLOW
     notification_setting_type_enum = NotificationSettingEnum.WORKFLOW
     template_path = "sentry/emails/activity/generic"
 

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -10,7 +10,7 @@ from sentry.models.commit import Commit
 from sentry.models.commitfilechange import CommitFileChange
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
-from sentry.notifications.types import NotificationSettingEnum, NotificationSettingTypes
+from sentry.notifications.types import NotificationSettingEnum
 from sentry.notifications.utils import (
     get_deploy,
     get_environment_for_deploy,
@@ -29,7 +29,6 @@ from .base import ActivityNotification
 
 class ReleaseActivityNotification(ActivityNotification):
     metrics_key = "release_activity"
-    notification_setting_type = NotificationSettingTypes.DEPLOY
     notification_setting_type_enum = NotificationSettingEnum.DEPLOY
     template_path = "sentry/emails/activity/release"
 

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -36,14 +36,22 @@ class BaseNotification(abc.ABC):
     }
     message_builder = "SlackNotificationsMessageBuilder"
     # some notifications have no settings for it which is why it is optional
-    # TODO(steve): Replace notification_setting_type with notification_setting_type_enum
-    notification_setting_type: NotificationSettingTypes | None = None
     notification_setting_type_enum: NotificationSettingEnum | None = None
     analytics_event: str = ""
 
     def __init__(self, organization: Organization, notification_uuid: str | None = None):
         self.organization = organization
         self.notification_uuid = notification_uuid if notification_uuid else str(uuid.uuid4())
+
+    # TODO(Steve): Remove notification_setting_type
+    @property
+    def notification_setting_type(self) -> NotificationSettingTypes | None:
+        if self.notification_setting_type_enum is not None:
+            # find the matching NotificationSettingTypes
+            for key, value in NOTIFICATION_SETTING_TYPES.items():
+                if value == self.notification_setting_type_enum.value:
+                    return key
+        return None
 
     @property
     def from_email(self) -> str | None:
@@ -236,8 +244,8 @@ class BaseNotification(abc.ABC):
         from sentry.notifications.utils.participants import get_notification_recipients
 
         setting_type = (
-            NotificationSettingEnum(NOTIFICATION_SETTING_TYPES[self.notification_setting_type])
-            if self.notification_setting_type
+            self.notification_setting_type_enum
+            if self.notification_setting_type_enum
             else NotificationSettingEnum.ISSUE_ALERTS
         )
         return get_notification_recipients(

--- a/src/sentry/notifications/notifications/codeowners_auto_sync.py
+++ b/src/sentry/notifications/notifications/codeowners_auto_sync.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping
 
 from sentry.notifications.notifications.base import ProjectNotification
-from sentry.notifications.types import NotificationSettingEnum, NotificationSettingTypes
+from sentry.notifications.types import NotificationSettingEnum
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.types.integrations import ExternalProviders
 
@@ -13,7 +13,6 @@ if TYPE_CHECKING:
 
 class AutoSyncNotification(ProjectNotification):
     metrics_key = "auto_sync"
-    notification_setting_type = NotificationSettingTypes.DEPLOY
     notification_setting_type_enum = NotificationSettingEnum.DEPLOY
     template_path = "sentry/emails/codeowners-auto-sync-failure"
 

--- a/src/sentry/notifications/notifications/missing_members_nudge.py
+++ b/src/sentry/notifications/notifications/missing_members_nudge.py
@@ -8,7 +8,7 @@ from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notifications.strategies.member_write_role_recipient_strategy import (
     MemberWriteRoleRecipientStrategy,
 )
-from sentry.notifications.types import NotificationSettingEnum, NotificationSettingTypes
+from sentry.notifications.types import NotificationSettingEnum
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.types.integrations import ExternalProviders
 
@@ -21,7 +21,6 @@ class MissingMembersNudgeNotification(BaseNotification):
     template_path = "sentry/emails/missing-members-nudge"
 
     RoleBasedRecipientStrategyClass = MemberWriteRoleRecipientStrategy
-    notification_setting_type = NotificationSettingTypes.APPROVAL
     notification_setting_type_enum = NotificationSettingEnum.APPROVAL
 
     def __init__(

--- a/src/sentry/notifications/notifications/organization_request/base.py
+++ b/src/sentry/notifications/notifications/organization_request/base.py
@@ -9,7 +9,7 @@ from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.notifications.strategies.role_based_recipient_strategy import (
     RoleBasedRecipientStrategy,
 )
-from sentry.notifications.types import NotificationSettingEnum, NotificationSettingTypes
+from sentry.notifications.types import NotificationSettingEnum
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.types.integrations import ExternalProviders
 
@@ -21,7 +21,6 @@ logger = logging.getLogger(__name__)
 
 
 class OrganizationRequestNotification(BaseNotification, abc.ABC):
-    notification_setting_type = NotificationSettingTypes.APPROVAL
     notification_setting_type_enum = NotificationSettingEnum.APPROVAL
     RoleBasedRecipientStrategyClass: Type[RoleBasedRecipientStrategy]
 

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -17,7 +17,6 @@ from sentry.notifications.types import (
     ActionTargetType,
     FallthroughChoiceType,
     NotificationSettingEnum,
-    NotificationSettingTypes,
 )
 from sentry.notifications.utils import (
     get_commits,
@@ -62,7 +61,6 @@ GENERIC_TEMPLATE_NAME = "generic"
 class AlertRuleNotification(ProjectNotification):
     message_builder = "IssueNotificationMessageBuilder"
     metrics_key = "issue_alert"
-    notification_setting_type = NotificationSettingTypes.ISSUE_ALERTS
     notification_setting_type_enum = NotificationSettingEnum.ISSUE_ALERTS
     template_path = "sentry/emails/error"
 


### PR DESCRIPTION
I am trying to remove `NotificationSettingTypes` from our code base slowly. The next step is to remove the `notification_setting_type` field. But to ensure compatibility, I'm making a property to set it based on `notification_setting_type_enum`. Slowly but surely I'll replace all instances of it.