### PR TITLE
feat(relocation): Add GET /relocations/{uuid} details endpoint

### DIFF
--- a/src/sentry/api/endpoints/relocations/details.py
+++ b/src/sentry/api/endpoints/relocations/details.py
@@ -1,0 +1,34 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.permissions import SuperuserPermission
+from sentry.api.serializers import serialize
+from sentry.models.relocation import Relocation
+
+
+@region_silo_endpoint
+class RelocationDetailsEndpoint(Endpoint):
+    owner = ApiOwner.RELOCATION
+    publish_status = {
+        # TODO(getsentry/team-ospo#214): Stabilize before GA.
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    # TODO(getsentry/team-ospo#214): Open up permissions before GA.
+    permission_classes = (SuperuserPermission,)
+
+    def get(self, request: Request, relocation_uuid: str) -> Response:
+        """
+        Get a single relocation.
+        ``````````````````````````````````````````````````
+
+        :auth: required
+        """
+
+        try:
+            return self.respond(serialize(Relocation.objects.get(uuid=relocation_uuid)))
+        except Relocation.DoesNotExist:
+            raise ResourceDoesNotExist

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -38,6 +38,7 @@ from sentry.api.endpoints.release_thresholds.release_threshold_index import (
 from sentry.api.endpoints.release_thresholds.release_threshold_status_index import (
     ReleaseThresholdStatusIndexEndpoint,
 )
+from sentry.api.endpoints.relocations.details import RelocationDetailsEndpoint
 from sentry.api.endpoints.relocations.index import RelocationIndexEndpoint
 from sentry.api.endpoints.relocations.public_key import RelocationPublicKeyEndpoint
 from sentry.api.endpoints.source_map_debug_blue_thunder_edition import (
@@ -750,9 +751,9 @@ RELOCATION_URLS = [
         name="sentry-api-0-relocations-index",
     ),
     re_path(
-        r"^public-key/$",
-        RelocationPublicKeyEndpoint.as_view(),
-        name="sentry-api-0-relocations-public-key",
+        r"^(?P<relocation_uuid>[^\/]+)/$",
+        RelocationDetailsEndpoint.as_view(),
+        name="sentry-api-0-relocations-details",
     ),
 ]
 
@@ -3052,6 +3053,11 @@ urlpatterns = [
     re_path(
         r"^relocations/",
         include(RELOCATION_URLS),
+    ),
+    re_path(
+        r"^publickeys/relocations/$",
+        RelocationPublicKeyEndpoint.as_view(),
+        name="sentry-api-0-relocations-public-key",
     ),
     # Catch all
     re_path(

--- a/tests/sentry/api/endpoints/relocations/test_details.py
+++ b/tests/sentry/api/endpoints/relocations/test_details.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sentry.models.relocation import Relocation
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
+from sentry.utils.relocation import OrderedTask
+
+TEST_DATE_ADDED = datetime(2023, 1, 23, 1, 23, 45, tzinfo=timezone.utc)
+TEST_DATE_UPDATED = datetime(2023, 1, 23, 1, 24, 45, tzinfo=timezone.utc)
+
+
+@region_silo_test
+class GetRelocationDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-relocations-details"
+
+    def setUp(self):
+        super().setUp()
+        self.owner = self.create_user(
+            email="owner", is_superuser=False, is_staff=True, is_active=True
+        )
+        self.superuser = self.create_user(
+            "superuser", is_superuser=True, is_staff=True, is_active=True
+        )
+        self.relocation: Relocation = Relocation.objects.create(
+            date_added=TEST_DATE_ADDED,
+            creator_id=self.superuser.id,
+            owner_id=self.owner.id,
+            status=Relocation.Status.SUCCESS.value,
+            step=Relocation.Step.COMPLETED.value,
+            want_org_slugs='["foo"]',
+            want_usernames='["emily", "fred"]',
+            latest_notified=Relocation.EmailKind.SUCCEEDED.value,
+            latest_unclaimed_emails_sent_at=TEST_DATE_UPDATED,
+            latest_task=OrderedTask.COMPLETED.name,
+            latest_task_attempts=1,
+        )
+
+    def test_good_found(self):
+        self.login_as(user=self.superuser, superuser=True)
+        response = self.client.get(f"/api/0/relocations/{str(self.relocation.uuid)}/")
+
+        assert response.status_code == 200
+        assert response.data["uuid"] == str(self.relocation.uuid)
+
+    def test_bad_not_found(self):
+        self.login_as(user=self.superuser, superuser=True)
+        does_not_exist_uuid = uuid4().hex
+        response = self.client.get(f"/api/0/relocations/{str(does_not_exist_uuid)}/")
+
+        assert response.status_code == 404
+
+    # TODO(getsentry/team-ospo#214): Add test for non-superusers to view their own relocations, but
+    # not other owners'.
+    def test_bad_no_auth(self):
+        response = self.client.get(f"/api/0/relocations/{str(self.relocation.uuid)}/")
+
+        assert response.status_code == 401

--- a/tests/sentry/api/endpoints/relocations/test_public_key.py
+++ b/tests/sentry/api/endpoints/relocations/test_public_key.py
@@ -15,13 +15,12 @@ from sentry.testutils.silo import region_silo_test
     "sentry.backup.helpers.KeyManagementServiceClient",
     new_callable=lambda: FakeKeyManagementServiceClient,
 )
-class RelocationPublicKeyTest(APITestCase):
+class GetRelocationPublicKeyTest(APITestCase):
     endpoint = "sentry-api-0-relocations-public-key"
 
     def setUp(self):
         super().setUp()
-        self.user = self.create_user("user", is_superuser=False, is_staff=True, is_active=True)
-        self.login_as(user=self.user, superuser=True)
+        self.user = self.create_user("user", is_superuser=False, is_staff=False, is_active=True)
 
         (_, pub_key_pem) = generate_rsa_key_pair()
         self.pub_key_pem = pub_key_pem
@@ -33,7 +32,19 @@ class RelocationPublicKeyTest(APITestCase):
         )
         fake_kms_client.get_public_key.side_effect = None
 
-    def test_success_simple(self, fake_kms_client: FakeKeyManagementServiceClient):
+    def test_success_superuser_auth(self, fake_kms_client: FakeKeyManagementServiceClient):
+        superuser = self.create_user("superuser", is_superuser=True, is_staff=True, is_active=True)
+        self.login_as(user=superuser, superuser=True)
+        self.mock_kms_client(fake_kms_client)
+
+        with self.options({"relocation.enabled": True}):
+            response = self.client.get(reverse(self.endpoint), {})
+
+        assert response.status_code == 200
+        assert fake_kms_client.get_public_key.call_count == 1
+
+    def test_success_regular_user_auth(self, fake_kms_client: FakeKeyManagementServiceClient):
+        self.login_as(user=self.user, superuser=False)
         self.mock_kms_client(fake_kms_client)
 
         with self.options({"relocation.enabled": True}):
@@ -43,6 +54,7 @@ class RelocationPublicKeyTest(APITestCase):
         assert fake_kms_client.get_public_key.call_count == 1
 
     def test_fail_feature_disabled(self, fake_kms_client: FakeKeyManagementServiceClient):
+        self.login_as(user=self.user, superuser=False)
         self.mock_kms_client(fake_kms_client)
 
         response = self.client.get(reverse(self.endpoint), {})
@@ -53,6 +65,7 @@ class RelocationPublicKeyTest(APITestCase):
         assert response.data.get("detail") == ERR_FEATURE_DISABLED
 
     def test_fail_network_error(self, fake_kms_client: FakeKeyManagementServiceClient):
+        self.login_as(user=self.user, superuser=False)
         self.mock_kms_client(fake_kms_client)
         fake_kms_client.get_public_key.return_value = None
         fake_kms_client.get_public_key.side_effect = GoogleAPIError("Test")
@@ -62,3 +75,12 @@ class RelocationPublicKeyTest(APITestCase):
 
         assert response.status_code == 500
         assert fake_kms_client.get_public_key.call_count == 1
+
+    def test_fail_no_auth(self, fake_kms_client: FakeKeyManagementServiceClient):
+        self.mock_kms_client(fake_kms_client)
+
+        with self.feature("relocation:enabled"):
+            response = self.client.get(reverse(self.endpoint), {})
+
+        assert response.status_code == 401
+        assert fake_kms_client.get_public_key.call_count == 0


### PR DESCRIPTION
This PR also adds some permission tests to all of the endpoints in `relocation/`, and renames the public-key endpoint so as not to collide with the newly created one. It now lives at `publickeys/relocations`.

Issue: getsentry/team-ospo#222