### PR TITLE
ref(slack): Convert issue alerts to use block kit

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1870,7 +1870,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Updated spike protection heuristic
     "organizations:spike-protection-decay-heuristic": False,
     # Enable Slack messages using Block Kit
-    "organizations:slack-block-kit": True,
+    "organizations:slack-block-kit": False,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1870,7 +1870,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Updated spike protection heuristic
     "organizations:spike-protection-decay-heuristic": False,
     # Enable Slack messages using Block Kit
-    "organizations:slack-block-kit": False,
+    "organizations:slack-block-kit": True,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1869,6 +1869,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:sourcemaps-upload-release-as-artifact-bundle": False,
     # Updated spike protection heuristic
     "organizations:spike-protection-decay-heuristic": False,
+    # Enable Slack messages using Block Kit
+    "organizations:slack-block-kit": True,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -225,6 +225,7 @@ default_manager.add("organizations:session-replay-new-zero-state", OrganizationF
 default_manager.add("organizations:session-replay-enable-canvas", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-overage-notifications", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:slack-block-kit", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:stacktrace-processing-caching", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:starfish-view", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -27,10 +27,9 @@ class AbstractMessageBuilder(ABC):
 def format_actor_options(
     actors: Sequence[Team | RpcUser], use_block_kit: bool = False
 ) -> Sequence[Mapping[str, str]]:
+    sort_func: Callable[[Mapping[str, str]], Any] = lambda actor: actor["text"]
     if use_block_kit:
-        sort_func: Callable[[Mapping[str, str]], Any] = lambda actor: actor["text"]["text"]
-    else:
-        sort_func: Callable[[Mapping[str, str]], Any] = lambda actor: actor["text"]
+        sort_func = lambda actor: actor["text"]["text"]
     return sorted((format_actor_option(actor, use_block_kit) for actor in actors), key=sort_func)
 
 

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -24,15 +24,37 @@ class AbstractMessageBuilder(ABC):
     pass
 
 
-def format_actor_options(actors: Sequence[Team | RpcUser]) -> Sequence[Mapping[str, str]]:
-    sort_func: Callable[[Mapping[str, str]], Any] = lambda actor: actor["text"]
-    return sorted((format_actor_option(actor) for actor in actors), key=sort_func)
+def format_actor_options(
+    actors: Sequence[Team | RpcUser], use_block_kit: bool = False
+) -> Sequence[Mapping[str, str]]:
+    if use_block_kit:
+        sort_func: Callable[[Mapping[str, str]], Any] = lambda actor: actor["text"]["text"]
+    else:
+        sort_func: Callable[[Mapping[str, str]], Any] = lambda actor: actor["text"]
+    return sorted((format_actor_option(actor, use_block_kit) for actor in actors), key=sort_func)
 
 
-def format_actor_option(actor: Team | RpcUser) -> Mapping[str, str]:
+def format_actor_option(actor: Team | RpcUser, use_block_kit: bool = False) -> Mapping[str, str]:
     if isinstance(actor, RpcUser):
+        if use_block_kit:
+            return {
+                "text": {
+                    "type": "plain_text",
+                    "text": actor.get_display_name(),
+                },
+                "value": f"user:{actor.id}",
+            }
+
         return {"text": actor.get_display_name(), "value": f"user:{actor.id}"}
     if isinstance(actor, Team):
+        if use_block_kit:
+            return {
+                "text": {
+                    "type": "plain_text",
+                    "text": f"#{actor.slug}",
+                },
+                "value": f"team:{actor.id}",
+            }
         return {"text": f"#{actor.slug}", "value": f"team:{actor.id}"}
 
     raise NotImplementedError

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -75,6 +75,15 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 "link_names": 1,
                 "attachments": json.dumps(attachments),
             }
+            # TODO: feature flag this
+            # TODO: we don't need "attachments" as a list here, if we add on additional_attachment
+            # it just needs to be added to the blocks which is already a list
+            if attachments[0].get("blocks"):
+                payload = {
+                    "text": attachments[0].get("text"),
+                    "blocks": json.dumps(attachments[0].get("blocks")),
+                    "channel": channel,
+                }
 
             client = SlackClient(integration_id=integration.id)
             try:

--- a/src/sentry/integrations/slack/message_builder/__init__.py
+++ b/src/sentry/integrations/slack/message_builder/__init__.py
@@ -3,7 +3,7 @@ from typing import Any, List, Mapping, Union
 # TODO(mgaeta): Continue fleshing out these types.
 SlackAttachment = Mapping[str, Any]
 SlackBlock = Mapping[str, Any]
-SlackBody = Union[SlackAttachment, List[SlackAttachment]]
+SlackBody = Union[SlackAttachment, SlackBlock, List[SlackAttachment]]
 
 # Attachment colors used for issues with no actions take.
 LEVEL_TO_COLOR = {

--- a/src/sentry/integrations/slack/message_builder/__init__.py
+++ b/src/sentry/integrations/slack/message_builder/__init__.py
@@ -23,3 +23,13 @@ INCIDENT_COLOR_MAPPING = {
 }
 
 SLACK_URL_FORMAT = "<{url}|{text}>"
+
+LEVEL_TO_EMOJI = {
+    "_actioned_issue": ":white_check_mark:",
+    "_incident_resolved": ":green_circle:",
+    "debug": ":yellow_circle:",
+    "error": ":red_circle:",
+    "fatal": ":red_circle:",
+    "info": ":large_blue_circle:",
+    "warning": ":yellow_circle:",
+}

--- a/src/sentry/integrations/slack/message_builder/base/base.py
+++ b/src/sentry/integrations/slack/message_builder/base/base.py
@@ -5,7 +5,7 @@ from typing import Any, Mapping, MutableMapping, Sequence
 
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.message_builder import AbstractMessageBuilder
-from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR, SlackBody
+from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR, SlackAttachment, SlackBody
 from sentry.models.group import Group
 from sentry.notifications.utils.actions import MessageAction
 from sentry.utils.assets import get_asset_url
@@ -59,7 +59,7 @@ class SlackMessageBuilder(AbstractMessageBuilder, ABC):
         color: str | None = None,
         actions: Sequence[MessageAction] | None = None,
         **kwargs: Any,
-    ) -> SlackBody:
+    ) -> SlackAttachment:
         """
         Helper to DRY up Slack specific fields.
 

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -73,7 +73,8 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
     def get_button_action(action):
         button = {
             "type": "button",
-            "action_id": action.label,  # hard coded for now, needs to be dynamic
+            "action_id": action.value,  # hard coded for now, needs to be dynamic
+            # ^ changed this from action.label for the resolve dialog, might need to change it back to work for ignore
             "text": {"type": "plain_text", "text": action.label},
             "value": action.value,
         }

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -53,15 +53,15 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
     def get_static_action(action):
         options = []
         for option in action.option_groups:
-            for group in option["options"]:
-                opt = {
-                    "text": {
-                        "type": "plain_text",
-                        "text": group["text"],
-                        "emoji": True,
-                    }
-                }
-                options.append(opt)
+            opt = {
+                "text": {
+                    "type": "plain_text",
+                    "text": option["label"],
+                    "emoji": True,
+                },
+                "value": option["value"],
+            }
+            options.append(opt)
 
         return {
             "type": "static_select",
@@ -69,6 +69,20 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
             "options": options,
             "action_id": action.name,
         }
+
+    @staticmethod
+    def get_button_action(action):
+        # for text, label, url, value in actions:  # this will probably break other usages
+        button = {
+            "type": "button",
+            "action_id": action.label,  # hard coded for now, needs to be dynamic
+            "text": {"type": "plain_text", "text": action.label},
+            "value": action.value,
+        }
+        if action.url:
+            button["url"] = action.url
+
+        return button
 
     @staticmethod
     def get_action_block(actions: Sequence[Tuple[str, Optional[str], str]]) -> SlackBlock:

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -90,10 +90,9 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
             elements: List[Dict[str, Any]]
 
         action_block: SlackBlockType = {"type": "actions", "elements": []}
-        for text, label, url, value in actions:  # this will probably break other usages
+        for text, url, value in actions:
             button = {
                 "type": "button",
-                "action_id": label,  # hard coded for now, needs to be dynamic
                 "text": {"type": "plain_text", "text": text},
                 "value": value,
             }
@@ -128,17 +127,13 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
     ) -> SlackBody:
         blocks: dict[str, Any] = {"blocks": list(args)}
 
-        # TODO put this back in, debugging clicking ignore not changing the message
-
-        # if fallback_text:
-        #     blocks["text"] = fallback_text
+        if fallback_text:
+            blocks["text"] = fallback_text
 
         if color:
             blocks["color"] = color
-        # TODO: not sure if color is supported in block kit. https://api.slack.com/messaging/attachments-to-blocks#direct_equivalents
-        # references it but links to attachment documentation, which we are not using
 
-        # put the block_id into the first block - can probably be smarter here
+        # put the block_id into the first block
         if block_id:
             blocks["blocks"][0]["block_id"] = block_id
 

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -36,7 +36,6 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
 
     @staticmethod
     def get_tags_block(tags) -> SlackBlock:
-        # TODO: rewrite build_tag_fields instead of doing this
         fields = []
         for tag in tags:
             title = tag["title"]

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -72,7 +72,6 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
 
     @staticmethod
     def get_button_action(action):
-        # for text, label, url, value in actions:  # this will probably break other usages
         button = {
             "type": "button",
             "action_id": action.label,  # hard coded for now, needs to be dynamic

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -50,22 +50,10 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
 
     @staticmethod
     def get_static_action(action):
-        options = []
-        for option in action.option_groups:
-            opt = {
-                "text": {
-                    "type": "plain_text",
-                    "text": option["label"],
-                    "emoji": True,
-                },
-                "value": option["value"],
-            }
-            options.append(opt)
-
         return {
             "type": "static_select",
             "placeholder": {"type": "plain_text", "text": action.label, "emoji": True},
-            "options": options,
+            "option_groups": [option for option in action.option_groups],
             "action_id": action.name,
         }
 

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -4,7 +4,7 @@ from abc import ABC
 from datetime import datetime
 from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple, TypedDict
 
-from sentry.integrations.slack.message_builder import SlackBlock, SlackBody
+from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.base.base import SlackMessageBuilder
 
 
@@ -114,7 +114,7 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         fallback_text: Optional[str] = None,
         color: Optional[str] = None,
         block_id: Optional[dict[str, int]] = None,
-    ) -> SlackBody:
+    ) -> SlackBlock:
         blocks: dict[str, Any] = {"blocks": list(args)}
 
         if fallback_text:

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -73,8 +73,7 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
     def get_button_action(action):
         button = {
             "type": "button",
-            "action_id": action.value,  # hard coded for now, needs to be dynamic
-            # ^ changed this from action.label for the resolve dialog, might need to change it back to work for ignore
+            "action_id": action.value,
             "text": {"type": "plain_text", "text": action.label},
             "value": action.value,
         }

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -29,7 +29,9 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         return block
 
     @staticmethod
-    def get_markdown_block(text: str) -> SlackBlock:
+    def get_markdown_block(text: str, emoji: Optional[str]) -> SlackBlock:
+        if emoji:
+            text = f"{emoji} {text}"
         return {
             "type": "section",
             "text": {"type": "mrkdwn", "text": text},

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -29,7 +29,7 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         return block
 
     @staticmethod
-    def get_markdown_block(text: str, emoji: Optional[str]) -> SlackBlock:
+    def get_markdown_block(text: str, emoji: Optional[str] = None) -> SlackBlock:
         if emoji:
             text = f"{emoji} {text}"
         return {

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -77,9 +77,10 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
             elements: List[Dict[str, Any]]
 
         action_block: SlackBlockType = {"type": "actions", "elements": []}
-        for text, url, value in actions:
+        for text, label, url, value in actions:  # this will probably break other usages
             button = {
                 "type": "button",
+                "action_id": label,  # hard coded for now, needs to be dynamic
                 "text": {"type": "plain_text", "text": text},
                 "value": value,
             }
@@ -107,17 +108,26 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
 
     @staticmethod
     def _build_blocks(
-        *args: SlackBlock, fallback_text: Optional[str] = None, color: Optional[str] = None
+        *args: SlackBlock,
+        fallback_text: Optional[str] = None,
+        color: Optional[str] = None,
+        block_id: Optional[dict(str, int)] = None,
     ) -> SlackBody:
         blocks: dict[str, Any] = {"blocks": list(args)}
 
-        if fallback_text:
-            blocks["text"] = fallback_text
+        # TODO put this back in, debugging clicking ignore not changing the message
+
+        # if fallback_text:
+        #     blocks["text"] = fallback_text
 
         if color:
             blocks["color"] = color
         # TODO: not sure if color is supported in block kit. https://api.slack.com/messaging/attachments-to-blocks#direct_equivalents
         # references it but links to attachment documentation, which we are not using
+
+        # put the block_id into the first block - can probably be smarter here
+        if block_id:
+            blocks["blocks"][0]["block_id"] = block_id
 
         return blocks
 

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
+from datetime import datetime
 from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple, TypedDict
 
 from sentry.integrations.slack.message_builder import SlackBlock, SlackBody
@@ -91,7 +92,7 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         return action_block
 
     @staticmethod
-    def get_context_block(text: str, timestamp: Optional[float] = None) -> SlackBlock:
+    def get_context_block(text: str, timestamp: Optional[datetime] = None) -> SlackBlock:
         if timestamp:
             time = timestamp.strftime("%b %d")
             text += f" | {time}"
@@ -110,7 +111,7 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         *args: SlackBlock,
         fallback_text: Optional[str] = None,
         color: Optional[str] = None,
-        block_id: Optional[dict(str, int)] = None,
+        block_id: Optional[dict[str, int]] = None,
     ) -> SlackBody:
         blocks: dict[str, Any] = {"blocks": list(args)}
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Sequence, Union
 
 from sentry import features, tagstore
 from sentry.eventstore.models import GroupEvent
@@ -14,7 +14,7 @@ from sentry.integrations.message_builder import (
     get_timestamp,
     get_title_link,
 )
-from sentry.integrations.slack.message_builder import SLACK_URL_FORMAT, SlackBody
+from sentry.integrations.slack.message_builder import SLACK_URL_FORMAT, SlackAttachment, SlackBlock
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.utils.escape import escape_slack_text
 from sentry.issues.grouptype import GroupCategory
@@ -327,7 +327,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         """
         return True
 
