### PR TITLE
fix(hybrid-cloud): Fix Discord /link bug and update tests

### DIFF
--- a/src/sentry/integrations/discord/requests/base.py
+++ b/src/sentry/integrations/discord/requests/base.py
@@ -86,8 +86,14 @@ class DiscordRequest:
     @property
     def user_id(self) -> str | None:
         try:
-            return self._data.get("member")["user"]["id"]  # type: ignore
-        except (AttributeError, TypeError):
+            # 'member' object is sent when the interaction is invoked in a guild, and 'user' object is sent when
+            # invoked in a DM.
+            # See: https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object
+            user_source = self._data.get("member", None)
+            if user_source is None:
+                user_source = self._data
+            return user_source["user"]["id"]  # type: ignore
+        except (AttributeError, TypeError, KeyError):
             return None
 
     @property

--- a/tests/sentry/integrations/discord/webhooks/test_command.py
+++ b/tests/sentry/integrations/discord/webhooks/test_command.py
@@ -1,10 +1,16 @@
 from unittest import mock
 
 from sentry.integrations.discord.requests.base import DiscordRequestTypes
+from sentry.integrations.discord.webhooks.command import HELP_MESSAGE, NOT_LINKED_MESSAGE
+from sentry.integrations.discord.webhooks.types import DiscordResponseTypes
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import region_silo_test
 
 WEBHOOK_URL = "/extensions/discord/interactions/"
+
+# https://discord.com/developers/docs/resources/channel#message-object-message-flags
+# this message is only visible to the user who invoked the Interaction
+EPHEMERAL_FLAG = 1 << 6
 
 
 @region_silo_test
@@ -12,16 +18,18 @@ class DiscordCommandInteractionTest(APITestCase):
     @mock.patch("sentry.integrations.discord.requests.base.verify_signature")
     def test_command_interaction(self, mock_verify_signature):
         mock_verify_signature.return_value = True
