### PR TITLE
fix(security): add email notification about failed MFA attempts

### DIFF
--- a/src/sentry/templates/sentry/emails/mfa-too-many-attempts.html
+++ b/src/sentry/templates/sentry/emails/mfa-too-many-attempts.html
@@ -1,0 +1,14 @@
+{% extends "sentry/emails/base.html" %}
+
+{% load i18n %}
+
+{% block main %}
+    <h3>Suspicious Activity Detected</h3>
+    <p>This is a notice that your Sentry account ({{ email }}) has failed multiple login attempts at the 2FA step from the following location:</p>
+    <p><small><pre>
+IP address: {{ ip_address }}
+Geolocation: {{ city }}, {{ country_code }}
+Date: {{ datetime|date:"N j, Y, P e" }}</pre></small></p>
+    <p>If you have lost your 2FA credentials, you can follow our <a href="https://help.sentry.io/account/account-settings/how-do-i-recover-my-account-if-i-lost-my-2fa-credentials/">account recovery steps here</a>.</p>
+    <p>If these logins are not from you, we recommend you log in to your Sentry account and reset your password under <a href="{{ url }}">your account security settings</a>. On the same account security page, we also recommend you click the “Sign out of all devices” button to remove all currently logged-in sessions of your account.</p>
+{% endblock %}

--- a/src/sentry/templates/sentry/emails/mfa-too-many-attempts.html
+++ b/src/sentry/templates/sentry/emails/mfa-too-many-attempts.html
@@ -7,7 +7,9 @@
     <p>This is a notice that your Sentry account ({{ email }}) has failed multiple login attempts at the 2FA step from the following location:</p>
     <p><small><pre>
 IP address: {{ ip_address }}
-Geolocation: {{ city }}, {{ country_code }}
+{% if geo %}
+Geolocation: {{ geo.city }}, {{ geo.country_code }}
+{% endif %}
 Date: {{ datetime|date:"N j, Y, P e" }}</pre></small></p>
     <p>If you have lost your 2FA credentials, you can follow our <a href="https://help.sentry.io/account/account-settings/how-do-i-recover-my-account-if-i-lost-my-2fa-credentials/">account recovery steps here</a>.</p>
     <p>If these logins are not from you, we recommend you log in to your Sentry account and reset your password under <a href="{{ url }}">your account security settings</a>. On the same account security page, we also recommend you click the “Sign out of all devices” button to remove all currently logged-in sessions of your account.</p>

--- a/src/sentry/templates/sentry/emails/mfa-too-many-attempts.html
+++ b/src/sentry/templates/sentry/emails/mfa-too-many-attempts.html
@@ -5,12 +5,12 @@
 {% block main %}
     <h3>Suspicious Activity Detected</h3>
     <p>This is a notice that your Sentry account ({{ email }}) has failed multiple login attempts at the 2FA step from the following location:</p>
-    <p><small><pre>
+    <p><pre>
 IP address: {{ ip_address }}
 {% if geo %}
 Geolocation: {{ geo.city }}, {{ geo.country_code }}
 {% endif %}
-Date: {{ datetime|date:"N j, Y, P e" }}</pre></small></p>
+Date: {{ datetime|date:"N j, Y, P e" }}</pre></p>
     <p>If you have lost your 2FA credentials, you can follow our <a href="https://help.sentry.io/account/account-settings/how-do-i-recover-my-account-if-i-lost-my-2fa-credentials/">account recovery steps here</a>.</p>
     <p>If these logins are not from you, we recommend you log in to your Sentry account and reset your password under <a href="{{ url }}">your account security settings</a>. On the same account security page, we also recommend you click the “Sign out of all devices” button to remove all currently logged-in sessions of your account.</p>
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/mfa-too-many-attempts.txt
+++ b/src/sentry/templates/sentry/emails/mfa-too-many-attempts.txt
@@ -1,0 +1,13 @@
+This is a notice that your Sentry account ({{ email }}) has failed multiple login attempts at the 2FA step from the following location:
+
+IP address: {{ ip_address }}
+Geolocation: {{ city }}, {{ country_code }}
+Date: {{ datetime|date:"N j, Y, P e" }}
+
+If you ave lost your 2FA credentials, you can follow our account recovery steps here:
+https://help.sentry.io/account/account-settings/how-do-i-recover-my-account-if-i-lost-my-2fa-credentials/
+
+If these logins are not from you, we recommend you log in to your Sentry account and reset your password under your account security settings:
+{{ url }}
+
+On the same account security page, we also recommend you click the “Sign out of all devices” button to remove all currently logged-in sessions of your account.

