### PR TITLE
fix(hybridcloud) Fix not found error when installations lack a token

### DIFF
--- a/src/sentry/services/hybrid_cloud/app/serial.py
+++ b/src/sentry/services/hybrid_cloud/app/serial.py
@@ -52,6 +52,9 @@ def serialize_sentry_app_installation(
     if app is None:
         app = installation.sentry_app
         assert app is not None
+    api_token = None
+    if installation.api_token_id and installation.api_token:
+        api_token = installation.api_token.token
 
     return RpcSentryAppInstallation(
         id=installation.id,
@@ -60,7 +63,7 @@ def serialize_sentry_app_installation(
         sentry_app=serialize_sentry_app(app),
         date_deleted=installation.date_deleted,
         uuid=installation.uuid,
-        api_token=installation.api_token.token if installation.api_token_id else None,
+        api_token=api_token,
     )
 
 

--- a/src/sentry/services/hybrid_cloud/app/serial.py
+++ b/src/sentry/services/hybrid_cloud/app/serial.py
@@ -60,7 +60,7 @@ def serialize_sentry_app_installation(
         sentry_app=serialize_sentry_app(app),
         date_deleted=installation.date_deleted,
         uuid=installation.uuid,
-        api_token=installation.api_token.token if installation.api_token else None,
+        api_token=installation.api_token.token if installation.api_token_id else None,
     )
 
 


### PR DESCRIPTION
Not all sentryapp installations have an API token but using `.api_token` will raise an error when the relation is undefined which we don't want.

Fixes SENTRY-19C0
