### PR TITLE
fix(metrics_extraction): user_misery

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -348,7 +348,7 @@ class MetricsQueryBuilder(QueryBuilder):
             for column in selected_columns:
                 try:
                     self.resolve_select([column], [])
-                except IncompatibleMetricsQuery:
+                except (IncompatibleMetricsQuery, InvalidSearchQuery):
                     # This may fail for some columns like apdex but it will still enter into the field_alias_map
                     pass
 

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 from django.urls import reverse
+from rest_framework.response import Response
 
 from sentry.api.bases.organization_events import DATASET_OPTIONS
 from sentry.discover.models import TeamKeyTransaction
@@ -2943,7 +2944,6 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
 
     def setUp(self) -> None:
         super().setUp()
-        self.features = {"organizations:on-demand-metrics-extraction-widgets": True}
 
     def do_request(self, query: Any) -> Any:
         self.login_as(user=self.user)
@@ -2960,7 +2960,8 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         groupbys: Optional[list[str]] = None,
         expected_on_demand_query: Optional[bool] = True,
         expected_dataset: Optional[str] = "metricsEnhanced",
-    ) -> None:
+    ) -> Response:
+        """Do a request to the events endpoint with metrics enhanced and on-demand enabled."""
         for field in params.get("field"):
             spec = OnDemandMetricSpec(
                 field=field,
@@ -2990,30 +2991,21 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
     def test_transaction_user_misery(self) -> None:
         self._on_demand_query_check(
             {
+                # TODO: Create environment for organization
+                # "environment": "production",  # Adding this gives a 404
                 "field": ["user_misery(300)"],
-                "query": "transaction.duration:>=91",
+                "query": "",
+                "project": self.project.id,
+                "sort": "-user_misery(300)",
                 "yAxis": "user_misery(300)",
+                "name": "",
+                "per_page": "20",
+                "query": "",
+                "referrer": "api.dashboards.tablewidget",
+                "sort": "-user_misery(300)",  # Is this orderby?
             },
             groupbys=["transaction"],
         )
-        # self._on_demand_query_check(
-        #     {
-        #         "environment": "production",
-        #         "field": ["transaction", "user_misery(300)"],
-        #         "name": "",
-        #         "onDemandType": "dynamic_query",
-        #         "per_page": "20",
-        #         "project": self.project.id,
-        #         "query": "",
-        #         "referrer": "api.dashboards.tablewidget",
-        #         "sort": "-user_misery(300)",  # Is this orderby?
-        #         "useOnDemandMetrics": "true",
-        #         "yAxis": "user_misery(300)",
-        #         "dataset": "metricsEnhanced",
-        #     },
-        #     expected_on_demand_query=True,
-        #     dataset="metricsEnhanced",
-        # )
 
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -2962,7 +2962,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         expected_dataset: Optional[str] = "metricsEnhanced",
     ) -> Response:
         """Do a request to the events endpoint with metrics enhanced and on-demand enabled."""
