### PR TITLE
Use a single filter for ArtifactBundle query

### DIFF
--- a/src/sentry/debug_files/artifact_bundles.py
+++ b/src/sentry/debug_files/artifact_bundles.py
@@ -407,7 +407,7 @@ def get_bundles_indexing_state(
     total_bundles = 0
     indexed_bundles = 0
 
-    filter = {
+    filter: dict = {
         "releaseartifactbundle__release_name": release_name,
         "releaseartifactbundle__dist_name": dist_name,
     }


### PR DESCRIPTION
Looks like django didn't like chaining of multiple `filter` expressions and generated another join which resulted in a very suboptimal query. Now this should generate a single JOIN which will result in the same query as previously.