### PR TITLE
fix(alerts): Hide migration banner when creating/editing

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1024,6 +1024,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       !!ruleId && hasMigrationFeatureFlag(organization) && ruleNeedsMigration(rule);
     const showErrorMigrationWarning =
       !!ruleId &&
+      location?.query?.migration === '1' &&
       hasIgnoreArchivedFeatureFlag(organization) &&
       ruleNeedsErrorMigration(rule);
 


### PR DESCRIPTION
Only show the banner on the migration page
