### PR TITLE
feat(crons): Simplify boolean logic in consumer

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -124,8 +124,8 @@ def mark_failed_threshold(failed_checkin: MonitorCheckIn, failure_issue_threshol
                 .values("id", "date_added", "status")[:failure_issue_threshold]
             )
         )
-        # check for successive failed previous check-ins
-        if not all([checkin["status"] != CheckInStatus.OK for checkin in previous_checkins]):
+        # If any checkin was successful quit early.
+        if any([checkin["status"] == CheckInStatus.OK for checkin in previous_checkins]):
             return False
 
         # change monitor status + update fingerprint timestamp


### PR DESCRIPTION
"if not all checkins failed" is logically equivalent to "if any checkin succeeded".  Any is just easier to read and understand.

```
>>> x = ["failed", "failed"]
>>> y = ["ok", "failed"]
>>> z = ["ok", "ok"]
>>> fn1 = lambda vs: [v != "ok" for v in vs]
>>> (not all(fn1(x)), not all(fn1(y)), not all(fn1(z)))
(False, True, True)
>>> fn2 = lambda vs: [v == "ok" for v in vs]
>>> (any(fn2(x)), any(fn2(y)), any(fn2(z)))
(False, True, True)
```