### PR TITLE
chore(api-docs): Set SetupWizard endpoints to experimental

### DIFF
--- a/src/sentry/api/endpoints/setup_wizard.py
+++ b/src/sentry/api/endpoints/setup_wizard.py
@@ -22,8 +22,8 @@ SETUP_WIZARD_CACHE_TIMEOUT = 600
 class SetupWizard(Endpoint):
     owner = ApiOwner.WEB_FRONTEND_SDKS
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = ()
 

--- a/src/sentry/api/endpoints/setup_wizard.py
+++ b/src/sentry/api/endpoints/setup_wizard.py
@@ -22,8 +22,8 @@ SETUP_WIZARD_CACHE_TIMEOUT = 600
 class SetupWizard(Endpoint):
     owner = ApiOwner.WEB_FRONTEND_SDKS
     publish_status = {
-        "DELETE": ApiPublishStatus.PRIVATE,
-        "GET": ApiPublishStatus.PRIVATE,
+        "DELETE": ApiPublishStatus.EXPERIMENTAL,
+        "GET": ApiPublishStatus.EXPERIMENTAL,
     }
     permission_classes = ()
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

Sets the SetupWizard endpoints to private as we might have to change the endpoint in the future

