### PR TITLE
ref(ts): Remove usage of `TestStubs.Team`

### DIFF
--- a/fixtures/js-stubs/team.tsx
+++ b/fixtures/js-stubs/team.tsx
@@ -1,6 +1,6 @@
 import {uuid4} from '@sentry/utils';
 
-import type {Team as TeamType} from 'sentry/types';
+import type {DetailedTeam as TeamType} from 'sentry/types';
 
 export function Team(params: Partial<TeamType> = {}): TeamType {
   return {
@@ -17,6 +17,7 @@ export function Team(params: Partial<TeamType> = {}): TeamType {
       'idp:provisioned': false,
     },
     externalTeams: [],
+    projects: [],
     hasAccess: false,
     isPending: false,
     ...params,

--- a/static/app/actionCreators/onboardingTasks.spec.tsx
+++ b/static/app/actionCreators/onboardingTasks.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {updateOnboardingTask} from 'sentry/actionCreators/onboardingTasks';
 import ConfigStore from 'sentry/stores/configStore';

--- a/static/app/actionCreators/onboardingTasks.spec.tsx
+++ b/static/app/actionCreators/onboardingTasks.spec.tsx
@@ -14,7 +14,7 @@ describe('actionCreators/onboardingTasks', function () {
   describe('updateOnboardingTask', function () {
     it('Adds the task to the organization when task does not exists', async function () {
       const detailedOrg = Organization({
-        teams: [TestStubs.Team()],
+        teams: [Team()],
         projects: [TestStubs.Project()],
       });
 
@@ -42,7 +42,7 @@ describe('actionCreators/onboardingTasks', function () {
 
     it('Updates existing onboarding task', async function () {
       const detailedOrg = Organization({
-        teams: [TestStubs.Team()],
+        teams: [Team()],
         projects: [TestStubs.Project()],
         onboardingTasks: [{task: OnboardingTaskKey.FIRST_EVENT, status: 'skipped'}],
       });
@@ -73,7 +73,7 @@ describe('actionCreators/onboardingTasks', function () {
 
     it('Does not make API request without api object', async function () {
       const detailedOrg = Organization({
-        teams: [TestStubs.Team()],
+        teams: [Team()],
         projects: [TestStubs.Project()],
       });
 

--- a/static/app/actionCreators/organization.spec.tsx
+++ b/static/app/actionCreators/organization.spec.tsx
@@ -10,7 +10,7 @@ import TeamStore from 'sentry/stores/teamStore';
 describe('OrganizationActionCreator', function () {
   const org = Organization();
 
-  const teams = [TestStubs.Team()];
+  const teams = [Team()];
   const projects = [TestStubs.Project()];
 
   const api = new MockApiClient();

--- a/static/app/actionCreators/organization.spec.tsx
+++ b/static/app/actionCreators/organization.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organization';
 import * as OrganizationsActionCreator from 'sentry/actionCreators/organizations';

--- a/static/app/components/acl/access.spec.tsx
+++ b/static/app/components/acl/access.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/components/acl/access.spec.tsx
+++ b/static/app/components/acl/access.spec.tsx
@@ -46,7 +46,7 @@ describe('Access', function () {
       const org = Organization({access: []});
       const nextRouterContext = TestStubs.routerContext([{organization: org}]);
 
-      const team1 = TestStubs.Team({access: []});
+      const team1 = Team({access: []});
       render(
         <Access access={['team:admin']} team={team1}>
           {childrenMock}
@@ -61,7 +61,7 @@ describe('Access', function () {
         })
       );
 
-      const team2 = TestStubs.Team({
+      const team2 = Team({
         access: ['team:read', 'team:write', 'team:admin'],
       });
       render(

--- a/static/app/components/assigneeSelector.spec.tsx
+++ b/static/app/components/assigneeSelector.spec.tsx
@@ -1,3 +1,5 @@
+import {Team} from 'sentry-fixture/team';
+
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {openInviteMembersModal} from 'sentry/actionCreators/modal';

--- a/static/app/components/assigneeSelector.spec.tsx
+++ b/static/app/components/assigneeSelector.spec.tsx
@@ -46,7 +46,7 @@ describe('AssigneeSelector', () => {
       team_slug: 'cool-team2',
     });
 
-    TEAM_1 = TestStubs.Team({
+    TEAM_1 = Team({
       id: '3',
       name: 'COOL TEAM',
       slug: 'cool-team',

--- a/static/app/components/avatar/avatarList.spec.tsx
+++ b/static/app/components/avatar/avatarList.spec.tsx
@@ -1,3 +1,5 @@
+import {Team} from 'sentry-fixture/team';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import AvatarList from 'sentry/components/avatar/avatarList';

--- a/static/app/components/avatar/avatarList.spec.tsx
+++ b/static/app/components/avatar/avatarList.spec.tsx
@@ -14,7 +14,7 @@ function renderComponent({
 
 describe('AvatarList', () => {
   const user = TestStubs.User();
-  const team = TestStubs.Team();
+  const team = Team();
 
   it('renders with user letter avatars', () => {
     const users = [

--- a/static/app/components/avatar/index.spec.tsx
+++ b/static/app/components/avatar/index.spec.tsx
@@ -1,5 +1,6 @@
 import {Organization} from 'sentry-fixture/organization';
 import {SentryApp} from 'sentry-fixture/sentryApp';
+import {Team} from 'sentry-fixture/team';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/components/avatar/index.spec.tsx
+++ b/static/app/components/avatar/index.spec.tsx
@@ -134,7 +134,7 @@ describe('Avatar', function () {
     });
 
     it('can display a team Avatar', function () {
-      const team = TestStubs.Team({slug: 'test-team_test'});
+      const team = Team({slug: 'test-team_test'});
 
       render(<AvatarComponent team={team} />);
 

--- a/static/app/components/group/assignedTo.spec.tsx
+++ b/static/app/components/group/assignedTo.spec.tsx
@@ -2,6 +2,7 @@ import {Commit} from 'sentry-fixture/commit';
 import {CommitAuthor} from 'sentry-fixture/commitAuthor';
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -15,14 +16,14 @@ import type {
   Group,
   Organization as TOrganization,
   Project,
-  Team,
+  Team as TTeam,
   User,
 } from 'sentry/types';
 
 describe('Group > AssignedTo', () => {
   let USER_1!: User;
   let USER_2!: User;
-  let TEAM_1!: Team;
+  let TEAM_1!: TTeam;
   let PROJECT_1!: Project;
   let GROUP_1!: Group;
   let event!: Event;

--- a/static/app/components/group/assignedTo.spec.tsx
+++ b/static/app/components/group/assignedTo.spec.tsx
@@ -16,14 +16,14 @@ import type {
   Group,
   Organization as TOrganization,
   Project,
-  Team as TTeam,
+  Team as TeamType,
   User,
 } from 'sentry/types';
 
 describe('Group > AssignedTo', () => {
   let USER_1!: User;
   let USER_2!: User;
-  let TEAM_1!: TTeam;
+  let TEAM_1!: TeamType;
   let PROJECT_1!: Project;
   let GROUP_1!: Group;
   let event!: Event;

--- a/static/app/components/group/assignedTo.spec.tsx
+++ b/static/app/components/group/assignedTo.spec.tsx
@@ -42,7 +42,7 @@ describe('Group > AssignedTo', () => {
       email: 'johnsmith@example.com',
     });
 
-    TEAM_1 = TestStubs.Team({
+    TEAM_1 = Team({
       id: '3',
       name: 'COOL TEAM',
       slug: 'cool-team',

--- a/static/app/components/idBadge/index.spec.tsx
+++ b/static/app/components/idBadge/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/components/idBadge/index.spec.tsx
+++ b/static/app/components/idBadge/index.spec.tsx
@@ -13,7 +13,7 @@ describe('IdBadge', function () {
   });
 
   it('renders the correct component when `team` property is passed', function () {
-    render(<IdBadge team={TestStubs.Team()} />);
+    render(<IdBadge team={Team()} />);
     expect(screen.getByTestId('badge-styled-avatar')).toHaveTextContent('TS');
     expect(screen.getByTestId('badge-display-name')).toHaveTextContent('#team-slug');
   });

--- a/static/app/components/idBadge/teamBadge/index.spec.tsx
+++ b/static/app/components/idBadge/teamBadge/index.spec.tsx
@@ -9,13 +9,13 @@ describe('TeamBadge', function () {
   });
 
   it('renders with Avatar and team name', function () {
-    render(<TeamBadge team={TestStubs.Team()} />);
+    render(<TeamBadge team={Team()} />);
     expect(screen.getByTestId('badge-styled-avatar')).toBeInTheDocument();
     expect(screen.getByText(/#team-slug/)).toBeInTheDocument();
   });
 
   it('listens for avatar changes from TeamStore', async function () {
-    const team = TestStubs.Team();
+    const team = Team();
     render(<TeamBadge team={team} />);
 
     act(() => {
@@ -29,9 +29,9 @@ describe('TeamBadge', function () {
   });
 
   it('updates state from props', async function () {
-    const team = TestStubs.Team();
+    const team = Team();
     const {rerender} = render(<TeamBadge team={team} />);
-    rerender(<TeamBadge team={TestStubs.Team({slug: 'new-team-slug'})} />);
+    rerender(<TeamBadge team={Team({slug: 'new-team-slug'})} />);
     expect(await screen.findByText(/#new-team-slug/)).toBeInTheDocument();
   });
 });

--- a/static/app/components/idBadge/teamBadge/index.spec.tsx
+++ b/static/app/components/idBadge/teamBadge/index.spec.tsx
@@ -1,3 +1,5 @@
+import {Team} from 'sentry-fixture/team';
+
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {TeamBadge} from 'sentry/components/idBadge/teamBadge';

--- a/static/app/components/modals/commandPalette.spec.tsx
+++ b/static/app/components/modals/commandPalette.spec.tsx
@@ -31,7 +31,7 @@ function renderMockRequests() {
 
   MockApiClient.addMockResponse({
     url: '/organizations/org-slug/teams/',
-    body: [TestStubs.Team({slug: 'foo-team'})],
+    body: [Team({slug: 'foo-team'})],
   });
 
   MockApiClient.addMockResponse({

--- a/static/app/components/modals/commandPalette.spec.tsx
+++ b/static/app/components/modals/commandPalette.spec.tsx
@@ -1,5 +1,6 @@
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/components/modals/helpSearchModal.spec.tsx
+++ b/static/app/components/modals/helpSearchModal.spec.tsx
@@ -21,7 +21,7 @@ describe('Docs Search Modal', function () {
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/teams/',
-      body: [TestStubs.Team({slug: 'foo-team'})],
+      body: [Team({slug: 'foo-team'})],
     });
 
     MockApiClient.addMockResponse({

--- a/static/app/components/modals/helpSearchModal.spec.tsx
+++ b/static/app/components/modals/helpSearchModal.spec.tsx
@@ -1,5 +1,6 @@
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';

--- a/static/app/components/modals/inviteMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.spec.tsx
@@ -1,6 +1,7 @@
 import selectEvent from 'react-select-event';
 import styled from '@emotion/styled';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';

--- a/static/app/components/modals/inviteMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.spec.tsx
@@ -12,7 +12,7 @@ import InviteMembersModal, {
 import TeamStore from 'sentry/stores/teamStore';
 
 describe('InviteMembersModal', function () {
-  const team = TestStubs.Team();
+  const team = Team();
   const org = Organization({access: ['member:write'], teams: [team]});
   TeamStore.loadInitialData([team]);
 

--- a/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
@@ -2,6 +2,7 @@ import selectEvent from 'react-select-event';
 import styled from '@emotion/styled';
 import {MissingMembers} from 'sentry-fixture/missingMembers';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
@@ -32,7 +32,7 @@ const mockRefObject = {
 };
 
 describe('InviteMissingMembersModal', function () {
-  const team = TestStubs.Team();
+  const team = Team();
   const org = Organization({access: ['member:write'], teams: [team]});
   TeamStore.loadInitialData([team]);
   const missingMembers = MissingMembers();

--- a/static/app/components/modals/teamAccessRequestModal.spec.tsx
+++ b/static/app/components/modals/teamAccessRequestModal.spec.tsx
@@ -14,7 +14,7 @@ describe('TeamAccessRequestModal', function () {
   const closeModal = jest.fn();
   const orgId = Organization().slug;
   const memberId = TestStubs.Member().id;
-  const teamId = TestStubs.Team().slug;
+  const teamId = Team().slug;
 
   const styledWrapper = styled(c => c.children);
   const modalRenderProps: CreateTeamAccessRequestModalProps = {

--- a/static/app/components/modals/teamAccessRequestModal.spec.tsx
+++ b/static/app/components/modals/teamAccessRequestModal.spec.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/components/noProjectMessage.spec.tsx
+++ b/static/app/components/noProjectMessage.spec.tsx
@@ -47,7 +47,7 @@ describe('NoProjectMessage', function () {
   it('shows "Create Project" button when user has team-level access', function () {
     ProjectsStore.loadInitialData([]);
     TeamStore.loadInitialData([
-      {...TestStubs.Team(), access: ['team:admin', 'team:write', 'team:read']},
+      {...Team(), access: ['team:admin', 'team:write', 'team:read']},
     ]);
 
     // No org-level access

--- a/static/app/components/noProjectMessage.spec.tsx
+++ b/static/app/components/noProjectMessage.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/components/search/sources/apiSource.spec.tsx
+++ b/static/app/components/search/sources/apiSource.spec.tsx
@@ -48,7 +48,7 @@ describe('ApiSource', function () {
     });
     teamsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/teams/',
-      body: [TestStubs.Team({slug: 'foo-team'})],
+      body: [Team({slug: 'foo-team'})],
     });
     membersMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/',

--- a/static/app/components/search/sources/apiSource.spec.tsx
+++ b/static/app/components/search/sources/apiSource.spec.tsx
@@ -4,6 +4,7 @@ import {EventIdQueryResult} from 'sentry-fixture/eventIdQueryResult';
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
 import {ShortIdQueryResult} from 'sentry-fixture/shortIdQueryResult';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';

--- a/static/app/components/teamSelector.spec.tsx
+++ b/static/app/components/teamSelector.spec.tsx
@@ -33,7 +33,7 @@ const teamData = [
     name: 'Team 3',
   },
 ];
-const teams = teamData.map(data => TestStubs.Team(data));
+const teams = teamData.map(data => Team(data));
 const project = TestStubs.Project({teams: [teams[0]]});
 const organization = Organization({access: ['project:write']});
 act(() => OrganizationStore.onUpdate(organization, {replace: true}));

--- a/static/app/components/teamSelector.spec.tsx
+++ b/static/app/components/teamSelector.spec.tsx
@@ -1,5 +1,6 @@
 import selectEvent from 'react-select-event';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/stores/teamStore.spec.tsx
+++ b/static/app/stores/teamStore.spec.tsx
@@ -1,3 +1,5 @@
+import {Team} from 'sentry-fixture/team';
+
 import TeamStore from 'sentry/stores/teamStore';
 
 describe('TeamStore', function () {

--- a/static/app/stores/teamStore.spec.tsx
+++ b/static/app/stores/teamStore.spec.tsx
@@ -1,11 +1,11 @@
 import TeamStore from 'sentry/stores/teamStore';
 
 describe('TeamStore', function () {
-  const teamFoo = TestStubs.Team({
+  const teamFoo = Team({
     id: '1',
     slug: 'team-foo',
   });
-  const teamBar = TestStubs.Team({
+  const teamBar = Team({
     id: '2',
     slug: 'team-bar',
   });

--- a/static/app/stores/useLegacyStore.spec.tsx
+++ b/static/app/stores/useLegacyStore.spec.tsx
@@ -4,7 +4,7 @@ import TeamStore from 'sentry/stores/teamStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 
 describe('useLegacyStore', () => {
-  const team = TestStubs.Team();
+  const team = Team();
 
   beforeEach(() => void TeamStore.reset());
 

--- a/static/app/stores/useLegacyStore.spec.tsx
+++ b/static/app/stores/useLegacyStore.spec.tsx
@@ -1,3 +1,5 @@
+import {Team} from 'sentry-fixture/team';
+
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
 import TeamStore from 'sentry/stores/teamStore';

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -101,6 +101,10 @@ export interface Team {
   orgRole?: string | null;
 }
 
+export interface DetailedTeam extends Team {
+  projects: Project[];
+}
+
 // TODO: Rename to BaseRole
 export interface MemberRole {
   desc: string;

--- a/static/app/utils/discover/teamKeyTransactionField.spec.tsx
+++ b/static/app/utils/discover/teamKeyTransactionField.spec.tsx
@@ -10,8 +10,8 @@ import TeamKeyTransactionField from 'sentry/utils/discover/teamKeyTransactionFie
 describe('TeamKeyTransactionField', function () {
   const organization = Organization();
   const teams = [
-    TestStubs.Team({id: '1', slug: 'team1', name: 'Team 1'}),
-    TestStubs.Team({id: '2', slug: 'team2', name: 'Team 2'}),
+    Team({id: '1', slug: 'team1', name: 'Team 1'}),
+    Team({id: '2', slug: 'team2', name: 'Team 2'}),
   ];
   const project = TestStubs.Project({teams});
 

--- a/static/app/utils/discover/teamKeyTransactionField.spec.tsx
+++ b/static/app/utils/discover/teamKeyTransactionField.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/utils/getProjectsByTeams.spec.tsx
+++ b/static/app/utils/getProjectsByTeams.spec.tsx
@@ -1,3 +1,5 @@
+import {Team} from 'sentry-fixture/team';
+
 import getProjectsByTeams from 'sentry/utils/getProjectsByTeams';
 
 describe('getProjectsByTeams', function () {

--- a/static/app/utils/getProjectsByTeams.spec.tsx
+++ b/static/app/utils/getProjectsByTeams.spec.tsx
@@ -3,8 +3,8 @@ import getProjectsByTeams from 'sentry/utils/getProjectsByTeams';
 describe('getProjectsByTeams', function () {
   let projectsByTeams;
   beforeEach(function () {
-    const team1 = TestStubs.Team({id: '1', slug: 'team1'});
-    const team2 = TestStubs.Team({id: '2', slug: 'team2'});
+    const team1 = Team({id: '1', slug: 'team1'});
+    const team2 = Team({id: '2', slug: 'team2'});
     const teams = [team1, team2];
     const projects = [
       TestStubs.Project({slug: 'project1', teams}),

--- a/static/app/utils/projects.spec.tsx
+++ b/static/app/utils/projects.spec.tsx
@@ -205,7 +205,7 @@ describe('utils.projects', function () {
         )
       );
 
-      const newTeam = TestStubs.Team();
+      const newTeam = Team();
       act(() => ProjectsStore.onAddTeam(newTeam, 'foo'));
 
       await waitFor(() =>
@@ -650,7 +650,7 @@ describe('utils.projects', function () {
         )
       );
 
-      const newTeam = TestStubs.Team();
+      const newTeam = Team();
       act(() => ProjectsStore.onAddTeam(newTeam, 'a'));
 
       // Expect new team information to be available

--- a/static/app/utils/projects.spec.tsx
+++ b/static/app/utils/projects.spec.tsx
@@ -1,3 +1,5 @@
+import {Team} from 'sentry-fixture/team';
+
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';

--- a/static/app/utils/teams.spec.tsx
+++ b/static/app/utils/teams.spec.tsx
@@ -8,8 +8,8 @@ describe('utils.teams', function () {
 
   beforeEach(function () {
     TeamStore.loadInitialData([
-      TestStubs.Team({id: '1', slug: 'bar'}),
-      TestStubs.Team({id: '2', slug: 'foo'}),
+      Team({id: '1', slug: 'bar'}),
+      Team({id: '2', slug: 'foo'}),
     ]);
     renderer.mockClear();
   });

--- a/static/app/utils/teams.spec.tsx
+++ b/static/app/utils/teams.spec.tsx
@@ -1,3 +1,5 @@
+import {Team} from 'sentry-fixture/team';
+
 import {act, render} from 'sentry-test/reactTestingLibrary';
 
 import TeamStore from 'sentry/stores/teamStore';

--- a/static/app/utils/useTeams.spec.tsx
+++ b/static/app/utils/useTeams.spec.tsx
@@ -9,7 +9,7 @@ import {useTeams} from 'sentry/utils/useTeams';
 describe('useTeams', function () {
   const org = Organization();
 
-  const mockTeams = [TestStubs.Team()];
+  const mockTeams = [Team()];
 
   beforeEach(function () {
     TeamStore.reset();
@@ -27,8 +27,8 @@ describe('useTeams', function () {
 
   it('loads more teams when using onSearch', async function () {
     TeamStore.loadInitialData(mockTeams);
-    const newTeam2 = TestStubs.Team({id: '2', slug: 'test-team2'});
-    const newTeam3 = TestStubs.Team({id: '3', slug: 'test-team3'});
+    const newTeam2 = Team({id: '2', slug: 'test-team2'});
+    const newTeam3 = Team({id: '3', slug: 'test-team3'});
 
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/teams/`,
@@ -62,8 +62,8 @@ describe('useTeams', function () {
   });
 
   it('provides only the users teams', function () {
-    const userTeams = [TestStubs.Team({id: '1', isMember: true})];
-    const nonUserTeams = [TestStubs.Team({id: '2', isMember: false})];
+    const userTeams = [Team({id: '1', isMember: true})];
+    const nonUserTeams = [Team({id: '2', isMember: false})];
     TeamStore.loadInitialData([...userTeams, ...nonUserTeams], false, null);
 
     const {result} = reactHooks.renderHook(useTeams, {
@@ -77,7 +77,7 @@ describe('useTeams', function () {
 
   it('provides only the specified slugs', async function () {
     TeamStore.loadInitialData(mockTeams);
-    const teamFoo = TestStubs.Team({slug: 'foo'});
+    const teamFoo = Team({slug: 'foo'});
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/teams/`,
       method: 'GET',

--- a/static/app/utils/useTeams.spec.tsx
+++ b/static/app/utils/useTeams.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/utils/withIssueTags.spec.tsx
+++ b/static/app/utils/withIssueTags.spec.tsx
@@ -99,8 +99,8 @@ describe('withIssueTags HoC', function () {
   it('groups assignees and puts suggestions first', function () {
     const Container = withIssueTags(MyComponent);
     TeamStore.loadInitialData([
-      Team({id: 1, slug: 'best-team', name: 'Best Team', isMember: true}),
-      Team({id: 2, slug: 'worst-team', name: 'Worst Team', isMember: false}),
+      Team({id: '1', slug: 'best-team', name: 'Best Team', isMember: true}),
+      Team({id: '2', slug: 'worst-team', name: 'Worst Team', isMember: false}),
     ]);
     MemberListStore.loadInitialData([
       TestStubs.User(),

--- a/static/app/utils/withIssueTags.spec.tsx
+++ b/static/app/utils/withIssueTags.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/utils/withIssueTags.spec.tsx
+++ b/static/app/utils/withIssueTags.spec.tsx
@@ -76,7 +76,7 @@ describe('withIssueTags HoC', function () {
 
     act(() => {
       TeamStore.loadInitialData([
-        TestStubs.Team({slug: 'best-team-na', name: 'Best Team NA', isMember: true}),
+        Team({slug: 'best-team-na', name: 'Best Team NA', isMember: true}),
       ]);
       MemberListStore.loadInitialData([
         TestStubs.User(),
@@ -98,8 +98,8 @@ describe('withIssueTags HoC', function () {
   it('groups assignees and puts suggestions first', function () {
     const Container = withIssueTags(MyComponent);
     TeamStore.loadInitialData([
-      TestStubs.Team({id: 1, slug: 'best-team', name: 'Best Team', isMember: true}),
-      TestStubs.Team({id: 2, slug: 'worst-team', name: 'Worst Team', isMember: false}),
+      Team({id: 1, slug: 'best-team', name: 'Best Team', isMember: true}),
+      Team({id: 2, slug: 'worst-team', name: 'Worst Team', isMember: false}),
     ]);
     MemberListStore.loadInitialData([
       TestStubs.User(),

--- a/static/app/views/acceptProjectTransfer/index.spec.tsx
+++ b/static/app/views/acceptProjectTransfer/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/acceptProjectTransfer/index.spec.tsx
+++ b/static/app/views/acceptProjectTransfer/index.spec.tsx
@@ -20,7 +20,7 @@ describe('AcceptProjectTransfer', function () {
       method: 'GET',
       body: {
         project: TestStubs.Project(),
-        organizations: [Organization({teams: [TestStubs.Team()]})],
+        organizations: [Organization({teams: [Team()]})],
       },
     });
 
@@ -51,7 +51,7 @@ describe('AcceptProjectTransfer', function () {
       method: 'GET',
       body: {
         project: TestStubs.Project(),
-        organizations: [Organization({teams: [TestStubs.Team()]})],
+        organizations: [Organization({teams: [Team()]})],
       },
       match: [(_url, options) => options.host === 'http://us.sentry.io'],
     });

--- a/static/app/views/alerts/list/incidents/index.spec.tsx
+++ b/static/app/views/alerts/list/incidents/index.spec.tsx
@@ -223,7 +223,7 @@ describe('IncidentsList', () => {
   });
 
   it('displays owner from alert rule', async () => {
-    const team = TestStubs.Team();
+    const team = Team();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/incidents/',
       body: [

--- a/static/app/views/alerts/list/incidents/index.spec.tsx
+++ b/static/app/views/alerts/list/incidents/index.spec.tsx
@@ -2,6 +2,7 @@ import selectEvent from 'react-select-event';
 import {Incident} from 'sentry-fixture/incident';
 import {IncidentStats} from 'sentry-fixture/incidentStats';
 import {MetricRule} from 'sentry-fixture/metricRule';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
@@ -27,7 +27,7 @@ describe('AlertRulesList', () => {
   const defaultOrg = Organization({
     access: ['alerts:write'],
   });
-  TeamStore.loadInitialData([TestStubs.Team()], false, null);
+  TeamStore.loadInitialData([Team()], false, null);
   let rulesMock!: jest.Mock;
   let projectMock!: jest.Mock;
   const pageLinks =
@@ -65,7 +65,7 @@ describe('AlertRulesList', () => {
         TestStubs.Project({
           slug: 'earth',
           platform: 'javascript',
-          teams: [TestStubs.Team()],
+          teams: [Team()],
         }),
       ],
     });

--- a/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
@@ -2,6 +2,7 @@ import {Incident} from 'sentry-fixture/incident';
 import {MetricRule} from 'sentry-fixture/metricRule';
 import {Organization} from 'sentry-fixture/organization';
 import {ProjectAlertRule} from 'sentry-fixture/projectAlertRule';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {

--- a/static/app/views/discover/tags.spec.tsx
+++ b/static/app/views/discover/tags.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {

--- a/static/app/views/discover/tags.spec.tsx
+++ b/static/app/views/discover/tags.spec.tsx
@@ -26,7 +26,7 @@ const commonQueryConditions = {
   topEvents: '',
   yAxis: '',
   createdBy: TestStubs.User(),
-  team: TestStubs.Team(),
+  team: Team(),
   statsPeriod: '14d',
 };
 

--- a/static/app/views/discover/tags.spec.tsx
+++ b/static/app/views/discover/tags.spec.tsx
@@ -27,7 +27,7 @@ const commonQueryConditions = {
   topEvents: '',
   yAxis: '',
   createdBy: TestStubs.User(),
-  team: Team(),
+  team: [parseInt(Team().id, 10)],
   statsPeriod: '14d',
 };
 

--- a/static/app/views/issueDetails/groupActivity.spec.tsx
+++ b/static/app/views/issueDetails/groupActivity.spec.tsx
@@ -54,7 +54,7 @@ describe('GroupActivity', function () {
       organization: additionalOrg,
     });
     GroupStore.add([group]);
-    TeamStore.loadInitialData([TestStubs.Team({id: '999', slug: 'no-team'})]);
+    TeamStore.loadInitialData([Team({id: '999', slug: 'no-team'})]);
     OrganizationStore.onUpdate(organization, {replace: true});
     return render(
       <GroupActivity
@@ -298,7 +298,7 @@ describe('GroupActivity', function () {
   });
 
   it('requests assignees that are not in the team store', async function () {
-    const team = TestStubs.Team({id: '123', name: 'workflow'});
+    const team = Team({id: '123', name: 'workflow'});
     const teamRequest = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/teams/`,
       body: [team],

--- a/static/app/views/issueDetails/groupActivity.spec.tsx
+++ b/static/app/views/issueDetails/groupActivity.spec.tsx
@@ -1,5 +1,6 @@
 import {Organization} from 'sentry-fixture/organization';
 import {Repository} from 'sentry-fixture/repository';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -19,7 +19,7 @@ const SAMPLE_EVENT_ALERT_TEXT =
 describe('groupDetails', () => {
   const group = TestStubs.Group({issueCategory: IssueCategory.ERROR});
   const event = EventFixture();
-  const project = TestStubs.Project({teams: [TestStubs.Team()]});
+  const project = TestStubs.Project({teams: [Team()]});
 
   const routes = [
     {path: '/', childRoutes: []},

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -1,4 +1,5 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/issueDetails/groupSidebar.spec.tsx
+++ b/static/app/views/issueDetails/groupSidebar.spec.tsx
@@ -1,5 +1,6 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {Tags} from 'sentry-fixture/tags';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {

--- a/static/app/views/issueDetails/groupSidebar.spec.tsx
+++ b/static/app/views/issueDetails/groupSidebar.spec.tsx
@@ -192,7 +192,7 @@ describe('GroupSidebar', function () {
     const org = {
       ...organization,
     };
-    const teams = [{...TestStubs.Team(), type: 'team'}];
+    const teams = [{...Team(), type: 'team'}];
     const users = [
       TestStubs.User({
         id: '2',

--- a/static/app/views/issueDetails/header.spec.tsx
+++ b/static/app/views/issueDetails/header.spec.tsx
@@ -1,5 +1,6 @@
 import {browserHistory} from 'react-router';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/views/issueDetails/header.spec.tsx
+++ b/static/app/views/issueDetails/header.spec.tsx
@@ -11,7 +11,7 @@ describe('groupDetails', () => {
   const baseUrl = 'BASE_URL/';
   const organization = Organization();
   const project = TestStubs.Project({
-    teams: [TestStubs.Team()],
+    teams: [Team()],
   });
 
   describe('issue category: error, js project', () => {

--- a/static/app/views/organizationContextContainer.spec.tsx
+++ b/static/app/views/organizationContextContainer.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/organizationContextContainer.spec.tsx
+++ b/static/app/views/organizationContextContainer.spec.tsx
@@ -18,7 +18,7 @@ jest.mock('sentry/stores/configStore', () => ({
 
 describe('OrganizationContextContainer', function () {
   const {organization, projects, routerProps} = initializeOrg();
-  const teams = [TestStubs.Team()];
+  const teams = [Team()];
 
   const api = new MockApiClient();
   let getOrgMock: jest.Mock;

--- a/static/app/views/organizationDetails/index.spec.tsx
+++ b/static/app/views/organizationDetails/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/organizationDetails/index.spec.tsx
+++ b/static/app/views/organizationDetails/index.spec.tsx
@@ -39,7 +39,7 @@ describe('OrganizationDetails', function () {
     });
     getTeamsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/teams/',
-      body: [TestStubs.Team()],
+      body: [Team()],
     });
     getProjectsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',

--- a/static/app/views/organizationStats/teamInsights/health.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 import {TeamAlertsTriggered} from 'sentry-fixture/teamAlertsTriggered';
 import {TeamResolutionTime} from 'sentry-fixture/teamResolutionTime';
 
@@ -7,7 +8,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
-import {Project, Team} from 'sentry/types';
+import {Project, Team as TTeam} from 'sentry/types';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import localStorage from 'sentry/utils/localStorage';
 import TeamStatsHealth from 'sentry/views/organizationStats/teamInsights/health';
@@ -161,7 +162,10 @@ describe('TeamStatsHealth', () => {
     jest.resetAllMocks();
   });
 
-  function createWrapper({projects, teams}: {projects?: Project[]; teams?: Team[]} = {}) {
+  function createWrapper({
+    projects,
+    teams,
+  }: {projects?: Project[]; teams?: TTeam[]} = {}) {
     teams = teams ?? [team1, team2, team3];
     projects = projects ?? [project1, project2];
     ProjectsStore.loadInitialData(projects);

--- a/static/app/views/organizationStats/teamInsights/health.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.spec.tsx
@@ -8,7 +8,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
-import {Project, Team as TTeam} from 'sentry/types';
+import {Project, Team as TeamType} from 'sentry/types';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import localStorage from 'sentry/utils/localStorage';
 import TeamStatsHealth from 'sentry/views/organizationStats/teamInsights/health';
@@ -165,7 +165,7 @@ describe('TeamStatsHealth', () => {
   function createWrapper({
     projects,
     teams,
-  }: {projects?: Project[]; teams?: TTeam[]} = {}) {
+  }: {projects?: Project[]; teams?: TeamType[]} = {}) {
     teams = teams ?? [team1, team2, team3];
     projects = projects ?? [project1, project2];
     ProjectsStore.loadInitialData(projects);

--- a/static/app/views/organizationStats/teamInsights/health.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.spec.tsx
@@ -20,21 +20,21 @@ jest.mock('sentry/utils/isActiveSuperuser', () => ({
 describe('TeamStatsHealth', () => {
   const project1 = TestStubs.Project({id: '2', name: 'js', slug: 'js'});
   const project2 = TestStubs.Project({id: '3', name: 'py', slug: 'py'});
-  const team1 = TestStubs.Team({
+  const team1 = Team({
     id: '2',
     slug: 'frontend',
     name: 'frontend',
     projects: [project1],
     isMember: true,
   });
-  const team2 = TestStubs.Team({
+  const team2 = Team({
     id: '3',
     slug: 'backend',
     name: 'backend',
     projects: [project2],
     isMember: true,
   });
-  const team3 = TestStubs.Team({
+  const team3 = Team({
     id: '4',
     slug: 'internal',
     name: 'internal',

--- a/static/app/views/organizationStats/teamInsights/issues.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 import {TeamIssuesBreakdown} from 'sentry-fixture/teamIssuesBreakdown';
 import {TeamResolutionTime} from 'sentry-fixture/teamResolutionTime';
 
@@ -7,7 +8,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
-import {Project, Team} from 'sentry/types';
+import {Project, Team as TTeam} from 'sentry/types';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import localStorage from 'sentry/utils/localStorage';
 import TeamStatsIssues from 'sentry/views/organizationStats/teamInsights/issues';
@@ -129,7 +130,10 @@ describe('TeamStatsIssues', () => {
     jest.resetAllMocks();
   });
 
-  function createWrapper({projects, teams}: {projects?: Project[]; teams?: Team[]} = {}) {
+  function createWrapper({
+    projects,
+    teams,
+  }: {projects?: Project[]; teams?: TTeam[]} = {}) {
     teams = teams ?? [team1, team2, team3];
     projects = projects ?? [project1, project2];
     ProjectsStore.loadInitialData(projects);

--- a/static/app/views/organizationStats/teamInsights/issues.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.spec.tsx
@@ -32,21 +32,21 @@ describe('TeamStatsIssues', () => {
     slug: 'py',
     environments: [env1, env2],
   });
-  const team1 = TestStubs.Team({
+  const team1 = Team({
     id: '2',
     slug: 'frontend',
     name: 'frontend',
     projects: [project1],
     isMember: true,
   });
-  const team2 = TestStubs.Team({
+  const team2 = Team({
     id: '3',
     slug: 'backend',
     name: 'backend',
     projects: [project2],
     isMember: true,
   });
-  const team3 = TestStubs.Team({
+  const team3 = Team({
     id: '4',
     slug: 'internal',
     name: 'internal',

--- a/static/app/views/organizationStats/teamInsights/issues.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.spec.tsx
@@ -8,7 +8,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
-import {Project, Team as TTeam} from 'sentry/types';
+import {Project, Team as TeamType} from 'sentry/types';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import localStorage from 'sentry/utils/localStorage';
 import TeamStatsIssues from 'sentry/views/organizationStats/teamInsights/issues';
@@ -133,7 +133,7 @@ describe('TeamStatsIssues', () => {
   function createWrapper({
     projects,
     teams,
-  }: {projects?: Project[]; teams?: TTeam[]} = {}) {
+  }: {projects?: Project[]; teams?: TeamType[]} = {}) {
     teams = teams ?? [team1, team2, team3];
     projects = projects ?? [project1, project2];
     ProjectsStore.loadInitialData(projects);

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 import {TeamAlertsTriggered as TeamAlertsTriggeredFixture} from 'sentry-fixture/teamAlertsTriggered';
 
 import {render} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.spec.tsx
@@ -7,7 +7,7 @@ import TeamAlertsTriggered from 'sentry/views/organizationStats/teamInsights/tea
 
 describe('TeamAlertsTriggered', () => {
   it('should render graph of alerts triggered', () => {
-    const team = TestStubs.Team();
+    const team = Team();
     const organization = Organization();
     const project = TestStubs.Project();
 

--- a/static/app/views/organizationStats/teamInsights/teamIssuesAge.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesAge.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/views/organizationStats/teamInsights/teamIssuesAge.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesAge.spec.tsx
@@ -6,7 +6,7 @@ import TeamIssuesAge from 'sentry/views/organizationStats/teamInsights/teamIssue
 
 describe('TeamIssuesAge', () => {
   it('should render graph with table of oldest issues', async () => {
-    const team = TestStubs.Team();
+    const team = Team();
     const organization = Organization();
     const timeToResolutionApi = MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team.slug}/unresolved-issue-age/`,

--- a/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 import {TeamIssuesBreakdown as TeamIssuesBreakdownFixture} from 'sentry-fixture/teamIssuesBreakdown';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.spec.tsx
@@ -7,7 +7,7 @@ import TeamIssuesBreakdown from 'sentry/views/organizationStats/teamInsights/tea
 
 describe('TeamIssuesBreakdown', () => {
   it('should render graph with table of issues reviewed', async () => {
-    const team = TestStubs.Team();
+    const team = Team();
     const project = TestStubs.Project({id: '2', slug: 'javascript'});
     const organization = Organization();
     const teamIssuesActions = MockApiClient.addMockResponse({

--- a/static/app/views/organizationStats/teamInsights/teamReleases.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.spec.tsx
@@ -10,7 +10,7 @@ describe('TeamReleases', () => {
     MockApiClient.clearMockResponses();
   });
   it('should compare selected past release count with current week', async () => {
-    const team = TestStubs.Team();
+    const team = Team();
     const organization = Organization();
     const project = TestStubs.Project({id: 123});
 
@@ -40,7 +40,7 @@ describe('TeamReleases', () => {
       url: `/teams/org-slug/team-slug/release-count/`,
       body: TeamReleaseCounts(),
     });
-    const team = TestStubs.Team();
+    const team = Team();
     const organization = Organization();
     const noReleaseProject = TestStubs.Project({id: 321});
 
@@ -57,7 +57,7 @@ describe('TeamReleases', () => {
   });
 
   it('should render multiple projects', async () => {
-    const team = TestStubs.Team();
+    const team = Team();
     const organization = Organization();
     const projectA = TestStubs.Project({id: 123});
     const projectB = TestStubs.Project({id: 234, slug: 'other-project-slug'});

--- a/static/app/views/organizationStats/teamInsights/teamReleases.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 import {TeamReleaseCounts} from 'sentry-fixture/teamReleaseCounts';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/organizationStats/teamInsights/teamResolutionTime.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamResolutionTime.spec.tsx
@@ -7,7 +7,7 @@ import TeamResolutionTime from 'sentry/views/organizationStats/teamInsights/team
 
 describe('TeamResolutionTime', () => {
   it('should render graph of issue time to resolution', () => {
-    const team = TestStubs.Team();
+    const team = Team();
     const organization = Organization();
     const timeToResolutionApi = MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team.slug}/time-to-resolution/`,

--- a/static/app/views/organizationStats/teamInsights/teamResolutionTime.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamResolutionTime.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 import {TeamResolutionTime as TeamResolutionTimeFixture} from 'sentry-fixture/teamResolutionTime';
 
 import {render} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.spec.tsx
@@ -6,7 +6,7 @@ import {TeamUnresolvedIssues} from './teamUnresolvedIssues';
 
 describe('TeamUnresolvedIssues', () => {
   it('should render graph with table with % change', async () => {
-    const team = TestStubs.Team();
+    const team = Team();
     const project = TestStubs.Project();
     const organization = Organization({projects: [project]});
     const issuesApi = MockApiClient.addMockResponse({

--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/views/performance/transactionSummary/teamKeyTransactionButton.spec.tsx
+++ b/static/app/views/performance/transactionSummary/teamKeyTransactionButton.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/views/performance/transactionSummary/teamKeyTransactionButton.spec.tsx
+++ b/static/app/views/performance/transactionSummary/teamKeyTransactionButton.spec.tsx
@@ -18,8 +18,8 @@ async function clickTeamKeyTransactionDropdown() {
 describe('TeamKeyTransactionButton', function () {
   const organization = Organization({features: ['performance-view']});
   const teams = [
-    TestStubs.Team({id: '1', slug: 'team1', name: 'Team 1'}),
-    TestStubs.Team({id: '2', slug: 'team2', name: 'Team 2'}),
+    Team({id: '1', slug: 'team1', name: 'Team 1'}),
+    Team({id: '2', slug: 'team2', name: 'Team 2'}),
   ];
   const project = TestStubs.Project({teams});
   const eventView = new EventView({

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -1,5 +1,6 @@
 import {browserHistory, InjectedRouter} from 'react-router';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {makeTestQueryClient} from 'sentry-test/queryClient';

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -26,8 +26,8 @@ import TransactionSummary from 'sentry/views/performance/transactionSummary/tran
 import {RouteContext} from 'sentry/views/routeContext';
 
 const teams = [
-  TestStubs.Team({id: '1', slug: 'team1', name: 'Team 1'}),
-  TestStubs.Team({id: '2', slug: 'team2', name: 'Team 2'}),
+  Team({id: '1', slug: 'team1', name: 'Team 1'}),
+  Team({id: '2', slug: 'team2', name: 'Team 2'}),
 ];
 
 function initializeData({

--- a/static/app/views/projectDetail/projectTeamAccess.spec.tsx
+++ b/static/app/views/projectDetail/projectTeamAccess.spec.tsx
@@ -10,7 +10,7 @@ describe('ProjectDetail > ProjectTeamAccess', function () {
     render(
       <ProjectTeamAccess
         organization={organization}
-        project={TestStubs.Project({teams: [TestStubs.Team()]})}
+        project={TestStubs.Project({teams: [Team()]})}
       />,
       {context: routerContext}
     );
@@ -23,7 +23,7 @@ describe('ProjectDetail > ProjectTeamAccess', function () {
     render(
       <ProjectTeamAccess
         organization={organization}
-        project={TestStubs.Project({teams: [TestStubs.Team()]})}
+        project={TestStubs.Project({teams: [Team()]})}
       />,
       {context: routerContext}
     );
@@ -63,13 +63,13 @@ describe('ProjectDetail > ProjectTeamAccess', function () {
         organization={organization}
         project={TestStubs.Project({
           teams: [
-            TestStubs.Team({slug: 'team1'}),
-            TestStubs.Team({slug: 'team2'}),
-            TestStubs.Team({slug: 'team3'}),
-            TestStubs.Team({slug: 'team4'}),
-            TestStubs.Team({slug: 'team5'}),
-            TestStubs.Team({slug: 'team6'}),
-            TestStubs.Team({slug: 'team7'}),
+            Team({slug: 'team1'}),
+            Team({slug: 'team2'}),
+            Team({slug: 'team3'}),
+            Team({slug: 'team4'}),
+            Team({slug: 'team5'}),
+            Team({slug: 'team6'}),
+            Team({slug: 'team7'}),
           ],
         })}
       />,
@@ -90,11 +90,7 @@ describe('ProjectDetail > ProjectTeamAccess', function () {
       <ProjectTeamAccess
         organization={organization}
         project={TestStubs.Project({
-          teams: [
-            TestStubs.Team({slug: 'c'}),
-            TestStubs.Team({slug: 'z'}),
-            TestStubs.Team({slug: 'a'}),
-          ],
+          teams: [Team({slug: 'c'}), Team({slug: 'z'}), Team({slug: 'a'})],
         })}
       />,
       {context: routerContext}

--- a/static/app/views/projectDetail/projectTeamAccess.spec.tsx
+++ b/static/app/views/projectDetail/projectTeamAccess.spec.tsx
@@ -1,3 +1,5 @@
+import {Team} from 'sentry-fixture/team';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -1,5 +1,6 @@
 import {Organization} from 'sentry-fixture/organization';
 import {MOCK_RESP_VERBOSE} from 'sentry-fixture/ruleConditions';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -107,7 +107,7 @@ describe('CreateProject', function () {
     });
 
     renderFrameworkModalMockRequests({organization, teamSlug: 'team-two'});
-    TeamStore.loadUserTeams([Team({id: 2, slug: 'team-two', access: []})]);
+    TeamStore.loadUserTeams([Team({id: '2', slug: 'team-two', access: []})]);
 
     render(<CreateProject />, {
       context: TestStubs.routerContext([
@@ -139,9 +139,9 @@ describe('CreateProject', function () {
 
     OrganizationStore.onUpdate(organization);
     TeamStore.loadUserTeams([
-      Team({id: 1, slug: 'team-one', access: []}),
-      Team({id: 2, slug: 'team-two', access: ['team:admin']}),
-      Team({id: 3, slug: 'team-three', access: ['team:admin']}),
+      Team({id: '1', slug: 'team-one', access: []}),
+      Team({id: '2', slug: 'team-two', access: ['team:admin']}),
+      Team({id: '3', slug: 'team-three', access: ['team:admin']}),
     ]);
     render(<CreateProject />, {
       context: TestStubs.routerContext([{organization}]),

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -33,7 +33,7 @@ function renderFrameworkModalMockRequests({
 
   MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/teams/`,
-    body: [TestStubs.Team({slug: teamSlug})],
+    body: [Team({slug: teamSlug})],
   });
 
   MockApiClient.addMockResponse({
@@ -62,14 +62,14 @@ function renderFrameworkModalMockRequests({
 }
 
 describe('CreateProject', function () {
-  const teamNoAccess = TestStubs.Team({
+  const teamNoAccess = Team({
     slug: 'test',
     id: '1',
     name: 'test',
     access: ['team:read'],
   });
 
-  const teamWithAccess = TestStubs.Team({
+  const teamWithAccess = Team({
     access: ['team:admin', 'team:write', 'team:read'],
   });
 
@@ -106,7 +106,7 @@ describe('CreateProject', function () {
     });
 
     renderFrameworkModalMockRequests({organization, teamSlug: 'team-two'});
-    TeamStore.loadUserTeams([TestStubs.Team({id: 2, slug: 'team-two', access: []})]);
+    TeamStore.loadUserTeams([Team({id: 2, slug: 'team-two', access: []})]);
 
     render(<CreateProject />, {
       context: TestStubs.routerContext([
@@ -138,9 +138,9 @@ describe('CreateProject', function () {
 
     OrganizationStore.onUpdate(organization);
     TeamStore.loadUserTeams([
-      TestStubs.Team({id: 1, slug: 'team-one', access: []}),
-      TestStubs.Team({id: 2, slug: 'team-two', access: ['team:admin']}),
-      TestStubs.Team({id: 3, slug: 'team-three', access: ['team:admin']}),
+      Team({id: 1, slug: 'team-one', access: []}),
+      Team({id: 2, slug: 'team-two', access: ['team:admin']}),
+      Team({id: 3, slug: 'team-three', access: ['team:admin']}),
     ]);
     render(<CreateProject />, {
       context: TestStubs.routerContext([{organization}]),

--- a/static/app/views/projectsDashboard/index.spec.tsx
+++ b/static/app/views/projectsDashboard/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {
   act,

--- a/static/app/views/projectsDashboard/index.spec.tsx
+++ b/static/app/views/projectsDashboard/index.spec.tsx
@@ -39,7 +39,7 @@ jest.mock('lodash/debounce', () => {
 describe('ProjectsDashboard', function () {
   const api = new MockApiClient();
   const org = Organization();
-  const team = TestStubs.Team();
+  const team = Team();
   const teams = [team];
 
   beforeEach(function () {
@@ -57,7 +57,7 @@ describe('ProjectsDashboard', function () {
 
   describe('empty state', function () {
     it('renders with no projects', function () {
-      const noProjectTeams = [TestStubs.Team({isMember: false, projects: []})];
+      const noProjectTeams = [Team({isMember: false, projects: []})];
 
       render(
         <Dashboard
@@ -77,7 +77,7 @@ describe('ProjectsDashboard', function () {
       const projects = [TestStubs.Project({teams, firstEvent: false})];
       ProjectsStore.loadInitialData(projects);
 
-      const teamsWithOneProject = [TestStubs.Team({projects})];
+      const teamsWithOneProject = [Team({projects})];
 
       render(
         <Dashboard
@@ -103,7 +103,7 @@ describe('ProjectsDashboard', function () {
 
   describe('with projects', function () {
     it('renders with two projects', function () {
-      const teamA = TestStubs.Team({slug: 'team1', isMember: true});
+      const teamA = Team({slug: 'team1', isMember: true});
       const projects = [
         TestStubs.Project({
           id: '1',
@@ -121,7 +121,7 @@ describe('ProjectsDashboard', function () {
       ];
 
       ProjectsStore.loadInitialData(projects);
-      const teamsWithTwoProjects = [TestStubs.Team({projects})];
+      const teamsWithTwoProjects = [Team({projects})];
 
       render(
         <Dashboard
@@ -138,7 +138,7 @@ describe('ProjectsDashboard', function () {
     });
 
     it('renders correct project with selected team', function () {
-      const teamC = TestStubs.Team({
+      const teamC = Team({
         id: '1',
         slug: 'teamC',
         isMember: true,
@@ -153,7 +153,7 @@ describe('ProjectsDashboard', function () {
           }),
         ],
       });
-      const teamD = TestStubs.Team({
+      const teamD = Team({
         id: '2',
         slug: 'teamD',
         isMember: true,
@@ -229,7 +229,7 @@ describe('ProjectsDashboard', function () {
     });
 
     it('renders projects by search', async function () {
-      const teamA = TestStubs.Team({slug: 'team1', isMember: true});
+      const teamA = Team({slug: 'team1', isMember: true});
       MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/projects/`,
         body: [],
@@ -251,7 +251,7 @@ describe('ProjectsDashboard', function () {
       ];
 
       ProjectsStore.loadInitialData(projects);
-      const teamsWithTwoProjects = [TestStubs.Team({projects})];
+      const teamsWithTwoProjects = [Team({projects})];
 
       render(
         <Dashboard
@@ -274,7 +274,7 @@ describe('ProjectsDashboard', function () {
     });
 
     it('renders bookmarked projects first in team list', function () {
-      const teamA = TestStubs.Team({slug: 'team1', isMember: true});
+      const teamA = Team({slug: 'team1', isMember: true});
       const projects = [
         TestStubs.Project({
           id: '11',
@@ -321,7 +321,7 @@ describe('ProjectsDashboard', function () {
       ];
 
       ProjectsStore.loadInitialData(projects);
-      const teamsWithFavProjects = [TestStubs.Team({projects})];
+      const teamsWithFavProjects = [Team({projects})];
 
       MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/projects/`,
@@ -365,7 +365,7 @@ describe('ProjectsDashboard', function () {
   });
 
   describe('ProjectsStatsStore', function () {
-    const teamA = TestStubs.Team({slug: 'team1', isMember: true});
+    const teamA = Team({slug: 'team1', isMember: true});
     const projects = [
       TestStubs.Project({
         id: '1',
@@ -405,7 +405,7 @@ describe('ProjectsDashboard', function () {
       }),
     ];
 
-    const teamsWithStatTestProjects = [TestStubs.Team({projects})];
+    const teamsWithStatTestProjects = [Team({projects})];
 
     it('uses ProjectsStatsStore to load stats', async function () {
       ProjectsStore.loadInitialData(projects);

--- a/static/app/views/settings/components/settingsSearch/index.spec.tsx
+++ b/static/app/views/settings/components/settingsSearch/index.spec.tsx
@@ -34,7 +34,7 @@ describe('SettingsSearch', function () {
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/teams/',
-      body: [TestStubs.Team({slug: 'foo-team'})],
+      body: [Team({slug: 'foo-team'})],
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/',

--- a/static/app/views/settings/components/settingsSearch/index.spec.tsx
+++ b/static/app/views/settings/components/settingsSearch/index.spec.tsx
@@ -1,5 +1,6 @@
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {fireEvent, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';

--- a/static/app/views/settings/organizationMembers/inviteRequestRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteRequestRow.spec.tsx
@@ -173,8 +173,8 @@ describe('InviteRequestRow', function () {
     });
 
     void TeamStore.loadInitialData([
-      TestStubs.Team({id: '1', slug: 'one'}),
-      TestStubs.Team({id: '2', slug: 'two'}),
+      Team({id: '1', slug: 'one'}),
+      Team({id: '2', slug: 'two'}),
     ]);
     const mockUpdate = jest.fn();
 

--- a/static/app/views/settings/organizationMembers/inviteRequestRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteRequestRow.spec.tsx
@@ -1,5 +1,6 @@
 import selectEvent from 'react-select-event';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {
   render,

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
@@ -22,8 +22,8 @@ jest.mock('sentry/actionCreators/members', () => ({
 }));
 
 describe('OrganizationMemberDetail', function () {
-  const team = TestStubs.Team();
-  const idpTeam = TestStubs.Team({
+  const team = Team();
+  const idpTeam = Team({
     id: '3',
     slug: 'idp-member-team',
     name: 'Idp Member Team',
@@ -32,8 +32,8 @@ describe('OrganizationMemberDetail', function () {
       'idp:provisioned': true,
     },
   });
-  const managerTeam = TestStubs.Team({id: '5', orgRole: 'manager', slug: 'manager-team'});
-  const otherManagerTeam = TestStubs.Team({
+  const managerTeam = Team({id: '5', orgRole: 'manager', slug: 'manager-team'});
+  const otherManagerTeam = Team({
     id: '4',
     slug: 'org-role-team',
     name: 'Org Role Team',
@@ -42,7 +42,7 @@ describe('OrganizationMemberDetail', function () {
   });
   const teams = [
     team,
-    TestStubs.Team({
+    Team({
       id: '2',
       slug: 'new-team',
       name: 'New Team',

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
@@ -2,6 +2,7 @@ import selectEvent from 'react-select-event';
 import {Authenticators} from 'sentry-fixture/authenticators';
 import {Organization} from 'sentry-fixture/organization';
 import {OrgRoleList} from 'sentry-fixture/roleList';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
@@ -23,7 +23,7 @@ describe('OrganizationMemberRow', function () {
     groupOrgRoles: [],
   });
 
-  const managerTeam = TestStubs.Team({
+  const managerTeam = Team({
     orgRole: 'manager',
   });
 

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -55,7 +55,7 @@ const roles = [
 describe('OrganizationMembersList', function () {
   const members = TestStubs.Members();
 
-  const ownerTeam = TestStubs.Team({slug: 'owner-team', orgRole: 'owner'});
+  const ownerTeam = Team({slug: 'owner-team', orgRole: 'owner'});
   const member = TestStubs.Member({
     id: '5',
     email: 'member@sentry.io',
@@ -135,7 +135,7 @@ describe('OrganizationMembersList', function () {
               name: 'sentry@test.com',
             },
           },
-          team: TestStubs.Team(),
+          team: Team(),
         },
       ],
     });
@@ -150,7 +150,7 @@ describe('OrganizationMembersList', function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/teams/',
       method: 'GET',
-      body: [TestStubs.Team(), ownerTeam],
+      body: [Team(), ownerTeam],
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/invite-requests/',

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -3,6 +3,7 @@ import selectEvent from 'react-select-event';
 import {AuthProvider} from 'sentry-fixture/authProvider';
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {
   render,

--- a/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
@@ -57,7 +57,7 @@ describe('OrganizationTeams', function () {
 
     it('can join team and have link to details', function () {
       const mockTeams = [
-        TestStubs.Team({
+        Team({
           hasAccess: true,
           isMember: false,
         }),
@@ -73,7 +73,7 @@ describe('OrganizationTeams', function () {
     });
 
     it('reloads projects after joining a team', async function () {
-      const team = TestStubs.Team({
+      const team = Team({
         hasAccess: true,
         isMember: false,
       });
@@ -99,9 +99,7 @@ describe('OrganizationTeams', function () {
     });
 
     it('cannot leave idp-provisioned team', function () {
-      const mockTeams = [
-        TestStubs.Team({flags: {'idp:provisioned': true}, isMember: true}),
-      ];
+      const mockTeams = [Team({flags: {'idp:provisioned': true}, isMember: true})];
       act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       createWrapper();
 
@@ -109,9 +107,7 @@ describe('OrganizationTeams', function () {
     });
 
     it('cannot join idp-provisioned team', function () {
-      const mockTeams = [
-        TestStubs.Team({flags: {'idp:provisioned': true}, isMember: false}),
-      ];
+      const mockTeams = [Team({flags: {'idp:provisioned': true}, isMember: false})];
       act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       createWrapper({
         access: new Set([]),
@@ -145,7 +141,7 @@ describe('OrganizationTeams', function () {
 
     it('can request access to team and does not have link to details', function () {
       const mockTeams = [
-        TestStubs.Team({
+        Team({
           hasAccess: false,
           isMember: false,
         }),
@@ -161,7 +157,7 @@ describe('OrganizationTeams', function () {
 
     it('can leave team when you are a member', function () {
       const mockTeams = [
-        TestStubs.Team({
+        Team({
           hasAccess: true,
           isMember: true,
         }),
@@ -175,9 +171,7 @@ describe('OrganizationTeams', function () {
     });
 
     it('cannot request to join idp-provisioned team', function () {
-      const mockTeams = [
-        TestStubs.Team({flags: {'idp:provisioned': true}, isMember: false}),
-      ];
+      const mockTeams = [Team({flags: {'idp:provisioned': true}, isMember: false})];
       act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       createWrapper({
         access: new Set([]),
@@ -187,9 +181,7 @@ describe('OrganizationTeams', function () {
     });
 
     it('cannot leave idp-provisioned team', function () {
-      const mockTeams = [
-        TestStubs.Team({flags: {'idp:provisioned': true}, isMember: true}),
-      ];
+      const mockTeams = [Team({flags: {'idp:provisioned': true}, isMember: true})];
       act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       createWrapper({
         access: new Set([]),

--- a/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
@@ -1,5 +1,6 @@
 import {AccessRequest} from 'sentry-fixture/accessRequest';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/settings/organizationTeams/teamDetails.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamDetails.spec.tsx
@@ -10,8 +10,8 @@ describe('TeamMembers', () => {
   let joinMock;
 
   const organization = Organization();
-  const team = TestStubs.Team({hasAccess: false});
-  const teamHasAccess = TestStubs.Team({id: '1337', slug: 'django', hasAccess: true});
+  const team = Team({hasAccess: false});
+  const teamHasAccess = Team({id: '1337', slug: 'django', hasAccess: true});
 
   beforeEach(() => {
     TeamStore.init();

--- a/static/app/views/settings/organizationTeams/teamDetails.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamDetails.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
@@ -1,5 +1,6 @@
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
@@ -19,8 +19,8 @@ describe('TeamMembers', function () {
   let createMock;
 
   const organization = Organization();
-  const team = TestStubs.Team();
-  const managerTeam = TestStubs.Team({orgRole: 'manager'});
+  const team = Team();
+  const managerTeam = Team({orgRole: 'manager'});
   const members = Members();
   const member = TestStubs.Member({
     id: '9',
@@ -404,7 +404,7 @@ describe('TeamMembers', function () {
   });
 
   it('cannot add or remove members if team is idp:provisioned', function () {
-    const team2 = TestStubs.Team({
+    const team2 = Team({
       flags: {
         'idp:provisioned': true,
       },
@@ -452,7 +452,7 @@ describe('TeamMembers', function () {
   });
 
   it('cannot add or remove members or leave if team has org role and no access', function () {
-    const team2 = TestStubs.Team({orgRole: 'manager'});
+    const team2 = Team({orgRole: 'manager'});
 
     const me = TestStubs.Member({
       id: '123',

--- a/static/app/views/settings/organizationTeams/teamNotifications.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.spec.tsx
@@ -24,7 +24,7 @@ const EXAMPLE_INTEGRATION = {
 
 describe('TeamNotificationSettings', () => {
   const {organization, routerContext, routerProps} = initializeOrg();
-  const team = TestStubs.Team();
+  const team = Team();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();

--- a/static/app/views/settings/organizationTeams/teamNotifications.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.spec.tsx
@@ -1,3 +1,5 @@
+import {Team} from 'sentry-fixture/team';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,

--- a/static/app/views/settings/organizationTeams/teamProjects.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamProjects.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';

--- a/static/app/views/settings/organizationTeams/teamProjects.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamProjects.spec.tsx
@@ -11,7 +11,7 @@ describe('OrganizationTeamProjects', function () {
   let postMock!: jest.Mock;
   let deleteMock!: jest.Mock;
 
-  const team = TestStubs.Team({slug: 'team-slug'});
+  const team = Team({slug: 'team-slug'});
   const project = TestStubs.Project({
     teams: [team],
     access: ['project:read', 'project:write', 'project:admin'],

--- a/static/app/views/settings/organizationTeams/teamSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamSettings/index.spec.tsx
@@ -28,7 +28,7 @@ describe('TeamSettings', function () {
   });
 
   it('can change slug', async function () {
-    const team = TestStubs.Team();
+    const team = Team();
     const putMock = MockApiClient.addMockResponse({
       url: `/teams/org-slug/${team.slug}/`,
       method: 'PUT',
@@ -63,7 +63,7 @@ describe('TeamSettings', function () {
   });
 
   it('can set team org-role', async function () {
-    const team = TestStubs.Team({orgRole: ''});
+    const team = Team({orgRole: ''});
     const putMock = MockApiClient.addMockResponse({
       url: `/teams/org-slug/${team.slug}/`,
       method: 'PUT',
@@ -112,7 +112,7 @@ describe('TeamSettings', function () {
   });
 
   it('needs team:admin in order to see an enabled Remove Team button', function () {
-    const team = TestStubs.Team();
+    const team = Team();
     const organization = Organization({access: []});
 
     render(<TeamSettings {...routerProps} team={team} params={{teamId: team.slug}} />, {
@@ -123,7 +123,7 @@ describe('TeamSettings', function () {
   });
 
   it('needs org:admin in order to set team org-role', function () {
-    const team = TestStubs.Team();
+    const team = Team();
     const organization = Organization({
       access: [],
       features: ['org-roles-for-teams'],
@@ -137,7 +137,7 @@ describe('TeamSettings', function () {
   });
 
   it('cannot set team org-role for idp:provisioned team', function () {
-    const team = TestStubs.Team({flags: {'idp:provisioned': true}});
+    const team = Team({flags: {'idp:provisioned': true}});
     const organization = Organization({
       access: ['org:admin'],
       features: ['org-roles-for-teams'],
@@ -151,7 +151,7 @@ describe('TeamSettings', function () {
   });
 
   it('can remove team', async function () {
-    const team = TestStubs.Team({hasAccess: true});
+    const team = Team({hasAccess: true});
     const deleteMock = MockApiClient.addMockResponse({
       url: `/teams/org-slug/${team.slug}/`,
       method: 'DELETE',

--- a/static/app/views/settings/organizationTeams/teamSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamSettings/index.spec.tsx
@@ -1,6 +1,7 @@
 import {browserHistory} from 'react-router';
 import selectEvent from 'react-select-event';
 import {Organization} from 'sentry-fixture/organization';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {

--- a/static/app/views/settings/project/projectOwnership/ruleBuilder.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/ruleBuilder.spec.tsx
@@ -41,13 +41,13 @@ describe('RuleBuilder', function () {
     },
   });
 
-  const TEAM_1 = TestStubs.Team({
+  const TEAM_1 = Team({
     id: '3',
     slug: 'cool-team',
   });
 
   // This team is in project
-  const TEAM_2 = TestStubs.Team({
+  const TEAM_2 = Team({
     id: '4',
     slug: 'team-not-in-project',
   });

--- a/static/app/views/settings/project/projectOwnership/ruleBuilder.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/ruleBuilder.spec.tsx
@@ -1,4 +1,5 @@
 import selectEvent from 'react-select-event';
+import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {

--- a/static/app/views/settings/project/projectTeams.spec.tsx
+++ b/static/app/views/settings/project/projectTeams.spec.tsx
@@ -1,3 +1,5 @@
+import {Team} from 'sentry-fixture/team';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,

--- a/static/app/views/settings/project/projectTeams.spec.tsx
+++ b/static/app/views/settings/project/projectTeams.spec.tsx
@@ -16,17 +16,17 @@ describe('ProjectTeams', function () {
   let project: Project;
   let routerContext: Record<string, any>;
 
-  const team1WithAdmin = TestStubs.Team({
+  const team1WithAdmin = Team({
     access: ['team:read', 'team:write', 'team:admin'],
   });
-  const team2WithAdmin = TestStubs.Team({
+  const team2WithAdmin = Team({
     id: '2',
     slug: 'team-slug-2',
     name: 'Team Name 2',
     hasAccess: true,
     access: ['team:read', 'team:write', 'team:admin'],
   });
-  const team3NoAdmin = TestStubs.Team({
+  const team3NoAdmin = Team({
     id: '3',
     slug: 'team-slug-3',
     name: 'Team Name 3',


### PR DESCRIPTION
This one was pretty straight-forward. You can check the commit history to find the spec changes I had to make, there are just a few.

- Bulk replace usage
- Add correct imports
- Add `DetailedTeam` type
- Convert team IDs to strings
- Rename gross type import
- Convert team to integer when mocking EventView
