### PR TITLE
fix(replays): don't save sort query when going to selector table

### DIFF
--- a/static/app/views/replays/tabs.tsx
+++ b/static/app/views/replays/tabs.tsx
@@ -21,6 +21,7 @@ export default function ReplayTabs({selected}: Props) {
         key: 'replays',
         label: t('Replays'),
         pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
+        query: {sort: undefined},
       },
       {
         key: 'selectors',
@@ -30,6 +31,7 @@ export default function ReplayTabs({selected}: Props) {
           </Fragment>
         ),
         pathname: normalizeUrl(`/organizations/${organization.slug}/replays/selectors/`),
+        query: {sort: '-count_dead_clicks'},
       },
     ],
     [organization.slug]
@@ -44,6 +46,7 @@ export default function ReplayTabs({selected}: Props) {
             to={{
               ...location,
               pathname: tab.pathname,
+              query: tab.query,
             }}
           >
             {tab.label}


### PR DESCRIPTION
Sort the selector table by `-count_dead_clicks` by default when switching to that tab. When switching back to replay index, reset the sort.

We need to do this because the selector index table can't be sorted by all the parameters that replay index can, like `activity`.

Fixes this issue:
<img width="1462" alt="fix" src="https://github.com/getsentry/sentry/assets/56095982/a57f9fd5-707b-4f56-aaf2-d6a83d109827">


