### PR TITLE
chore(spike protection): mark project flags as deprecated

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -260,9 +260,8 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
         # This project has sent feedbacks
         has_feedbacks: bool
 
-        # spike_protection_error_currently_active
+        # spike protection flags are DEPRECATED
         spike_protection_error_currently_active: bool
-
         spike_protection_transaction_currently_active: bool
         spike_protection_attachment_currently_active: bool
 


### PR DESCRIPTION
We cannot remove the project flags as they are in the middle of the bit field, and removing them would scramble the rest of the flags (see #61303). We could name the flags to `deprecated__flag_name` but a comment should be sufficient.