### PR TITLE
ref(notifications): more refactoring of enums

### DIFF
--- a/src/sentry/api/endpoints/notification_defaults.py
+++ b/src/sentry/api/endpoints/notification_defaults.py
@@ -4,7 +4,10 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
-from sentry.notifications.defaults import DEFAULT_ON_PROVIDERS, NOTIFICATION_SETTINGS_TYPE_DEFAULTS
+from sentry.notifications.defaults import (
+    DEFAULT_ENABLED_PROVIDERS,
+    NOTIFICATION_SETTINGS_TYPE_DEFAULTS,
+)
 
 
 @control_silo_endpoint
@@ -23,7 +26,7 @@ class NotificationDefaultsEndpoints(Endpoint):
         """
         return Response(
             {
-                "providerDefaults": [provider.value for provider in DEFAULT_ON_PROVIDERS],
+                "providerDefaults": [provider.value for provider in DEFAULT_ENABLED_PROVIDERS],
                 "typeDefaults": {
                     type.value: default.value
                     for type, default in NOTIFICATION_SETTINGS_TYPE_DEFAULTS.items()

--- a/src/sentry/api/endpoints/notification_defaults.py
+++ b/src/sentry/api/endpoints/notification_defaults.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
-from sentry.notifications.helpers import PROVIDER_DEFAULTS, TYPE_DEFAULTS
+from sentry.notifications.defaults import DEFAULT_ON_PROVIDERS, NOTIFICATION_SETTINGS_TYPE_DEFAULTS
 
 
 @control_silo_endpoint
@@ -23,9 +23,10 @@ class NotificationDefaultsEndpoints(Endpoint):
         """
         return Response(
             {
-                "providerDefaults": [provider.value for provider in PROVIDER_DEFAULTS],
+                "providerDefaults": [provider.value for provider in DEFAULT_ON_PROVIDERS],
                 "typeDefaults": {
-                    type.value: default.value for type, default in TYPE_DEFAULTS.items()
+                    type.value: default.value
+                    for type, default in NOTIFICATION_SETTINGS_TYPE_DEFAULTS.items()
                 },
             }
         )

