### PR TITLE
feat(relocation): Enable pausing

### DIFF
--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -142,7 +142,6 @@ def uploading_complete(uuid: str) -> None:
     attempts_left: int
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
-        step=Relocation.Step.UPLOADING,
         task=OrderedTask.UPLOADING_COMPLETE,
         allowed_task_attempts=MAX_FAST_TASK_ATTEMPTS,
     )
@@ -205,7 +204,6 @@ def preprocessing_scan(uuid: str) -> None:
     attempts_left: int
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
-        step=Relocation.Step.PREPROCESSING,
         task=OrderedTask.PREPROCESSING_SCAN,
         allowed_task_attempts=MAX_FAST_TASK_ATTEMPTS,
     )
@@ -350,7 +348,6 @@ def preprocessing_baseline_config(uuid: str) -> None:
     attempts_left: int
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
-        step=Relocation.Step.PREPROCESSING,
         task=OrderedTask.PREPROCESSING_BASELINE_CONFIG,
         allowed_task_attempts=MAX_FAST_TASK_ATTEMPTS,
     )
@@ -407,7 +404,6 @@ def preprocessing_colliding_users(uuid: str) -> None:
     attempts_left: int
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
-        step=Relocation.Step.PREPROCESSING,
         task=OrderedTask.PREPROCESSING_COLLIDING_USERS,
         allowed_task_attempts=MAX_FAST_TASK_ATTEMPTS,
     )
@@ -463,7 +459,6 @@ def preprocessing_complete(uuid: str) -> None:
     attempts_left: int
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
-        step=Relocation.Step.PREPROCESSING,
         task=OrderedTask.PREPROCESSING_COMPLETE,
         allowed_task_attempts=MAX_FAST_TASK_ATTEMPTS,
     )
@@ -694,7 +689,6 @@ def validating_start(uuid: str) -> None:
     attempts_left: int
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
-        step=Relocation.Step.VALIDATING,
         task=OrderedTask.VALIDATING_START,
         allowed_task_attempts=MAX_FAST_TASK_ATTEMPTS,
     )
@@ -771,7 +765,6 @@ def validating_poll(uuid: str, build_id: str) -> None:
     attempts_left: int
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
-        step=Relocation.Step.VALIDATING,
         task=OrderedTask.VALIDATING_POLL,
         allowed_task_attempts=MAX_VALIDATION_POLL_ATTEMPTS,
     )
@@ -867,7 +860,6 @@ def validating_complete(uuid: str, build_id: str) -> None:
     attempts_left: int
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
-        step=Relocation.Step.VALIDATING,
         task=OrderedTask.VALIDATING_COMPLETE,
         allowed_task_attempts=MAX_FAST_TASK_ATTEMPTS,
     )
@@ -933,7 +925,6 @@ def importing(uuid: str) -> None:
     attempts_left: int
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
-        step=Relocation.Step.IMPORTING,
         task=OrderedTask.IMPORTING,
         allowed_task_attempts=1,
     )
@@ -991,7 +982,6 @@ def postprocessing(uuid: str) -> None:
     attempts_left: int
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
-        step=Relocation.Step.POSTPROCESSING,
         task=OrderedTask.POSTPROCESSING,
         allowed_task_attempts=MAX_FAST_TASK_ATTEMPTS,
     )
@@ -1063,7 +1053,6 @@ def notifying_users(uuid: str) -> None:
     attempts_left: int
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
-        step=Relocation.Step.NOTIFYING,
         task=OrderedTask.NOTIFYING_USERS,
         allowed_task_attempts=MAX_FAST_TASK_ATTEMPTS,
     )
@@ -1124,7 +1113,6 @@ def notifying_owner(uuid: str) -> None:
     attempts_left: int
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
-        step=Relocation.Step.NOTIFYING,
         task=OrderedTask.NOTIFYING_OWNER,
         allowed_task_attempts=MAX_FAST_TASK_ATTEMPTS,
     )
