### PR TITLE
fix(ddm): Allow derived metrics in alerts with the metrics layer enabled

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -122,6 +122,15 @@ class MetricsQueryBuilder(QueryBuilder):
         if self.use_on_demand:
             return True
 
+        # If we are using the metrics layer, we consider columns to be resolved if they are of type `Function` or
+        # `AlisedExpression`. The reason for why we have to check for `AlisedExpression` is because some derived metrics
+        # are passed as aliased expressions to the MQB query transformer.
+        if self.use_metrics_layer:
+            first_column = self.columns[0]
+            return self.columns and (
+                isinstance(first_column, Function) or isinstance(first_column, AliasedExpression)
+            )
+
         return super().are_columns_resolved()
 
     def _get_on_demand_metric_spec(self, field: str) -> Optional[OnDemandMetricSpec]:

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -768,6 +768,33 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
                 == "Performance alerts must use the `generic_metrics` dataset"
             )
 
+    def test_alert_with_metrics_layer(self):
+        with self.feature(
+            [
+                "organizations:incidents",
+                "organizations:performance-view",
+                "organizations:mep-rollout-flag",
+                "organizations:dynamic-sampling",
+                "organizations:use-metrics-layer-in-alerts",
+            ]
+        ):
+            for mri in ("apdex()", "failure_rate()"):
+                test_params = {
+                    **self.alert_rule_dict,
+                    "aggregate": mri,
+                    "dataset": "generic_metrics",
+                }
+
+                resp = self.get_success_response(
+                    self.organization.slug,
+                    status_code=201,
+                    **test_params,
+                )
+
+                assert "id" in resp.data
+                alert_rule = AlertRule.objects.get(id=resp.data["id"])
+                assert resp.data == serialize(alert_rule, self.user)
+
     def test_alert_with_metric_mri(self):
         with self.feature(
             [


### PR DESCRIPTION
This PR implements a fix for derived metrics validation in which we were not validating correctly derived metrics, since when the query builder is using the metrics layer, such metrics are resolved as `AliasedExpression` and not `Function` like it should be.

Closes https://github.com/getsentry/sentry/issues/61112