### PR TITLE
ref(replays): [2/4] migrate nextjs remix vue svelte sveltekit electron onboarding docs

### DIFF
--- a/static/app/gettingStartedDocs/replay-onboarding/electron/electron.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/electron/electron.tsx
@@ -1,0 +1,127 @@
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {tct} from 'sentry/locale';
+import type {Organization, PlatformKey} from 'sentry/types';
+
+type StepProps = {
+  newOrg: boolean;
+  organization: Organization;
+  platformKey: PlatformKey;
+  projectId: string;
+  sentryInitContent: string;
+};
+
+// Configuration Start
+const replayIntegration = `
+new Sentry.Replay(),
+`;
+
+const replayOtherConfig = `
+// This sets the sample rate to be 10%. You may want this to be 100% while
+// in development and sample at a lower rate in production.
+replaysSessionSampleRate: 0.1,
+// If the entire session is not sampled, use the below sample rate to sample
+// sessions when an error occurs.
+replaysOnErrorSampleRate: 1.0,
+`;
+
+export const steps = ({
+  sentryInitContent,
+}: Partial<StepProps> = {}): LayoutProps['steps'] => [
+  {
+    type: StepType.INSTALL,
+    description: tct(
+      'For the Session Replay to work, you must have the framework SDK (e.g. [code:@sentry/electron]) installed, minimum version 4.2.0.',
+      {code: <code />}
+    ),
+    configurations: [
+      {
+        language: 'bash',
+        code: [
+          {
+            label: 'npm',
+            value: 'npm',
+            language: 'bash',
+            code: 'npm install --save @sentry/electron',
+          },
+          {
+            label: 'yarn',
+            value: 'yarn',
+            language: 'bash',
+            code: 'yarn add @sentry/electron',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: tct(
+      'Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set using the [code:integrations] constructor. Learn more about configuring Session Replay by reading the [link:configuration docs].',
+      {
+        code: <code />,
+        link: (
+          <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/" />
+        ),
+      }
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        import * as Sentry from "@sentry/electron";
+
+        Sentry.init({
+          ${sentryInitContent}
+        });
+        `,
+      },
+    ],
+  },
+];
+
+// Configuration End
+
+export function GettingStartedWithElectronReplay({
+  dsn,
+  organization,
+  newOrg,
+  platformKey,
+  projectId,
+  ...props
+}: ModuleProps) {
+  const integrations: string[] = [];
+  const otherConfigs: string[] = [];
+  integrations.push(replayIntegration.trim());
+  otherConfigs.push(replayOtherConfig.trim());
+
+  let sentryInitContent: string[] = [`dsn: "${dsn}",`];
+
+  if (integrations.length > 0) {
+    sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
+  }
+
+  if (otherConfigs.length > 0) {
+    sentryInitContent = sentryInitContent.concat(otherConfigs);
+  }
+
+  return (
+    <Layout
+      steps={steps({
+        sentryInitContent: sentryInitContent.join('\n'),
+        organization,
+        newOrg,
+        platformKey,
+        projectId,
+      })}
+      platformKey={platformKey}
+      newOrg={newOrg}
+      hideHeader
+      {...props}
+    />
+  );
+}
+
+export default GettingStartedWithElectronReplay;

--- a/static/app/gettingStartedDocs/replay-onboarding/electron/electron.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/electron/electron.tsx
@@ -92,20 +92,11 @@ export function GettingStartedWithElectronReplay({
   projectId,
   ...props
 }: ModuleProps) {
-  const integrations: string[] = [];
-  const otherConfigs: string[] = [];
-  integrations.push(replayIntegration.trim());
-  otherConfigs.push(replayOtherConfig.trim());
-
+  const integrations = replayIntegration.trim();
+  const otherConfigs = replayOtherConfig.trim();
   let sentryInitContent: string[] = [`dsn: "${dsn}",`];
-
-  if (integrations.length > 0) {
-    sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
-  }
-
-  if (otherConfigs.length > 0) {
-    sentryInitContent = sentryInitContent.concat(otherConfigs);
-  }
+  sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
+  sentryInitContent = sentryInitContent.concat(otherConfigs);
 
   return (
     <Layout

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/javascript.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/javascript.tsx
@@ -92,20 +92,11 @@ export function GettingStartedWithJavaScriptReplay({
   projectId,
   ...props
 }: ModuleProps) {
-  const integrations: string[] = [];
-  const otherConfigs: string[] = [];
-  integrations.push(replayIntegration.trim());
-  otherConfigs.push(replayOtherConfig.trim());
-
+  const integrations = replayIntegration.trim();
+  const otherConfigs = replayOtherConfig.trim();
   let sentryInitContent: string[] = [`dsn: "${dsn}",`];
-
-  if (integrations.length > 0) {
-    sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
-  }
-
-  if (otherConfigs.length > 0) {
-    sentryInitContent = sentryInitContent.concat(otherConfigs);
-  }
+  sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
+  sentryInitContent = sentryInitContent.concat(otherConfigs);
 
   return (
     <Layout

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/nextjs.tsx
@@ -1,0 +1,120 @@
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {tct} from 'sentry/locale';
+import type {Organization, PlatformKey} from 'sentry/types';
+
+type StepProps = {
+  newOrg: boolean;
+  organization: Organization;
+  platformKey: PlatformKey;
+  projectId: string;
+  sentryInitContent: string;
+};
+
+// Configuration Start
+const replayIntegration = `
+new Sentry.Replay(),
+`;
+
+const replayOtherConfig = `
+// This sets the sample rate to be 10%. You may want this to be 100% while
+// in development and sample at a lower rate in production.
+replaysSessionSampleRate: 0.1,
+// If the entire session is not sampled, use the below sample rate to sample
+// sessions when an error occurs.
+replaysOnErrorSampleRate: 1.0,
+`;
+
+export const steps = ({
+  sentryInitContent,
+}: Partial<StepProps> = {}): LayoutProps['steps'] => [
+  {
+    type: StepType.INSTALL,
+    description: tct('Configure your app automatically with the Sentry wizard.', {
+      code: <code />,
+    }),
+    configurations: [
+      {
+        language: 'bash',
+        code: [
+          {
+            label: 'Bash',
+            value: 'bash',
+            language: 'bash',
+            code: 'npx @sentry/wizard@latest -i nextjs',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: tct(
+      'Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set using the [code:integrations] constructor. Learn more about configuring Session Replay by reading the [link:configuration docs].',
+      {
+        code: <code />,
+        link: (
+          <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/" />
+        ),
+      }
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        import * as Sentry from "@sentry/nextjs";
+
+        Sentry.init({
+          ${sentryInitContent}
+        });
+        `,
+      },
+    ],
+  },
+];
+
+// Configuration End
+
+export function GettingStartedWithNextjsReplay({
+  dsn,
+  organization,
+  newOrg,
+  platformKey,
+  projectId,
+  ...props
+}: ModuleProps) {
+  const integrations: string[] = [];
+  const otherConfigs: string[] = [];
+  integrations.push(replayIntegration.trim());
+  otherConfigs.push(replayOtherConfig.trim());
+
+  let sentryInitContent: string[] = [`dsn: "${dsn}",`];
+
+  if (integrations.length > 0) {
+    sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
+  }
+
+  if (otherConfigs.length > 0) {
+    sentryInitContent = sentryInitContent.concat(otherConfigs);
+  }
+
+  return (
+    <Layout
+      steps={steps({
+        sentryInitContent: sentryInitContent.join('\n'),
+        organization,
+        newOrg,
+        platformKey,
+        projectId,
+      })}
+      platformKey={platformKey}
+      newOrg={newOrg}
+      hideHeader
+      {...props}
+    />
+  );
+}
+
+export default GettingStartedWithNextjsReplay;

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/nextjs.tsx
@@ -85,20 +85,11 @@ export function GettingStartedWithNextjsReplay({
   projectId,
   ...props
 }: ModuleProps) {
-  const integrations: string[] = [];
-  const otherConfigs: string[] = [];
-  integrations.push(replayIntegration.trim());
-  otherConfigs.push(replayOtherConfig.trim());
-
+  const integrations = replayIntegration.trim();
+  const otherConfigs = replayOtherConfig.trim();
   let sentryInitContent: string[] = [`dsn: "${dsn}",`];
-
-  if (integrations.length > 0) {
-    sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
-  }
-
-  if (otherConfigs.length > 0) {
-    sentryInitContent = sentryInitContent.concat(otherConfigs);
-  }
+  sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
+  sentryInitContent = sentryInitContent.concat(otherConfigs);
 
   return (
     <Layout

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/remix.tsx
@@ -1,0 +1,120 @@
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {tct} from 'sentry/locale';
+import type {Organization, PlatformKey} from 'sentry/types';
+
+type StepProps = {
+  newOrg: boolean;
+  organization: Organization;
+  platformKey: PlatformKey;
+  projectId: string;
+  sentryInitContent: string;
+};
+
+// Configuration Start
+const replayIntegration = `
+new Sentry.Replay(),
+`;
+
+const replayOtherConfig = `
+// This sets the sample rate to be 10%. You may want this to be 100% while
+// in development and sample at a lower rate in production.
+replaysSessionSampleRate: 0.1,
+// If the entire session is not sampled, use the below sample rate to sample
+// sessions when an error occurs.
+replaysOnErrorSampleRate: 1.0,
+`;
+
+export const steps = ({
+  sentryInitContent,
+}: Partial<StepProps> = {}): LayoutProps['steps'] => [
+  {
+    type: StepType.INSTALL,
+    description: tct('Configure your app automatically with the Sentry wizard.', {
+      code: <code />,
+    }),
+    configurations: [
+      {
+        language: 'bash',
+        code: [
+          {
+            label: 'Bash',
+            value: 'bash',
+            language: 'bash',
+            code: 'npx @sentry/wizard@latest -i remix',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: tct(
+      'Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set using the [code:integrations] constructor. Learn more about configuring Session Replay by reading the [link:configuration docs].',
+      {
+        code: <code />,
+        link: (
+          <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/" />
+        ),
+      }
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        import * as Sentry from "@sentry/remix";
+
+        Sentry.init({
+          ${sentryInitContent}
+        });
+        `,
+      },
+    ],
+  },
+];
+
+// Configuration End
+
+export function GettingStartedWithRemixReplay({
+  dsn,
+  organization,
+  newOrg,
+  platformKey,
+  projectId,
+  ...props
+}: ModuleProps) {
+  const integrations: string[] = [];
+  const otherConfigs: string[] = [];
+  integrations.push(replayIntegration.trim());
+  otherConfigs.push(replayOtherConfig.trim());
+
+  let sentryInitContent: string[] = [`dsn: "${dsn}",`];
+
+  if (integrations.length > 0) {
+    sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
+  }
+
+  if (otherConfigs.length > 0) {
+    sentryInitContent = sentryInitContent.concat(otherConfigs);
+  }
+
+  return (
+    <Layout
+      steps={steps({
+        sentryInitContent: sentryInitContent.join('\n'),
+        organization,
+        newOrg,
+        platformKey,
+        projectId,
+      })}
+      platformKey={platformKey}
+      newOrg={newOrg}
+      hideHeader
+      {...props}
+    />
+  );
+}
+
+export default GettingStartedWithRemixReplay;

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/remix.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/remix.tsx
@@ -85,20 +85,11 @@ export function GettingStartedWithRemixReplay({
   projectId,
   ...props
 }: ModuleProps) {
-  const integrations: string[] = [];
-  const otherConfigs: string[] = [];
-  integrations.push(replayIntegration.trim());
-  otherConfigs.push(replayOtherConfig.trim());
-
+  const integrations = replayIntegration.trim();
+  const otherConfigs = replayOtherConfig.trim();
   let sentryInitContent: string[] = [`dsn: "${dsn}",`];
-
-  if (integrations.length > 0) {
-    sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
-  }
-
-  if (otherConfigs.length > 0) {
-    sentryInitContent = sentryInitContent.concat(otherConfigs);
-  }
+  sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
+  sentryInitContent = sentryInitContent.concat(otherConfigs);
 
   return (
     <Layout

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/svelte.tsx
@@ -32,17 +32,9 @@ export const steps = ({
 }: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: (
-      <p>
-        {tct(
-          'Add the Sentry SDK as a dependency using [codeNpm:npm] or [codeYarn:yarn]. You need a minimum version 7.27.0 of [code:@sentry/react] in order to use Session Replay. You do not need to install any additional packages.',
-          {
-            code: <code />,
-            codeYarn: <code />,
-            codeNpm: <code />,
-          }
-        )}
-      </p>
+    description: tct(
+      'For the Session Replay to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/react]) installed, minimum version 7.27.0.',
+      {code: <code />}
     ),
     configurations: [
       {
@@ -52,13 +44,13 @@ export const steps = ({
             label: 'npm',
             value: 'npm',
             language: 'bash',
-            code: 'npm install --save @sentry/react',
+            code: 'npm install --save @sentry/svelte',
           },
           {
             label: 'yarn',
             value: 'yarn',
             language: 'bash',
-            code: 'yarn add @sentry/react',
+            code: 'yarn add @sentry/svelte',
           },
         ],
       },
@@ -79,15 +71,11 @@ export const steps = ({
       {
         language: 'javascript',
         code: `
-import * as Sentry from "@sentry/react";
+        import * as Sentry from "@sentry/svelte";
 
-Sentry.init({
-  ${sentryInitContent}
-});
-
-const container = document.getElementById(“app”);
-const root = createRoot(container);
-root.render(<App />);
+        Sentry.init({
+          ${sentryInitContent}
+        });
         `,
       },
     ],
@@ -96,7 +84,7 @@ root.render(<App />);
 
 // Configuration End
 
-export function GettingStartedWithReactReplay({
+export function GettingStartedWithSvelteReplay({
   dsn,
   organization,
   newOrg,
@@ -119,12 +107,12 @@ export function GettingStartedWithReactReplay({
         platformKey,
         projectId,
       })}
-      newOrg={newOrg}
       platformKey={platformKey}
+      newOrg={newOrg}
       hideHeader
       {...props}
     />
   );
 }
 
-export default GettingStartedWithReactReplay;
+export default GettingStartedWithSvelteReplay;

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/sveltekit.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/sveltekit.tsx
@@ -32,33 +32,18 @@ export const steps = ({
 }: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: (
-      <p>
-        {tct(
-          'Add the Sentry SDK as a dependency using [codeNpm:npm] or [codeYarn:yarn]. You need a minimum version 7.27.0 of [code:@sentry/react] in order to use Session Replay. You do not need to install any additional packages.',
-          {
-            code: <code />,
-            codeYarn: <code />,
-            codeNpm: <code />,
-          }
-        )}
-      </p>
-    ),
+    description: tct('Configure your app automatically with the Sentry wizard.', {
+      code: <code />,
+    }),
     configurations: [
       {
         language: 'bash',
         code: [
           {
-            label: 'npm',
-            value: 'npm',
+            label: 'Bash',
+            value: 'bash',
             language: 'bash',
-            code: 'npm install --save @sentry/react',
-          },
-          {
-            label: 'yarn',
-            value: 'yarn',
-            language: 'bash',
-            code: 'yarn add @sentry/react',
+            code: 'npx @sentry/wizard@latest -i sveltekit',
           },
         ],
       },
@@ -79,15 +64,11 @@ export const steps = ({
       {
         language: 'javascript',
         code: `
-import * as Sentry from "@sentry/react";
+        import * as Sentry from "@sentry/sveltekit";
 
-Sentry.init({
-  ${sentryInitContent}
-});
-
-const container = document.getElementById(“app”);
-const root = createRoot(container);
-root.render(<App />);
+        Sentry.init({
+          ${sentryInitContent}
+        });
         `,
       },
     ],
@@ -96,7 +77,7 @@ root.render(<App />);
 
 // Configuration End
 
-export function GettingStartedWithReactReplay({
+export function GettingStartedWithSvelteKitReplay({
   dsn,
   organization,
   newOrg,
@@ -119,12 +100,12 @@ export function GettingStartedWithReactReplay({
         platformKey,
         projectId,
       })}
-      newOrg={newOrg}
       platformKey={platformKey}
+      newOrg={newOrg}
       hideHeader
       {...props}
     />
   );
 }
 
-export default GettingStartedWithReactReplay;
+export default GettingStartedWithSvelteKitReplay;

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/vue.tsx
@@ -91,20 +91,11 @@ export function GettingStartedWithVueReplay({
   projectId,
   ...props
 }: ModuleProps) {
-  const integrations: string[] = [];
-  const otherConfigs: string[] = [];
-  integrations.push(replayIntegration.trim());
-  otherConfigs.push(replayOtherConfig.trim());
-
+  const integrations = replayIntegration.trim();
+  const otherConfigs = replayOtherConfig.trim();
   let sentryInitContent: string[] = [`dsn: "${dsn}",`];
-
-  if (integrations.length > 0) {
-    sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
-  }
-
-  if (otherConfigs.length > 0) {
-    sentryInitContent = sentryInitContent.concat(otherConfigs);
-  }
+  sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
+  sentryInitContent = sentryInitContent.concat(otherConfigs);
 
   return (
     <Layout

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/vue.tsx
@@ -1,0 +1,126 @@
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
+import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {t, tct} from 'sentry/locale';
+import type {Organization, PlatformKey} from 'sentry/types';
+
+type StepProps = {
+  newOrg: boolean;
+  organization: Organization;
+  platformKey: PlatformKey;
+  projectId: string;
+  sentryInitContent: string;
+};
+
+// Configuration Start
+const replayIntegration = `
+new Sentry.Replay(),
+`;
+
+const replayOtherConfig = `
+// This sets the sample rate to be 10%. You may want this to be 100% while
+// in development and sample at a lower rate in production.
+replaysSessionSampleRate: 0.1,
+// If the entire session is not sampled, use the below sample rate to sample
+// sessions when an error occurs.
+replaysOnErrorSampleRate: 1.0,
+`;
+
+export const steps = ({
+  sentryInitContent,
+}: Partial<StepProps> = {}): LayoutProps['steps'] => [
+  {
+    type: StepType.INSTALL,
+    description: t(
+      'The Replay integration is already included with the Vue SDK package.'
+    ),
+    configurations: [
+      {
+        language: 'bash',
+        code: [
+          {
+            label: 'npm',
+            value: 'npm',
+            language: 'bash',
+            code: 'npm install --save @sentry/vue',
+          },
+          {
+            label: 'yarn',
+            value: 'yarn',
+            language: 'bash',
+            code: 'yarn add @sentry/vue',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: StepType.CONFIGURE,
+    description: tct(
+      'Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set using the [code:integrations] constructor. Learn more about configuring Session Replay by reading the [link:configuration docs].',
+      {
+        code: <code />,
+        link: (
+          <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/" />
+        ),
+      }
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        import * as Sentry from "@sentry/vue";
+
+        Sentry.init({
+          ${sentryInitContent}
+        });
+        `,
+      },
+    ],
+  },
+];
+
+// Configuration End
+
+export function GettingStartedWithVueReplay({
+  dsn,
+  organization,
+  newOrg,
+  platformKey,
+  projectId,
+  ...props
+}: ModuleProps) {
+  const integrations: string[] = [];
+  const otherConfigs: string[] = [];
+  integrations.push(replayIntegration.trim());
+  otherConfigs.push(replayOtherConfig.trim());
+
+  let sentryInitContent: string[] = [`dsn: "${dsn}",`];
+
+  if (integrations.length > 0) {
+    sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
+  }
+
+  if (otherConfigs.length > 0) {
+    sentryInitContent = sentryInitContent.concat(otherConfigs);
+  }
+
+  return (
+    <Layout
+      steps={steps({
+        sentryInitContent: sentryInitContent.join('\n'),
+        organization,
+        newOrg,
+        platformKey,
+        projectId,
+      })}
+      platformKey={platformKey}
+      newOrg={newOrg}
+      hideHeader
+      {...props}
+    />
+  );
+}
+
+export default GettingStartedWithVueReplay;


### PR DESCRIPTION
relates to https://github.com/getsentry/sentry/issues/61001