### PR TITLE
ref(onboarding docs): [4/4] convert vue & angular, and clean up capacitor

### DIFF
--- a/static/app/gettingStartedDocs/javascript/angular.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.spec.tsx
@@ -19,7 +19,7 @@ describe('javascript-angular onboarding docs', function () {
     // Includes import statement
     expect(
       screen.getByText(
-        textWithMarkupMatcher(/import \* as Sentry from "@sentry\/angular"/)
+        textWithMarkupMatcher(/import { enableProdMode } from "@angular\/core"/)
       )
     ).toBeInTheDocument();
   });

--- a/static/app/gettingStartedDocs/javascript/angular.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/angular.spec.tsx
@@ -1,47 +1,75 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 
-import {AngularVersion, GettingStartedWithAngular, nextSteps, steps} from './angular';
+import docs from './angular';
 
-describe('GettingStartedWithAngular', function () {
-  it('all products are selected', function () {
-    render(
-      <GettingStartedWithAngular
-        dsn="test-dsn"
-        projectSlug="test-project"
-        activeProductSelection={[
-          ProductSolution.PERFORMANCE_MONITORING,
-          ProductSolution.SESSION_REPLAY,
-        ]}
-      />
-    );
+describe('javascript-angular onboarding docs', function () {
+  it('renders onboarding docs correctly', () => {
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({
-      angularVersion: AngularVersion.V12,
-      errorHandlerProviders: 'test-error-handler-providers',
-      sentryInitContent: 'test-init-content',
-    })) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Upload Source Maps'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
-    // Next Steps
-    const filteredNextStepsLinks = nextSteps.filter(
-      nextStep =>
-        ![
-          ProductSolution.PERFORMANCE_MONITORING,
-          ProductSolution.SESSION_REPLAY,
-        ].includes(nextStep.id as ProductSolution)
-    );
+    // Includes import statement
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(/import \* as Sentry from "@sentry\/angular"/)
+      )
+    ).toBeInTheDocument();
+  });
 
-    for (const filteredNextStepsLink of filteredNextStepsLinks) {
-      expect(
-        screen.getByRole('link', {name: filteredNextStepsLink.name})
-      ).toBeInTheDocument();
-    }
+  it('displays sample rates by default', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+        ProductSolution.SESSION_REPLAY,
+      ],
+    });
+
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/tracesSampleRate/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/replaysSessionSampleRate/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/replaysOnErrorSampleRate/))
+    ).toBeInTheDocument();
+  });
+
+  it('enables performance setting the tracesSampleRate to 1', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+      ],
+    });
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+  });
+
+  it('enables replay by setting replay samplerates', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.SESSION_REPLAY,
+      ],
+    });
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/replaysSessionSampleRate: 0\.1/))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/replaysOnErrorSampleRate: 1\.0/))
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript/vue.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.spec.tsx
@@ -1,46 +1,73 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 
-import {GettingStartedWithVue, nextSteps, steps, VueVersion} from './vue';
+import docs from './vue';
 
