### PR TITLE
feat(alerts): Allow alerts on span breakdown fields

### DIFF
--- a/static/app/views/alerts/rules/metric/constants.tsx
+++ b/static/app/views/alerts/rules/metric/constants.tsx
@@ -1,7 +1,11 @@
 import {t} from 'sentry/locale';
 import {parsePeriodToHours} from 'sentry/utils/dates';
 import EventView from 'sentry/utils/discover/eventView';
-import {AggregationKeyWithAlias, LooseFieldKey} from 'sentry/utils/discover/fields';
+import {
+  AggregationKeyWithAlias,
+  LooseFieldKey,
+  SPAN_OP_BREAKDOWN_FIELDS,
+} from 'sentry/utils/discover/fields';
 import {AggregationKey} from 'sentry/utils/fields';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {
@@ -46,6 +50,7 @@ export type OptionConfig = {
   aggregations: AggregationKeyWithAlias[];
   fields: LooseFieldKey[];
   measurementKeys?: string[];
+  spanOperationBreakdownKeys?: string[];
 };
 
 /**
@@ -121,11 +126,18 @@ export function getWizardAlertFieldConfig(
     alertType === 'apdex' || alertType === 'custom_transactions'
       ? allAggregations
       : commonAggregations;
-  return {
+
+  const config: OptionConfig = {
     aggregations,
     fields: ['transaction.duration'],
     measurementKeys: Object.keys(WEB_VITAL_DETAILS),
   };
+
+  if ([Dataset.TRANSACTIONS, Dataset.GENERIC_METRICS].includes(dataset)) {
+    config.spanOperationBreakdownKeys = SPAN_OP_BREAKDOWN_FIELDS;
+  }
+
+  return config;
 }
 
 /**
@@ -134,6 +146,7 @@ export function getWizardAlertFieldConfig(
 export const transactionFieldConfig: OptionConfig = {
   aggregations: allAggregations,
   fields: ['transaction.duration'],
+  spanOperationBreakdownKeys: SPAN_OP_BREAKDOWN_FIELDS,
   measurementKeys: Object.keys(WEB_VITAL_DETAILS),
 };
 

--- a/static/app/views/alerts/rules/metric/metricField.tsx
+++ b/static/app/views/alerts/rules/metric/metricField.tsx
@@ -80,10 +80,15 @@ export const getFieldOptionConfig = ({
     return key;
   });
 
-  const {measurementKeys} = config;
+  const {measurementKeys, spanOperationBreakdownKeys} = config;
 
   return {
-    fieldOptionsConfig: {aggregations, fieldKeys, measurementKeys},
+    fieldOptionsConfig: {
+      aggregations,
+      fieldKeys,
+      measurementKeys,
+      spanOperationBreakdownKeys,
+    },
     hidePrimarySelector,
     hideParameterSelector,
   };


### PR DESCRIPTION
`spanOperationBreakdownKeys` is an optional field expected by `generateFieldOptions` but the alerts wizard chooses never to pass it it, it isn't part of any config. Because of this, span breakdown fields like `spans.db` cannot be alerted on.

Adds `generateFieldOptions` to wizard field configs for transactions and generic metrics.

**e.g.,**
![Screenshot 2023-12-05 at 2 01 59 PM](https://github.com/getsentry/sentry/assets/989898/a6729def-649e-44ac-b58b-de76a46d20b7)

![Screenshot 2023-12-05 at 2 02 20 PM](https://github.com/getsentry/sentry/assets/989898/231f183b-b523-41dc-aea1-59deb490f516)
