### PR TITLE
chore: use correct type on fossa.yml

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -8,7 +8,7 @@ project:
 # ignore a noisy warning produced by this file, it's a schema not a package.json
 targets:
   exclude:
-    - type: projectjson
+    - type: projectassetjson
       path: api-docs/components/schemas
     - type: setuptools
       path: src/sentry/templates/sentry/emails


### PR DESCRIPTION
I'm not sure the correctness of this change, but from the documentations and PyCharm's recommendation, the proposed change seems to be the correct one.

I couldn't find any `projectjson` type in fossa json schema. But there is a type called `projectassetjson`.

Ref: https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.v3.schema.json#L235