### PR TITLE
add ReleaseThreshold to project deletion task

### DIFF
--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -35,6 +35,7 @@ class ProjectDeletionTask(ModelDeletionTask):
             models.LatestAppConnectBuildsCheck,
             models.ProjectBookmark,
             models.ProjectKey,
+            models.ReleaseThreshold,
             ProjectTeam,
             models.PromptsActivity,
             # order matters, ProjectCodeOwners to be deleted before RepositoryProjectPathConfig

--- a/src/sentry/models/__init__.py
+++ b/src/sentry/models/__init__.py
@@ -97,6 +97,7 @@ from .rawevent import *  # NOQA
 from .recentsearch import *  # NOQA
 from .relay import *  # NOQA
 from .release import *  # NOQA
+from .release_threshold import *  # NOQA
 from .releaseactivity import *  # NOQA
 from .releasecommit import *  # NOQA
 from .releaseenvironment import *  # NOQA

--- a/src/sentry/models/release_threshold/__init__.py
+++ b/src/sentry/models/release_threshold/__init__.py
@@ -1,0 +1,3 @@
+from .release_threshold import ReleaseThreshold
+
+__all__ = ("ReleaseThreshold",)


### PR DESCRIPTION
Delete the ReleaseThreshold if the associated project is deleted