### PR TITLE
fix(notification-actions): disable add action dropdown if no notification actions to add

### DIFF
--- a/static/app/components/notificationActions/notificationActionManager.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.tsx
@@ -213,20 +213,19 @@ function NotificationActionManager({
     return dropdownMenuItems;
   }, [actionsMap, availableServices, notificationActions, project, updateAlertCount]);
 
-  const toolTipText = () => {
-    if (disabled) {
-      return t('You do not have permission to add notification actions for this project');
-    }
-    if (menuItems.length === 0) {
-      return t('You do not have any notification actions to add');
-    }
-    return undefined;
-  };
+  let toolTipText: undefined | string = undefined;
+  if (disabled) {
+    toolTipText = t(
+      'You do not have permission to add notification actions for this project'
+    );
+  } else if (menuItems.length === 0) {
+    toolTipText = t('You do not have any notification actions to add');
+  }
 
   const isAddAlertDisabled = disabled || menuItems.length === 0;
 
   const addAlertButton = (
-    <Tooltip disabled={!isAddAlertDisabled} title={toolTipText()}>
+    <Tooltip disabled={!isAddAlertDisabled} title={toolTipText}>
       <DropdownMenu
         items={menuItems}
         trigger={(triggerProps, isOpen) => (

--- a/static/app/components/notificationActions/notificationActionManager.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.tsx
@@ -220,7 +220,7 @@ function NotificationActionManager({
       return t('You do not have permission to add notification actions for this project');
     }
     if (menuItems.length === 0) {
-      return t('You do not any notification actions to add');
+      return t('You do not have any notification actions to add');
     }
     return undefined;
   };

--- a/static/app/components/notificationActions/notificationActionManager.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.tsx
@@ -213,13 +213,24 @@ function NotificationActionManager({
     return menuItems;
   };
 
+  const menuItems = getMenuItems();
+
+  const toolTipText = () => {
+    if (disabled) {
+      return t('You do not have permission to add notification actions for this project');
+    }
+    if (menuItems.length === 0) {
+      return t('You do not any notification actions to add');
+    }
+    return undefined;
+  };
+
+  const isAddAlertDisabled = disabled || menuItems.length === 0;
+
   const addAlertButton = (
-    <Tooltip
-      disabled={!disabled}
-      title={t('You do not have permission to add notification actions for this project')}
-    >
+    <Tooltip disabled={!isAddAlertDisabled} title={toolTipText()}>
       <DropdownMenu
-        items={getMenuItems()}
+        items={menuItems}
         trigger={(triggerProps, isOpen) => (
           <DropdownButton
             {...triggerProps}
@@ -227,12 +238,12 @@ function NotificationActionManager({
             aria-label={t('Add Action')}
             size="xs"
             icon={<IconAdd isCircled color="gray300" />}
-            disabled={disabled}
+            disabled={isAddAlertDisabled}
           >
             {t('Add Action')}
           </DropdownButton>
         )}
-        isDisabled={disabled}
+        isDisabled={isAddAlertDisabled}
         data-test-id="add-action-button"
       />
     </Tooltip>

--- a/static/app/components/notificationActions/notificationActionManager.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.tsx
@@ -185,8 +185,8 @@ function NotificationActionManager({
     }
   };
 
-  const getMenuItems = () => {
-    const menuItems: MenuItemProps[] = [];
+  const menuItems = useMemo(() => {
+    const dropdownMenuItems: MenuItemProps[] = [];
     Object.entries(availableServices).forEach(([serviceType, validActions]) => {
       if (validActions.length === 0) {
         return;
@@ -199,7 +199,7 @@ function NotificationActionManager({
         return;
       }
       const label = getLabel(serviceType);
-      menuItems.push({
+      dropdownMenuItems.push({
         key: serviceType,
         label,
         onAction: () => {
@@ -210,10 +210,8 @@ function NotificationActionManager({
         },
       });
     });
-    return menuItems;
-  };
-
-  const menuItems = getMenuItems();
+    return dropdownMenuItems;
+  }, [actionsMap, availableServices, notificationActions, project, updateAlertCount]);
 
   const toolTipText = () => {
     if (disabled) {


### PR DESCRIPTION
Before (weird tiny dropdown)
<img width="1289" alt="Screenshot 2023-12-06 at 15 32 12" src="https://github.com/getsentry/sentry/assets/70817427/e4642ee6-b029-4a5a-98ce-09f7fa7d3c8e">

After
No notification actions to add
<img width="1289" alt="Screenshot 2023-12-06 at 15 28 42" src="https://github.com/getsentry/sentry/assets/70817427/44ed3faa-91af-4409-bcd2-afee7269e3f5">


No permission to add (regardless if there are any notification actions available to add)
<img width="1290" alt="Screenshot 2023-12-06 at 15 16 21" src="https://github.com/getsentry/sentry/assets/70817427/c0cfd42d-3838-4466-8fce-6061ce4905db">

For ER-1765
