### PR TITLE
fix(discord): Fix Discord extension install flow

### DIFF
--- a/src/sentry/integrations/discord/urls.py
+++ b/src/sentry/integrations/discord/urls.py
@@ -1,5 +1,7 @@
 from django.urls import re_path
 
+from sentry.web.frontend.discord_extension_configuration import DiscordExtensionConfigurationView
+
 from .views.link_identity import DiscordLinkIdentityView
 from .views.unlink_identity import DiscordUnlinkIdentityView
 from .webhooks.base import DiscordInteractionsEndpoint
@@ -19,5 +21,11 @@ urlpatterns = [
         r"unlink-identity/(?P<signed_params>[^\/]+)/$",
         DiscordUnlinkIdentityView.as_view(),
         name="sentry-integration-discord-unlink-identity",
+    ),
+    # Discord App Directory extension install flow
+    re_path(
+        r"^configure/$",
+        DiscordExtensionConfigurationView.as_view(),
+        name="discord-extension-configuration",
     ),
 ]

--- a/src/sentry/web/frontend/discord_extension_configuration.py
+++ b/src/sentry/web/frontend/discord_extension_configuration.py
@@ -1,0 +1,6 @@
+from .integration_extension_configuration import IntegrationExtensionConfigurationView
+
+
+class DiscordExtensionConfigurationView(IntegrationExtensionConfigurationView):
+    provider = "discord"
+    external_provider_key = "discord"


### PR DESCRIPTION
Closes https://github.com/getsentry/getsentry/issues/12287

Flow of adding Sentry to Discord from Discord is broken.