### PR TITLE
meta(linting): Fixing flake8-logging issues (partial, migrations)

### DIFF
--- a/src/sentry/migrations/0210_backfill_project_transaction_thresholds.py
+++ b/src/sentry/migrations/0210_backfill_project_transaction_thresholds.py
@@ -40,7 +40,9 @@ def migrate_project_transaction_thresholds(apps, schema_editor):
                 )
             except Exception:
                 logging.exception(
-                    f"Error migrating project {project.id} for organization {option.organization_id}"
+                    "Error migrating project %s for organization %s",
+                    project.id,
+                    option.organization_id,
                 )
 
 

--- a/src/sentry/migrations/0349_issue_alert_fallback.py
+++ b/src/sentry/migrations/0349_issue_alert_fallback.py
@@ -78,7 +78,7 @@ def migrate_to_issue_alert_fallback(apps, schema_editor):
             except Exception:
                 # If a project fails we'll just log and continue. We shouldn't see any
                 # failures, but if we do we can analyze them and run a new migration.
-                logging.exception(f"Error migrating project {project.id}")
+                logging.exception("Error migrating project %s", project.id)
 
 
 class Migration(CheckedMigration):

--- a/src/sentry/migrations/0492_pickle_to_json_sentry_groupedmessage.py
+++ b/src/sentry/migrations/0492_pickle_to_json_sentry_groupedmessage.py
@@ -16,7 +16,7 @@ def _backfill(apps, schema_editor):
         try:
             obj.save(update_fields=["data"])
         except DatabaseError as e:
-            logging.warning(f"ignoring save error (row was likely deleted): {e}")
+            logging.warning("ignoring save error (row was likely deleted): %s", e)
 
 
 class Migration(CheckedMigration):

--- a/src/sentry/migrations/0493_pickle_to_json_sentry_activity.py
+++ b/src/sentry/migrations/0493_pickle_to_json_sentry_activity.py
@@ -16,7 +16,7 @@ def _backfill(apps, schema_editor):
         try:
             obj.save(update_fields=["data"])
         except DatabaseError as e:
-            logging.warning(f"ignoring save error (row was likely deleted): {e}")
+            logging.warning("ignoring save error (row was likely deleted): %s", e)
 
 
 class Migration(CheckedMigration):

--- a/src/sentry/migrations/0511_pickle_to_json_sentry_rawevent.py
+++ b/src/sentry/migrations/0511_pickle_to_json_sentry_rawevent.py
@@ -16,7 +16,7 @@ def _backfill(apps, schema_editor):
         try:
             obj.save(update_fields=["data"])
         except DatabaseError as e:
-            logging.warning(f"ignoring save error (row was likely deleted): {e}")
+            logging.warning("ignoring save error (row was likely deleted): %s", e)
 
 
 class Migration(CheckedMigration):


### PR DESCRIPTION
Fixing [flake8-logging](https://github.com/adamchainz/flake8-logging#rules) issues in existing migration files, splitting from https://github.com/getsentry/sentry/pull/60850 to make reviewing more manageable.

Alternatively if we really do not want to touch old migration files _at all_, we could leave these files alone and exclude migrations from `flake8`. 