### PR TITLE
feat(ddm): Add the new metrics layer flag for meta endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -57,7 +57,12 @@ class OrganizationMetricsEndpoint(OrganizationEndpoint):
     def get(self, request: Request, organization) -> Response:
         projects = self.get_projects(request, organization)
 
-        metrics = get_metrics_meta(projects, use_case_id=get_use_case_id(request))
+        use_new_metrics_layer = request.GET.get("useNewMetricsLayer", "false") == "true"
+        metrics = get_metrics_meta(
+            projects,
+            use_case_id=get_use_case_id(request),
+            use_new_metrics_layer=use_new_metrics_layer,
+        )
 
         return Response(metrics, status=200)
 

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -133,6 +133,7 @@ class OrganizationMetricsMetaTest(OrganizationMetricMetaIntegrationTestCase):
         )
 
         assert len(response.data) == 1
+        assert response.data[0]["mri"] == set_mri
         assert "uniq" in response.data[0]["operations"]
 
     def test_metrics_meta_invalid_use_case(self):

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -112,6 +112,29 @@ class OrganizationMetricsMetaTest(OrganizationMetricMetaIntegrationTestCase):
 
         assert isinstance(response.data, list)
 
+    def test_metrics_meta_with_metrics_layer(self):
+        set_mri = "s:custom/user_click@none"
+        self.store_metric(
+            self.project.organization.id,
+            self.project.id,
+            "set",
+            set_mri,
+            {},
+            int(self.now.timestamp()),
+            "marco",
+            UseCaseID.CUSTOM,
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            project=[self.project.id],
+            useCase=["custom"],
+            useNewMetricsLayer="true",
+        )
+
+        assert len(response.data) == 1
+        assert "uniq" in response.data[0]["operations"]
+
     def test_metrics_meta_invalid_use_case(self):
         response = self.get_error_response(
             self.organization.slug, project=[self.project.id], useCase=["not-a-use-case"]

--- a/tests/sentry/sentry_metrics/querying/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/test_api.py
@@ -352,6 +352,39 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
                 referrer="metrics.data.api",
             )
 
+    def test_query_with_custom_set(self):
+        mri = "s:custom/user_click@none"
+        for user in ("marco", "marco", "john"):
+            self.store_metric(
+                self.project.organization.id,
+                self.project.id,
+                "set",
+                mri,
+                {},
+                self.ts(self.now()),
+                user,
+                UseCaseID.CUSTOM,
+            )
+
+        field = f"uniq({mri})"
+        results = run_metrics_query(
+            fields=[field],
+            query=None,
+            group_bys=None,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        groups = results["groups"]
+        assert len(groups) == 1
+        assert groups[0]["by"] == {}
+        assert groups[0]["series"] == {field: [0, 2, 0]}
+        assert groups[0]["totals"] == {field: 2}
+
     @pytest.mark.skip(reason="sessions are not supported in the new metrics layer")
     def test_with_sessions(self) -> None:
         self.store_session(


### PR DESCRIPTION
This PR adds a new flag for the metric meta endpoint which will return transformed operations that are needed to correctly query the new metrics API.

The only transformation implemented now is `count_unique` -> `uniq` which means that `uniq` will be used if the new metrics API is queried and `count_unique` if the old one is queried.