-        resp = self.client.post(
+        response = self.client.post(
             path=WEBHOOK_URL,
             data={"type": 2, "data": {"name": "command_name"}},
             format="json",
             HTTP_X_SIGNATURE_ED25519="signature",
             HTTP_X_SIGNATURE_TIMESTAMP="timestamp",
         )
-
-        assert resp.status_code == 200
-        assert resp.json()["type"] == 4
+        data = response.json()
+        assert data["type"] == DiscordResponseTypes.MESSAGE
+        assert HELP_MESSAGE in data["data"]["content"]
+        assert data["data"]["flags"] == EPHEMERAL_FLAG
+        assert response.status_code == 200
 
     def test_link_no_integration(self):
         with mock.patch(
@@ -66,7 +74,7 @@ class DiscordCommandInteractionTest(APITestCase):
             )
         assert resp.status_code == 400
 
-    def test_link(self):
+    def test_link_guild(self):
         guild_id = "guild-id"
         self.create_integration(
             provider="discord",
@@ -78,13 +86,11 @@ class DiscordCommandInteractionTest(APITestCase):
         with mock.patch(
             "sentry.integrations.discord.requests.base.verify_signature", return_value=True
         ):
-            resp = self.client.post(
+            response = self.client.post(
                 path=WEBHOOK_URL,
                 data={
                     "type": DiscordRequestTypes.COMMAND,
-                    "data": {
-                        "name": "link",
-                    },
+                    "data": {"name": "link", "type": 1},
                     "guild_id": guild_id,
                     "channel_id": "channel-id",
                     "member": {"user": {"id": "user1234"}},
@@ -93,8 +99,46 @@ class DiscordCommandInteractionTest(APITestCase):
                 HTTP_X_SIGNATURE_ED25519="signature",
                 HTTP_X_SIGNATURE_TIMESTAMP="timestamp",
             )
+            data = response.json()
+            assert data["type"] == DiscordResponseTypes.MESSAGE
+            assert data["data"]["content"].endswith(
+                "to link your Discord account to your Sentry account."
+            )
+            assert data["data"]["flags"] == EPHEMERAL_FLAG
+            assert response.status_code == 200
 
-        assert resp.status_code == 200
+    def test_link_dm(self):
+        guild_id = "guild-id"
+        self.create_integration(
+            provider="discord",
+            name="Cool server",
+            external_id=guild_id,
+            organization=self.organization,
+        )
+
+        with mock.patch(
+            "sentry.integrations.discord.requests.base.verify_signature", return_value=True
+        ):
+            response = self.client.post(
+                path=WEBHOOK_URL,
+                data={
+                    "type": DiscordRequestTypes.COMMAND,
+                    "data": {"name": "link", "type": 1},
+                    "channel_id": "channel-id",
+                    # user object is sent when the command is invoked in a DM
+                    "user": {"id": "user1234"},
+                },
+                format="json",
+                HTTP_X_SIGNATURE_ED25519="signature",
+                HTTP_X_SIGNATURE_TIMESTAMP="timestamp",
+            )
+            data = response.json()
+            assert data["type"] == DiscordResponseTypes.MESSAGE
+            assert data["data"]["content"].endswith(
+                "to link your Discord account to your Sentry account."
+            )
+            assert data["data"]["flags"] == EPHEMERAL_FLAG
+            assert response.status_code == 200
 
     def test_link_already_linked(self):
         guild_id = "guild-id"
@@ -113,7 +157,7 @@ class DiscordCommandInteractionTest(APITestCase):
         with mock.patch(
             "sentry.integrations.discord.requests.base.verify_signature", return_value=True
         ):
-            resp = self.client.post(
+            response = self.client.post(
                 path=WEBHOOK_URL,
                 data={
                     "type": DiscordRequestTypes.COMMAND,
@@ -132,14 +176,19 @@ class DiscordCommandInteractionTest(APITestCase):
                 HTTP_X_SIGNATURE_ED25519="signature",
                 HTTP_X_SIGNATURE_TIMESTAMP="timestamp",
             )
-
-        assert resp.status_code == 200
+            data = response.json()
+            assert data["type"] == DiscordResponseTypes.MESSAGE
+            assert data["data"]["content"].startswith(
+                "You are already linked to the Sentry account with email:"
+            )
+            assert data["data"]["flags"] == EPHEMERAL_FLAG
+            assert response.status_code == 200
 
     def test_unlink_no_identity(self):
         with mock.patch(
             "sentry.integrations.discord.requests.base.verify_signature", return_value=True
         ):
-            resp = self.client.post(
+            response = self.client.post(
                 path=WEBHOOK_URL,
                 data={
                     "type": DiscordRequestTypes.COMMAND,
@@ -151,7 +200,11 @@ class DiscordCommandInteractionTest(APITestCase):
                 HTTP_X_SIGNATURE_ED25519="signature",
                 HTTP_X_SIGNATURE_TIMESTAMP="timestamp",
             )
-        assert resp.status_code == 200
+            data = response.json()
+            assert data["type"] == DiscordResponseTypes.MESSAGE
+            assert data["data"]["content"] == NOT_LINKED_MESSAGE
+            assert data["data"]["flags"] == EPHEMERAL_FLAG
+            assert response.status_code == 200
 
     def test_unlink(self):
         guild_id = "guild-id"
@@ -170,7 +223,7 @@ class DiscordCommandInteractionTest(APITestCase):
         with mock.patch(
             "sentry.integrations.discord.requests.base.verify_signature", return_value=True
         ):
-            resp = self.client.post(
+            response = self.client.post(
                 path=WEBHOOK_URL,
                 data={
                     "type": DiscordRequestTypes.COMMAND,
@@ -190,13 +243,19 @@ class DiscordCommandInteractionTest(APITestCase):
                 HTTP_X_SIGNATURE_TIMESTAMP="timestamp",
             )
 
-        assert resp.status_code == 200
+            data = response.json()
+            assert data["type"] == DiscordResponseTypes.MESSAGE
+            assert data["data"]["content"].endswith(
+                "to unlink your Discord account from your Sentry Account."
+            )
+            assert data["data"]["flags"] == EPHEMERAL_FLAG
+            assert response.status_code == 200
 
     def test_help(self):
         with mock.patch(
             "sentry.integrations.discord.requests.base.verify_signature", return_value=True
         ):
-            resp = self.client.post(
+            response = self.client.post(
                 path=WEBHOOK_URL,
                 data={
                     "type": DiscordRequestTypes.COMMAND,
@@ -208,4 +267,8 @@ class DiscordCommandInteractionTest(APITestCase):
                 HTTP_X_SIGNATURE_ED25519="signature",
                 HTTP_X_SIGNATURE_TIMESTAMP="timestamp",
             )
-        assert resp.status_code == 200
+            data = response.json()
+            assert data["type"] == DiscordResponseTypes.MESSAGE
+            assert HELP_MESSAGE in data["data"]["content"]
+            assert data["data"]["flags"] == EPHEMERAL_FLAG
+            assert response.status_code == 200


### PR DESCRIPTION
This PR fixes `/link` for Discord DMs. 

I've updated the tests such that they're a lot more useful whenever we make changes to the Discord command handler.