### PR TITLE
chore(starfish): Show perf onboarding for mobile screens

### DIFF
--- a/static/app/views/starfish/modules/mobile/pageload.tsx
+++ b/static/app/views/starfish/modules/mobile/pageload.tsx
@@ -16,11 +16,14 @@ import {
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useOnboardingProject} from 'sentry/views/performance/browser/webVitals/utils/useOnboardingProject';
+import Onboarding from 'sentry/views/performance/onboarding';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
 import {ScreensView, YAxis} from 'sentry/views/starfish/views/screens';
 
 export default function PageloadModule() {
   const organization = useOrganization();
+  const onboardingProject = useOnboardingProject();
 
   return (
     <SentryDocumentTitle title={t('Mobile')} orgSlug={organization.slug}>
@@ -46,7 +49,17 @@ export default function PageloadModule() {
                   <ReleaseComparisonSelector />
                 </Container>
                 <ErrorBoundary mini>
-                  <ScreensView yAxes={[YAxis.TTID, YAxis.TTFD]} chartHeight={240} />
+                  {onboardingProject && (
+                    <OnboardingContainer>
+                      <Onboarding
+                        organization={organization}
+                        project={onboardingProject}
+                      />
+                    </OnboardingContainer>
+                  )}
+                  {!onboardingProject && (
+                    <ScreensView yAxes={[YAxis.TTID, YAxis.TTFD]} chartHeight={240} />
+                  )}
                 </ErrorBoundary>
               </PageFiltersContainer>
             </Layout.Main>
@@ -67,4 +80,8 @@ const Container = styled('div')`
     grid-template-rows: auto;
     grid-template-columns: auto 1fr auto;
   }
+`;
+
+const OnboardingContainer = styled('div')`
+  margin-top: ${space(2)};
 `;


### PR DESCRIPTION
Shows perf onboarding if project doesn't have perf setup.

<img width="1253" alt="Screenshot 2023-12-08 at 11 10 56 AM" src="https://github.com/getsentry/sentry/assets/63818634/78e78006-64ae-4b7a-9506-acbbce6f16dd">
<img width="1246" alt="Screenshot 2023-12-08 at 11 11 09 AM" src="https://github.com/getsentry/sentry/assets/63818634/42d120fd-36e9-43d8-adc8-9561eaf99c0f">
