### PR TITLE
fix(alerts): Display disabled query on error migration

### DIFF
--- a/static/app/views/alerts/rules/metric/details/errorMigrationWarning.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/errorMigrationWarning.spec.tsx
@@ -61,4 +61,24 @@ describe('ErrorMigrationWarning', () => {
     expect(container).toBeEmptyDOMElement();
     expect(dismissMock).toHaveBeenCalledTimes(1);
   });
+
+  it('renders nothing if the alert was created after the `is:unresolved` feature became available', () => {
+    const rule = MetricRule({
+      projects: [project.slug],
+      latestIncident: null,
+      dataset: Dataset.ERRORS,
+      query: '',
+      dateCreated: '2024-01-01T00:00:00Z',
+    });
+    const promptApi = MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      body: {},
+    });
+    const {container} = render(<ErrorMigrationWarning project={project} rule={rule} />, {
+      organization,
+    });
+
+    expect(container).toBeEmptyDOMElement();
+    expect(promptApi).not.toHaveBeenCalled();
+  });
 });

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -77,8 +77,9 @@ type Props = {
   allowChangeEventTypes?: boolean;
   comparisonDelta?: number;
   disableProjectSelector?: boolean;
+  isErrorMigration?: boolean;
   isExtrapolatedChartData?: boolean;
-  isMigration?: boolean;
+  isTransactionMigration?: boolean;
   loadingProjects?: boolean;
 };
 
@@ -161,7 +162,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
   }
 
   renderEventTypeFilter() {
-    const {organization, disabled, alertType} = this.props;
+    const {organization, disabled, alertType, isErrorMigration} = this.props;
 
     const dataSourceOptions = [
       {
@@ -243,7 +244,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                 model.setValue('eventTypes', eventTypes);
               }}
               options={dataSourceOptions}
-              isDisabled={disabled}
+              isDisabled={disabled || isErrorMigration}
             />
           );
         }}
@@ -386,7 +387,8 @@ class RuleConditionsForm extends PureComponent<Props, State> {
       allowChangeEventTypes,
       dataset,
       isExtrapolatedChartData,
-      isMigration,
+      isTransactionMigration,
+      isErrorMigration,
       aggregate,
       project,
     } = this.props;
@@ -407,7 +409,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
         <ChartPanel>
           <StyledPanelBody>{this.props.thresholdChart}</StyledPanelBody>
         </ChartPanel>
-        {isMigration ? (
+        {isTransactionMigration ? (
           <Fragment>
             <Spacer />
             <HiddenListItem />
@@ -422,7 +424,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                 )}
               />
             )}
-            {this.renderInterval()}
+            {!isErrorMigration && this.renderInterval()}
             <StyledListItem>{t('Filter events')}</StyledListItem>
             <FormRow noMargin columns={1 + (allowChangeEventTypes ? 1 : 0) + 1}>
               {this.renderProjectSelector()}
@@ -443,7 +445,9 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                   }),
                 }}
                 options={environmentOptions}
-                isDisabled={disabled || this.state.environments === null}
+                isDisabled={
+                  disabled || this.state.environments === null || isErrorMigration
+                }
                 isClearable
                 inline={false}
                 flexibleControlStateSize
@@ -508,7 +512,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                         defaultQuery={initialData?.query ?? ''}
                         {...getSupportedAndOmittedTags(dataset, organization)}
                         includeSessionTagsValues={dataset === Dataset.SESSIONS}
-                        disabled={disabled}
+                        disabled={disabled || isErrorMigration}
                         useFormWrapper={false}
                         organization={organization}
                         placeholder={this.searchPlaceholder}

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -456,9 +456,7 @@ describe('Incident Rules Form', () => {
       });
 
       expect(
-        await screen.findByText(
-          /Check the chart above and make sure the current thresholds are still valid/
-        )
+        await screen.findByText(/please make sure the current thresholds are still valid/)
       ).toBeInTheDocument();
       await userEvent.click(screen.getByLabelText('Looks good to me!'), {delay: null});
       expect(onSubmitSuccess).toHaveBeenCalled();

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1024,7 +1024,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       !!ruleId && hasMigrationFeatureFlag(organization) && ruleNeedsMigration(rule);
     const showErrorMigrationWarning =
       !!ruleId &&
-      location?.query?.migration === '1' &&
+      isMigration &&
       hasIgnoreArchivedFeatureFlag(organization) &&
       ruleNeedsErrorMigration(rule);
 
@@ -1085,7 +1085,8 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
               project={project}
               aggregate={aggregate}
               organization={organization}
-              isMigration={isMigration}
+              isTransactionMigration={isMigration && !showErrorMigrationWarning}
+              isErrorMigration={showErrorMigrationWarning}
               router={router}
               disabled={formDisabled}
               thresholdChart={wizardBuilderChart}
@@ -1137,8 +1138,11 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
             )}
             {showErrorMigrationWarning && (
               <Alert type="warning" showIcon>
-                {t(
-                  'Check the chart above and make sure the current thresholds are still valid, given that this alert is now filtering out resolved and archived errors.'
+                {tct(
+                  "We've added [code:is:unresolved] to your events filter; please make sure the current thresholds are still valid as this alert is now filtering out resolved and archived errors.",
+                  {
+                    code: <code />,
+                  }
                 )}
               </Alert>
             )}


### PR DESCRIPTION
Fixes feedback on ignoring archived issues from metric alerts related to #60439

- Displays the modified query with `is:unresolved` when migrating.
- Hides the migration banner if the alert was created or modified after the feature went live

the migration ui with the query displayed but disabled
![image](https://github.com/getsentry/sentry/assets/1400464/3e1e4c07-2467-4703-a68d-5a04a026050a)
