### PR TITLE
fix(replays): Parse timestamp as float

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_accessibility_issues.py
+++ b/src/sentry/replays/endpoints/project_replay_accessibility_issues.py
@@ -76,7 +76,7 @@ class ProjectReplayAccessibilityIssuesEndpoint(ProjectEndpoint):
             timestamp = None
         else:
             try:
-                timestamp = int(timestamp_param)
+                timestamp = float(timestamp_param)
             except TypeError:
                 timestamp = None
             except ValueError:

--- a/src/sentry/replays/usecases/segment.py
+++ b/src/sentry/replays/usecases/segment.py
@@ -14,7 +14,7 @@ def query_segment_storage_meta_by_timestamp(
     organization_id: int,
     project_id: int,
     replay_id: str,
-    timestamp: int,
+    timestamp: float,
 ) -> Mapping[str, Any]:
     # These timestamps do not specify a timezone. They are presumed UTC but we can not verify.
     # Since these times originate from the same place it is enough to treat them relatively. We

--- a/tests/sentry/replays/test_project_replay_accessibility_issues.py
+++ b/tests/sentry/replays/test_project_replay_accessibility_issues.py
@@ -160,9 +160,7 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
 
         with self.feature(REPLAYS_FEATURES):
             # Query at a time interval which returns only the first segment.
-            response = self.client.get(
-                self.url + f"?timestamp={int(seq2_timestamp.timestamp()) - 1}"
-            )
+            response = self.client.get(self.url + f"?timestamp={seq2_timestamp.timestamp() - 1}")
             assert request_accessibility_issues.called
             assert len(request_accessibility_issues.call_args[0][0]) == 1
             assert response.status_code == 200


### PR DESCRIPTION
Fixes [SENTRY-1999](https://sentry.sentry.io/issues/?project=1&query=SENTRY-1999)