### PR TITLE
ref: upgrade docker to 6.x

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -47,8 +47,7 @@ django-csp==3.7
 django-pg-zero-downtime-migrations==0.13
 django-stubs-ext==4.2.7
 djangorestframework==3.14.0
-docker==3.7.0
-docker-pycreds==0.4.0
+docker==6.1.3
 drf-spectacular==0.26.3
 email-reply-parser==0.5.12
 exceptiongroup==1.0.0rc9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 
 covdefaults>=2.3.0
-docker>=3.7.0,<3.8.0
+docker>=6
 time-machine>=2.13.0
 honcho>=1.1.0
 openapi-core>=0.14.2


### PR DESCRIPTION
this avoids some breakage with legacy distutils Version classes and modern setuptools

```
.venv/lib/python3.8/site-packages/docker/client.py:40: in __init__
    self.api = APIClient(*args, **kwargs)
.venv/lib/python3.8/site-packages/docker/api/client.py:194: in __init__
    if utils.version_lt(self._version, MINIMUM_DOCKER_API_VERSION):
.venv/lib/python3.8/site-packages/docker/utils/utils.py:77: in version_lt
    return compare_version(v1, v2) > 0
.venv/lib/python3.8/site-packages/docker/utils/utils.py:66: in compare_version
    s1 = StrictVersion(v1)
.venv/lib/python3.8/site-packages/setuptools/_distutils/version.py:55: in __init__
    warnings.warn(
E   DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
```


<!-- Describe your PR here. -->