### PR TITLE
fix(feedback): Iterate on Feedback product UI with a mobile/responsive layout

### DIFF
--- a/static/app/components/feedback/list/feedbackList.tsx
+++ b/static/app/components/feedback/list/feedbackList.tsx
@@ -154,6 +154,7 @@ const OverflowPanelItem = styled(PanelItem)`
   display: grid;
   overflow: scroll;
   flex-grow: 1;
+  min-height: 300px;
 `;
 
 const FloatingContainer = styled('div')`

--- a/static/app/components/layouts/fullViewport.tsx
+++ b/static/app/components/layouts/fullViewport.tsx
@@ -17,6 +17,10 @@ const FullViewport = styled('div')`
     display: none;
   }
 
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    height: auto;
+  }
+
   /*
   TODO: Set \`body { overflow: hidden; }\` so that the body doesn't wiggle
   when you try to scroll something that is non-scrollable.

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -81,7 +81,6 @@ export default function FeedbackListPage({}: Props) {
 
 const LayoutGrid = styled('div')`
   background: ${p => p.theme.background};
-  padding: ${space(2)} ${space(4)} ${space(2)} ${space(4)};
   overflow: hidden;
 
   flex-grow: 1;
@@ -90,11 +89,33 @@ const LayoutGrid = styled('div')`
   gap: ${space(2)};
   place-items: stretch;
 
-  grid-template-columns: minmax(390px, 1fr) 2fr;
   grid-template-rows: max-content 1fr;
   grid-template-areas:
     'filters search'
     'list details';
+
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    padding: ${space(2)};
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'filters'
+      'search'
+      'list'
+      'details';
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    padding: ${space(2)};
+    grid-template-columns: minmax(1fr, 195px) 1fr;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    padding: ${space(2)} ${space(4)} ${space(2)} ${space(4)};
+    grid-template-columns: 390px 1fr;
+  }
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    grid-template-columns: minmax(390px, 1fr) 2fr;
+  }
 `;
 
 const Container = styled(FluidHeight)`


### PR DESCRIPTION
When it's narrowest it looks like this
- The whole page can scroll, so you can see all the details. 
- The list part has it's own scroller, which isn't great, but it's usable

<img width="437" alt="SCR-20231209-knoq" src="https://github.com/getsentry/sentry/assets/187460/f06497e8-252f-4123-ad44-ccee463bb0cc">

Fixes https://github.com/getsentry/sentry/issues/61356
