### PR TITLE
feat(profiling): use different tooltip per chart type

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
@@ -207,6 +207,7 @@ export function FlamegraphPreview({
       hoveredNode ? (
         <FlamegraphTooltip
           frame={hoveredNode}
+          flamegraph={flamegraph}
           configSpaceCursor={configSpaceCursor}
           flamegraphCanvas={flamegraphCanvas}
           flamegraphRenderer={flamegraphRenderer}

--- a/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
@@ -7,20 +7,23 @@ import {IconLightning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
+import {formatPercentage} from 'sentry/utils/formatters';
 import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
+import {DifferentialFlamegraph} from 'sentry/utils/profiling/differentialFlamegraph';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {formatColorForFrame} from 'sentry/utils/profiling/gl/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 import {Rect} from 'sentry/utils/profiling/speedscope';
+import {relativeChange} from 'sentry/utils/profiling/units/units';
 
 export function formatWeightToProfileDuration(
   frame: CallTreeNode,
   flamegraph: Flamegraph
 ) {
-  return `(${Math.round((frame.totalWeight / flamegraph.profile.duration) * 100)}%)`;
+  return `${Math.round((frame.totalWeight / flamegraph.profile.duration) * 100)}%`;
 }
 
 function formatFileNameAndLineColumn(frame: FlamegraphFrame): string | null {
@@ -39,12 +42,19 @@ function formatFileNameAndLineColumn(frame: FlamegraphFrame): string | null {
 export interface FlamegraphTooltipProps {
   canvasBounds: Rect;
   configSpaceCursor: vec2;
+  flamegraph: Flamegraph | DifferentialFlamegraph;
   flamegraphCanvas: FlamegraphCanvas;
   flamegraphRenderer: FlamegraphRenderer;
   flamegraphView: CanvasView<Flamegraph>;
   frame: FlamegraphFrame;
   platform: 'javascript' | 'python' | 'ios' | 'android' | string | undefined;
   disableColorCoding?: boolean;
+}
+
+function isDifferentiableFlamegraph(
+  flamegraph: Flamegraph | DifferentialFlamegraph
+): flamegraph is DifferentialFlamegraph {
+  return 'beforeCounts' in flamegraph && 'afterCounts' in flamegraph;
 }
 
 export function FlamegraphTooltip(props: FlamegraphTooltipProps) {
@@ -57,7 +67,43 @@ export function FlamegraphTooltip(props: FlamegraphTooltipProps) {
     ).transformRect(props.flamegraphView.configSpaceTransform);
   }, [props.flamegraphView, props.frame]);
 
-  const isCount = props.flamegraphRenderer.flamegraph.profile.unit === 'count';
+  if (
+    props.flamegraphRenderer.flamegraph.profile.unit === 'count' &&
+    !isDifferentiableFlamegraph(props.flamegraph)
+  ) {
+    return (
+      <AggregateFlamegraphTooltip {...props} frameInConfigSpace={frameInConfigSpace} />
+    );
+  }
+
+  if (isDifferentiableFlamegraph(props.flamegraph)) {
+    return (
+      <DifferentialFlamegraphTooltip
+        {...props}
+        flamegraph={props.flamegraph}
+        frameInConfigSpace={frameInConfigSpace}
+      />
+    );
+  }
+
+  return <FlamechartTooltip {...props} frameInConfigSpace={frameInConfigSpace} />;
+}
+
+interface DifferentialFlamegraphTooltipProps extends FlamegraphTooltipProps {
+  flamegraph: DifferentialFlamegraph;
+  frameInConfigSpace: Rect;
+}
+function DifferentialFlamegraphTooltip(props: DifferentialFlamegraphTooltipProps) {
+  const countAfter = useMemo(() => {
+    return (
+      props.flamegraph.afterCounts.get(DifferentialFlamegraph.FrameKey(props.frame)) ?? 0
+    );
+  }, [props.frame, props.flamegraph]);
+  const countBefore = useMemo(() => {
+    return (
+      props.flamegraph.beforeCounts.get(DifferentialFlamegraph.FrameKey(props.frame)) ?? 0
+    );
+  }, [props.frame, props.flamegraph]);
 
   return (
     <BoundTooltip
@@ -71,11 +117,14 @@ export function FlamegraphTooltip(props: FlamegraphTooltipProps) {
           backgroundColor={formatColorForFrame(props.frame, props.flamegraphRenderer)}
         />
         {props.flamegraphRenderer.flamegraph.formatter(props.frame.node.totalWeight)}{' '}
-        {isCount && t('samples') + ' '}
-        {formatWeightToProfileDuration(
+        {t('samples, ') +
+          `${countAfter > countBefore ? '+' : ''}${formatPercentage(
+            relativeChange(countAfter, countBefore)
+          )}`}{' '}
+        {`(${formatWeightToProfileDuration(
           props.frame.node,
           props.flamegraphRenderer.flamegraph
-        )}{' '}
+        )})`}{' '}
         {props.frame.frame.name}
       </FlamegraphTooltipFrameMainInfo>
       <FlamegraphTooltipTimelineInfo>
@@ -88,23 +137,96 @@ export function FlamegraphTooltip(props: FlamegraphTooltipProps) {
           {props.frame.frame.is_application ? t('application frame') : t('system frame')}
         </FlamegraphTooltipTimelineInfo>
       </FlamegraphTooltipTimelineInfo>
-      {!isCount && (
+    </BoundTooltip>
+  );
+}
+
+interface AggregateFlamegraphTooltipProps extends FlamegraphTooltipProps {
+  frameInConfigSpace: Rect;
+}
+function AggregateFlamegraphTooltip(props: AggregateFlamegraphTooltipProps) {
+  return (
+    <BoundTooltip
+      bounds={props.canvasBounds}
+      cursor={props.configSpaceCursor}
+      canvas={props.flamegraphCanvas}
+      canvasView={props.flamegraphView}
+    >
+      <FlamegraphTooltipFrameMainInfo>
+        <FlamegraphTooltipColorIndicator
+          backgroundColor={formatColorForFrame(props.frame, props.flamegraphRenderer)}
+        />
+        {props.flamegraphRenderer.flamegraph.formatter(props.frame.node.totalWeight)}{' '}
+        {t('samples') + ' '}
+        {`(${formatWeightToProfileDuration(
+          props.frame.node,
+          props.flamegraphRenderer.flamegraph
+        )})`}{' '}
+        {props.frame.frame.name}
+      </FlamegraphTooltipFrameMainInfo>
+      <FlamegraphTooltipTimelineInfo>
+        {defined(props.frame.frame.file) && (
+          <Fragment>
+            {t('source')}:{formatFileNameAndLineColumn(props.frame)}
+          </Fragment>
+        )}
         <FlamegraphTooltipTimelineInfo>
-          {props.flamegraphRenderer.flamegraph.timelineFormatter(frameInConfigSpace.left)}{' '}
-          {' \u2014 '}
-          {props.flamegraphRenderer.flamegraph.timelineFormatter(
-            frameInConfigSpace.right
-          )}
-          {props.frame.frame.inline ? (
-            <FlamegraphInlineIndicator>
-              <IconLightning width={10} />
-              {t('inline frame')}
-            </FlamegraphInlineIndicator>
-          ) : (
-            ''
-          )}
+          {props.frame.frame.is_application ? t('application frame') : t('system frame')}
         </FlamegraphTooltipTimelineInfo>
-      )}
+      </FlamegraphTooltipTimelineInfo>
+    </BoundTooltip>
+  );
+}
+
+interface FlamechartTooltipProps extends FlamegraphTooltipProps {
+  frameInConfigSpace: Rect;
+}
+function FlamechartTooltip(props: FlamechartTooltipProps) {
+  return (
+    <BoundTooltip
+      bounds={props.canvasBounds}
+      cursor={props.configSpaceCursor}
+      canvas={props.flamegraphCanvas}
+      canvasView={props.flamegraphView}
+    >
+      <FlamegraphTooltipFrameMainInfo>
+        <FlamegraphTooltipColorIndicator
+          backgroundColor={formatColorForFrame(props.frame, props.flamegraphRenderer)}
+        />
+        {props.flamegraphRenderer.flamegraph.formatter(props.frame.node.totalWeight)}{' '}
+        {`(${formatWeightToProfileDuration(
+          props.frame.node,
+          props.flamegraphRenderer.flamegraph
+        )})`}{' '}
+        {props.frame.frame.name}
+      </FlamegraphTooltipFrameMainInfo>
+      <FlamegraphTooltipTimelineInfo>
+        {defined(props.frame.frame.file) && (
+          <Fragment>
+            {t('source')}:{formatFileNameAndLineColumn(props.frame)}
+          </Fragment>
+        )}
+        <FlamegraphTooltipTimelineInfo>
+          {props.frame.frame.is_application ? t('application frame') : t('system frame')}
+        </FlamegraphTooltipTimelineInfo>
+      </FlamegraphTooltipTimelineInfo>
+      <FlamegraphTooltipTimelineInfo>
+        {props.flamegraphRenderer.flamegraph.timelineFormatter(
+          props.frameInConfigSpace.left
+        )}{' '}
+        {' \u2014 '}
+        {props.flamegraphRenderer.flamegraph.timelineFormatter(
+          props.frameInConfigSpace.right
+        )}
+        {props.frame.frame.inline ? (
+          <FlamegraphInlineIndicator>
+            <IconLightning width={10} />
+            {t('inline frame')}
+          </FlamegraphInlineIndicator>
+        ) : (
+          ''
+        )}
+      </FlamegraphTooltipTimelineInfo>
     </BoundTooltip>
   );
 }

--- a/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
@@ -778,6 +778,7 @@ function FlamegraphZoomView({
       configSpaceCursor &&
       hoveredNode ? (
         <FlamegraphTooltip
+          flamegraph={flamegraph}
           frame={hoveredNode}
           configSpaceCursor={configSpaceCursor}
           flamegraphCanvas={flamegraphCanvas}


### PR DESCRIPTION
The different tooltip states are starting to get confusing so split them per chart type (flamechart, aggregate flamegraph and differential flamegraph)