### PR TITLE
ref(ts): Add more specific types to `span.data`

### DIFF
--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -14,8 +14,16 @@ export type GapSpanType = {
   description?: string;
 };
 
+interface SpanSourceCodeAttributes {
+  'code.column'?: number;
+  'code.filepath'?: string;
+  'code.function'?: string;
+  'code.lineno'?: number;
+  'code.namespace'?: string;
+}
+
 export type RawSpanType = {
-  data: Record<string, any>;
+  data: SpanSourceCodeAttributes & Record<string, any>;
   span_id: string;
   start_timestamp: number;
   // this is essentially end_timestamp

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -22,8 +22,15 @@ interface SpanSourceCodeAttributes {
   'code.namespace'?: string;
 }
 
+interface SpanDatabaseAttributes {
+  'db.name'?: string;
+  'db.operation'?: string;
+  'db.system'?: string;
+  'db.user'?: string;
+}
+
 export type RawSpanType = {
-  data: SpanSourceCodeAttributes & Record<string, any>;
+  data: SpanSourceCodeAttributes & SpanDatabaseAttributes & Record<string, any>;
   span_id: string;
   start_timestamp: number;
   // this is essentially end_timestamp

--- a/static/app/views/starfish/components/spanDescription.tsx
+++ b/static/app/views/starfish/components/spanDescription.tsx
@@ -3,13 +3,24 @@ import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
-import {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
 import {StackTraceMiniFrame} from 'sentry/views/starfish/components/stackTraceMiniFrame';
-import {SpanIndexedFieldTypes, SpanMetricsField} from 'sentry/views/starfish/types';
+import {MetricsResponse, SpanMetricsField} from 'sentry/views/starfish/types';
 import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatter';
 
 type Props = {
-  span: SpanIndexedFieldTypes & RawSpanType;
+  span: Pick<
+    MetricsResponse,
+    SpanMetricsField.SPAN_OP | SpanMetricsField.SPAN_DESCRIPTION
+  > & {
+    project_id?: number;
+    'transaction.id'?: string;
+  } & {
+    data?: {
+      'code.filepath'?: string;
+      'code.function'?: string;
+      'code.lineno'?: number;
+    };
+  };
 };
 
 export function SpanDescription({span}: Props) {

--- a/static/app/views/starfish/components/spanDescription.tsx
+++ b/static/app/views/starfish/components/spanDescription.tsx
@@ -3,24 +3,13 @@ import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
 import {StackTraceMiniFrame} from 'sentry/views/starfish/components/stackTraceMiniFrame';
-import {MetricsResponse, SpanMetricsField} from 'sentry/views/starfish/types';
+import {SpanIndexedFieldTypes, SpanMetricsField} from 'sentry/views/starfish/types';
 import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatter';
 
 type Props = {
-  span: Pick<
-    MetricsResponse,
-    SpanMetricsField.SPAN_OP | SpanMetricsField.SPAN_DESCRIPTION
-  > & {
-    project_id?: number;
-    'transaction.id'?: string;
-  } & {
-    data?: {
-      'code.filepath'?: string;
-      'code.function'?: string;
-      'code.lineno'?: number;
-    };
-  };
+  span: SpanIndexedFieldTypes & RawSpanType;
 };
 
 export function SpanDescription({span}: Props) {


### PR DESCRIPTION
`span.data` is a generic data bag _but_ it also has some well-known possible properties! I'm adding types that describe them, to improve autocomplete experience.

- Add code source keys to span data bag typing
- Simplify `SpanDescription` types
- Add database keys to span data types
