### PR TITLE
fix: move clone-suffix removal before removing...

### DIFF
--- a/src/sentry/stacktraces/functions.py
+++ b/src/sentry/stacktraces/functions.py
@@ -136,6 +136,14 @@ def trim_native_function_name(function, platform, normalize_lambdas=True):
     if function.startswith(("[", "+[", "-[")):
         return function
 
+    # Remove special `[clone .foo]` annotations for cloned/split functions
+    def process_brackets(value, start):
+        if value.startswith("clone ."):
+            return ""
+        return "[%s]" % value
+
+    function = replace_enclosed_string(function, "[", "]", process_brackets).rstrip()
+
     # Chop off C++ trailers
     while True:
         match = _cpp_trailer_re.search(function)
@@ -198,14 +206,6 @@ def trim_native_function_name(function, platform, normalize_lambdas=True):
         return value.split(" as ", 1)[0]
 
     function = replace_enclosed_string(function, "<", ">", process_generics)
-
-    # Remove special `[clone .foo]` annotations for cloned/split functions
-    def process_brackets(value, start):
-        if value.startswith("clone ."):
-            return ""
-        return "[%s]" % value
-
-    function = replace_enclosed_string(function, "[", "]", process_brackets)
 
     is_thunk = "thunk for " in function  # swift
 

--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -92,6 +92,7 @@ from sentry.stacktraces.functions import (
         ["lambda_7156c3ceaa11256748687ab67e3ef4cd", "lambda"],
         ["<lambda_7156c3ceaa11256748687ab67e3ef4cd>::operator()", "<lambda>::operator()"],
         ["trigger_crash_a(int*) [clone .constprop.0]", "trigger_crash_a"],
+        ["ShellCorona::screenInvariants() const [clone .cold]", "ShellCorona::screenInvariants"],
         [
             "__gnu_cxx::__verbose_terminate_handler() [clone .cold]",
             "__gnu_cxx::__verbose_terminate_handler",


### PR DESCRIPTION
...the C++ trailers when trimming native functions.

`trim_native_function_name()` removes `const` as part of a trailers-regex right at the beginning. If the function also has a clone suffix, then the `const` will not be removed at that early stage (because it is not at the end of the full name).

When the clone suffix is removed, `const` ends up being the last remaining name token, which, as part of a heuristic, is defined to be the function name.

Fixes #61114.

CC: @kahest, @Swatinem 