### PR TITLE
ref: validate the subdomain redirect directly in the test

### DIFF
--- a/tests/sentry/middleware/test_subdomain.py
+++ b/tests/sentry/middleware/test_subdomain.py
@@ -111,7 +111,7 @@ class End2EndTest(APITestCase):
         response = self.client.get(
             reverse("test-endpoint"),
             SERVER_NAME="albertos_apples.testserver",
-            follow=True,
         )
-        assert response.status_code == 200
-        assert response.redirect_chain == [("http://testserver", 302)]
+        assert isinstance(response, HttpResponseRedirect)
+        assert response.status_code == 302
+        assert response.url == "http://testserver"


### PR DESCRIPTION
django 3.x has a bug in the test client which incorrectly preserves the url on redirects -- django 4.x correctly 404s after the redirect here

<!-- Describe your PR here. -->