### PR TITLE
ref: upgrade to the latest django-stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ module = [
     "celery.*",
     "confluent_kafka.*",
     "cssselect.*",
-    "datadog.*",
     "django_zero_downtime_migrations.backends.postgres.schema.*",
     "docker.*",
     "fido2.*",

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -45,7 +45,7 @@ django==3.2.23
 django-crispy-forms==1.14.0
 django-csp==3.7
 django-pg-zero-downtime-migrations==0.13
-django-stubs-ext==4.2.5
+django-stubs-ext==4.2.7
 djangorestframework==3.14.0
 docker==3.7.0
 docker-pycreds==0.4.0
@@ -173,7 +173,7 @@ s3transfer==0.6.1
 selenium==4.3.0
 sentry-arroyo==2.14.25
 sentry-cli==2.16.0
-sentry-forked-django-stubs==4.2.6.post3
+sentry-forked-django-stubs==4.2.7.post1
 sentry-forked-djangorestframework-stubs==3.14.4.post2
 sentry-kafka-schemas==0.1.37
 sentry-redis-tools==0.1.7

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,7 +31,7 @@ pip-tools>=6.7.0
 packaging>=21.3
 
 # for type checking
-sentry-forked-django-stubs>=4.2.6.post3
+sentry-forked-django-stubs>=4.2.7.post1
 sentry-forked-djangorestframework-stubs>=3.14.4.post2
 lxml-stubs
 msgpack-types>=0.2.0

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Iterable, List, Mapping, Optional, Union
 
 from django.db import IntegrityError, models, router, transaction
-from django.db.models.expressions import F
+from django.db.models.expressions import CombinedExpression, F
 from django.dispatch import Signal
 
 from sentry import roles
@@ -285,7 +285,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         return [r.organization for r in results]
 
     def update_flags(self, *, organization_id: int, flags: RpcOrganizationFlagsUpdate) -> None:
-        updates: models.F | models.CombinedExpression = models.F("flags")
+        updates: F | CombinedExpression = models.F("flags")
         for (name, value) in flags.items():
             if value is True:
                 updates = updates.bitor(getattr(Organization.flags, name))


### PR DESCRIPTION
- all of our patches applied cleanly
- this reduced our total errors by exactly 1 (and adjusted the messages slightly of 3 other errors)

```diff
$ diff -u <(sort .artifacts/mypy-all.old) <(sort .artifacts/mypy-all) | grep '^[-+].*error:'
-src/sentry/api/serializers/rest_framework/dashboard.py:119: error: Incompatible types in assignment (expression has type "ListField", base class "Serializer" defined the type as "Callable[[Serializer[Any]], BindingDict]")  [assignment]
+src/sentry/api/serializers/rest_framework/dashboard.py:119: error: Incompatible types in assignment (expression has type "ListField", base class "Serializer" defined the type as "BindingDict")  [assignment]
-src/sentry/discover/endpoints/serializers.py:148: error: Incompatible types in assignment (expression has type "ListField", base class "Serializer" defined the type as "Callable[[Serializer[Any]], BindingDict]")  [assignment]
+src/sentry/discover/endpoints/serializers.py:148: error: Incompatible types in assignment (expression has type "ListField", base class "Serializer" defined the type as "BindingDict")  [assignment]
-src/sentry/discover/endpoints/serializers.py:29: error: Incompatible types in assignment (expression has type "ListField", base class "Serializer" defined the type as "Callable[[Serializer[Any]], BindingDict]")  [assignment]
+src/sentry/discover/endpoints/serializers.py:29: error: Incompatible types in assignment (expression has type "ListField", base class "Serializer" defined the type as "BindingDict")  [assignment]
-src/sentry/search/events/builder/metrics.py:1639: error: Signature of "_on_demand_metric_spec_map" incompatible with supertype "MetricsQueryBuilder"  [override]
```