### PR TITLE
ref(replays): [4/4] migrate capacitor and angular onboarding docs

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -97,6 +97,10 @@ type ConfigurationType = {
    */
   description?: React.ReactNode;
   /**
+   * Header to be placed above the configuration
+   */
+  header?: React.ReactNode;
+  /**
    * The language of the code to be rendered (python, javascript, etc)
    */
   language?: string;
@@ -142,6 +146,7 @@ function getConfiguration({
   description,
   code,
   language,
+  header,
   additionalInfo,
   onCopy,
   onSelectAndCopy,
@@ -150,6 +155,7 @@ function getConfiguration({
   return (
     <Configuration>
       {description && <Description>{description}</Description>}
+      {header && <Header>{header}</Header>}
       {Array.isArray(code) ? (
         <TabbedCodeSnippet
           tabs={code}
@@ -235,6 +241,8 @@ const Description = styled('div')`
     color: ${p => p.theme.pink400};
   }
 `;
+
+const Header = styled(Description)``;
 
 const AdditionalInfo = styled(Description)``;
 

--- a/static/app/gettingStartedDocs/replay-onboarding/capacitor/capacitor.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/capacitor/capacitor.tsx
@@ -32,16 +32,67 @@ export const steps = ({
 }: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: t('Configure your app automatically with the Sentry wizard.'),
+    description: t(
+      'Install the Sentry Capacitor SDK alongside the corresponding Sentry SDK for the framework you are using.'
+    ),
     configurations: [
       {
         language: 'bash',
+        header: tct('Using [code:NPM:]', {code: <code />}),
         code: [
           {
-            label: 'Bash',
-            value: 'bash',
+            label: 'Angular',
+            value: 'angular',
             language: 'bash',
-            code: 'npx @sentry/wizard@latest -i remix',
+            code: `npm install --save @sentry/capacitor @sentry/angular-ivy`,
+          },
+          {
+            label: 'React',
+            value: 'react',
+            language: 'bash',
+            code: `npm install --save @sentry/capacitor @sentry/react`,
+          },
+          {
+            label: 'Vue',
+            value: 'vue',
+            language: 'bash',
+            code: `npm install --save @sentry/capacitor @sentry/vue`,
+          },
+          {
+            label: 'Other',
+            value: 'other',
+            language: 'bash',
+            code: `npm install --save @sentry/capacitor @sentry/browser`,
+          },
+        ],
+      },
+      {
+        language: 'bash',
+        header: tct('Using [code:Yarn:]', {code: <code />}),
+        code: [
+          {
+            label: 'Angular',
+            value: 'angular',
+            language: 'bash',
+            code: `yarn add @sentry/capacitor @sentry/angular-ivy`,
+          },
+          {
+            label: 'React',
+            value: 'react',
+            language: 'bash',
+            code: `yarn add @sentry/capacitor @sentry/react`,
+          },
+          {
+            label: 'Vue',
+            value: 'vue',
+            language: 'bash',
+            code: `yarn add @sentry/capacitor @sentry/vue`,
+          },
+          {
+            label: 'Other',
+            value: 'other',
+            language: 'bash',
+            code: `yarn add @sentry/capacitor @sentry/browser`,
           },
         ],
       },
@@ -62,7 +113,7 @@ export const steps = ({
       {
         language: 'javascript',
         code: `
-        import * as Sentry from "@sentry/remix";
+        import * as Sentry from "@sentry/capacitor";
 
         Sentry.init({
           ${sentryInitContent}
@@ -70,16 +121,12 @@ export const steps = ({
         `,
       },
     ],
-    additionalInfo: tct(
-      'Note: The Replay integration only needs to be added to your [codeEntry:entry.client.tsx] file. It will not run if it is added into [codeSentry:sentry.server.config.js].',
-      {codeEntry: <code />, codeSentry: <code />}
-    ),
   },
 ];
 
 // Configuration End
 
-export function GettingStartedWithRemixReplay({
+export function GettingStartedWithCapacitorReplay({
   dsn,
   organization,
   newOrg,
@@ -110,4 +157,4 @@ export function GettingStartedWithRemixReplay({
   );
 }
 
-export default GettingStartedWithRemixReplay;
+export default GettingStartedWithCapacitorReplay;

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/angular.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/angular.tsx
@@ -2,7 +2,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {t, tct} from 'sentry/locale';
+import {tct} from 'sentry/locale';
 import type {Organization, PlatformKey} from 'sentry/types';
 
 type StepProps = {
@@ -32,16 +32,25 @@ export const steps = ({
 }: Partial<StepProps> = {}): LayoutProps['steps'] => [
   {
     type: StepType.INSTALL,
-    description: t('Configure your app automatically with the Sentry wizard.'),
+    description: tct(
+      'In order to use Session Replay, you will need version 7.27.0 of [codeAngular:@sentry/angular] or [codeIvy:@sentry/angular-ivy] at minimum. You do not need to install any additional packages.',
+      {codeAngular: <code />, codeIvy: <code />}
+    ),
     configurations: [
       {
         language: 'bash',
         code: [
           {
-            label: 'Bash',
-            value: 'bash',
+            label: 'npm',
+            value: 'npm',
             language: 'bash',
-            code: 'npx @sentry/wizard@latest -i remix',
+            code: `# Angular 12 and newer: \nnpm install --save @sentry/angular-ivy \n\n# Angular 10 and 11: \nnpm install --save @sentry/angular`,
+          },
+          {
+            label: 'yarn',
+            value: 'yarn',
+            language: 'bash',
+            code: `# Angular 12 and newer:\nyarn add @sentry/angular-ivy\n\n# Angular 10 and 11:\nyarn add @sentry/angular`,
           },
         ],
       },
@@ -62,7 +71,7 @@ export const steps = ({
       {
         language: 'javascript',
         code: `
-        import * as Sentry from "@sentry/remix";
+        import * as Sentry from "@sentry/angular-ivy";
 
         Sentry.init({
           ${sentryInitContent}
@@ -70,16 +79,12 @@ export const steps = ({
         `,
       },
     ],
-    additionalInfo: tct(
-      'Note: The Replay integration only needs to be added to your [codeEntry:entry.client.tsx] file. It will not run if it is added into [codeSentry:sentry.server.config.js].',
-      {codeEntry: <code />, codeSentry: <code />}
-    ),
   },
 ];
 
 // Configuration End
 
-export function GettingStartedWithRemixReplay({
+export function GettingStartedWithAngularReplay({
   dsn,
   organization,
   newOrg,
@@ -110,4 +115,4 @@ export function GettingStartedWithRemixReplay({
   );
 }
 
-export default GettingStartedWithRemixReplay;
+export default GettingStartedWithAngularReplay;

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/gatsby.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/gatsby.tsx
@@ -1,5 +1,3 @@
-import {Fragment} from 'react';
-
 import ExternalLink from 'sentry/components/links/externalLink';
 import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
 import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
@@ -108,6 +106,15 @@ export const steps = ({
         `,
       },
     ],
+    additionalInfo: tct(
+      'Note: If [codeGatsby:gatsby-config.js] has any settings for the [codeSentry:@sentry/gatsby plugin], they need to be moved into [codeConfig:sentry.config.js]. The [codeGatsby:gatsby-config.js] file does not support non-serializable options, like [codeNew:new Replay()].',
+      {
+        codeGatsby: <code />,
+        codeSentry: <code />,
+        codeConfig: <code />,
+        codeNew: <code />,
+      }
+    ),
   },
 ];
 
@@ -128,33 +135,19 @@ export function GettingStartedWithGatsbyReplay({
   sentryInitContent = sentryInitContent.concat(otherConfigs);
 
   return (
-    <Fragment>
-      <Layout
-        steps={steps({
-          sentryInitContent: sentryInitContent.join('\n'),
-          organization,
-          newOrg,
-          platformKey,
-          projectId,
-        })}
-        platformKey={platformKey}
-        newOrg={newOrg}
-        hideHeader
-        {...props}
-      />
-      <div>
-        <br />
-        {tct(
-          'Note: If [codeGatsby:gatsby-config.js] has any settings for the [codeSentry:@sentry/gatsby plugin], they need to be moved into [codeConfig:sentry.config.js]. The [codeGatsby:gatsby-config.js] file does not support non-serializable options, like [codeNew:new Replay()].',
-          {
-            codeGatsby: <code />,
-            codeSentry: <code />,
-            codeConfig: <code />,
-            codeNew: <code />,
-          }
-        )}
-      </div>
-    </Fragment>
+    <Layout
+      steps={steps({
+        sentryInitContent: sentryInitContent.join('\n'),
+        organization,
+        newOrg,
+        platformKey,
+        projectId,
+      })}
+      platformKey={platformKey}
+      newOrg={newOrg}
+      hideHeader
+      {...props}
+    />
   );
 }
 

--- a/static/app/gettingStartedDocs/replay-onboarding/javascript/nextjs.tsx
+++ b/static/app/gettingStartedDocs/replay-onboarding/javascript/nextjs.tsx
@@ -50,13 +50,9 @@ export const steps = ({
   {
     type: StepType.CONFIGURE,
     description: tct(
-      'Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set using the [codeIntegrations:integrations] constructor. Learn more about configuring Session Replay by reading the [link:configuration docs]. [break] [break] Alert: The Replay integration must be added to your [codeClient:sentry.client.config.js] file. Adding it into [codeServer:sentry.server.config.js] or [codeEdge:sentry.edge.config.js] may break your build.',
+      'Add the following to your SDK config. There are several privacy and sampling options available, all of which can be set using the [codeIntegrations:integrations] constructor. Learn more about configuring Session Replay by reading the [link:configuration docs].',
       {
         codeIntegrations: <code />,
-        codeClient: <code />,
-        codeServer: <code />,
-        codeEdge: <code />,
-        break: <br />,
         link: (
           <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/" />
         ),
@@ -74,6 +70,10 @@ export const steps = ({
         `,
       },
     ],
+    additionalInfo: tct(
+      'Note: The Replay integration must be added to your [codeClient:sentry.client.config.js] file. Adding it into [codeServer:sentry.server.config.js] or [codeEdge:sentry.edge.config.js] may break your build.',
+      {codeClient: <code />, codeServer: <code />, codeEdge: <code />}
+    ),
   },
 ];
 


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/61001

Lots of refactoring to come to make these files slimmer and reduce duplication of code

<img width="492" alt="SCR-20231205-rpit" src="https://github.com/getsentry/sentry/assets/56095982/01924ed4-f84f-49ac-92b3-ad69db3c802b">
<img width="500" alt="SCR-20231205-rphc" src="https://github.com/getsentry/sentry/assets/56095982/1b1cb0ee-c436-46be-834c-311f1541858d">
