### PR TITLE
feat(issue-details): Add analytics for number of event tags

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -30,6 +30,7 @@ export type BaseEventAnalyticsParams = {
   has_trace: boolean;
   is_symbolicated: boolean;
   num_commits: number;
+  num_event_tags: number;
   num_in_app_stack_frames: number;
   num_stack_frames: number;
   num_threads_with_names: number;

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -433,6 +433,7 @@ export function getAnalyticsDataForEvent(event?: Event | null): BaseEventAnalyti
   return {
     event_id: event?.eventID || '-1',
     num_commits: event?.release?.commitCount || 0,
+    num_event_tags: event?.tags?.length ?? 0,
     num_stack_frames: event ? getNumberOfStackFrames(event) : 0,
     num_in_app_stack_frames: event ? getNumberOfInAppStackFrames(event) : 0,
     num_threads_with_names: event ? getNumberOfThreadsWithNames(event) : 0,


### PR DESCRIPTION
We want to know how many tags we're dealing with in the tag cloud for our redesign.