@@ -1166,7 +1154,6 @@ def completed(uuid: str) -> None:
     attempts_left: int
     (relocation, attempts_left) = start_relocation_task(
         uuid=uuid,
-        step=Relocation.Step.COMPLETED,
         task=OrderedTask.COMPLETED,
         allowed_task_attempts=MAX_FAST_TASK_ATTEMPTS,
     )

--- a/src/sentry/utils/relocation.py
+++ b/src/sentry/utils/relocation.py
@@ -42,6 +42,28 @@ class OrderedTask(Enum):
     COMPLETED = 13
 
 
+# Match each `OrderedTask` to the `Relocation.Step` it is part of.
+TASK_TO_STEP: dict[OrderedTask, Relocation.Step] = {
+    OrderedTask.NONE: Relocation.Step.UNKNOWN,
+    OrderedTask.UPLOADING_COMPLETE: Relocation.Step.UPLOADING,
+    OrderedTask.PREPROCESSING_SCAN: Relocation.Step.PREPROCESSING,
+    OrderedTask.PREPROCESSING_BASELINE_CONFIG: Relocation.Step.PREPROCESSING,
+    OrderedTask.PREPROCESSING_COLLIDING_USERS: Relocation.Step.PREPROCESSING,
+    OrderedTask.PREPROCESSING_COMPLETE: Relocation.Step.PREPROCESSING,
+    OrderedTask.VALIDATING_START: Relocation.Step.VALIDATING,
+    OrderedTask.VALIDATING_POLL: Relocation.Step.VALIDATING,
+    OrderedTask.VALIDATING_COMPLETE: Relocation.Step.VALIDATING,
+    OrderedTask.IMPORTING: Relocation.Step.IMPORTING,
+    OrderedTask.POSTPROCESSING: Relocation.Step.POSTPROCESSING,
+    OrderedTask.NOTIFYING_USERS: Relocation.Step.NOTIFYING,
+    OrderedTask.NOTIFYING_OWNER: Relocation.Step.NOTIFYING,
+    OrderedTask.COMPLETED: Relocation.Step.COMPLETED,
+}
+
+
+assert list(OrderedTask._member_map_.keys()) == [k.name for k in TASK_TO_STEP.keys()]
+
+
 # The file type for a relocation export tarball of any kind.
 RELOCATION_FILE_TYPE = "relocation.file"
 
@@ -54,7 +76,7 @@ RELOCATION_FILE_TYPE = "relocation.file"
 # per blob.
 #
 # Note that the actual production file size limit, set by uwsgi, is currently 209715200 bytes, or
-# ~200MB, so we should never see more than ~4 blobs in
+# ~200MB, so we should never see more than ~4 blobs in practice.
 RELOCATION_BLOB_SIZE = int((2**31) / 32)
 
 
