### PR TITLE
feat(relocation): Get Started and Encrypt Backup pages

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -394,6 +394,11 @@ urlpatterns += [
         r"^onboarding/",
         generic_react_page_view,
     ),
+    # Relocation
+    re_path(
+        r"^relocation/",
+        generic_react_page_view,
+    ),
     # Admin
     re_path(
         r"^manage/",

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -394,11 +394,6 @@ urlpatterns += [
         r"^onboarding/",
         generic_react_page_view,
     ),
-    # Relocation
-    re_path(
-        r"^relocation/",
-        generic_react_page_view,
-    ),
     # Admin
     re_path(
         r"^manage/",

--- a/static/app/components/onboarding/relocationOnboardingContext.tsx
+++ b/static/app/components/onboarding/relocationOnboardingContext.tsx
@@ -3,7 +3,9 @@ import {createContext, useCallback} from 'react';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 
 type Data = {
-  formData?: FormData;
+  orgSlugs: string;
+  region: string;
+  file?: File;
 };
 
 export type RelocationOnboardingContextProps = {
@@ -14,21 +16,25 @@ export type RelocationOnboardingContextProps = {
 export const RelocationOnboardingContext =
   createContext<RelocationOnboardingContextProps>({
     data: {
-      formData: undefined,
+      orgSlugs: '',
+      region: '',
+      file: undefined,
     },
     setData: () => {},
   });
 
 type ProviderProps = {
   children: React.ReactNode;
-  value?: FormData;
+  value?: Data;
 };
 
 export function RelocationOnboardingContextProvider({children, value}: ProviderProps) {
   const [sessionStorage, setSessionStorage] = useSessionStorage<Data>(
     'relocationOnboarding',
     {
-      formData: value,
+      orgSlugs: value?.orgSlugs || '',
+      region: value?.region || '',
+      file: value?.file || undefined,
     }
   );
 

--- a/static/app/components/onboarding/relocationOnboardingContext.tsx
+++ b/static/app/components/onboarding/relocationOnboardingContext.tsx
@@ -1,0 +1,52 @@
+import {createContext, useCallback} from 'react';
+
+import {useSessionStorage} from 'sentry/utils/useSessionStorage';
+
+type Data = {
+  formData?: FormData;
+};
+
+export type RelocationOnboardingContextProps = {
+  data: Data;
+  setData: (data: Data) => void;
+};
+
+export const RelocationOnboardingContext =
+  createContext<RelocationOnboardingContextProps>({
+    data: {
+      formData: undefined,
+    },
+    setData: () => {},
+  });
+
+type ProviderProps = {
+  children: React.ReactNode;
+  value?: FormData;
+};
+
+export function RelocationOnboardingContextProvider({children, value}: ProviderProps) {
+  const [sessionStorage, setSessionStorage] = useSessionStorage<Data>(
+    'relocationOnboarding',
+    {
+      formData: value,
+    }
+  );
+
+  const setData = useCallback(
+    (data: Data) => {
+      setSessionStorage(data);
+    },
+    [setSessionStorage]
+  );
+
+  return (
+    <RelocationOnboardingContext.Provider
+      value={{
+        data: sessionStorage,
+        setData,
+      }}
+    >
+      {children}
+    </RelocationOnboardingContext.Provider>
+  );
+}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -281,6 +281,27 @@ function buildRoutes() {
       />
       {usingCustomerDomain && (
         <Route
+          path="/relocation/"
+          component={errorHandler(withDomainRequired(OrganizationContextContainer))}
+          key="orgless-relocation"
+        >
+          <IndexRedirect to="welcome/" />
+          <Route
+            path=":step/"
+            component={make(() => import('sentry/views/relocation'))}
+          />
+        </Route>
+      )}
+      <Route
+        path="/relocation/:orgId/"
+        component={withDomainRedirect(errorHandler(OrganizationContextContainer))}
+        key="org-relocation"
+      >
+        <IndexRedirect to="welcome/" />
+        <Route path=":step/" component={make(() => import('sentry/views/relocation'))} />
+      </Route>
+      {usingCustomerDomain && (
+        <Route
           path="/onboarding/"
           component={errorHandler(withDomainRequired(OrganizationContextContainer))}
           key="orgless-onboarding"

--- a/static/app/views/relocation/components/stepHeading.tsx
+++ b/static/app/views/relocation/components/stepHeading.tsx
@@ -1,0 +1,40 @@
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+
+import {space} from 'sentry/styles/space';
+import testableTransition from 'sentry/utils/testableTransition';
+
+const StepHeading = styled(motion.h2)<{step: number}>`
+  position: relative;
+  display: inline-grid;
+  grid-template-columns: max-content auto;
+  gap: ${space(2)};
+  align-items: center;
+  font-size: 21px;
+
+  &:before {
+    content: '${p => p.step}';
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    background-color: ${p => p.theme.yellow300};
+    border-radius: 50%;
+    color: ${p => p.theme.textColor};
+    font-size: 1rem;
+  }
+`;
+
+StepHeading.defaultProps = {
+  variants: {
+    initial: {clipPath: 'inset(0% 100% 0% 0%)', opacity: 1},
+    animate: {clipPath: 'inset(0% 0% 0% 0%)', opacity: 1},
+    exit: {opacity: 0},
+  },
+  transition: testableTransition({
+    duration: 0.3,
+  }),
+};
+
+export default StepHeading;

--- a/static/app/views/relocation/encryptBackup.tsx
+++ b/static/app/views/relocation/encryptBackup.tsx
@@ -1,0 +1,103 @@
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+
+import {Button} from 'sentry/components/button';
+import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import testableTransition from 'sentry/utils/testableTransition';
+import StepHeading from 'sentry/views/relocation/components/stepHeading';
+
+import {StepProps} from './types';
+
+export function EncryptBackup(props: StepProps) {
+  const code =
+    './sentry-admin.sh export global--encrypt-with /path/to/public/\nkey/file.pub /path/to/encrypted/backup/output/file.tar';
+  return (
+    <Wrapper>
+      <StepHeading step={3}>
+        {t('Create an encrypted back up of current self-hosted instance')}
+      </StepHeading>
+      <motion.div
+        transition={testableTransition()}
+        variants={{
+          initial: {y: 30, opacity: 0},
+          animate: {y: 0, opacity: 1},
+          exit: {opacity: 0},
+        }}
+      >
+        <p>
+          {t(
+            'You’ll need to have the public key saved in the previous step accessible and run the command below in your terminal to ensure success'
+          )}
+        </p>
+        <EncryptCodeSnippet
+          dark
+          language="bash"
+          filename=">_ TERMINAL"
+          hideCopyButton={false}
+        >
+          {code}
+        </EncryptCodeSnippet>
+        <p className="encrypt-help">
+          <b>{t('Understanding the command:')}</b>
+        </p>
+        <p>
+          <mark>{'./sentry-admin.sh'}</mark>
+          {'this is a script present in your self-hosted installation'}
+        </p>
+        <p>
+          <mark>{'/path/to/public/key/file.pub'}</mark>
+          {'path to file you created in the previous step'}
+        </p>
+        <p>
+          <mark>{'/path/to/encrypted/backup/output/file.tar'}</mark>
+          {'file that will be uploaded in the next step'}
+        </p>
+        <ContinueButton size="md" priority="primary" onClick={() => props.onComplete()}>
+          {t('Continue')}
+        </ContinueButton>
+      </motion.div>
+    </Wrapper>
+  );
+}
+
+export default EncryptBackup;
+
+const EncryptCodeSnippet = styled(CodeSnippet)`
+  margin: ${space(2)} 0 ${space(4)};
+  padding: 4px;
+`;
+
+const Wrapper = styled('div')`
+  max-width: 769px;
+  max-height: 525px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: ${space(4)};
+  background-color: #ffffff;
+  z-index: 100;
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
+  border-radius: 10px;
+  width: 100%;
+  color: #80708f;
+  mark {
+    border-radius: 8px;
+    padding: ${space(0.25)} ${space(0.5)} ${space(0.25)} ${space(0.5)};
+    background: #f0ecf3;
+    margin-right: ${space(1)};
+  }
+  h2 {
+    color: #4d4158;
+  }
+  p {
+    margin-bottom: ${space(1)};
+  }
+  .encrypt-help {
+    color: #4d4158;
+  }
+`;
+
+const ContinueButton = styled(Button)`
+  margin-top: ${space(1.5)};
+`;

--- a/static/app/views/relocation/encryptBackup.tsx
+++ b/static/app/views/relocation/encryptBackup.tsx
@@ -12,11 +12,11 @@ import {StepProps} from './types';
 
 export function EncryptBackup(props: StepProps) {
   const code =
-    './sentry-admin.sh export global--encrypt-with /path/to/public/\nkey/file.pub /path/to/encrypted/backup/output/file.tar';
+    './sentry-admin.sh export global --encrypt-with /path/to/public_key.pub\n/path/to/encrypted/backup/file.tar';
   return (
     <Wrapper>
       <StepHeading step={3}>
-        {t('Create an encrypted back up of current self-hosted instance')}
+        {t('Create an encrypted backup of current self-hosted instance')}
       </StepHeading>
       <motion.div
         transition={testableTransition()}
@@ -28,7 +28,7 @@ export function EncryptBackup(props: StepProps) {
       >
         <p>
           {t(
-            'You’ll need to have the public key saved in the previous step accessible and run the command below in your terminal to ensure success'
+            'You’ll need to have the public key saved in the previous step accessible when you run the following command in your terminal. Make sure your current working directory is the root of your `self-hosted` install when you execute it.'
           )}
         </p>
         <EncryptCodeSnippet
@@ -44,15 +44,15 @@ export function EncryptBackup(props: StepProps) {
         </p>
         <p>
           <mark>{'./sentry-admin.sh'}</mark>
-          {'this is a script present in your self-hosted installation'}
+          {t('this is a script present in your self-hosted installation')}
         </p>
         <p>
           <mark>{'/path/to/public/key/file.pub'}</mark>
-          {'path to file you created in the previous step'}
+          {t('path to file you created in the previous step')}
         </p>
         <p>
           <mark>{'/path/to/encrypted/backup/output/file.tar'}</mark>
-          {'file that will be uploaded in the next step'}
+          {t('file that will be uploaded in the next step')}
         </p>
         <ContinueButton size="md" priority="primary" onClick={() => props.onComplete()}>
           {t('Continue')}

--- a/static/app/views/relocation/encryptBackup.tsx
+++ b/static/app/views/relocation/encryptBackup.tsx
@@ -75,26 +75,26 @@ const Wrapper = styled('div')`
   margin-left: auto;
   margin-right: auto;
   padding: ${space(4)};
-  background-color: #ffffff;
+  background-color: ${p => p.theme.surface400};
   z-index: 100;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
   border-radius: 10px;
   width: 100%;
-  color: #80708f;
+  color: ${p => p.theme.gray300};
   mark {
     border-radius: 8px;
     padding: ${space(0.25)} ${space(0.5)} ${space(0.25)} ${space(0.5)};
-    background: #f0ecf3;
+    background: ${p => p.theme.gray100};
     margin-right: ${space(1)};
   }
   h2 {
-    color: #4d4158;
+    color: ${p => p.theme.gray500};
   }
   p {
     margin-bottom: ${space(1)};
   }
   .encrypt-help {
-    color: #4d4158;
+    color: ${p => p.theme.gray500};
   }
 `;
 

--- a/static/app/views/relocation/getStarted.tsx
+++ b/static/app/views/relocation/getStarted.tsx
@@ -1,0 +1,146 @@
+import {useContext, useState} from 'react';
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+
+import {Button} from 'sentry/components/button';
+import SelectControl from 'sentry/components/forms/controls/selectControl';
+import Input from 'sentry/components/input';
+import {RelocationOnboardingContext} from 'sentry/components/onboarding/relocationOnboardingContext';
+import {t} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
+import {space} from 'sentry/styles/space';
+import testableTransition from 'sentry/utils/testableTransition';
+import StepHeading from 'sentry/views/relocation/components/stepHeading';
+
+import {StepProps} from './types';
+
+function GetStarted(props: StepProps) {
+  const regions = ConfigStore.get('regions');
+  const [region, setRegion] = useState(regions[0].name);
+  const [orgSlugs, setOrgSlugs] = useState('');
+  const relocationOnboardingContext = useContext(RelocationOnboardingContext);
+
+  const handleContinue = (event: any) => {
+    event.preventDefault();
+    const formData = new FormData(event.target);
+    relocationOnboardingContext.setData({formData});
+    props.onComplete();
+  };
+  return (
+    <Wrapper>
+      <StepHeading step={1}>{t('Basic Information Needed to Get Started')}</StepHeading>
+      <motion.div
+        transition={testableTransition()}
+        variants={{
+          initial: {y: 30, opacity: 0},
+          animate: {y: 0, opacity: 1},
+          exit: {opacity: 0},
+        }}
+      >
+        <Form onSubmit={handleContinue}>
+          <p>
+            {t(
+              'In order to best facilitate the process some basic information will be required to ensure sucess with the relocation process of you self-hosted instance'
+            )}
+          </p>
+          <RequiredLabel>{t('Organization Slugs')}</RequiredLabel>
+          <Input
+            type="text"
+            name="org-slugs"
+            aria-label="org-slugs"
+            onChange={evt => setOrgSlugs(evt.target.value)}
+            required
+            minLength={1}
+            placeholder=""
+          />
+          <Label>{t('Choose a Datacenter Region')}</Label>
+          <RegionSelect
+            value={region}
+            name="region"
+            aria-label="region"
+            options={regions.map(r => ({label: r.name, value: r.name}))}
+            onChange={opt => setRegion(opt.value)}
+          />
+          <ContinueButton disabled={!orgSlugs} size="md" priority="primary" type="submit">
+            {t('Continue')}
+          </ContinueButton>
+        </Form>
+      </motion.div>
+    </Wrapper>
+  );
+}
+
+export default GetStarted;
+
+const AnimatedContentWrapper = styled(motion.div)`
+  overflow: hidden;
+`;
+
+AnimatedContentWrapper.defaultProps = {
+  initial: {
+    height: 0,
+  },
+  animate: {
+    height: 'auto',
+  },
+  exit: {
+    height: 0,
+  },
+};
+
+const DocsWrapper = styled(motion.div)``;
+
+DocsWrapper.defaultProps = {
+  initial: {opacity: 0, y: 40},
+  animate: {opacity: 1, y: 0},
+  exit: {opacity: 0},
+};
+
+const Wrapper = styled('div')`
+  margin-left: auto;
+  margin-right: auto;
+  padding: ${space(4)};
+  background-color: #ffffff;
+  z-index: 100;
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
+  border-radius: 10px;
+  max-width: 769px;
+  max-height: 525px;
+  color: #80708f;
+  h2 {
+    color: #4d4158;
+  }
+`;
+
+const ContinueButton = styled(Button)`
+  margin-top: ${space(1.5)};
+`;
+
+const Form = styled('form')`
+  position: relative;
+`;
+
+const Label = styled('label')`
+  display: block;
+  text-transform: uppercase;
+  color: #4d4158;
+  margin-top: ${space(2)};
+`;
+
+const RequiredLabel = styled('label')`
+  display: block;
+  text-transform: uppercase;
+  color: #4d4158;
+  margin-top: ${space(2)};
+  &:after {
+    content: '•';
+    width: 6px;
+    color: #f55459;
+  }
+`;
+
+const RegionSelect = styled(SelectControl)`
+  button {
+    width: 709px;
+  }
+`;

--- a/static/app/views/relocation/getStarted.tsx
+++ b/static/app/views/relocation/getStarted.tsx
@@ -16,7 +16,7 @@ import {StepProps} from './types';
 
 function GetStarted(props: StepProps) {
   const regions = ConfigStore.get('regions');
-  const [region, setRegion] = useState(regions[0].name);
+  const [region, setRegion] = useState('');
   const [orgSlugs, setOrgSlugs] = useState('');
   const relocationOnboardingContext = useContext(RelocationOnboardingContext);
 
@@ -28,7 +28,7 @@ function GetStarted(props: StepProps) {
   };
   return (
     <Wrapper>
-      <StepHeading step={1}>{t('Basic Information Needed to Get Started')}</StepHeading>
+      <StepHeading step={1}>{t('Basic information needed to get started')}</StepHeading>
       <motion.div
         transition={testableTransition()}
         variants={{
@@ -43,7 +43,7 @@ function GetStarted(props: StepProps) {
               'In order to best facilitate the process some basic information will be required to ensure sucess with the relocation process of you self-hosted instance'
             )}
           </p>
-          <RequiredLabel>{t('Organization Slugs')}</RequiredLabel>
+          <RequiredLabel>{t('Organization slugs being relocated')}</RequiredLabel>
           <Input
             type="text"
             name="org-slugs"
@@ -51,17 +51,24 @@ function GetStarted(props: StepProps) {
             onChange={evt => setOrgSlugs(evt.target.value)}
             required
             minLength={1}
-            placeholder=""
+            placeholder="org-slugs-here"
           />
-          <Label>{t('Choose a Datacenter Region')}</Label>
+          <Label>{t('Choose a datacenter region')}</Label>
           <RegionSelect
             value={region}
             name="region"
             aria-label="region"
+            placeholder="Select Region"
             options={regions.map(r => ({label: r.name, value: r.name}))}
             onChange={opt => setRegion(opt.value)}
           />
-          <ContinueButton disabled={!orgSlugs} size="md" priority="primary" type="submit">
+          {region && <p>{t('This is an important decision and cannot be changed.')}</p>}
+          <ContinueButton
+            disabled={!orgSlugs || !region}
+            size="md"
+            priority="primary"
+            type="submit"
+          >
             {t('Continue')}
           </ContinueButton>
         </Form>
@@ -113,7 +120,7 @@ const Wrapper = styled('div')`
 `;
 
 const ContinueButton = styled(Button)`
-  margin-top: ${space(1.5)};
+  margin-top: ${space(4)};
 `;
 
 const Form = styled('form')`
@@ -140,6 +147,7 @@ const RequiredLabel = styled('label')`
 `;
 
 const RegionSelect = styled(SelectControl)`
+  padding-bottom: ${space(2)};
   button {
     width: 709px;
   }

--- a/static/app/views/relocation/getStarted.tsx
+++ b/static/app/views/relocation/getStarted.tsx
@@ -22,10 +22,10 @@ function GetStarted(props: StepProps) {
 
   const handleContinue = (event: any) => {
     event.preventDefault();
-    const formData = new FormData(event.target);
-    relocationOnboardingContext.setData({formData});
+    relocationOnboardingContext.setData({orgSlugs, region});
     props.onComplete();
   };
+  // TODO(getsentry/team-ospo#214): Make a popup to warn users about data region selection
   return (
     <Wrapper>
       <StepHeading step={1}>{t('Basic information needed to get started')}</StepHeading>
@@ -46,12 +46,12 @@ function GetStarted(props: StepProps) {
           <RequiredLabel>{t('Organization slugs being relocated')}</RequiredLabel>
           <Input
             type="text"
-            name="org-slugs"
+            name="orgs"
             aria-label="org-slugs"
             onChange={evt => setOrgSlugs(evt.target.value)}
             required
             minLength={3}
-            placeholder="org-slugs-here"
+            placeholder="org-slug-1, org-slug-2, ..."
           />
           <Label>{t('Choose a datacenter region')}</Label>
           <RegionSelect

--- a/static/app/views/relocation/getStarted.tsx
+++ b/static/app/views/relocation/getStarted.tsx
@@ -50,7 +50,7 @@ function GetStarted(props: StepProps) {
             aria-label="org-slugs"
             onChange={evt => setOrgSlugs(evt.target.value)}
             required
-            minLength={1}
+            minLength={3}
             placeholder="org-slugs-here"
           />
           <Label>{t('Choose a datacenter region')}</Label>
@@ -107,15 +107,15 @@ const Wrapper = styled('div')`
   margin-left: auto;
   margin-right: auto;
   padding: ${space(4)};
-  background-color: #ffffff;
+  background-color: ${p => p.theme.surface400};
   z-index: 100;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
   border-radius: 10px;
   max-width: 769px;
   max-height: 525px;
-  color: #80708f;
+  color: ${p => p.theme.gray300};
   h2 {
-    color: #4d4158;
+    color: ${p => p.theme.gray500};
   }
 `;
 
@@ -130,19 +130,19 @@ const Form = styled('form')`
 const Label = styled('label')`
   display: block;
   text-transform: uppercase;
-  color: #4d4158;
+  color: ${p => p.theme.gray500};
   margin-top: ${space(2)};
 `;
 
 const RequiredLabel = styled('label')`
   display: block;
   text-transform: uppercase;
-  color: #4d4158;
+  color: ${p => p.theme.gray500};
   margin-top: ${space(2)};
   &:after {
     content: '•';
     width: 6px;
-    color: #f55459;
+    color: ${p => p.theme.red300};
   }
 `;
 

--- a/static/app/views/relocation/index.spec.tsx
+++ b/static/app/views/relocation/index.spec.tsx
@@ -1,0 +1,40 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ConfigStore from 'sentry/stores/configStore';
+
+import RelocationOnboardingContainer from './index';
+
+describe('Relocation Onboarding Container', function () {
+  it('should render if feature enabled', function () {
+    const {routerProps, routerContext, organization} = initializeOrg({
+      router: {
+        params: {step: '1'},
+      },
+    });
+    ConfigStore.set('features', new Set(['relocation:enabled']));
+    render(<RelocationOnboardingContainer {...routerProps} />, {
+      context: routerContext,
+      organization,
+    });
+    expect(
+      screen.queryByText("You don't have access to this feature")
+    ).not.toBeInTheDocument();
+  });
+
+  it('should not render if feature disabled', async function () {
+    const {routerProps, routerContext, organization} = initializeOrg({
+      router: {
+        params: {step: '1'},
+      },
+    });
+    ConfigStore.set('features', new Set([]));
+    render(<RelocationOnboardingContainer {...routerProps} />, {
+      context: routerContext,
+      organization,
+    });
+    expect(
+      await screen.queryByText("You don't have access to this feature")
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/relocation/index.tsx
+++ b/static/app/views/relocation/index.tsx
@@ -1,9 +1,25 @@
 import {RouteComponentProps} from 'react-router';
 
+import Feature from 'sentry/components/acl/feature';
+import {Alert} from 'sentry/components/alert';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {t} from 'sentry/locale';
+
 import RelocationOnboarding from './relocation';
 
 type Props = RouteComponentProps<{step: string}, {}>;
 
 export default function RelocationOnboardingContainer(props: Props) {
-  return <RelocationOnboarding {...props} />;
+  return (
+    <Feature
+      features={['relocation:enabled']}
+      renderDisabled={() => (
+        <Layout.Page withPadding>
+          <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+        </Layout.Page>
+      )}
+    >
+      <RelocationOnboarding {...props} />
+    </Feature>
+  );
 }

--- a/static/app/views/relocation/index.tsx
+++ b/static/app/views/relocation/index.tsx
@@ -1,0 +1,9 @@
+import {RouteComponentProps} from 'react-router';
+
+import RelocationOnboarding from './relocation';
+
+type Props = RouteComponentProps<{step: string}, {}>;
+
+export default function RelocationOnboardingContainer(props: Props) {
+  return <RelocationOnboarding {...props} />;
+}

--- a/static/app/views/relocation/relocation.spec.tsx
+++ b/static/app/views/relocation/relocation.spec.tsx
@@ -58,6 +58,7 @@ describe('Relocation', function () {
           'Create an encrypted backup of current self-hosted instance'
         )
       ).toBeInTheDocument();
+      expect(await screen.findByText('./sentry-admin.sh')).toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/relocation/relocation.spec.tsx
+++ b/static/app/views/relocation/relocation.spec.tsx
@@ -1,0 +1,90 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {RelocationOnboardingContextProvider} from 'sentry/components/onboarding/relocationOnboardingContext';
+import Relocation from 'sentry/views/relocation/relocation';
+
+describe('Relocation', function () {
+  function renderPage(step) {
+    const routeParams = {
+      step,
+    };
+
+    const {routerProps, routerContext, organization} = initializeOrg({
+      router: {
+        params: routeParams,
+      },
+    });
+
+    render(
+      <RelocationOnboardingContextProvider>
+        <Relocation {...routerProps} />
+      </RelocationOnboardingContextProvider>,
+      {
+        context: routerContext,
+        organization,
+      }
+    );
+  }
+  describe('Get Started', function () {
+    it('renders', async function () {
+      renderPage('get-started');
+      expect(
+        await screen.findByText('Basic Information Needed to Get Started')
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText(
+          'In order to best facilitate the process some basic information will be required to ensure sucess with the relocation process of you self-hosted instance'
+        )
+      ).toBeInTheDocument();
+      expect(await screen.findByText('Organization Slugs')).toBeInTheDocument();
+      expect(await screen.findByText('Choose a Datacenter Region')).toBeInTheDocument();
+    });
+
+    it('should prevent user from going to the next step if no org slugs are entered', async function () {
+      renderPage('get-started');
+      expect(await screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+    });
+
+    it('should be allowed to go to next step if org slug is entered', async function () {
+      renderPage('get-started');
+      const orgSlugsInput = await screen.getByLabelText('org-slugs');
+      const continueButton = await screen.getByRole('button', {name: 'Continue'});
+      await userEvent.type(orgSlugsInput, 'test-org');
+      expect(continueButton).toBeEnabled();
+    });
+  });
+
+  describe('Select Platform', function () {
+    it('renders', async function () {
+      renderPage('encrypt-backup');
+      expect(
+        await screen.findByText(
+          'Create an encrypted back up of current self-hosted instance'
+        )
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText(
+          'You’ll need to have the public key saved in the previous step accessible and run the command below in your terminal to ensure success'
+        )
+      ).toBeInTheDocument();
+      expect(await screen.findByText('Understanding the command:')).toBeInTheDocument();
+      expect(await screen.findByText('./sentry-admin.sh')).toBeInTheDocument();
+      expect(
+        await screen.findByText(
+          'this is a script present in your self-hosted installation'
+        )
+      ).toBeInTheDocument();
+      expect(await screen.findByText('/path/to/public/key/file.pub')).toBeInTheDocument();
+      expect(
+        await screen.findByText('path to file you created in the previous step')
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText('/path/to/encrypted/backup/output/file.tar')
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText('file that will be uploaded in the next step')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/relocation/relocation.spec.tsx
+++ b/static/app/views/relocation/relocation.spec.tsx
@@ -1,6 +1,7 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import ConfigStore from 'sentry/stores/configStore';
 import Relocation from 'sentry/views/relocation/relocation';
 
 describe('Relocation', function () {
@@ -15,7 +16,7 @@ describe('Relocation', function () {
       },
     });
 
-    render(<Relocation {...routerProps} />, {
+    return render(<Relocation {...routerProps} />, {
       context: routerContext,
       organization,
     });
@@ -24,27 +25,27 @@ describe('Relocation', function () {
     it('renders', async function () {
       renderPage('get-started');
       expect(
-        await screen.findByText('Basic Information Needed to Get Started')
+        await screen.findByText('Basic information needed to get started')
       ).toBeInTheDocument();
       expect(
-        await screen.findByText(
-          'In order to best facilitate the process some basic information will be required to ensure sucess with the relocation process of you self-hosted instance'
-        )
+        await screen.findByText('Organization slugs being relocated')
       ).toBeInTheDocument();
-      expect(await screen.findByText('Organization Slugs')).toBeInTheDocument();
-      expect(await screen.findByText('Choose a Datacenter Region')).toBeInTheDocument();
+      expect(await screen.findByText('Choose a datacenter region')).toBeInTheDocument();
     });
 
-    it('should prevent user from going to the next step if no org slugs are entered', async function () {
+    it('should prevent user from going to the next step if no org slugs or region are entered', function () {
       renderPage('get-started');
-      expect(await screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+      expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
     });
 
-    it('should be allowed to go to next step if org slug is entered', async function () {
+    it('should be allowed to go to next step if org slug is entered and region is selected', async function () {
       renderPage('get-started');
-      const orgSlugsInput = await screen.getByLabelText('org-slugs');
-      const continueButton = await screen.getByRole('button', {name: 'Continue'});
+      ConfigStore.set('regions', [{name: 'USA', url: 'https://example.com'}]);
+      const orgSlugsInput = screen.getByLabelText('org-slugs');
+      const continueButton = screen.getByRole('button', {name: 'Continue'});
       await userEvent.type(orgSlugsInput, 'test-org');
+      await userEvent.type(screen.getByLabelText('region'), 'U');
+      await userEvent.click(screen.getByRole('menuitemradio'));
       expect(continueButton).toBeEnabled();
     });
   });
@@ -54,30 +55,8 @@ describe('Relocation', function () {
       renderPage('encrypt-backup');
       expect(
         await screen.findByText(
-          'Create an encrypted back up of current self-hosted instance'
+          'Create an encrypted backup of current self-hosted instance'
         )
-      ).toBeInTheDocument();
-      expect(
-        await screen.findByText(
-          'You’ll need to have the public key saved in the previous step accessible and run the command below in your terminal to ensure success'
-        )
-      ).toBeInTheDocument();
-      expect(await screen.findByText('Understanding the command:')).toBeInTheDocument();
-      expect(await screen.findByText('./sentry-admin.sh')).toBeInTheDocument();
-      expect(
-        await screen.findByText(
-          'this is a script present in your self-hosted installation'
-        )
-      ).toBeInTheDocument();
-      expect(await screen.findByText('/path/to/public/key/file.pub')).toBeInTheDocument();
-      expect(
-        await screen.findByText('path to file you created in the previous step')
-      ).toBeInTheDocument();
-      expect(
-        await screen.findByText('/path/to/encrypted/backup/output/file.tar')
-      ).toBeInTheDocument();
-      expect(
-        await screen.findByText('file that will be uploaded in the next step')
       ).toBeInTheDocument();
     });
   });

--- a/static/app/views/relocation/relocation.spec.tsx
+++ b/static/app/views/relocation/relocation.spec.tsx
@@ -1,7 +1,6 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {RelocationOnboardingContextProvider} from 'sentry/components/onboarding/relocationOnboardingContext';
 import Relocation from 'sentry/views/relocation/relocation';
 
 describe('Relocation', function () {
@@ -16,15 +15,10 @@ describe('Relocation', function () {
       },
     });
 
-    render(
-      <RelocationOnboardingContextProvider>
-        <Relocation {...routerProps} />
-      </RelocationOnboardingContextProvider>,
-      {
-        context: routerContext,
-        organization,
-      }
-    );
+    render(<Relocation {...routerProps} />, {
+      context: routerContext,
+      organization,
+    });
   }
   describe('Get Started', function () {
     it('renders', async function () {

--- a/static/app/views/relocation/relocation.tsx
+++ b/static/app/views/relocation/relocation.tsx
@@ -1,0 +1,275 @@
+import {useCallback, useEffect, useRef} from 'react';
+import {RouteComponentProps} from 'react-router';
+import styled from '@emotion/styled';
+import {AnimatePresence, motion, MotionProps, useAnimation} from 'framer-motion';
+
+import {Button, ButtonProps} from 'sentry/components/button';
+import LogoSentry from 'sentry/components/logoSentry';
+import {RelocationOnboardingContextProvider} from 'sentry/components/onboarding/relocationOnboardingContext';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {IconArrow} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import Redirect from 'sentry/utils/redirect';
+import testableTransition from 'sentry/utils/testableTransition';
+import useOrganization from 'sentry/utils/useOrganization';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import PageCorners from 'sentry/views/onboarding/components/pageCorners';
+import Stepper from 'sentry/views/onboarding/components/stepper';
+
+import EncryptBackup from './encryptBackup';
+import GetStarted from './getStarted';
+import {StepDescriptor} from './types';
+
+type RouteParams = {
+  step: string;
+};
+
+type Props = RouteComponentProps<RouteParams, {}>;
+
+function getOrganizationOnboardingSteps(): StepDescriptor[] {
+  return [
+    {
+      id: 'get-started',
+      title: t('Get Started'),
+      Component: GetStarted,
+      cornerVariant: 'top-left',
+    },
+    {
+      id: 'encrypt-backup',
+      title: t('Encrypt backup'),
+      Component: EncryptBackup,
+      cornerVariant: 'top-left',
+    },
+  ];
+}
+
+function RelocationOnboarding(props: Props) {
+  const organization = useOrganization();
+
+  const {
+    params: {step: stepId},
+  } = props;
+
+  const onboardingSteps = getOrganizationOnboardingSteps();
+  const stepObj = onboardingSteps.find(({id}) => stepId === id);
+  const stepIndex = onboardingSteps.findIndex(({id}) => stepId === id);
+
+  const cornerVariantTimeoutRed = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    return () => {
+      window.clearTimeout(cornerVariantTimeoutRed.current);
+    };
+  }, []);
+
+  const cornerVariantControl = useAnimation();
+  const updateCornerVariant = () => {
+    // TODO: find better way to delay the corner animation
+    window.clearTimeout(cornerVariantTimeoutRed.current);
+
+    cornerVariantTimeoutRed.current = window.setTimeout(
+      () => cornerVariantControl.start(stepIndex === 0 ? 'top-right' : 'top-left'),
+      1000
+    );
+  };
+
+  useEffect(updateCornerVariant, [stepIndex, cornerVariantControl]);
+
+  // Called onExitComplete
+  const updateAnimationState = () => {
+    if (!stepObj) {
+      return;
+    }
+  };
+
+  const goToStep = (step: StepDescriptor) => {
+    if (!stepObj) {
+      return;
+    }
+    if (step.cornerVariant !== stepObj.cornerVariant) {
+      cornerVariantControl.start('none');
+    }
+    props.router.push(normalizeUrl(`/relocation/${organization.slug}/${step.id}/`));
+  };
+
+  const goNextStep = useCallback(
+    (step: StepDescriptor) => {
+      const currentStepIndex = onboardingSteps.findIndex(s => s.id === step.id);
+      const nextStep = onboardingSteps[currentStepIndex + 1];
+
+      if (step.cornerVariant !== nextStep.cornerVariant) {
+        cornerVariantControl.start('none');
+      }
+
+      props.router.push(normalizeUrl(`/relocation/${organization.slug}/${nextStep.id}/`));
+    },
+    [organization.slug, onboardingSteps, cornerVariantControl, props.router]
+  );
+
+  if (!stepObj || stepIndex === -1) {
+    return (
+      <Redirect
+        to={normalizeUrl(`/relocation/${organization.slug}/${onboardingSteps[0].id}/`)}
+      />
+    );
+  }
+
+  return (
+    <OnboardingWrapper data-test-id="relocation-onboarding">
+      <RelocationOnboardingContextProvider>
+        <SentryDocumentTitle title={stepObj.title} />
+        <Header>
+          <LogoSvg />
+          {stepIndex !== -1 && (
+            <StyledStepper
+              numSteps={onboardingSteps.length}
+              currentStepIndex={stepIndex}
+              onClick={i => {
+                goToStep(onboardingSteps[i]);
+              }}
+            />
+          )}
+        </Header>
+        <Container>
+          <Back
+            onClick={() => goToStep(onboardingSteps[stepIndex - 1])}
+            animate={stepIndex > 0 ? 'visible' : 'hidden'}
+          />
+          <AnimatePresence exitBeforeEnter onExitComplete={updateAnimationState}>
+            <OnboardingStep
+              key={stepObj.id}
+              data-test-id={`onboarding-step-${stepObj.id}`}
+            >
+              {stepObj.Component && (
+                <stepObj.Component
+                  active
+                  data-test-id={`onboarding-step-${stepObj.id}`}
+                  stepIndex={stepIndex}
+                  onComplete={() => {
+                    if (stepObj) {
+                      goNextStep(stepObj);
+                    }
+                  }}
+                  route={props.route}
+                  router={props.router}
+                  location={props.location}
+                />
+              )}
+            </OnboardingStep>
+          </AnimatePresence>
+          <AdaptivePageCorners animateVariant={cornerVariantControl} />
+        </Container>
+      </RelocationOnboardingContextProvider>
+    </OnboardingWrapper>
+  );
+}
+
+const Container = styled('div')`
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  background: #faf9fb;
+  padding: 120px ${space(3)};
+  width: 100%;
+  margin: 0 auto;
+`;
+
+const Header = styled('header')`
+  background: ${p => p.theme.background};
+  padding-left: ${space(4)};
+  padding-right: ${space(4)};
+  position: sticky;
+  height: 80px;
+  align-items: center;
+  top: 0;
+  z-index: 100;
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.05);
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  justify-items: stretch;
+`;
+
+const LogoSvg = styled(LogoSentry)`
+  width: 130px;
+  height: 30px;
+  color: ${p => p.theme.textColor};
+`;
+
+const OnboardingStep = styled(motion.div)`
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+`;
+
+OnboardingStep.defaultProps = {
+  initial: 'initial',
+  animate: 'animate',
+  exit: 'exit',
+  variants: {animate: {}},
+  transition: testableTransition({
+    staggerChildren: 0.2,
+  }),
+};
+
+const AdaptivePageCorners = styled(PageCorners)`
+  --corner-scale: 1;
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
+    --corner-scale: 0.5;
+  }
+`;
+
+const StyledStepper = styled(Stepper)`
+  justify-self: center;
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    display: none;
+  }
+`;
+
+interface BackButtonProps extends Omit<ButtonProps, 'icon' | 'priority'> {
+  animate: MotionProps['animate'];
+  className?: string;
+}
+
+const Back = styled(({className, animate, ...props}: BackButtonProps) => (
+  <motion.div
+    className={className}
+    animate={animate}
+    transition={testableTransition()}
+    variants={{
+      initial: {opacity: 0, visibility: 'hidden'},
+      visible: {
+        opacity: 1,
+        visibility: 'visible',
+        transition: testableTransition({delay: 1}),
+      },
+      hidden: {
+        opacity: 0,
+        transitionEnd: {
+          visibility: 'hidden',
+        },
+      },
+    }}
+  >
+    <Button {...props} icon={<IconArrow direction="left" size="sm" />} priority="link">
+      {t('Back')}
+    </Button>
+  </motion.div>
+))`
+  position: absolute;
+  top: 40px;
+  left: 20px;
+
+  button {
+    font-size: ${p => p.theme.fontSizeSmall};
+  }
+`;
+
+const OnboardingWrapper = styled('main')`
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+`;
+
+export default RelocationOnboarding;

--- a/static/app/views/relocation/types.ts
+++ b/static/app/views/relocation/types.ts
@@ -1,6 +1,5 @@
 import {RouteComponentProps} from 'react-router';
 
-// Not sure if we need platform info to be passed down
 export type StepProps = Pick<
   RouteComponentProps<{}, {}>,
   'router' | 'route' | 'location'

--- a/static/app/views/relocation/types.ts
+++ b/static/app/views/relocation/types.ts
@@ -1,0 +1,18 @@
+import {RouteComponentProps} from 'react-router';
+
+// Not sure if we need platform info to be passed down
+export type StepProps = Pick<
+  RouteComponentProps<{}, {}>,
+  'router' | 'route' | 'location'
+> & {
+  active: boolean;
+  onComplete: () => void;
+  stepIndex: number;
+};
+
+export type StepDescriptor = {
+  Component: React.ComponentType<StepProps>;
+  cornerVariant: 'top-right' | 'top-left';
+  id: string;
+  title: string;
+};


### PR DESCRIPTION
This PR includes the get started page and encrypt backup page.

If `relocation:enabled` is not set, the page will not load

<img width="1174" alt="Screenshot 2023-12-07 at 1 20 51 PM" src="https://github.com/getsentry/sentry/assets/25517925/4c43601c-4452-48d2-bc2b-03348d7dfffd">

<img width="1172" alt="Screenshot 2023-12-07 at 1 21 00 PM" src="https://github.com/getsentry/sentry/assets/25517925/18aee989-dbbc-4663-8c9c-d6d58b097274">
