### PR TITLE
docs: remove `0-alert` from JS frameworks

### DIFF
--- a/static/app/components/profiling/ProfilingOnboarding/util.ts
+++ b/static/app/components/profiling/ProfilingOnboarding/util.ts
@@ -43,16 +43,8 @@ export const supportedPlatformExpectedDocKeys: Record<
   'php-laravel': ['1-install', '2-configure-performance', '3-configure-profiling'],
   'php-symfony2': ['1-install', '2-configure-performance', '3-configure-profiling'],
   ruby: ['0-alert', '1-install', '2-configure-performance', '3-configure-profiling'],
-  'javascript-nextjs': [
-    '1-install',
-    '2-configure-performance',
-    '3-configure-profiling',
-  ],
-  'javascript-remix': [
-    '1-install',
-    '2-configure-performance',
-    '3-configure-profiling',
-  ],
+  'javascript-nextjs': ['1-install', '2-configure-performance', '3-configure-profiling'],
+  'javascript-remix': ['1-install', '2-configure-performance', '3-configure-profiling'],
   'javascript-sveltekit': [
     '1-install',
     '2-configure-performance',

--- a/static/app/components/profiling/ProfilingOnboarding/util.ts
+++ b/static/app/components/profiling/ProfilingOnboarding/util.ts
@@ -44,19 +44,16 @@ export const supportedPlatformExpectedDocKeys: Record<
   'php-symfony2': ['1-install', '2-configure-performance', '3-configure-profiling'],
   ruby: ['0-alert', '1-install', '2-configure-performance', '3-configure-profiling'],
   'javascript-nextjs': [
-    '0-alert',
     '1-install',
     '2-configure-performance',
     '3-configure-profiling',
   ],
   'javascript-remix': [
-    '0-alert',
     '1-install',
     '2-configure-performance',
     '3-configure-profiling',
   ],
   'javascript-sveltekit': [
-    '0-alert',
     '1-install',
     '2-configure-performance',
     '3-configure-profiling',


### PR DESCRIPTION
Removes invalid information on Next.js, Remix and Sveltekit profiling node documentation.