### PR TITLE
chore(hybrid-cloud): Relax logging in Discord request parser

### DIFF
--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -61,7 +61,7 @@ class DiscordRequestParser(BaseRequestParser):
 
         with sentry_sdk.push_scope() as scope:
             scope.set_extra("path", self.request.path)
-            scope.set_extra("guild_id", str(discord_request.guild_id))
+            scope.set_extra("guild_id", str(discord_request.guild_id if discord_request else None))
             sentry_sdk.capture_exception(
                 Exception(
                     f"Unexpected view class in {self.provider} request parser: {self.view_class.__name__}"

--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -64,7 +64,7 @@ class DiscordRequestParser(BaseRequestParser):
             scope.set_extra("guild_id", str(discord_request.guild_id if discord_request else None))
             sentry_sdk.capture_exception(
                 Exception(
-                    f"Unexpected view class in {self.provider} request parser: {self.view_class.__name__}"
+                    f"Unexpected view class in {self.provider} request parser: {self.view_class.__name__ if self.view_class else None}"
                 )
             )
 

--- a/src/sentry/middleware/integrations/parsers/discord.py
+++ b/src/sentry/middleware/integrations/parsers/discord.py
@@ -47,27 +47,26 @@ class DiscordRequestParser(BaseRequestParser):
             params = unsign(self.match.kwargs.get("signed_params"))
             integration_id = params.get("integration_id")
 
-            logger.info(
-                "%s.get_integration_from_request.%s",
-                self.provider,
-                self.view_class.__name__,
-                extra={"path": self.request.path, "integration_id": integration_id},
-            )
             return Integration.objects.filter(id=integration_id).first()
 
         discord_request = self.discord_request
         if self.view_class == DiscordInteractionsEndpoint and discord_request:
-            with sentry_sdk.push_scope() as scope:
-                scope.set_extra("path", self.request.path)
-                scope.set_extra("guild_id", discord_request.guild_id)
-                sentry_sdk.capture_message(
-                    f"{self.provider}.get_integration_from_request.discord_interactions_endpoint"
-                )
+            if discord_request.guild_id is None:
+                return None
 
             return Integration.objects.filter(
                 provider=self.provider,
                 external_id=discord_request.guild_id,
             ).first()
+
+        with sentry_sdk.push_scope() as scope:
+            scope.set_extra("path", self.request.path)
+            scope.set_extra("guild_id", str(discord_request.guild_id))
+            sentry_sdk.capture_exception(
+                Exception(
+                    f"Unexpected view class in {self.provider} request parser: {self.view_class.__name__}"
+                )
+            )
 
         logger.info(
             "%s.get_integration_from_request.no_view_class",
@@ -82,13 +81,6 @@ class DiscordRequestParser(BaseRequestParser):
             return self.get_response_from_control_silo()
 
         is_discord_interactions_endpoint = self.view_class == DiscordInteractionsEndpoint
-
-        with sentry_sdk.push_scope() as scope:
-            scope.set_extra(
-                "discord_request._data",
-                self.discord_request._data if self.discord_request else None,
-            )
-            sentry_sdk.capture_message("discord.request_parser.get_response.request")
 
         # Handle any Requests that doesn't depend on Integration/Organization prior to fetching the Regions.
         if is_discord_interactions_endpoint and self.discord_request:


### PR DESCRIPTION
Now that the Discord integration is now validated in the hybrid cloud world, I'm relaxing the logging in the request parser.