### PR TITLE
ref: disable test which (ab)uses atexit -- breaking interpreter state for the rest of the testsuite

### DIFF
--- a/tests/sentry/usage_accountant/test_accountant.py
+++ b/tests/sentry/usage_accountant/test_accountant.py
@@ -2,6 +2,7 @@ import atexit
 from typing import Optional
 from unittest import mock
 
+import pytest
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
@@ -35,6 +36,7 @@ def assert_msg(
     }
 
 
+@pytest.mark.skip(reason="usage of atexit breaks interpreter")
 @django_db_all
 @mock.patch("time.time")
 def test_accountant(mock_time: mock.Mock) -> None:


### PR DESCRIPTION
example pollution:

```console
$ python3 -m pytest -p detect_test_pollution tests/sentry/usage_accountant/test_accountant.py tests/snuba/api/endpoints/test_organization_sessions.py --dtp-testids-input-file testlist
/Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/trio/_core/_multierror.py:511: RuntimeWarning: You seem to already have a custom sys.excepthook handler installed. I'll skip installing Trio's custom handler, but this means MultiErrors will not show full tracebacks.
  warnings.warn(
================================== test session starts ==================================
platform darwin -- Python 3.8.15, pytest-7.2.1, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: fail-slow-0.3.0, rerunfailures-11.0, sentry-0.1.11, time-machine-2.13.0, xdist-3.0.2, anyio-3.7.1, cov-4.0.0, django-4.4.0
collected 98 items                                                                      

tests/sentry/usage_accountant/test_accountant.py .                                [ 50%]
tests/snuba/api/endpoints/test_organization_sessions.py E                         [100%]

======================================== ERRORS =========================================
____ ERROR at setup of OrganizationSessionsEndpointTest.test_sessions_without_users _____
src/sentry/testutils/pytest/fixtures.py:482: in reset_snuba
    assert all(
../../opt/pythons/cp38-cp38/lib/python3.8/concurrent/futures/_base.py:608: in map
    fs = [self.submit(fn, *args) for args in zip(*iterables)]
../../opt/pythons/cp38-cp38/lib/python3.8/concurrent/futures/_base.py:608: in <listcomp>
    fs = [self.submit(fn, *args) for args in zip(*iterables)]
../../opt/pythons/cp38-cp38/lib/python3.8/concurrent/futures/thread.py:181: in submit
    raise RuntimeError('cannot schedule new futures after '
E   RuntimeError: cannot schedule new futures after interpreter shutdown
================================ short test summary info ================================
ERROR tests/snuba/api/endpoints/test_organization_sessions.py::OrganizationSessionsEndpointTest::test_sessions_without_users - RuntimeError: cannot schedule new futures after interpreter shutdown
============================== 1 passed, 1 error in 4.59s ===============================
```

concurrent.futures uses `atexit` to understand when the interpreter is dead and it cannot spawn new pools.  atexit shouldn't really be used and this should get refactored to an explicit context manager instead of relying on interpreter state (`atexit` also isn't guaranteed to get called so it shouldn't be relied on for timing)