### PR TITLE
feat(on-demand): Add support for p90 in on demand and remove one dependency from query builders

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -1166,18 +1166,6 @@ class MetricsQueryBuilder(QueryBuilder):
             return None
 
 
-class UnresolvedMetricsQuery(MetricsQueryBuilder):
-    def resolve_query(
-        self,
-        query: Optional[str] = None,
-        selected_columns: Optional[List[str]] = None,
-        groupby_columns: Optional[List[str]] = None,
-        equations: Optional[List[str]] = None,
-        orderby: list[str] | str | None = None,
-    ) -> None:
-        pass
-
-
 class AlertMetricsQueryBuilder(MetricsQueryBuilder):
     is_alerts_query = True
 

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -1166,6 +1166,18 @@ class MetricsQueryBuilder(QueryBuilder):
             return None
 
 
+class UnresolvedMetricsQuery(MetricsQueryBuilder):
+    def resolve_query(
+        self,
+        query: Optional[str] = None,
+        selected_columns: Optional[List[str]] = None,
+        groupby_columns: Optional[List[str]] = None,
+        equations: Optional[List[str]] = None,
+        orderby: list[str] | str | None = None,
+    ) -> None:
+        pass
+
+
 class AlertMetricsQueryBuilder(MetricsQueryBuilder):
     is_alerts_query = True
 

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -174,6 +174,7 @@ _SEARCH_TO_METRIC_AGGREGATES: Dict[str, MetricOperationType] = {
     "max": "max",
     "p50": "p50",
     "p75": "p75",
+    "p90": "p90",
     "p95": "p95",
     "p99": "p99",
     # p100 is not supported in the metrics layer, so we convert to max which is equivalent.
@@ -490,6 +491,8 @@ def _get_percentile_op(args: Sequence[str]) -> Optional[MetricOperationType]:
         return "p50"
     if percentile == "0.75":
         return "p75"
+    if percentile in ["0.9", "0.90"]:
+        return "p90"
     if percentile == "0.95":
         return "p95"
     if percentile == "0.99":

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -44,6 +44,12 @@ from sentry.testutils.pytest.fixtures import django_db_all
             "transaction.duration:>1",
             True,
         ),  # transaction.duration query is on-demand
