### PR TITLE
feat(perf): Add release information to transaction event serializer

### DIFF
--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -46,7 +46,9 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         if hasattr(event, "for_group") and event.group:
             event = event.for_group(event.group)
 
-        data = serialize(event, request.user, SqlFormatEventSerializer())
+        data = serialize(
+            event, request.user, SqlFormatEventSerializer(), include_full_release_data=False
+        )
         data["projectSlug"] = project_slug
 
         return Response(data)

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -321,6 +321,9 @@ class SqlFormatEventSerializer(EventSerializer):
         super().__init__()
         self.formatted_sql_cache: Dict[str, str] = {}
 
+    def get_attrs(self, item_list, user, is_public=False, **kwargs):
+        return super().get_attrs(item_list, user, is_public=is_public)
+
     # Various checks to ensure that we don't spend too much time formatting
     def _should_skip_formatting(self, query: str):
         if (

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -414,12 +414,13 @@ class SqlFormatEventSerializer(EventSerializer):
             sentry_sdk.capture_exception(exc)
             return event_data
 
-    def serialize(self, obj, attrs, user):
+    def serialize(self, obj, attrs, user, include_full_release_data=False):
         result = super().serialize(obj, attrs, user)
 
         with sentry_sdk.start_span(op="serialize", description="Format SQL"):
             result = self._format_breadcrumb_messages(result, obj, user)
             result = self._format_db_spans(result, obj, user)
+            result["release"] = self._get_release_info(user, obj, include_full_release_data)
 
         return result
 
@@ -450,8 +451,7 @@ class IssueEventSerializer(SqlFormatEventSerializer):
         return list(unique_resolution_methods)
 
     def serialize(self, obj, attrs, user, include_full_release_data=False):
-        result = super().serialize(obj, attrs, user)
-        result["release"] = self._get_release_info(user, obj, include_full_release_data)
+        result = super().serialize(obj, attrs, user, include_full_release_data)
         result["userReport"] = self._get_user_report(user, obj)
         result["sdkUpdates"] = self._get_sdk_updates(obj)
         result["resolvedWith"] = self._get_resolved_with(obj)


### PR DESCRIPTION
In some contexts (e.g., the Database module) we want to know the release associated with a given transaction, but the release isn't in the payload, unlike for errors. This PR updates `SqlFormatEventSerializer` to include `"release"` as a key in the response. I moved some methods around to make this easier, see commit log for details!

- Move `_get_release_info` into parent class
- Add missing `get_attrs` method
- Add release into to serialized event