-    def build(self, notification_uuid: str | None = None) -> SlackBody:
+    def build(self, notification_uuid: str | None = None) -> Union[SlackBlock, SlackAttachment]:
         # XXX(dcramer): options are limited to 100 choices, even when nested
         text = build_attachment_text(self.group, self.event) or ""
 
@@ -456,7 +456,7 @@ def build_group_attachment(
     issue_details: bool = False,
     is_unfurl: bool = False,
     notification_uuid: str | None = None,
-) -> SlackBody:
+) -> Union[SlackBlock, SlackAttachment]:
 
     return SlackIssuesMessageBuilder(
         group,

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -14,7 +14,7 @@ from sentry.integrations.message_builder import (
     get_timestamp,
     get_title_link,
 )
-from sentry.integrations.slack.message_builder import SLACK_URL_FORMAT, SlackBody
+from sentry.integrations.slack.message_builder import LEVEL_TO_EMOJI, SLACK_URL_FORMAT, SlackBody
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.utils.escape import escape_slack_text
 from sentry.issues.grouptype import GroupCategory
@@ -403,9 +403,11 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             rule_id,
             notification_uuid=notification_uuid,
         )
+        level_emoji = LEVEL_TO_EMOJI.get(color)
         blocks = [
             self.get_markdown_block(
-                text=f"<{title_link}|*{escape_slack_text(build_attachment_title(obj))}*>  \n{text}"
+                text=f"<{title_link}|*{escape_slack_text(build_attachment_title(obj))}*>  \n{text}",
+                emoji=level_emoji,
             )
         ]
         # build tags block

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -184,7 +184,6 @@ def build_actions(
     group: Group,
     project: Project,
     text: str,
-    color: str,
     actions: Sequence[MessageAction] | None = None,
     identity: RpcIdentity | None = None,
 ) -> tuple[Sequence[MessageAction], str, str]:
@@ -279,7 +278,7 @@ def build_actions(
         if a is not None
     ]
 
-    return action_list, text, color
+    return action_list, text
 
 
 class SlackIssuesMessageBuilder(SlackMessageBuilder):
@@ -348,8 +347,8 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
         if not self.issue_details or (
             self.recipient and self.recipient.actor_type == ActorType.TEAM
         ):
