### PR TITLE
chore(hybrid-cloud): Inject tracing information on pageload

### DIFF
--- a/fixtures/js-stubs/config.tsx
+++ b/fixtures/js-stubs/config.tsx
@@ -26,6 +26,10 @@ export function Config(params: Partial<ConfigType> = {}): ConfigType {
     isSelfHosted: false,
     lastOrganization: null,
     gravatarBaseUrl: 'https://gravatar.com',
+    initialTrace: {
+      baggage: 'baggage',
+      sentry_trace: 'sentry_trace',
+    },
     dsn: 'test-dsn',
     userIdentity: {
       ip_address: '127.0.0.1',

--- a/src/sentry/templates/sentry/partial/preload-data.html
+++ b/src/sentry/templates/sentry/partial/preload-data.html
@@ -1,4 +1,8 @@
 {% load sentry_assets %}
+{% load sentry_trace %}
+
+<meta name="sentry-trace" content="{% get_sentry_trace %}">
+<meta name="baggage" content="{% get_sentry_baggage %}">
 
 {% script %}
 <script type="text/javascript">
@@ -20,6 +24,8 @@
       return new Promise(function (resolve, reject) {
         var xhr = new XMLHttpRequest();
         xhr.open('GET', url);
+        xhr.setRequestHeader("sentry-trace", window.__initialData.initialTrace.sentry_trace);
+        xhr.setRequestHeader("baggage", window.__initialData.initialTrace.baggage);
         xhr.withCredentials = true;
         xhr.onload = function () {
           try {

--- a/src/sentry/templatetags/sentry_trace.py
+++ b/src/sentry/templatetags/sentry_trace.py
@@ -1,0 +1,14 @@
+import sentry_sdk
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def get_sentry_trace():
+    return sentry_sdk.get_traceparent()
+
+
+@register.simple_tag
+def get_sentry_baggage():
+    return sentry_sdk.get_baggage()

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from functools import cached_property
 from typing import Any, Iterable, List, Mapping, MutableMapping, Tuple
 
+import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages import get_messages
@@ -158,6 +159,13 @@ class _ClientConfig:
             "sentryUrl": options.get("system.url-prefix"),
         }
 
+    @cached_property
+    def tracing_data(self) -> Mapping[str, str]:
+        return {
+            "sentry_trace": sentry_sdk.get_traceparent() or "",
+            "baggage": sentry_sdk.get_baggage() or "",
+        }
+
     @property
     def enabled_features(self) -> Iterable[str]:
         if features.has("organizations:create", actor=self.user):
@@ -299,6 +307,7 @@ class _ClientConfig:
 
     def get_context(self) -> Mapping[str, Any]:
         return {
+            "initialTrace": self.tracing_data,
             "customerDomain": self.customer_domain,
             "singleOrganization": settings.SENTRY_SINGLE_ORGANIZATION,
             "supportEmail": get_support_mail(),

--- a/static/app/bootstrap/index.tsx
+++ b/static/app/bootstrap/index.tsx
@@ -44,6 +44,8 @@ function promiseRequest(url: string): Promise<any> {
   return new Promise(function (resolve, reject) {
     const xhr = new XMLHttpRequest();
     xhr.open('GET', url);
+    xhr.setRequestHeader('sentry-trace', window.__initialData.initialTrace.sentry_trace);
+    xhr.setRequestHeader('baggage', window.__initialData.initialTrace.baggage);
     xhr.withCredentials = true;
     xhr.onload = function () {
       try {

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -139,6 +139,10 @@ export interface Config {
   enableAnalytics: boolean;
   features: Set<string>;
   gravatarBaseUrl: string;
+  initialTrace: {
+    baggage: string;
+    sentry_trace: string;
+  };
   invitesEnabled: boolean;
   isAuthenticated: boolean;
 


### PR DESCRIPTION
Some preload HTTP requests do not have tracing headers in them.

I'm adding them here for pageloads as documented in: https://docs.sentry.io/platforms/python/usage/distributed-tracing/custom-instrumentation/