### PR TITLE
fix(stacktrace): Fix missing Prism.js language recording

### DIFF
--- a/static/app/utils/analytics/stackTraceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/stackTraceAnalyticsEvents.tsx
@@ -72,6 +72,9 @@ export type StackTraceEventParameters = {
     project_slug: string;
     platform?: string;
   };
+  'stack_trace.prism_missing_language': {
+    attempted_language: string;
+  };
   'stack_trace.threads.thread_selected': {
     has_stacktrace: boolean;
     num_in_app_frames: number;
@@ -114,4 +117,5 @@ export const stackTraceEventMap: Record<keyof StackTraceEventParameters, string>
     'Stack Trace: Sort Option - Recent Last - Clicked',
   'stack_trace.threads.thread_selected': 'Stack Trace: Thread Selected',
   'stack_trace.threads.thread_selector_opened': 'Stack Trace: Thread Selector Opened',
+  'stack_trace.prism_missing_language': 'Stack Trace: Prism.js Language Not Found',
 };


### PR DESCRIPTION
It looks like the `onLoad` only gets fired when the language does exist but fails to load. What we really want is to record any languages that we don't have the correct mapping for.

I also changed this to an analytic event because that will be easier to query than a Sentry issue.