### PR TITLE
ref: remove wheel from craft release

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -7,12 +7,6 @@ statusProvider:
   config:
     contexts:
       - 'self-hosted-builder (sentryio)'
-artifactProvider:
-  name: gcs
-  config:
-    bucket: sentryio-cloudbuild-opensource
-requireNames:
-  - /^sentry-.+-py3\d?-none-any.whl$/
 targets:
   - id: release
     name: docker

--- a/self-hosted/cloudbuild.yaml
+++ b/self-hosted/cloudbuild.yaml
@@ -33,10 +33,6 @@ steps:
       ]
     timeout: 300s
 timeout: 2640s
-artifacts:
-  objects:
-    location: 'gs://sentryio-cloudbuild-opensource/getsentry/sentry/$COMMIT_SHA/'
-    paths: ['dist/*.whl']
 options:
   # We need more memory for Webpack builds & e2e self-hosted tests
   machineType: 'E2_HIGHCPU_8'


### PR DESCRIPTION
we no longer publish to pypi so we do not need to pass this wheel around

additionally I'm looking to factor this out to improve production build time and local development setup time

<!-- Describe your PR here. -->