### PR TITLE
fix(replay): Detect and show an error when a replay is missing the EventType.Meta frame

### DIFF
--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -11,7 +11,7 @@ import Placeholder from 'sentry/components/placeholder';
 import {Flex} from 'sentry/components/profiling/flex';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
-import ReplayNotFound from 'sentry/components/replays/replayProcessingErrors';
+import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
 import {IconDelete, IconPlay} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -166,7 +166,7 @@ function ReplayPreview({
     >
       <PlayerContainer data-test-id="player-container">
         {replay?.hasProcessingErrors() ? (
-          <ReplayNotFound />
+          <ReplayProcessingError />
         ) : (
           <Fragment>
             <StaticPanel>

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -1,4 +1,4 @@
-import {ComponentProps, useMemo} from 'react';
+import {ComponentProps, Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from 'sentry/components/alert';
@@ -11,6 +11,7 @@ import Placeholder from 'sentry/components/placeholder';
 import {Flex} from 'sentry/components/profiling/flex';
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
+import ReplayNotFound from 'sentry/components/replays/replayProcessingErrors';
 import {IconDelete, IconPlay} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -93,6 +94,7 @@ function ReplayPreview({
 
   if (fetchError) {
     const reasons = [
+      t('The replay is still processing'),
       tct(
         'The replay was rate-limited and could not be accepted. [link:View the stats page] for more information.',
         {
@@ -163,19 +165,26 @@ function ReplayPreview({
       initialTimeOffsetMs={{offsetMs: initialTimeOffsetMs}}
     >
       <PlayerContainer data-test-id="player-container">
-        <StaticPanel>
-          <ReplayPlayer isPreview />
-        </StaticPanel>
-        <CTAOverlay>
-          <LinkButton
-            {...buttonProps}
-            icon={<IconPlay />}
-            priority="primary"
-            to={fullReplayUrl}
-          >
-            {t('Open Replay')}
-          </LinkButton>
-        </CTAOverlay>
+        {replay?.hasProcessingErrors() ? (
+          <ReplayNotFound />
+        ) : (
+          <Fragment>
+            <StaticPanel>
+              <ReplayPlayer isPreview />
+            </StaticPanel>
+
+            <CTAOverlay>
+              <LinkButton
+                {...buttonProps}
+                icon={<IconPlay />}
+                priority="primary"
+                to={fullReplayUrl}
+              >
+                {t('Open Replay')}
+              </LinkButton>
+            </CTAOverlay>
+          </Fragment>
+        )}
       </PlayerContainer>
     </ReplayContextProvider>
   );

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -166,7 +166,7 @@ function ReplayPreview({
     >
       <PlayerContainer data-test-id="player-container">
         {replay?.hasProcessingErrors() ? (
-          <ReplayProcessingError />
+          <ReplayProcessingError processingErrors={replay.processingErrors()} />
         ) : (
           <Fragment>
             <StaticPanel>

--- a/static/app/components/replays/replayProcessingError.tsx
+++ b/static/app/components/replays/replayProcessingError.tsx
@@ -1,4 +1,6 @@
+import {useEffect} from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 
 import {Alert} from 'sentry/components/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -6,10 +8,21 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 interface Props {
+  processingErrors: readonly string[];
   className?: string;
 }
 
-export default function ReplayProcessingError({className}: Props) {
+export default function ReplayProcessingError({className, processingErrors}: Props) {
+  useEffect(() => {
+    Sentry.withScope(scope => {
+      scope.setLevel('warning');
+      scope.setFingerprint(['replay-processing-error']);
+      processingErrors.forEach(error => {
+        Sentry.captureException(error);
+      });
+    });
+  }, [processingErrors]);
+
   return (
     <StyledAlert type="error" showIcon className={className}>
       <Heading>{t('Replay Not Found')}</Heading>

--- a/static/app/components/replays/replayProcessingError.tsx
+++ b/static/app/components/replays/replayProcessingError.tsx
@@ -9,7 +9,7 @@ interface Props {
   className?: string;
 }
 
-export default function ReplayNotFound({className}: Props) {
+export default function ReplayProcessingError({className}: Props) {
   return (
     <StyledAlert type="error" showIcon className={className}>
       <Heading>{t('Replay Not Found')}</Heading>
@@ -42,7 +42,6 @@ export default function ReplayNotFound({className}: Props) {
 const StyledAlert = styled(Alert)`
   margin: 0;
   height: 100%;
-  border-collapse: collapse;
 `;
 
 const Heading = styled('h1')`

--- a/static/app/components/replays/replayProcessingErrors.tsx
+++ b/static/app/components/replays/replayProcessingErrors.tsx
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+
+import {Alert} from 'sentry/components/alert';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+interface Props {
+  className?: string;
+}
+
+export default function ReplayNotFound({className}: Props) {
+  return (
+    <StyledAlert type="error" showIcon className={className}>
+      <Heading>{t('Replay Not Found')}</Heading>
+      <p>{t('The replay you are looking for was not found.')}</p>
+      <p>{t('The replay might be missing events or metadata.')}</p>
+      <p>
+        {t(
+          'Or there may be an issue loading the actions from the server, click to try loading the Replay again.'
+        )}
+      </p>
+      <ul>
+        <li>
+          {t(
+            `If you followed a link here, try hitting back and reloading the
+           page. It's possible the resource was moved out from under you.`
+          )}
+        </li>
+        <li>
+          {tct('If all else fails, [link:contact us] with more details', {
+            link: (
+              <ExternalLink href="https://github.com/getsentry/sentry/issues/new/choose" />
+            ),
+          })}
+        </li>
+      </ul>
+    </StyledAlert>
+  );
+}
+
+const StyledAlert = styled(Alert)`
+  margin: 0;
+  height: 100%;
+  border-collapse: collapse;
+`;
+
+const Heading = styled('h1')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  line-height: 1.4;
+  margin-bottom: ${space(1)};
+`;

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -6,7 +6,7 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import ReplayController from 'sentry/components/replays/replayController';
 import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
-import ReplayNotFound from 'sentry/components/replays/replayProcessingErrors';
+import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -42,7 +42,7 @@ function ReplayView({toggleFullscreen}: Props) {
             ) : null}
           </ContextContainer>
           {replay?.hasProcessingErrors() ? (
-            <ReplayNotFound />
+            <ReplayProcessingError />
           ) : (
             <Panel>
               <ReplayPlayer />

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -42,7 +42,7 @@ function ReplayView({toggleFullscreen}: Props) {
             ) : null}
           </ContextContainer>
           {replay?.hasProcessingErrors() ? (
-            <ReplayProcessingError />
+            <ReplayProcessingError processingErrors={replay.processingErrors()} />
           ) : (
             <Panel>
               <ReplayPlayer />

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -2,9 +2,11 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
 import ReplayController from 'sentry/components/replays/replayController';
 import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
+import ReplayNotFound from 'sentry/components/replays/replayProcessingErrors';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -20,6 +22,7 @@ type Props = {
 function ReplayView({toggleFullscreen}: Props) {
   const isFullscreen = useIsFullscreen();
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const {replay} = useReplayContext();
 
   return (
     <Fragment>
@@ -38,9 +41,13 @@ function ReplayView({toggleFullscreen}: Props) {
               </Button>
             ) : null}
           </ContextContainer>
-          <Panel>
-            <ReplayPlayer />
-          </Panel>
+          {replay?.hasProcessingErrors() ? (
+            <ReplayNotFound />
+          ) : (
+            <Panel>
+              <ReplayPlayer />
+            </Panel>
+          )}
         </PlayerContainer>
         {isFullscreen && isSidebarOpen ? (
           <BreadcrumbContainer>

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -196,6 +196,14 @@ export default class ReplayReader {
 
   toJSON = () => this._cacheKey;
 
+  hasProcessingErrors = () => {
+    const checks = [
+      this.getRRWebFrames().length < 2,
+      !this.getRRWebFrames().some(frame => frame.type === EventType.Meta),
+    ];
+    return checks.some(Boolean);
+  };
+
   /**
    * @returns Duration of Replay (milliseonds)
    */

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -3,6 +3,7 @@ import {incrementalSnapshotEvent, IncrementalSource} from '@sentry-internal/rrwe
 import memoize from 'lodash/memoize';
 import {duration} from 'moment';
 
+import {defined} from 'sentry/utils';
 import domId from 'sentry/utils/domId';
 import localStorageWrapper from 'sentry/utils/localStorage';
 import hydrateBreadcrumbs, {
@@ -196,12 +197,19 @@ export default class ReplayReader {
 
   toJSON = () => this._cacheKey;
 
+  processingErrors = memoize(() => {
+    return [
+      this.getRRWebFrames().length < 2
+        ? `Replay has ${this.getRRWebFrames().length} frames`
+        : null,
+      !this.getRRWebFrames().some(frame => frame.type === EventType.Meta)
+        ? 'Missing Meta Frame'
+        : null,
+    ].filter(defined);
+  });
+
   hasProcessingErrors = () => {
-    const checks = [
-      this.getRRWebFrames().length < 2,
-      !this.getRRWebFrames().some(frame => frame.type === EventType.Meta),
-    ];
-    return checks.some(Boolean);
+    return this.processingErrors().length;
   };
 
   /**

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -43,7 +43,7 @@ function ReplayLayout({layout = LayoutKey.TOPBAR}: Props) {
   );
 
   const controller = (
-    <ErrorBoundary>
+    <ErrorBoundary mini>
       <ReplayController toggleFullscreen={toggleFullscreen} />
     </ErrorBoundary>
   );

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -147,36 +147,6 @@ function ReplayDetails({params: {replaySlug}}: Props) {
     );
   }
 
-  if (!fetching && replay && replay.getRRWebFrames().length < 2) {
-    return (
-      <Page
-        orgSlug={orgSlug}
-        replayRecord={replayRecord}
-        projectSlug={projectSlug}
-        replayErrors={replayErrors}
-      >
-        <DetailedError
-          hideSupportLinks
-          heading={t('Error loading replay')}
-          message={
-            <Fragment>
-              <p>
-                {t(
-                  'Expected two or more replay events. This Replay may not have captured any user actions.'
-                )}
-              </p>
-              <p>
-                {t(
-                  'Or there may be an issue loading the actions from the server, click to try loading the Replay again.'
-                )}
-              </p>
-            </Fragment>
-          }
-        />
-      </Page>
-    );
-  }
-
   return (
     <ReplayContextProvider
       isFetching={fetching}


### PR DESCRIPTION
The error message looks like this in a preview, or on the Replay Details page:
| Preview (ie: Issue or Feedback) | Details Page |
| --- | --- |
| <img width="857" alt="SCR-20231207-lxcr" src="https://github.com/getsentry/sentry/assets/187460/44a07c24-61ef-40ef-9bef-7dd3b674e481"> | <img width="822" alt="SCR-20231207-lxaf" src="https://github.com/getsentry/sentry/assets/187460/680d1056-60f4-43a8-a610-ab36ffd8ff0f"> |

Before we had a specific message on the details page for when the replay was less-than 2 frames long, this has been rolled into this new error alert format. 

Relates to https://github.com/getsentry/sentry/issues/60800