-        for field in params.get("field"):
+        for field in params["field"]:
             spec = OnDemandMetricSpec(
                 field=field,
                 query=params["query"],
@@ -2983,13 +2983,15 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         assert meta.get("isMetricsExtractedData", False) is expected_on_demand_query
         assert meta["dataset"] == expected_dataset
 
+        return response
+
     def test_is_metrics_extracted_data_is_included(self) -> None:
         self._on_demand_query_check(
             {"field": ["count()"], "query": "transaction.duration:>=91", "yAxis": "count()"}
         )
 
     def test_transaction_user_misery(self) -> None:
-        self._on_demand_query_check(
+        resp = self._on_demand_query_check(
             {
                 # TODO: Create environment for organization
                 # "environment": "production",  # Adding this gives a 404
@@ -3006,6 +3008,18 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
             },
             groupbys=["transaction"],
         )
+        assert resp.data == {
+            "data": [{"user_misery_300": 0.05}],
+            "meta": {
+                "fields": {"user_misery_300": "number"},
+                "units": {"user_misery_300": None},
+                "isMetricsData": True,
+                "isMetricsExtractedData": True,
+                "tips": {},
+                "datasetReason": "unchanged",
+                "dataset": "metricsEnhanced",
+            },
+        }
 
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -2953,14 +2953,13 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         with self.feature({"organizations:on-demand-metrics-extraction-widgets": True}):
             return self.client.get(url, query, format="json")
 
-    def _test_is_metrics_extracted_data(
+    def _on_demand_query_and_assert(
         self, params: dict[str, Any], expected_on_demand_query: bool, dataset: str
     ) -> None:
         spec = OnDemandMetricSpec(
-            field="count()",
-            query="transaction.duration:>1s",
-            spec_type=MetricSpecType.DYNAMIC_QUERY,
+            field=params["field"], query=params["query"], spec_type=MetricSpecType.DYNAMIC_QUERY
         )
+        assert params["dataset"] == "metricsEnhanced"
 
         self.store_on_demand_metric(1, spec=spec)
         response = self.do_request(params)
@@ -2973,13 +2972,33 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
         return meta
 
     def test_is_metrics_extracted_data_is_included(self):
-        self._test_is_metrics_extracted_data(
+        self._on_demand_query_and_assert(
             {
                 "field": ["count()"],
                 "dataset": "metricsEnhanced",
                 "query": "transaction.duration:>=91",
                 "useOnDemandMetrics": "true",
                 "yAxis": "count()",
+            },
+            expected_on_demand_query=True,
+            dataset="metricsEnhanced",
+        )
+
+    def test_transaction_user_misery(self):
+        self._on_demand_query_and_assert(
+            {
+                "environment": "production",
+                "field": ["transaction", "user_misery(300)"],
+                "name": "",
+                "onDemandType": "dynamic_query",
+                "per_page": "20",
+                "project": self.project.id,
+                "query": "",
+                "referrer": "api.dashboards.tablewidget",
+                "sort": "-user_misery(300)",  # Is this orderby?
+                "useOnDemandMetrics": "true",
+                "yAxis": "user_misery(300)",
+                "dataset": "metricsEnhanced",
             },
             expected_on_demand_query=True,
             dataset="metricsEnhanced",

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -2995,11 +2995,11 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
             {
                 # TODO: Create environment for organization
                 # "environment": "production",  # Adding this gives a 404
-                "field": ["user_misery(300)"],
+                "field": ["user_misery(300)", "apdex(300)"],
                 "query": "",
                 "project": self.project.id,
                 "sort": "-user_misery(300)",
-                "yAxis": "user_misery(300)",
+                "yAxis": ["user_misery(300)", "apdex(300)"],
                 "name": "",
                 "per_page": "20",
                 "query": "",
@@ -3009,10 +3009,10 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
             groupbys=["transaction"],
         )
         assert resp.data == {
-            "data": [{"user_misery_300": 0.05}],
+            "data": [{"user_misery(300)": 0.0, "apdex(300)": 0.0}],
             "meta": {
-                "fields": {"user_misery_300": "number"},
-                "units": {"user_misery_300": None},
+                "fields": {"user_misery(300)": "number", "apdex(300)": "number"},
+                "units": {"user_misery(300)": None, "apdex(300)": None},
                 "isMetricsData": True,
                 "isMetricsExtractedData": True,
                 "tips": {},

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -2993,18 +2993,12 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
     def test_transaction_user_misery(self) -> None:
         resp = self._on_demand_query_check(
             {
-                # TODO: Create environment for organization
-                # "environment": "production",  # Adding this gives a 404
                 "field": ["user_misery(300)", "apdex(300)"],
-                "query": "",
                 "project": self.project.id,
-                "sort": "-user_misery(300)",
-                "yAxis": ["user_misery(300)", "apdex(300)"],
-                "name": "",
-                "per_page": "20",
                 "query": "",
+                "sort": "-user_misery(300)",
+                "per_page": "20",
                 "referrer": "api.dashboards.tablewidget",
-                "sort": "-user_misery(300)",  # Is this orderby?
             },
             groupbys=["transaction"],
         )


### PR DESCRIPTION
### Summary
Add tests for user_misery for on-demand extraction. This should also confirm that aliasing is happening for functions when querying for table widgets.
(edited by @k-fish)