### PR TITLE
ref(database): Fetch full span info using `OrganizationEventDetailsEndpoint` instead of `EventJsonEndpoint`

### DIFF
--- a/static/app/views/starfish/queries/useEventDetails.tsx
+++ b/static/app/views/starfish/queries/useEventDetails.tsx
@@ -1,0 +1,18 @@
+import {EventTransaction} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+interface Props {
+  eventId?: EventTransaction['id'];
+  projectSlug?: string;
+}
+
+export function useEventDetails(props: Props) {
+  const organization = useOrganization();
+  const {eventId, projectSlug} = props;
+
+  return useApiQuery<EventTransaction>(
+    [`/organizations/${organization.slug}/events/${projectSlug}:${eventId}/`],
+    {staleTime: Infinity, enabled: Boolean(eventId && projectSlug && organization.slug)}
+  );
+}

--- a/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
+++ b/static/app/views/starfish/queries/useFullSpanFromTrace.tsx
@@ -24,12 +24,8 @@ export function useFullSpanFromTrace(
   const firstIndexedSpan = indexedSpansResponse.data?.[0];
 
   const eventDetailsResponse = useEventDetails({
-    eventId: firstIndexedSpan
-      ? firstIndexedSpan[SpanIndexedField.TRANSACTION_ID]
-      : undefined,
-    projectSlug: firstIndexedSpan
-      ? firstIndexedSpan[SpanIndexedField.PROJECT]
-      : undefined,
+    eventId: firstIndexedSpan?.[SpanIndexedField.TRANSACTION_ID],
+    projectSlug: firstIndexedSpan?.[SpanIndexedField.PROJECT],
   });
 
   const spanEntry = eventDetailsResponse.data?.entries.find(


### PR DESCRIPTION
`EventJsonEndpoint` is more convenient in some cases, but using that endpoint in the UI didn't make solid sense. It doesn't return any familiar or useful type, it omits a lot of useful data, etc. Instead, we should use `OrganizationEventDetailsEndpoint` which serializes the event property with useful information.

Prepares for "Open in GitHub" links in the Database module.

- Add `useEventDetails` hook
- Fetch span info from full event details endpoint
