### PR TITLE
fix: Forbid second units in time range selector

### DIFF
--- a/static/app/components/timeRangeSelector/utils.spec.tsx
+++ b/static/app/components/timeRangeSelector/utils.spec.tsx
@@ -1,0 +1,19 @@
+import {getArbitraryRelativePeriod} from 'sentry/components/timeRangeSelector/utils';
+
+describe('getArbitraryRelativePeriod', function () {
+  it('parses a well-formed range of hours', function () {
+    expect(getArbitraryRelativePeriod('2h')).toEqual({'2h': 'Last 2 hours'});
+  });
+
+  it('parses a well-formed range of days', function () {
+    expect(getArbitraryRelativePeriod('14d')).toEqual({'14d': 'Last 14 days'});
+  });
+
+  it('rejects an malformed range', function () {
+    expect(getArbitraryRelativePeriod('hello')).toEqual({});
+  });
+
+  it('rejects an unsupported range', function () {
+    expect(getArbitraryRelativePeriod('14s')).toEqual({});
+  });
+});

--- a/static/app/components/timeRangeSelector/utils.tsx
+++ b/static/app/components/timeRangeSelector/utils.tsx
@@ -29,7 +29,7 @@ export type RelativeUnitsMapping = {
 
 const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
-const STATS_PERIOD_REGEX = /^(\d+)([smhdw]{1})$/;
+const STATS_PERIOD_REGEX = /^(\d+)([mhdw]{1})$/;
 
 const SUPPORTED_RELATIVE_PERIOD_UNITS: RelativeUnitsMapping = {
   m: {


### PR DESCRIPTION
Strangely, the `"s"` relative time unit is supported in the `STATS_PERIOD_REGEX` but not in `SUPPORTED_RELATIVE_PERIOD_UNITS`. This creates an inconsistency, where someone can put a time duration like `"14s"` in the URL, which then parses correctly but isn't supported, and throws an exception.

Removes `"s"` from the regular expression, since that unit is not actually supported.

Closes JAVASCRIPT-2PKY
