### PR TITLE
fix(dashboard): Apply quotes around release filters

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -237,7 +237,7 @@ describe('add to dashboard modal', () => {
           orderby: '',
           partial: '1',
           project: [1],
-          query: ' release:abc@v1.2.0 ',
+          query: ' release:"abc@v1.2.0" ',
           statsPeriod: '1h',
           yAxis: ['count()'],
         }),

--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -241,7 +241,7 @@ describe('Modals -> WidgetViewerModal', function () {
             query: expect.objectContaining({
               query:
                 // The release was injected into the discover query
-                'title:/organizations/:orgId/performance/summary/ release:project-release@1.2.0 ',
+                'title:/organizations/:orgId/performance/summary/ release:"project-release@1.2.0" ',
             }),
           })
         );

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -440,7 +440,7 @@ describe('Dashboards > Detail', function () {
           '/organizations/org-slug/events-stats/',
           expect.objectContaining({
             query: expect.objectContaining({
-              query: 'event.type:transaction transaction:/api/cats release:abc@1.2.0 ',
+              query: 'event.type:transaction transaction:/api/cats release:"abc@1.2.0" ',
             }),
           })
         )

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -656,9 +656,11 @@ export function dashboardFiltersToString(
   if (dashboardFilters) {
     for (const [key, activeFilters] of Object.entries(dashboardFilters)) {
       if (activeFilters.length === 1) {
-        dashboardFilterConditions += `${key}:${activeFilters[0]} `;
+        dashboardFilterConditions += `${key}:"${activeFilters[0]}" `;
       } else if (activeFilters.length > 1) {
-        dashboardFilterConditions += `${key}:[${activeFilters.join(',')}] `;
+        dashboardFilterConditions += `${key}:[${activeFilters
+          .map(f => `"${f}"`)
+          .join(',')}] `;
       }
     }
   }

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.spec.tsx
@@ -222,7 +222,7 @@ describe('VisualizationStep', function () {
       expect(eventsMock).toHaveBeenCalledWith(
         '/organizations/org-slug/events/',
         expect.objectContaining({
-          query: expect.objectContaining({query: ' release:v1 '}),
+          query: expect.objectContaining({query: ' release:"v1" '}),
         })
       )
     );

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -1108,7 +1108,7 @@ describe('WidgetBuilder', function () {
         '/organizations/org-slug/events/',
         expect.objectContaining({
           query: expect.objectContaining({
-            query: ' release:abc@1.2.0 ',
+            query: ' release:"abc@1.2.0" ',
           }),
         })
       );

--- a/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetQueries.spec.tsx
@@ -141,7 +141,7 @@ describe('IssueWidgetQueries', function () {
       expect.objectContaining({
         data: expect.objectContaining({
           query:
-            'assigned_or_suggested:#visibility timesSeen:>100 release:[abc@1.2.0,abc@1.3.0] ',
+            'assigned_or_suggested:#visibility timesSeen:>100 release:["abc@1.2.0","abc@1.3.0"] ',
         }),
       })
     );

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.spec.tsx
@@ -252,7 +252,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
       '/organizations/org-slug/metrics/data/',
       expect.objectContaining({
         query: expect.objectContaining({
-          query: ' release:abc@1.3.0 ',
+          query: ' release:"abc@1.3.0" ',
         }),
       })
     );

--- a/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
@@ -142,7 +142,7 @@ describe('Dashboards > WidgetQueries', function () {
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
-          query: 'event.type:error release:[abc@1.2.0,abc@1.3.0] ',
+          query: 'event.type:error release:["abc@1.2.0","abc@1.3.0"] ',
         }),
       })
     );
@@ -170,7 +170,7 @@ describe('Dashboards > WidgetQueries', function () {
       '/organizations/org-slug/events/',
       expect.objectContaining({
         query: expect.objectContaining({
-          query: 'event.type:error release:abc@1.3.0 ',
+          query: 'event.type:error release:"abc@1.3.0" ',
         }),
       })
     );


### PR DESCRIPTION
Releases were being injected into the query string by just concatenating the
filter string. Spaces in release names weren't being taken into account as
they need to be quoted to be treated as a single token.

Adds quotes to the filters for now. Long term, we should migrate the
filter application to use MutableSearch which handles escaping characters
better.

Closes #61339