### PR TITLE
ref(relocation): Swap feature flag for option [1/2]

### DIFF
--- a/src/sentry/api/endpoints/relocations/index.py
+++ b/src/sentry/api/endpoints/relocations/index.py
@@ -8,7 +8,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
+from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
@@ -97,7 +97,7 @@ class RelocationIndexEndpoint(Endpoint):
         """
 
         logger.info("post.start", extra={"caller": request.user.id})
-        if not features.has("relocation:enabled"):
+        if not options.get("relocation.enabled"):
             return Response({"detail": ERR_FEATURE_DISABLED}, status=400)
 
         serializer = RelocationPostSerializer(data=request.data)

--- a/src/sentry/api/endpoints/relocations/public_key.py
+++ b/src/sentry/api/endpoints/relocations/public_key.py
@@ -4,7 +4,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
+from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
@@ -35,7 +35,7 @@ class RelocationPublicKeyEndpoint(Endpoint):
         """
 
         logger.info("get.start", extra={"caller": request.user.id})
-        if not features.has("relocation:enabled"):
+        if not options.get("relocation.enabled"):
             return Response({"detail": ERR_FEATURE_DISABLED}, status=400)
 
         # TODO(getsentry/team-ospo#190): We should support per-user keys in the future.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1750,7 +1750,8 @@ register(
 )
 
 # Relocation
-#
+register("relocation.enabled", default=False)
+
 # Throttling limits for relocation requests
 register("relocation.daily-limit-small", default=0)
 register("relocation.daily-limit-medium", default=0)

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -53,8 +53,11 @@ class RelocationCreateTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with self.feature("relocation:enabled"), self.options(
-                {"relocation.daily-limit-small": 1}
+            with self.options(
+                {
+                    "relocation.enabled": True,
+                    "relocation.daily-limit-small": 1,
+                }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
@@ -99,8 +102,11 @@ class RelocationCreateTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with self.feature("relocation:enabled"), self.options(
-                {"relocation.daily-limit-small": 1}
+            with self.options(
+                {
+                    "relocation.enabled": True,
+                    "relocation.daily-limit-small": 1,
+                }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
@@ -153,8 +159,11 @@ class RelocationCreateTest(APITestCase):
     def test_fail_missing_file(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with self.feature("relocation:enabled"), self.options(
-                {"relocation.daily-limit-small": 1}
+            with self.options(
+                {
+                    "relocation.enabled": True,
+                    "relocation.daily-limit-small": 1,
+                }
             ):
                 response = self.client.post(
                     reverse(self.endpoint),
@@ -172,8 +181,11 @@ class RelocationCreateTest(APITestCase):
     def test_fail_missing_orgs(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with self.feature("relocation:enabled"), self.options(
-                {"relocation.daily-limit-small": 1}
+            with self.options(
+                {
+                    "relocation.enabled": True,
+                    "relocation.daily-limit-small": 1,
+                }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
@@ -199,8 +211,11 @@ class RelocationCreateTest(APITestCase):
     def test_fail_missing_owner(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with self.feature("relocation:enabled"), self.options(
-                {"relocation.daily-limit-small": 1}
+            with self.options(
+                {
+                    "relocation.enabled": True,
+                    "relocation.daily-limit-small": 1,
+                }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
@@ -226,8 +241,11 @@ class RelocationCreateTest(APITestCase):
     def test_fail_nonexistent_owner(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with self.feature("relocation:enabled"), self.options(
-                {"relocation.daily-limit-small": 1}
+            with self.options(
+                {
+                    "relocation.enabled": True,
+                    "relocation.daily-limit-small": 1,
+                }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
@@ -261,8 +279,11 @@ class RelocationCreateTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with self.feature("relocation:enabled"), self.options(
-                {"relocation.daily-limit-small": 1}
+            with self.options(
+                {
+                    "relocation.enabled": True,
+                    "relocation.daily-limit-small": 1,
+                }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
@@ -290,8 +311,11 @@ class RelocationCreateTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with self.feature("relocation:enabled"), self.options(
-                {"relocation.daily-limit-small": 1}
+            with self.options(
+                {
+                    "relocation.enabled": True,
+                    "relocation.daily-limit-small": 1,
+                }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
@@ -350,8 +374,12 @@ class RelocationCreateTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with self.feature("relocation:enabled"), self.options(
-                {"relocation.daily-limit-small": 1, "relocation.daily-limit-medium": 1}
+            with self.options(
+                {
+                    "relocation.enabled": True,
+                    "relocation.daily-limit-small": 1,
+                    "relocation.daily-limit-medium": 1,
+                }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:
@@ -406,8 +434,11 @@ class RelocationCreateTest(APITestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with self.feature("relocation:enabled"), self.options(
-                {"relocation.daily-limit-small": 1}
+            with self.options(
+                {
+                    "relocation.enabled": True,
+                    "relocation.daily-limit-small": 1,
+                }
             ), open(FRESH_INSTALL_PATH) as f, freeze_time("2023-11-28 00:00:00") as frozen_time:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:

--- a/tests/sentry/api/endpoints/relocations/test_public_key.py
+++ b/tests/sentry/api/endpoints/relocations/test_public_key.py
@@ -36,7 +36,7 @@ class RelocationPublicKeyTest(APITestCase):
     def test_success_simple(self, fake_kms_client: FakeKeyManagementServiceClient):
         self.mock_kms_client(fake_kms_client)
 
-        with self.feature("relocation:enabled"):
+        with self.options({"relocation.enabled": True}):
             response = self.client.get(reverse(self.endpoint), {})
 
         assert response.status_code == 200
@@ -57,7 +57,7 @@ class RelocationPublicKeyTest(APITestCase):
         fake_kms_client.get_public_key.return_value = None
         fake_kms_client.get_public_key.side_effect = GoogleAPIError("Test")
 
-        with self.feature("relocation:enabled"):
+        with self.options({"relocation.enabled": True}):
             response = self.client.get(reverse(self.endpoint), {})
 
         assert response.status_code == 500


### PR DESCRIPTION
This is the first of 2 PRs to remove the `relocation:enabled` feature flag, and replace it with the `relocation.enabled` option. This PR adds the option, but leaves the feature flag untouched. Once this is picked up by `getsentry`, the follow up PR removing the feature flag will roll as well.

Issue: getsentry/team-ospo#214