### PR TITLE
feat(relocation): Track emails sent on relocation

### DIFF
--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -1092,6 +1092,9 @@ def notifying_users(uuid: str) -> None:
             hash = lost_password_hash_service.get_or_create(user_id=user.id).hash
             LostPasswordHash.send_relocate_account_email(user, hash, relocation.want_org_slugs)
 
+        relocation.latest_unclaimed_emails_sent_at = datetime.now()
+        relocation.save()
+
         notifying_owner.delay(uuid)
 
 

--- a/src/sentry/utils/relocation.py
+++ b/src/sentry/utils/relocation.py
@@ -327,7 +327,7 @@ class LoggingPrinter(Printer):
 
 def send_relocation_update_email(
     relocation: Relocation, email_kind: Relocation.EmailKind, args: dict[str, Any]
-):
+) -> None:
     name = str(email_kind.name)
     name_lower = name.lower()
     msg = MessageBuilder(
@@ -348,6 +348,9 @@ def send_relocation_update_email(
             email_to.append(creator.email)
 
     msg.send_async(to=email_to)
+
+    relocation.latest_notified = email_kind.value
+    relocation.save()
 
 
 def start_relocation_task(

--- a/tests/sentry/utils/test_relocation.py
+++ b/tests/sentry/utils/test_relocation.py
@@ -171,8 +171,9 @@ class RelocationFailTestCase(RelocationUtilsTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        relocation = Relocation.objects.get(uuid=self.uuid)
+        relocation: Relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
+        assert relocation.latest_notified == Relocation.EmailKind.FAILED.value
         assert not relocation.failure_reason
 
     def test_with_reason(self, fake_message_builder: Mock):
@@ -186,8 +187,9 @@ class RelocationFailTestCase(RelocationUtilsTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        relocation = Relocation.objects.get(uuid=self.uuid)
+        relocation: Relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
+        assert relocation.latest_notified == Relocation.EmailKind.FAILED.value
         assert relocation.failure_reason == "foo"
 
 
@@ -202,7 +204,10 @@ class RelocationRetryOrFailTestCase(RelocationUtilsTestCase):
 
         assert fake_message_builder.call_count == 0
 
-        assert Relocation.objects.get(uuid=self.uuid).status == Relocation.Status.IN_PROGRESS.value
+        relocation: Relocation = Relocation.objects.get(uuid=self.uuid)
+        assert relocation.status == Relocation.Status.IN_PROGRESS.value
+        assert relocation.latest_notified != Relocation.EmailKind.FAILED.value
+        assert not relocation.failure_reason
 
     def test_no_reason_last_attempt(self, fake_message_builder: Mock):
         self.mock_message_builder(fake_message_builder)
@@ -220,7 +225,9 @@ class RelocationRetryOrFailTestCase(RelocationUtilsTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        assert Relocation.objects.get(uuid=self.uuid).status == Relocation.Status.FAILURE.value
+        relocation: Relocation = Relocation.objects.get(uuid=self.uuid)
+        assert relocation.status == Relocation.Status.FAILURE.value
+        assert relocation.latest_notified == Relocation.EmailKind.FAILED.value
 
     def test_with_reason_attempts_left(self, fake_message_builder: Mock):
         self.mock_message_builder(fake_message_builder)
@@ -233,9 +240,9 @@ class RelocationRetryOrFailTestCase(RelocationUtilsTestCase):
 
         assert fake_message_builder.call_count == 0
 
-        relocation = Relocation.objects.get(uuid=self.uuid)
-        assert relocation is not None
+        relocation: Relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.IN_PROGRESS.value
+        assert relocation.latest_notified != Relocation.EmailKind.FAILED.value
         assert not relocation.failure_reason
 
     def test_with_reason_last_attempt(self, fake_message_builder: Mock):
@@ -256,7 +263,7 @@ class RelocationRetryOrFailTestCase(RelocationUtilsTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        relocation = Relocation.objects.get(uuid=self.uuid)
-        assert relocation is not None
+        relocation: Relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
+        assert relocation.latest_notified == Relocation.EmailKind.FAILED.value
         assert relocation.failure_reason == "foo"


### PR DESCRIPTION
We now utilize two newly added model fields, `latest_notified` and `latest_unclaimed_sent_emails_at`, to notes when we've sent out notification emails. The first of these tracks emails sent to the owner of the relocation, while the latter tracks emails sent to unclaimed users.

Issue: getsentry/team-ospo#222