### PR TITLE
fix(hybridcloud) Fix cross silo queries in sentry apps

### DIFF
--- a/src/sentry/models/integrations/utils.py
+++ b/src/sentry/models/integrations/utils.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     )
     from sentry.models.integrations.integration import Integration
     from sentry.models.integrations.sentry_app import SentryApp
+    from sentry.services.hybrid_cloud.app.model import RpcSentryApp
     from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 
 
@@ -48,14 +49,13 @@ def is_response_error(resp) -> bool:
     return False
 
 
-def get_redis_key(sentryapp: SentryApp, org_id):
-    from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
+def get_redis_key(sentryapp: SentryApp | RpcSentryApp, org_id):
+    from sentry.services.hybrid_cloud.app.service import app_service
 
-    installations = SentryAppInstallation.objects.filter(
+    installation = app_service.get_installation(
+        sentry_app_id=sentryapp.id,
         organization_id=org_id,
-        sentry_app=sentryapp,
     )
-    if installations.exists():
-        installation = installations.first()
+    if installation:
         return f"sentry-app-error:{installation.uuid}"
     return ""

--- a/src/sentry/services/hybrid_cloud/app/service.py
+++ b/src/sentry/services/hybrid_cloud/app/service.py
@@ -78,6 +78,18 @@ class AppService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
+    def get_installation_by_id(self, *, id: int) -> Optional[RpcSentryAppInstallation]:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
+    def get_installation(
+        self, *, sentry_app_id: int, organization_id: int
+    ) -> Optional[RpcSentryAppInstallation]:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
     def get_installation_token(self, *, organization_id: int, provider: str) -> Optional[str]:
         pass
 
@@ -151,6 +163,11 @@ class AppService(RpcService):
     def prepare_sentry_app_components(
         self, *, installation_id: int, component_type: str, project_slug: Optional[str] = None
     ) -> Optional[RpcSentryAppComponent]:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
+    def disable_sentryapp(self, *, id: int) -> None:
         pass
 
 


### PR DESCRIPTION
Webhook delivery for sentryapps contains a few cross silo queries. Replace those queries with service calls and add new service calls to replace existing query patterns.

Fixes HC-1014
Fixes HC-1015
