### PR TITLE
fix(COGS) Fix accountant test not to rely on atexit

### DIFF
--- a/tests/sentry/usage_accountant/test_accountant.py
+++ b/tests/sentry/usage_accountant/test_accountant.py
@@ -1,8 +1,6 @@
-import atexit
 from typing import Optional
 from unittest import mock
 
-import pytest
 from arroyo.backends.kafka.consumer import KafkaPayload
 from arroyo.backends.local.backend import LocalBroker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
@@ -36,7 +34,6 @@ def assert_msg(
     }
 
 
-@pytest.mark.skip(reason="usage of atexit breaks interpreter")
 @django_db_all
 @mock.patch("time.time")
 def test_accountant(mock_time: mock.Mock) -> None:
@@ -54,7 +51,7 @@ def test_accountant(mock_time: mock.Mock) -> None:
     record("resource_1", "feature_1", 100, UsageUnit.BYTES)
     record("resource_1", "feature_2", 100, UsageUnit.BYTES)
 
-    atexit._run_exitfuncs()
+    accountant._shutdown()
 
     msg1 = broker.consume(Partition(topic, 0), 0)
     assert_msg(


### PR DESCRIPTION
Using `atexit` in the test is making other tests fail. 
This should fix it.