### PR TITLE
fix(hybridcloud) Fix sentry-app region API proxying

### DIFF
--- a/tests/sentry/hybridcloud/apigateway/test_apigateway.py
+++ b/tests/sentry/hybridcloud/apigateway/test_apigateway.py
@@ -174,6 +174,35 @@ class ApiGatewayTest(ApiGatewayTestCase):
 
     @override_settings(SILO_MODE=SiloMode.CONTROL, SENTRY_MONOLITH_REGION="us")
     @responses.activate
+    def test_proxy_sentryapp_path(self):
+        sentry_app = self.create_sentry_app()
+
+        responses.add(
+            responses.GET,
+            f"http://us.internal.sentry.io/sentry-apps/{sentry_app.slug}/interaction/",
+            json={"proxy": True, "name": "interaction"},
+        )
+        responses.add(
+            responses.GET,
+            f"http://us.internal.sentry.io/sentry-apps/{sentry_app.slug}/requests/",
+            json={"proxy": True, "name": "requests"},
+        )
+
+        with override_settings(MIDDLEWARE=tuple(self.middleware)):
+            resp = self.client.get(f"/sentry-apps/{sentry_app.slug}/interaction/")
+            assert resp.status_code == 200
+            resp_json = json.loads(close_streaming_response(resp))
+            assert resp_json["proxy"]
+            assert resp_json["name"] == "interaction"
+
+            resp = self.client.get(f"/sentry-apps/{sentry_app.slug}/requests/")
+            assert resp.status_code == 200
+            resp_json = json.loads(close_streaming_response(resp))
+            assert resp_json["proxy"]
+            assert resp_json["name"] == "requests"
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL, SENTRY_MONOLITH_REGION="us")
+    @responses.activate
     def test_proxy_sentryapp_installation_path_invalid(self):
         # No responses configured so that requests will fail if they are made.
         with override_settings(MIDDLEWARE=tuple(self.middleware)):


### PR DESCRIPTION
There are two sentryapp API endpoints (requests/interactions) that store data in the creating org's region. These endpoints need to be proxied to the region where the sentryapp was created for now. I found this while working on #61435

Refs HC-1023