### PR TITLE
fix(sentryapps) Fix sentryapp relation traversal in project rule details

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -120,9 +120,14 @@ class RuleSerializer(Serializer):
             if sentry_app_uuid is not None
         ]
 
-        sentry_app_ids: List[int] = [
-            i.sentry_app.id for i in app_service.get_many(filter=dict(uuids=sentry_app_uuids))
-        ]
+        sentry_app_installs = app_service.get_many(filter=dict(uuids=sentry_app_uuids))
+        sentry_app_map = {
+            install.sentry_app.id: install.sentry_app for install in sentry_app_installs
+        }
+        sentry_app_ids: List[int] = list(sentry_app_map.keys())
+
+        # TODO(hybridcloud) Having this RPC method return RPC objects would save translation
+        # layers with dict
         sentry_app_installations_by_uuid = app_service.get_related_sentry_app_components(
             organization_ids=[rule.project.organization_id for rule in rules.values()],
             sentry_app_ids=sentry_app_ids,
@@ -152,8 +157,10 @@ class RuleSerializer(Serializer):
                     str(action.get("sentryAppInstallationUuid"))
                 )
                 if install:
+                    installation = install.get("sentry_app_installation")
                     action["_sentry_app_component"] = install.get("sentry_app_component")
-                    action["_sentry_app_installation"] = install.get("sentry_app_installation")
+                    action["_sentry_app_installation"] = installation
+                    action["_sentry_app"] = sentry_app_map.get(installation.get("sentry_app_id"))
 
         if "lastTriggered" in self.expand:
             last_triggered_lookup = {

--- a/src/sentry/mediators/external_requests/util.py
+++ b/src/sentry/mediators/external_requests/util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Any
 
@@ -7,6 +9,7 @@ from requests.models import Response
 
 from sentry.http import safe_urlopen
 from sentry.models.integrations.sentry_app import SentryApp, track_response_code
+from sentry.services.hybrid_cloud.app.model import RpcSentryApp
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
 from sentry.utils.sentry_apps.webhooks import TIMEOUT_STATUS_CODE
 
@@ -49,7 +52,7 @@ def validate(instance, schema_type):
 
 def send_and_save_sentry_app_request(
     url: str,
-    sentry_app: SentryApp,
+    sentry_app: SentryApp | RpcSentryApp,
     org_id: int,
     event: str,
     **kwargs: Any,

--- a/src/sentry/services/hybrid_cloud/app/impl.py
+++ b/src/sentry/services/hybrid_cloud/app/impl.py
@@ -290,8 +290,7 @@ class DatabaseBackedAppService(AppService):
         from sentry.models.integrations.sentry_app_installation import prepare_sentry_app_components
 
         installation = SentryAppInstallation.objects.get(id=installation_id)
-        component = prepare_sentry_app_components(installation, component_type, project_slug)
-        return serialize_sentry_app_component(component) if component else None
+        return prepare_sentry_app_components(installation, component_type, project_slug)
 
     def disable_sentryapp(self, *, id: int) -> None:
         try:

--- a/src/sentry/services/hybrid_cloud/app/impl.py
+++ b/src/sentry/services/hybrid_cloud/app/impl.py
@@ -133,12 +133,15 @@ class DatabaseBackedAppService(AppService):
         ):
             component = prepare_sentry_app_components(install, "alert-rule-action", project_slug)
             if component:
+                # Refetch the app component to be compatible with serializer
+                orm_component = SentryAppComponent.objects.get(uuid=component.uuid)
+                orm_component.schema = component.app_schema
                 kwargs = {
                     "install": install,
                     "event_action": event_data,
                 }
                 action_details = serialize(
-                    component, None, SentryAppAlertRuleActionSerializer(), **kwargs
+                    orm_component, None, SentryAppAlertRuleActionSerializer(), **kwargs
                 )
                 action_list.append(action_details)
 

--- a/src/sentry/services/hybrid_cloud/app/model.py
+++ b/src/sentry/services/hybrid_cloud/app/model.py
@@ -6,7 +6,7 @@
 import datetime
 import hmac
 from hashlib import sha256
-from typing import Any, Dict, List, Mapping, Optional, Protocol
+from typing import Any, Dict, List, Optional, Protocol
 
 from pydantic.fields import Field
 from typing_extensions import TypedDict
@@ -88,7 +88,7 @@ class RpcSentryAppComponent(RpcModel):
     uuid: str = ""
     sentry_app_id: int = -1
     type: str = ""
-    app_schema: Mapping[str, Any] = Field(default_factory=dict)
+    app_schema: Dict[str, Any] = Field(default_factory=dict)
 
 
 class RpcAlertRuleActionResult(RpcModel):


### PR DESCRIPTION
The ProjectRuleDetails endpoint was traversing ORM relations between SentryAppInstallation and SentryApp. This was passing in tests because both the region & control databases are accessible. However, in the test silo environment this traversal cannot be done in the region instances.

Update UI component resolution to work on Rpc objects that will work in both silos.

Refs HC-1023
