### PR TITLE
ref(hc): Remove RpcServiceUnimplementedException

### DIFF
--- a/src/sentry/services/hybrid_cloud/region.py
+++ b/src/sentry/services/hybrid_cloud/region.py
@@ -7,7 +7,6 @@ from typing import Any
 from django.conf import settings
 
 from sentry.services.hybrid_cloud import ArgumentDict
-from sentry.services.hybrid_cloud.rpc import RpcServiceUnimplementedException
 from sentry.types.region import (
     Region,
     RegionMappingNotFound,
@@ -117,21 +116,3 @@ class RequireSingleOrganization(RegionResolutionStrategy):
 
         (single_region_name,) = all_region_names
         return get_region_by_name(single_region_name)
-
-
-class UnimplementedRegionResolution(RegionResolutionStrategy):
-    """Indicate that a method's region resolution logic has not been implemented yet.
-
-    A remote call to the method will be interrupted and will default to the
-    monolithic fallback implementation. See the RpcServiceUnimplementedException
-    documentation for details.
-    """
-
-    def __init__(self, service_name: str, method_name: str) -> None:
-        self.service_name = service_name
-        self.method_name = method_name
-
-    def resolve(self, arguments: ArgumentDict) -> Region:
-        raise RpcServiceUnimplementedException(
-            self.service_name, self.method_name, "Need to resolve to remote region silo"
-        )

--- a/tests/sentry/hybridcloud/test_region.py
+++ b/tests/sentry/hybridcloud/test_region.py
@@ -8,9 +8,7 @@ from sentry.services.hybrid_cloud.region import (
     ByOrganizationObject,
     ByOrganizationSlug,
     RequireSingleOrganization,
-    UnimplementedRegionResolution,
 )
-from sentry.services.hybrid_cloud.rpc import RpcServiceUnimplementedException
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.region import override_regions
@@ -77,9 +75,3 @@ class RegionResolutionTest(TestCase):
             self.create_organization(region=_TEST_REGIONS[1])
             with pytest.raises(RegionResolutionError):
                 region_resolution.resolve({})
-
-    def test_unimplemented_region_resolution(self):
-        region_resolution = UnimplementedRegionResolution("some_service", "some_method")
-        with pytest.raises(RpcServiceUnimplementedException):
-            arguments = {"team_id": 1234}
-            region_resolution.resolve(arguments)


### PR DESCRIPTION
Because all RPC services should be implemented by now. 😎

Also remove UnimplementedRegionResolution. Replace remaining places where they are raised from core silo utilities with more appropriate exception types.