### PR TITLE
feat(replay): Mark the Accessibility tab as Alpha for release to EA orgs

### DIFF
--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -39,7 +39,10 @@ function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
         >
           {t('Accessibility')}
         </Tooltip>
-        <FeatureBadge type="beta" />
+        <FeatureBadge
+          type="alpha"
+          title={t('This feature is available for early adopters and may change')}
+        />
       </Fragment>
     ) : null,
     [TabKey.MEMORY]: t('Memory'),


### PR DESCRIPTION
Related to: https://github.com/getsentry/sentry/issues/55501