+        ("p90(transaction.duration)", "release:a", False),  # supported by standard metrics
+        (
+            "p90(transaction.duration)",
+            "transaction.duration:>1",
+            True,
+        ),  # transaction.duration query is on-demand
         ("count()", "", False),  # Malformed aggregate should return false
         (
             "count()",
@@ -120,6 +126,8 @@ class TestCreatesOndemandMetricSpec:
             # we don't support custom percentiles that can be mapped to one of standard percentiles
             ("percentile(transaction.duration, 0.5)", "transaction.duration>0"),
             ("percentile(transaction.duration, 0.50)", "transaction.duration>0"),
+            ("percentile(transaction.duration, 0.9)", "transaction.duration>0"),
+            ("percentile(transaction.duration, 0.90)", "transaction.duration>0"),
             ("percentile(transaction.duration, 0.95)", "transaction.duration>0"),
             ("percentile(transaction.duration, 0.99)", "transaction.duration>0"),
             ("percentile(transaction.duration, 1)", "transaction.duration>0"),

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -20,57 +20,72 @@ from sentry.testutils.pytest.fixtures import django_db_all
 @pytest.mark.parametrize(
     "agg, query, result",
     [
-        # ("count()", "release:a", False),  # supported by standard metrics
-        # ("failure_rate()", "release:a", False),  # supported by standard metrics
-        # ("count_unique(geo.city)", "release:a", False),
-        # # geo.city not supported by standard metrics, but also not by on demand
-        # (
-        #     "count()",
-        #     "transaction.duration:>1",
-        #     True,
-        # ),  # transaction.duration not supported by standard metrics
-        # ("failure_count()", "transaction.duration:>1", True),  # supported by on demand
-        # ("failure_rate()", "transaction.duration:>1", True),  # supported by on demand
-        # ("apdex(10)", "", True),  # every apdex query is on-demand
-        # ("apdex(10)", "transaction.duration:>10", True),  # supported by on demand
-        # (
-        #     "count_if(transaction.duration,equals,0)",
-        #     "release:a",
-        #     False,
-        # ),  # count_if supported by standard metrics
-        # ("p75(transaction.duration)", "release:a", False),  # supported by standard metrics
-        # (
-        #     "p75(transaction.duration)",
-        #     "transaction.duration:>1",
-        #     True,
-        # ),  # transaction.duration query is on-demand
-        # ("p90(transaction.duration)", "release:a", False),  # supported by standard metrics
-        # (
-        #     "p90(transaction.duration)",
-        #     "transaction.duration:>1",
-        #     True,
-        # ),  # transaction.duration query is on-demand
-        # ("count()", "", False),  # Malformed aggregate should return false
-        # (
-        #     "count()",
-        #     "event.type:error transaction.duration:>0",
-        #     False,
-        # ),  # event.type:error not supported by metrics
-        # (
-        #     "count()",
-        #     "event.type:default transaction.duration:>0",
-        #     False,
-        # ),  # event.type:error not supported by metrics
-        # (
-        #     "count()",
-        #     "error.handled:true transaction.duration:>0",
-        #     False,
-        # ),  # error.handled is an error search term
+        ("count()", "release:a", False),  # supported by standard metrics
+        ("failure_rate()", "release:a", False),  # supported by standard metrics
+        ("count_unique(geo.city)", "release:a", False),
+        # geo.city not supported by standard metrics, but also not by on demand
+        (
+            "count()",
+            "transaction.duration:>1",
+            True,
+        ),  # transaction.duration not supported by standard metrics
+        ("failure_count()", "transaction.duration:>1", True),  # supported by on demand
+        ("failure_rate()", "transaction.duration:>1", True),  # supported by on demand
+        ("apdex(10)", "", True),  # every apdex query is on-demand
+        ("apdex(10)", "transaction.duration:>10", True),  # supported by on demand
+        (
+            "count_if(transaction.duration,equals,0)",
+            "release:a",
+            False,
+        ),  # count_if supported by standard metrics
+        ("p75(transaction.duration)", "release:a", False),  # supported by standard metrics
+        (
+            "p75(transaction.duration)",
+            "transaction.duration:>1",
+            True,
+        ),  # transaction.duration query is on-demand
+        ("p90(transaction.duration)", "release:a", False),  # supported by standard metrics
         (
             "p90(transaction.duration)",
             "transaction.duration:>1",
             True,
         ),  # transaction.duration query is on-demand
+        (
+            "percentile(transaction.duration, 0.9)",
+            "release:a",
+            False,
+        ),  # supported by standard metrics
+        (
+            "percentile(transaction.duration, 0.9)",
+            "transaction.duration:>1",
+            True,
+        ),  # transaction.duration query is on-demand
+        (
+            "percentile(transaction.duration, 0.90)",
+            "release:a",
+            False,
+        ),  # supported by standard metrics
+        (
+            "percentile(transaction.duration, 0.90)",
+            "transaction.duration:>1",
+            True,
+        ),
+        ("count()", "", False),  # Malformed aggregate should return false
+        (
+            "count()",
+            "event.type:error transaction.duration:>0",
+            False,
+        ),  # event.type:error not supported by metrics
+        (
+            "count()",
+            "event.type:default transaction.duration:>0",
+            False,
+        ),  # event.type:error not supported by metrics
+        (
+            "count()",
+            "error.handled:true transaction.duration:>0",
+            False,
+        ),  # error.handled is an error search term
     ],
 )
 def test_should_use_on_demand(agg, query, result):

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -212,6 +212,24 @@ class TestCreatesOndemandMetricSpec:
         assert not create_spec_if_needed(self.dataset, aggregate, query)
 
 
+@pytest.mark.parametrize(
+    "percentile",
+    [0.5, 0.75, 0.9, 0.95, 0.99],
+)
+def test_spec_equivalence_with_percentiles(percentile):
+    fixed_percentile = f"p{int(percentile * 100)}"
+
+    spec_1 = OnDemandMetricSpec(f"{fixed_percentile}(measurements.fp)", "transaction.duration:>1s")
+    spec_2 = OnDemandMetricSpec(
+        f"percentile(measurements.fp, {percentile})", "transaction.duration:>1s"
+    )
+
+    assert spec_1._metric_type == spec_2._metric_type
+    assert spec_1.field_to_extract == spec_2.field_to_extract
+    assert spec_1.op == spec_2.op
+    assert spec_1.condition == spec_2.condition
+
+
 def test_spec_simple_query_count():
     spec = OnDemandMetricSpec("count()", "transaction.duration:>1s")
 

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -20,52 +20,57 @@ from sentry.testutils.pytest.fixtures import django_db_all
 @pytest.mark.parametrize(
     "agg, query, result",
     [
-        ("count()", "release:a", False),  # supported by standard metrics
-        ("failure_rate()", "release:a", False),  # supported by standard metrics
-        ("count_unique(geo.city)", "release:a", False),
-        # geo.city not supported by standard metrics, but also not by on demand
-        (
-            "count()",
-            "transaction.duration:>1",
-            True,
-        ),  # transaction.duration not supported by standard metrics
-        ("failure_count()", "transaction.duration:>1", True),  # supported by on demand
-        ("failure_rate()", "transaction.duration:>1", True),  # supported by on demand
-        ("apdex(10)", "", True),  # every apdex query is on-demand
-        ("apdex(10)", "transaction.duration:>10", True),  # supported by on demand
-        (
-            "count_if(transaction.duration,equals,0)",
-            "release:a",
-            False,
-        ),  # count_if supported by standard metrics
-        ("p75(transaction.duration)", "release:a", False),  # supported by standard metrics
-        (
-            "p75(transaction.duration)",
-            "transaction.duration:>1",
-            True,
-        ),  # transaction.duration query is on-demand
-        ("p90(transaction.duration)", "release:a", False),  # supported by standard metrics
+        # ("count()", "release:a", False),  # supported by standard metrics
+        # ("failure_rate()", "release:a", False),  # supported by standard metrics
+        # ("count_unique(geo.city)", "release:a", False),
+        # # geo.city not supported by standard metrics, but also not by on demand
+        # (
+        #     "count()",
+        #     "transaction.duration:>1",
+        #     True,
+        # ),  # transaction.duration not supported by standard metrics
+        # ("failure_count()", "transaction.duration:>1", True),  # supported by on demand
+        # ("failure_rate()", "transaction.duration:>1", True),  # supported by on demand
+        # ("apdex(10)", "", True),  # every apdex query is on-demand
+        # ("apdex(10)", "transaction.duration:>10", True),  # supported by on demand
+        # (
+        #     "count_if(transaction.duration,equals,0)",
+        #     "release:a",
+        #     False,
+        # ),  # count_if supported by standard metrics
+        # ("p75(transaction.duration)", "release:a", False),  # supported by standard metrics
+        # (
+        #     "p75(transaction.duration)",
+        #     "transaction.duration:>1",
+        #     True,
+        # ),  # transaction.duration query is on-demand
+        # ("p90(transaction.duration)", "release:a", False),  # supported by standard metrics
+        # (
+        #     "p90(transaction.duration)",
+        #     "transaction.duration:>1",
+        #     True,
+        # ),  # transaction.duration query is on-demand
+        # ("count()", "", False),  # Malformed aggregate should return false
+        # (
+        #     "count()",
+        #     "event.type:error transaction.duration:>0",
+        #     False,
+        # ),  # event.type:error not supported by metrics
+        # (
+        #     "count()",
+        #     "event.type:default transaction.duration:>0",
+        #     False,
+        # ),  # event.type:error not supported by metrics
+        # (
+        #     "count()",
+        #     "error.handled:true transaction.duration:>0",
+        #     False,
+        # ),  # error.handled is an error search term
         (
             "p90(transaction.duration)",
             "transaction.duration:>1",
             True,
         ),  # transaction.duration query is on-demand
-        ("count()", "", False),  # Malformed aggregate should return false
-        (
-            "count()",
-            "event.type:error transaction.duration:>0",
-            False,
-        ),  # event.type:error not supported by metrics
-        (
-            "count()",
-            "event.type:default transaction.duration:>0",
-            False,
-        ),  # event.type:error not supported by metrics
-        (
-            "count()",
-            "error.handled:true transaction.duration:>0",
-            False,
-        ),  # error.handled is an error search term
     ],
 )
 def test_should_use_on_demand(agg, query, result):


### PR DESCRIPTION
This PR adds the support for `p90` in on-demand alerts and refactors the code to remove the dependency of function parsing from the query builders.

The rationale behind removing the dependency is that `p90` is not a supported operation for `Discover` thus the query builder `parse_function` won't work, due to internal validation. Since the operators that are supported are validated by the on demand code directly, I have lifted out some of the logic from the builder that exclusively parses the string and doesn't validate the aggregates used.

Closes https://github.com/getsentry/sentry/issues/61122