### PR TITLE
fix(feedback): linked issue stack trace preview is on top for smaller screens

### DIFF
--- a/static/app/components/groupPreviewTooltip/groupPreviewHovercard.tsx
+++ b/static/app/components/groupPreviewTooltip/groupPreviewHovercard.tsx
@@ -24,13 +24,14 @@ export function GroupPreviewHovercard({
 
   // No need to preview on hover for small devices
   const shouldNotPreview = useMedia(`(max-width: ${theme.breakpoints.large})`);
+  const shouldShowPositionTop = useMedia(`(max-width: ${theme.breakpoints.xlarge})`);
 
   return (
     <StyledHovercardWithBodyClass
       className={className}
       displayTimeout={200}
       delay={100}
-      position="right"
+      position={shouldShowPositionTop ? 'top' : 'right'}
       tipBorderColor="border"
       tipColor="background"
       hide={shouldNotPreview || hide}


### PR DESCRIPTION
- On smaller screens, the stacktrace preview is already hidden. 
- On slightly larger screens, we should show the tooltip above the content so that the title is still clickable.
- On larger screens, show the tooltip to the right, as it was before.

Fixes https://github.com/getsentry/team-replay/issues/313


https://github.com/getsentry/sentry/assets/56095982/2531c7d5-891b-40d5-9c81-d24b92dca82a

