### PR TITLE
ref(crons): Remove unused waiting status

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -82,11 +82,6 @@ class MonitorObjectStatus:
     PENDING_DELETION = 2
     DELETION_IN_PROGRESS = 3
 
-    WAITING = 4
-    """
-    Active but does not have a seat assigned yet
-    """
-
     @classmethod
     def as_choices(cls) -> Sequence[Tuple[int, str]]:
         return (
@@ -96,7 +91,6 @@ class MonitorObjectStatus:
             (cls.MUTED, "muted"),
             (cls.PENDING_DELETION, "pending_deletion"),
             (cls.DELETION_IN_PROGRESS, "deletion_in_progress"),
-            (cls.WAITING, "waiting"),
         )
 
 


### PR DESCRIPTION
We will not be using this for billing. Monitors will always be
immediately go into some seating status.