### PR TITLE
bug(feedback): Pass the number of `hits` into the Infinite Loader so that we load all pages of data

### DIFF
--- a/static/app/components/feedback/list/feedbackList.tsx
+++ b/static/app/components/feedback/list/feedbackList.tsx
@@ -40,8 +40,6 @@ function NoFeedback({title, subtitle}: {subtitle: string; title: string}) {
 
 export default function FeedbackList() {
   const {
-    hasNextPage,
-    isFetching, // If the network is active
     isFetchingNextPage,
     isFetchingPreviousPage,
     isLoading, // If anything is loaded yet
@@ -99,7 +97,7 @@ export default function FeedbackList() {
         <InfiniteLoader
           isRowLoaded={isRowLoaded}
           loadMoreRows={loadMoreRows}
-          rowCount={hasNextPage ? issues.length + 1 : issues.length}
+          rowCount={hits}
         >
           {({onRowsRendered, registerChild}) => (
             <AutoSizer onResize={updateList}>
@@ -108,7 +106,7 @@ export default function FeedbackList() {
                   deferredMeasurementCache={cache}
                   height={height}
                   noRowsRenderer={() =>
-                    isFetching ? (
+                    isLoading ? (
                       <LoadingIndicator />
                     ) : (
                       <NoFeedback

--- a/static/app/components/feedback/useFeedbackListQueryKey.tsx
+++ b/static/app/components/feedback/useFeedbackListQueryKey.tsx
@@ -30,7 +30,7 @@ export default function useFeedbackListQueryKey({organization}: Props): ApiQuery
     },
   });
 
-  const fixedQueryView = useMemo(() => {
+  const {mailbox, ...fixedQueryView} = useMemo(() => {
     // We don't want to use `statsPeriod` directly, because that will mean the
     // start time of our infinite list will change, shifting the index/page
     // where items appear if we invalidate the cache and refetch specific pages.
@@ -66,10 +66,10 @@ export default function useFeedbackListQueryKey({organization}: Props): ApiQuery
             'pluginIssues', // Gives us plugin issues available
           ],
           shortIdLookup: 0,
-          query: `issue.category:feedback status:${fixedQueryView.mailbox} ${fixedQueryView.query}`,
+          query: `issue.category:feedback status:${mailbox} ${fixedQueryView.query}`,
         },
       },
     ],
-    [fixedQueryView, organization.slug]
+    [fixedQueryView, mailbox, organization.slug]
   );
 }

--- a/static/app/components/feedback/useFeedbackListQueryKey.tsx
+++ b/static/app/components/feedback/useFeedbackListQueryKey.tsx
@@ -11,7 +11,7 @@ interface Props {
   organization: Organization;
 }
 
-const PER_PAGE = 5;
+const PER_PAGE = 25;
 
 export default function useFeedbackListQueryKey({organization}: Props): ApiQueryKey {
   const queryView = useLocationQuery({

--- a/static/app/components/feedback/useFetchFeedbackInfiniteListData.tsx
+++ b/static/app/components/feedback/useFetchFeedbackInfiniteListData.tsx
@@ -61,12 +61,12 @@ export default function useFetchFeedbackInfiniteListData() {
     [issues]
   );
 
-  const isRowLoaded = useCallback(({index}: Index) => Boolean(issues?.[index]), [issues]);
+  const isRowLoaded = useCallback(({index}: Index) => Boolean(issues[index]), [issues]);
 
   const loadMoreRows = useCallback(
-    ({startIndex: _1, stopIndex: _2}: IndexRange) =>
-      hasNextPage && !isFetching ? fetchNextPage() : Promise.resolve(),
-    [hasNextPage, isFetching, fetchNextPage]
+    ({startIndex: _1, stopIndex: _2}: IndexRange): Promise<any> =>
+      hasNextPage ? fetchNextPage() : Promise.resolve(),
+    [hasNextPage, fetchNextPage]
   );
 
   const hits = useMemo(

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -18,6 +18,21 @@ const DEFAULT_QUERY_CLIENT_CONFIG: QueryClientConfig = {
   },
 };
 
+// XXX: We need to set persistInFlight to disable query cancellation on
+//      unmount. The current implementation of our API client does not
+//      reject on query cancellation, which causes React Query to never
+//      update from the isLoading state. This matches the library default
+//      as well [0].
+//
+//      This is slightly different from our typical usage of our api client
+//      in components, where we do not want it to resolve, since we would
+//      then have to guard our setState's against being unmounted.
+//
+//      This has the advantage of storing the result in the cache as well.
+//
+//      [0]: https://tanstack.com/query/v4/docs/guides/query-cancellation#default-behavior
+const PERSIST_IN_FLIGHT = true;
+
 type QueryKeyEndpointOptions<
   Headers = Record<string, string>,
   Query = Record<string, any>,
@@ -96,22 +111,7 @@ function useApiQuery<TResponseData, TError = RequestError>(
   queryKey: ApiQueryKey,
   options: UseApiQueryOptions<TResponseData, TError>
 ): UseApiQueryResult<TResponseData, TError> {
-  const api = useApi({
-    // XXX: We need to set persistInFlight to disable query cancellation on
-    //      unmount. The current implementation of our API client does not
-    //      reject on query cancellation, which causes React Query to never
-    //      update from the isLoading state. This matches the library default
-    //      as well [0].
-    //
-    //      This is slightly different from our typical usage of our api client
-    //      in components, where we do not want it to resolve, since we would
-    //      then have to guard our setState's against being unmounted.
-    //
-    //      This has the advantage of storing the result in the cache as well.
-    //
-    //      [0]: https://tanstack.com/query/v4/docs/guides/query-cancellation#default-behavior
-    persistInFlight: true,
-  });
+  const api = useApi({persistInFlight: PERSIST_IN_FLIGHT});
 
   const [path, endpointOptions] = queryKey;
 
@@ -206,7 +206,7 @@ function parsePageParam(dir: 'previous' | 'next') {
 }
 
 function useInfiniteApiQuery<TResponseData>({queryKey}: {queryKey: ApiQueryKey}) {
-  const api = useApi();
+  const api = useApi({persistInFlight: PERSIST_IN_FLIGHT});
   return useInfiniteQuery({
     queryKey,
     queryFn: fetchInfiniteQuery<TResponseData>(api),


### PR DESCRIPTION
The main change here is setting `<InfiniteLoader rowCount={hits}>`. We need to tell the infinite loader the total number of rows in the database, so that it can know to keep fetching more pages. We've already got the `isRowLoaded` guard inside `useFetchFeedbackInfiniteListData` which prevents the same pages from being re-loaded, but this is the only way to say something exists even if it's not loaded yet.

See `rowCount={remoteRowCount}` in https://github.com/bvaughn/react-virtualized/blob/master/docs/InfiniteLoader.md 

Fixes https://github.com/getsentry/team-replay/issues/297
