### PR TITLE
feat(ai): add openai sdk integration to sentry sdk internally

### DIFF
--- a/src/sentry/utils/openai_sdk_integration.py
+++ b/src/sentry/utils/openai_sdk_integration.py
@@ -1,0 +1,75 @@
+import hashlib
+
+from sentry_sdk.hub import Hub
+from sentry_sdk.integrations import DidNotEnable, Integration
+
+try:
+    from openai import resources
+except ImportError:
+    raise DidNotEnable("OpenAI is not installed")
+
+
+class OpenAiIntegration(Integration):
+    identifier = "openai"
+
+    def __init__(self, capture_prompts=False):
+        self.capture_prompts = capture_prompts
+
+    @staticmethod
+    def setup_once():
+        patch_openai()
+
+
+def patch_openai():
+    old_open_ai_resources_chat_completions_create = resources.chat.completions.Completions.create
+
+    def monkeypatched_openai_completions_create(*args, **kwargs):
+        hub = Hub.current
+
+        integration = hub.get_integration(OpenAiIntegration)
+        if integration is None:
+            return old_open_ai_resources_chat_completions_create(*args, **kwargs)
+
+        # for now, simply make the description (which is how grouping is defined)
+        # simply the first message in the chat. This is not ideal, but it's a start.
+        with hub.start_span(
+            op="ai.llm.completion",
+            description=_get_description(kwargs.get("messages"), integration.capture_prompts),
+        ) as span:
+            if integration.capture_prompts:
+                span.set_data(
+                    "chat_completion_input",
+                    {"messages": kwargs.get("messages")},
+                )
+            return_value = old_open_ai_resources_chat_completions_create(*args, **kwargs)
+            if getattr(return_value, "usage", None):
+                completion_output = {
+                    "created": return_value.created,
+                    "id": return_value.id,
+                }
+                if integration.capture_prompts:
+                    completion_output["choices"] = return_value.model_dump(exclude_unset=True).get(
+                        "choices"
+                    )
+
+                span.set_data(
+                    "chat_completion_output",
+                    completion_output,
+                )
+                span.set_data("llm_prompt_tkens", return_value.usage.prompt_tokens)
+                span.set_data("llm_completion_tkens", return_value.usage.completion_tokens)
+                span.set_data("llm_total_tkens", return_value.usage.total_tokens)
+                span.set_data("language_model", return_value.model)
+            return return_value
+
+    resources.chat.completions.Completions.create = monkeypatched_openai_completions_create
+
+
+def _get_description(messages, capture_prompts):
+    if messages is None or len(messages) == 0:
+        return ""
+    if capture_prompts:
+        # TODO: should we handle truncation here?
+        return messages[0]["content"]
+    else:
+        return hashlib.md5(messages[0]["content"].encode("utf-8")).hexdigest()

--- a/src/sentry/utils/openai_sdk_integration.py
+++ b/src/sentry/utils/openai_sdk_integration.py
@@ -62,7 +62,7 @@ def patch_openai():
                 span.set_data("language_model", return_value.model)
             return return_value
 
-    resources.chat.completions.Completions.create = monkeypatched_openai_completions_create
+    resources.chat.completions.Completions.create = monkeypatched_openai_completions_create  # type: ignore[method-assign]
 
 
 def _get_description(messages, capture_prompts):

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -22,6 +22,7 @@ from sentry import options
 from sentry.conf.types.sdk_config import SdkConfig
 from sentry.utils import metrics
 from sentry.utils.db import DjangoAtomicIntegration
+from sentry.utils.openai_sdk_integration import OpenAiIntegration
 from sentry.utils.rust import RustInfoIntegration
 
 # Can't import models in utils because utils should be the bottom of the food chain
@@ -454,6 +455,7 @@ def configure_sdk():
             RustInfoIntegration(),
             RedisIntegration(),
             ThreadingIntegration(propagate_hub=True),
+            OpenAiIntegration(capture_prompts=True),
         ],
         **sdk_options,
     )


### PR DESCRIPTION
- [x] Adds OpenAI SDK integration which is actively under development. Done here in Sentry repo instead of `sentry-python` so we can rapidly iterate on the sdk without having to do releases.
- [x] Existing test coverage of `suggested_fix` should cover this, as it is simply wrapping those function calls, and the SDK is initialized during tests.
- [x] Will be putting up a draft in the `sentry-python` repo soon, once i can figure out `tox` and the rest of our testing infra there :D

As part of https://github.com/getsentry/getsentry/issues/12171. See https://www.notion.so/sentry/LLM-v0-Tech-Spec-81a1aaae56b54c0e93606edcd882cfcd?pvs=4 for spec.

What This looks like in Sentry:
![Screenshot 2023-12-04 at 2 46 10 PM](https://github.com/getsentry/sentry/assets/1976777/5d10cdfb-e5f3-4dd0-8d83-6d371387e385)
![Screenshot 2023-12-04 at 2 46 05 PM](https://github.com/getsentry/sentry/assets/1976777/63706956-b586-4981-932a-56c70e987593)
![Screenshot 2023-12-04 at 2 45 54 PM](https://github.com/getsentry/sentry/assets/1976777/fd6d42ed-7429-4fb2-8c00-7a5416524703)


![Screenshot 2023-12-04 at 2 45 47 PM](https://github.com/getsentry/sentry/assets/1976777/e4d0bad4-6db3-4446-889b-21c70e9336bb)