-describe('GettingStartedWithVue', function () {
-  it('all products are selected', function () {
-    render(
-      <GettingStartedWithVue
-        dsn="test-dsn"
-        projectSlug="test-project"
-        activeProductSelection={[
-          ProductSolution.PERFORMANCE_MONITORING,
-          ProductSolution.SESSION_REPLAY,
-        ]}
-      />
-    );
+describe('javascript-vue onboarding docs', function () {
+  it('renders onboarding docs correctly', () => {
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({
-      vueVersion: VueVersion.V3,
-      sentryInitContent: 'test-init-content',
-    })) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Upload Source Maps'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
-    // Next Steps
-    const filteredNextStepsLinks = nextSteps.filter(
-      nextStep =>
-        ![
-          ProductSolution.PERFORMANCE_MONITORING,
-          ProductSolution.SESSION_REPLAY,
-        ].includes(nextStep.id as ProductSolution)
-    );
+    // Includes import statement
+    expect(
+      screen.getByText(textWithMarkupMatcher(/import \* as Sentry from "@sentry\/vue"/))
+    ).toBeInTheDocument();
+  });
 
-    for (const filteredNextStepsLink of filteredNextStepsLinks) {
-      expect(
-        screen.getByRole('link', {name: filteredNextStepsLink.name})
-      ).toBeInTheDocument();
-    }
+  it('displays sample rates by default', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+        ProductSolution.SESSION_REPLAY,
+      ],
+    });
+
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/tracesSampleRate/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/replaysSessionSampleRate/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/replaysOnErrorSampleRate/))
+    ).toBeInTheDocument();
+  });
+
+  it('enables performance setting the tracesSampleRate to 1', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.PERFORMANCE_MONITORING,
+      ],
+    });
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0/))
+    ).toBeInTheDocument();
+  });
+
+  it('enables replay by setting replay samplerates', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [
+        ProductSolution.ERROR_MONITORING,
+        ProductSolution.SESSION_REPLAY,
+      ],
+    });
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/replaysSessionSampleRate: 0\.1/))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/replaysOnErrorSampleRate: 1\.0/))
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -1,184 +1,160 @@
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {PlatformOption} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+  PlatformOption,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
-import {useUrlPlatformOptions} from 'sentry/components/onboarding/platformOptionsControl';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t, tct} from 'sentry/locale';
-import type {Organization, PlatformKey} from 'sentry/types';
 
-export enum VueVersion {
-  V3 = 'v3',
-  V2 = 'v2',
+export enum SiblingOption {
+  VUE3 = 'vue3',
+  VUE2 = 'vue2',
 }
 
-type PlaformOptionKey = 'vueVersion';
+type PlaformOptionKey = 'siblingOption';
 
-type StepProps = {
-  sentryInitContent: string;
-  vueVersion: VueVersion;
-  newOrg?: boolean;
-  organization?: Organization;
-  platformKey?: PlatformKey;
-  projectId?: string;
-};
-
-// Configuration Start
 const platformOptions: Record<PlaformOptionKey, PlatformOption> = {
-  vueVersion: {
-    label: t('Spring Boot Version'),
+  siblingOption: {
+    label: t('Vue Version'),
     items: [
       {
         label: t('Vue 3'),
-        value: VueVersion.V3,
+        value: SiblingOption.VUE3,
       },
       {
         label: t('Vue 2'),
-        value: VueVersion.V2,
+        value: SiblingOption.VUE2,
       },
     ],
   },
 };
 
-const replayIntegration = `
-new Sentry.Replay(),
-`;
+type PlatformOptions = typeof platformOptions;
+type Params = DocsParams<PlatformOptions>;
 
-const replayOtherConfig = `
-// Session Replay
-replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
-`;
+const getSentryInitLayout = (params: Params, siblingOption: string): string => {
+  return `Sentry.init({
+    ${siblingOption === SiblingOption.VUE2 ? `Vue,` : ''}dsn: "${params.dsn}",
+    integrations: [${
+      params.isPerformanceSelected
+        ? `
+          new Sentry.BrowserTracing({
+            // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
+            tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],
+          }),`
+        : ''
+    }${
+      params.isReplaySelected
+        ? `
+          new Sentry.Replay(),`
+        : ''
+    }
+  ],${
+    params.isPerformanceSelected
+      ? `
+        // Performance Monitoring
+        tracesSampleRate: 1.0, //  Capture 100% of the transactions`
+      : ''
+  }${
+    params.isReplaySelected
+      ? `
+        // Session Replay
+        replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+        replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.`
+      : ''
+  }
+  });`;
+};
 
-const performanceIntegration = `
-new Sentry.BrowserTracing({
-  // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
-  tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/],
-  routingInstrumentation:  Sentry.vueRouterInstrumentation(router),
-}),
-`;
+const getNextStep = (
+  params: Params
+): {
+  description: string;
+  id: string;
+  link: string;
+  name: string;
+}[] => {
+  let nextStepDocs = [...nextSteps];
 
-const performanceOtherConfig = `
-// Performance Monitoring
-tracesSampleRate: 1.0, // Capture 100% of the transactions`;
+  if (params.isPerformanceSelected) {
+    nextStepDocs = nextStepDocs.filter(
+      step => step.id !== ProductSolution.PERFORMANCE_MONITORING
+    );
+  }
 
