### PR TITLE
fix(replays): preserve entire location query when tabs clicked

### DIFF
--- a/static/app/views/replays/deadRageClick/selectorTable.tsx
+++ b/static/app/views/replays/deadRageClick/selectorTable.tsx
@@ -249,6 +249,8 @@ const MessageContainer = styled('div')`
   grid-auto-flow: row;
   gap: ${space(1)};
   justify-items: center;
+  text-align: center;
+  padding: ${space(4)};
 `;
 
 const WidgetProjectContainer = styled('div')`

--- a/static/app/views/replays/tabs.tsx
+++ b/static/app/views/replays/tabs.tsx
@@ -21,7 +21,7 @@ export default function ReplayTabs({selected}: Props) {
         key: 'replays',
         label: t('Replays'),
         pathname: normalizeUrl(`/organizations/${organization.slug}/replays/`),
-        query: {sort: undefined},
+        query: {...location.query, sort: undefined},
       },
       {
         key: 'selectors',
@@ -31,10 +31,10 @@ export default function ReplayTabs({selected}: Props) {
           </Fragment>
         ),
         pathname: normalizeUrl(`/organizations/${organization.slug}/replays/selectors/`),
-        query: {sort: '-count_dead_clicks'},
+        query: {...location.query, sort: '-count_dead_clicks'},
       },
     ],
-    [organization.slug]
+    [organization.slug, location.query]
   );
 
   return (


### PR DESCRIPTION
- Fixes https://github.com/getsentry/sentry/issues/61231
- Also added some extraneous style tweaks for the selector table empty state

Before:

https://github.com/getsentry/sentry/assets/56095982/612bfe24-4686-4c46-b95f-f58d9b5900a9



After:

https://github.com/getsentry/sentry/assets/56095982/255895e6-401d-4c74-b672-8347e82ef71f

