### PR TITLE
feat(ddm): Add `transaction.source` and improve implementation of parsing

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -82,6 +82,7 @@ _SEARCH_TO_PROTOCOL_FIELDS = {
     "http.method": "request.method",
     "http.url": "request.url",
     "http.referer": "request.headers.Referer",
+    "transaction.source": "transaction.source",
     # url is a tag extracted by Sentry itself, on Relay it's received as `request.url`
     "url": "request.url",
     "sdk.name": "sdk.name",
@@ -367,7 +368,7 @@ def _parse_search_query(
     # As first step, we transform the search query by applying basic transformations.
     tokens = _transform_search_query(tokens)
     if removed_blacklisted:
-        # As second step, if enabled, we remove elements from the query which are redundant.
+        # As second step, if enabled, we remove elements from the query which are blacklisted.
         tokens = _cleanup_query(_remove_blacklisted_search_filters(tokens))
 
     return tokens
@@ -628,6 +629,7 @@ def _is_standard_metrics_search_term(field: str) -> bool:
 
 
 def _is_on_demand_supported_field(field: str) -> bool:
+    # If it's a black listed field, we consider it as compatible with on demand.
     if field in _BLACKLISTED_METRIC_FIELDS:
         return True
 

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -238,10 +238,10 @@ _STANDARD_METRIC_FIELDS = [
     "browser.name",
     "os.name",
     "geo.country_code",
-    # These are skipped during on demand spec generation and will not be converted to metric extraction conditions
-    "event.type",
-    "project",
 ]
+
+# Query fields that we do not consider for the extraction since they are not needed.
+_BLACKLISTED_METRIC_FIELDS = ["event.type", "project"]
 
 # Operators used in ``ComparingRuleCondition``.
 CompareOp = Literal["eq", "gt", "gte", "lt", "lte", "glob"]
@@ -356,12 +356,21 @@ def _transform_search_query(query: Sequence[QueryToken]) -> Sequence[QueryToken]
     return transformed_query
 
 
-def _parse_search_query(query: Optional[str]) -> Sequence[QueryToken]:
+def _parse_search_query(
+    query: Optional[str], removed_blacklisted: bool = False
+) -> Sequence[QueryToken]:
     """
     Parses a search query with the discover grammar and performs some transformations on the AST in order to account for
     edge cases.
     """
-    return _transform_search_query(event_search.parse_search_query(query))
+    tokens = event_search.parse_search_query(query)
+    # As first step, we transform the search query by applying basic transformations.
+    tokens = _transform_search_query(tokens)
+    if removed_blacklisted:
+        # As second step, if enabled, we remove elements from the query which are redundant.
+        tokens = _cleanup_query(_remove_blacklisted_search_filters(tokens))
+
+    return tokens
 
 
 @dataclass(frozen=True)
@@ -528,7 +537,7 @@ def _get_groupbys_support(groupbys: Sequence[str]) -> SupportedBy:
 
 def _get_query_supported_by(query: Optional[str]) -> SupportedBy:
     try:
-        parsed_query = _parse_search_query(query)
+        parsed_query = _parse_search_query(query=query, removed_blacklisted=False)
 
         standard_metrics = _is_standard_metrics_query(parsed_query)
         on_demand_metrics = _is_on_demand_supported_query(parsed_query)
@@ -543,7 +552,6 @@ def _is_standard_metrics_query(tokens: Sequence[QueryToken]) -> bool:
     """
     Recursively checks if any of the supplied token contain search filters that can't be handled by standard metrics.
     """
-
     for token in tokens:
         if not _is_standard_metrics_search_filter(token):
             return False
@@ -565,7 +573,6 @@ def _is_on_demand_supported_query(tokens: Sequence[QueryToken]) -> bool:
     """
     Recursively checks if any of the supplied token contain search filters that can't be handled by standard metrics.
     """
-
     for token in tokens:
         if not _is_on_demand_supported_search_filter(token):
             return False
@@ -621,6 +628,9 @@ def _is_standard_metrics_search_term(field: str) -> bool:
 
 
 def _is_on_demand_supported_field(field: str) -> bool:
+    if field in _BLACKLISTED_METRIC_FIELDS:
+        return True
+
     try:
         _map_field_name(field)
         return True
@@ -646,7 +656,7 @@ def to_standard_metrics_query(query: str) -> str:
         "transaction.duration:>=1s AND browser.version:1" -> ""
     """
     try:
-        tokens = _parse_search_query(query)
+        tokens = _parse_search_query(query=query, removed_blacklisted=False)
     except InvalidSearchQuery:
         logger.error(f"Failed to parse search query: {query}", exc_info=True)
         raise
@@ -661,7 +671,7 @@ def to_standard_metrics_tokens(tokens: Sequence[QueryToken]) -> Sequence[QueryTo
     that has all on-demand filters removed and can be run using only standard metrics.
     """
     remaining_tokens = _remove_on_demand_search_filters(tokens)
-    cleaned_query = cleanup_query(remaining_tokens)
+    cleaned_query = _cleanup_query(remaining_tokens)
     return cleaned_query
 
 
@@ -680,7 +690,7 @@ def query_tokens_to_string(tokens: Sequence[QueryToken]) -> str:
 
 def _remove_on_demand_search_filters(tokens: Sequence[QueryToken]) -> Sequence[QueryToken]:
     """
-    removes tokens that contain filters that can only be handled by on demand metrics.
+    Removes tokens that contain filters that can only be handled by on demand metrics.
     """
     ret_val: List[QueryToken] = []
     for token in tokens:
@@ -691,26 +701,28 @@ def _remove_on_demand_search_filters(tokens: Sequence[QueryToken]) -> Sequence[Q
             ret_val.append(ParenExpression(_remove_on_demand_search_filters(token.children)))
         else:
             ret_val.append(token)
+
     return ret_val
 
 
-def _remove_event_type_and_project_filter(tokens: Sequence[QueryToken]) -> Sequence[QueryToken]:
+def _remove_blacklisted_search_filters(tokens: Sequence[QueryToken]) -> Sequence[QueryToken]:
     """
-    removes event.type: transaction and project:* from the query
+    Removes tokens that contain filters that are blacklisted.
     """
     ret_val: List[QueryToken] = []
     for token in tokens:
         if isinstance(token, SearchFilter):
-            if token.key.name not in ["event.type", "project"]:
+            if token.key.name not in _BLACKLISTED_METRIC_FIELDS:
                 ret_val.append(token)
         elif isinstance(token, ParenExpression):
-            ret_val.append(ParenExpression(_remove_event_type_and_project_filter(token.children)))
+            ret_val.append(ParenExpression(_remove_blacklisted_search_filters(token.children)))
         else:
             ret_val.append(token)
+
     return ret_val
 
 
-def cleanup_query(tokens: Sequence[QueryToken]) -> Sequence[QueryToken]:
+def _cleanup_query(tokens: Sequence[QueryToken]) -> Sequence[QueryToken]:
     """
     Recreates a valid query from an original query that has had on demand search filters removed.
 
@@ -729,9 +741,10 @@ def cleanup_query(tokens: Sequence[QueryToken]) -> Sequence[QueryToken]:
         if not isinstance(token, ParenExpression):
             removed_empty_parens.append(token)
         else:
-            children = cleanup_query(token.children)
+            children = _cleanup_query(token.children)
             if len(children) > 0:
                 removed_empty_parens.append(ParenExpression(children))
+
     # remove AND and OR operators at the start of the query
     while len(removed_empty_parens) > 0 and isinstance(removed_empty_parens[0], str):
         removed_empty_parens.pop(0)
@@ -761,6 +774,7 @@ def cleanup_query(tokens: Sequence[QueryToken]) -> Sequence[QueryToken]:
         elif previous_token is not None:
             ret_val.append(previous_token)
         previous_token = token
+
     # take care of the last token (if any)
     if previous_token is not None:
         ret_val.append(previous_token)
@@ -1249,9 +1263,8 @@ class OnDemandMetricSpec:
     def _parse_query(value: str) -> QueryParsingResult:
         """Parse query string into our internal AST format."""
         try:
-            conditions = _parse_search_query(value)
-            clean_conditions = cleanup_query(_remove_event_type_and_project_filter(conditions))
-            return QueryParsingResult(conditions=clean_conditions)
+            conditions = _parse_search_query(query=value, removed_blacklisted=True)
+            return QueryParsingResult(conditions=conditions)
         except InvalidSearchQuery as e:
             raise Exception(f"Invalid search query '{value}' in on demand spec: {e}")
 

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -364,11 +364,12 @@ def _parse_search_query(
     Parses a search query with the discover grammar and performs some transformations on the AST in order to account for
     edge cases.
     """
-    tokens = event_search.parse_search_query(query)
+    tokens = cast(Sequence[QueryToken], event_search.parse_search_query(query))
     # As first step, we transform the search query by applying basic transformations.
     tokens = _transform_search_query(tokens)
+
+    # As second step, if enabled, we remove elements from the query which are blacklisted.
     if removed_blacklisted:
-        # As second step, if enabled, we remove elements from the query which are blacklisted.
         tokens = _cleanup_query(_remove_blacklisted_search_filters(tokens))
 
     return tokens

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -20,51 +20,46 @@ from sentry.testutils.pytest.fixtures import django_db_all
 @pytest.mark.parametrize(
     "agg, query, result",
     [
-        # ("count()", "release:a", False),  # supported by standard metrics
-        # ("failure_rate()", "release:a", False),  # supported by standard metrics
-        # ("count_unique(geo.city)", "release:a", False),
-        # # geo.city not supported by standard metrics, but also not by on demand
-        # (
-        #     "count()",
-        #     "transaction.duration:>1",
-        #     True,
-        # ),  # transaction.duration not supported by standard metrics
-        # ("failure_count()", "transaction.duration:>1", True),  # supported by on demand
-        # ("failure_rate()", "transaction.duration:>1", True),  # supported by on demand
-        # ("apdex(10)", "", True),  # every apdex query is on-demand
-        # ("apdex(10)", "transaction.duration:>10", True),  # supported by on demand
-        # (
-        #     "count_if(transaction.duration,equals,0)",
-        #     "release:a",
-        #     False,
-        # ),  # count_if supported by standard metrics
-        # ("p75(transaction.duration)", "release:a", False),  # supported by standard metrics
-        # (
-        #     "p75(transaction.duration)",
-        #     "transaction.duration:>1",
-        #     True,
-        # ),  # transaction.duration query is on-demand
-        # ("count()", "", False),  # Malformed aggregate should return false
-        # (
-        #     "count()",
-        #     "event.type:error transaction.duration:>0",
-        #     False,
-        # ),  # event.type:error not supported by metrics
-        # (
-        #     "count()",
-        #     "event.type:default transaction.duration:>0",
-        #     False,
-        # ),  # event.type:error not supported by metrics
-        # (
-        #     "count()",
-        #     "error.handled:true transaction.duration:>0",
-        #     False,
-        # ),  # error.handled is an error search term
+        ("count()", "release:a", False),  # supported by standard metrics
+        ("failure_rate()", "release:a", False),  # supported by standard metrics
+        ("count_unique(geo.city)", "release:a", False),
+        # geo.city not supported by standard metrics, but also not by on demand
         (
-            "p95(transaction.duration)",
-            "(event.type:transaction) AND (event.type:transaction transaction:/gmeet/boards-picker.html project:google-meet-fe transaction.source:url)",
+            "count()",
+            "transaction.duration:>1",
             True,
-        )
+        ),  # transaction.duration not supported by standard metrics
+        ("failure_count()", "transaction.duration:>1", True),  # supported by on demand
+        ("failure_rate()", "transaction.duration:>1", True),  # supported by on demand
+        ("apdex(10)", "", True),  # every apdex query is on-demand
+        ("apdex(10)", "transaction.duration:>10", True),  # supported by on demand
+        (
+            "count_if(transaction.duration,equals,0)",
+            "release:a",
+            False,
+        ),  # count_if supported by standard metrics
+        ("p75(transaction.duration)", "release:a", False),  # supported by standard metrics
+        (
+            "p75(transaction.duration)",
+            "transaction.duration:>1",
+            True,
+        ),  # transaction.duration query is on-demand
+        ("count()", "", False),  # Malformed aggregate should return false
+        (
+            "count()",
+            "event.type:error transaction.duration:>0",
+            False,
+        ),  # event.type:error not supported by metrics
+        (
+            "count()",
+            "event.type:default transaction.duration:>0",
+            False,
+        ),  # event.type:error not supported by metrics
+        (
+            "count()",
+            "error.handled:true transaction.duration:>0",
+            False,
+        ),  # error.handled is an error search term
     ],
 )
 def test_should_use_on_demand(agg, query, result):
@@ -149,6 +144,7 @@ class TestCreatesOndemandMetricSpec:
                 "",
             ),  # apdex with specified threshold is on-demand metric even without query
             ("count()", "transaction.duration:>0 my-transaction"),
+            ("count()", "transaction.source:route"),
         ],
     )
     def test_creates_on_demand_spec(self, aggregate, query):


### PR DESCRIPTION
This PR adds the `transaction.source` to the list of event fields that are supported by Relay (PR for Relay here: https://github.com/getsentry/relay/pull/2820) and also makes some driveby improvements.

The improvements involve making it more explicit that we have a blacklist of fields that are removed by the query parsing. This also encapsulates the blacklisting removal behavior in a single parsing function.

Closes https://github.com/getsentry/sentry/issues/61121