### PR TITLE
docs(alerts): Clarify docs to restrict metric alerts to single project

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -297,7 +297,7 @@ class OrganizationAlertRuleIndexPostSerializer(serializers.Serializer):
     # projects is not required in the serializer, however, the UI requires a project is chosen
     projects = serializers.ListField(
         child=ProjectField(scope="project:read"),
-        help_text="Metric alerts are currently restricted to a single project to filter by. The array length must be 1.",
+        help_text="Metric alerts are currently limited to one project. The array should contain a single slug of the project to filter by.",
     )
     query = serializers.CharField(
         help_text='An event search query to subscribe to and monitor for alerts. For example, to filter transactions so that only those with status code 400 are included, you could use `"query": "http.status_code:400"`. Use an empty string for no filter.'

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -297,7 +297,7 @@ class OrganizationAlertRuleIndexPostSerializer(serializers.Serializer):
     # projects is not required in the serializer, however, the UI requires a project is chosen
     projects = serializers.ListField(
         child=ProjectField(scope="project:read"),
-        help_text="Metric alerts are currently limited to one project. The array should contain a single slug of the project to filter by.",
+        help_text="Metric alerts are currently limited to one project. The array should contain a single slug, representing the project to filter by.",
     )
     query = serializers.CharField(
         help_text='An event search query to subscribe to and monitor for alerts. For example, to filter transactions so that only those with status code 400 are included, you could use `"query": "http.status_code:400"`. Use an empty string for no filter.'

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -297,7 +297,7 @@ class OrganizationAlertRuleIndexPostSerializer(serializers.Serializer):
     # projects is not required in the serializer, however, the UI requires a project is chosen
     projects = serializers.ListField(
         child=ProjectField(scope="project:read"),
-        help_text="The names of the projects to filter by.",
+        help_text="Metric alerts are currently restricted to a single project to filter by. The array length must be 1.",
     )
     query = serializers.CharField(
         help_text='An event search query to subscribe to and monitor for alerts. For example, to filter transactions so that only those with status code 400 are included, you could use `"query": "http.status_code:400"`. Use an empty string for no filter.'


### PR DESCRIPTION
Clarifies https://github.com/getsentry/sentry/issues/61031