### PR TITLE
fix(scopes): Keep scope hierarchy when updating integration scopes

### DIFF
--- a/src/sentry/receivers/tokens.py
+++ b/src/sentry/receivers/tokens.py
@@ -1,3 +1,5 @@
+from typing import List, Sequence
+
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 
@@ -6,13 +8,28 @@ from sentry.models.apikey import ApiKey
 from sentry.models.apitoken import ApiToken
 
 
+def add_scope_hierarchy(curr_scopes: Sequence[str]) -> List[str]:
+    """
+    Adds missing hierarchy scopes to the list of scopes. Returns an
+    alphabetically sorted list of final scopes.
+    """
+    new_scopes = set(curr_scopes)
+    for scope in curr_scopes:
+        if scope in SENTRY_SCOPES:
+            new_scopes = new_scopes.union(SENTRY_SCOPE_HIERARCHY_MAPPING[scope])
+    return sorted(new_scopes)
+
+
 @receiver(pre_save, sender=ApiKey, dispatch_uid="enforce_scope_hierarchy_api_key")
 @receiver(pre_save, sender=ApiToken, dispatch_uid="enforce_scope_hierarchy_api_token")
 def enforce_scope_hierarchy(instance, **kwargs) -> None:
-    # It's impossible to know if the token scopes have been modified without
-    # fetching it from the DB, so we always enforce scope hierarchy
-    new_scopes = set(instance.get_scopes())
-    for scope in instance.scope_list:
-        if scope in SENTRY_SCOPES:
-            new_scopes = new_scopes.union(SENTRY_SCOPE_HIERARCHY_MAPPING[scope])
-    instance.scope_list = sorted(new_scopes)
+    """
+    This pre_save signal enforces scope hierarchy in the ApiToken and ApiKey
+    models. It's impossible to know if the scopes have been modified without
+    # fetching it from the DB, so we're required to always iterate through them
+    to avoid the DB call.
+
+    We use the add_scope_hierarchy helper so we can reuse it in other places
+    where this pre_save signal is skipped when updating scopes.
+    """
+    instance.scope_list = add_scope_hierarchy(instance.scope_list)

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -340,6 +340,17 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert response.status_code == 200
         assert SentryApp.objects.get(id=app.id).get_scopes() == ["event:read"]
 
+    def test_updating_scopes_maintains_scope_hierarchy(self):
+        self.login_as(user=self.user)
+        app = self.create_sentry_app(
+            name="SampleApp", organization=self.org, scopes=["event:read", "event:write"]
+        )
+        url = reverse("sentry-api-0-sentry-app-details", args=[app.slug])
+        # scopes is None here
+        response = self.client.put(url, data={"scopes": ["event:write"]}, format="json")
+        assert response.status_code == 200
+        assert SentryApp.objects.get(id=app.id).get_scopes() == ["event:read", "event:write"]
+
     @patch("sentry.analytics.record")
     def test_bad_schema(self, record):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -346,7 +346,6 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             name="SampleApp", organization=self.org, scopes=["event:read", "event:write"]
         )
         url = reverse("sentry-api-0-sentry-app-details", args=[app.slug])
-        # scopes is None here
         response = self.client.put(url, data={"scopes": ["event:write"]}, format="json")
         assert response.status_code == 200
         assert SentryApp.objects.get(id=app.id).get_scopes() == ["event:read", "event:write"]


### PR DESCRIPTION
### Summary
There were a couple of tokens slipping through without hierarchy, and I figured out it's because we don't enforce scope hierarchy when manually sending an API request to update an integration's scopes.

We use `bulk_update` to update all the tokens connected to an integration, and that skips the `pre_save` signal I have attached to the ApiToken model.

---

### Example of tokens not maintaining hierarchy
<img width="672" alt="Screenshot 2023-12-07 at 2 20 12 PM" src="https://github.com/getsentry/sentry/assets/67301797/ae1a857e-c0bb-4629-93e0-92dbebc1504b">

