### PR TITLE
feat(hybrid-cloud): Add retry deadline for RegionSiloClient

### DIFF
--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -8,10 +8,16 @@ and perform RPC calls to propagate changes to relevant region(s).
 from __future__ import annotations
 
 import logging
+from hashlib import sha1
 from typing import Any, Mapping
 
+import sentry_sdk
 from django.dispatch import receiver
+from requests import Response
+from requests.exceptions import HTTPError
+from rest_framework import status
 
+from sentry.exceptions import RestrictedIPAddress
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.sentry_app import SentryApp
@@ -19,8 +25,15 @@ from sentry.models.outbox import OutboxCategory, process_control_outbox
 from sentry.receivers.outbox import maybe_process_tombstone
 from sentry.services.hybrid_cloud.issue import issue_service
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSignal, organization_service
-from sentry.shared_integrations.exceptions import ApiConflictError
+from sentry.shared_integrations.exceptions import (
+    ApiConflictError,
+    ApiConnectionResetError,
+    ApiError,
+    ApiHostError,
+    ApiTimeoutError,
+)
 from sentry.silo.base import SiloMode
+from sentry.silo.client import SiloClientError
 
 logger = logging.getLogger(__name__)
 
@@ -59,44 +72,99 @@ def process_api_application_updates(object_identifier: int, region_name: str, **
 
 
 @receiver(process_control_outbox, sender=OutboxCategory.WEBHOOK_PROXY)
-def process_async_webhooks(payload: Mapping[str, Any], region_name: str, **kwds: Any):
+def process_async_webhooks(
+    payload: Mapping[str, Any],
+    region_name: str,
+    shard_identifier: int,
+    object_identifier: int,
+    **kwds: Any,
+):
     from sentry.models.outbox import ControlOutbox
     from sentry.silo.client import RegionSiloClient
     from sentry.types.region import get_region_by_name
 
+    if SiloMode.get_current_mode() == SiloMode.REGION:
+        sentry_sdk.capture_exception(Exception("Called process_async_webhooks in REGION mode"))
+        return
+
+    if SiloMode.get_current_mode() != SiloMode.CONTROL:
+        return
+
     region = get_region_by_name(name=region_name)
     webhook_payload = ControlOutbox.get_webhook_payload_from_outbox(payload=payload)
 
-    if SiloMode.get_current_mode() == SiloMode.CONTROL:
-        # By default, these clients will raise errors on non-20x response codes
-        try:
-            response = RegionSiloClient(region=region).request(
-                method=webhook_payload.method,
-                path=webhook_payload.path,
-                headers=webhook_payload.headers,
-                # We need to send the body as raw bytes to avoid interfering with webhook signatures
-                data=webhook_payload.body,
-                json=False,
-            )
-            logger.info(
-                "webhook_proxy.complete",
-                extra={
-                    "status": getattr(
-                        response, "status_code", 204
-                    ),  # Request returns empty dict instead of a response object when the code is a 204
-                    "request_path": webhook_payload.path,
-                    "request_method": webhook_payload.method,
+    try:
+        client = RegionSiloClient(region=region)
+        response = client.request(
+            method=webhook_payload.method,
+            path=webhook_payload.path,
+            headers=webhook_payload.headers,
+            # We need to send the body as raw bytes to avoid interfering with webhook signatures
+            data=webhook_payload.body,
+            json=False,
+            prefix_hash=sha1(f"{shard_identifier}{object_identifier}".encode()).hexdigest(),
+        )
+        logger.info(
+            "webhook_proxy.complete",
+            extra={
+                "status": getattr(
+                    response, "status_code", 204
+                ),  # Request returns empty dict instead of a response object when the code is a 204
+                "request_path": webhook_payload.path,
+                "request_method": webhook_payload.method,
+            },
+        )
+    except SiloClientError as e:
+        sentry_sdk.capture_exception(e)
+    except ApiHostError as err:
+        with sentry_sdk.push_scope() as scope:
+            scope.set_context(
+                "region",
+                {
+                    "name": region.name,
+                    "id": region.category,
+                    "address": region.address,
                 },
             )
-        except ApiConflictError as e:
-            logger.warning(
-                "webhook_proxy.conflict_occurred",
-                extra={
-                    "request_path": webhook_payload.path,
-                    "request_method": webhook_payload.method,
-                    "conflict_text": e.text,
-                },
-            )
+            err_cause = err.__cause__
+            if err_cause is not None and isinstance(err_cause, RestrictedIPAddress):
+                # Region silos that are IP address restricted are actionable.
+                silo_client_err = SiloClientError("Region silo is IP address restricted")
+                silo_client_err.__cause__ = err
+                sentry_sdk.capture_exception(silo_client_err)
+                return
+            sentry_sdk.capture_exception(err)
+        return
+    except ApiConflictError as e:
+        logger.warning(
+            "webhook_proxy.conflict_occurred",
+            extra={
+                "request_path": webhook_payload.path,
+                "request_method": webhook_payload.method,
+                "conflict_text": e.text,
+            },
+        )
+    except ApiTimeoutError as err:
+        raise err
+    except ApiConnectionResetError as err:
+        raise err
+    except ApiError as api_err:
+        err_cause = api_err.__cause__
+        if err_cause is not None and isinstance(err_cause, HTTPError):
+            orig_response: Response | None = err_cause.response
+            if (
+                orig_response is not None
+                and status.HTTP_500_INTERNAL_SERVER_ERROR <= orig_response.status_code < 600
+            ):
+                # Retry on 5xx errors
+                raise api_err
+        # For some integrations, we make use of outboxes to handle asynchronous webhook requests.
+        # There is an edge case where webhook requests eventually become invalid and
+        # the 3rd-party destination (integration provider) will reject them.
+        # JWT expirations is one example of causing this issue. Issues like these are no longer salvageable, and we must
+        # discard these associated webhook outbox messages. If we do not discard them, then these outbox messages
+        # will be re-processed causing a backlog on the ControlOutbox table.
+        return
 
 
 @receiver(process_control_outbox, sender=OutboxCategory.SEND_SIGNAL)

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -87,9 +87,6 @@ def process_async_webhooks(
         sentry_sdk.capture_exception(Exception("Called process_async_webhooks in REGION mode"))
         return
 
-    if SiloMode.get_current_mode() != SiloMode.CONTROL:
-        return
-
     region = get_region_by_name(name=region_name)
     webhook_payload = ControlOutbox.get_webhook_payload_from_outbox(payload=payload)
 

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -237,9 +237,7 @@ class RegionSiloClient(BaseSiloClient):
         """
         hash = None
         if prefix_hash is not None:
-            hash = sha1(
-                f"{prefix_hash}{self.region.name}{method}{path}".encode("utf-8")
-            ).hexdigest()
+            hash = sha1(f"{prefix_hash}{self.region.name}{method}{path}".encode()).hexdigest()
 
         try:
             response = super().request(

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import ipaddress
 import socket
+from hashlib import sha1
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, Set
 
 import sentry_sdk
 import urllib3
+from django.core.cache import cache
 from django.http import HttpResponse
 from django.http.request import HttpRequest
 from django.utils.encoding import force_str
@@ -29,6 +31,9 @@ from sentry.types.region import (
 
 if TYPE_CHECKING:
     from typing import FrozenSet
+
+REQUEST_ATTEMPTS_LIMIT = 10
+CACHE_TIMEOUT = 600  # 10 minutes = 600 seconds
 
 
 class SiloClientError(Exception):
@@ -188,3 +193,66 @@ class RegionSiloClient(BaseSiloClient):
         This injects a custom is_ipaddress_permitted function to allow only connections to Region Silo IP addresses.
         """
         return build_session(is_ipaddress_permitted=validate_region_ip_address)
+
+    def _get_hash_cache_key(self, hash: str) -> str:
+        return f"region_silo_client:request_attempts:{hash}"
+
+    def check_request_attempts(self, hash: str | None, method: str, path: str) -> None:
+        if hash is None:
+            return
+
+        cache_key = self._get_hash_cache_key(hash=hash)
+        request_attempts: int | None = cache.get(cache_key)
+
+        if not isinstance(request_attempts, int):
+            request_attempts = 0
+
+        if request_attempts < REQUEST_ATTEMPTS_LIMIT:
+            request_attempts += 1
+            cache.set(cache_key, request_attempts, timeout=CACHE_TIMEOUT)
+        else:
+            cache.delete(cache_key)
+            raise SiloClientError(f"Request attempts limit reached for: {method} {path}")
+
+    def cleanup_request_attempts(self, hash: str | None) -> None:
+        if hash is None:
+            return
+        cache_key = self._get_hash_cache_key(hash=hash)
+        cache.delete(cache_key)
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        headers: Mapping[str, Any] | None = None,
+        data: Any | None = None,
+        params: Mapping[str, Any] | None = None,
+        json: bool = True,
+        raw_response: bool = False,
+        prefix_hash: str | None = None,
+    ) -> BaseApiResponseX:
+        """
+        Sends a request to the region silo.
+        If prefix_hash is provided, the request will be retries up to REQUEST_ATTEMPTS_LIMIT times.
+        """
+        hash = None
+        if prefix_hash is not None:
+            hash = sha1(
+                f"{prefix_hash}{self.region.name}{method}{path}".encode("utf-8")
+            ).hexdigest()
+
+        try:
+            response = super().request(
+                method=method,
+                path=path,
+                headers=headers,
+                data=data,
+                params=params,
+                json=json,
+                raw_response=raw_response,
+            )
+        except Exception as error:
+            self.check_request_attempts(hash=hash, method=method, path=path)
+            raise error
+        self.cleanup_request_attempts(hash=hash)
+        return response

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -1,4 +1,5 @@
 from hashlib import sha1
+from typing import Type
 from unittest import mock
 from unittest.mock import patch
 
@@ -449,7 +450,7 @@ class ProcessControlOutboxTest(TestCase):
             parent_mock.attach_mock(mock_cache.set, "cache_set")
             parent_mock.attach_mock(mock_cache.delete, "cache_delete")
 
-            expected_exception: Exception = ApiTimeoutError
+            expected_exception: Type[Exception] = ApiTimeoutError
             if api_host_error == ApiConnectionResetError:
                 expected_exception = ApiConnectionResetError
 

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -1,20 +1,31 @@
+from hashlib import sha1
+from unittest import mock
 from unittest.mock import patch
 
 import responses
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 from pytest import raises
+from requests.exceptions import ConnectionError, Timeout
 from rest_framework import status
 
+from sentry.exceptions import RestrictedIPAddress
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.integrations.integration import Integration
 from sentry.models.outbox import ControlOutbox, WebhookProviderIdentifier
+from sentry.net.http import Session
 from sentry.receivers.outbox.control import (
     process_api_application_updates,
     process_async_webhooks,
     process_integration_updates,
 )
-from sentry.shared_integrations.exceptions import ApiError
+from sentry.shared_integrations.exceptions import (
+    ApiConnectionResetError,
+    ApiError,
+    ApiHostError,
+    ApiTimeoutError,
+)
 from sentry.silo.base import SiloMode
+from sentry.silo.client import CACHE_TIMEOUT, REQUEST_ATTEMPTS_LIMIT, SiloClientError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
@@ -25,6 +36,31 @@ _TEST_REGION = Region("eu", 1, "http://eu.testserver", RegionCategory.MULTI_TENA
 @control_silo_test(regions=[_TEST_REGION])
 class ProcessControlOutboxTest(TestCase):
     identifier = 1
+
+    def generate_outbox(self):
+        request = RequestFactory().post(
+            "/extensions/github/webhook/",
+            data={"installation": {"id": "github:1"}},
+            content_type="application/json",
+            HTTP_X_GITHUB_EMOTICON=">:^]",
+        )
+        [outbox] = ControlOutbox.for_webhook_update(
+            webhook_identifier=WebhookProviderIdentifier.GITHUB,
+            region_names=[_TEST_REGION.name],
+            request=request,
+        )
+        outbox.save()
+        outbox.refresh_from_db()
+
+        prefix_hash = sha1(
+            f"{outbox.shard_identifier}{outbox.object_identifier}".encode("utf-8")
+        ).hexdigest()
+        hash = sha1(
+            f"{prefix_hash}{_TEST_REGION.name}POST/extensions/github/webhook/".encode("utf-8")
+        ).hexdigest()
+        cache_key = f"region_silo_client:request_attempts:{hash}"
+
+        return request, outbox, cache_key
 
     @patch("sentry.receivers.outbox.control.maybe_process_tombstone")
     def test_process_integration_updatess(self, mock_maybe_process):
@@ -45,49 +81,75 @@ class ProcessControlOutboxTest(TestCase):
         )
 
     @responses.activate
-    def test_process_async_webhooks_success(self):
-        request = RequestFactory().post(
-            "/extensions/github/webhook/",
-            data={"installation": {"id": "github:1"}},
-            content_type="application/json",
-            HTTP_X_GITHUB_EMOTICON=">:^]",
+    def test_process_async_webhooks_region_silo(self):
+        request, outbox, _ = self.generate_outbox()
+
+        mock_response = responses.add(
+            request.method,
+            f"{_TEST_REGION.address}{request.path}",
+            status=status.HTTP_504_GATEWAY_TIMEOUT,
         )
-        [outbox] = ControlOutbox.for_webhook_update(
-            webhook_identifier=WebhookProviderIdentifier.GITHUB,
-            region_names=[_TEST_REGION.name],
-            request=request,
-        )
-        outbox.save()
-        outbox.refresh_from_db()
+        with override_settings(SILO_MODE=SiloMode.REGION), mock.patch(
+            "sentry_sdk.capture_exception"
+        ) as capture_exception:
+            process_async_webhooks(
+                payload=outbox.payload,
+                region_name=_TEST_REGION.name,
+                shard_identifier=outbox.shard_identifier,
+                object_identifier=outbox.object_identifier,
+            )
+            assert len(responses.calls) == 0
+            assert mock_response.call_count == 0
+            assert capture_exception.call_count == 1
+            exception = capture_exception.call_args.args[0]
+            assert exception.args[0] == "Called process_async_webhooks in REGION mode"
+
+    @responses.activate
+    @mock.patch("sentry.silo.client.cache")
+    def test_process_async_webhooks_success(self, mock_cache):
+        parent_mock = mock.Mock()
+        parent_mock.attach_mock(mock_cache.get, "cache_get")
+        parent_mock.attach_mock(mock_cache.set, "cache_set")
+        parent_mock.attach_mock(mock_cache.delete, "cache_delete")
+
+        request, outbox, cache_key = self.generate_outbox()
 
         mock_response = responses.add(
             request.method,
             f"{_TEST_REGION.address}{request.path}",
             status=status.HTTP_200_OK,
         )
-        process_async_webhooks(payload=outbox.payload, region_name=_TEST_REGION.name)
-        request_claim = (
-            mock_response.call_count == 1
-            if SiloMode.get_current_mode() == SiloMode.CONTROL
-            else mock_response.call_count == 0
+        process_async_webhooks(
+            payload=outbox.payload,
+            region_name=_TEST_REGION.name,
+            shard_identifier=outbox.shard_identifier,
+            object_identifier=outbox.object_identifier,
         )
-        assert request_claim
+        if SiloMode.get_current_mode() == SiloMode.CONTROL:
+            assert mock_response.call_count == 1
+
+            assert mock_cache.get.call_count == 0
+            assert mock_cache.set.call_count == 0
+            assert mock_cache.delete.call_count == 1
+
+            # Assert order of cache method calls
+            expected_calls = [
+                mock.call.cache_delete(cache_key),
+            ]
+            assert parent_mock.mock_calls == expected_calls
+        else:
+            assert mock_response.call_count == 0
 
     @responses.activate
-    def test_process_async_webhooks_failure(self):
-        request = RequestFactory().post(
-            "/extensions/github/webhook/",
-            data={"installation": {"id": "github:1"}},
-            content_type="application/json",
-            HTTP_X_GITHUB_EMOTICON=">:^]",
-        )
-        [outbox] = ControlOutbox.for_webhook_update(
-            webhook_identifier=WebhookProviderIdentifier.GITHUB,
-            region_names=[_TEST_REGION.name],
-            request=request,
-        )
-        outbox.save()
-        outbox.refresh_from_db()
+    @mock.patch("sentry.silo.client.cache")
+    def test_process_async_webhooks_server_failure(self, mock_cache):
+        mock_cache.get.return_value = None
+        parent_mock = mock.Mock()
+        parent_mock.attach_mock(mock_cache.get, "cache_get")
+        parent_mock.attach_mock(mock_cache.set, "cache_set")
+        parent_mock.attach_mock(mock_cache.delete, "cache_delete")
+
+        request, outbox, cache_key = self.generate_outbox()
 
         mock_response = responses.add(
             request.method,
@@ -96,8 +158,408 @@ class ProcessControlOutboxTest(TestCase):
         )
         if SiloMode.get_current_mode() == SiloMode.CONTROL:
             with raises(ApiError):
-                process_async_webhooks(payload=outbox.payload, region_name=_TEST_REGION.name)
+                process_async_webhooks(
+                    payload=outbox.payload,
+                    region_name=_TEST_REGION.name,
+                    shard_identifier=outbox.shard_identifier,
+                    object_identifier=outbox.object_identifier,
+                )
             assert mock_response.call_count == 1
+
+            assert mock_cache.get.call_count == 1
+            assert mock_cache.set.call_count == 1
+            assert mock_cache.delete.call_count == 0
+
+            # Assert order of cache method calls
+            expected_calls = [
+                mock.call.cache_get(cache_key),
+                mock.call.cache_set(cache_key, 1, timeout=CACHE_TIMEOUT),
+            ]
+            assert parent_mock.mock_calls == expected_calls
         else:
-            process_async_webhooks(payload=outbox.payload, region_name=_TEST_REGION.name)
+            process_async_webhooks(
+                payload=outbox.payload,
+                region_name=_TEST_REGION.name,
+                shard_identifier=outbox.shard_identifier,
+                object_identifier=outbox.object_identifier,
+            )
             assert mock_response.call_count == 0
+
+    @responses.activate
+    @mock.patch("sentry.silo.client.cache")
+    def test_process_async_webhooks_retry_limit_reached(self, mock_cache):
+        request, outbox, cache_key = self.generate_outbox()
+
+        responses.add(
+            request.method,
+            f"{_TEST_REGION.address}{request.path}",
+            status=status.HTTP_504_GATEWAY_TIMEOUT,
+        )
+        num_of_request_attempts = 0
+
+        while True:
+            if num_of_request_attempts > REQUEST_ATTEMPTS_LIMIT:
+                assert False, "Request attempts limit not captured"
+
+            mock_cache.reset_mock()
+            responses.calls.reset()
+
+            if num_of_request_attempts == 0:
+                mock_cache.get.return_value = None
+            else:
+                mock_cache.get.return_value = num_of_request_attempts
+
+            parent_mock = mock.Mock()
+            parent_mock.attach_mock(mock_cache.get, "cache_get")
+            parent_mock.attach_mock(mock_cache.set, "cache_set")
+            parent_mock.attach_mock(mock_cache.delete, "cache_delete")
+
+            if num_of_request_attempts == REQUEST_ATTEMPTS_LIMIT:
+                with mock.patch("sentry_sdk.capture_exception") as capture_exception:
+                    process_async_webhooks(
+                        payload=outbox.payload,
+                        region_name=_TEST_REGION.name,
+                        shard_identifier=outbox.shard_identifier,
+                        object_identifier=outbox.object_identifier,
+                    )
+                    assert len(responses.calls) == 1
+
+                    assert capture_exception.call_count == 1
+                    exception = capture_exception.call_args.args[0]
+                    assert isinstance(exception, SiloClientError)
+                    assert (
+                        exception.args[0]
+                        == f"Request attempts limit reached for: {request.method} {request.path}"
+                    )
+
+                assert mock_cache.get.call_count == 1
+                assert mock_cache.set.call_count == 0
+                assert mock_cache.delete.call_count == 1
+
+                # Assert order of cache method calls
+                expected_calls = [
+                    mock.call.cache_get(cache_key),
+                    mock.call.cache_delete(cache_key),
+                ]
+                assert parent_mock.mock_calls == expected_calls
+                return
+            else:
+                with raises(ApiError):
+                    process_async_webhooks(
+                        payload=outbox.payload,
+                        region_name=_TEST_REGION.name,
+                        shard_identifier=outbox.shard_identifier,
+                        object_identifier=outbox.object_identifier,
+                    )
+                assert len(responses.calls) == 1
+                resp = responses.calls[0].response
+                assert resp.status_code == status.HTTP_504_GATEWAY_TIMEOUT
+
+                num_of_request_attempts += 1
+
+                assert mock_cache.get.call_count == 1
+                assert mock_cache.set.call_count == 1
+                assert mock_cache.delete.call_count == 0
+
+                # Assert order of cache method calls
+                expected_calls = [
+                    mock.call.cache_get(cache_key),
+                    mock.call.cache_set(cache_key, num_of_request_attempts, timeout=CACHE_TIMEOUT),
+                ]
+                assert parent_mock.mock_calls == expected_calls
+
+    @responses.activate
+    @mock.patch("sentry.silo.client.cache")
+    def test_process_async_webhooks_retry_within_limit(self, mock_cache):
+        request, outbox, cache_key = self.generate_outbox()
+
+        responses.add(
+            request.method,
+            f"{_TEST_REGION.address}{request.path}",
+            status=status.HTTP_504_GATEWAY_TIMEOUT,
+        )
+        num_of_request_attempts = 0
+
+        while True:
+            mock_cache.reset_mock()
+            responses.calls.reset()
+
+            if num_of_request_attempts == (REQUEST_ATTEMPTS_LIMIT - 1):
+                responses.replace(
+                    request.method,
+                    f"{_TEST_REGION.address}{request.path}",
+                    status=200,
+                    json={"ok": True},
+                )
+
+            if num_of_request_attempts == 0:
+                mock_cache.get.return_value = None
+            else:
+                mock_cache.get.return_value = num_of_request_attempts
+
+            parent_mock = mock.Mock()
+            parent_mock.attach_mock(mock_cache.get, "cache_get")
+            parent_mock.attach_mock(mock_cache.set, "cache_set")
+            parent_mock.attach_mock(mock_cache.delete, "cache_delete")
+
+            if num_of_request_attempts == (REQUEST_ATTEMPTS_LIMIT - 1):
+                with mock.patch("sentry_sdk.capture_exception") as capture_exception:
+                    process_async_webhooks(
+                        payload=outbox.payload,
+                        region_name=_TEST_REGION.name,
+                        shard_identifier=outbox.shard_identifier,
+                        object_identifier=outbox.object_identifier,
+                    )
+                    assert len(responses.calls) == 1
+
+                    assert capture_exception.call_count == 0
+
+                assert mock_cache.get.call_count == 0
+                assert mock_cache.set.call_count == 0
+                assert mock_cache.delete.call_count == 1
+
+                # Assert order of cache method calls
+                expected_calls = [
+                    mock.call.cache_delete(cache_key),
+                ]
+                assert parent_mock.mock_calls == expected_calls
+                return
+            else:
+                with raises(ApiError):
+                    process_async_webhooks(
+                        payload=outbox.payload,
+                        region_name=_TEST_REGION.name,
+                        shard_identifier=outbox.shard_identifier,
+                        object_identifier=outbox.object_identifier,
+                    )
+                assert len(responses.calls) == 1
+                resp = responses.calls[0].response
+                assert resp.status_code == status.HTTP_504_GATEWAY_TIMEOUT
+
+                num_of_request_attempts += 1
+
+                assert mock_cache.get.call_count == 1
+                assert mock_cache.set.call_count == 1
+                assert mock_cache.delete.call_count == 0
+
+                # Assert order of cache method calls
+                expected_calls = [
+                    mock.call.cache_get(cache_key),
+                    mock.call.cache_set(cache_key, num_of_request_attempts, timeout=CACHE_TIMEOUT),
+                ]
+                assert parent_mock.mock_calls == expected_calls
+
+    @responses.activate
+    @patch("sentry.silo.client.RegionSiloClient", side_effect=SiloClientError)
+    def test_process_async_webhooks_region_silo_client_exception(self, mock_region_silo_client):
+        request, outbox, _ = self.generate_outbox()
+
+        mock_response = responses.add(
+            request.method,
+            f"{_TEST_REGION.address}{request.path}",
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+        with mock.patch("sentry_sdk.capture_exception") as capture_exception:
+            process_async_webhooks(
+                payload=outbox.payload,
+                region_name=_TEST_REGION.name,
+                shard_identifier=outbox.shard_identifier,
+                object_identifier=outbox.object_identifier,
+            )
+            assert mock_response.call_count == 0
+            assert capture_exception.call_count == 1
+            exception = capture_exception.call_args.args[0]
+            assert isinstance(exception, SiloClientError)
+
+    @responses.activate
+    @mock.patch("sentry.silo.client.cache")
+    def test_process_async_webhooks_api_host_error(self, mock_cache):
+        request, outbox, cache_key = self.generate_outbox()
+
+        api_host_errors = [RestrictedIPAddress, ConnectionError, ApiHostError]
+
+        for api_host_error in api_host_errors:
+            mock_cache.reset_mock()
+            responses.calls.reset()
+            responses.add(
+                request.method,
+                f"{_TEST_REGION.address}{request.path}",
+                status=status.HTTP_504_GATEWAY_TIMEOUT,
+            )
+
+            mock_cache.get.return_value = None
+            parent_mock = mock.Mock()
+            parent_mock.attach_mock(mock_cache.get, "cache_get")
+            parent_mock.attach_mock(mock_cache.set, "cache_set")
+            parent_mock.attach_mock(mock_cache.delete, "cache_delete")
+
+            with patch.object(Session, "send", side_effect=api_host_error("oh no")), mock.patch(
+                "sentry_sdk.capture_exception"
+            ) as capture_exception:
+                # Does not raise on ApiHostError exceptions
+                process_async_webhooks(
+                    payload=outbox.payload,
+                    region_name=_TEST_REGION.name,
+                    shard_identifier=outbox.shard_identifier,
+                    object_identifier=outbox.object_identifier,
+                )
+
+                assert capture_exception.call_count == 1
+                exception = capture_exception.call_args.args[0]
+
+                if api_host_error == RestrictedIPAddress:
+                    assert isinstance(exception, SiloClientError)
+                    assert exception.args[0] == "Region silo is IP address restricted"
+                    assert isinstance(exception.__cause__, ApiHostError)
+                    assert isinstance(exception.__cause__.__cause__, RestrictedIPAddress)
+                else:
+                    assert isinstance(exception, ApiHostError)
+                    if api_host_error != ApiHostError:
+                        assert isinstance(exception.__cause__, api_host_error)
+
+                assert mock_cache.get.call_count == 1
+                assert mock_cache.set.call_count == 1
+                assert mock_cache.delete.call_count == 0
+
+                # Assert order of cache method calls
+                expected_calls = [
+                    mock.call.cache_get(cache_key),
+                    mock.call.cache_set(cache_key, 1, timeout=CACHE_TIMEOUT),
+                ]
+                assert parent_mock.mock_calls == expected_calls
+
+    @responses.activate
+    @mock.patch("sentry.silo.client.cache")
+    def test_process_async_webhooks_connection_errors(self, mock_cache):
+        request, outbox, cache_key = self.generate_outbox()
+
+        api_host_errors = [ApiTimeoutError, Timeout, ApiConnectionResetError]
+        for api_host_error in api_host_errors:
+            mock_cache.reset_mock()
+            responses.calls.reset()
+            responses.add(
+                request.method,
+                f"{_TEST_REGION.address}{request.path}",
+                status=status.HTTP_504_GATEWAY_TIMEOUT,
+            )
+
+            mock_cache.get.return_value = None
+            parent_mock = mock.Mock()
+            parent_mock.attach_mock(mock_cache.get, "cache_get")
+            parent_mock.attach_mock(mock_cache.set, "cache_set")
+            parent_mock.attach_mock(mock_cache.delete, "cache_delete")
+
+            expected_exception = ApiTimeoutError
+            if api_host_error == ApiConnectionResetError:
+                expected_exception = ApiConnectionResetError
+
+            with patch.object(Session, "send", side_effect=api_host_error("oh no")), raises(
+                expected_exception
+            ) as exception_info:
+                # Raises on timeout errors
+                process_async_webhooks(
+                    payload=outbox.payload,
+                    region_name=_TEST_REGION.name,
+                    shard_identifier=outbox.shard_identifier,
+                    object_identifier=outbox.object_identifier,
+                )
+
+            if expected_exception == ApiConnectionResetError:
+                assert isinstance(exception_info.value, ApiConnectionResetError)
+            else:
+                assert isinstance(exception_info.value, ApiTimeoutError)
+
+            assert mock_cache.get.call_count == 1
+            assert mock_cache.set.call_count == 1
+            assert mock_cache.delete.call_count == 0
+
+            # Assert order of cache method calls
+            expected_calls = [
+                mock.call.cache_get(cache_key),
+                mock.call.cache_set(cache_key, 1, timeout=CACHE_TIMEOUT),
+            ]
+            assert parent_mock.mock_calls == expected_calls
+
+    @responses.activate
+    @mock.patch("sentry.silo.client.cache")
+    def test_process_async_webhooks_4xx_error(self, mock_cache):
+        parent_mock = mock.Mock()
+        parent_mock.attach_mock(mock_cache.get, "cache_get")
+        parent_mock.attach_mock(mock_cache.set, "cache_set")
+        parent_mock.attach_mock(mock_cache.delete, "cache_delete")
+
+        request, outbox, cache_key = self.generate_outbox()
+
+        mock_response = responses.add(
+            request.method,
+            f"{_TEST_REGION.address}{request.path}",
+            status=status.HTTP_400_BAD_REQUEST,
+            json={"error": "bad request"},
+        )
+        with mock.patch("sentry_sdk.capture_exception") as capture_exception:
+            process_async_webhooks(
+                payload=outbox.payload,
+                region_name=_TEST_REGION.name,
+                shard_identifier=outbox.shard_identifier,
+                object_identifier=outbox.object_identifier,
+            )
+            assert len(responses.calls) == 1
+            assert mock_response.call_count == 1
+
+            assert capture_exception.call_count == 1
+            exception = capture_exception.call_args.args[0]
+            assert isinstance(exception, ApiError)
+
+            assert mock_cache.get.call_count == 1
+            assert mock_cache.set.call_count == 1
+            assert mock_cache.delete.call_count == 0
+
+            # Assert order of cache method calls
+            expected_calls = [
+                mock.call.cache_get(cache_key),
+                mock.call.cache_set(cache_key, 1, timeout=CACHE_TIMEOUT),
+            ]
+            assert parent_mock.mock_calls == expected_calls
+
+    @responses.activate
+    @mock.patch("sentry.silo.client.cache")
+    def test_process_async_webhooks_5xx_error(self, mock_cache):
+        parent_mock = mock.Mock()
+        parent_mock.attach_mock(mock_cache.get, "cache_get")
+        parent_mock.attach_mock(mock_cache.set, "cache_set")
+        parent_mock.attach_mock(mock_cache.delete, "cache_delete")
+
+        request, outbox, cache_key = self.generate_outbox()
+
+        mock_response = responses.add(
+            request.method,
+            f"{_TEST_REGION.address}{request.path}",
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            json={"error": "server exploded"},
+        )
+        with mock.patch("sentry_sdk.capture_exception") as capture_exception, raises(
+            ApiError
+        ) as exception_info:
+            process_async_webhooks(
+                payload=outbox.payload,
+                region_name=_TEST_REGION.name,
+                shard_identifier=outbox.shard_identifier,
+                object_identifier=outbox.object_identifier,
+            )
+            assert len(responses.calls) == 1
+            assert mock_response.call_count == 1
+
+            assert capture_exception.call_count == 0
+            exception = exception_info.value
+            assert isinstance(exception, ApiError)
+
+            assert mock_cache.get.call_count == 1
+            assert mock_cache.set.call_count == 1
+            assert mock_cache.delete.call_count == 0
+
+            # Assert order of cache method calls
+            expected_calls = [
+                mock.call.cache_get(cache_key),
+                mock.call.cache_set(cache_key, 1, timeout=CACHE_TIMEOUT),
+            ]
+            assert parent_mock.mock_calls == expected_calls

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -13,7 +13,6 @@ from sentry.exceptions import RestrictedIPAddress
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.integrations.integration import Integration
 from sentry.models.outbox import ControlOutbox, WebhookProviderIdentifier
-from sentry.net.http import Session
 from sentry.receivers.outbox.control import (
     process_api_application_updates,
     process_async_webhooks,

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -449,7 +449,7 @@ class ProcessControlOutboxTest(TestCase):
             parent_mock.attach_mock(mock_cache.set, "cache_set")
             parent_mock.attach_mock(mock_cache.delete, "cache_delete")
 
-            expected_exception = ApiTimeoutError
+            expected_exception: Exception = ApiTimeoutError
             if api_host_error == ApiConnectionResetError:
                 expected_exception = ApiConnectionResetError
 

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -375,6 +375,7 @@ class ProcessControlOutboxTest(TestCase):
             responses.add(
                 request.method,
                 f"{_TEST_REGION.address}{request.path}",
+                body=api_host_error("oh no"),
                 status=status.HTTP_504_GATEWAY_TIMEOUT,
             )
 
@@ -384,9 +385,7 @@ class ProcessControlOutboxTest(TestCase):
             parent_mock.attach_mock(mock_cache.set, "cache_set")
             parent_mock.attach_mock(mock_cache.delete, "cache_delete")
 
-            with patch.object(Session, "send", side_effect=api_host_error("oh no")), mock.patch(
-                "sentry_sdk.capture_exception"
-            ) as capture_exception:
+            with mock.patch("sentry_sdk.capture_exception") as capture_exception:
                 # Does not raise on ApiHostError exceptions
                 process_async_webhooks(
                     payload=outbox.payload,
@@ -431,6 +430,7 @@ class ProcessControlOutboxTest(TestCase):
             responses.add(
                 request.method,
                 f"{_TEST_REGION.address}{request.path}",
+                body=api_host_error("oh no"),
                 status=status.HTTP_504_GATEWAY_TIMEOUT,
             )
 
@@ -444,9 +444,7 @@ class ProcessControlOutboxTest(TestCase):
             if api_host_error == ApiConnectionResetError:
                 expected_exception = ApiConnectionResetError
 
-            with patch.object(Session, "send", side_effect=api_host_error("oh no")), raises(
-                expected_exception
-            ) as exception_info:
+            with raises(expected_exception) as exception_info:
                 # Raises on timeout errors
                 process_async_webhooks(
                     payload=outbox.payload,

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -53,10 +53,10 @@ class ProcessControlOutboxTest(TestCase):
         outbox.refresh_from_db()
 
         prefix_hash = sha1(
-            f"{outbox.shard_identifier}{outbox.object_identifier}".encode("utf-8")
+            f"{outbox.shard_identifier}{outbox.object_identifier}".encode()
         ).hexdigest()
         hash = sha1(
-            f"{prefix_hash}{_TEST_REGION.name}POST/extensions/github/webhook/".encode("utf-8")
+            f"{prefix_hash}{_TEST_REGION.name}POST/extensions/github/webhook/".encode()
         ).hexdigest()
         cache_key = f"region_silo_client:request_attempts:{hash}"
 

--- a/tests/sentry/silo/test_client.py
+++ b/tests/sentry/silo/test_client.py
@@ -190,7 +190,6 @@ class SiloClientTest(TestCase):
                             cache_key, num_of_request_attempts, timeout=CACHE_TIMEOUT
                         ),
                     ]
-                    # breakpoint()
                     assert parent_mock.mock_calls == expected_calls
 
     @responses.activate

--- a/tests/sentry/silo/test_client.py
+++ b/tests/sentry/silo/test_client.py
@@ -110,7 +110,7 @@ class SiloClientTest(TestCase):
             assert mock_cache.set.call_count == 0
             assert mock_cache.delete.call_count == 1
 
-            hash = sha1(f"{prefix_hash}{self.region.name}GET{path}".encode("utf-8")).hexdigest()
+            hash = sha1(f"{prefix_hash}{self.region.name}GET{path}".encode()).hexdigest()
             cache_key = f"region_silo_client:request_attempts:{hash}"
             mock_cache.delete.assert_called_with(cache_key)
 
@@ -129,7 +129,7 @@ class SiloClientTest(TestCase):
             )
 
             prefix_hash = "123"
-            hash = sha1(f"{prefix_hash}{self.region.name}POST{path}".encode("utf-8")).hexdigest()
+            hash = sha1(f"{prefix_hash}{self.region.name}POST{path}".encode()).hexdigest()
             cache_key = f"region_silo_client:request_attempts:{hash}"
             num_of_request_attempts = 0
 
@@ -208,7 +208,7 @@ class SiloClientTest(TestCase):
             )
 
             prefix_hash = "123"
-            hash = sha1(f"{prefix_hash}{self.region.name}POST{path}".encode("utf-8")).hexdigest()
+            hash = sha1(f"{prefix_hash}{self.region.name}POST{path}".encode()).hexdigest()
             cache_key = f"region_silo_client:request_attempts:{hash}"
             num_of_request_attempts = 0
 


### PR DESCRIPTION
For some integrations, we make use of outboxes to handle asynchronous webhook requests. There is an edge case where webhook requests eventually become invalid and the 3rd-party destination (integration provider) will reject them. JWT expirations is one example of causing this issue. Issues like these are no longer salvageable, and we must discard these associated webhook outbox messages. If we do not discard them, then they will cause a backlog.

To handle this, for each webhook outbox message, we allow outboxes to be retried until a **_deadline_**, which is a timestamp 5 minutes into the future relative to the first webhook outbox message processing attempt. 

We retry webhook outbox message whenever `RegionSiloClient` API calls raises on non-2xx response codes.
However, `RegionSiloClient` may raise `SiloClientError`, which we do not want to retry webhook outbox messages against.

### TODO

- [x] add tests