### PR TITLE
feat(database): Improve database query page loading strategy

### DIFF
--- a/static/app/views/starfish/components/spanDescription.spec.tsx
+++ b/static/app/views/starfish/components/spanDescription.spec.tsx
@@ -7,12 +7,10 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {EntryType} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {DatabaseSpanDescription} from 'sentry/views/starfish/components/spanDescription';
 
 jest.mock('sentry/utils/useOrganization');
-
 jest.mock('sentry/utils/usePageFilters');
-
-import {DatabaseSpanDescription} from 'sentry/views/starfish/components/spanDescription';
 
 describe('DatabaseSpanDescription', function () {
   const organization = Organization({

--- a/static/app/views/starfish/components/spanDescription.spec.tsx
+++ b/static/app/views/starfish/components/spanDescription.spec.tsx
@@ -1,0 +1,159 @@
+import {Organization} from 'sentry-fixture/organization';
+import {Project} from 'sentry-fixture/project';
+
+import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
+
+import {EntryType} from 'sentry/types';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+
+jest.mock('sentry/utils/useOrganization');
+
+jest.mock('sentry/utils/usePageFilters');
+
+import {DatabaseSpanDescription} from 'sentry/views/starfish/components/spanDescription';
+
+describe('DatabaseSpanDescription', function () {
+  const organization = Organization({
+    features: ['performance-database-view-query-source'],
+  });
+  jest.mocked(useOrganization).mockReturnValue(organization);
+
+  const project = Project();
+
+  jest.mocked(usePageFilters).mockReturnValue({
+    isReady: true,
+    desyncedFilters: new Set(),
+    pinnedFilters: new Set(),
+    shouldPersist: true,
+    selection: {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+      environments: [],
+      projects: [],
+    },
+  });
+
+  const groupId = '2ed2abf6ce7e3577';
+  const spanId = 'abfed2aabf';
+  const eventId = '65c7d8647b8a76ef8f4c05d41deb7860';
+
+  it('shows preliminary description if no more data is available', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: [],
+    });
+
+    render(
+      <DatabaseSpanDescription
+        groupId={groupId}
+        preliminaryDescription="SELECT USERS FRO*"
+      />
+    );
+
+    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+
+    expect(screen.getByText('SELECT USERS FRO*')).toBeInTheDocument();
+  });
+
+  it('shows full query if full event is available', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [
+          {
+            'transaction.id': eventId,
+            project: project.slug,
+            span_id: spanId,
+          },
+        ],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/${project.slug}:${eventId}/`,
+      body: {
+        id: eventId,
+        entries: [
+          {
+            type: EntryType.SPANS,
+            data: [
+              {
+                span_id: spanId,
+                description: 'SELECT users FROM my_table LIMIT 1;',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <DatabaseSpanDescription
+        groupId={groupId}
+        preliminaryDescription="SELECT USERS FRO*"
+      />
+    );
+
+    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+
+    expect(screen.getByText('SELECT users FROM my_table LIMIT 1;')).toBeInTheDocument();
+  });
+
+  it('shows query source if available', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [
+          {
+            'transaction.id': eventId,
+            project: project.slug,
+            span_id: spanId,
+          },
+        ],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/${project.slug}:${eventId}/`,
+      body: {
+        id: eventId,
+        entries: [
+          {
+            type: EntryType.SPANS,
+            data: [
+              {
+                span_id: spanId,
+                description: 'SELECT users FROM my_table LIMIT 1;',
+                data: {
+                  'code.filepath': '/app/views/users.py',
+                  'code.lineno': 78,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <DatabaseSpanDescription
+        groupId={groupId}
+        preliminaryDescription="SELECT USERS FRO*"
+      />,
+      {organization}
+    );
+
+    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+
+    expect(screen.getByText('SELECT users FROM my_table LIMIT 1;')).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher('/app/views/users.py at line 78'))
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/starfish/components/spanDescription.tsx
+++ b/static/app/views/starfish/components/spanDescription.tsx
@@ -36,7 +36,7 @@ export function DatabaseSpanDescription({
   groupId,
   preliminaryDescription,
 }: Omit<Props, 'op'>) {
-  const {data: indexedSpans, isLoading: areIndexedSpansLoading} = useIndexedSpans(
+  const {data: indexedSpans, isFetching: areIndexedSpansLoading} = useIndexedSpans(
     {'span.group': groupId},
     [INDEXED_SPAN_SORT],
     1
@@ -44,9 +44,11 @@ export function DatabaseSpanDescription({
   const indexedSpan = indexedSpans?.[0];
 
   // NOTE: We only need this for `span.data`! If this info existed in indexed spans, we could skip it
-  const {data: rawSpan, isLoading: isRawSpanLoading} = useFullSpanFromTrace(groupId, [
-    INDEXED_SPAN_SORT,
-  ]);
+  const {data: rawSpan, isFetching: isRawSpanLoading} = useFullSpanFromTrace(
+    groupId,
+    [INDEXED_SPAN_SORT],
+    Boolean(indexedSpan)
+  );
 
   const rawDescription =
     rawSpan?.description || indexedSpan?.['span.description'] || preliminaryDescription;

--- a/static/app/views/starfish/components/spanDescription.tsx
+++ b/static/app/views/starfish/components/spanDescription.tsx
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {space} from 'sentry/styles/space';
 import {StackTraceMiniFrame} from 'sentry/views/starfish/components/stackTraceMiniFrame';
 import {useFullSpanFromTrace} from 'sentry/views/starfish/queries/useFullSpanFromTrace';
 import {useIndexedSpans} from 'sentry/views/starfish/queries/useIndexedSpans';
@@ -50,9 +52,15 @@ export function DatabaseSpanDescription({
 
   return (
     <Frame>
-      <CodeSnippet language="sql" isRounded={false}>
-        {formatterDescription}
-      </CodeSnippet>
+      {areIndexedSpansLoading ? (
+        <WithPadding>
+          <LoadingIndicator mini />
+        </WithPadding>
+      ) : (
+        <CodeSnippet language="sql" isRounded={false}>
+          {formatterDescription}
+        </CodeSnippet>
+      )}
 
       <Feature features={['organizations:performance-database-view-query-source']}>
         {rawSpan?.data?.['code.filepath'] && (
@@ -80,6 +88,11 @@ const Frame = styled('div')`
   border: solid 1px ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   overflow: hidden;
+`;
+
+const WithPadding = styled('div')`
+  display: flex;
+  padding: ${space(1)} ${space(2)};
 `;
 
 const WordBreak = styled('div')`

--- a/static/app/views/starfish/components/stackTraceMiniFrame.tsx
+++ b/static/app/views/starfish/components/stackTraceMiniFrame.tsx
@@ -59,7 +59,7 @@ export function MissingFrame() {
     <FrameContainer>
       <Deemphasize>
         {tct(
-          'Could not find query location in selected date range. Learn more in our [documentation:documentation].',
+          'Could not find query source in the selected date range. Learn more in our [documentation:documentation].',
           {
             documentation: (
               <ExternalLink href="https://docs.sentry.io/product/performance/queries/#query-sources" />

--- a/static/app/views/starfish/components/stackTraceMiniFrame.tsx
+++ b/static/app/views/starfish/components/stackTraceMiniFrame.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import useStacktraceLink from 'sentry/components/events/interfaces/frame/useStacktraceLink';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Project} from 'sentry/types';
 import {getIntegrationIcon, getIntegrationSourceUrl} from 'sentry/utils/integrationUtil';
@@ -50,6 +50,23 @@ export function StackTraceMiniFrame({frame, eventId, projectId}: Props) {
           <SourceCodeIntegrationLink event={event} project={project} frame={frame} />
         </PushRight>
       )}
+    </FrameContainer>
+  );
+}
+
+export function MissingFrame() {
+  return (
+    <FrameContainer>
+      <Deemphasize>
+        {tct(
+          'Could not find query location in selected date range. Learn more in our [documentation:documentation].',
+          {
+            documentation: (
+              <ExternalLink href="https://docs.sentry.io/product/performance/queries/#query-sources" />
+            ),
+          }
+        )}
+      </Deemphasize>
     </FrameContainer>
   );
 }

--- a/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanSummaryView.tsx
@@ -10,7 +10,6 @@ import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/char
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import StarfishDatePicker from 'sentry/views/starfish/components/datePicker';
 import {SpanDescription} from 'sentry/views/starfish/components/spanDescription';
-import {useFullSpanFromTrace} from 'sentry/views/starfish/queries/useFullSpanFromTrace';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
 import {
@@ -41,8 +40,6 @@ type Query = {
 export function SpanSummaryView({groupId}: Props) {
   const location = useLocation<Query>();
   const {endpoint, endpointMethod} = location.query;
-
-  const {data: fullSpan} = useFullSpanFromTrace(groupId);
 
   const filters: SpanMetricsQueryFilters = {
     'span.group': groupId,
@@ -117,11 +114,9 @@ export function SpanSummaryView({groupId}: Props) {
       {span?.[SpanMetricsField.SPAN_DESCRIPTION] && (
         <DescriptionContainer>
           <SpanDescription
-            span={{
-              ...span,
-              [SpanMetricsField.SPAN_DESCRIPTION]:
-                fullSpan?.description ?? spanMetrics?.[SpanMetricsField.SPAN_DESCRIPTION],
-            }}
+            groupId={groupId}
+            op={spanMetrics[SpanMetricsField.SPAN_OP]}
+            preliminaryDescription={spanMetrics[SpanMetricsField.SPAN_DESCRIPTION]}
           />
         </DescriptionContainer>
       )}


### PR DESCRIPTION
This is a refactor with small UX improvements as a result!

The biggest change is that all the data fetching logic (getting the indexed span, getting the raw span from the event itself) has moved into `DatabaseSpanDescription`. This makes for a much cleaner API, simpler types, and more control. Now that `DatabaseSpanDescription` is in charge of fetching data, it can decide when to show loading spinners and so on. By the way, I added a loading spinner to it.

Also, I added a little "We couldn't find the query source" message if the requests fail, _and_ a much-needed spec for all this data loading.
