### PR TITLE
fix(jira) Don't 500 on expired signatures

### DIFF
--- a/tests/sentry/integrations/utils/test_atlassian_connect.py
+++ b/tests/sentry/integrations/utils/test_atlassian_connect.py
@@ -33,6 +33,8 @@ class AtlassianConnectTest(TestCase):
         self.unknown_issuer_jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0c2VydmVyLmppcmE6dW5rbm93biIsImlhdCI6MTIzNDU2Nzg5MCwiZXhwIjo5OTk5OTk5OTk5LCJxc2giOiIzNmY0M2I4OGQ2YThjZGY4OWJiOGY3NDRlMjM3OGJiMGNlYjYzNzhlODBhYjBiNTEzMDgyYThiNzIzOTZiY2NjIiwic3ViIjoiY29ubmVjdDoxMjMifQ.dhIYA45uNkp4jONnpniNeW-k7E3dywJhPzMI55KVlus"
         self.invalid_secret_jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0c2VydmVyLmppcmE6MTIzIiwiaWF0IjoxMjM0NTY3ODkwLCJleHAiOjk5OTk5OTk5OTksInFzaCI6IjM2ZjQzYjg4ZDZhOGNkZjg5YmI4Zjc0NGUyMzc4YmIwY2ViNjM3OGU4MGFiMGI1MTMwODJhOGI3MjM5NmJjY2MiLCJzdWIiOiJjb25uZWN0OjEyMyJ9.7nGQQWUeXewnfL8_yvwzLGyf_rgkGdaQxKbDoi7tu_g"
 
+        self.expired_jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0c2VydmVyLmppcmE6MTIzIiwiaWF0IjoxMjM0NTY3ODkwLCJleHAiOjEyMzQ1Njc4OTAsInFzaCI6IjM2ZjQzYjg4ZDZhOGNkZjg5YmI4Zjc0NGUyMzc4YmIwY2ViNjM3OGU4MGFiMGI1MTMwODJhOGI3MjM5NmJjY2MiLCJzdWIiOiJjb25uZWN0OjEyMyJ9.1ZIrXDbaS6nUMgtmdCE1BFbsT7yvNKTkzVnSjX-Q7TA"
+
     def test_get_token_success(self):
         request = self.factory.post(path=self.path, HTTP_AUTHORIZATION=f"JWT {self.valid_jwt}")
         assert get_token(request) == self.valid_jwt
@@ -103,6 +105,17 @@ class AtlassianConnectTest(TestCase):
             )
         except AtlassianConnectValidationError as e:
             assert str(e) == "Query hash mismatch"
+
+        try:
+            get_integration_from_jwt(
+                token=self.expired_jwt,
+                path=self.path,
+                provider=self.provider,
+                query_params=self.query_params,
+                method=self.method,
+            )
+        except AtlassianConnectValidationError as e:
+            assert str(e) == "Signature is expired"
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_parse_integration_from_request(self):


### PR DESCRIPTION
Jira webhooks use JWT for authentication. The JWT's I've observed in testing are valid for 15 minutes, and after that we 500 responses.

In a multi-region configuration we could experience connectivity issues between region/control that delay webhook delivery for more than 15 minutes and we don't want to retry these hooks indefinitely as they will never process. By returning a 400 we can let the outbox delivery task know that we cannot process this hook.

Refs HC-1012
