### PR TITLE
fix(ui): align headings on invite members modal

### DIFF
--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -363,6 +363,7 @@ class InviteMembersModal extends DeprecatedAsyncComponent<
           <div>{t('Email addresses')}</div>
           <div>{t('Role')}</div>
           <div>{t('Add to team')}</div>
+          <div />
         </InviteeHeadings>
 
         <Rows>
@@ -474,7 +475,7 @@ const Subtext = styled('p')`
 const inviteRowGrid = css`
   display: grid;
   gap: ${space(1.5)};
-  grid-template-columns: 3fr 180px 2fr max-content;
+  grid-template-columns: 3fr 180px 2fr 0.5fr;
   align-items: start;
 `;
 


### PR DESCRIPTION
Before

<img width="878" alt="Screenshot 2023-12-05 at 10 23 06" src="https://github.com/getsentry/sentry/assets/70817427/8565e87e-d4a2-4ea8-9ff9-563a52e9a168">

After

<img width="878" alt="Screenshot 2023-12-05 at 10 22 36" src="https://github.com/getsentry/sentry/assets/70817427/b0272e0b-0c5e-4d3a-acc4-106bbf425114">
