### PR TITLE
feat: Bump sentry sdk to 67c963d9c8d5e7e9de6347aee0edcf0c58d9fb24

### DIFF
--- a/requirements-getsentry-overrides.txt
+++ b/requirements-getsentry-overrides.txt
@@ -7,3 +7,4 @@
 # the format is:
 # # comment explaining what you're doing
 # library-name @ https://github.com/getsentry/<repo>/archive/<40 char sha>.zip
+sentry-sdk @ https://github.com/getsentry/sentry-python/archive/67c963d9c8d5e7e9de6347aee0edcf0c58d9fb24.zip


### PR DESCRIPTION
Bumps up the sentry SDK to a version with fixed metric summaries.

Addresses the incorrect format so that summaries are stored as lists.

Refs https://github.com/getsentry/snuba/pull/5152