### PR TITLE
feat(hybrid-cloud): Cache some RPC call responses on thread local storage for each Django request

### DIFF
--- a/src/sentry/app.py
+++ b/src/sentry/app.py
@@ -10,6 +10,7 @@ class State(local):
     request: HttpRequest | None = None
     request_stack: List[HttpRequest] | None = None
     data: dict[str, Any] = {}
+    rpc_cache: dict[int, Any] = {}
 
     def clear(self) -> None:
         self.request = None


### PR DESCRIPTION
On each Django request thread, we may be performing duplicate RPC calls just for fetching and reading RPC objects. 

These kinds of RPC calls can be cached, and we can store them on thread-local storage (i.e. `threading.local()`).