-export const steps = ({
-  sentryInitContent,
-  vueVersion,
-  ...props
-}: StepProps): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: (
-      <p>
-        {tct(
-          'Add the Sentry SDK as a dependency using [codeNpm:npm] or [codeYarn:yarn]:',
-          {
-            codeYarn: <code />,
-            codeNpm: <code />,
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'bash',
-        code: [
-          {
-            label: 'npm',
-            value: 'npm',
-            language: 'bash',
-            code: 'npm install --save @sentry/vue',
-          },
-          {
-            label: 'yarn',
-            value: 'yarn',
-            language: 'bash',
-            code: 'yarn add @sentry/vue',
-          },
-        ],
-      },
-    ],
-  },
-  {
-    type: StepType.CONFIGURE,
-    description: t(
-      "Initialize Sentry as early as possible in your application's lifecycle."
-    ),
-    configurations:
-      vueVersion === VueVersion.V3
-        ? [
+  if (params.isReplaySelected) {
+    nextStepDocs = nextStepDocs.filter(
+      step => step.id !== ProductSolution.SESSION_REPLAY
+    );
+  }
+  return nextStepDocs;
+};
+
+const onboarding: OnboardingConfig<PlatformOptions> = {
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: (
+        <p>
+          {tct(
+            `Install the Sentry Capacitor SDK as a dependency using [codeNpm:npm] or [codeYarn:yarn], alongside the Sentry Vue SDK:`,
             {
-              language: 'javascript',
-              code: `
-        import { createApp } from "vue";
-        import { createRouter } from "vue-router";
-        import * as Sentry from "@sentry/vue";
-
-        const app = createApp({
-          // ...
-        });
-        const router = createRouter({
-          // ...
-        });
-
-        Sentry.init({
-          app,
-          ${sentryInitContent}
-        });
-
-        app.use(router);
-        app.mount("#app");
-        `,
+              codeYarn: <code />,
+              codeNpm: <code />,
+            }
+          )}
+        </p>
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: [
+            {
+              label: 'npm',
+              value: 'npm',
+              language: 'bash',
+              code: `npm install --save @sentry/vue`,
             },
-          ]
-        : [
             {
-              language: 'javascript',
-              code: `
-        import Vue from "vue";
-        import Router from "vue-router";
-        import * as Sentry from "@sentry/vue";
-
-        Vue.use(Router);
-
-        const router = new Router({
-          // ...
-        });
-
-        Sentry.init({
-          Vue,
-          ${sentryInitContent}
-        });
-
-        // ...
-
-        new Vue({
-          router,
-          render: (h) => h(App),
-        }).$mount("#app");
-        `,
+              label: 'yarn',
+              value: 'yarn',
+              language: 'bash',
+              code: `yarn add @sentry/vue`,
             },
           ],
-  },
-  getUploadSourceMapsStep({
-    guideLink: 'https://docs.sentry.io/platforms/javascript/guides/vue/sourcemaps/',
-    ...props,
-  }),
-  {
-    type: StepType.VERIFY,
-    description: t(
-      "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
-    ),
-    configurations: [
-      {
-        language: 'javascript',
-        code: 'myUndefinedFunction();',
-      },
-    ],
-  },
-];
+        },
+      ],
+    },
+  ],
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      configurations: getSetupConfiguration(params),
+    },
+    getUploadSourceMapsStep({
+      guideLink: 'https://docs.sentry.io/platforms/javascript/guides/vue/sourcemaps/',
+      ...params,
+    }),
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        "This snippet contains an intentional error and can be used as a test to make sure that everything's working as expected."
+      ),
+      configurations: [
+        {
+          language: 'javascript',
+          code: `myUndefinedFunction();`,
+        },
+      ],
+    },
+  ],
+  nextSteps: params => getNextStep(params),
+};
 
 export const nextSteps = [
   {
@@ -210,66 +186,81 @@ export const nextSteps = [
     link: 'https://docs.sentry.io/platforms/javascript/guides/vue/session-replay/',
   },
 ];
-// Configuration End
 
-export function GettingStartedWithVue({
-  dsn,
-  activeProductSelection = [],
-  organization,
-  newOrg,
-  platformKey,
-  projectId,
-  ...props
-}: ModuleProps) {
-  const optionValues = useUrlPlatformOptions(platformOptions);
-  const integrations: string[] = [];
-  const otherConfigs: string[] = [];
-
-  let nextStepDocs = [...nextSteps];
-
-  if (activeProductSelection.includes(ProductSolution.PERFORMANCE_MONITORING)) {
-    integrations.push(performanceIntegration.trim());
-    otherConfigs.push(performanceOtherConfig.trim());
-    nextStepDocs = nextStepDocs.filter(
-      step => step.id !== ProductSolution.PERFORMANCE_MONITORING
-    );
+function getSiblingImportsSetupConfiguration(siblingOption: string): string {
+  switch (siblingOption) {
+    case SiblingOption.VUE3:
+      return `import {createApp} from "vue";
+          import {createRouter} from "vue-router";`;
+    case SiblingOption.VUE2:
+    default:
+      return `import Vue from "vue";
+          import Router from "vue-router";`;
   }
-
-  if (activeProductSelection.includes(ProductSolution.SESSION_REPLAY)) {
-    integrations.push(replayIntegration.trim());
-    otherConfigs.push(replayOtherConfig.trim());
-    nextStepDocs = nextStepDocs.filter(
-      step => step.id !== ProductSolution.SESSION_REPLAY
-    );
-  }
-
-  let sentryInitContent: string[] = [`dsn: "${dsn}",`];
-
-  if (integrations.length > 0) {
-    sentryInitContent = sentryInitContent.concat('integrations: [', integrations, '],');
-  }
-
-  if (otherConfigs.length > 0) {
-    sentryInitContent = sentryInitContent.concat(otherConfigs);
-  }
-
-  return (
-    <Layout
-      steps={steps({
-        sentryInitContent: sentryInitContent.join('\n'),
-        vueVersion: optionValues.vueVersion as VueVersion,
-        organization,
-        newOrg,
-        platformKey,
-        projectId,
-      })}
-      nextSteps={nextStepDocs}
-      newOrg={newOrg}
-      platformKey={platformKey}
-      platformOptions={platformOptions}
-      {...props}
-    />
-  );
 }
 
-export default GettingStartedWithVue;
+function getSiblingSuffix(siblingOption: string): string {
+  switch (siblingOption) {
+    case SiblingOption.VUE3:
+      return `app.use(router);
+      app.mount("#app");`;
+    case SiblingOption.VUE2:
+    default:
+      return `new Vue({
+        router,
+        render: (h) => h(App),
+      }).$mount("#app");`;
+  }
+}
+
+function getVueConstSetup(siblingOption: string): string {
+  switch (siblingOption) {
+    case SiblingOption.VUE3:
+      return `
+          const app = createApp({
+            // ...
+          });
+          const router = createRouter({
+            // ...
+          });
+          `;
+    case SiblingOption.VUE2:
+      return `
+          Vue.use(Router);
+
+          const router = new Router({
+            // ...
+          });
+          `;
+    default:
+      return '';
+  }
+}
+
+function getSetupConfiguration(params: Params) {
+  const siblingOption = params.platformOptions.siblingOption;
+  const sentryInitLayout = getSentryInitLayout(params, siblingOption);
+  const configuration = [
+    {
+      description: t(
+        "Initialize Sentry as early as possible in your application's lifecycle."
+      ),
+      language: 'javascript',
+      code: `${getSiblingImportsSetupConfiguration(siblingOption)}
+          import * as Sentry from "@sentry/vue";
+          ${getVueConstSetup(siblingOption)}
+          ${sentryInitLayout}
+
+          ${getSiblingSuffix(siblingOption)}`,
+    },
+  ];
+
+  return configuration;
+}
+
+const docs: Docs<PlatformOptions> = {
+  onboarding,
+  platformOptions,
+};
+
+export default docs;

--- a/static/app/gettingStartedDocs/javascript/vue.tsx
+++ b/static/app/gettingStartedDocs/javascript/vue.tsx
@@ -9,7 +9,7 @@ import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStart
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import {t, tct} from 'sentry/locale';
 
-export enum SiblingOption {
+export enum VueVersion {
   VUE3 = 'vue3',
   VUE2 = 'vue2',
 }
@@ -22,11 +22,11 @@ const platformOptions: Record<PlaformOptionKey, PlatformOption> = {
     items: [
       {
         label: t('Vue 3'),
-        value: SiblingOption.VUE3,
+        value: VueVersion.VUE3,
       },
       {
         label: t('Vue 2'),
-        value: SiblingOption.VUE2,
+        value: VueVersion.VUE2,
       },
     ],
   },
@@ -37,7 +37,7 @@ type Params = DocsParams<PlatformOptions>;
 
 const getSentryInitLayout = (params: Params, siblingOption: string): string => {
   return `Sentry.init({
-    ${siblingOption === SiblingOption.VUE2 ? `Vue,` : ''}dsn: "${params.dsn}",
+    ${siblingOption === VueVersion.VUE2 ? `Vue,` : ''}dsn: "${params.dsn}",
     integrations: [${
       params.isPerformanceSelected
         ? `
@@ -189,10 +189,10 @@ export const nextSteps = [
 
 function getSiblingImportsSetupConfiguration(siblingOption: string): string {
   switch (siblingOption) {
-    case SiblingOption.VUE3:
+    case VueVersion.VUE3:
       return `import {createApp} from "vue";
           import {createRouter} from "vue-router";`;
-    case SiblingOption.VUE2:
+    case VueVersion.VUE2:
     default:
       return `import Vue from "vue";
           import Router from "vue-router";`;
@@ -201,10 +201,10 @@ function getSiblingImportsSetupConfiguration(siblingOption: string): string {
 
 function getSiblingSuffix(siblingOption: string): string {
   switch (siblingOption) {
-    case SiblingOption.VUE3:
+    case VueVersion.VUE3:
       return `app.use(router);
       app.mount("#app");`;
-    case SiblingOption.VUE2:
+    case VueVersion.VUE2:
     default:
       return `new Vue({
         router,
@@ -215,7 +215,7 @@ function getSiblingSuffix(siblingOption: string): string {
 
 function getVueConstSetup(siblingOption: string): string {
   switch (siblingOption) {
-    case SiblingOption.VUE3:
+    case VueVersion.VUE3:
       return `
           const app = createApp({
             // ...
@@ -224,7 +224,7 @@ function getVueConstSetup(siblingOption: string): string {
             // ...
           });
           `;
-    case SiblingOption.VUE2:
+    case VueVersion.VUE2:
       return `
           Vue.use(Router);
 


### PR DESCRIPTION
Convert Vue & Angular. These two were a bit harder since there are different instructions for different framework versions.  

I based these on the Capacitor file - I saw there were some formatting problems in that file, so I cleaned the Capacitor file up a bit as well. In that file, I replaced `SiblingSdk` import name with a more clear name, specific to the framework (e.g. `SentryAngular` or `SentryVue`).

Closes https://github.com/getsentry/sentry/issues/61266