--- a/src/sentry/templates/sentry/emails/mfa-too-many-attempts.txt
+++ b/src/sentry/templates/sentry/emails/mfa-too-many-attempts.txt
@@ -1,10 +1,12 @@
 This is a notice that your Sentry account ({{ email }}) has failed multiple login attempts at the 2FA step from the following location:
 
 IP address: {{ ip_address }}
-Geolocation: {{ city }}, {{ country_code }}
+{% if geo %}
+Geolocation: {{ geo.city }}, {{ geo.country_code }}
+{% endif %}
 Date: {{ datetime|date:"N j, Y, P e" }}
 
-If you ave lost your 2FA credentials, you can follow our account recovery steps here:
+If you have lost your 2FA credentials, you can follow our account recovery steps here:
 https://help.sentry.io/account/account-settings/how-do-i-recover-my-account-if-i-lost-my-2fa-credentials/
 
 If these logins are not from you, we recommend you log in to your Sentry account and reset your password under your account security settings:

--- a/src/sentry/web/frontend/twofactor.py
+++ b/src/sentry/web/frontend/twofactor.py
@@ -116,18 +116,10 @@ class TwoFactorAuthView(BaseView):
         context = {
             "datetime": timezone.now(),
             "email": email,
+            "geo": geo_by_addr(ip_address),
             "ip_address": ip_address,
             "url": absolute_uri(reverse("sentry-account-settings-security")),
         }
-
-        geo = geo_by_addr(ip_address)
-        if geo:
-            context.update(
-                {
-                    "city": geo["city"],
-                    "country_code": geo["country_code"],
-                }
-            )
 
         subject = "Suspicious Activity Detected"
         template = "mfa-too-many-attempts"

--- a/tests/sentry/web/frontend/test_twofactor.py
+++ b/tests/sentry/web/frontend/test_twofactor.py
@@ -1,9 +1,15 @@
 from time import time
 from unittest import mock
 
+from django.core import mail
+from django.urls import reverse
+
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import control_silo_test
+from sentry.utils.http import absolute_uri
 
 
 @control_silo_test
@@ -72,3 +78,28 @@ class TwoFactorTest(TestCase):
             ("/auth/login/", 302),
             ("/organizations/new/", 302),
         ]
+
+    @mock.patch("sentry.auth.authenticators.TotpInterface.validate_otp", return_value=False)
+    @mock.patch("time.sleep")
+    def test_rate_limit(self, mock_validate, mock_sleep):
+        user = self.create_user()
+        interface = TotpInterface()
+        interface.enroll(user)
+
+        self.login_as(user)
+        self.session["_pending_2fa"] = [user.id, time() - 2]
+        self.save_session()
+        with freeze_time("2000-01-01"):
+            for _ in range(5 + 1):
+                with self.tasks(), outbox_runner():
+                    resp = self.client.post("/auth/2fa/", data={"otp": "123456"}, follow=False)
+        assert resp.status_code == 429
+        assert mock_validate.called
+
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+
+        assert msg.to == [user.email]
+        assert msg.subject == "[Sentry]Suspicious Activity Detected"
+        url = absolute_uri(reverse("sentry-account-settings-security"))
+        assert url in msg.body


### PR DESCRIPTION
1. Add a second harder rate limit on 2FA attempts (20 attempts / hour)
2. Add email notification in case of too many failed 2FA attempts:
<img width="743" alt="image" src="https://github.com/getsentry/sentry/assets/1127549/e56fa2b2-f331-49b7-a3fa-cd94d14abf6e">

3. Email notifications are also rate limited, not more than once per 30 minutes.