### PR TITLE
ref(superuser): add org:superuser scope for active superuser

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -41,6 +41,9 @@ from sentry.services.hybrid_cloud.organization.serial import summarize_member
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.utils import metrics
 
+SUPERUSER_SCOPES = settings.SENTRY_SCOPES
+SUPERUSER_SCOPES.add("org:superuser")
+
 
 def has_role_in_organization(role: str, organization: Organization, user_id: int) -> bool:
     query = OrganizationMember.objects.filter(
@@ -958,7 +961,7 @@ def from_request_org_and_scopes(
         return ApiBackedOrganizationGlobalAccess(
             rpc_user_organization_context=rpc_user_org_context,
             auth_state=auth_state,
-            scopes=scopes if scopes is not None else settings.SENTRY_SCOPES,
+            scopes=scopes if scopes is not None else SUPERUSER_SCOPES,
         )
 
     if hasattr(request, "auth") and not request.user.is_authenticated:
@@ -1045,7 +1048,7 @@ def from_request(
         return OrganizationGlobalAccess(
             organization=organization,
             _member=member,
-            scopes=scopes if scopes is not None else settings.SENTRY_SCOPES,
+            scopes=scopes if scopes is not None else SUPERUSER_SCOPES,
             sso_is_valid=sso_state.is_valid,
             requires_sso=sso_state.is_required,
             permissions=access_service.get_permissions_for_user(request.user.id),

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -41,8 +41,7 @@ from sentry.services.hybrid_cloud.organization.serial import summarize_member
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.utils import metrics
 
-SUPERUSER_SCOPES = settings.SENTRY_SCOPES
-SUPERUSER_SCOPES.add("org:superuser")
+SUPERUSER_SCOPES = settings.SENTRY_SCOPES.union({"org:superuser"})
 
 
 def has_role_in_organization(role: str, organization: Organization, user_id: int) -> bool:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2373,7 +2373,7 @@ SENTRY_SCOPES = {
     "org:admin",
     "org:integrations",
     "org:ci",
-    # "org:superuser",  Do not use for any type of superuser permission/access checks 
+    # "org:superuser",  Do not use for any type of superuser permission/access checks
     # Assigned to active SU sessions in src/sentry/auth/access.py to enable UI elements
     "member:read",
     "member:write",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2373,6 +2373,7 @@ SENTRY_SCOPES = {
     "org:admin",
     "org:integrations",
     "org:ci",
+    # "org:superuser",  # only for active superusers, not assignable
     "member:read",
     "member:write",
     "member:admin",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2373,7 +2373,8 @@ SENTRY_SCOPES = {
     "org:admin",
     "org:integrations",
     "org:ci",
-    # "org:superuser",  # only for active superusers, not assignable
+    # "org:superuser",  Do not use for any type of superuser permission/access checks 
+    # Assigned to active SU sessions in src/sentry/auth/access.py to enable UI elements
     "member:read",
     "member:write",
     "member:admin",

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -562,6 +562,7 @@ class FromRequestTest(AccessFactoryTestCase):
         result = self.from_request(request, self.org)
         assert_memberships(result)
         assert not result.has_permission("test.permission")
+        assert "org:superuser" not in result.scopes
 
         request = self.make_request(user=self.superuser, is_superuser=True)
         result = self.from_request(request, self.org)
@@ -569,11 +570,15 @@ class FromRequestTest(AccessFactoryTestCase):
         assert result.has_permission("test.permission")
         assert result.requires_sso
         assert not result.sso_is_valid
+        # org:superuser is only attached when an org is present + active superuser
+        assert "org:superuser" in result.scopes
 
     def test_superuser_with_organization_without_membership(self):
         request = self.make_request(user=self.superuser, is_superuser=True)
         result = self.from_request(request, self.org)
         assert result.has_permission("test.permission")
+        # org:superuser is only attached when an org is present + active superuser
+        assert "org:superuser" in result.scopes
 
         assert not result.requires_sso
         assert result.sso_is_valid

--- a/tests/sentry/conf/test_scopes.py
+++ b/tests/sentry/conf/test_scopes.py
@@ -4,6 +4,7 @@ from sentry.testutils.cases import TestCase
 
 class ScopesTest(TestCase):
     def test_scope_hierarchy_maintained(self):
+        assert "org:superuser" not in SENTRY_SCOPES
         for scope in SENTRY_SCOPES:
             assert scope in SENTRY_SCOPE_HIERARCHY_MAPPING
 


### PR DESCRIPTION
Requires #61329

Adds the scope `org:superuser` to `request.access` for active superuser to allow the sidebar to turn red.