### PR TITLE
ref(tokens): Use integration token as main name and combine test utils

### DIFF
--- a/src/sentry/api/endpoints/organization_member/team_details.py
+++ b/src/sentry/api/endpoints/organization_member/team_details.py
@@ -57,7 +57,6 @@ class OrganizationMemberTeamDetailsSerializer(Serializer):
 
 
 class OrganizationTeamMemberPermission(OrganizationPermission):
-
     scope_map = {
         "GET": [
             "org:read",
@@ -116,9 +115,9 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
         access = request.access
 
         # When open membership is disabled, we need to check if the token has elevated permissions
-        # in order to ensure org tokens with only "org:read" scope cannot add members. This check
-        # comes first because access.has_global_access is True for all org tokens
-        if access.is_org_auth_token and not access.has_open_membership:
+        # in order to ensure integration tokens with only "org:read" scope cannot add members. This check
+        # comes first because access.has_global_access is True for all integration tokens
+        if access.is_integration_token and not access.has_open_membership:
             return _has_elevated_scope(access)
         return access.has_global_access or can_admin_team(access, team)
 

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -121,7 +121,7 @@ class Access(abc.ABC):
         pass
 
     @property
-    def is_org_auth_token(self) -> bool:
+    def is_integration_token(self) -> bool:
         return False
 
     def has_permission(self, permission: str) -> bool:
@@ -783,7 +783,7 @@ class ApiOrganizationGlobalMembership(ApiBackedOrganizationGlobalAccess):
     """Access to all an organization's teams and projects with simulated membership."""
 
     @property
-    def is_org_auth_token(self) -> bool:
+    def is_integration_token(self) -> bool:
         return True
 
     @property

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2852,7 +2852,7 @@ class MonitorIngestTestCase(MonitorTestCase):
         app = self.create_sentry_app_installation(
             slug=sentry_app.slug, organization=self.organization
         )
-        self.token = self.create_internal_integration_token(app, user=self.user)
+        self.token = self.create_internal_integration_token(install=app, user=self.user)
 
     def _get_path_functions(self):
         # Monitor paths are supported both with an org slug and without.  We test both as long as we support both.

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1003,7 +1003,7 @@ class Factories:
         if install is None:
             assert org
             sentry_app = Factories.create_sentry_app(
-                name="Org Token",
+                name="Integration Token",
                 organization=org,
                 scopes=scopes,
             )

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -997,26 +997,22 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)
-    def create_internal_integration_token(install, **kwargs):
-        user = kwargs.pop("user")
-        request = kwargs.pop("request", None)
-        return SentryAppInstallationTokenCreator(sentry_app_installation=install, **kwargs).run(
+    def create_internal_integration_token(user, install=None, request=None, org=None, scopes=None):
+        if scopes is None:
+            scopes = []
+        if install is None:
+            assert org
+            sentry_app = Factories.create_sentry_app(
+                name="Org Token",
+                organization=org,
+                scopes=scopes,
+            )
+            install = Factories.create_sentry_app_installation(
+                organization=org, slug=sentry_app.slug, user=user
+            )
+        return SentryAppInstallationTokenCreator(sentry_app_installation=install).run(
             user=user, request=request
         )
-
-    @staticmethod
-    @assume_test_silo_mode(SiloMode.CONTROL)
-    def create_org_auth_token(organization, user, scopes, **kwargs):
-        sentry_app = Factories.create_sentry_app(
-            name="Org Token",
-            organization=organization,
-            scopes=scopes,
-        )
-
-        install = Factories.create_sentry_app_installation(
-            organization=organization, slug=sentry_app.slug, user=user
-        )
-        return Factories.create_internal_integration_token(install=install, user=user)
 
     @staticmethod
     def _sentry_app_kwargs(**kwargs):

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -290,9 +290,6 @@ class Fixtures:
     def create_internal_integration_token(self, *args, **kwargs):
         return Factories.create_internal_integration_token(*args, **kwargs)
 
-    def create_org_auth_token(self, *args, **kwargs):
-        return Factories.create_org_auth_token(*args, **kwargs)
-
     def create_sentry_app_installation(self, *args, **kwargs):
         return Factories.create_sentry_app_installation(*args, **kwargs)
 

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -376,15 +376,17 @@ class CreateWithClosedMembershipTest(CreateOrganizationMemberTeamTest):
             team=self.team, organizationmember=self.member
         ).exists()
 
-    def test_org_token_needs_elevated_permissions(self):
-        # Org tokens with org:read should generate an access request when open membership is off
-        org_token = self.create_org_auth_token(self.org, self.user, ["org:read"])
+    def test_integration_token_needs_elevated_permissions(self):
+        # Integration tokens with org:read should generate an access request when open membership is off
+        integration_token = self.create_internal_integration_token(
+            user=self.user, org=self.org, scopes=["org:read"]
+        )
 
         self.get_success_response(
             self.org.slug,
             self.member.id,
             self.team.slug,
-            extra_headers={"HTTP_AUTHORIZATION": f"Bearer {org_token.token}"},
+            extra_headers={"HTTP_AUTHORIZATION": f"Bearer {integration_token.token}"},
             status_code=status.HTTP_202_ACCEPTED,
         )
 


### PR DESCRIPTION
To match our documentation, we should use the name integration token (previously I was using org auth token).

Also combine test utils to make an internal integration token. There were originally 2 helpers, one that made the token with and installation and without an installation. I combined them into 1 helper.