--- a/src/sentry/notifications/defaults.py
+++ b/src/sentry/notifications/defaults.py
@@ -26,7 +26,7 @@ NOTIFICATION_SETTINGS_TYPE_DEFAULTS = {
 
 
 # email and slack are defaulted to being on
-DEFAULT_ON_PROVIDERS = [
+DEFAULT_ENABLED_PROVIDERS = [
     ExternalProviderEnum.EMAIL,
     ExternalProviderEnum.SLACK,
 ]

--- a/src/sentry/notifications/defaults.py
+++ b/src/sentry/notifications/defaults.py
@@ -1,5 +1,5 @@
 from sentry.notifications.types import NotificationSettingEnum, NotificationSettingsOptionEnum
-from sentry.types.integrations import ExternalProviders
+from sentry.types.integrations import ExternalProviderEnum
 
 """
 These mappings represents how to interpret the absence of a DB row for a given
@@ -7,8 +7,8 @@ provider. For example, a user with no NotificationSettings should be opted
 into receiving emails but no Slack messages.
 """
 
-# Each type has a different "sometimes" value.
-NOTIFICATION_SETTINGS_ALL_SOMETIMES = {
+# This specifies the default value for each type of notification
+NOTIFICATION_SETTINGS_TYPE_DEFAULTS = {
     NotificationSettingEnum.DEPLOY: NotificationSettingsOptionEnum.COMMITTED_ONLY,
     NotificationSettingEnum.ISSUE_ALERTS: NotificationSettingsOptionEnum.ALWAYS,
     NotificationSettingEnum.WORKFLOW: NotificationSettingsOptionEnum.SUBSCRIBE_ONLY,
@@ -25,26 +25,8 @@ NOTIFICATION_SETTINGS_ALL_SOMETIMES = {
 }
 
 
-NOTIFICATION_SETTINGS_DEFAULT_OFF = {
-    NotificationSettingEnum.DEPLOY: NotificationSettingsOptionEnum.NEVER,
-    NotificationSettingEnum.ISSUE_ALERTS: NotificationSettingsOptionEnum.NEVER,
-    NotificationSettingEnum.WORKFLOW: NotificationSettingsOptionEnum.NEVER,
-    NotificationSettingEnum.APPROVAL: NotificationSettingsOptionEnum.NEVER,
-    NotificationSettingEnum.QUOTA: NotificationSettingsOptionEnum.NEVER,
-    NotificationSettingEnum.QUOTA_ERRORS: NotificationSettingsOptionEnum.NEVER,
-    NotificationSettingEnum.QUOTA_TRANSACTIONS: NotificationSettingsOptionEnum.NEVER,
-    NotificationSettingEnum.QUOTA_ATTACHMENTS: NotificationSettingsOptionEnum.NEVER,
-    NotificationSettingEnum.QUOTA_REPLAYS: NotificationSettingsOptionEnum.NEVER,
-    NotificationSettingEnum.QUOTA_WARNINGS: NotificationSettingsOptionEnum.NEVER,
-    NotificationSettingEnum.QUOTA_SPEND_ALLOCATIONS: NotificationSettingsOptionEnum.NEVER,
-    NotificationSettingEnum.SPIKE_PROTECTION: NotificationSettingsOptionEnum.NEVER,
-    NotificationSettingEnum.REPORTS: NotificationSettingsOptionEnum.NEVER,
-}
-
-
 # email and slack are defaulted to being on
-NOTIFICATION_SETTING_DEFAULTS = {
-    ExternalProviders.EMAIL: NOTIFICATION_SETTINGS_ALL_SOMETIMES,
-    ExternalProviders.SLACK: NOTIFICATION_SETTINGS_ALL_SOMETIMES,
-    ExternalProviders.MSTEAMS: NOTIFICATION_SETTINGS_DEFAULT_OFF,
-}
+DEFAULT_ON_PROVIDERS = [
+    ExternalProviderEnum.EMAIL,
+    ExternalProviderEnum.SLACK,
+]

--- a/src/sentry/notifications/defaults.py
+++ b/src/sentry/notifications/defaults.py
@@ -1,4 +1,4 @@
-from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.notifications.types import NotificationSettingEnum, NotificationSettingsOptionEnum
 from sentry.types.integrations import ExternalProviders
 
 """
@@ -9,36 +9,36 @@ into receiving emails but no Slack messages.
 
 # Each type has a different "sometimes" value.
 NOTIFICATION_SETTINGS_ALL_SOMETIMES = {
-    NotificationSettingTypes.DEPLOY: NotificationSettingOptionValues.COMMITTED_ONLY,
-    NotificationSettingTypes.ISSUE_ALERTS: NotificationSettingOptionValues.ALWAYS,
-    NotificationSettingTypes.WORKFLOW: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
-    NotificationSettingTypes.APPROVAL: NotificationSettingOptionValues.ALWAYS,
-    NotificationSettingTypes.QUOTA: NotificationSettingOptionValues.ALWAYS,
-    NotificationSettingTypes.QUOTA_ERRORS: NotificationSettingOptionValues.ALWAYS,
-    NotificationSettingTypes.QUOTA_TRANSACTIONS: NotificationSettingOptionValues.ALWAYS,
-    NotificationSettingTypes.QUOTA_ATTACHMENTS: NotificationSettingOptionValues.ALWAYS,
-    NotificationSettingTypes.QUOTA_REPLAYS: NotificationSettingOptionValues.ALWAYS,
-    NotificationSettingTypes.QUOTA_WARNINGS: NotificationSettingOptionValues.ALWAYS,
-    NotificationSettingTypes.QUOTA_SPEND_ALLOCATIONS: NotificationSettingOptionValues.ALWAYS,
-    NotificationSettingTypes.SPIKE_PROTECTION: NotificationSettingOptionValues.ALWAYS,
-    NotificationSettingTypes.REPORTS: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingEnum.DEPLOY: NotificationSettingsOptionEnum.COMMITTED_ONLY,
+    NotificationSettingEnum.ISSUE_ALERTS: NotificationSettingsOptionEnum.ALWAYS,
+    NotificationSettingEnum.WORKFLOW: NotificationSettingsOptionEnum.SUBSCRIBE_ONLY,
+    NotificationSettingEnum.APPROVAL: NotificationSettingsOptionEnum.ALWAYS,
+    NotificationSettingEnum.QUOTA: NotificationSettingsOptionEnum.ALWAYS,
+    NotificationSettingEnum.QUOTA_ERRORS: NotificationSettingsOptionEnum.ALWAYS,
+    NotificationSettingEnum.QUOTA_TRANSACTIONS: NotificationSettingsOptionEnum.ALWAYS,
+    NotificationSettingEnum.QUOTA_ATTACHMENTS: NotificationSettingsOptionEnum.ALWAYS,
+    NotificationSettingEnum.QUOTA_REPLAYS: NotificationSettingsOptionEnum.ALWAYS,
+    NotificationSettingEnum.QUOTA_WARNINGS: NotificationSettingsOptionEnum.ALWAYS,
+    NotificationSettingEnum.QUOTA_SPEND_ALLOCATIONS: NotificationSettingsOptionEnum.ALWAYS,
+    NotificationSettingEnum.SPIKE_PROTECTION: NotificationSettingsOptionEnum.ALWAYS,
+    NotificationSettingEnum.REPORTS: NotificationSettingsOptionEnum.ALWAYS,
 }
 
 
 NOTIFICATION_SETTINGS_DEFAULT_OFF = {
-    NotificationSettingTypes.DEPLOY: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.ISSUE_ALERTS: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.WORKFLOW: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.APPROVAL: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.QUOTA: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.QUOTA_ERRORS: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.QUOTA_TRANSACTIONS: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.QUOTA_ATTACHMENTS: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.QUOTA_REPLAYS: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.QUOTA_WARNINGS: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.QUOTA_SPEND_ALLOCATIONS: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.SPIKE_PROTECTION: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.REPORTS: NotificationSettingOptionValues.NEVER,
+    NotificationSettingEnum.DEPLOY: NotificationSettingsOptionEnum.NEVER,
+    NotificationSettingEnum.ISSUE_ALERTS: NotificationSettingsOptionEnum.NEVER,
+    NotificationSettingEnum.WORKFLOW: NotificationSettingsOptionEnum.NEVER,
+    NotificationSettingEnum.APPROVAL: NotificationSettingsOptionEnum.NEVER,
+    NotificationSettingEnum.QUOTA: NotificationSettingsOptionEnum.NEVER,
+    NotificationSettingEnum.QUOTA_ERRORS: NotificationSettingsOptionEnum.NEVER,
+    NotificationSettingEnum.QUOTA_TRANSACTIONS: NotificationSettingsOptionEnum.NEVER,
+    NotificationSettingEnum.QUOTA_ATTACHMENTS: NotificationSettingsOptionEnum.NEVER,
+    NotificationSettingEnum.QUOTA_REPLAYS: NotificationSettingsOptionEnum.NEVER,
+    NotificationSettingEnum.QUOTA_WARNINGS: NotificationSettingsOptionEnum.NEVER,
+    NotificationSettingEnum.QUOTA_SPEND_ALLOCATIONS: NotificationSettingsOptionEnum.NEVER,
+    NotificationSettingEnum.SPIKE_PROTECTION: NotificationSettingsOptionEnum.NEVER,
+    NotificationSettingEnum.REPORTS: NotificationSettingsOptionEnum.NEVER,
 }
 
 

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -9,7 +9,10 @@ from django.db.models import Subquery
 from sentry.hybridcloud.models.externalactorreplica import ExternalActorReplica
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
-from sentry.notifications.defaults import DEFAULT_ON_PROVIDERS, NOTIFICATION_SETTINGS_TYPE_DEFAULTS
+from sentry.notifications.defaults import (
+    DEFAULT_ENABLED_PROVIDERS,
+    NOTIFICATION_SETTINGS_TYPE_DEFAULTS,
+)
 from sentry.notifications.types import (
     SUBSCRIPTION_REASON_MAP,
     VALID_VALUES_FOR_KEY,
@@ -33,8 +36,8 @@ def get_default_for_provider(
     type: NotificationSettingEnum,
     provider: ExternalProviderEnum,
 ) -> NotificationSettingsOptionEnum:
-    # check if the provider is enable in our defaults an that the type exists as an enum
-    if provider not in DEFAULT_ON_PROVIDERS or type not in NotificationSettingEnum:
+    # check if the provider is enable in our defaults and that the type exists as an enum
+    if provider not in DEFAULT_ENABLED_PROVIDERS or type not in NotificationSettingEnum:
         return NotificationSettingsOptionEnum.NEVER
 
     # TODO(Steve): Make sure that all keys are present in NOTIFICATION_SETTINGS_TYPE_DEFAULTS

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -9,13 +9,8 @@ from django.db.models import Subquery
 from sentry.hybridcloud.models.externalactorreplica import ExternalActorReplica
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
-from sentry.notifications.defaults import (
-    NOTIFICATION_SETTING_DEFAULTS,
-    NOTIFICATION_SETTINGS_ALL_SOMETIMES,
-)
+from sentry.notifications.defaults import DEFAULT_ON_PROVIDERS, NOTIFICATION_SETTINGS_TYPE_DEFAULTS
 from sentry.notifications.types import (
-    NOTIFICATION_SETTING_OPTION_VALUES,
-    NOTIFICATION_SETTING_TYPES,
     SUBSCRIPTION_REASON_MAP,
     VALID_VALUES_FOR_KEY,
     GroupSubscriptionReason,
@@ -24,11 +19,7 @@ from sentry.notifications.types import (
 )
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.services.hybrid_cloud.user.model import RpcUser
-from sentry.types.integrations import (
-    EXTERNAL_PROVIDERS,
-    PERSONAL_NOTIFICATION_PROVIDERS_AS_INT,
-    ExternalProviderEnum,
-)
+from sentry.types.integrations import PERSONAL_NOTIFICATION_PROVIDERS_AS_INT, ExternalProviderEnum
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
@@ -38,40 +29,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def get_provider_defaults() -> list[ExternalProviderEnum]:
-    # create the data structure outside the endpoint
-    provider_defaults = []
-    for key, value in NOTIFICATION_SETTING_DEFAULTS.items():
-        provider = EXTERNAL_PROVIDERS[key]
-        # if the value is NOTIFICATION_SETTINGS_ALL_SOMETIMES then it means the provider
-        # is on by default
-        if value == NOTIFICATION_SETTINGS_ALL_SOMETIMES:
-            provider_defaults.append(ExternalProviderEnum(provider))
-    return provider_defaults
-
-
 def get_default_for_provider(
     type: NotificationSettingEnum,
     provider: ExternalProviderEnum,
 ) -> NotificationSettingsOptionEnum:
-    defaults = PROVIDER_DEFAULTS
-    if provider not in defaults or type not in NotificationSettingEnum:
+    # check if the provider is enable in our defaults an that the type exists as an enum
+    if provider not in DEFAULT_ON_PROVIDERS or type not in NotificationSettingEnum:
         return NotificationSettingsOptionEnum.NEVER
 
+    # special case to disable reports for non-email providers
     if type == NotificationSettingEnum.REPORTS and provider != ExternalProviderEnum.EMAIL:
         # Reports are only sent to email
         return NotificationSettingsOptionEnum.NEVER
 
-    return defaults[provider][type]
+    return NOTIFICATION_SETTINGS_TYPE_DEFAULTS[type]
 
 
 def get_type_defaults() -> Mapping[NotificationSettingEnum, NotificationSettingsOptionEnum]:
     # this tells us what the default value is for each notification type
     type_defaults = {}
-    for key, value in NOTIFICATION_SETTINGS_ALL_SOMETIMES.items():
+    for notification_type, default in NOTIFICATION_SETTINGS_TYPE_DEFAULTS.items():
         # for the given notification type, figure out what the default value is
-        notification_type = NotificationSettingEnum(NOTIFICATION_SETTING_TYPES[key])
-        default = NotificationSettingsOptionEnum(NOTIFICATION_SETTING_OPTION_VALUES[value])
         type_defaults[notification_type] = default
     return type_defaults
 
@@ -175,9 +153,3 @@ def get_team_members(team: Team | RpcActor) -> list[RpcActor]:
         for user_id in members.values_list("user_id", flat=True)
         if user_id
     ]
-
-
-PROVIDER_DEFAULTS: list[ExternalProviderEnum] = get_provider_defaults()
-TYPE_DEFAULTS: Mapping[
-    NotificationSettingEnum, NotificationSettingsOptionEnum
-] = get_type_defaults()

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -55,29 +55,14 @@ def get_default_for_provider(
     provider: ExternalProviderEnum,
 ) -> NotificationSettingsOptionEnum:
     defaults = PROVIDER_DEFAULTS
-    if provider not in defaults:
-        return NotificationSettingsOptionEnum.NEVER
-
-    # Defaults are defined for the old int enum
-    _type = [key for key, val in NOTIFICATION_SETTING_TYPES.items() if val == type.value]
-    if len(_type) != 1 or _type[0] not in NOTIFICATION_SETTINGS_ALL_SOMETIMES:
-        # some keys are missing that we should default to never
-        return NotificationSettingsOptionEnum.NEVER
-
-    try:
-        default_value = NOTIFICATION_SETTINGS_ALL_SOMETIMES[_type[0]]
-        default_enum = NotificationSettingsOptionEnum(
-            NOTIFICATION_SETTING_OPTION_VALUES[default_value]
-        )
-    except KeyError:
-        # If we don't have a default value for the type, then it's never
+    if provider not in defaults or type not in NotificationSettingEnum:
         return NotificationSettingsOptionEnum.NEVER
 
     if type == NotificationSettingEnum.REPORTS and provider != ExternalProviderEnum.EMAIL:
         # Reports are only sent to email
         return NotificationSettingsOptionEnum.NEVER
 
-    return default_enum or NotificationSettingsOptionEnum.NEVER
+    return defaults[provider][type]
 
 
 def get_type_defaults() -> Mapping[NotificationSettingEnum, NotificationSettingsOptionEnum]:

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -37,6 +37,10 @@ def get_default_for_provider(
     if provider not in DEFAULT_ON_PROVIDERS or type not in NotificationSettingEnum:
         return NotificationSettingsOptionEnum.NEVER
 
+    # TODO(Steve): Make sure that all keys are present in NOTIFICATION_SETTINGS_TYPE_DEFAULTS
+    if type not in NOTIFICATION_SETTINGS_TYPE_DEFAULTS:
+        return NotificationSettingsOptionEnum.NEVER
+
     # special case to disable reports for non-email providers
     if type == NotificationSettingEnum.REPORTS and provider != ExternalProviderEnum.EMAIL:
         # Reports are only sent to email

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -74,6 +74,7 @@ class NotificationSettingTypes(ValueEqualityEnum):
 
 
 class NotificationSettingEnum(ValueEqualityEnum):
+    DEFAULT = "default"
     DEPLOY = "deploy"
     ISSUE_ALERTS = "alerts"
     WORKFLOW = "workflow"
@@ -93,6 +94,7 @@ class NotificationSettingEnum(ValueEqualityEnum):
 
 # TODO(Steve): clean up after we finish migrating to settings 2.0
 NOTIFICATION_SETTING_TYPES = {
+    NotificationSettingTypes.DEFAULT: NotificationSettingEnum.DEFAULT.value,
     NotificationSettingTypes.DEPLOY: NotificationSettingEnum.DEPLOY.value,
     NotificationSettingTypes.ISSUE_ALERTS: NotificationSettingEnum.ISSUE_ALERTS.value,
     NotificationSettingTypes.WORKFLOW: NotificationSettingEnum.WORKFLOW.value,

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -74,7 +74,6 @@ class NotificationSettingTypes(ValueEqualityEnum):
 
 
 class NotificationSettingEnum(ValueEqualityEnum):
-    DEFAULT = "default"
     DEPLOY = "deploy"
     ISSUE_ALERTS = "alerts"
     WORKFLOW = "workflow"

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -93,7 +93,6 @@ class NotificationSettingEnum(ValueEqualityEnum):
 
 # TODO(Steve): clean up after we finish migrating to settings 2.0
 NOTIFICATION_SETTING_TYPES = {
-    NotificationSettingTypes.DEFAULT: NotificationSettingEnum.DEFAULT.value,
     NotificationSettingTypes.DEPLOY: NotificationSettingEnum.DEPLOY.value,
     NotificationSettingTypes.ISSUE_ALERTS: NotificationSettingEnum.ISSUE_ALERTS.value,
     NotificationSettingTypes.WORKFLOW: NotificationSettingEnum.WORKFLOW.value,


### PR DESCRIPTION
This PR consolidates to use the new `NotificationSettingEnum` in a few places where we use/define constants. It also renames `NOTIFICATION_SETTINGS_ALL_SOMETIMES` to `NOTIFICATION_SETTINGS_TYPE_DEFAULTS` which is a better name for what it does.