### PR TITLE
ref(useApiQuery): Refactor useApiQuery to extract fetchDataQuery for re-use

### DIFF
--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -10,7 +10,7 @@ import useApi from 'sentry/utils/useApi';
 
 // Overrides to the default react-query options.
 // See https://tanstack.com/query/v4/docs/guides/important-defaults
-const DEFAULT_QUERY_CLIENT_CONFIG: QueryClientConfig = {
+export const DEFAULT_QUERY_CLIENT_CONFIG: QueryClientConfig = {
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
@@ -41,14 +41,14 @@ type QueryKeyEndpointOptions<
   query?: Query;
 };
 
-type ApiQueryKey =
+export type ApiQueryKey =
   | readonly [url: string]
   | readonly [
       url: string,
       options: QueryKeyEndpointOptions<Record<string, string>, Record<string, any>>,
     ];
 
-interface UseApiQueryOptions<TApiResponse, TError = RequestError>
+export interface UseApiQueryOptions<TApiResponse, TError = RequestError>
   extends Omit<
     reactQuery.UseQueryOptions<
       ApiResult<TApiResponse>,
@@ -95,8 +95,7 @@ export type UseApiQueryResult<TData, TError> = reactQuery.UseQueryResult<
 /**
  * Wraps React Query's useQuery for consistent usage in the Sentry app.
  * Query keys should be an array which include an endpoint URL and options such as query params.
- * This wrapper will execute the request using the query key URL, but if you need custom behavior
- * you may supply your own query function as the second argument.
+ * This wrapper will execute the request using the query key URL.
  *
  * See https://tanstack.com/query/v4/docs/overview for docs on React Query.
  *
@@ -107,7 +106,7 @@ export type UseApiQueryResult<TData, TError> = reactQuery.UseQueryResult<
  *   {staleTime: 0}
  * );
  */
-function useApiQuery<TResponseData, TError = RequestError>(
+export function useApiQuery<TResponseData, TError = RequestError>(
   queryKey: ApiQueryKey,
   options: UseApiQueryOptions<TResponseData, TError>
 ): UseApiQueryResult<TResponseData, TError> {
@@ -128,8 +127,17 @@ function useApiQuery<TResponseData, TError = RequestError>(
   return queryResult as UseApiQueryResult<TResponseData, TError>;
 }
 
+/**
+ * This method, given an `api` will return a new method which can be used as a
+ * default `queryFn` with `useApiQuery` or even the raw `reactQuery.useQuery` hook.
+ *
+ * This returned method, the `queryFn`, unwraps react-query's `QueryFunctionContext`
+ * type into parts that will be passed into api.requestPromise
+ *
+ * See also: fetchInfiniteQuery & fetchMutation
+ */
 export function fetchDataQuery(api: Client) {
-  return function fetchQueryImpl(context: QueryFunctionContext<ApiQueryKey>) {
+  return function fetchDataQueryImpl(context: QueryFunctionContext<ApiQueryKey>) {
     const [url, opts] = context.queryKey;
 
     return api.requestPromise(url, {
@@ -157,7 +165,7 @@ export function getApiQueryData<TResponseData>(
  * Wraps React Query's queryClient.setQueryData to allow setting of API
  * response data without needing to provide a request object.
  */
-function setApiQueryData<TResponseData>(
+export function setApiQueryData<TResponseData>(
   queryClient: reactQuery.QueryClient,
   queryKey: ApiQueryKey,
   updater: reactQuery.Updater<TResponseData, TResponseData>,
@@ -183,6 +191,16 @@ function setApiQueryData<TResponseData>(
   return newResponse[0];
 }
 
+/**
+ * This method, given an `api` will return a new method which can be used as a
+ * default `queryFn` with `reactQuery.useInfiniteQuery` hook.
+ *
+ * This returned method, the `queryFn`, unwraps react-query's `QueryFunctionContext`
+ * type into parts that will be passed into api.requestPromise including the next
+ * page cursor.
+ *
+ * See also: fetchDataQuery & fetchMutation
+ */
 export function fetchInfiniteQuery<TResponseData>(api: Client) {
   return function fetchInfiniteQueryImpl({
     pageParam,
@@ -209,7 +227,14 @@ function parsePageParam(dir: 'previous' | 'next') {
   };
 }
 
-function useInfiniteApiQuery<TResponseData>({queryKey}: {queryKey: ApiQueryKey}) {
+/**
+ * Wraps React Query's useInfiniteQuery for consistent usage in the Sentry app.
+ * Query keys should be an array which include an endpoint URL and options such as query params.
+ * This wrapper will execute the request using the query key URL.
+ *
+ * See https://tanstack.com/query/v4/docs/overview for docs on React Query.
+ */
+export function useInfiniteApiQuery<TResponseData>({queryKey}: {queryKey: ApiQueryKey}) {
   const api = useApi({persistInFlight: PERSIST_IN_FLIGHT});
   return useInfiniteQuery({
     queryKey,
@@ -232,6 +257,16 @@ type ApiMutationVariables<
       Record<string, unknown>,
     ];
 
+/**
+ * This method, given an `api` will return a new method which can be used as a
+ * default `queryFn` with `reactQuery.useMutation` hook.
+ *
+ * This returned method, the `queryFn`, unwraps react-query's `QueryFunctionContext`
+ * type into parts that will be passed into api.requestPromise including different
+ * `method` and supports putting & posting `data.
+ *
+ * See also: fetchDataQuery & fetchInfiniteQuery
+ */
 export function fetchMutation(api: Client) {
   return function fetchMutationImpl(variables: ApiMutationVariables) {
     const [method, url, opts, data] = variables;
@@ -247,13 +282,3 @@ export function fetchMutation(api: Client) {
 
 // eslint-disable-next-line import/export
 export * from '@tanstack/react-query';
-
-// eslint-disable-next-line import/export
-export {
-  DEFAULT_QUERY_CLIENT_CONFIG,
-  useApiQuery,
-  setApiQueryData,
-  useInfiniteApiQuery,
-  UseApiQueryOptions,
-  ApiQueryKey,
-};


### PR DESCRIPTION
I wanted to extract a `fetchDataQuery()` method from `useApiQuery` so it's easier re re-use. The extracted method is nice because it knows how to read from the `QueryFunctionContext` and turn a query key into a query.