### PR TITLE
fix(security): add user id check while email confirmation

### DIFF
--- a/src/sentry/templates/sentry/emails/confirm_email.html
+++ b/src/sentry/templates/sentry/emails/confirm_email.html
@@ -8,5 +8,10 @@
         <p>Thanks for signing up for Sentry!</p>
     {% endif %}
     <p>Please confirm your email ({{ confirm_email }}) by clicking the button below. This link will expire in 48 hours.</p>
-    <a href="{{ url }}" class="btn">Confirm</a>
+    <p><a href="{{ url }}" class="btn">Confirm</a></p>
+    {% if is_new_user %}
+        <p>If you did not sign up, you may simply ignore this email.</p>
+    {% else %}
+        <p>If you did not make this request, you may simply ignore this email.</p>
+    {% endif %}
 {% endblock %}

--- a/tests/sentry/web/frontend/test_accounts.py
+++ b/tests/sentry/web/frontend/test_accounts.py
@@ -194,7 +194,7 @@ class TestAccounts(TestCase):
             follow=True,
         )
         assert resp.status_code == 200
-        assert resp.redirect_chain == [("/settings/account/emails/", 302)]
+        assert resp.redirect_chain == [(reverse("sentry-account-settings-emails"), 302)]
 
         useremail = UserEmail.objects.get(user=self.user, email="new@example.com")
         assert useremail.is_verified
@@ -202,3 +202,62 @@ class TestAccounts(TestCase):
         messages = list(resp.context["messages"])
         assert len(messages) == 1
         assert messages[0].message == "Thanks for confirming your email"
+
+    def test_confirm_email_userid_mismatch(self):
+        victim_user = self.create_user(email="victim@example.com")
+        self.login_as(victim_user)
+
+        attacker_user = self.user
+
+        useremail = UserEmail(user=attacker_user, email="victim@example.com")
+        useremail.save()
+
+        assert not useremail.is_verified
+
+        resp = self.client.get(
+            reverse(
+                "sentry-account-confirm-email",
+                kwargs={"user_id": str(attacker_user.id), "hash": useremail.validation_hash},
+            ),
+            follow=True,
+        )
+        assert resp.status_code == 200
+        assert resp.redirect_chain == [(reverse("sentry-account-settings-emails"), 302)]
+
+        useremail = UserEmail.objects.get(user=attacker_user, email="victim@example.com")
+        assert not useremail.is_verified
+
+        messages = list(resp.context["messages"])
+        assert len(messages) == 1
+        assert (
+            messages[0].message
+            == "There was an error confirming your email. Please try again or visit your Account Settings to resend the verification email."
+        )
+
+    def test_confirm_email_invalid_hash(self):
+        self.login_as(self.user)
+
+        useremail = UserEmail(user=self.user, email="new@example.com")
+        useremail.save()
+
+        assert not useremail.is_verified
+
+        resp = self.client.get(
+            reverse(
+                "sentry-account-confirm-email",
+                kwargs={"user_id": self.user.id, "hash": "WrongValidationHashRightHere1234"},
+            ),
+            follow=True,
+        )
+        assert resp.status_code == 200
+        assert resp.redirect_chain == [(reverse("sentry-account-settings-emails"), 302)]
+
+        useremail = UserEmail.objects.get(user=self.user, email="new@example.com")
+        assert not useremail.is_verified
+
+        messages = list(resp.context["messages"])
+        assert len(messages) == 1
+        assert (
+            messages[0].message
+            == "There was an error confirming your email. Please try again or visit your Account Settings to resend the verification email."
+        )


### PR DESCRIPTION
1. Confirmation link should work only within the context of the user who requested it. Added the check for the user id.
2. Small addition to text "If you did not make this request..." (now similar to plain text version)
3. Added missing tests for email confirmation + test for the new check
