### PR TITLE
ref(replays): [3/4] migrate ember gatsby astro onboarding docs

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -8,12 +8,14 @@ import {space} from 'sentry/styles/space';
 
 export enum StepType {
   INSTALL = 'install',
+  REGISTER = 'register',
   CONFIGURE = 'configure',
   VERIFY = 'verify',
 }
 
 export const StepTitle = {
   [StepType.INSTALL]: t('Install'),
+  [StepType.REGISTER]: t('Register'),
   [StepType.CONFIGURE]: t('Configure SDK'),
   [StepType.VERIFY]: t('Verify'),
 };

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -197,7 +197,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     );
   }
 
-  if (!currentPlatform || (!hasOnboardingContents && !newOnboarding)) {
+  if (!currentPlatform || !hasOnboardingContents) {
     return (
       <Fragment>
         <div>

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -197,7 +197,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     );
   }
 
-  if (!currentPlatform || !hasOnboardingContents) {
+  if (!currentPlatform || (!hasOnboardingContents && !newOnboarding)) {
     return (
       <Fragment>
         <div>

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/astro.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/astro.tsx
@@ -34,7 +34,9 @@ export const steps = ({
 }: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: t('Configure your app automatically with the Sentry wizard.'),
+    description: t(
+      'The Replay integration is already included with the Sentry Astro SDK.'
+    ),
     configurations: [
       {
         language: 'bash',
@@ -43,7 +45,7 @@ export const steps = ({
             label: 'Bash',
             value: 'bash',
             language: 'bash',
-            code: 'npx @sentry/wizard@latest -i remix',
+            code: 'npx astro add @sentry/astro',
           },
         ],
       },
@@ -64,7 +66,7 @@ export const steps = ({
       {
         language: 'javascript',
         code: `
-        import * as Sentry from "@sentry/remix";
+        import * as Sentry from "@sentry/astro";
 
         Sentry.init({
           ${sentryInitContent}
@@ -77,7 +79,7 @@ export const steps = ({
 
 // Configuration End
 
-export function GettingStartedWithRemixReplay({
+export function GettingStartedWithAstroReplay({
   dsn,
   organization,
   newOrg,
@@ -106,15 +108,8 @@ export function GettingStartedWithRemixReplay({
         hideHeader
         {...props}
       />
-      <div>
-        <br />
-        {tct(
-          'Note: The Replay integration only needs to be added to your [codeEntry:entry.client.tsx] file. It will not run if it is added into [codeSentry:sentry.server.config.js].',
-          {codeEntry: <code />, codeSentry: <code />}
-        )}
-      </div>
     </Fragment>
   );
 }
 
-export default GettingStartedWithRemixReplay;
+export default GettingStartedWithAstroReplay;

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/ember.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/ember.tsx
@@ -1,10 +1,8 @@
-import {Fragment} from 'react';
-
 import ExternalLink from 'sentry/components/links/externalLink';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {t, tct} from 'sentry/locale';
+import {tct} from 'sentry/locale';
 import type {Organization, PlatformKey} from 'sentry/types';
 
 type StepProps = {
@@ -34,16 +32,19 @@ export const steps = ({
 }: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: t('Configure your app automatically with the Sentry wizard.'),
+    description: tct(
+      'You need a minimum version 7.27.0 of [code:@sentry/ember] in order to use Session Replay. You do not need to install any additional packages.',
+      {code: <code />}
+    ),
     configurations: [
       {
         language: 'bash',
         code: [
           {
-            label: 'Bash',
-            value: 'bash',
+            label: 'ember-cli',
+            value: 'ember-cli',
             language: 'bash',
-            code: 'npx @sentry/wizard@latest -i remix',
+            code: 'ember install @sentry/ember',
           },
         ],
       },
@@ -64,7 +65,7 @@ export const steps = ({
       {
         language: 'javascript',
         code: `
-        import * as Sentry from "@sentry/remix";
+        import * as Sentry from "@sentry/ember";
 
         Sentry.init({
           ${sentryInitContent}
@@ -77,7 +78,7 @@ export const steps = ({
 
 // Configuration End
 
-export function GettingStartedWithRemixReplay({
+export function GettingStartedWithEmberReplay({
   dsn,
   organization,
   newOrg,
@@ -92,29 +93,20 @@ export function GettingStartedWithRemixReplay({
   sentryInitContent = sentryInitContent.concat(otherConfigs);
 
   return (
-    <Fragment>
-      <Layout
-        steps={steps({
-          sentryInitContent: sentryInitContent.join('\n'),
-          organization,
-          newOrg,
-          platformKey,
-          projectId,
-        })}
-        platformKey={platformKey}
-        newOrg={newOrg}
-        hideHeader
-        {...props}
-      />
-      <div>
-        <br />
-        {tct(
-          'Note: The Replay integration only needs to be added to your [codeEntry:entry.client.tsx] file. It will not run if it is added into [codeSentry:sentry.server.config.js].',
-          {codeEntry: <code />, codeSentry: <code />}
-        )}
-      </div>
-    </Fragment>
+    <Layout
+      steps={steps({
+        sentryInitContent: sentryInitContent.join('\n'),
+        organization,
+        newOrg,
+        platformKey,
+        projectId,
+      })}
+      platformKey={platformKey}
+      newOrg={newOrg}
+      hideHeader
+      {...props}
+    />
   );
 }
 
-export default GettingStartedWithRemixReplay;
+export default GettingStartedWithEmberReplay;

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/gatsby.tsx
@@ -4,7 +4,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {t, tct} from 'sentry/locale';
+import {tct} from 'sentry/locale';
 import type {Organization, PlatformKey} from 'sentry/types';
 
 type StepProps = {
@@ -34,18 +34,54 @@ export const steps = ({
 }: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: t('Configure your app automatically with the Sentry wizard.'),
+    description: tct(
+      'To use Sentry with your Gatsby application, you will need to use [code:@sentry/gatsby] (Sentry’s Gatsby SDK):',
+      {code: <code />}
+    ),
     configurations: [
       {
         language: 'bash',
         code: [
           {
-            label: 'Bash',
-            value: 'bash',
+            label: 'npm',
+            value: 'npm',
             language: 'bash',
-            code: 'npx @sentry/wizard@latest -i remix',
+            code: 'npm install --save @sentry/gatsby',
+          },
+          {
+            label: 'yarn',
+            value: 'yarn',
+            language: 'bash',
+            code: 'yarn add @sentry/gatsby',
           },
         ],
+      },
+    ],
+  },
+  {
+    type: StepType.REGISTER,
+    description: tct(
+      'Register the [codeSentry:@sentry/gatsby] plugin in your Gatsby configuration file (typically [codeGatsby:gatsby-config.js]).',
+      {
+        codeSentry: <code />,
+        codeGatsby: <code />,
+        link: (
+          <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/" />
+        ),
+      }
+    ),
+    configurations: [
+      {
+        language: 'javascript',
+        code: `
+        module.exports = {
+          plugins: [
+            {
+              resolve: "@sentry/gatsby",
+            },
+          ],
+        };
+        `,
       },
     ],
   },
@@ -64,7 +100,7 @@ export const steps = ({
       {
         language: 'javascript',
         code: `
-        import * as Sentry from "@sentry/remix";
+        import * as Sentry from "@sentry/gatsby";
 
         Sentry.init({
           ${sentryInitContent}
@@ -77,7 +113,7 @@ export const steps = ({
 
 // Configuration End
 
-export function GettingStartedWithRemixReplay({
+export function GettingStartedWithGatsbyReplay({
   dsn,
   organization,
   newOrg,
@@ -109,12 +145,17 @@ export function GettingStartedWithRemixReplay({
       <div>
         <br />
         {tct(
-          'Note: The Replay integration only needs to be added to your [codeEntry:entry.client.tsx] file. It will not run if it is added into [codeSentry:sentry.server.config.js].',
-          {codeEntry: <code />, codeSentry: <code />}
+          'Note: If [codeGatsby:gatsby-config.js] has any settings for the [codeSentry:@sentry/gatsby plugin], they need to be moved into [codeConfig:sentry.config.js]. The [codeGatsby:gatsby-config.js] file does not support non-serializable options, like [codeNew:new Replay()].',
+          {
+            codeGatsby: <code />,
+            codeSentry: <code />,
+            codeConfig: <code />,
+            codeNew: <code />,
+          }
         )}
       </div>
     </Fragment>
   );
 }
 
-export default GettingStartedWithRemixReplay;
+export default GettingStartedWithGatsbyReplay;

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/nextjs.tsx
@@ -2,7 +2,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Organization, PlatformKey} from 'sentry/types';
 
 type StepProps = {
@@ -32,9 +32,7 @@ export const steps = ({
 }: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: tct('Configure your app automatically with the Sentry wizard.', {
-      code: <code />,
-    }),
+    description: t('Configure your app automatically with the Sentry wizard.'),
     configurations: [
       {
         language: 'bash',
@@ -52,9 +50,13 @@ export const steps = ({
   {
     type: StepType.CONFIGURE,
     description: tct(
-      'Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set using the [code:integrations] constructor. Learn more about configuring Session Replay by reading the [link:configuration docs].',
+      'Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set using the [codeIntegrations:integrations] constructor. Learn more about configuring Session Replay by reading the [link:configuration docs]. [break] [break] Alert: The Replay integration must be added to your [codeClient:sentry.client.config.js] file. Adding it into [codeServer:sentry.server.config.js] or [codeEdge:sentry.edge.config.js] may break your build.',
       {
-        code: <code />,
+        codeIntegrations: <code />,
+        codeClient: <code />,
+        codeServer: <code />,
+        codeEdge: <code />,
+        break: <br />,
         link: (
           <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/" />
         ),

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/svelte.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/svelte.tsx
@@ -33,7 +33,7 @@ export const steps = ({
   {
     type: StepType.INSTALL,
     description: tct(
-      'For the Session Replay to work, you must have the Sentry browser SDK package, or an equivalent framework SDK (e.g. [code:@sentry/react]) installed, minimum version 7.27.0.',
+      'You need a minimum version 7.27.0 of [code:@sentry/svelte] in order to use Session Replay. You do not need to install any additional packages.',
       {code: <code />}
     ),
     configurations: [

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/sveltekit.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/sveltekit.tsx
@@ -2,7 +2,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {Organization, PlatformKey} from 'sentry/types';
 
 type StepProps = {
@@ -32,9 +32,7 @@ export const steps = ({
 }: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: tct('Configure your app automatically with the Sentry wizard.', {
-      code: <code />,
-    }),
+    description: t('Configure your app automatically with the Sentry wizard.'),
     configurations: [
       {
         language: 'bash',


### PR DESCRIPTION
relates to https://github.com/getsentry/sentry/issues/61001

- astro docs are new, they don't exist for our old onboarding docs