### PR TITLE
fix(jira) Restore jira script tag

### DIFF
--- a/src/sentry/templates/sentry/integrations/jira-config.html
+++ b/src/sentry/templates/sentry/integrations/jira-config.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  {% script src=ac_js_src %}{% endscript %}
   <style>
     {% include 'sentry/integrations/jira/aui-prototyping.9.1.5.css' %}
     :root {

--- a/src/sentry/templates/sentry/integrations/jira-issue.html
+++ b/src/sentry/templates/sentry/integrations/jira-issue.html
@@ -3,6 +3,7 @@
 {% load sentry_assets %}
 <html lang="en">
   <head>
+    {% script src=ac_js_src %}{% endscript %}
     <style>
       {% include 'sentry/integrations/jira/aui-prototyping.9.1.5.css' %}
       body {


### PR DESCRIPTION
When removing the aui library I also removed the ac_js script reference which is necessary for jira to sucessfully connect with our integration.

Refs #60869
Refs #59622
