### PR TITLE
fix(webvitals): remove pagefilters isready check to remove potential stuck loading loop

### DIFF
--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
@@ -51,7 +51,6 @@ export const useProjectRawWebVitalsQuery = ({transaction, tag, dataset}: Props =
     orgSlug: organization.slug,
     cursor: '',
     options: {
-      enabled: pageFilters.isReady,
       refetchOnWindowFocus: false,
     },
     skipAbort: true,

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawWebVitalsQuery.tsx
@@ -66,7 +66,7 @@ export const useTransactionRawWebVitalsQuery = ({
     location,
     orgSlug: organization.slug,
     options: {
-      enabled: pageFilters.isReady && enabled,
+      enabled,
       refetchOnWindowFocus: false,
     },
     referrer: 'api.performance.browser.web-vitals.transactions',

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -55,7 +55,7 @@ export const useProjectWebVitalsScoresQuery = ({
     orgSlug: organization.slug,
     cursor: '',
     options: {
-      enabled: pageFilters.isReady && enabled,
+      enabled,
       refetchOnWindowFocus: false,
     },
     skipAbort: true,

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -74,7 +74,7 @@ export const useTransactionWebVitalsScoresQuery = ({
     location,
     orgSlug: organization.slug,
     options: {
-      enabled: pageFilters.isReady && enabled,
+      enabled,
       refetchOnWindowFocus: false,
     },
     referrer: 'api.performance.browser.web-vitals.transactions-scores',

--- a/static/app/views/performance/browser/webVitals/utils/queries/useProjectWebVitalsTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/useProjectWebVitalsTimeseriesQuery.tsx
@@ -74,7 +74,6 @@ export const useProjectWebVitalsTimeseriesQuery = ({transaction, tag}: Props) =>
       interval: projectTimeSeriesEventView.interval,
     }),
     options: {
-      enabled: pageFilters.isReady,
       refetchOnWindowFocus: false,
     },
     referrer: 'api.performance.browser.web-vitals.timeseries-scores',

--- a/static/app/views/performance/browser/webVitals/utils/queries/useProjectWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/useProjectWebVitalsValuesTimeseriesQuery.tsx
@@ -71,7 +71,6 @@ export const useProjectWebVitalsValuesTimeseriesQuery = ({
       interval: projectTimeSeriesEventView.interval,
     }),
     options: {
-      enabled: pageFilters.isReady,
       refetchOnWindowFocus: false,
     },
     referrer: 'api.performance.browser.web-vitals.timeseries',

--- a/static/app/views/performance/browser/webVitals/utils/queries/useTransactionSamplesWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/useTransactionSamplesWebVitalsQuery.tsx
@@ -76,7 +76,7 @@ export const useTransactionSamplesWebVitalsQuery = ({
     location,
     orgSlug: organization.slug,
     options: {
-      enabled: enabled && pageFilters.isReady,
+      enabled,
       refetchOnWindowFocus: false,
     },
     referrer: 'api.performance.browser.web-vitals.transaction',

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -948,7 +948,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     expect(await screen.findByTestId('performance-widget-title')).toHaveTextContent(
       'Best Page Opportunities'
     );
-    expect(eventsMock).toHaveBeenCalledTimes(1);
+    expect(eventsMock).toHaveBeenCalledTimes(2);
     expect(eventsMock).toHaveBeenNthCalledWith(
       1,
       expect.anything(),
@@ -972,6 +972,16 @@ describe('Performance > Widgets > WidgetContainer', function () {
           query: 'transaction.op:pageload',
           sort: '-count()',
           statsPeriod: '7d',
+          referrer: 'api.performance.generic-widget-chart.highest-opportunity-pages',
+        }),
+      })
+    );
+    expect(eventsMock).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          referrer: 'api.performance.browser.web-vitals.project',
         }),
       })
     );


### PR DESCRIPTION
We have a pagefilters.isready check on the webvitals module before firing any queries. This check isn't essential and was more for optimization, but it's potentially blocking the webvitals module from loading entirely if pagefilters is somehow never ready.