### PR TITLE
ref(crons): Fix environment_status_ordering clause enum usage

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -130,7 +130,7 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
 
         queryset = queryset.annotate(
             environment_status_ordering=Case(
-                When(status=MonitorStatus.DISABLED, then=Value(len(DEFAULT_ORDERING))),
+                When(status=MonitorObjectStatus.MUTED, then=Value(len(DEFAULT_ORDERING))),
                 default=Subquery(
                     monitor_environments_query.annotate(
                         status_ordering=MONITOR_ENVIRONMENT_ORDERING


### PR DESCRIPTION
This is a MonitorObjectStatus not a MonitorStatus. This just happened to
work since the values were the same