### PR TITLE
nit(security): store a single number in `s2fai` cookie

### DIFF
--- a/src/sentry/web/frontend/twofactor.py
+++ b/src/sentry/web/frontend/twofactor.py
@@ -40,7 +40,7 @@ class TwoFactorAuthView(BaseView):
             if not interface.is_backup_interface:
                 rv.set_cookie(
                     COOKIE_NAME,
-                    str(interface.type).encode("utf-8"),
+                    str(interface.type),
                     max_age=COOKIE_MAX_AGE,
                     path="/",
                 )


### PR DESCRIPTION
The `s2fai` cookie is being set to this weird value `b'1'`.
<img width="275" alt="image" src="https://github.com/getsentry/sentry/assets/1127549/4c083844-243a-4f1f-aa1c-ca0b6d2922de">

`str(interface.type)` is already a string, there is no need to convert it to bytes (with `.encode("utf-8")` and then back to string (implicitly).

`interface.type` could only be a single-digit number, see authenticators [here](https://github.com/getsentry/sentry/tree/master/src/sentry/auth/authenticators).

For transition period, the value of this cookie should not matter because if there is no match, then the first available authenticator will be chosen:
```
        # Fallback case an interface was remembered in a cookie, go with that
        # one first.
        interface_type = request.COOKIES.get(COOKIE_NAME)
        if interface_type:
            for interface in interfaces:
                if str(interface.type) == interface_type:
                    return interface

        # Fallback is to go the highest ranked as default.  This will be
        # the most common path for first time users.
        return interfaces[0]
```