### PR TITLE
fix(security): allow to delete OTP in the same session if the sudo cookie expired

### DIFF
--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -15,6 +15,7 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.models.authenticator import Authenticator
 from sentry.models.user import User
 from sentry.security import capture_security_activity
+from sentry.utils.auth import MFA_SESSION_KEY
 
 
 @control_silo_endpoint
@@ -210,5 +211,7 @@ class UserAuthenticatorDetailsEndpoint(UserEndpoint):
                 context={"authenticator": authenticator},
                 send_email=not interface.is_backup_interface,
             )
+
+        request.session.pop(MFA_SESSION_KEY, None)
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -22,6 +22,7 @@ from sentry.models.authenticator import Authenticator
 from sentry.models.user import User
 from sentry.security import capture_security_activity
 from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.utils.auth import MFA_SESSION_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -291,6 +292,8 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
         user.refresh_session_nonce(self.request)
         user.save()
         Authenticator.objects.auto_add_recovery_codes(user)
+
+        request.session[MFA_SESSION_KEY] = str(user.id)
 
         response = Response(status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
1. Log in
2. Set up the TOTP MFA
3. Delete sudo cookie (emulate like it’s expired)
4. Press “trash bin” button near TOTP, Confirm
5. Enter password (we need to restore sudo cookie)
6. The PUT /api/0/auth/ returns 200 but no sudo cookie
7. The DELETE /api/0/users/me/authenticators/16/ fails again (401).

There is this [part of code](https://github.com/getsentry/sentry/blob/9f959b91f9fc34ce1863d05dfbab46193e6d4552/src/sentry/utils/auth.py#L306-L314):
```
    if passed_2fa is None:
        passed_2fa = request.session.get(MFA_SESSION_KEY, "") == str(user.id)

    if user.has_2fa() and not passed_2fa:
        request.session["_pending_2fa"] = [user.id, time(), organization_id]
        if after_2fa is not None:
            request.session["_after_2fa"] = after_2fa
        request.session.modified = True
        return False
```
When a user sets up the MFA, the session does not receive the `mfa` key. Further, when `sudo` cookie is expiring, then it's not possible to pass this set of checks because:
* `passed_2fa` is always None or False
* `user.has_2fa()` is True

The workaround would be to relogin, this will add `mfa` to the session.

Ticket SECURITY-3455