### PR TITLE
feat(dashboard-widget-indicators): Setting flag to True by default.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1817,7 +1817,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enable feature to load more than 100 rows in performance trace view.
     "organizations:trace-view-load-more": False,
     # Enable dashboard widget indicators.
-    "organizations:dashboard-widget-indicators": False,
+    "organizations:dashboard-widget-indicators": True,
     # Enables updated all events tab in a performance issue
     "organizations:performance-issues-all-events-tab": False,
     # Temporary flag to test search performance that's running slow in S4S

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -78,6 +78,7 @@ class OrganizationSerializerTest(TestCase):
             "integrations-alert-rule",
             "integrations-chat-unfurl",
             "integrations-deployment",
+            "dashboard-widget-indicators",
             "integrations-enterprise-alert-rule",
             "integrations-enterprise-incident-management",
             "integrations-event-hooks",


### PR DESCRIPTION
ST/SH can't see the thresholds step in the dashboard widget builder.