### PR TITLE
ref(notifications): use enum in participants

### DIFF
--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -104,7 +104,7 @@ class AlertRuleNotification(ProjectNotification):
             target_type=self.target_type,
             target_identifier=self.target_identifier,
             event=self.event,
-            notification_type=self.notification_setting_type,
+            notification_type_enum=self.notification_setting_type_enum,
             fallthrough_choice=self.fallthrough_choice,
             rules=self.rules,
             notification_uuid=self.notification_uuid,

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -34,7 +34,6 @@ from sentry.models.rulesnooze import RuleSnooze
 from sentry.models.team import Team
 from sentry.models.user import User
 from sentry.notifications.types import (
-    NOTIFICATION_SETTING_TYPES,
     ActionTargetType,
     FallthroughChoiceType,
     GroupSubscriptionReason,
@@ -394,7 +393,7 @@ def get_send_to(
     target_type: ActionTargetType,
     target_identifier: int | None = None,
     event: Event | None = None,
-    notification_type: NotificationSettingTypes = NotificationSettingTypes.ISSUE_ALERTS,
+    notification_type_enum: NotificationSettingEnum = NotificationSettingEnum.ISSUE_ALERTS,
     fallthrough_choice: FallthroughChoiceType | None = None,
     rules: Iterable[Rule] | None = None,
     notification_uuid: str | None = None,
@@ -417,7 +416,12 @@ def get_send_to(
                 lambda x: x.actor_type != ActorType.USER or x.id not in muted_user_ids, recipients
             )
     return get_recipients_by_provider(
-        project, recipients, notification_type, target_type, target_identifier, notification_uuid
+        project,
+        recipients,
+        notification_type_enum,
+        target_type,
+        target_identifier,
+        notification_uuid,
     )
 
 
@@ -579,7 +583,7 @@ def get_notification_recipients_v2(
 def get_recipients_by_provider(
     project: Project,
     recipients: Iterable[RpcActor],
-    notification_type: NotificationSettingTypes = NotificationSettingTypes.ISSUE_ALERTS,
+    notification_type_enum: NotificationSettingEnum = NotificationSettingEnum.ISSUE_ALERTS,
     target_type: ActionTargetType | None = None,
     target_identifier: int | None = None,
     notification_uuid: str | None = None,
@@ -590,7 +594,7 @@ def get_recipients_by_provider(
     users = recipients_by_type[ActorType.USER]
 
     # First evaluate the teams.
-    setting_type = NotificationSettingEnum(NOTIFICATION_SETTING_TYPES[notification_type])
+    setting_type = notification_type_enum
     teams_by_provider: Mapping[ExternalProviders, Iterable[RpcActor]] = {}
 
     # get by team

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -22,7 +22,7 @@ from sentry.models.user import User
 from sentry.notifications.types import (
     ActionTargetType,
     FallthroughChoiceType,
-    NotificationSettingTypes,
+    NotificationSettingEnum,
 )
 from sentry.notifications.utils.participants import (
     FALLTHROUGH_NOTIFICATION_LIMIT,
@@ -230,7 +230,7 @@ class GetSendToTeamTest(_ParticipantsTest):
             project=self.project,
             target_type=ActionTargetType.TEAM,
             target_identifier=self.team.id,
-            notification_type=NotificationSettingTypes.WORKFLOW,
+            notification_type_enum=NotificationSettingEnum.WORKFLOW,
         ) == {
             ExternalProviders.SLACK: {RpcActor.from_orm_team(self.team)},
         }


### PR DESCRIPTION
This PR switches `get_participants` to use the `NotificationSettingEnum` instead of `NotificationSettingType`