### PR TITLE
feat(metrics-extraction): Add task checking dashboard on-demand

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -796,6 +796,7 @@ CELERY_IMPORTS = (
     "sentry.dynamic_sampling.tasks.collect_orgs",
     "sentry.tasks.statistical_detectors",
     "sentry.debug_files.tasks",
+    "sentry.tasks.on_demand_metrics",
 )
 
 default_exchange = Exchange("default", type="direct")
@@ -929,6 +930,7 @@ CELERY_QUEUES_REGION = [
     CELERY_ISSUE_STATES_QUEUE,
     Queue("nudge.invite_missing_org_members", routing_key="invite_missing_org_members"),
     Queue("auto_resolve_issues", routing_key="auto_resolve_issues"),
+    Queue("on_demand_metrics", routing_key="on_demand_metrics"),
 ]
 
 from celery.schedules import crontab
@@ -1201,6 +1203,10 @@ CELERYBEAT_SCHEDULE_REGION = {
         "task": "sentry.debug_files.tasks.refresh_artifact_bundles_in_use",
         "schedule": crontab(minute="*/1"),
         "options": {"expires": 60},
+    },
+    "on-demand-metrics-schedule-on-demand-check": {
+        "task": "sentry.tasks.on_demand_metrics.schedule_on_demand_check",
+        "schedule": crontab(minute="*/5"),
     },
 }
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -13,7 +13,7 @@ from sentry.options.manager import (
     FLAG_PRIORITIZE_DISK,
     FLAG_REQUIRED,
 )
-from sentry.utils.types import Any, Bool, Dict, Int, Sequence, String
+from sentry.utils.types import Any, Bool, Dict, Float, Int, Sequence, String
 
 # Cache
 # register('cache.backend', flags=FLAG_NOSTORE)
