### PR TITLE
feat(app-start): Add App Start Breakdown to table

### DIFF
--- a/static/app/views/starfish/views/appStartup/appStartBreakdown.tsx
+++ b/static/app/views/starfish/views/appStartup/appStartBreakdown.tsx
@@ -1,0 +1,126 @@
+import styled from '@emotion/styled';
+
+import {RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import toPercent from 'sentry/utils/number/toPercent';
+import toRoundedPercent from 'sentry/utils/number/toRoundedPercent';
+
+const COLD_START_COLOR = '#F58C46';
+const WARM_START_COLOR = '#F2B712';
+
+interface Row {
+  'count_starts(measurements.app_start_cold)': number;
+  'count_starts(measurements.app_start_warm)': number;
+}
+
+function TooltipContents({row, total}: {row: Row; total: number}) {
+  return (
+    <TooltipContentWrapper>
+      <StartupType>
+        <StartupNameContainer>
+          <StartupDot style={{backgroundColor: COLD_START_COLOR}} />
+          <StartupName>{t('Cold Start')}</StartupName>
+        </StartupNameContainer>
+        {toRoundedPercent(row['count_starts(measurements.app_start_cold)'] / total)}
+      </StartupType>
+      <StartupType>
+        <StartupNameContainer>
+          <StartupDot style={{backgroundColor: WARM_START_COLOR}} />
+          <StartupName>{t('Warm Start')}</StartupName>
+        </StartupNameContainer>
+        {toRoundedPercent(row['count_starts(measurements.app_start_warm)'] / total)}
+      </StartupType>
+    </TooltipContentWrapper>
+  );
+}
+
+function AppStartBreakdown({row}: {row: Row}) {
+  const total =
+    row['count_starts(measurements.app_start_cold)'] +
+    row['count_starts(measurements.app_start_warm)'];
+
+  if (total === 0) {
+    return null;
+  }
+  return (
+    <Tooltip title={<TooltipContents row={row} total={total} />}>
+      <RelativeOpsBreakdown>
+        <div
+          key="cold-start"
+          style={{
+            width: toPercent(row['count_starts(measurements.app_start_cold)'] / total),
+          }}
+        >
+          <RectangleRelativeOpsBreakdown
+            style={{
+              backgroundColor: COLD_START_COLOR,
+            }}
+          />
+        </div>
+        <div
+          key="warm-start"
+          style={{
+            width: toPercent(row['count_starts(measurements.app_start_warm)'] / total),
+          }}
+        >
+          <RectangleRelativeOpsBreakdown
+            style={{
+              backgroundColor: WARM_START_COLOR,
+            }}
+          />
+        </div>
+      </RelativeOpsBreakdown>
+    </Tooltip>
+  );
+}
+
+export default AppStartBreakdown;
+
+const RelativeOpsBreakdown = styled('div')`
+  position: relative;
+  display: flex;
+`;
+
+const RectangleRelativeOpsBreakdown = styled(RowRectangle)`
+  position: relative;
+  width: 100%;
+`;
+
+const StartupDot = styled('div')`
+  content: '';
+  display: block;
+  width: 8px;
+  min-width: 8px;
+  height: 8px;
+  margin-right: ${space(1)};
+  border-radius: 100%;
+`;
+
+const OpsContent = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const StartupNameContainer = styled(OpsContent)`
+  overflow: hidden;
+`;
+
+const StartupType = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  gap: ${space(4)};
+`;
+
+const StartupName = styled('div')`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const TooltipContentWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+`;

--- a/static/app/views/starfish/views/appStartup/index.tsx
+++ b/static/app/views/starfish/views/appStartup/index.tsx
@@ -20,15 +20,10 @@ import {prepareQueryForLandingPage} from 'sentry/views/performance/data';
 import {getTransactionSearchQuery} from 'sentry/views/performance/utils';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
+import {ScreensTable} from 'sentry/views/starfish/views/appStartup/screensTable';
 import {getFreeTextFromQuery} from 'sentry/views/starfish/views/screens';
-import {
-  ScreensTable,
-  useTableQuery,
-} from 'sentry/views/starfish/views/screens/screensTable';
-
-const MAX_TABLE_RELEASE_CHARS = 15;
+import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
 type Props = {
   additionalFilters?: string[];
@@ -47,14 +42,6 @@ function AppStartup({additionalFilters}: Props) {
     secondaryRelease,
     isLoading: isReleasesLoading,
   } = useReleaseSelection();
-  const truncatedPrimary = formatVersionAndCenterTruncate(
-    primaryRelease ?? '',
-    MAX_TABLE_RELEASE_CHARS
-  );
-  const truncatedSecondary = formatVersionAndCenterTruncate(
-    secondaryRelease ?? '',
-    MAX_TABLE_RELEASE_CHARS
-  );
 
   const router = useRouter();
 
@@ -81,6 +68,8 @@ function AppStartup({additionalFilters}: Props) {
       `avg_if(measurements.app_start_cold,release,${secondaryRelease})`,
       `avg_if(measurements.app_start_warm,release,${primaryRelease})`,
       `avg_if(measurements.app_start_warm,release,${secondaryRelease})`,
+      'count_starts(measurements.app_start_cold)',
+      'count_starts(measurements.app_start_warm)',
       'count()',
     ],
     query: queryString,
@@ -154,26 +143,6 @@ function AppStartup({additionalFilters}: Props) {
         data={topTransactionsData}
         isLoading={topTransactionsLoading}
         pageLinks={pageLinks}
-        columnNameMap={{
-          transaction: t('Screen'),
-          [`avg_if(measurements.app_start_cold,release,${primaryRelease})`]: t(
-            'Cold Start (%s)',
-            truncatedPrimary
-          ),
-          [`avg_if(measurements.app_start_cold,release,${secondaryRelease})`]: t(
-            'Cold Start (%s)',
-            truncatedSecondary
-          ),
-          [`avg_if(measurements.app_start_warm,release,${primaryRelease})`]: t(
-            'Warm Start (%s)',
-            truncatedPrimary
-          ),
-          [`avg_if(measurements.app_start_warm,release,${secondaryRelease})`]: t(
-            'Warm Start (%s)',
-            truncatedSecondary
-          ),
-          'count()': t('Total Count'),
-        }}
       />
     </div>
   );

--- a/static/app/views/starfish/views/appStartup/screensTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screensTable.tsx
@@ -1,31 +1,25 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment} from 'react';
 import * as qs from 'query-string';
 
-import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  GridColumnHeader,
+} from 'sentry/components/gridEditable';
 import SortLink from 'sentry/components/gridEditable/sortLink';
-import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import Pagination from 'sentry/components/pagination';
-import {Tooltip} from 'sentry/components/tooltip';
-import {t, tct} from 'sentry/locale';
-import {
-  TableData,
-  TableDataRow,
-  useDiscoverQuery,
-} from 'sentry/utils/discover/discoverQuery';
+import {t} from 'sentry/locale';
+import {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import EventView, {isFieldSortable, MetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {fieldAlignment} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
-import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import TopResultsIndicator from 'sentry/views/discover/table/topResultsIndicator';
-import {TableColumn} from 'sentry/views/discover/table/types';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import AppStartBreakdown from 'sentry/views/starfish/views/appStartup/appStartBreakdown';
 import {TOP_SCREENS} from 'sentry/views/starfish/views/screens';
 
 const MAX_TABLE_RELEASE_CHARS = 15;
@@ -39,8 +33,6 @@ type Props = {
 
 export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
   const location = useLocation();
-  const {selection} = usePageFilters();
-  const {projects} = useProjects();
   const organization = useOrganization();
   const {primaryRelease, secondaryRelease} = useReleaseSelection();
   const truncatedPrimary = formatVersionAndCenterTruncate(
@@ -52,33 +44,25 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
     MAX_TABLE_RELEASE_CHARS
   );
 
-  const project = useMemo(() => {
-    if (selection.projects.length !== 1) {
-      return null;
-    }
-    return projects.find(p => p.id === String(selection.projects));
-  }, [projects, selection.projects]);
-
-  const eventViewColumns = eventView.getColumns();
-
   const columnNameMap = {
     transaction: t('Screen'),
-    [`avg_if(measurements.time_to_initial_display,release,${primaryRelease})`]: t(
-      'TTID (%s)',
+    [`avg_if(measurements.app_start_cold,release,${primaryRelease})`]: t(
+      'Cold Start (%s)',
       truncatedPrimary
     ),
-    [`avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`]: t(
-      'TTID (%s)',
+    [`avg_if(measurements.app_start_cold,release,${secondaryRelease})`]: t(
+      'Cold Start (%s)',
       truncatedSecondary
     ),
-    [`avg_if(measurements.time_to_full_display,release,${primaryRelease})`]: t(
-      'TTFD (%s)',
+    [`avg_if(measurements.app_start_warm,release,${primaryRelease})`]: t(
+      'Warm Start (%s)',
       truncatedPrimary
     ),
-    [`avg_if(measurements.time_to_full_display,release,${secondaryRelease})`]: t(
-      'TTFD (%s)',
+    [`avg_if(measurements.app_start_warm,release,${secondaryRelease})`]: t(
+      'Warm Start (%s)',
       truncatedSecondary
     ),
+    app_start_breakdown: t('App Start Breakdown'),
     'count()': t('Total Count'),
   };
 
@@ -115,41 +99,16 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
       );
     }
 
+    if (field === 'app_start_breakdown') {
+      return <AppStartBreakdown row={row} />;
+    }
+
     const renderer = getFieldRenderer(column.key, data?.meta.fields, false);
-    const rendered = renderer(row, {
+    return renderer(row, {
       location,
       organization,
       unit: data?.meta.units?.[column.key],
     });
-    if (
-      column.key.includes('time_to_full_display') &&
-      row[column.key] === 0 &&
-      project?.platform &&
-      ['android', 'apple-ios'].includes(project.platform)
-    ) {
-      const docsUrl =
-        project?.platform === 'android'
-          ? 'https://docs.sentry.io/platforms/android/performance/instrumentation/automatic-instrumentation/#time-to-full-display'
-          : 'https://docs.sentry.io/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#time-to-full-display';
-      return (
-        <div style={{textAlign: 'right'}}>
-          <Tooltip
-            title={tct(
-              'Measuring TTFD requires manual instrumentation in your application. To learn how to collect TTFD, see the documentation [link].',
-              {
-                link: <ExternalLink href={docsUrl}>{t('here')}</ExternalLink>,
-              }
-            )}
-            showUnderline
-            isHoverable
-          >
-            {rendered}
-          </Tooltip>
-        </div>
-      );
-    }
-
-    return rendered;
   }
 
   function renderHeadCell(
@@ -198,15 +157,21 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
       <GridEditable
         isLoading={isLoading}
         data={data?.data as TableDataRow[]}
-        columnOrder={eventViewColumns
-          .filter(
-            (col: TableColumn<React.ReactText>) =>
-              col.name !== SpanMetricsField.PROJECT_ID &&
-              !col.name.startsWith('avg_compare')
-          )
-          .map((col: TableColumn<React.ReactText>) => {
-            return {...col, name: columnNameMap[col.key] ?? col.name};
-          })}
+        columnOrder={[
+          'transaction',
+          `avg_if(measurements.app_start_cold,release,${primaryRelease})`,
+          `avg_if(measurements.app_start_cold,release,${secondaryRelease})`,
+          `avg_if(measurements.app_start_warm,release,${primaryRelease})`,
+          `avg_if(measurements.app_start_warm,release,${secondaryRelease})`,
+          `app_start_breakdown`,
+          'count()',
+        ].map(columnKey => {
+          return {
+            key: columnKey,
+            name: columnNameMap[columnKey],
+            width: COL_WIDTH_UNDEFINED,
+          };
+        })}
         columnSortBy={[
           {
             key: 'count()',
@@ -222,47 +187,4 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
       <Pagination pageLinks={pageLinks} />
     </Fragment>
   );
-}
-
-export function useTableQuery({
-  eventView,
-  enabled,
-  referrer,
-  initialData,
-  limit,
-  staleTime,
-  cursor,
-}: {
-  eventView: EventView;
-  cursor?: string;
-  enabled?: boolean;
-  excludeOther?: boolean;
-  initialData?: TableData;
-  limit?: number;
-  referrer?: string;
-  staleTime?: number;
-}) {
-  const location = useLocation();
-  const organization = useOrganization();
-  const {isReady: pageFiltersReady} = usePageFilters();
-
-  const result = useDiscoverQuery({
-    eventView,
-    location,
-    orgSlug: organization.slug,
-    limit: limit ?? 25,
-    referrer,
-    cursor,
-    options: {
-      refetchOnWindowFocus: false,
-      enabled: enabled && pageFiltersReady,
-      staleTime,
-    },
-  });
-
-  return {
-    ...result,
-    data: result.isLoading ? initialData : result.data,
-    pageLinks: result.pageLinks,
-  };
 }

--- a/static/app/views/starfish/views/screens/index.tsx
+++ b/static/app/views/starfish/views/screens/index.tsx
@@ -51,7 +51,6 @@ export enum YAxis {
 
 export const TOP_SCREENS = 5;
 const MAX_CHART_RELEASE_CHARS = 12;
-const MAX_TABLE_RELEASE_CHARS = 15;
 
 export const YAXIS_COLUMNS: Readonly<Record<YAxis, string>> = {
   [YAxis.WARM_START]: 'avg(measurements.app_start_warm)',
@@ -271,17 +270,9 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
     });
   }
 
-  const truncatedPrimary = formatVersionAndCenterTruncate(
-    primaryRelease ?? '',
-    MAX_TABLE_RELEASE_CHARS
-  );
   const truncatedPrimaryChart = formatVersionAndCenterTruncate(
     primaryRelease ?? '',
     MAX_CHART_RELEASE_CHARS
-  );
-  const truncatedSecondary = formatVersionAndCenterTruncate(
-    secondaryRelease ?? '',
-    MAX_TABLE_RELEASE_CHARS
   );
   const truncatedSecondaryChart = formatVersionAndCenterTruncate(
     secondaryRelease ?? '',
@@ -380,26 +371,6 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
         data={topTransactionsData}
         isLoading={topTransactionsLoading}
         pageLinks={pageLinks}
-        columnNameMap={{
-          transaction: t('Screen'),
-          [`avg_if(measurements.time_to_initial_display,release,${primaryRelease})`]: t(
-            'TTID (%s)',
-            truncatedPrimary
-          ),
-          [`avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`]: t(
-            'TTID (%s)',
-            truncatedSecondary
-          ),
-          [`avg_if(measurements.time_to_full_display,release,${primaryRelease})`]: t(
-            'TTFD (%s)',
-            truncatedPrimary
-          ),
-          [`avg_if(measurements.time_to_full_display,release,${secondaryRelease})`]: t(
-            'TTFD (%s)',
-            truncatedSecondary
-          ),
-          'count()': t('Total Count'),
-        }}
       />
     </div>
   );


### PR DESCRIPTION
Adding the app start breakdown required more column massaging than was maintainable if I had added it to the existing screen table. Instead, I reverted my changes to extract the column names and copied over the values that I'd need for the cold/warm start table.

The table now shows a breakdown of cold/warm starts and on hover gives a breakdown in text.

<img width="1486" alt="Screenshot 2023-12-07 at 3 16 13 PM" src="https://github.com/getsentry/sentry/assets/22846452/1beeaf6b-b013-4391-889c-9d3558ce2e19">
