### PR TITLE
feat(severity): Pass has_escalated to RuleProcessor

### DIFF
--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -116,8 +116,10 @@ class EventState:
         is_regression: bool,
         is_new_group_environment: bool,
         has_reappeared: bool,
+        has_escalated: bool,
     ) -> None:
         self.is_new = is_new
         self.is_regression = is_regression
         self.is_new_group_environment = is_new_group_environment
         self.has_reappeared = has_reappeared
+        self.has_escalated = has_escalated

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -64,6 +64,7 @@ class RuleProcessor:
         is_regression: bool,
         is_new_group_environment: bool,
         has_reappeared: bool,
+        has_escalated: bool = False,
     ) -> None:
         self.event = event
         self.group = event.group
@@ -73,6 +74,7 @@ class RuleProcessor:
         self.is_regression = is_regression
         self.is_new_group_environment = is_new_group_environment
         self.has_reappeared = has_reappeared
+        self.has_escalated = has_escalated
 
         self.grouped_futures: MutableMapping[
             str, Tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], List[RuleFuture]]
@@ -179,6 +181,7 @@ class RuleProcessor:
             is_regression=self.is_regression,
             is_new_group_environment=self.is_new_group_environment,
             has_reappeared=self.has_reappeared,
+            has_escalated=self.has_escalated,
         )
 
     def apply_rule(self, rule: Rule, status: GroupRuleStatus) -> None:
@@ -196,6 +199,7 @@ class RuleProcessor:
             "is_new": self.is_new,
             "is_regression": self.is_regression,
             "has_reappeared": self.has_reappeared,
+            "has_escalated": self.has_escalated,
             "new_group_environment": self.is_new_group_environment,
         }
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1018,12 +1018,18 @@ def process_rules(job: PostProcessJob) -> None:
     is_regression = job["group_state"]["is_regression"]
     is_new_group_environment = job["group_state"]["is_new_group_environment"]
     has_reappeared = job["has_reappeared"]
+    has_escalated = job["has_escalated"]
 
     has_alert = False
 
     with metrics.timer("post_process.process_rules.duration"):
         rp = RuleProcessor(
-            group_event, is_new, is_regression, is_new_group_environment, has_reappeared
+            group_event,
+            is_new,
+            is_regression,
+            is_new_group_environment,
+            has_reappeared,
+            has_escalated,
         )
         with sentry_sdk.start_span(op="tasks.post_process_group.rule_processor_callbacks"):
             # TODO(dcramer): ideally this would fanout, but serializing giant

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -870,6 +870,7 @@ class RuleTestCase(TestCase):
         kwargs.setdefault("is_regression", True)
         kwargs.setdefault("is_new_group_environment", True)
         kwargs.setdefault("has_reappeared", True)
+        kwargs.setdefault("has_escalated", False)
         return EventState(**kwargs)
 
     def get_condition_activity(self, **kwargs) -> ConditionActivity:


### PR DESCRIPTION
Pass has_escalated to RuleProcessor so we can use it in severity alerts. 