### PR TITLE
feat(ddm): Add support for count_unique in metrics layer

### DIFF
--- a/src/sentry/snuba/metrics_layer/query.py
+++ b/src/sentry/snuba/metrics_layer/query.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import datetime
-from typing import Any, Mapping, Union
+from typing import Any, List, Mapping, Union, cast
 
 from snuba_sdk import (
     AliasedExpression,
@@ -15,6 +15,7 @@ from snuba_sdk import (
     Request,
     Timeseries,
 )
+from snuba_sdk.formula import FormulaParameterGroup
 
 from sentry.api.utils import InvalidParams
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
@@ -417,12 +418,12 @@ def _resolve_aggregate_aliases(metrics_query: MetricsQuery) -> MetricsQuery:
         if not metrics_query.query.parameters:
             return metrics_query
 
-        aliased_parameters = []
-        for i, p in enumerate(metrics_query.query.parameters):
+        aliased_parameters = cast(List[FormulaParameterGroup], metrics_query.query.parameters)
+        for i, p in enumerate(aliased_parameters):
             if isinstance(p, Timeseries):
                 if p.aggregate in AGGREGATE_ALIASES:
                     new_aggregate, new_parameters = AGGREGATE_ALIASES[p.aggregate]
-                    aliased_parameters.append(p.set_aggregate(new_aggregate, new_parameters))
+                    aliased_parameters[i] = p.set_aggregate(new_aggregate, new_parameters)
 
         return metrics_query.set_query(metrics_query.query.set_parameters(aliased_parameters))
 

--- a/src/sentry/snuba/metrics_layer/query.py
+++ b/src/sentry/snuba/metrics_layer/query.py
@@ -40,7 +40,7 @@ AGGREGATE_ALIASES = {
     "p90": ("quantiles", [0.9]),
     "p95": ("quantiles", [0.95]),
     "p99": ("quantiles", [0.99]),
-    "count_unique": ("uniq", None),
+    "count_unique": ("uniq", []),
 }
 
 
@@ -411,7 +411,7 @@ def _resolve_aggregate_aliases(metrics_query: MetricsQuery) -> MetricsQuery:
         series = metrics_query.query
         if series.aggregate in AGGREGATE_ALIASES:
             aggregate, parameters = AGGREGATE_ALIASES[series.aggregate]
-            series = series.set_aggregate(aggregate, parameters)
+            series = series.set_aggregate(aggregate, parameters or None)
             return metrics_query.set_query(series)
 
     elif isinstance(metrics_query.query, Formula):
@@ -420,8 +420,8 @@ def _resolve_aggregate_aliases(metrics_query: MetricsQuery) -> MetricsQuery:
             if isinstance(p, Timeseries):
                 if p.aggregate in AGGREGATE_ALIASES:
                     aggregate, parameters = AGGREGATE_ALIASES[p.aggregate]
-                    parameters[i] = p.set_aggregate(aggregate, parameters)
+                    parameters[i] = p.set_aggregate(aggregate, parameters or None)
 
-        return metrics_query.set_query(metrics_query.query.set_parameters(parameters))
+        return metrics_query.set_query(metrics_query.query.set_parameters(parameters or None))
 
     return metrics_query

--- a/src/sentry/snuba/metrics_layer/query.py
+++ b/src/sentry/snuba/metrics_layer/query.py
@@ -40,6 +40,7 @@ AGGREGATE_ALIASES = {
     "p90": ("quantiles", [0.9]),
     "p95": ("quantiles", [0.95]),
     "p99": ("quantiles", [0.99]),
+    "count_unique": ("uniq", None),
 }
 
 


### PR DESCRIPTION
This PR adds the `count_unique` aggregate alias in the metrics layer.