### PR TITLE
feat(perf): Add frames delay to mobile vitals

### DIFF
--- a/src/sentry/api/endpoints/organization_events_has_measurements.py
+++ b/src/sentry/api/endpoints/organization_events_has_measurements.py
@@ -27,6 +27,7 @@ MEASUREMENT_TYPES = {
         "measurements.frames_total",
         "measurements.frames_slow",
         "measurements.frames_frozen",
+        "measurements.frames_delay",
         "measurements.stall_count",
         "measurements.stall_stall_total_time",
         "measurements.stall_stall_longest_time",

--- a/src/sentry/data/samples/android-transaction.json
+++ b/src/sentry/data/samples/android-transaction.json
@@ -225,6 +225,10 @@
       "value": 1,
       "unit": "none"
     },
+    "frames_delay": {
+      "value": 1234.42,
+      "unit": "millisecond"
+    },
     "screen_load_count": {
       "value": 1,
       "unit": "test"

--- a/src/sentry/relay/config/measurements.py
+++ b/src/sentry/relay/config/measurements.py
@@ -35,6 +35,7 @@ BUILTIN_MEASUREMENTS: Sequence[BuiltinMeasurementKey] = [
     {"name": "frames_slow_rate", "unit": "ratio"},
     {"name": "frames_slow", "unit": "none"},
     {"name": "frames_total", "unit": "none"},
+    {"name": "frames_delay", "unit": "millisecond"},
     {"name": "inp", "unit": "millisecond"},
     {"name": "lcp", "unit": "millisecond"},
     {"name": "stall_count", "unit": "none"},

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -258,6 +258,7 @@ METRICS_MAP = {
     "measurements.frames_frozen": "d:transactions/measurements.frames_frozen@none",
     "measurements.frames_slow": "d:transactions/measurements.frames_slow@none",
     "measurements.frames_total": "d:transactions/measurements.frames_total@none",
+    "measurements.frames_delay": "d:transactions/measurements.frames_delay@millisecond",
     "measurements.lcp": "d:transactions/measurements.lcp@millisecond",
     "measurements.time_to_initial_display": "d:transactions/measurements.time_to_initial_display@millisecond",
     "measurements.time_to_full_display": "d:transactions/measurements.time_to_full_display@millisecond",

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -101,6 +101,7 @@ TRANSACTION_METRICS_NAMES = {
     "d:transactions/measurements.score.weight.fid@ratio": PREFIX + 146,
     "d:transactions/measurements.score.weight.lcp@ratio": PREFIX + 147,
     "d:transactions/measurements.score.weight.ttfb@ratio": PREFIX + 148,
+    "d:transactions/measurements.frames_delay@millisecond": PREFIX + 149,
     # Last possible index: 199
 }
 

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -114,6 +114,7 @@ class TransactionMRI(Enum):
     MEASUREMENTS_FRAMES_SLOW = "d:transactions/measurements.frames_slow@none"
     MEASUREMENTS_FRAMES_SLOW_RATE = "d:transactions/measurements.frames_slow_rate@ratio"
     MEASUREMENTS_FRAMES_TOTAL = "d:transactions/measurements.frames_total@none"
+    MEASUREMENTS_FRAMES_DELAY = "d:transactions/measurements.frames_delay@millisecond"
     MEASUREMENTS_TIME_TO_INITIAL_DISPLAY = (
         "d:transactions/measurements.time_to_initial_display@millisecond"
     )

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -76,6 +76,7 @@ class TransactionMetricKey(Enum):
     MEASUREMENTS_FRAMES_SLOW = "transaction.measurements.frames_slow"
     MEASUREMENTS_FRAMES_SLOW_RATE = "transaction.measurements.frames_slow_rate"
     MEASUREMENTS_FRAMES_TOTAL = "transaction.measurements.frames_total"
+    MEASUREMENTS_FRAMES_DELAY = "transaction.measurements.frames_delay"
     MEASUREMENTS_TIME_TO_INITIAL_DISPLAY = "transaction.measurements.time_to_initial_display"
     MEASUREMENTS_TIME_TO_FULL_DISPLAY = "transaction.measurements.time_to_full_display"
     MEASUREMENTS_STALL_COUNT = "transaction.measurements.stall_count"

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1581,6 +1581,7 @@ def is_duration_measurement(key):
         "measurements.app_start_warm",
         "measurements.time_to_full_display",
         "measurements.time_to_initial_display",
+        "measurements.frames_delay",
     ]
 
 

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -155,6 +155,7 @@ export enum MobileVital {
   FRAMES_FROZEN = 'measurements.frames_frozen',
   FRAMES_SLOW_RATE = 'measurements.frames_slow_rate',
   FRAMES_FROZEN_RATE = 'measurements.frames_frozen_rate',
+  FRAMES_DELAY = 'measurements.frames_delay',
   STALL_COUNT = 'measurements.stall_count',
   STALL_TOTAL_TIME = 'measurements.stall_total_time',
   STALL_LONGEST_TIME = 'measurements.stall_longest_time',
@@ -431,6 +432,11 @@ export const MEASUREMENT_FIELDS: Record<WebVital | MobileVital, FieldDefinition>
     desc: t('Number of frozen frames out of the total'),
     kind: FieldKind.METRICS,
     valueType: FieldValueType.PERCENTAGE,
+  },
+  [MobileVital.FRAMES_DELAY]: {
+    desc: t('Duration of all delayed frames.'),
+    kind: FieldKind.METRICS,
+    valueType: FieldValueType.DURATION,
   },
   [MobileVital.STALL_COUNT]: {
     desc: t('Count of slow Javascript event loops (React Native)'),

--- a/static/app/utils/performance/vitals/constants.tsx
+++ b/static/app/utils/performance/vitals/constants.tsx
@@ -133,6 +133,14 @@ export const MOBILE_VITAL_DETAILS: Record<MobileVital, Vital> = {
     ),
     type: measurementType(MobileVital.FRAMES_FROZEN_RATE),
   },
+  [MobileVital.FRAMES_DELAY]: {
+    slug: 'frames_delay',
+    name: t('Frames Delay'),
+    description: t(
+      'Frames delay is the duration of all delayed frames recorded within a transaction.'
+    ),
+    type: measurementType(MobileVital.FRAMES_DELAY),
+  },
   [MobileVital.STALL_COUNT]: {
     slug: 'stall_count',
     name: t('Stalls'),

--- a/tests/relay_integration/test_metrics_extraction.py
+++ b/tests/relay_integration/test_metrics_extraction.py
@@ -48,6 +48,7 @@ class MetricsExtractionTest(RelayStoreHelper, TransactionTestCase):
                     "frames_total": {"value": 100},
                     "frames_slow": {"value": 10},
                     "frames_frozen": {"value": 5},
+                    "frames_delay": {"value": 0.0145},
                     "stall_count": {"value": 2},
                     "stall_total_time": {"value": 12},
                     "stall_longest_time": {"value": 7},

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -4961,6 +4961,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         self.transaction_data["measurements"]["frames_total"] = {"value": 100}
         self.transaction_data["measurements"]["frames_slow"] = {"value": 10}
         self.transaction_data["measurements"]["frames_frozen"] = {"value": 5}
+        self.transaction_data["measurements"]["frames_delay"] = {"value": 0.16}
         self.transaction_data["measurements"]["stall_count"] = {"value": 2}
         self.transaction_data["measurements"]["stall_total_time"] = {"value": 12}
         self.transaction_data["measurements"]["stall_longest_time"] = {"value": 7}
@@ -4973,6 +4974,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
                 "measurements.frames_frozen",
                 "measurements.frames_slow_rate",
                 "measurements.frames_frozen_rate",
+                "measurements.frames_delay",
                 "measurements.stall_count",
                 "measurements.stall_total_time",
                 "measurements.stall_longest_time",
@@ -4990,6 +4992,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         assert data[0]["measurements.frames_frozen"] == 5
         assert data[0]["measurements.frames_slow_rate"] == 0.1
         assert data[0]["measurements.frames_frozen_rate"] == 0.05
+        assert data[0]["measurements.frames_delay"] == 0.16
         assert data[0]["measurements.stall_count"] == 2
         assert data[0]["measurements.stall_total_time"] == 12
         assert data[0]["measurements.stall_longest_time"] == 7
@@ -5000,6 +5003,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         assert meta["measurements.frames_frozen"] == "number"
         assert meta["measurements.frames_slow_rate"] == "percentage"
         assert meta["measurements.frames_frozen_rate"] == "percentage"
+        assert meta["measurements.frames_delay"] == "duration"
         assert meta["measurements.stall_count"] == "number"
         assert meta["measurements.stall_total_time"] == "number"
         assert meta["measurements.stall_longest_time"] == "number"


### PR DESCRIPTION
Add frames delay as a known mobile measurement.

We need this for sending frames delay with the mobile SDKs: https://github.com/getsentry/team-mobile/issues/160. Otherwise, the transactions show that custom measurement

![CleanShot 2023-12-07 at 13 50 34@2x](https://github.com/getsentry/sentry/assets/2443292/99c01090-477e-4600-b158-97c61e9ae5bd)