### PR TITLE
ref(crons): Read muted from `is_muted` over `status`

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -130,7 +130,7 @@ class OrganizationMonitorIndexEndpoint(OrganizationEndpoint):
 
         queryset = queryset.annotate(
             environment_status_ordering=Case(
-                When(status=MonitorObjectStatus.MUTED, then=Value(len(DEFAULT_ORDERING))),
+                When(is_muted=True, then=Value(len(DEFAULT_ORDERING))),
                 default=Subquery(
                     monitor_environments_query.annotate(
                         status_ordering=MONITOR_ENVIRONMENT_ORDERING

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -21,7 +21,6 @@ from sentry.monitors.models import (
     MonitorCheckIn,
     MonitorEnvironment,
     MonitorIncident,
-    MonitorObjectStatus,
     MonitorStatus,
 )
 
@@ -106,7 +105,7 @@ def mark_failed_threshold(failed_checkin: MonitorCheckIn, failure_issue_threshol
 
     monitor_env = failed_checkin.monitor_environment
 
-    monitor_muted = monitor_env.monitor.status == MonitorObjectStatus.MUTED
+    monitor_muted = monitor_env.monitor.is_muted
 
     fingerprint = None
 
@@ -186,7 +185,7 @@ def mark_failed_no_threshold(failed_checkin: MonitorCheckIn):
     monitor_env = failed_checkin.monitor_environment
 
     # Do not create event if monitor is muted
-    if monitor_env.monitor.status == MonitorObjectStatus.MUTED:
+    if monitor_env.monitor.is_muted:
         return True
 
     use_issue_platform = False

--- a/src/sentry/monitors/logic/mark_ok.py
+++ b/src/sentry/monitors/logic/mark_ok.py
@@ -5,7 +5,6 @@ from sentry.monitors.models import (
     MonitorCheckIn,
     MonitorEnvironment,
     MonitorIncident,
-    MonitorObjectStatus,
     MonitorStatus,
 )
 
@@ -22,10 +21,7 @@ def mark_ok(checkin: MonitorCheckIn, ts: datetime):
         "next_checkin_latest": next_checkin_latest,
     }
 
-    if (
-        monitor_env.monitor.status != MonitorObjectStatus.MUTED
-        and monitor_env.status != MonitorStatus.OK
-    ):
+    if not monitor_env.monitor.is_muted and monitor_env.status != MonitorStatus.OK:
         params["status"] = MonitorStatus.OK
         recovery_threshold = monitor_env.monitor.config.get("recovery_threshold")
 

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -43,6 +43,7 @@ class MonitorSerializerResponse(MonitorSerializerResponseOptional):
     name: str
     slug: str
     status: str
+    isMuted: bool
     type: str
     config: Any
     dateCreated: datetime
@@ -112,6 +113,7 @@ class MonitorSerializer(Serializer):
         result: MonitorSerializerResponse = {
             "id": str(obj.guid),
             "status": obj.get_status_display(),
+            "isMuted": obj.is_muted,
             "type": obj.get_type_display(),
             "name": obj.name,
             "slug": obj.slug,

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -244,10 +244,13 @@ def check_missing(current_datetime: datetime):
         )
         .exclude(
             monitor__status__in=[
+                # TODO(epurkhiser): This will change to DISABLED when this
+                # moves back to regual ObjectStatus. This means we will create
+                # missed check-ins for muted monitors.
                 MonitorObjectStatus.MUTED,
                 MonitorObjectStatus.PENDING_DELETION,
                 MonitorObjectStatus.DELETION_IN_PROGRESS,
-            ]
+            ],
         )[:MONITOR_LIMIT]
     )
 

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -168,7 +168,7 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
 
     def test_muted(self):
         for path_func in self._get_path_functions():
-            monitor = self._create_monitor(is_muted=True, status=MonitorObjectStatus.MUTED)
+            monitor = self._create_monitor(is_muted=True)
             path = path_func(monitor.guid)
 
             resp = self.client.post(path, {"status": "error"}, **self.token_auth_headers)

--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -19,7 +19,6 @@ from sentry.monitors.models import (
     MonitorCheckIn,
     MonitorEnvironment,
     MonitorIncident,
-    MonitorObjectStatus,
     MonitorStatus,
     MonitorType,
     ScheduleType,
@@ -560,7 +559,6 @@ class MarkFailedTestCase(TestCase):
                 "max_runtime": None,
                 "checkin_margin": None,
             },
-            status=MonitorObjectStatus.MUTED,
             is_muted=True,
         )
         monitor_environment = MonitorEnvironment.objects.create(
@@ -578,7 +576,6 @@ class MarkFailedTestCase(TestCase):
 
         monitor.refresh_from_db()
         monitor_environment.refresh_from_db()
-        assert monitor.status == MonitorObjectStatus.MUTED
         assert monitor.is_muted
         assert monitor_environment.status == MonitorStatus.ERROR
 
@@ -802,7 +799,6 @@ class MarkFailedTestCase(TestCase):
                 "max_runtime": None,
                 "checkin_margin": None,
             },
-            status=MonitorObjectStatus.MUTED,
             is_muted=True,
         )
         monitor_environment = MonitorEnvironment.objects.create(
@@ -821,7 +817,6 @@ class MarkFailedTestCase(TestCase):
 
         monitor.refresh_from_db()
         monitor_environment.refresh_from_db()
-        assert monitor.status == MonitorObjectStatus.MUTED
         assert monitor.is_muted
         assert monitor_environment.status == MonitorStatus.ERROR
 

--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -18,7 +18,6 @@ from sentry.monitors.models import (
     Monitor,
     MonitorCheckIn,
     MonitorEnvironment,
-    MonitorObjectStatus,
     MonitorStatus,
     MonitorType,
     ScheduleType,
@@ -179,7 +178,7 @@ class MonitorConsumerTest(TestCase):
         )
 
     def test_muted(self):
-        monitor = self._create_monitor(is_muted=True, status=MonitorObjectStatus.MUTED)
+        monitor = self._create_monitor(is_muted=True)
         self.send_checkin(monitor.slug, status="error")
 
         checkin = MonitorCheckIn.objects.get(guid=self.guid)

--- a/tests/sentry/monitors/test_tasks.py
+++ b/tests/sentry/monitors/test_tasks.py
@@ -476,6 +476,7 @@ class MonitorTaskCheckMissingTest(TestCase):
         assert mark_environment_missing_mock.delay.call_count == 0
 
     def test_missing_checkin_but_muted(self):
+        # TODO(epurkhiser): Switch to disalbed when we re-introduce the disabled status
         self.assert_state_does_not_change_for_status(MonitorObjectStatus.MUTED)
 
     def test_missing_checkin_but_pending_deletion(self):


### PR DESCRIPTION
After https://github.com/getsentry/sentry/pull/61471 we will be dual writing the muted status and will have gaurenteed that previous values were synchornzied over.

This now only reads from the is_muted field