@@ -329,7 +351,7 @@ def send_relocation_update_email(
 
 
 def start_relocation_task(
-    uuid: str, step: Relocation.Step, task: OrderedTask, allowed_task_attempts: int
+    uuid: str, task: OrderedTask, allowed_task_attempts: int
 ) -> Tuple[Optional[Relocation], int]:
     """
     All tasks for relocation are done sequentially, and take the UUID of the `Relocation` model as
@@ -344,7 +366,11 @@ def start_relocation_task(
     except Relocation.DoesNotExist as exc:
         logger.error(f"Could not locate Relocation model by UUID: {uuid}", exc_info=exc)
         return (None, 0)
-    if relocation.status != Relocation.Status.IN_PROGRESS.value:
+
+    if relocation.status not in {
+        Relocation.Status.IN_PROGRESS.value,
+        Relocation.Status.PAUSE.value,
+    }:
         logger.error(
             f"Relocation has already completed as `{Relocation.Status(relocation.status)}`",
             extra=logger_data,
@@ -371,6 +397,24 @@ def start_relocation_task(
     else:
         relocation.latest_task = task.name
         relocation.latest_task_attempts = 1
+
+    # TODO(getsentry/team-ospo#216): Add an option like 'relocation:autopause-at-steps', which will
+    # be an array of steps that we want relocations to automatically pause at. Will be useful once
+    # we have self-serve relocations, and want a means by which to check their validity (bugfixes,
+    # etc).
+    step = TASK_TO_STEP[task]
+    at_scheduled_pause = (
+        relocation.step + 1 == step.value and relocation.scheduled_pause_at_step == step.value
+    )
+    if relocation.status == Relocation.Status.PAUSE.value or at_scheduled_pause:
+        logger.info("Task aborted due to relocation pause", extra=logger_data)
+
+        # Pause the relocation. We will not be able to pause at this step again once we restart.
+        relocation.step = step.value
+        relocation.status = Relocation.Status.PAUSE.value
+        relocation.scheduled_pause_at_step = None
+        relocation.save()
+        return (None, 0)
 
     relocation.step = step.value
     relocation.save()

--- a/tests/sentry/utils/test_relocation.py
+++ b/tests/sentry/utils/test_relocation.py
@@ -40,13 +40,11 @@ class RelocationStartTestCase(RelocationUtilsTestCase):
         self.mock_message_builder(fake_message_builder)
 
         uuid = uuid4().hex
-        (relocation, attempts_left) = start_relocation_task(
-            uuid, Relocation.Step.UPLOADING, OrderedTask.UPLOADING_COMPLETE, 3
-        )
+        (rel, attempts_left) = start_relocation_task(uuid, OrderedTask.UPLOADING_COMPLETE, 3)
 
         assert fake_message_builder.call_count == 0
 
-        assert relocation is None
+        assert rel is None
         assert not attempts_left
 
     def test_bad_relocation_completed(self, fake_message_builder: Mock):
@@ -55,22 +53,18 @@ class RelocationStartTestCase(RelocationUtilsTestCase):
         self.relocation.status = Relocation.Status.FAILURE.value
         self.relocation.save()
 
-        (relocation, attempts_left) = start_relocation_task(
-            self.uuid, Relocation.Step.UPLOADING, OrderedTask.UPLOADING_COMPLETE, 3
-        )
+        (rel, attempts_left) = start_relocation_task(self.uuid, OrderedTask.UPLOADING_COMPLETE, 3)
 
         assert fake_message_builder.call_count == 0
 
-        assert relocation is None
+        assert rel is None
         assert not attempts_left
         assert Relocation.objects.get(uuid=self.uuid).status == Relocation.Status.FAILURE.value
 
     def test_bad_unknown_task(self, fake_message_builder: Mock):
         self.mock_message_builder(fake_message_builder)
 
-        (relocation, attempts_left) = start_relocation_task(
-            self.uuid, Relocation.Step.UPLOADING, OrderedTask.NONE, 3
-        )
+        (rel, attempts_left) = start_relocation_task(self.uuid, OrderedTask.NONE, 3)
 
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
@@ -78,7 +72,7 @@ class RelocationStartTestCase(RelocationUtilsTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        assert relocation is None
+        assert rel is None
         assert not attempts_left
         assert Relocation.objects.get(uuid=self.uuid).status == Relocation.Status.FAILURE.value
 
@@ -88,9 +82,7 @@ class RelocationStartTestCase(RelocationUtilsTestCase):
         self.relocation.latest_task = OrderedTask.PREPROCESSING_SCAN.name
         self.relocation.save()
 
-        (relocation, attempts_left) = start_relocation_task(
-            self.uuid, Relocation.Step.UPLOADING, OrderedTask.UPLOADING_COMPLETE, 3
-        )
+        (rel, attempts_left) = start_relocation_task(self.uuid, OrderedTask.UPLOADING_COMPLETE, 3)
 
         assert fake_message_builder.call_count == 1
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
@@ -98,24 +90,19 @@ class RelocationStartTestCase(RelocationUtilsTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        assert relocation is None
+        assert rel is None
         assert not attempts_left
         assert Relocation.objects.get(uuid=self.uuid).status == Relocation.Status.FAILURE.value
 
     def test_good_first_task(self, fake_message_builder: Mock):
         self.mock_message_builder(fake_message_builder)
 
-        (relocation, attempts_left) = start_relocation_task(
-            self.uuid, Relocation.Step.UPLOADING, OrderedTask.UPLOADING_COMPLETE, 3
-        )
+        (rel, attempts_left) = start_relocation_task(self.uuid, OrderedTask.UPLOADING_COMPLETE, 3)
 
         assert fake_message_builder.call_count == 0
-
-        assert relocation is not None
         assert attempts_left == 2
 
-        relocation = Relocation.objects.get(uuid=self.uuid)
-        assert relocation is not None
+        relocation: Relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.step == Relocation.Step.UPLOADING.value
         assert relocation.status != Relocation.Status.FAILURE.value
 
@@ -125,21 +112,50 @@ class RelocationStartTestCase(RelocationUtilsTestCase):
         self.relocation.latest_task = OrderedTask.UPLOADING_COMPLETE.name
         self.relocation.save()
 
-        assert self.relocation.step == Relocation.Step.UPLOADING.value
-
-        (relocation, attempts_left) = start_relocation_task(
-            self.uuid, Relocation.Step.PREPROCESSING, OrderedTask.PREPROCESSING_SCAN, 3
-        )
+        (rel, attempts_left) = start_relocation_task(self.uuid, OrderedTask.PREPROCESSING_SCAN, 3)
 
         assert fake_message_builder.call_count == 0
-
-        assert relocation is not None
         assert attempts_left == 2
 
-        relocation = Relocation.objects.get(uuid=self.uuid)
-        assert relocation is not None
+        relocation: Relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.step == Relocation.Step.PREPROCESSING.value
         assert relocation.status != Relocation.Status.FAILURE.value
+
+    def test_good_pause_at_scheduled_pause(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
+        self.relocation.latest_task = OrderedTask.UPLOADING_COMPLETE.name
+        self.relocation.scheduled_pause_at_step = Relocation.Step.PREPROCESSING.value
+        self.relocation.save()
+
+        (rel, attempts_left) = start_relocation_task(self.uuid, OrderedTask.PREPROCESSING_SCAN, 3)
+
+        assert fake_message_builder.call_count == 0
+        assert attempts_left == 0
+
+        relocation: Relocation = Relocation.objects.get(uuid=self.uuid)
+        assert relocation.step == Relocation.Step.PREPROCESSING.value
+        assert relocation.latest_task == OrderedTask.PREPROCESSING_SCAN.name
+        assert relocation.status == Relocation.Status.PAUSE.value
+        assert relocation.scheduled_pause_at_step is None
+
+    def test_good_already_paused(self, fake_message_builder: Mock):
+        self.mock_message_builder(fake_message_builder)
+
+        self.relocation.latest_task = OrderedTask.UPLOADING_COMPLETE.name
+        self.relocation.status = Relocation.Status.PAUSE.value
+        self.relocation.save()
+
+        (rel, attempts_left) = start_relocation_task(self.uuid, OrderedTask.UPLOADING_COMPLETE, 3)
+
+        assert fake_message_builder.call_count == 0
+        assert attempts_left == 0
+
+        relocation: Relocation = Relocation.objects.get(uuid=self.uuid)
+        assert relocation.step == Relocation.Step.UPLOADING.value
+        assert relocation.latest_task == OrderedTask.UPLOADING_COMPLETE.name
+        assert relocation.status == Relocation.Status.PAUSE.value
+        assert relocation.scheduled_pause_at_step is None
 
 
 @patch("sentry.utils.relocation.MessageBuilder")


### PR DESCRIPTION
This allows relocations to be "paused" before a particular step by setting the `scheduled_pause_at_step` on a model instance. This is useful for debugging and carefully monitoring relocations - for example, if we ant to "verify" with a user that their relocation looks okay, we could set it to pause before the `NOTIFYING` step, thereby getting a sanity check before all of the emails to the newly imported users go out.

Issue: getsentry/team-ospo#222