### PR TITLE
feat(eventuser): Deprecate API docs response properties

### DIFF
--- a/api-docs/paths/projects/users.json
+++ b/api-docs/paths/projects/users.json
@@ -40,14 +40,8 @@
               "type": "array",
               "items": {
                 "type": "object",
-                "required": ["dateCreated", "id", "username", "email"],
+                "required": ["username", "email"],
                 "properties": {
-                  "dateCreated": {
-                    "type": "string"
-                  },
-                  "id": {
-                    "type": "string"
-                  },
                   "username": {
                     "type": "string",
                     "nullable": true
@@ -61,8 +55,6 @@
             },
             "example": [
               {
-                "dateCreated": "2020-07-16T00:50:40.342174Z",
-                "id": "21077833046",
                 "username": "sentry",
                 "email": "sentry@example.com"
               }

--- a/tests/apidocs/endpoints/projects/test_users.py
+++ b/tests/apidocs/endpoints/projects/test_users.py
@@ -55,6 +55,7 @@ class ProjectUsersDocs(APIDocsTestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
     def test_get(self):
-        response = self.client.get(self.url)
-        request = RequestFactory().get(self.url)
-        self.validate_schema(request, response)
+        with self.feature("organizations:eventuser-from-snuba"):
+            response = self.client.get(self.url)
+            request = RequestFactory().get(self.url)
+            self.validate_schema(request, response)


### PR DESCRIPTION
## Objective:
We will not have the `id` and `dateCreated` properties. These are `None` when we query from Snuba. I want to remove those properties from the docs.