### PR TITLE
feat(app-start): Add top screens table

### DIFF
--- a/static/app/views/starfish/modules/mobile/appStartup.tsx
+++ b/static/app/views/starfish/modules/mobile/appStartup.tsx
@@ -17,6 +17,7 @@ import {
 import useOrganization from 'sentry/utils/useOrganization';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
 import {ROUTE_NAMES} from 'sentry/views/starfish/utils/routeNames';
+import AppStartup from 'sentry/views/starfish/views/appStartup';
 
 export default function InitializationModule() {
   const organization = useOrganization();
@@ -45,7 +46,7 @@ export default function InitializationModule() {
                     <ReleaseComparisonSelector />
                   </Container>
                   <ErrorBoundary mini>
-                    <div>App Start Content</div>
+                    <AppStartup />
                   </ErrorBoundary>
                 </PageFiltersContainer>
               </Layout.Main>

--- a/static/app/views/starfish/views/appStartup/index.tsx
+++ b/static/app/views/starfish/views/appStartup/index.tsx
@@ -1,0 +1,186 @@
+import styled from '@emotion/styled';
+
+import Alert from 'sentry/components/alert';
+import LoadingContainer from 'sentry/components/loading/loadingContainer';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import SearchBar from 'sentry/components/performance/searchBar';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {NewQuery} from 'sentry/types';
+import {defined} from 'sentry/utils';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useRouter from 'sentry/utils/useRouter';
+import {prepareQueryForLandingPage} from 'sentry/views/performance/data';
+import {getTransactionSearchQuery} from 'sentry/views/performance/utils';
+import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
+import {getFreeTextFromQuery} from 'sentry/views/starfish/views/screens';
+import {
+  ScreensTable,
+  useTableQuery,
+} from 'sentry/views/starfish/views/screens/screensTable';
+
+const MAX_TABLE_RELEASE_CHARS = 15;
+
+type Props = {
+  additionalFilters?: string[];
+  chartHeight?: number;
+};
+
+function AppStartup({additionalFilters}: Props) {
+  const pageFilter = usePageFilters();
+  const {selection} = pageFilter;
+  const location = useLocation();
+  const organization = useOrganization();
+  const {query: locationQuery} = location;
+
+  const {
+    primaryRelease,
+    secondaryRelease,
+    isLoading: isReleasesLoading,
+  } = useReleaseSelection();
+  const truncatedPrimary = formatVersionAndCenterTruncate(
+    primaryRelease ?? '',
+    MAX_TABLE_RELEASE_CHARS
+  );
+  const truncatedSecondary = formatVersionAndCenterTruncate(
+    secondaryRelease ?? '',
+    MAX_TABLE_RELEASE_CHARS
+  );
+
+  const router = useRouter();
+
+  const query = new MutableSearch([
+    'event.type:transaction',
+    'transaction.op:[app.start.cold,app.start.warm]',
+    ...(additionalFilters ?? []),
+  ]);
+
+  const searchQuery = decodeScalar(locationQuery.query, '');
+  if (searchQuery) {
+    query.addStringFilter(prepareQueryForLandingPage(searchQuery, false));
+  }
+
+  const queryString = appendReleaseFilters(query, primaryRelease, secondaryRelease);
+
+  const orderby = decodeScalar(locationQuery.sort, `-count`);
+  const newQuery: NewQuery = {
+    name: '',
+    fields: [
+      'transaction',
+      SpanMetricsField.PROJECT_ID,
+      `avg_if(measurements.app_start_cold,release,${primaryRelease})`,
+      `avg_if(measurements.app_start_cold,release,${secondaryRelease})`,
+      `avg_if(measurements.app_start_warm,release,${primaryRelease})`,
+      `avg_if(measurements.app_start_warm,release,${secondaryRelease})`,
+      'count()',
+    ],
+    query: queryString,
+    dataset: DiscoverDatasets.METRICS,
+    version: 2,
+    projects: selection.projects,
+  };
+  newQuery.orderby = orderby;
+  const tableEventView = EventView.fromNewQueryWithLocation(newQuery, location);
+
+  const {
+    data: topTransactionsData,
+    isLoading: topTransactionsLoading,
+    pageLinks,
+  } = useTableQuery({
+    eventView: tableEventView,
+    enabled: !isReleasesLoading,
+    referrer: 'api.starfish.mobile-startup-screen-table',
+  });
+
+  if (isReleasesLoading) {
+    return (
+      <LoadingContainer>
+        <LoadingIndicator />
+      </LoadingContainer>
+    );
+  }
+
+  if (!defined(primaryRelease) && !isReleasesLoading) {
+    return (
+      <Alert type="warning" showIcon>
+        {t(
+          'No screens found on recent releases. Please try a single iOS or Android project, a single environment or a smaller date range.'
+        )}
+      </Alert>
+    );
+  }
+
+  const derivedQuery = getTransactionSearchQuery(location, tableEventView.query);
+
+  const tableSearchFilters = new MutableSearch([
+    'event.type:transaction',
+    'transaction.op:[app.start.cold,app.start.warm]',
+  ]);
+
+  return (
+    <div data-test-id="starfish-mobile-app-startup-view">
+      <StyledSearchBar
+        eventView={tableEventView}
+        onSearch={search => {
+          router.push({
+            pathname: router.location.pathname,
+            query: {
+              ...location.query,
+              cursor: undefined,
+              query: String(search).trim() || undefined,
+            },
+          });
+        }}
+        organization={organization}
+        query={getFreeTextFromQuery(derivedQuery)}
+        placeholder={t('Search for Screens')}
+        additionalConditions={
+          new MutableSearch(
+            appendReleaseFilters(tableSearchFilters, primaryRelease, secondaryRelease)
+          )
+        }
+      />
+      <ScreensTable
+        eventView={tableEventView}
+        data={topTransactionsData}
+        isLoading={topTransactionsLoading}
+        pageLinks={pageLinks}
+        columnNameMap={{
+          transaction: t('Screen'),
+          [`avg_if(measurements.app_start_cold,release,${primaryRelease})`]: t(
+            'Cold Start (%s)',
+            truncatedPrimary
+          ),
+          [`avg_if(measurements.app_start_cold,release,${secondaryRelease})`]: t(
+            'Cold Start (%s)',
+            truncatedSecondary
+          ),
+          [`avg_if(measurements.app_start_warm,release,${primaryRelease})`]: t(
+            'Warm Start (%s)',
+            truncatedPrimary
+          ),
+          [`avg_if(measurements.app_start_warm,release,${secondaryRelease})`]: t(
+            'Warm Start (%s)',
+            truncatedSecondary
+          ),
+          'count()': t('Total Count'),
+        }}
+      />
+    </div>
+  );
+}
+
+export default AppStartup;
+
+const StyledSearchBar = styled(SearchBar)`
+  margin-bottom: ${space(1)};
+`;

--- a/static/app/views/starfish/views/appStartup/index.tsx
+++ b/static/app/views/starfish/views/appStartup/index.tsx
@@ -60,7 +60,7 @@ function AppStartup({additionalFilters}: Props) {
 
   const query = new MutableSearch([
     'event.type:transaction',
-    'transaction.op:[app.start.cold,app.start.warm]',
+    'transaction.op:ui.load',
     ...(additionalFilters ?? []),
   ]);
 
@@ -123,7 +123,7 @@ function AppStartup({additionalFilters}: Props) {
 
   const tableSearchFilters = new MutableSearch([
     'event.type:transaction',
-    'transaction.op:[app.start.cold,app.start.warm]',
+    'transaction.op:ui.load',
   ]);
 
   return (

--- a/static/app/views/starfish/views/screens/index.tsx
+++ b/static/app/views/starfish/views/screens/index.tsx
@@ -50,6 +50,8 @@ export enum YAxis {
 }
 
 export const TOP_SCREENS = 5;
+const MAX_CHART_RELEASE_CHARS = 12;
+const MAX_TABLE_RELEASE_CHARS = 15;
 
 export const YAXIS_COLUMNS: Readonly<Record<YAxis, string>> = {
   [YAxis.WARM_START]: 'avg(measurements.app_start_warm)',
@@ -269,6 +271,14 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
     });
   }
 
+  const truncatedPrimary = formatVersionAndCenterTruncate(
+    primaryRelease ?? '',
+    MAX_TABLE_RELEASE_CHARS
+  );
+  const truncatedSecondary = formatVersionAndCenterTruncate(
+    secondaryRelease ?? '',
+    MAX_TABLE_RELEASE_CHARS
+  );
   const derivedQuery = getTransactionSearchQuery(location, tableEventView.query);
 
   const tableSearchFilters = new MutableSearch(['transaction.op:ui.load']);
@@ -290,9 +300,15 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
                   subtitle: primaryRelease
                     ? t(
                         '%s v. %s',
-                        formatVersionAndCenterTruncate(primaryRelease, 12),
+                        formatVersionAndCenterTruncate(
+                          primaryRelease,
+                          MAX_CHART_RELEASE_CHARS
+                        ),
                         secondaryRelease
-                          ? formatVersionAndCenterTruncate(secondaryRelease, 12)
+                          ? formatVersionAndCenterTruncate(
+                              secondaryRelease,
+                              MAX_CHART_RELEASE_CHARS
+                            )
                           : ''
                       )
                     : '',
@@ -324,9 +340,15 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
                     subtitle: primaryRelease
                       ? t(
                           '%s v. %s',
-                          formatVersionAndCenterTruncate(primaryRelease, 12),
+                          formatVersionAndCenterTruncate(
+                            primaryRelease,
+                            MAX_CHART_RELEASE_CHARS
+                          ),
                           secondaryRelease
-                            ? formatVersionAndCenterTruncate(secondaryRelease, 12)
+                            ? formatVersionAndCenterTruncate(
+                                secondaryRelease,
+                                MAX_CHART_RELEASE_CHARS
+                              )
                             : ''
                         )
                       : '',
@@ -366,12 +388,32 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
         data={topTransactionsData}
         isLoading={topTransactionsLoading}
         pageLinks={pageLinks}
+        columnNameMap={{
+          transaction: t('Screen'),
+          [`avg_if(measurements.time_to_initial_display,release,${primaryRelease})`]: t(
+            'TTID (%s)',
+            truncatedPrimary
+          ),
+          [`avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`]: t(
+            'TTID (%s)',
+            truncatedSecondary
+          ),
+          [`avg_if(measurements.time_to_full_display,release,${primaryRelease})`]: t(
+            'TTFD (%s)',
+            truncatedPrimary
+          ),
+          [`avg_if(measurements.time_to_full_display,release,${secondaryRelease})`]: t(
+            'TTFD (%s)',
+            truncatedSecondary
+          ),
+          'count()': t('Total Count'),
+        }}
       />
     </div>
   );
 }
 
-function getFreeTextFromQuery(query: string) {
+export function getFreeTextFromQuery(query: string) {
   const conditions = new MutableSearch(query);
   const transactionValues = conditions.getFilterValues('transaction');
   if (transactionValues.length) {

--- a/static/app/views/starfish/views/screens/index.tsx
+++ b/static/app/views/starfish/views/screens/index.tsx
@@ -275,9 +275,17 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
     primaryRelease ?? '',
     MAX_TABLE_RELEASE_CHARS
   );
+  const truncatedPrimaryChart = formatVersionAndCenterTruncate(
+    primaryRelease ?? '',
+    MAX_CHART_RELEASE_CHARS
+  );
   const truncatedSecondary = formatVersionAndCenterTruncate(
     secondaryRelease ?? '',
     MAX_TABLE_RELEASE_CHARS
+  );
+  const truncatedSecondaryChart = formatVersionAndCenterTruncate(
+    secondaryRelease ?? '',
+    MAX_CHART_RELEASE_CHARS
   );
   const derivedQuery = getTransactionSearchQuery(location, tableEventView.query);
 
@@ -300,16 +308,8 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
                   subtitle: primaryRelease
                     ? t(
                         '%s v. %s',
-                        formatVersionAndCenterTruncate(
-                          primaryRelease,
-                          MAX_CHART_RELEASE_CHARS
-                        ),
-                        secondaryRelease
-                          ? formatVersionAndCenterTruncate(
-                              secondaryRelease,
-                              MAX_CHART_RELEASE_CHARS
-                            )
-                          : ''
+                        truncatedPrimaryChart,
+                        secondaryRelease ? truncatedSecondaryChart : ''
                       )
                     : '',
                 },
@@ -340,16 +340,8 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
                     subtitle: primaryRelease
                       ? t(
                           '%s v. %s',
-                          formatVersionAndCenterTruncate(
-                            primaryRelease,
-                            MAX_CHART_RELEASE_CHARS
-                          ),
-                          secondaryRelease
-                            ? formatVersionAndCenterTruncate(
-                                secondaryRelease,
-                                MAX_CHART_RELEASE_CHARS
-                              )
-                            : ''
+                          truncatedPrimaryChart,
+                          secondaryRelease ? truncatedSecondaryChart : ''
                         )
                       : '',
                   },

--- a/static/app/views/starfish/views/screens/screensTable.tsx
+++ b/static/app/views/starfish/views/screens/screensTable.tsx
@@ -25,24 +25,28 @@ import TopResultsIndicator from 'sentry/views/discover/table/topResultsIndicator
 import {TableColumn} from 'sentry/views/discover/table/types';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {TOP_SCREENS} from 'sentry/views/starfish/views/screens';
 
 type Props = {
+  columnNameMap: Record<string, string>;
   data: TableData | undefined;
   eventView: EventView;
   isLoading: boolean;
   pageLinks: string | undefined;
 };
 
-export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
+export function ScreensTable({
+  data,
+  eventView,
+  isLoading,
+  pageLinks,
+  columnNameMap,
+}: Props) {
   const location = useLocation();
   const {selection} = usePageFilters();
   const {projects} = useProjects();
   const organization = useOrganization();
   const {primaryRelease, secondaryRelease} = useReleaseSelection();
-  const truncatedPrimary = formatVersionAndCenterTruncate(primaryRelease ?? '', 15);
-  const truncatedSecondary = formatVersionAndCenterTruncate(secondaryRelease ?? '', 15);
 
   const project = useMemo(() => {
     if (selection.projects.length !== 1) {
@@ -52,27 +56,6 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
   }, [projects, selection.projects]);
 
   const eventViewColumns = eventView.getColumns();
-
-  const columnNameMap = {
-    transaction: t('Screen'),
-    [`avg_if(measurements.time_to_initial_display,release,${primaryRelease})`]: t(
-      'TTID (%s)',
-      truncatedPrimary
-    ),
-    [`avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`]: t(
-      'TTID (%s)',
-      truncatedSecondary
-    ),
-    [`avg_if(measurements.time_to_full_display,release,${primaryRelease})`]: t(
-      'TTFD (%s)',
-      truncatedPrimary
-    ),
-    [`avg_if(measurements.time_to_full_display,release,${secondaryRelease})`]: t(
-      'TTFD (%s)',
-      truncatedSecondary
-    ),
-    'count()': t('Total Count'),
-  };
 
   function renderBodyCell(column, row): React.ReactNode {
     if (!data?.meta || !data?.meta.fields) {
@@ -197,7 +180,7 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
               !col.name.startsWith('avg_compare')
           )
           .map((col: TableColumn<React.ReactText>) => {
-            return {...col, name: columnNameMap[col.key]};
+            return {...col, name: columnNameMap[col.key] ?? col.name};
           })}
         columnSortBy={[
           {


### PR DESCRIPTION
Makes queries to Discover to retrieve top screens and their cold/warm
starts and displays it in a table. I reused the screens table because
the functionality was largely the same, but instead of hardcoding the
column names into the component I made that a prop so we can customize
the behaviour.

We will likely do the same with custom rendering since there is logic
for linking to the screen details page, but we'll change that when the
page is developed.

A future PR will also be added for the cold/warm start count breakdown.