### PR TITLE
fix(hybridcloud) Omit control outbox delivery from cron monitoring

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -421,6 +421,7 @@ def configure_sdk():
 
     # exclude monitors with sub-minute schedules from using crons
     exclude_beat_tasks = [
+        "deliver-from-outbox-control",
         "flush-buffers",
         "sync-options",
         "sync-options-control",


### PR DESCRIPTION
Crons can't monitor tasks that run more than once per minute.

