### PR TITLE
meta(crons): Update monitor decorators

### DIFF
--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -5,7 +5,6 @@ from typing import List
 
 import sentry_sdk
 from django.db.models import Max
-from sentry_sdk.crons.decorator import monitor
 
 from sentry.conf.server import CELERY_ISSUE_STATES_QUEUE
 from sentry.issues.ongoing import bulk_transition_group_to_ongoing
@@ -59,7 +58,6 @@ def log_error_if_queue_has_items(func):
     acks_late=True,
     silo_mode=SiloMode.REGION,
 )
-@monitor(monitor_slug="schedule_auto_transition_to_ongoing")
 @log_error_if_queue_has_items
 def schedule_auto_transition_to_ongoing() -> None:
     """

--- a/src/sentry/tasks/deletion/hybrid_cloud.py
+++ b/src/sentry/tasks/deletion/hybrid_cloud.py
@@ -21,6 +21,7 @@ from django.db import connections, router
 from django.db.models import Max, Min
 from django.db.models.manager import BaseManager
 from django.utils import timezone
+from sentry_sdk.crons.decorator import monitor
 
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
 from sentry.models.tombstone import TombstoneBase
@@ -110,6 +111,8 @@ def schedule_hybrid_cloud_foreign_key_jobs_control():
     acks_late=True,
     silo_mode=SiloMode.REGION,
 )
+# TODO(rjo100): dual write check-ins for debugging
+@monitor(monitor_slug="schedule-hybrid-cloud-foreign-key-jobs-test")
 def schedule_hybrid_cloud_foreign_key_jobs():
     _schedule_hybrid_cloud_foreign_key(
         SiloMode.REGION, process_hybrid_cloud_foreign_key_cascade_batch

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -9,6 +9,7 @@ from typing import Any, List, Optional
 import sentry_sdk
 from django.db import connection
 from django.utils import timezone
+from sentry_sdk.crons.decorator import monitor
 from snuba_sdk import Column, Condition, Direction, Entity, Function, Op, OrderBy, Query
 from snuba_sdk import Request as SnubaRequest
 
@@ -296,6 +297,8 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
 @instrumented_task(
     name="sentry.tasks.integrations.github_comment_reactions", silo_mode=SiloMode.REGION
 )
+# TODO(rjo100): dual write check-ins for debugging
+@monitor(monitor_slug="github_comment_reactions_test")
 def github_comment_reactions():
     logger.info("github.pr_comment.reactions_task")
 

--- a/src/sentry/tasks/weekly_escalating_forecast.py
+++ b/src/sentry/tasks/weekly_escalating_forecast.py
@@ -2,8 +2,6 @@ import logging
 from datetime import datetime, timedelta
 from typing import Dict, List, TypedDict
 
-from sentry_sdk.crons.decorator import monitor
-
 from sentry.constants import ObjectStatus
 from sentry.issues.forecasts import generate_and_save_forecasts
 from sentry.models.group import Group, GroupStatus
@@ -33,7 +31,6 @@ ITERATOR_CHUNK = 10_000
     max_retries=0,  # TODO: Increase this when the task is changed to run weekly
     silo_mode=SiloMode.REGION,
 )
-@monitor(monitor_slug="escalating-issue-forecast-job-monitor")
 def run_escalating_forecast() -> None:
     """
     Run the escalating forecast algorithm on archived until escalating issues.


### PR DESCRIPTION
Removes unnecessary monitor decorators + adds new ones for debugging.

As the decorator doesn't upsert, these new decorators will fail at the consumer validation step if the monitors don't exist.