@@ -1754,6 +1754,33 @@ register(
     "performance_issues.file_io_main_thread.disabled",
     default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# Enables on-demand metric extraction for Dashboard Widgets.
+register(
+    "on_demand_metrics.check_widgets.enable",
+    default=False,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Rollout % for easing out rollout based on the dashboard widget query id
+register(
+    "on_demand_metrics.check_widgets.rollout",
+    default=0.0,
+    type=Float,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Number of DashboardWidgetQuery to be checked at once.
+register(
+    "on_demand_metrics.check_widgets.query.batch_size",
+    type=Int,
+    default=50,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Number of chunks to split queries across.
+register(
+    "on_demand_metrics.check_widgets.query.total_batches",
+    default=100,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 # Relocation

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -196,7 +196,7 @@ def _get_widget_metric_specs(
     specs = []
     with metrics.timer("on_demand_metrics.widget_spec_convert"):
         for widget in widget_queries:
-            for result in _convert_widget_query_to_metric(project, widget, prefilling):
+            for result in convert_widget_query_to_metric(project, widget, prefilling, True):
                 specs.append(result)
 
     max_widget_specs = options.get("on_demand.max_widget_specs") or _MAX_ON_DEMAND_WIDGETS
@@ -249,8 +249,8 @@ def _convert_snuba_query_to_metric(
     )
 
 
-def _convert_widget_query_to_metric(
-    project: Project, widget_query: DashboardWidgetQuery, prefilling: bool
+def convert_widget_query_to_metric(
+    project: Project, widget_query: DashboardWidgetQuery, prefilling: bool, check_cardinality: bool
 ) -> Sequence[HashedMetricSpec]:
     """
     Converts a passed metrics widget query to one or more MetricSpecs.
@@ -261,7 +261,7 @@ def _convert_widget_query_to_metric(
     if not widget_query.aggregates:
         return metrics_specs
 
-    if not _is_widget_query_low_cardinality(widget_query, project):
+    if check_cardinality and not _is_widget_query_low_cardinality(widget_query, project):
         # High cardinality widgets don't have metrics specs created
         return metrics_specs
 

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -78,7 +78,7 @@ class HighCardinalityWidgetException(Exception):
     max_retries=0,
     soft_time_limit=60,
     time_limit=120,
-    expires=60,
+    expires=180,
 )
 def schedule_on_demand_check() -> None:
     """
@@ -170,7 +170,7 @@ def schedule_on_demand_check() -> None:
     max_retries=0,
     soft_time_limit=60,
     time_limit=120,
-    expires=60,
+    expires=180,
 )
 def process_widget_specs(widget_query_ids: list[int], *args, **kwargs) -> None:
     """

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Sequence, Set
+
+import sentry_sdk
+from celery.exceptions import SoftTimeLimitExceeded
+
+from sentry import options
+from sentry.api.utils import get_date_range_from_params
+from sentry.models.dashboard_widget import (
+    DashboardWidgetQuery,
+    DashboardWidgetQueryOnDemand,
+    DashboardWidgetTypes,
+)
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.relay.config.metric_extraction import (
+    HashedMetricSpec,
+    convert_widget_query_to_metric,
+    on_demand_metrics_feature_flags,
+)
+from sentry.search.events import fields
+from sentry.search.events.builder import QueryBuilder
+from sentry.search.events.types import EventsResponse, QueryBuilderConfig
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.referrer import Referrer
+from sentry.tasks.base import instrumented_task
+from sentry.utils import metrics
+from sentry.utils.cache import cache
+from sentry.utils.query import RangeQuerySetWrapper
+
+logger = logging.getLogger("sentry.tasks.on_demand_metrics")
+
+OnDemandExtractionState = DashboardWidgetQueryOnDemand.OnDemandExtractionState
+
+# TTL for cardinality check
+_WIDGET_QUERY_CARDINALITY_TTL = 3600 * 24 * 7  # Cardinality outcome is valid for 7 days.
+
+
+def _get_widget_processing_batch_key() -> str:
+    return "on-demand-metrics:widgets:currently-processing-batch"
+
+
+def _get_widget_query_cardinality_cache_key(widget_query: DashboardWidgetQuery) -> str:
+    return f"check-widget-query-cardinality:{widget_query.id}"
+
+
+def _set_currently_processing_batch(current_batch: int) -> None:
+    cache.set(_get_widget_processing_batch_key(), current_batch, timeout=3600)
+
+
+def _set_cardinality_cache(cache_key: str, is_low_cardinality: bool) -> None:
+    cache.set(cache_key, is_low_cardinality, timeout=_WIDGET_QUERY_CARDINALITY_TTL)
+
+
+def _get_previous_processing_batch() -> int:
+    return cache.get(_get_widget_processing_batch_key(), 0)
+
+
+def _get_current_processing_batch(total_batches: int) -> int:
+    previous_batch = _get_previous_processing_batch()
+    current_batch = (previous_batch + 1) % total_batches
+    return current_batch
+
+
+def _get_batch_for_widget_query(widget_query_id: int, total_batches: int) -> int:
+    return widget_query_id % total_batches
+
+
+class HighCardinalityWidgetException(Exception):
+    pass
+
+
+@instrumented_task(
+    name="sentry.tasks.on_demand_metrics.schedule_on_demand_check",
+    queue="on_demand_metrics",
+    max_retries=0,
+    soft_time_limit=60,
+    time_limit=120,
+    expires=60,
+)
+def schedule_on_demand_check() -> None:
+    """
+    # Summary
+    This task schedules work to be done to check cardinality in group-by columns in dashboard widgets,
+    offloading it from `build_project_config` in the relay task (specifically in :func:`sentry.relay.config.metric_extraction.get_metric_extraction_config`).
+
+    Spawns a series of child tasks :func:`process_widget_specs`, and limits them using
+    a stateful (cached) count + modulo to spread out the work over `total_batches` number of scheduled task runs.
+
+    It's safe, but not ideal if a particular child tasks fails to run in cases where the current state is reset since memcache is ephemeral.
+
+    ### Other
+    - The amount of work being done can be reduced once extraction is stateful in our db, which would allow us to
+        only iterate over widgets with currently enabled extraction.
+
+    # Ops
+    Killswitch option: `on_demand_metrics.check_widgets.enable`
+    - It is safe to turn off for a period of `_WIDGET_QUERY_CARDINALITY_TTL`, customer data should not be lost. After this time
+        high cardinality metrics may inadverently be stored for on-demand-extraction.
+    """
+    if not options.get("on_demand_metrics.check_widgets.enable"):
+        return
+
+    rollout = options.get("on_demand_metrics.check_widgets.rollout")
+    total_batches = options.get("on_demand_metrics.check_widgets.query.total_batches")
+    widgets_per_batch = options.get("on_demand_metrics.check_widgets.query.batch_size")
+
+    currently_processing_batch = _get_current_processing_batch(total_batches)
+
+    widget_query_ids = []
+    dashboard_widget_pre_rollout_count = 0
+    dashboard_widget_count = 0
+
+    for (widget_query_id,) in RangeQuerySetWrapper(
+        DashboardWidgetQuery.objects.filter(
+            widget__widget_type=DashboardWidgetTypes.DISCOVER, columns__len__gt=0
+        )
+        .exclude(conditions__contains="event.type:error")
+        .values_list("id"),
+        result_value_getter=lambda item: item[0],
+    ):
+        dashboard_widget_pre_rollout_count += 1
+
+        if ((widget_query_id % 1_000) / 1_000) > rollout:
+            # % rollout based on widget_id accurate to 0.1%
+            continue
+
+        batch_for_widget_query = _get_batch_for_widget_query(widget_query_id, total_batches)
+        if batch_for_widget_query != currently_processing_batch:
+            continue
+
+        widget_query_ids.append(widget_query_id)
+        dashboard_widget_count += 1
+
+        if len(widget_query_ids) >= widgets_per_batch:
+            process_widget_specs.delay(
+                widget_query_ids,
+            )
+            widget_query_ids = []
+
+    # Clean up any remaining widgets
+    if widget_query_ids:
+        process_widget_specs.delay(
+            widget_query_ids,
+        )
+
+    _set_currently_processing_batch(currently_processing_batch)
+    metrics.incr(
+        "task.on_demand_metrics.widgets.currently_processing_batch",
+        amount=currently_processing_batch,  # Helps correlate which batch is currently being processed with metrics
+        sample_rate=1.0,
+    )
+    metrics.incr(
+        "task.on_demand_metrics.widgets.pre_rollout.total",
+        amount=dashboard_widget_pre_rollout_count,
+        sample_rate=1.0,
+    )
+    metrics.incr(
+        "task.on_demand_metrics.widgets.total",
+        amount=dashboard_widget_count,
+        sample_rate=1.0,
+    )
+
+
+@instrumented_task(
+    name="sentry.tasks.on_demand_metrics.process_widget_specs",
+    queue="on_demand_metrics",
+    max_retries=0,
+    soft_time_limit=60,
+    time_limit=120,
+    expires=60,
+)
+def process_widget_specs(widget_query_ids: list[int], *args, **kwargs) -> None:
+    """
+    Child task spawned from :func:`schedule_on_demand_check`.
+    """
+    if not options.get("on_demand_metrics.check_widgets.enable"):
+        return
+
+    widget_query_count = 0
+    widget_query_high_cardinality_count = 0
+    widget_query_no_spec_count = 0
+
+    for query in DashboardWidgetQuery.objects.filter(id__in=widget_query_ids).select_related(
+        "widget__dashboard__organization"
+    ):
+        organization = query.widget.dashboard.organization
+        enabled_features = on_demand_metrics_feature_flags(organization)
+        widget_query_count += 1
+
+        widget_specs = _get_widget_on_demand_specs(query, organization)
+
+        if not widget_specs:
+            # It's possible this query doesn't qualify for on-demand.
+            widget_query_no_spec_count += 1
+
+        is_low_cardinality = None
+        # This only exists to make sure we're 1:1 with flagr since we're not fully rolled out.
+        # TODO: Remove feature flag check once we've checked metrics have gone to 0.
+        if "organizations:on-demand-metrics-extraction-widgets" in enabled_features:
+            if widget_specs:
+                is_low_cardinality = _get_widget_query_low_cardinality(query, organization)
+                if is_low_cardinality is not None:
+                    # Still setting to cache for now until switching cardinality out of build_project_config
+                    cache_key = _get_widget_query_cardinality_cache_key(query)
+                    _set_cardinality_cache(cache_key, is_low_cardinality)
+                if is_low_cardinality is False:
+                    widget_query_high_cardinality_count += 1
+        else:
+            metrics.incr(
+                "task.on_demand_metrics.widget_queries.per_run.flag_disabled",
+                sample_rate=1.0,
+            )
+
+        _set_widget_on_demand_state(
+            widget_query=query,
+            specs=widget_specs,
+            is_low_cardinality=is_low_cardinality,
+            enabled_features=enabled_features,
+        )
+
+    metrics.incr(
+        "tasks.on_demand_metrics.widget_queries.per_run.no_spec",
+        amount=widget_query_no_spec_count,
+        sample_rate=1.0,
+    )
+    metrics.incr(
+        "task.on_demand_metrics.widget_queries.per_run.high_cardinality",
+        amount=widget_query_high_cardinality_count,
+        sample_rate=1.0,
+    )
+    metrics.incr(
+        "task.on_demand_metrics.widget_queries.per_run.total",
+        amount=widget_query_count,
+        sample_rate=1.0,
+    )
+
+
+def _get_widget_on_demand_specs(
+    widget_query: DashboardWidgetQuery,
+    organization: Organization,
+) -> Sequence[HashedMetricSpec]:
+    """
+    Saves on-demand state for a widget query.
+    """
+    # This can just be the first project we find, since spec hashes should not be project
+    # dependent. If spec hashes become project dependent then this may need to change.
+    project_for_query = Project.objects.filter(organization=organization).first()
+
+    if not project_for_query:
+        return []
+
+    widget_specs = convert_widget_query_to_metric(project_for_query, widget_query, True, False)
+
+    return widget_specs
+
+
+def _set_widget_on_demand_state(
+    widget_query: DashboardWidgetQuery,
+    specs: Sequence[HashedMetricSpec],
+    is_low_cardinality: bool | None,
+    enabled_features: Set[str],
+):
+    extraction_state = _determine_extraction_state(specs, is_low_cardinality, enabled_features)
+    spec_hashes = [hashed_spec[0] for hashed_spec in specs]
+
+    DashboardWidgetQueryOnDemand.objects.update_or_create(
+        dashboard_widget_query=widget_query,
+        defaults={
+            "spec_hashes": spec_hashes,
+            "extraction_state": extraction_state,
+        },
+    )
+
+
+def _determine_extraction_state(
+    specs: Sequence[HashedMetricSpec], is_low_cardinality: bool | None, enabled_features: Set[str]
+) -> OnDemandExtractionState:
+    if not specs:
+        return OnDemandExtractionState.DISABLED_NOT_APPLICABLE
+
+    if "organizations:on-demand-metrics-extraction-widgets" not in enabled_features:
+        return OnDemandExtractionState.DISABLED_PREROLLOUT
+
+    if is_low_cardinality is False:
+        return OnDemandExtractionState.DISABLED_HIGH_CARDINALITY
+
+    return OnDemandExtractionState.ENABLED_ENROLLED
+
+
+def _get_widget_query_low_cardinality(
+    widget_query: DashboardWidgetQuery, organization: Organization
+) -> Optional[bool]:
+    """
+    Checks cardinality of existing widget queries before allowing the metric spec, so that
+    group-by clauses with high cardinality tags are not added to the on_demand metric.
+
+    New queries will be checked upon creation and not allowed at that time.
+    """
+
+    max_cardinality_allowed = options.get("on_demand.max_widget_cardinality.count")
+    cache_key = _get_widget_query_cardinality_cache_key(widget_query)
+
+    # We default low cardinality to true since if it's false we'll remove user data.
+    is_low_cardinality = cache.get(cache_key, default=True)
+    query_columns = widget_query.columns
+
+    if not query_columns:
+
+        return None
+
+    with sentry_sdk.push_scope() as scope:
+        scope.set_tag("widget_query.widget_id", widget_query.id)
+        scope.set_tag("widget_query.org_slug", organization.slug)
+        scope.set_tag("widget_query.conditions", widget_query.conditions)
+
+        try:
+            processed_results, columns_to_check = _query_cardinality(query_columns, organization)
+            for column in columns_to_check:
+                count = processed_results["data"][0][f"count_unique({column})"]
+                if count > max_cardinality_allowed:
+                    cache.set(cache_key, False, timeout=_WIDGET_QUERY_CARDINALITY_TTL)
+                    scope.set_tag("widget_query.column_name", column)
+                    raise HighCardinalityWidgetException(
+                        f"Cardinality exceeded for dashboard_widget_query:{widget_query.id} with count:{count} and column:{column}"
+                    )
+            # If it's made it here then cardinality is low.
+            is_low_cardinality = True
+
+        except HighCardinalityWidgetException as error:
+            sentry_sdk.capture_exception(error)
+            is_low_cardinality = False
+        except SoftTimeLimitExceeded as error:
+            scope.set_tag("widget_soft_deadline", True)
+            sentry_sdk.capture_exception(error)
+        except Exception as error:
+            sentry_sdk.capture_exception(error)
+
+    return is_low_cardinality
+
+
+def _query_cardinality(
+    query_columns: list[str], organization: Organization
+) -> tuple[EventsResponse, list[str]]:
+    params: dict[str, Any] = {
+        "statsPeriod": "30m",
+        "organization_id": organization.id,
+    }
+    start, end = get_date_range_from_params(params)
+    params["start"] = start
+    params["end"] = end
+
+    columns_to_check = [column for column in query_columns if not fields.is_function(column)]
+    unique_columns = [f"count_unique({column})" for column in columns_to_check]
+
+    query_builder = QueryBuilder(
+        dataset=Dataset.Discover,
+        params=params,
+        selected_columns=unique_columns,
+        config=QueryBuilderConfig(
+            transform_alias_to_input_format=True,
+        ),
+    )
+
+    results = query_builder.run_query(Referrer.METRIC_EXTRACTION_CARDINALITY_CHECK.value)
+    processed_results = query_builder.process_results(results)
+
+    return processed_results, columns_to_check

--- a/tests/sentry/tasks/test_on_demand_metrics.py
+++ b/tests/sentry/tasks/test_on_demand_metrics.py
@@ -187,14 +187,12 @@ def create_widget(
         ),  # Checking 2nd batch of 4. Widgets[1, 4], 1 child task, 2 queries made (batch size 2)
     ],
 )
-@mock.patch("sentry.tasks.on_demand_metrics._get_previous_processing_batch")
 @mock.patch(
     "sentry.tasks.on_demand_metrics._query_cardinality", return_value=_CARDINALITY_DISCOVER_DATA
 )
 @django_db_all
 def test_schedule_on_demand_check(
     _query_cardinality,
-    _get_previous_processing_batch,
     feature_flags,
     option_enable,
     option_rollout,
@@ -218,7 +216,7 @@ def test_schedule_on_demand_check(
     }
     query_columns = ["custom-tag"] if has_columns else []
 
-    _get_previous_processing_batch.return_value = previous_batch
+    on_demand_metrics._set_currently_processing_batch(previous_batch)
 
     # Reuse the same dashboard to speed up fixture calls and avoid managing dashboard unique title constraint.
     _, __, dashboard = create_widget(

--- a/tests/sentry/tasks/test_on_demand_metrics.py
+++ b/tests/sentry/tasks/test_on_demand_metrics.py
@@ -1,0 +1,416 @@
+from typing import Optional, Sequence, Tuple
+from unittest import mock
+
+import pytest
+
+from sentry.models.dashboard import Dashboard
+from sentry.models.dashboard_widget import (
+    DashboardWidget,
+    DashboardWidgetDisplayTypes,
+    DashboardWidgetQuery,
+    DashboardWidgetQueryOnDemand,
+    DashboardWidgetTypes,
+)
+from sentry.models.project import Project
+from sentry.tasks.on_demand_metrics import process_widget_specs, schedule_on_demand_check
+from sentry.testutils.factories import Factories
+from sentry.testutils.helpers import Feature, override_options
+from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.utils.cache import cache
+
+_WIDGET_EXTRACTION_FEATURES = {"organizations:on-demand-metrics-extraction-widgets": True}
+
+_CARDINALITY_DISCOVER_DATA = ({"data": [{"count_unique(custom-tag)": 50}]}, ["custom-tag"])
+_SNQL_DATA_LOW_CARDINALITY = {"data": [{"count_unique(custom-tag)": 10000}]}
+_SNQL_DATA_HIGH_CARDINALITY = {"data": [{"count_unique(custom-tag)": 10001}]}
+
+OnDemandExtractionState = DashboardWidgetQueryOnDemand.OnDemandExtractionState
+
+
+@pytest.fixture
+def owner():
+    return Factories.create_user()
+
+
+@pytest.fixture
+def organization(owner):
+    return Factories.create_organization(owner=owner)
+
+
+@pytest.fixture
+def project(organization):
+    return Factories.create_project(organization=organization)
+
+
+# TODO: Move this into a method to be shared with test_metric_extraction
+def create_widget(
+    aggregates: Sequence[str],
+    query: str,
+    project: Project,
+    title="Dashboard",
+    id: Optional[int] = None,
+    columns: Optional[Sequence[str]] = None,
+    dashboard: Optional[Dashboard] = None,
+    widget: Optional[DashboardWidget] = None,
+) -> Tuple[DashboardWidgetQuery, DashboardWidget, Dashboard]:
+    columns = columns or []
+    dashboard = dashboard or Dashboard.objects.create(
+        organization=project.organization,
+        created_by_id=1,
+        title=title,
+    )
+    id = id or 1
+    widget = widget or DashboardWidget.objects.create(
+        dashboard=dashboard,
+        order=id - 1,
+        widget_type=DashboardWidgetTypes.DISCOVER,
+        display_type=DashboardWidgetDisplayTypes.LINE_CHART,
+    )
+
+    widget_query = DashboardWidgetQuery.objects.create(
+        id=id, aggregates=aggregates, conditions=query, columns=columns, order=id - 1, widget=widget
+    )
+
+    return widget_query, widget, dashboard
+
+
+@pytest.mark.parametrize(
+    [
+        "feature_flags",
+        "option_enable",
+        "option_rollout",
+        "option_batch_size",
+        "option_total_batches",
+        "option_max_widget_cardinality",
+        "has_columns",
+        "previous_batch",
+        "expected_number_of_child_tasks_run",
+        "expected_discover_queries_run",
+        "expected_cache_set",
+    ],
+    [
+        # Testing options and task batching
+        pytest.param({}, False, 0.0, 1, 1, 100, True, 0, 0, 0, None, id="nothing_enabled"),
+        pytest.param({}, True, 0.0, 1, 1, 100, True, 0, 0, 0, None, id="option_enabled_no_rollout"),
+        pytest.param(
+            {}, True, 1.0, 1, 1, 100, True, 0, 5, 0, None, id="option_enabled_rollout_max"
+        ),
+        pytest.param(
+            {},
+            True,
+            0.0,
+            1,
+            1,
+            100,
+            False,
+            0,
+            0,
+            0,
+            None,
+            id="option_enabled_rollout_max_no_columns",
+        ),
+        pytest.param(
+            {}, True, 0.001, 1, 1, 100, True, 0, 1, 0, None, id="option_enabled_rollout_only_one"
+        ),
+        pytest.param(
+            {}, True, 0.002, 1, 1, 100, True, 0, 2, 0, None, id="option_enabled_rollout_two"
+        ),
+        pytest.param(
+            {}, True, 1.0, 2, 1, 100, True, 0, 3, 0, None, id="fully_enabled_batch_size_remainder"
+        ),  # Should be 3 calls since 5 / 2 has remainder
+        pytest.param(
+            {}, True, 1.0, 1, 2, 100, True, 1, 2, 0, None, id="test_offset_batch_0"
+        ),  # first batch of two (previous batch 1 rolls over), with batch size 1. Widgets [2,4]
+        pytest.param(
+            {}, True, 1.0, 1, 2, 100, True, 0, 3, 0, None, id="test_offset_batch_1"
+        ),  # second batch of two, with batch size 1.  Widgets [1,3,5]
+        pytest.param(
+            {}, True, 1.0, 5, 1, 100, True, 0, 1, 0, None, id="fully_enabled_batch_size_all"
+        ),
+        pytest.param(
+            {},
+            True,
+            1.0,
+            10,
+            1,
+            100,
+            True,
+            0,
+            1,
+            0,
+            None,
+            id="fully_enabled_batch_size_larger_batch",
+        ),
+        # Testing cardinality checks
+        pytest.param(
+            _WIDGET_EXTRACTION_FEATURES,
+            True,
+            1.0,
+            10,
+            1,
+            100,
+            True,
+            0,
+            1,
+            5,
+            True,
+            id="fully_enabled_with_features",
+        ),  # 1 task, 5 queries.
+        pytest.param(
+            _WIDGET_EXTRACTION_FEATURES,
+            True,
+            1.0,
+            10,
+            1,
+            49,
+            True,
+            0,
+            1,
+            5,
+            False,
+            id="fully_enabled_with_features_high_cardinality",
+        ),  # Below cardinality limit.
+        pytest.param(
+            _WIDGET_EXTRACTION_FEATURES,
+            True,
+            1.0,
+            2,
+            4,
+            100,
+            True,
+            0,
+            1,
+            2,
+            True,
+            id="test_offset_batch_larger_size_with_features",
+        ),  # Checking 2nd batch of 4. Widgets[1, 4], 1 child task, 2 queries made (batch size 2)
+    ],
+)
+@mock.patch("sentry.tasks.on_demand_metrics._get_previous_processing_batch")
+@mock.patch("sentry.tasks.on_demand_metrics._set_cardinality_cache")
+@mock.patch(
+    "sentry.tasks.on_demand_metrics._query_cardinality", return_value=_CARDINALITY_DISCOVER_DATA
+)
+@django_db_all
+def test_schedule_on_demand_check(
+    _query_cardinality,
+    _cardinality_cache,
+    _get_previous_processing_batch,
+    feature_flags,
+    option_enable,
+    option_rollout,
+    option_batch_size,
+    option_total_batches,
+    option_max_widget_cardinality,
+    previous_batch,
+    has_columns,
+    expected_number_of_child_tasks_run,
+    expected_discover_queries_run,
+    expected_cache_set,
+    project,
+):
+    cache.clear()
+    options = {
+        "on_demand_metrics.check_widgets.enable": option_enable,
+        "on_demand_metrics.check_widgets.rollout": option_rollout,
+        "on_demand_metrics.check_widgets.query.batch_size": option_batch_size,
+        "on_demand_metrics.check_widgets.query.total_batches": option_total_batches,
+        "on_demand.max_widget_cardinality.count": option_max_widget_cardinality,
+    }
+    query_columns = ["custom-tag"] if has_columns else []
+
+    _get_previous_processing_batch.return_value = previous_batch
+
+    # Reuse the same dashboard to speed up fixture calls and avoid managing dashboard unique title constraint.
+    _, __, dashboard = create_widget(
+        ["count()"], "transaction.duration:>=1", project, columns=query_columns, id=1
+    )
+    create_widget(
+        ["count()"],
+        "transaction.duration:>=2",
+        project,
+        columns=query_columns,
+        id=2,
+        dashboard=dashboard,
+    )
+    create_widget(
+        ["count()"],
+        "transaction.duration:>=3",
+        project,
+        columns=query_columns,
+        id=3,
+        dashboard=dashboard,
+    )
+    create_widget(
+        ["count()"],
+        "transaction.duration:>=4",
+        project,
+        columns=query_columns,
+        id=4,
+        dashboard=dashboard,
+    )
+    create_widget(
+        ["count()"],
+        "transaction.duration:>=5",
+        project,
+        columns=query_columns,
+        id=5,
+        dashboard=dashboard,
+    )
+
+    with mock.patch.object(
+        process_widget_specs, "delay", wraps=process_widget_specs
+    ) as process_widget_specs_spy, override_options(options), Feature(feature_flags):
+        assert not process_widget_specs_spy.called
+        schedule_on_demand_check()
+        assert process_widget_specs_spy.call_count == expected_number_of_child_tasks_run
+
+    assert _query_cardinality.call_count == expected_discover_queries_run
+    assert _cardinality_cache.call_count == expected_discover_queries_run
+    if _cardinality_cache.call_count:
+        # Can't assert order, tasks aren't guaranteed to fire in order.
+        assert all(
+            mock_call.args[1] == expected_cache_set for mock_call in _cardinality_cache.mock_calls
+        )
+
+
+@pytest.mark.parametrize(
+    [
+        "feature_flags",
+        "option_enable",
+        "widget_query_ids",
+        "set_high_cardinality",
+        "expected_discover_queries_run",
+        "expected_low_cardinality",
+    ],
+    [
+        pytest.param({}, False, [], False, 0, None, id="nothing_enabled"),
+        pytest.param(_WIDGET_EXTRACTION_FEATURES, True, [1], False, 1, True, id="enabled_low_card"),
+        pytest.param({}, True, [1], False, 0, True, id="enabled_low_card_no_features"),
+        pytest.param(
+            _WIDGET_EXTRACTION_FEATURES, True, [1], True, 1, False, id="enabled_high_card"
+        ),
+        pytest.param(
+            _WIDGET_EXTRACTION_FEATURES,
+            True,
+            [1, 2, 3],
+            False,
+            2,
+            True,
+            id="enabled_low_card_all_widgets",
+        ),  # Only 2 widgets are on-demand
+    ],
+)
+@mock.patch("sentry.tasks.on_demand_metrics._set_cardinality_cache")
+@mock.patch("sentry.search.events.builder.discover.raw_snql_query")
+@django_db_all
+def test_process_widget_specs(
+    raw_snql_query,
+    _set_cardinality_cache,
+    feature_flags,
+    widget_query_ids,
+    set_high_cardinality,
+    option_enable,
+    expected_discover_queries_run,
+    expected_low_cardinality,
+    project,
+):
+
+    raw_snql_query.return_value = (
+        _SNQL_DATA_HIGH_CARDINALITY if set_high_cardinality else _SNQL_DATA_LOW_CARDINALITY
+    )
+    options = {
+        "on_demand_metrics.check_widgets.enable": option_enable,
+    }
+
+    query_columns = ["custom-tag"]
+
+    # Reuse the same dashboard to speed up fixture calls and avoid managing dashboard unique title constraint.
+    _, __, dashboard = create_widget(
+        ["count()"], "transaction.duration:>=1", project, columns=query_columns, id=1
+    )
+    create_widget(
+        ["count()"],
+        "transaction.duration:>=2",
+        project,
+        columns=query_columns,
+        id=2,
+        dashboard=dashboard,
+    )
+    create_widget(
+        ["count()"],
+        "",  # Not a on-demand widget
+        project,
+        columns=[],
+        id=3,
+        dashboard=dashboard,
+    )
+
+    with override_options(options), Feature(feature_flags):
+        process_widget_specs(widget_query_ids)
+
+    assert raw_snql_query.call_count == expected_discover_queries_run
+
+    assert _set_cardinality_cache.call_count == expected_discover_queries_run
+    if _set_cardinality_cache.call_count:
+        # Can't assert order, tasks aren't guaranteed to fire in order.
+        assert all(
+            mock_call.args[1] == expected_low_cardinality
+            for mock_call in _set_cardinality_cache.mock_calls
+        )
+
+    if 1 in widget_query_ids:
+        widget_model = DashboardWidgetQueryOnDemand.objects.get(dashboard_widget_query_id=1)
+        assert_on_demand_model(
+            widget_model,
+            is_low_cardinality=expected_low_cardinality,
+            has_features=bool(feature_flags),
+            expected_applicable=True,
+            expected_hashes=["43adeb86"],
+        )
+
+    if 2 in widget_query_ids:
+        widget_model = DashboardWidgetQueryOnDemand.objects.get(dashboard_widget_query_id=2)
+        assert_on_demand_model(
+            widget_model,
+            is_low_cardinality=expected_low_cardinality,
+            has_features=bool(feature_flags),
+            expected_applicable=True,
+            expected_hashes=["8f74e5da"],
+        )
+
+    if 3 in widget_query_ids:
+        widget_model = DashboardWidgetQueryOnDemand.objects.get(dashboard_widget_query_id=3)
+        assert_on_demand_model(
+            widget_model,
+            is_low_cardinality=expected_low_cardinality,
+            has_features=bool(feature_flags),
+            expected_applicable=False,
+            expected_hashes=[],
+        )
+
+
+def assert_on_demand_model(
+    model: DashboardWidgetQueryOnDemand,
+    is_low_cardinality: bool,
+    has_features: bool,
+    expected_applicable: bool,
+    expected_hashes: Sequence[str],
+):
+    if not expected_applicable:
+        assert model.extraction_state == OnDemandExtractionState.DISABLED_NOT_APPLICABLE
+        assert model.spec_hashes == []
+        return
+
+    if not has_features:
+        assert model.extraction_state == OnDemandExtractionState.DISABLED_PREROLLOUT
+        assert model.spec_hashes == expected_hashes  # Still include hashes
+        return
+
+    expected_state = (
+        OnDemandExtractionState.ENABLED_ENROLLED
+        if is_low_cardinality
+        else OnDemandExtractionState.DISABLED_HIGH_CARDINALITY
+    )
+    assert model.extraction_state == expected_state
+    assert model.spec_hashes == expected_hashes


### PR DESCRIPTION
### Summary

This moves the on-demand-metrics extraction widget cardinality check (it checks that widget group-bys don't cause too many metrics ingested per specification) into its own task. It currently executes within the relay task 'build_project_config' which causes it to hit its task deadline.

This adds a task to check applicable dashboard query widgets, spread across N (=100) scheduled runs.

This also prevents loosing extraction for certain metrics when the relay task would time out.

#### Other
- Carried on from the draft https://github.com/getsentry/sentry/pull/61199