-            payload_actions, text, color = build_actions(
-                self.group, project, text, color, self.actions, self.identity
+            payload_actions, text = build_actions(
+                self.group, project, text, self.actions, self.identity
             )
         else:
             payload_actions = []
@@ -438,13 +437,12 @@ class SlackIssueAlertMessageBuilder(BlockSlackMessageBuilder):
         # If an event is unspecified, use the tags of the latest event (if one exists).
         event_for_tags = self.event or self.group.get_latest_event()
         tags = get_tags(event_for_tags, self.tags)
-        color = get_color(event_for_tags, self.notification, self.group)
         obj = self.event if self.event is not None else self.group
         if not self.issue_details or (
             self.recipient and self.recipient.actor_type == ActorType.TEAM
         ):
-            payload_actions, text, color = build_actions(
-                self.group, project, text, color, self.actions, self.identity
+            payload_actions, text = build_actions(
+                self.group, project, text, self.actions, self.identity
             )
         else:
             payload_actions = []

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -184,9 +184,10 @@ def build_actions(
     group: Group,
     project: Project,
     text: str,
+    color: str,
     actions: Sequence[MessageAction] | None = None,
     identity: RpcIdentity | None = None,
-) -> tuple[Sequence[MessageAction], str, str]:
+) -> tuple[Sequence[MessageAction], str]:
     """Having actions means a button will be shown on the Slack message e.g. ignore, resolve, assign."""
     has_escalating = features.has("organizations:escalating-issues", project.organization)
     use_block_kit = features.has("organizations:slack-block-kit", project.organization)
@@ -278,7 +279,7 @@ def build_actions(
         if a is not None
     ]
 
-    return action_list, text
+    return action_list, text, color
 
 
 class SlackIssuesMessageBuilder(SlackMessageBuilder):
@@ -347,8 +348,8 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
         if not self.issue_details or (
             self.recipient and self.recipient.actor_type == ActorType.TEAM
         ):
-            payload_actions, text = build_actions(
-                self.group, project, text, self.actions, self.identity
+            payload_actions, text, color = build_actions(
+                self.group, project, text, color, self.actions, self.identity
             )
         else:
             payload_actions = []
@@ -441,7 +442,7 @@ class SlackIssueAlertMessageBuilder(BlockSlackMessageBuilder):
         if not self.issue_details or (
             self.recipient and self.recipient.actor_type == ActorType.TEAM
         ):
-            payload_actions, text = build_actions(
+            payload_actions, text, _ = build_actions(
                 self.group, project, text, self.actions, self.identity
             )
         else:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -110,6 +110,7 @@ def get_tags(
     event_for_tags: Any,
     tags: set[str] | None = None,
 ) -> Sequence[Mapping[str, str | bool]]:
+    """Get tag keys and values for block kit"""
     fields = []
     if tags:
         event_tags = event_for_tags.tags if event_for_tags else []
@@ -123,7 +124,6 @@ def get_tags(
                 {
                     "title": std_key,
                     "value": labeled_value,
-                    # "short": True,
                 }
             )
     return fields
@@ -145,6 +145,7 @@ def get_option_groups(group: Group) -> Sequence[Mapping[str, Any]]:
 
 
 def get_group_assignees(group: Group) -> Sequence[Mapping[str, Any]]:
+    """Get teams and users that can be issue assignees for block kit"""
     all_members = group.project.get_members_as_rpc_users()
     members = list({m.id: m for m in all_members}.values())
     teams = group.project.teams.all()
@@ -484,6 +485,7 @@ class SlackIssueAlertMessageBuilder(BlockSlackMessageBuilder):
             timestamp = max(ts, self.event.datetime) if self.event else ts
         blocks.append(self.get_context_block(text=footer, timestamp=timestamp))
 
+        # build actions
         actions = []
         for action in payload_actions:
             if action.label in ("Archive", "Ignore", "Mark as Ongoing", "Stop Ignoring"):

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -14,7 +14,7 @@ from sentry.integrations.message_builder import (
     get_timestamp,
     get_title_link,
 )
-from sentry.integrations.slack.message_builder import LEVEL_TO_EMOJI, SLACK_URL_FORMAT, SlackBody
+from sentry.integrations.slack.message_builder import SLACK_URL_FORMAT, SlackBody
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.utils.escape import escape_slack_text
 from sentry.issues.grouptype import GroupCategory
@@ -403,11 +403,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             rule_id,
             notification_uuid=notification_uuid,
         )
-        level_emoji = LEVEL_TO_EMOJI.get(color)
         blocks = [
             self.get_markdown_block(
                 text=f"<{title_link}|*{escape_slack_text(build_attachment_title(obj))}*>  \n{text}",
-                emoji=level_emoji,
             )
         ]
         # build tags block

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -218,17 +218,6 @@ def build_actions(
     def _resolve_button(use_block_kit) -> MessageAction:
 
         if use_block_kit:
-            # resolve_options = [
-            #     {"label": "Immediately", "value": "resolved"},
-            #     {"label": "In the next release", "value": "resolved:inNextRelease"},
-            #     {"label": "In the current release", "value": "resolved:inCurrentRelease"},
-            # ]
-            # return MessageAction(
-            #     name="status",
-            #     label="Resolve...",
-            #     type="select",
-            #     option_groups=resolve_options,
-            # )
             return MessageAction(
                 name="status",
                 label="Resolve",

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -218,16 +218,21 @@ def build_actions(
     def _resolve_button(use_block_kit) -> MessageAction:
 
         if use_block_kit:
-            resolve_options = [
-                {"label": "Immediately", "value": "resolved"},
-                {"label": "In the next release", "value": "resolved:inNextRelease"},
-                {"label": "In the current release", "value": "resolved:inCurrentRelease"},
-            ]
+            # resolve_options = [
+            #     {"label": "Immediately", "value": "resolved"},
+            #     {"label": "In the next release", "value": "resolved:inNextRelease"},
+            #     {"label": "In the current release", "value": "resolved:inCurrentRelease"},
+            # ]
+            # return MessageAction(
+            #     name="status",
+            #     label="Resolve...",
+            #     type="select",
+            #     option_groups=resolve_options,
+            # )
             return MessageAction(
                 name="status",
-                label="Resolve...",
-                type="select",
-                option_groups=resolve_options,
+                label="Resolve",
+                value="resolve_dialog",
             )
 
         if status == GroupStatus.RESOLVED:
@@ -492,7 +497,8 @@ class SlackIssueAlertMessageBuilder(BlockSlackMessageBuilder):
             elif action.label in ("Resolve", "Unresolve", "Resolve..."):
                 # TODO: to get parity with the existing alerts, this should open up a modal
                 # design is TBD though so unclear if we'll use it. maybe just build it out in case?
-                actions.append(self.get_static_action(action))
+                # actions.append(self.get_static_action(action))
+                actions.append(self.get_button_action(action))
             elif action.name == "assign":
                 actions.append(self.get_static_action(action))
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -237,6 +237,8 @@ def build_actions(
 
     def _resolve_button(use_block_kit) -> MessageAction:
         if use_block_kit:
+            # TODO(CEO): handle if the issue is resolved - render a button that unresolves
+            # TODO(CEO): handle if not project.flags.has_releases in block kit - render a resolve button instead of a modal
             return MessageAction(
                 name="status",
                 label="Resolve",

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -16,6 +16,7 @@ from sentry.integrations.message_builder import (
 )
 from sentry.integrations.slack.message_builder import SLACK_URL_FORMAT, SlackBody
 from sentry.integrations.slack.message_builder.base.base import SlackMessageBuilder
+from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.utils.escape import escape_slack_text
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.actor import ActorTuple
@@ -96,8 +97,10 @@ def build_tag_fields(
             labeled_value = tagstore.get_tag_value_label(key, value)
             fields.append(
                 {
-                    "title": std_key.encode("utf-8"),
-                    "value": labeled_value.encode("utf-8"),
+                    # "title": std_key.encode("utf-8"),
+                    # "value": labeled_value.encode("utf-8"),
+                    "title": std_key,
+                    "value": labeled_value,
                     "short": True,
                 }
             )
@@ -308,6 +311,126 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
         )
 
 
+class SlackIssueAlertMessageBuilder(BlockSlackMessageBuilder):
+    def __init__(
+        self,
+        group: Group,
+        event: GroupEvent | None = None,
+        tags: set[str] | None = None,
+        identity: RpcIdentity | None = None,
+        actions: Sequence[MessageAction] | None = None,
+        rules: list[Rule] | None = None,
+        link_to_event: bool = False,
+        issue_details: bool = False,
+        notification: ProjectNotification | None = None,
+        recipient: RpcActor | None = None,
+        is_unfurl: bool = False,
+    ) -> None:
+        super().__init__()
+        self.group = group
+        self.event = event
+        self.tags = tags
+        self.identity = identity
+        self.actions = actions
+        self.rules = rules
+        self.link_to_event = link_to_event
+        self.issue_details = issue_details
+        self.notification = notification
+        self.recipient = recipient
+        self.is_unfurl = is_unfurl
+        """
+        Builds an issue alert for Slack with Block Kit.
+        """
+
+    @property
+    def escape_text(self) -> bool:
+        """
+        Returns True if we need to escape the text in the message.
+        """
+        return True
+
+    def build(self, notification_uuid: str | None = None) -> SlackBody:
+        # XXX(dcramer): options are limited to 100 choices, even when nested
+        text = build_attachment_text(self.group, self.event) or ""
+
+        if self.escape_text:
+            text = escape_slack_text(text)
+            # XXX(scefali): Not sure why we actually need to do this just for unfurled messages.
+            # If we figure out why this is required we should note it here because it's quite strange
+            if self.is_unfurl:
+                text = escape_slack_text(text)
+
+        # This link does not contain user input (it's a static label and a url), must not escape it.
+        text += build_attachment_replay_link(self.group, self.event) or ""
+
+        project = Project.objects.get_from_cache(id=self.group.project_id)
+
+        # If an event is unspecified, use the tags of the latest event (if one exists).
+        event_for_tags = self.event or self.group.get_latest_event()
+        fields = build_tag_fields(event_for_tags, self.tags)
+        color = get_color(event_for_tags, self.notification, self.group)
+        obj = self.event if self.event is not None else self.group
+        if not self.issue_details or (
+            self.recipient and self.recipient.actor_type == ActorType.TEAM
+        ):
+            payload_actions, text, color = build_actions(
+                self.group, project, text, color, self.actions, self.identity
+            )
+        else:
+            payload_actions = []
+
+        rule_id = None
+        if self.rules:
+            rule_id = self.rules[0].id
+
+        # build title block
+        title_link = get_title_link(
+            self.group,
+            self.event,
+            self.link_to_event,
+            self.issue_details,
+            self.notification,
+            ExternalProviders.SLACK,
+            rule_id,
+            notification_uuid=notification_uuid,
+        )
+        blocks = [
+            self.get_markdown_block(
+                text=f"<{title_link}|*{escape_slack_text(build_attachment_title(obj))}*>  \n{text}"
+            )
+        ]
+        # build tags block
+        blocks.append(self.get_tags_block(fields))
+
+        # build footer block
+        footer = (
+            self.notification.build_notification_footer(self.recipient, ExternalProviders.SLACK)
+            if self.notification and self.recipient
+            else build_footer(self.group, project, self.rules, SLACK_URL_FORMAT)
+        )
+        timestamp = None
+        if not self.issue_details:
+            ts = self.group.last_seen
+            timestamp = max(ts, self.event.datetime) if self.event else ts
+        blocks.append(self.get_context_block(text=footer, timestamp=timestamp))
+
+        actions = []
+        for action in payload_actions:
+            # TODO: need to deal with assignee differently
+            # TODO: need to populate the dropdown options for resolve - just use ignore/archive for now to test webhook stuff
+            # actions.append(self.get_static_action(action))
+            if action.name != "assign":
+                actions.append((action.label, action.url, action.name))
+        # TODO: we need to handle the action payload differently
+        blocks.append(self.get_action_block(actions))
+
+        return self._build_blocks(
+            *blocks,
+            fallback_text=self.build_fallback_text(obj, project.slug),
+            # callback_id=json.dumps({"issue": self.group.id}), # replace this with action_id and/or block_id
+        )
+
+
 def build_group_attachment(
     group: Group,
     event: GroupEvent | None = None,
@@ -321,7 +444,8 @@ def build_group_attachment(
     notification_uuid: str | None = None,
 ) -> SlackBody:
     """@deprecated"""
-    return SlackIssuesMessageBuilder(
+    # return SlackIssuesMessageBuilder(
+    return SlackIssueAlertMessageBuilder(
         group,
         event,
         tags,

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -442,13 +442,14 @@ class SlackIssueAlertMessageBuilder(BlockSlackMessageBuilder):
 
         # If an event is unspecified, use the tags of the latest event (if one exists).
         event_for_tags = self.event or self.group.get_latest_event()
+        color = get_color(event_for_tags, self.notification, self.group)
         tags = get_tags(event_for_tags, self.tags)
         obj = self.event if self.event is not None else self.group
         if not self.issue_details or (
             self.recipient and self.recipient.actor_type == ActorType.TEAM
         ):
-            payload_actions, text, _ = build_actions(
-                self.group, project, text, self.actions, self.identity
+            payload_actions, text, color = build_actions(
+                self.group, project, text, color, self.actions, self.identity
             )
         else:
             payload_actions = []
@@ -495,9 +496,6 @@ class SlackIssueAlertMessageBuilder(BlockSlackMessageBuilder):
             if action.label in ("Archive", "Ignore", "Mark as Ongoing", "Stop Ignoring"):
                 actions.append(self.get_button_action(action))
             elif action.label in ("Resolve", "Unresolve", "Resolve..."):
-                # TODO: to get parity with the existing alerts, this should open up a modal
-                # design is TBD though so unclear if we'll use it. maybe just build it out in case?
-                # actions.append(self.get_static_action(action))
                 actions.append(self.get_button_action(action))
             elif action.name == "assign":
                 actions.append(self.get_static_action(action))

--- a/src/sentry/integrations/slack/message_builder/notifications/digest.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/digest.py
@@ -29,7 +29,7 @@ class DigestNotificationMessageBuilder(SlackNotificationsMessageBuilder):
         """
         digest: Digest = self.context.get("digest", {})
         return [
-            SlackIssuesMessageBuilder(  # type: ignore
+            SlackIssuesMessageBuilder(
                 group=group,
                 event=event,
                 rules=[rule],

--- a/src/sentry/integrations/slack/requests/action.py
+++ b/src/sentry/integrations/slack/requests/action.py
@@ -39,13 +39,14 @@ class SlackActionRequest(SlackRequest):
         if self.data.get("callback_id"):
             return json.loads(self.data["callback_id"])
 
-        # XXX(CEO): can't really feature flag this but the data is very different
+        # XXX(CEO): can't really feature flag this but the block kit data is very different
 
-        # modal dropdown seems to try to submit when an option is selected - I don't think we want that
-        # but just handling it for now
+        # modal dropdown seems to try to submit when an option is selected - we don't want that
+        # but just handling it so things don't blow up - can't figure out how to stop it
         if self.data["type"] == "block_actions":
-            return {"issue": 520}
-            # return json.loads(self.data["view"]["blocks"][0]["block_id"])
+            if self.data.get("view"):
+                return json.loads(self.data["view"]["private_metadata"])
+            return json.loads(self.data["message"]["blocks"][0]["block_id"])
 
         if self.data["type"] == "view_submission":
             return json.loads(self.data["view"]["callback_id"])

--- a/src/sentry/integrations/slack/requests/action.py
+++ b/src/sentry/integrations/slack/requests/action.py
@@ -49,7 +49,7 @@ class SlackActionRequest(SlackRequest):
             return json.loads(self.data["message"]["blocks"][0]["block_id"])
 
         if self.data["type"] == "view_submission":
-            return json.loads(self.data["view"]["callback_id"])
+            return json.loads(self.data["view"]["private_metadata"])
 
         for data in self.data["message"]["blocks"]:
             if data["type"] == "section" and len(data["block_id"]) > 5:

--- a/src/sentry/integrations/slack/requests/action.py
+++ b/src/sentry/integrations/slack/requests/action.py
@@ -36,7 +36,15 @@ class SlackActionRequest(SlackRequest):
             - orig_response_url: URL from the original message we received
             - is_message: did the original message have a 'message' type
         """
-        return json.loads(self.data["callback_id"])
+        if self.data.get("callback_id"):
+            return json.loads(self.data["callback_id"])
+
+        # XXX(CEO): can't really feature flag this but the data is very different
+        for data in self.data["message"]["blocks"]:
+            if data["type"] == "section" and len(data["block_id"]) > 5:
+                return json.loads(data["block_id"])
+                # a bit hacky, you can only provide a block ID per block (not per entire message),
+                # and if not provided slack generates a 5 char long one
 
     def _validate_data(self) -> None:
         """

--- a/src/sentry/integrations/slack/requests/action.py
+++ b/src/sentry/integrations/slack/requests/action.py
@@ -41,8 +41,8 @@ class SlackActionRequest(SlackRequest):
 
         # XXX(CEO): can't really feature flag this but the block kit data is very different
 
-        # modal dropdown seems to try to submit when an option is selected - we don't want that
-        # but just handling it so things don't blow up - can't figure out how to stop it
+        # slack sends us a response when a modal is opened and when an option is selected
+        # we don't do anything with it until the user hits "Submit" but we need to handle it anyway
         if self.data["type"] == "block_actions":
             if self.data.get("view"):
                 return json.loads(self.data["view"]["private_metadata"])
@@ -55,7 +55,8 @@ class SlackActionRequest(SlackRequest):
             if data["type"] == "section" and len(data["block_id"]) > 5:
                 return json.loads(data["block_id"])
                 # a bit hacky, you can only provide a block ID per block (not per entire message),
-                # and if not provided slack generates a 5 char long one
+                # and if not provided slack generates a 5 char long one. our provided block_id is at least '{issue: <issue_id>}'
+                # so we know it's longer than 5 chars
 
     def _validate_data(self) -> None:
         """

--- a/src/sentry/integrations/slack/requests/action.py
+++ b/src/sentry/integrations/slack/requests/action.py
@@ -40,6 +40,16 @@ class SlackActionRequest(SlackRequest):
             return json.loads(self.data["callback_id"])
 
         # XXX(CEO): can't really feature flag this but the data is very different
+
+        # modal dropdown seems to try to submit when an option is selected - I don't think we want that
+        # but just handling it for now
+        if self.data["type"] == "block_actions":
+            return {"issue": 520}
+            # return json.loads(self.data["view"]["blocks"][0]["block_id"])
+
+        if self.data["type"] == "view_submission":
+            return json.loads(self.data["view"]["callback_id"])
+
         for data in self.data["message"]["blocks"]:
             if data["type"] == "section" and len(data["block_id"]) > 5:
                 return json.loads(data["block_id"])

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -304,27 +304,22 @@ class SlackActionEndpoint(Endpoint):
                 }
             )
 
-        block_kit_payload = {
+        modal_payload = {
             "type": "modal",
             "title": {"type": "plain_text", "text": "Resolve Issue"},
             "blocks": [
                 {
                     "type": "section",
                     "text": {"type": "mrkdwn", "text": "Resolve in"},
-                    "initial_option": {
-                        "text": {
-                            "type": "plain_text",
-                            "text": "Immediately",
-                            "emoji": True,
-                        },
-                        "value": "resolved",
-                    },
                     "accessory": {
                         "type": "static_select",
-                        "placeholder": {
-                            "type": "plain_text",
-                            "text": "Select an item",
-                            "emoji": True,
+                        "initial_option": {
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Immediately",
+                                "emoji": True,
+                            },
+                            "value": "resolved",
                         },
                         "options": formatted_resolve_options,
                         "action_id": "static_select-action",
@@ -341,7 +336,7 @@ class SlackActionEndpoint(Endpoint):
         if use_block_kit:
             try:
                 payload = {
-                    "view": json.dumps(block_kit_payload),
+                    "view": json.dumps(modal_payload),
                     "trigger_id": slack_request.data["trigger_id"],
                 }
                 headers = {"content-type": "application/json; charset=utf-8"}

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -285,50 +285,50 @@ class SlackActionEndpoint(Endpoint):
             "trigger_id": slack_request.data["trigger_id"],
         }
         use_block_kit = features.has("organizations:slack-block-kit", group.project.organization)
-        # XXX(CEO): the second you make a selection (without hitting Submit) it sends a slightly different request
-        formatted_resolve_options = []
-        for text, value in RESOLVE_OPTIONS.items():
-            formatted_resolve_options.append(
-                {
-                    "text": {
-                        "type": "plain_text",
-                        "text": text,
-                        "emoji": True,
-                    },
-                    "value": value,
-                }
-            )
-
-        modal_payload = {
-            "type": "modal",
-            "title": {"type": "plain_text", "text": "Resolve Issue"},
-            "blocks": [
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": "Resolve in"},
-                    "accessory": {
-                        "type": "static_select",
-                        "initial_option": {
-                            "text": {
-                                "type": "plain_text",
-                                "text": "Immediately",
-                                "emoji": True,
-                            },
-                            "value": "resolved",
-                        },
-                        "options": formatted_resolve_options,
-                        "action_id": "static_select-action",
-                    },
-                }
-            ],
-            "close": {"type": "plain_text", "text": "Cancel"},
-            "submit": {"type": "plain_text", "text": "Resolve"},
-            "private_metadata": callback_id,
-            "callback_id": callback_id,
-        }
 
         slack_client = SlackClient(integration_id=slack_request.integration.id)
         if use_block_kit:
+            # XXX(CEO): the second you make a selection (without hitting Submit) it sends a slightly different request
+            formatted_resolve_options = []
+            for text, value in RESOLVE_OPTIONS.items():
+                formatted_resolve_options.append(
+                    {
+                        "text": {
+                            "type": "plain_text",
+                            "text": text,
+                            "emoji": True,
+                        },
+                        "value": value,
+                    }
+                )
+
+            modal_payload = {
+                "type": "modal",
+                "title": {"type": "plain_text", "text": "Resolve Issue"},
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": "Resolve in"},
+                        "accessory": {
+                            "type": "static_select",
+                            "initial_option": {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "Immediately",
+                                    "emoji": True,
+                                },
+                                "value": "resolved",
+                            },
+                            "options": formatted_resolve_options,
+                            "action_id": "static_select-action",
+                        },
+                    }
+                ],
+                "close": {"type": "plain_text", "text": "Cancel"},
+                "submit": {"type": "plain_text", "text": "Resolve"},
+                "private_metadata": callback_id,
+                "callback_id": callback_id,
+            }
             try:
                 payload = {
                     "view": json.dumps(modal_payload),
@@ -481,7 +481,6 @@ class SlackActionEndpoint(Endpoint):
         # Reload group as it may have been mutated by the action
         group = Group.objects.get(id=group.id)
 
-        use_block_kit = features.has("organizations:slack-block-kit", group.project.organization)
         if use_block_kit:
             response = SlackIssuesMessageBuilder(
                 group, identity=identity, actions=action_list, tags=original_tags_from_request

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -20,10 +20,7 @@ from sentry.auth.access import from_member
 from sentry.exceptions import UnableToAcceptMemberInvitationException
 from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.message_builder import SlackBody
-from sentry.integrations.slack.message_builder.issues import (
-    SlackIssueAlertMessageBuilder,
-    SlackIssuesMessageBuilder,
-)
+from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.integrations.slack.requests.action import SlackActionRequest
 from sentry.integrations.slack.requests.base import SlackRequestError
 from sentry.integrations.slack.views.link_identity import build_linking_url
@@ -413,7 +410,7 @@ class SlackActionEndpoint(Endpoint):
             except client.ApiError as error:
                 return self.api_error(slack_request, group, identity_user, error, "status_dialog")
 
-            attachment = SlackIssueAlertMessageBuilder(
+            attachment = SlackIssuesMessageBuilder(
                 group, identity=identity, actions=[action], tags=original_tags_from_request
             ).build()
             body = self.construct_reply(
@@ -489,7 +486,7 @@ class SlackActionEndpoint(Endpoint):
 
         use_block_kit = features.has("organizations:slack-block-kit", group.project.organization)
         if use_block_kit:
-            response = SlackIssueAlertMessageBuilder(
+            response = SlackIssuesMessageBuilder(
                 group, identity=identity, actions=action_list, tags=original_tags_from_request
             ).build()
             slack_client = SlackClient(integration_id=slack_request.integration.id)

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -451,7 +451,11 @@ class SlackActionEndpoint(Endpoint):
                         value=action_data["selected_option"]["value"],
                         action_id=action_data["action_id"],
                         block_id=action_data["block_id"],
+                        selected_options=[
+                            {"value": action_data.get("selected_option", {}).get("value")}
+                        ],
                     )
+                    # TODO: selected_options is kinda ridiculous, I think this is built to handle multi-select?
                 else:
                     action = BlockKitMessageAction(
                         name=action_data["action_id"],

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -443,14 +443,24 @@ class SlackActionEndpoint(Endpoint):
         if use_block_kit:
             action_list = []
             for action_data in slack_request.data.get("actions"):
-                action = BlockKitMessageAction(
-                    name=action_data["action_id"],
-                    label=action_data["text"]["text"],
-                    type=action_data["type"],
-                    value=action_data["value"],
-                    action_id=action_data["action_id"],
-                    block_id=action_data["block_id"],
-                )
+                if action_data.get("type") == "static_select":
+                    action = BlockKitMessageAction(
+                        name=action_data["action_id"],
+                        label=action_data["selected_option"]["text"]["text"],
+                        type=action_data["type"],
+                        value=action_data["selected_option"]["value"],
+                        action_id=action_data["action_id"],
+                        block_id=action_data["block_id"],
+                    )
+                else:
+                    action = BlockKitMessageAction(
+                        name=action_data["action_id"],
+                        label=action_data["text"]["text"],
+                        type=action_data["type"],
+                        value=action_data["value"],
+                        action_id=action_data["action_id"],
+                        block_id=action_data["block_id"],
+                    )
                 action_list.append(action)
 
             return action_list

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -284,9 +284,7 @@ class SlackActionEndpoint(Endpoint):
             "trigger_id": slack_request.data["trigger_id"],
         }
         use_block_kit = features.has("organizations:slack-block-kit", group.project.organization)
-        # XXX(CEO): idk if this is the default behavior, but instead of there being placeholder text it's an input field
-        # that filters to options in the dropdown (if a match is found)
-        # also, the second you make a selection (without hitting Submit) it sends a slightly different request
+        # XXX(CEO): the second you make a selection (without hitting Submit) it sends a slightly different request
         # and I don't need it to nor do I know how to stop it, it's making stuff harder in requests/action.py
         formatted_resolve_options = []
         for text, value in RESOLVE_OPTIONS.items():
@@ -393,7 +391,6 @@ class SlackActionEndpoint(Endpoint):
 
             # Masquerade a status action
             selection = None
-            # TODO this is ridiculously nested, is there a better way?
             values = slack_request.data["view"]["state"]["values"]
             for value in values:
                 for val in values[value]:

--- a/src/sentry/notifications/utils/actions.py
+++ b/src/sentry/notifications/utils/actions.py
@@ -34,6 +34,7 @@ class MessageAction:
 @dataclass
 class BlockKitMessageAction:
     name: str
+    label: str
     type: Literal["button", "select"] = "button"
     url: str | None = None
     value: str | None = None

--- a/src/sentry/notifications/utils/actions.py
+++ b/src/sentry/notifications/utils/actions.py
@@ -40,3 +40,4 @@ class BlockKitMessageAction:
     value: str | None = None
     action_id: str | None = None
     block_id: str | None = None
+    selected_options: Sequence[Mapping[str, Any]] | None = None

--- a/src/sentry/notifications/utils/actions.py
+++ b/src/sentry/notifications/utils/actions.py
@@ -29,3 +29,13 @@ class MessageAction:
     option_groups: Sequence[Mapping[str, Any]] | None = None
     block_id: str | None = None
     elements: Sequence[Mapping[str, Any]] | None = None
+
+
+@dataclass
+class BlockKitMessageAction:
+    name: str
+    type: Literal["button", "select"] = "button"
+    url: str | None = None
+    value: str | None = None
+    action_id: str | None = None
+    block_id: str | None = None

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -60,6 +60,9 @@ def build_test_message_blocks(
         if link_to_event:
             title_link += f"/events/{event.event_id}"
     title_link += "/?referrer=slack"
+    ts = group.last_seen
+    timestamp = max(ts, event.datetime) if event else ts
+    event_date = timestamp.strftime("%b %d")
     return {
         "blocks": [
             {
@@ -69,7 +72,7 @@ def build_test_message_blocks(
             },
             {
                 "type": "context",
-                "elements": [{"type": "mrkdwn", "text": f"BAR-{group.short_id} | Dec 08"}],
+                "elements": [{"type": "mrkdwn", "text": f"BAR-{group.short_id} | {event_date}"}],
             },
             {
                 "type": "actions",

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -688,7 +688,9 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.RESOLVED
         group.save()
 
-        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
 
         self._assert_message_actions_list(
             res[0],

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -588,7 +588,7 @@ class ActionsTest(TestCase):
         MOCKIDENTITY = Mock()
 
         assert build_actions(
-            group, self.project, "test txt", [MessageAction(name="TEST")], MOCKIDENTITY
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], MOCKIDENTITY
         ) == ([], "test txt\n", "_actioned_issue")
 
     def _assert_message_actions_list(self, actions, expected):
@@ -602,7 +602,9 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.IGNORED
         group.save()
 
-        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
 
         self._assert_message_actions_list(
             res[0],
@@ -620,7 +622,9 @@ class ActionsTest(TestCase):
         group.save()
 
         with self.feature({"organizations:escalating-issues": True}):
-            res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
 
         self._assert_message_actions_list(
             res[0],
@@ -637,7 +641,9 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.UNRESOLVED
         group.save()
 
-        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
 
         self._assert_message_actions_list(
             res[0],
@@ -655,7 +661,9 @@ class ActionsTest(TestCase):
         group.save()
 
         with self.feature({"organizations:escalating-issues": True}):
-            res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
 
         self._assert_message_actions_list(
             res[0],
@@ -669,7 +677,9 @@ class ActionsTest(TestCase):
 
     def test_no_ignore_if_feedback(self):
         group = self.create_group(project=self.project, type=FeedbackGroup.type_id)
-        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
         # no ignore action if feedback issue, so only assign and resolve
         assert len(res[0]) == 2
 
@@ -697,7 +707,9 @@ class ActionsTest(TestCase):
         self.project.flags.has_releases = False
         self.project.save()
 
-        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
 
         self._assert_message_actions_list(
             res[0],
@@ -716,7 +728,9 @@ class ActionsTest(TestCase):
         self.project.flags.has_releases = True
         self.project.save()
 
-        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
 
         self._assert_message_actions_list(
             res[0],
@@ -735,7 +749,9 @@ class ActionsTest(TestCase):
         self.project.flags.has_releases = True
         self.project.save()
 
-        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
 
         self._assert_message_actions_list(
             res[0],

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -588,7 +588,7 @@ class ActionsTest(TestCase):
         MOCKIDENTITY = Mock()
 
         assert build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], MOCKIDENTITY
+            group, self.project, "test txt", [MessageAction(name="TEST")], MOCKIDENTITY
         ) == ([], "test txt\n", "_actioned_issue")
 
     def _assert_message_actions_list(self, actions, expected):
@@ -602,9 +602,7 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.IGNORED
         group.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
 
         self._assert_message_actions_list(
             res[0],
@@ -622,9 +620,7 @@ class ActionsTest(TestCase):
         group.save()
 
         with self.feature({"organizations:escalating-issues": True}):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
+            res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
 
         self._assert_message_actions_list(
             res[0],
@@ -641,9 +637,7 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.UNRESOLVED
         group.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
 
         self._assert_message_actions_list(
             res[0],
@@ -661,9 +655,7 @@ class ActionsTest(TestCase):
         group.save()
 
         with self.feature({"organizations:escalating-issues": True}):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
+            res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
 
         self._assert_message_actions_list(
             res[0],
@@ -677,9 +669,7 @@ class ActionsTest(TestCase):
 
     def test_no_ignore_if_feedback(self):
         group = self.create_group(project=self.project, type=FeedbackGroup.type_id)
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
         # no ignore action if feedback issue, so only assign and resolve
         assert len(res[0]) == 2
 
@@ -688,9 +678,7 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.RESOLVED
         group.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
 
         self._assert_message_actions_list(
             res[0],
@@ -709,9 +697,7 @@ class ActionsTest(TestCase):
         self.project.flags.has_releases = False
         self.project.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
 
         self._assert_message_actions_list(
             res[0],
@@ -730,9 +716,7 @@ class ActionsTest(TestCase):
         self.project.flags.has_releases = True
         self.project.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
 
         self._assert_message_actions_list(
             res[0],
@@ -751,9 +735,7 @@ class ActionsTest(TestCase):
         self.project.flags.has_releases = True
         self.project.save()
 
-        res = build_actions(
-            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-        )
+        res = build_actions(group, self.project, "test txt", [MessageAction(name="TEST")], None)
 
         self._assert_message_actions_list(
             res[0],

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -32,6 +32,7 @@ class BaseEventTest(APITestCase):
         slack_user=None,
         original_message=None,
     ):
+
         if slack_user is None:
             slack_user = {"id": self.external_id, "domain": "example"}
 

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -76,6 +76,8 @@ class BaseEventTest(APITestCase):
         team_id="TXXXXXXX1",
         slack_user=None,
         original_message=None,
+        selected_option=None,
+        view=None,
     ):
 
         if slack_user is None:
@@ -91,40 +93,130 @@ class BaseEventTest(APITestCase):
 
         payload = {
             "type": type,
-            "user": slack_user,
-            "api_app_id": "A058NGW5NDP",
-            "token": "6IM9MzJR4Ees5x4jkW29iKbj",
-            "container": {
-                "type": "message",
-                "message_ts": "1702424381.221719",
-                "channel_id": "C065W1189",
-                "is_ephemeral": False,
-            },
-            "trigger_id": self.trigger_id,
             "team": {
                 "id": team_id,
                 "domain": "hb-meowcraft",
             },
+            "user": slack_user,
+            "api_app_id": "A058NGW5NDP",
+            "token": "6IM9MzJR4Ees5x4jkW29iKbj",
+            "trigger_id": self.trigger_id,
+            "view": view,
+            "response_urls": [],
             "enterprise": None,
             "is_enterprise_install": False,
-            "channel": {
+        }
+
+        if type == "view_submission":
+            view = {
+                "id": "V069MCJ1Y4X",
+                "team_id": "TA17GH2QL",
+                "type": "modal",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "block_id": "a6HD+",
+                        "text": {"type": "mrkdwn", "text": "Resolve in", "verbatim": False},
+                        "accessory": {
+                            "type": "static_select",
+                            "action_id": "static_select-action",
+                            "initial_option": {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "Immediately",
+                                    "emoji": True,
+                                },
+                                "value": "resolved",
+                            },
+                            "options": [
+                                {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Immediately",
+                                        "emoji": True,
+                                    },
+                                    "value": "resolved",
+                                },
+                                {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "In the next release",
+                                        "emoji": True,
+                                    },
+                                    "value": "resolved:inNextRelease",
+                                },
+                                {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "In the current release",
+                                        "emoji": True,
+                                    },
+                                    "value": "resolved:inCurrentRelease",
+                                },
+                            ],
+                        },
+                    }
+                ],
+                "private_metadata": "{'issue':618,'orig_response_url':'https://hooks.slack.com/actions/TA17GH2QL/6354598702337/EpJhd0O8CQPTTlgkEpTeponR','is_message':False}",
+                "callback_id": "{'issue':618,'orig_response_url':'https://hooks.slack.com/actions/TA17GH2QL/6354598702337/EpJhd0O8CQPTTlgkEpTeponR','is_message':False}",
+                "state": {
+                    "values": {
+                        "a6HD+": {
+                            "static_select-action": {
+                                "type": "static_select",
+                                "selected_option": {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Immediately",
+                                        "emoji": True,
+                                    },
+                                    "value": selected_option,
+                                },
+                            }
+                        }
+                    }
+                },
+                "hash": "1702502121.CZNlXHKw",
+                "title": {"type": "plain_text", "text": "Resolve Issue", "emoji": True},
+                "clear_on_close": False,
+                "notify_on_close": False,
+                "close": {"type": "plain_text", "text": "Cancel", "emoji": True},
+                "submit": {"type": "plain_text", "text": "Resolve", "emoji": True},
+                "previous_view_id": None,
+                "root_view_id": "V069MCJ1Y4X",
+                "app_id": "A058NGW5NDP",
+                "external_id": "",
+                "app_installed_team_id": "TA17GH2QL",
+                "bot_id": "B058CDV2LKW",
+            }
+            payload["response_urls"] = []
+            payload["view"] = view
+
+        elif type == "block_actions":
+            payload["container"] = {
+                "type": "message",
+                "message_ts": "1702424381.221719",
+                "channel_id": "C065W1189",
+                "is_ephemeral": False,
+            }
+            payload["channel"] = {
                 "id": "C065W1189",
                 "name": "general",
-            },
-            "message": original_message,
-            "state": {
+            }
+            payload["message"] = original_message
+            payload["state"] = {
                 "values": {
                     "bXwil": {
                         "assign": {
                             "type": "static_select",
-                            "selected_option": "None",
+                            "selected_option": selected_option,
                         }
                     }
                 }
-            },
-            "response_url": self.response_url,
-            "actions": action_data or [],
-        }
+            }
+            payload["response_url"] = self.response_url
+            payload["actions"] = action_data or []
+
         if data:
             payload.update(data)
 

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -32,7 +32,6 @@ class BaseEventTest(APITestCase):
         slack_user=None,
         original_message=None,
     ):
-
         if slack_user is None:
             slack_user = {"id": self.external_id, "domain": "example"}
 

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -74,7 +74,6 @@ class BaseEventTest(APITestCase):
         type="block_actions",
         data=None,
         team_id="TXXXXXXX1",
-        block_id=None,
         slack_user=None,
         original_message=None,
     ):
@@ -86,9 +85,6 @@ class BaseEventTest(APITestCase):
                 "username": "colleen",
                 "team_id": team_id,
             }
-
-        if block_id is None:
-            block_id = json.dumps({"issue": self.group.id})
 
         if original_message is None:
             original_message = {}

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -96,8 +96,8 @@ class BaseEventTest(APITestCase):
         payload = {
             "type": type,
             "user": slack_user,
-            # "api_app_id":"A058NGW5NDP",
-            # "token":"6IM9MzJR4Ees5x4jkW29iKbj",
+            "api_app_id": "A058NGW5NDP",
+            "token": "6IM9MzJR4Ees5x4jkW29iKbj",
             "container": {
                 "type": "message",
                 "message_ts": "1702424381.221719",
@@ -126,25 +126,11 @@ class BaseEventTest(APITestCase):
                     }
                 }
             },
-            "response_url": "https://hooks.slack.com/actions/TA17GH2QL/6358678090416/PgeMD97DohIqc1V2WCyhMAQx",
-            "actions": [
-                {
-                    "action_id": "ignored:forever",
-                    "block_id": "bXwil",
-                    "text": {
-                        "type": "plain_text",
-                        "text": "Ignore",
-                        "emoji": True,
-                    },
-                    "value": "ignored:forever",
-                    "type": "button",
-                    "action_ts": "1702424387.108033",
-                }
-            ],
+            "response_url": self.response_url,
+            "actions": action_data or [],
         }
         if data:
             payload.update(data)
 
         payload = {"payload": json.dumps(payload)}
-        with self.feature("organizations:slack-block-kit"):
-            return self.client.post("/extensions/slack/action/", data=payload)
+        return self.client.post("/extensions/slack/action/", data=payload)

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -62,3 +62,89 @@ class BaseEventTest(APITestCase):
         payload = {"payload": json.dumps(payload)}
 
         return self.client.post("/extensions/slack/action/", data=payload)
+
+    @patch(
+        "sentry.integrations.slack.requests.base.SlackRequest._check_signing_secret",
+        return_value=True,
+    )
+    def post_webhook_block_kit(
+        self,
+        check_signing_secret_mock,
+        action_data=None,
+        type="block_actions",
+        data=None,
+        team_id="TXXXXXXX1",
+        block_id=None,
+        slack_user=None,
+        original_message=None,
+    ):
+
+        if slack_user is None:
+            slack_user = {
+                "id": self.external_id,
+                "name": "colleen",
+                "username": "colleen",
+                "team_id": team_id,
+            }
+
+        if block_id is None:
+            block_id = json.dumps({"issue": self.group.id})
+
+        if original_message is None:
+            original_message = {}
+
+        payload = {
+            "type": type,
+            "user": slack_user,
+            # "api_app_id":"A058NGW5NDP",
+            # "token":"6IM9MzJR4Ees5x4jkW29iKbj",
+            "container": {
+                "type": "message",
+                "message_ts": "1702424381.221719",
+                "channel_id": "C065W1189",
+                "is_ephemeral": False,
+            },
+            "trigger_id": self.trigger_id,
+            "team": {
+                "id": team_id,
+                "domain": "hb-meowcraft",
+            },
+            "enterprise": None,
+            "is_enterprise_install": False,
+            "channel": {
+                "id": "C065W1189",
+                "name": "general",
+            },
+            "message": original_message,
+            "state": {
+                "values": {
+                    "bXwil": {
+                        "assign": {
+                            "type": "static_select",
+                            "selected_option": "None",
+                        }
+                    }
+                }
+            },
+            "response_url": "https://hooks.slack.com/actions/TA17GH2QL/6358678090416/PgeMD97DohIqc1V2WCyhMAQx",
+            "actions": [
+                {
+                    "action_id": "ignored:forever",
+                    "block_id": "bXwil",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Ignore",
+                        "emoji": True,
+                    },
+                    "value": "ignored:forever",
+                    "type": "button",
+                    "action_ts": "1702424387.108033",
+                }
+            ],
+        }
+        if data:
+            payload.update(data)
+
+        payload = {"payload": json.dumps(payload)}
+        with self.feature("organizations:slack-block-kit"):
+            return self.client.post("/extensions/slack/action/", data=payload)

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -78,6 +78,7 @@ class BaseEventTest(APITestCase):
         original_message=None,
         selected_option=None,
         view=None,
+        private_metadata=None,
     ):
 
         if slack_user is None:
@@ -157,8 +158,7 @@ class BaseEventTest(APITestCase):
                         },
                     }
                 ],
-                "private_metadata": "{'issue':618,'orig_response_url':'https://hooks.slack.com/actions/TA17GH2QL/6354598702337/EpJhd0O8CQPTTlgkEpTeponR','is_message':False}",
-                "callback_id": "{'issue':618,'orig_response_url':'https://hooks.slack.com/actions/TA17GH2QL/6354598702337/EpJhd0O8CQPTTlgkEpTeponR','is_message':False}",
+                "private_metadata": private_metadata,
                 "state": {
                     "values": {
                         "a6HD+": {

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -80,7 +80,7 @@ class BaseEventTest(APITestCase):
         view=None,
         private_metadata=None,
     ):
-
+        """Respond as if we were Slack"""
         if slack_user is None:
             slack_user = {
                 "id": self.external_id,

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -111,7 +111,7 @@ class BaseEventTest(APITestCase):
         if type == "view_submission":
             view = {
                 "id": "V069MCJ1Y4X",
-                "team_id": "TA17GH2QL",
+                "team_id": team_id,
                 "type": "modal",
                 "blocks": [
                     {

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -126,137 +126,29 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             project_id=self.project.id,
         )
         status_action = {
-            "type": "button",
-            "action_id": "ignored:forever",
-            "text": {"type": "plain_text", "text": "Ignore"},
+            "action_id": "status",
+            "block_id": "bXwil",
+            "text": {
+                "type": "plain_text",
+                "text": "Ignore",
+                "emoji": True,
+            },
             "value": "ignored:forever",
+            "type": "button",
+            "action_ts": "1702424387.108033",
         }
         original_message = {
-            "bot_id": "B058CDV2LKW",
-            "type": "message",
-            "text": "[internal] NameError: name 'chuchu' is not defined",
-            "user": "U058NJ6N2MP",
-            "ts": "1702424381.221719",
-            "app_id": "A058NGW5NDP",
             "blocks": [
                 {
                     "type": "section",
-                    "block_id": '{"issue":614}',
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "<http://dev.getsentry.net:8000/organizations/sentry/issues/614/?referrer=slack&amp;notification_uuid=de21e212-d96e-4ea0-b5e2-2d04821ab9a3&amp;environment=production&amp;alert_rule_id=218&amp;alert_type=issue|*NameError*>  nname 'chuchu' is not defined",
-                        "verbatim": False,
-                    },
-                },
-                {
-                    "type": "section",
-                    "block_id": "X+9VO",
-                    "fields": [
-                        {"type": "mrkdwn", "text": "*environment:*nproduction", "verbatim": False},
-                        {"type": "mrkdwn", "text": "*release:*nabcdefg", "verbatim": False},
-                    ],
-                },
-                {
-                    "type": "context",
-                    "block_id": "N7xyp",
-                    "elements": [
-                        {
-                            "type": "mrkdwn",
-                            "text": "INTERNAL-HN via <http://dev.getsentry.net:8000/organizations/sentry/alerts/rules/internal/218/details/|email my heart> | Dec 12",
-                            "verbatim": False,
-                        }
-                    ],
-                },
-                {
-                    "type": "actions",
-                    "block_id": "bXwil",
-                    "elements": [
-                        {
-                            "type": "button",
-                            "action_id": "resolve_dialog",
-                            "text": {"type": "plain_text", "text": "Resolve", "emoji": True},
-                            "value": "resolve_dialog",
-                        },
-                        {
-                            "type": "button",
-                            "action_id": "ignored:forever",
-                            "text": {"type": "plain_text", "text": "Ignore", "emoji": True},
-                            "value": "ignored:forever",
-                        },
-                        {
-                            "type": "static_select",
-                            "action_id": "assign",
-                            "placeholder": {
-                                "type": "plain_text",
-                                "text": "Select Assignee...",
-                                "emoji": True,
-                            },
-                            "option_groups": [
-                                {
-                                    "label": {"type": "plain_text", "text": "Teams", "emoji": True},
-                                    "options": [
-                                        {
-                                            "text": {
-                                                "type": "plain_text",
-                                                "text": "#captain-planet",
-                                                "emoji": True,
-                                            },
-                                            "value": "team:3",
-                                        },
-                                        {
-                                            "text": {
-                                                "type": "plain_text",
-                                                "text": "#sentry",
-                                                "emoji": True,
-                                            },
-                                            "value": "team:1",
-                                        },
-                                    ],
-                                },
-                                {
-                                    "label": {
-                                        "type": "plain_text",
-                                        "text": "People",
-                                        "emoji": True,
-                                    },
-                                    "options": [
-                                        {
-                                            "text": {
-                                                "type": "plain_text",
-                                                "text": "colleen@sentry.io",
-                                                "emoji": True,
-                                            },
-                                            "value": "user:1",
-                                        },
-                                        {
-                                            "text": {
-                                                "type": "plain_text",
-                                                "text": "dummy@example.com",
-                                                "emoji": True,
-                                            },
-                                            "value": "user:2",
-                                        },
-                                        {
-                                            "text": {
-                                                "type": "plain_text",
-                                                "text": "me me",
-                                                "emoji": True,
-                                            },
-                                            "value": "user:8",
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                    ],
+                    "block_id": json.dumps({"issue": event.group.id}),
+                    "text": {"type": "mrkdwn", "text": "boop", "verbatim": False},
                 },
             ],
-            "team": "TA17GH2QL",
         }
         assert event.group is not None
 
         with self.feature("organizations:slack-block-kit"):
-            # we're pretending to be slack here I think
             resp = self.post_webhook_block_kit(
                 action_data=[status_action],
                 original_message=original_message,

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -147,6 +147,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.data["attachments"][0]["text"] == expect_status
 
         with self.feature("organizations:slack-block-kit"):
+            # test backwards compatibility
             resp = self.post_webhook(
                 action_data=[status_action],
                 original_message=self.original_message,
@@ -206,6 +207,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.data["attachments"][0]["text"] == expect_status
 
         with self.feature("organizations:slack-block-kit"):
+            # test backwards compatibility
             resp = self.post_webhook(
                 action_data=[status_action],
                 original_message=self.original_message,
@@ -264,6 +266,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.data["text"].endswith(expect_status), resp.data["text"]
 
         with self.feature("organizations:slack-block-kit"):
+            # test backwards compatibility
             resp = self.post_webhook(action_data=[status_action])
             self.group = Group.objects.get(id=self.group.id)
 
@@ -342,6 +345,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.data["text"].endswith(expect_status), resp.data["text"]
 
         with self.feature("organizations:slack-block-kit"):
+            # test backwards compatibility
             resp = self.post_webhook(action_data=[status_action])
 
             assert resp.status_code == 200, resp.content
@@ -415,6 +419,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert not GroupAssignee.objects.filter(group=self.group).exists()
 
         with self.feature("organizations:slack-block-kit"):
+            # test backwards compatibility
             resp = self.post_webhook(action_data=[status_action])
 
             assert resp.status_code == 200, resp.content
@@ -467,6 +472,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.data["text"].endswith(expect_status), resp.data["text"]
 
         with self.feature("organizations:slack-block-kit"):
+            # test backwards compatibility
             resp = self.post_webhook(action_data=[status_action])
             assert resp.status_code == 200, resp.content
             assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -165,9 +165,10 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             data=self.event_data,
             project_id=self.project.id,
         )
-        original_message = self.get_original_message_block_kit(event.group.id)
-        status_action = self.get_ignore_status_action("Ignore", "ignored:forever")
         assert event.group is not None
+        group = event.group
+        original_message = self.get_original_message_block_kit(group.id)
+        status_action = self.get_ignore_status_action("Ignore", "ignored:forever")
 
         with self.feature("organizations:slack-block-kit"):
             resp = self.post_webhook_block_kit(
@@ -187,8 +188,8 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             data=self.event_data,
             project_id=self.project.id,
         )
-        status_action = {"name": "status", "value": "ignored:until_escalating", "type": "button"}
         assert event.group is not None
+        status_action = {"name": "status", "value": "ignored:until_escalating", "type": "button"}
         resp = self.post_webhook(
             action_data=[status_action],
             original_message=self.original_message,
@@ -223,9 +224,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             data=self.event_data,
             project_id=self.project.id,
         )
+        assert event.group is not None
         status_action = self.get_ignore_status_action("Archive", "ignored:until_escalating")
         original_message = self.get_original_message_block_kit(event.group.id)
-        assert event.group is not None
         with self.feature("organizations:slack-block-kit"):
             resp = self.post_webhook_block_kit(
                 action_data=[status_action],

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -94,6 +94,20 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = f"Identity not found.\n*Issue ignored by <@{self.external_id}>*"
         assert resp.data["attachments"][0]["text"] == expect_status
 
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook(
+                action_data=[status_action],
+                original_message=original_message,
+                type="interactive_message",
+                callback_id=json.dumps({"issue": event.group.id}),
+            )
+            self.group = Group.objects.get(id=event.group.id)
+
+            assert resp.status_code == 200, resp.content
+            assert self.group.get_status() == GroupStatus.IGNORED
+            assert self.group.substatus == GroupSubStatus.FOREVER
+            assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
+
     def test_archive_issue(self):
         event = self.store_event(
             data={
@@ -143,6 +157,20 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = f"Identity not found.\n*Issue ignored by <@{self.external_id}>*"
         assert resp.data["attachments"][0]["text"] == expect_status
 
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook(
+                action_data=[status_action],
+                original_message=original_message,
+                type="interactive_message",
+                callback_id=json.dumps({"issue": event.group.id}),
+            )
+            self.group = Group.objects.get(id=event.group.id)
+
+            assert resp.status_code == 200, resp.content
+            assert self.group.get_status() == GroupStatus.IGNORED
+            assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
+            assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
+
     def test_ignore_issue_with_additional_user_auth(self):
         """
         Ensure that we can act as a user even when the organization has SSO enabled
@@ -164,6 +192,15 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
 
         expect_status = f"*Issue ignored by <@{self.external_id}>*"
         assert resp.data["text"].endswith(expect_status), resp.data["text"]
+
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook(action_data=[status_action])
+            self.group = Group.objects.get(id=self.group.id)
+
+            assert resp.status_code == 200, resp.content
+            assert self.group.get_status() == GroupStatus.IGNORED
+            assert self.group.substatus == GroupSubStatus.FOREVER
+            assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
 
     def test_assign_issue(self):
         user2 = self.create_user(is_superuser=False)
@@ -204,6 +241,21 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
 
         assert resp.data["text"].endswith(expect_status), resp.data["text"]
 
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook(action_data=[status_action])
+
+            assert resp.status_code == 200, resp.content
+            assert GroupAssignee.objects.filter(group=self.group, team=self.team).exists()
+            activity = Activity.objects.filter(group=self.group).first()
+            assert activity.data == {
+                "assignee": str(user2.id),
+                "assigneeEmail": user2.email,
+                "assigneeType": "user",
+                "integration": ActivityIntegration.SLACK.value,
+            }
+
+            assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
+
     def test_assign_issue_where_team_not_in_project(self):
         user2 = self.create_user(is_superuser=False)
 
@@ -223,6 +275,15 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.status_code == 200, resp.content
         assert resp.data["text"] == "Cannot assign to a team without access to the project"
         assert not GroupAssignee.objects.filter(group=self.group).exists()
+
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook(action_data=[status_action])
+
+            assert resp.status_code == 200, resp.content
+            assert resp.data["text"].endswith(
+                "Cannot assign to a team without access to the project"
+            )
+            assert not GroupAssignee.objects.filter(group=self.group).exists()
 
     def test_assign_issue_user_has_identity(self):
         user2 = self.create_user(is_superuser=False)
@@ -250,6 +311,12 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
 
         assert resp.data["text"].endswith(expect_status), resp.data["text"]
 
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook(action_data=[status_action])
+            assert resp.status_code == 200, resp.content
+            assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
+            assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
+
     def test_response_differs_on_bot_message(self):
         status_action = {"name": "status", "value": "ignored:forever", "type": "button"}
 
@@ -263,6 +330,15 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.status_code == 200, resp.content
         assert "attachments" in resp.data
         assert resp.data["attachments"][0]["title"] == self.group.title
+
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook(action_data=[status_action], original_message=original_message)
+            self.group = Group.objects.get(id=self.group.id)
+            assert self.group.get_status() == GroupStatus.IGNORED
+            assert self.group.substatus == GroupSubStatus.FOREVER
+            assert resp.status_code == 200, resp.content
+            assert "blocks" in resp.data
+            assert self.group.title in resp.data["blocks"][0]["text"]["text"]
 
     def test_assign_user_with_multiple_identities(self):
         org2 = self.create_organization(owner=None)
@@ -294,6 +370,13 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         )
 
         assert resp.data["text"].endswith(expect_status), resp.data["text"]
+
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook(action_data=[status_action])
+
+            assert resp.status_code == 200, resp.content
+            assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
+            assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
 
     @responses.activate
     def test_resolve_issue(self):
@@ -346,6 +429,60 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert update_data["text"].endswith(expect_status)
+
+    @responses.activate
+    def test_resolve_issue_block_kit(self):
+        """Test backwards compatibility of resolving an issue from a legacy Slack notification
+        with the block kit feature flag enabled"""
+        status_action = {"name": "resolve_dialog", "value": "resolve_dialog"}
+
+        # Expect request to open dialog on slack
+        responses.add(
+            method=responses.POST,
+            url="https://slack.com/api/dialog.open",
+            body='{"ok": true}',
+            status=200,
+            content_type="application/json",
+        )
+
+        resp = self.post_webhook(action_data=[status_action])
+        assert resp.status_code == 200, resp.content
+
+        # Opening dialog should *not* cause the current message to be updated
+        assert resp.content == b""
+
+        data = parse_qs(responses.calls[0].request.body)
+        assert data["trigger_id"][0] == self.trigger_id
+        assert "dialog" in data
+
+        dialog = json.loads(data["dialog"][0])
+        callback_data = json.loads(dialog["callback_id"])
+        assert int(callback_data["issue"]) == self.group.id
+        assert callback_data["orig_response_url"] == self.response_url
+
+        # Completing the dialog will update the message
+        responses.add(
+            method=responses.POST,
+            url=self.response_url,
+            body='{"ok": true}',
+            status=200,
+            content_type="application/json",
+        )
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook(
+                type="dialog_submission",
+                callback_id=dialog["callback_id"],
+                data={"submission": {"resolve_type": "resolved"}},
+            )
+        self.group = Group.objects.get(id=self.group.id)
+
+        assert resp.status_code == 200, resp.content
+        assert self.group.get_status() == GroupStatus.RESOLVED
+
+        update_data = json.loads(responses.calls[1].request.body)
+
+        expect_status = f"*Issue resolved by <@{self.external_id}>*"
+        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
 
     @responses.activate
     def test_resolve_issue_in_next_release(self):
@@ -405,6 +542,66 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
         assert update_data["text"].endswith(expect_status)
 
+    @responses.activate
+    def test_resolve_issue_in_next_release_block_kit(self):
+        """Test backwards compatibility of resolving a legacy formatted Slack notification
+        with the block kit feature flag enabled"""
+        status_action = {"name": "resolve_dialog", "value": "resolve_dialog"}
+
+        release = Release.objects.create(
+            organization_id=self.organization.id,
+            version="1.0",
+        )
+        release.add_project(self.project)
+
+        # Expect request to open dialog on slack
+        responses.add(
+            method=responses.POST,
+            url="https://slack.com/api/dialog.open",
+            body='{"ok": true}',
+            status=200,
+            content_type="application/json",
+        )
+
+        resp = self.post_webhook(action_data=[status_action])
+        assert resp.status_code == 200, resp.content
+
+        # Opening dialog should *not* cause the current message to be updated
+        assert resp.content == b""
+
+        data = parse_qs(responses.calls[0].request.body)
+        assert data["trigger_id"][0] == self.trigger_id
+        assert "dialog" in data
+
+        dialog = json.loads(data["dialog"][0])
+        callback_data = json.loads(dialog["callback_id"])
+        assert int(callback_data["issue"]) == self.group.id
+        assert callback_data["orig_response_url"] == self.response_url
+
+        # Completing the dialog will update the message
+        responses.add(
+            method=responses.POST,
+            url=self.response_url,
+            body='{"ok": true}',
+            status=200,
+            content_type="application/json",
+        )
+
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook(
+                type="dialog_submission",
+                callback_id=dialog["callback_id"],
+                data={"submission": {"resolve_type": "resolved:inNextRelease"}},
+            )
+            self.group = Group.objects.get(id=self.group.id)
+
+            assert resp.status_code == 200, resp.content
+            assert self.group.get_status() == GroupStatus.RESOLVED
+
+            update_data = json.loads(responses.calls[1].request.body)
+            expect_status = f"*Issue resolved by <@{self.external_id}>*"
+            assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+
     def test_permission_denied(self):
         user2 = self.create_user(is_superuser=False)
 
@@ -431,6 +628,18 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert resp.data["text"] == UNLINK_IDENTITY_MESSAGE.format(
             associate_url=associate_url, user_email=user2.email, org_name=self.organization.name
         )
+
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook(
+                action_data=[status_action], slack_user={"id": user2_identity.external_id}
+            )
+
+            assert resp.status_code == 200, resp.content
+            assert resp.data["response_type"] == "ephemeral"
+            assert not resp.data["replace_original"]
+            assert resp.data["text"] == UNLINK_IDENTITY_MESSAGE.format(
+                associate_url=associate_url, user_email=user2.email, org_name=self.organization.name
+            )
 
     @freeze_time("2021-01-14T12:27:28.303Z")
     @responses.activate
@@ -494,6 +703,25 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             user_email=self.user.email,
             org_name=self.organization.name,
         )
+
+        with self.feature("organizations:slack-block-kit"):
+            response = self.post_webhook(
+                type="dialog_submission",
+                callback_id=dialog["callback_id"],
+                data={"submission": {"resolve_type": "resolved"}},
+            )
+
+            assert response.status_code == 200, response.content
+            assert response.data["text"] == UNLINK_IDENTITY_MESSAGE.format(
+                associate_url=build_unlinking_url(
+                    integration_id=self.integration.id,
+                    slack_id=self.external_id,
+                    channel_id="C065W1189",
+                    response_url=self.response_url,
+                ),
+                user_email=self.user.email,
+                org_name=self.organization.name,
+            )
 
     @patch(
         "sentry.integrations.slack.requests.SlackRequest._check_signing_secret", return_value=True

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -878,8 +878,63 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
 
     @responses.activate
-    def test_resolve_issue_in_next_release_block_kit(self):
-        pass
+    def test_resolve_in_next_release_block_kit(self):
+        release = Release.objects.create(
+            organization_id=self.organization.id,
+            version="1.0",
+        )
+        release.add_project(self.project)
+        status_action = self.get_resolve_status_action()
+        original_message = self.get_original_message_block_kit(self.group.id)
+        # Expect request to open dialog on slack
+        responses.add(
+            method=responses.POST,
+            url="https://slack.com/api/views.open",
+            body='{"ok": true}',
+            status=200,
+            content_type="application/json",
+        )
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook_block_kit(
+                action_data=[status_action], original_message=original_message
+            )
+        assert resp.status_code == 200, resp.content
+
+        # Opening dialog should *not* cause the current message to be updated
+        assert resp.content == b""
+
+        data = json.loads(responses.calls[0].request.body)
+        assert data["trigger_id"] == self.trigger_id
+        assert "view" in data
+
+        view = json.loads(data["view"])
+        private_metadata = json.loads(view["private_metadata"])
+        assert int(private_metadata["issue"]) == self.group.id
+        assert private_metadata["orig_response_url"] == self.response_url
+
+        # Completing the dialog will update the message
+        responses.add(
+            method=responses.POST,
+            url=self.response_url,
+            body='{"ok": true}',
+            status=200,
+            content_type="application/json",
+        )
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook_block_kit(
+                type="view_submission",
+                private_metadata=json.dumps(private_metadata),
+                selected_option="resolved:inNextRelease",
+            )
+
+        assert resp.status_code == 200, resp.content
+        self.group = Group.objects.get(id=self.group.id)
+        assert self.group.get_status() == GroupStatus.RESOLVED
+
+        update_data = json.loads(responses.calls[1].request.body)
+
+        expect_status = f"*Issue resolved by <@{self.external_id}>*"
+        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
 
     def test_permission_denied(self):
         user2 = self.create_user(is_superuser=False)
@@ -909,6 +964,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         )
 
         with self.feature("organizations:slack-block-kit"):
+            # test backwards compatibility
             resp = self.post_webhook(
                 action_data=[status_action], slack_user={"id": user2_identity.external_id}
             )
@@ -921,7 +977,32 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             )
 
     def test_permission_denied_block_kit(self):
-        pass
+        user2 = self.create_user(is_superuser=False)
+        user2_identity = self.create_identity(
+            external_id="slack_id2",
+            identity_provider=self.idp,
+            user=user2,
+        )
+        status_action = self.get_ignore_status_action("Ignore", "ignored:forever")
+        original_message = self.get_original_message_block_kit(self.group.id)
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook_block_kit(
+                action_data=[status_action],
+                original_message=original_message,
+                slack_user={"id": user2_identity.external_id},
+            )
+        self.group = Group.objects.get(id=self.group.id)
+
+        associate_url = build_unlinking_url(
+            self.integration.id, "slack_id2", "C065W1189", self.response_url
+        )
+
+        assert resp.status_code == 200, resp.content
+        assert resp.data["response_type"] == "ephemeral"
+        assert not resp.data["replace_original"]
+        assert resp.data["text"] == UNLINK_IDENTITY_MESSAGE.format(
+            associate_url=associate_url, user_email=user2.email, org_name=self.organization.name
+        )
 
     @freeze_time("2021-01-14T12:27:28.303Z")
     @responses.activate
@@ -987,6 +1068,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         )
 
         with self.feature("organizations:slack-block-kit"):
+            # test backwards compatibility
             response = self.post_webhook(
                 type="dialog_submission",
                 callback_id=dialog["callback_id"],
@@ -1008,7 +1090,67 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
     @freeze_time("2021-01-14T12:27:28.303Z")
     @responses.activate
     def test_handle_submission_fail_block_kit(self):
-        pass
+        status_action = self.get_resolve_status_action()
+        original_message = self.get_original_message_block_kit(self.group.id)
+        # Expect request to open dialog on slack
+        responses.add(
+            method=responses.POST,
+            url="https://slack.com/api/views.open",
+            body='{"ok": true}',
+            status=200,
+            content_type="application/json",
+        )
+        with self.feature("organizations:slack-block-kit"):
+            resp = self.post_webhook_block_kit(
+                action_data=[status_action], original_message=original_message
+            )
+        assert resp.status_code == 200, resp.content
+
+        # Opening dialog should *not* cause the current message to be updated
+        assert resp.content == b""
+
+        data = json.loads(responses.calls[0].request.body)
+        assert data["trigger_id"] == self.trigger_id
+        assert "view" in data
+
+        view = json.loads(data["view"])
+        private_metadata = json.loads(view["private_metadata"])
+        assert int(private_metadata["issue"]) == self.group.id
+        assert private_metadata["orig_response_url"] == self.response_url
+
+        # Completing the dialog will update the message
+        responses.add(
+            method=responses.POST,
+            url=self.response_url,
+            body='{"ok": true}',
+            status=200,
+            content_type="application/json",
+        )
+
+        # Remove the user from the organization.
+        member = OrganizationMember.objects.get(
+            user_id=self.user.id, organization=self.organization
+        )
+        member.remove_user()
+        member.save()
+        with self.feature("organizations:slack-block-kit"):
+            response = self.post_webhook_block_kit(
+                type="view_submission",
+                private_metadata=json.dumps(private_metadata),
+                selected_option="resolved",
+            )
+
+        assert response.status_code == 200, response.content
+        assert response.data["text"] == UNLINK_IDENTITY_MESSAGE.format(
+            associate_url=build_unlinking_url(
+                integration_id=self.integration.id,
+                slack_id=self.external_id,
+                channel_id="C065W1189",
+                response_url=self.response_url,
+            ),
+            user_email=self.user.email,
+            org_name=self.organization.name,
+        )
 
     @patch(
         "sentry.integrations.slack.requests.SlackRequest._check_signing_secret", return_value=True


### PR DESCRIPTION
Build issue alerts using block kit instead of the legacy attachments format.

<img width="438" alt="Screenshot 2023-12-06 at 4 55 27 PM" src="https://github.com/getsentry/sentry/assets/29959063/447c0ffd-9cac-4e77-90e8-614745f40719">

I called this out in the [tech spec](https://www.notion.so/sentry/Rich-Slack-Notifications-Tech-Spec-867736397b4f4ef29b1d0251f5ae98c8?pvs=4#ad3fbedaed6d4c379a9406dee73de554) but we can't use the `color` param to indicate level via the lefthand indentation bar, there is no equivalent in block kit unless we pass things as attachments (which is the legacy format we're moving away from. 

**Resolve Modal**
<img width="533" alt="Screenshot 2023-12-07 at 2 25 01 PM" src="https://github.com/getsentry/sentry/assets/29959063/768927d0-fb3c-48ba-8df2-cb12bf393e16">

<img width="706" alt="Screenshot 2023-12-07 at 2 28 20 PM" src="https://github.com/getsentry/sentry/assets/29959063/2b6d50cb-a3a4-4ef5-99cb-30b5887132f3">

**Assignee Dropdown**
![Screenshot 2023-12-07 at 1 15 31 PM](https://github.com/getsentry/sentry/assets/29959063/67029380-e752-4f8d-b40d-e3714c59c4ed)

This supports backwards compatibility if the flag is turned on and users interact with legacy style Slack issue alert notifications.

Closes #61456 