### PR TITLE
fix(crons): Correct monitor status query filter

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -164,7 +164,9 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
                 elif key == "status":
                     try:
                         queryset = queryset.filter(
-                            status__in=map_value_to_constant(MonitorStatus, value)
+                            monitorenvironment__status__in=map_value_to_constant(
+                                MonitorStatus, value
+                            )
                         )
                     except ValueError:
                         queryset = queryset.none()


### PR DESCRIPTION
This was incorrectly filtering the status of the Monitor. What we actually want is to filter down to monitors that have monitor environments in the provided status