### PR TITLE
fix(replay): Parse timestamp as float (seconds since unix epoch with decimal)

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_accessibility_issues.py
+++ b/src/sentry/replays/endpoints/project_replay_accessibility_issues.py
@@ -76,7 +76,7 @@ class ProjectReplayAccessibilityIssuesEndpoint(ProjectEndpoint):
             timestamp = None
         else:
             try:
-                timestamp = int(timestamp_param)
+                timestamp = float(timestamp_param)
             except TypeError:
                 timestamp = None
             except ValueError:


### PR DESCRIPTION
Fixes SENTRY-1999
