### PR TITLE
test: Replace TestStubs.routerContext calls with RouterContextFixture imports

### DIFF
--- a/static/app/components/acl/access.spec.tsx
+++ b/static/app/components/acl/access.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {Team} from 'sentry-fixture/team';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -10,7 +11,7 @@ describe('Access', function () {
   const organization = Organization({
     access: ['project:write', 'project:read'],
   });
-  const routerContext = TestStubs.routerContext([{organization}]);
+  const routerContext = RouterContextFixture([{organization}]);
 
   describe('as render prop', function () {
     const childrenMock = jest.fn().mockReturnValue(null);
@@ -45,7 +46,7 @@ describe('Access', function () {
 
     it('read access from team', function () {
       const org = Organization({access: []});
-      const nextRouterContext = TestStubs.routerContext([{organization: org}]);
+      const nextRouterContext = RouterContextFixture([{organization: org}]);
 
       const team1 = Team({access: []});
       render(
@@ -82,7 +83,7 @@ describe('Access', function () {
 
     it('read access from project', function () {
       const org = Organization({access: []});
-      const nextRouterContext = TestStubs.routerContext([{organization: org}]);
+      const nextRouterContext = RouterContextFixture([{organization: org}]);
 
       const proj1 = TestStubs.Project({access: []});
       render(

--- a/static/app/components/acl/feature.spec.tsx
+++ b/static/app/components/acl/feature.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -13,7 +14,7 @@ describe('Feature', function () {
   const project = TestStubs.Project({
     features: ['project-foo', 'project-bar'],
   });
-  const routerContext = TestStubs.routerContext([
+  const routerContext = RouterContextFixture([
     {
       organization,
       project,

--- a/static/app/components/acl/role.spec.tsx
+++ b/static/app/components/acl/role.spec.tsx
@@ -1,5 +1,6 @@
 import Cookies from 'js-cookie';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -36,7 +37,7 @@ describe('Role', function () {
       },
     ],
   });
-  const routerContext = TestStubs.routerContext([
+  const routerContext = RouterContextFixture([
     {
       organization,
     },

--- a/static/app/components/assigneeSelector.spec.tsx
+++ b/static/app/components/assigneeSelector.spec.tsx
@@ -1,3 +1,4 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {Team} from 'sentry-fixture/team';
 
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -286,7 +287,7 @@ describe('AssigneeSelector', () => {
   it('shows invite member button', async () => {
     MemberListStore.loadInitialData([USER_1, USER_2]);
     render(<AssigneeSelectorComponent id={GROUP_1.id} />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
     });
     jest.spyOn(ConfigStore, 'get').mockImplementation(() => true);
 

--- a/static/app/components/breadcrumbs.spec.tsx
+++ b/static/app/components/breadcrumbs.spec.tsx
@@ -1,9 +1,11 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 
 describe('Breadcrumbs', () => {
-  const routerContext = TestStubs.routerContext();
+  const routerContext = RouterContextFixture();
 
   afterEach(() => {
     jest.resetAllMocks();

--- a/static/app/components/commitRow.spec.tsx
+++ b/static/app/components/commitRow.spec.tsx
@@ -1,3 +1,5 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -58,7 +60,7 @@ describe('commitRow', () => {
       },
     } as Commit;
 
-    render(<CommitRow commit={commit} />, {context: TestStubs.routerContext()});
+    render(<CommitRow commit={commit} />, {context: RouterContextFixture()});
     expect(
       screen.getByText(
         textWithMarkupMatcher(

--- a/static/app/components/createAlertButton.spec.tsx
+++ b/static/app/components/createAlertButton.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -22,7 +23,7 @@ describe('CreateAlertFromViewButton', () => {
   });
 
   it('should trigger onClick callback', async () => {
-    const context = TestStubs.routerContext();
+    const context = RouterContextFixture();
 
     const eventView = EventView.fromSavedQuery({
       ...DEFAULT_EVENT_VIEW,
@@ -63,7 +64,7 @@ describe('CreateAlertFromViewButton', () => {
         onClick={onClickMock}
       />,
       {
-        context: TestStubs.routerContext([{organization: noAccessOrg}]),
+        context: RouterContextFixture([{organization: noAccessOrg}]),
         organization: noAccessOrg,
       }
     );
@@ -88,7 +89,7 @@ describe('CreateAlertFromViewButton', () => {
         onClick={onClickMock}
       />,
       {
-        context: TestStubs.routerContext([{organization}]),
+        context: RouterContextFixture([{organization}]),
         organization,
       }
     );
@@ -127,7 +128,7 @@ describe('CreateAlertFromViewButton', () => {
         onClick={onClickMock}
       />,
       {
-        context: TestStubs.routerContext([{organization: noAccessOrg}]),
+        context: RouterContextFixture([{organization: noAccessOrg}]),
         organization: noAccessOrg,
       }
     );
@@ -188,7 +189,7 @@ describe('CreateAlertFromViewButton', () => {
   });
 
   it('removes a duplicate project filter', async () => {
-    const context = TestStubs.routerContext();
+    const context = RouterContextFixture();
 
     const eventView = EventView.fromSavedQuery({
       ...DEFAULT_EVENT_VIEW,

--- a/static/app/components/dataExport.spec.tsx
+++ b/static/app/components/dataExport.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -22,7 +23,7 @@ const mockPayload = {
 };
 
 const mockRouterContext = (mockOrganization: TOrganization) =>
-  TestStubs.routerContext([
+  RouterContextFixture([
     {
       organization: mockOrganization,
     },

--- a/static/app/components/deployBadge.spec.tsx
+++ b/static/app/components/deployBadge.spec.tsx
@@ -1,3 +1,5 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import DeployBadge from 'sentry/components/deployBadge';
@@ -31,7 +33,7 @@ describe('DeployBadge', () => {
         version="1.2.3"
         projectId={projectId}
       />,
-      {context: TestStubs.routerContext()}
+      {context: RouterContextFixture()}
     );
 
     expect(screen.queryByRole('link')).toHaveAttribute(

--- a/static/app/components/discover/transactionsList.spec.tsx
+++ b/static/app/components/discover/transactionsList.spec.tsx
@@ -1,3 +1,5 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
@@ -53,7 +55,7 @@ describe('TransactionsList', function () {
     let generateLink, routerContext;
 
     beforeEach(function () {
-      routerContext = TestStubs.routerContext([{organization}]);
+      routerContext = RouterContextFixture([{organization}]);
       initialize();
       eventView = EventView.fromSavedQuery({
         id: '',

--- a/static/app/components/errorRobot.spec.tsx
+++ b/static/app/components/errorRobot.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -9,7 +10,7 @@ describe('ErrorRobot', function () {
   let routerContext;
 
   beforeEach(function () {
-    routerContext = TestStubs.routerContext();
+    routerContext = RouterContextFixture();
     getIssues = MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/issues/',
       method: 'GET',

--- a/static/app/components/eventOrGroupTitle.spec.tsx
+++ b/static/app/components/eventOrGroupTitle.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -63,7 +64,7 @@ describe('EventOrGroupTitle', function () {
   });
 
   it('renders with title override', function () {
-    const routerContext = TestStubs.routerContext([{organization: Organization()}]);
+    const routerContext = RouterContextFixture([{organization: Organization()}]);
 
     render(
       <EventOrGroupTitle
@@ -140,7 +141,7 @@ describe('EventOrGroupTitle', function () {
     } as BaseGroup;
 
     it('should correctly render title', () => {
-      const routerContext = TestStubs.routerContext([{organization: Organization()}]);
+      const routerContext = RouterContextFixture([{organization: Organization()}]);
 
       render(<EventOrGroupTitle data={perfData} />, {context: routerContext});
 

--- a/static/app/components/events/interfaces/frame/context.spec.tsx
+++ b/static/app/components/events/interfaces/frame/context.spec.tsx
@@ -2,6 +2,7 @@ import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 import {Repository} from 'sentry-fixture/repository';
 import {RepositoryProjectPathConfig} from 'sentry-fixture/repositoryProjectPathConfig';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render} from 'sentry-test/reactTestingLibrary';
 
@@ -64,7 +65,7 @@ describe('Frame - Context', function () {
         components={[]}
       />,
       {
-        context: TestStubs.routerContext([{organization: org}]),
+        context: RouterContextFixture([{organization: org}]),
         organization: org,
         project,
       }

--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -3,6 +3,7 @@ import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 import {Repository} from 'sentry-fixture/repository';
 import {RepositoryProjectPathConfig} from 'sentry-fixture/repositoryProjectPathConfig';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -49,7 +50,7 @@ describe('StacktraceLink', function () {
       body: {config: null, sourceUrl: null, integrations: []},
     });
     render(<StacktraceLink frame={frame} event={event} line="" />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
     });
     expect(
       await screen.findByText(
@@ -92,7 +93,7 @@ describe('StacktraceLink', function () {
       body: {},
     });
     const {container} = render(<StacktraceLink frame={frame} event={event} line="" />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
     });
     expect(
       await screen.findByText(
@@ -125,7 +126,7 @@ describe('StacktraceLink', function () {
       body: {config: null, sourceUrl: null, integrations: [integration]},
     });
     render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
     });
     expect(
       await screen.findByText('Tell us where your source code is')
@@ -138,7 +139,7 @@ describe('StacktraceLink', function () {
       body: {config, sourceUrl: 'https://something.io', integrations: [integration]},
     });
     render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
     });
     expect(await screen.findByRole('link')).toHaveAttribute(
       'href',
@@ -157,7 +158,7 @@ describe('StacktraceLink', function () {
       },
     });
     render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
     });
     expect(
       await screen.findByRole('button', {
@@ -181,7 +182,7 @@ describe('StacktraceLink', function () {
         event={{...event, platform: 'javascript'}}
         line="{snip} somethingInsane=e.IsNotFound {snip}"
       />,
-      {context: TestStubs.routerContext()}
+      {context: RouterContextFixture()}
     );
     await waitFor(() => {
       expect(container).toBeEmptyDOMElement();
@@ -199,7 +200,7 @@ describe('StacktraceLink', function () {
     });
     const {container} = render(
       <StacktraceLink frame={frame} event={{...event, platform: 'unreal'}} line="" />,
-      {context: TestStubs.routerContext()}
+      {context: RouterContextFixture()}
     );
     await waitFor(() => {
       expect(container).toBeEmptyDOMElement();
@@ -225,7 +226,7 @@ describe('StacktraceLink', function () {
       },
     });
     render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
       organization,
     });
 
@@ -256,7 +257,7 @@ describe('StacktraceLink', function () {
       },
     });
     render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
       organization,
     });
     expect(await screen.findByText('Code Coverage not found')).toBeInTheDocument();
@@ -284,7 +285,7 @@ describe('StacktraceLink', function () {
       },
     });
     render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
       organization,
     });
     expect(await screen.findByTestId('codecov-link')).toBeInTheDocument();
@@ -309,7 +310,7 @@ describe('StacktraceLink', function () {
         line="foo()"
       />,
       {
-        context: TestStubs.routerContext(),
+        context: RouterContextFixture(),
       }
     );
     expect(await screen.findByRole('link')).toHaveAttribute(
@@ -339,7 +340,7 @@ describe('StacktraceLink', function () {
         line="foo()"
       />,
       {
-        context: TestStubs.routerContext(),
+        context: RouterContextFixture(),
       }
     );
     expect(await screen.findByRole('link')).toHaveAttribute(
@@ -359,7 +360,7 @@ describe('StacktraceLink', function () {
     });
     const {container} = render(
       <StacktraceLink frame={frame} event={{...event, platform: 'csharp'}} line="" />,
-      {context: TestStubs.routerContext()}
+      {context: RouterContextFixture()}
     );
     await waitFor(() => {
       expect(container).toBeEmptyDOMElement();

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
@@ -1,6 +1,7 @@
 import {Organization} from 'sentry-fixture/organization';
 import {Repository} from 'sentry-fixture/repository';
 import {RepositoryProjectPathConfig} from 'sentry-fixture/repositoryProjectPathConfig';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {
   act,
@@ -121,7 +122,7 @@ describe('StacktraceLinkModal', () => {
       statusCode: 400,
     });
 
-    renderGlobalModal({context: TestStubs.routerContext()});
+    renderGlobalModal({context: RouterContextFixture()});
     act(() =>
       openModal(modalProps => (
         <StacktraceLinkModal

--- a/static/app/components/events/interfaces/message.spec.tsx
+++ b/static/app/components/events/interfaces/message.spec.tsx
@@ -1,5 +1,6 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
 import {Event as EventFixture} from 'sentry-fixture/event';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -7,7 +8,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {Message} from 'sentry/components/events/interfaces/message';
 
 describe('Message entry', function () {
-  const routerContext = TestStubs.routerContext();
+  const routerContext = RouterContextFixture();
   it('display redacted data', async function () {
     const event = EventFixture({
       entries: [

--- a/static/app/components/events/searchBar.spec.tsx
+++ b/static/app/components/events/searchBar.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -46,7 +47,7 @@ describe('Events > SearchBar', function () {
       {totalValues: 0, key: 'browser', name: 'Browser'},
     ]);
 
-    options = TestStubs.routerContext();
+    options = RouterContextFixture();
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/recent-searches/',

--- a/static/app/components/globalSelectionLink.spec.tsx
+++ b/static/app/components/globalSelectionLink.spec.tsx
@@ -1,3 +1,5 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
@@ -6,7 +8,7 @@ const path = 'http://some.url/';
 
 describe('GlobalSelectionLink', function () {
   const getContext = (query?: {environment: string; project: string[]}) =>
-    TestStubs.routerContext([
+    RouterContextFixture([
       {
         router: TestStubs.router({
           location: {query},

--- a/static/app/components/idBadge/memberBadge.spec.tsx
+++ b/static/app/components/idBadge/memberBadge.spec.tsx
@@ -1,10 +1,12 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import MemberBadge from 'sentry/components/idBadge/memberBadge';
 
 describe('MemberBadge', function () {
   let member;
-  const routerContext = TestStubs.routerContext();
+  const routerContext = RouterContextFixture();
   beforeEach(() => {
     member = TestStubs.Member();
   });

--- a/static/app/components/idBadge/projectBadge.spec.tsx
+++ b/static/app/components/idBadge/projectBadge.spec.tsx
@@ -1,10 +1,12 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 
 describe('ProjectBadge', function () {
   it('renders with Avatar and team name', function () {
-    const routerContext = TestStubs.routerContext();
+    const routerContext = RouterContextFixture();
     render(<ProjectBadge project={TestStubs.Project()} />, {context: routerContext});
 
     expect(screen.getByRole('img')).toBeInTheDocument();

--- a/static/app/components/modals/commandPalette.spec.tsx
+++ b/static/app/components/modals/commandPalette.spec.tsx
@@ -1,5 +1,6 @@
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {Team} from 'sentry-fixture/team';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -93,7 +94,7 @@ describe('Command Palette Modal', function () {
         Footer={ModalFooter}
       />,
       {
-        context: TestStubs.routerContext([
+        context: RouterContextFixture([
           {
             router: TestStubs.router({
               params: {orgId: 'org-slug'},

--- a/static/app/components/modals/emailVerificationModal.spec.tsx
+++ b/static/app/components/modals/emailVerificationModal.spec.tsx
@@ -1,9 +1,11 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import EmailVerificationModal from 'sentry/components/modals/emailVerificationModal';
 
 describe('Email Verification Modal', function () {
-  const routerContext = TestStubs.routerContext();
+  const routerContext = RouterContextFixture();
   it('renders', function () {
     MockApiClient.addMockResponse({
       url: '/users/me/emails/',

--- a/static/app/components/modals/recoveryOptionsModal.spec.tsx
+++ b/static/app/components/modals/recoveryOptionsModal.spec.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import {AllAuthenticators, Authenticators} from 'sentry-fixture/authenticators';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -9,7 +10,7 @@ import RecoveryOptionsModal from 'sentry/components/modals/recoveryOptionsModal'
 describe('RecoveryOptionsModal', function () {
   const closeModal = jest.fn();
   const mockId = Authenticators().Recovery().authId;
-  const routerContext = TestStubs.routerContext();
+  const routerContext = RouterContextFixture();
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();

--- a/static/app/components/quickTrace/index.spec.tsx
+++ b/static/app/components/quickTrace/index.spec.tsx
@@ -1,3 +1,5 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -383,7 +385,7 @@ describe('Quick Trace', function () {
 
   describe('Event Node Clicks', function () {
     it('renders single event targets', async function () {
-      const routerContext = TestStubs.routerContext();
+      const routerContext = RouterContextFixture();
       render(
         <QuickTrace
           event={makeTransactionEvent(3) as Event}

--- a/static/app/components/replays/replayTagsTableRow.spec.tsx
+++ b/static/app/components/replays/replayTagsTableRow.spec.tsx
@@ -1,3 +1,5 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ReplayTagsTableRow from './replayTagsTableRow';
@@ -26,7 +28,7 @@ describe('ReplayTagsTableRow', () => {
         values={['bar', 'baz']}
         generateUrl={(name, value) => ({pathname: '/home', query: {[name]: value}})}
       />,
-      {context: TestStubs.routerContext()}
+      {context: RouterContextFixture()}
     );
 
     expect(screen.getByText('bar').closest('a')).toHaveAttribute('href', '/home?foo=bar');
@@ -40,7 +42,7 @@ describe('ReplayTagsTableRow', () => {
         values={['biz baz']}
         generateUrl={(name, value) => ({pathname: '/home', query: {[name]: value}})}
       />,
-      {context: TestStubs.routerContext()}
+      {context: RouterContextFixture()}
     );
 
     expect(screen.getByText('foo bar')).toBeInTheDocument();

--- a/static/app/components/search/index.spec.tsx
+++ b/static/app/components/search/index.spec.tsx
@@ -1,4 +1,5 @@
 import Fuse from 'fuse.js';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -73,7 +74,7 @@ describe('Search', () => {
   it('renders search results from source', async () => {
     jest.useFakeTimers();
     render(<Search {...makeSearchProps()} />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
     });
 
     await userEvent.click(screen.getByPlaceholderText('Search Input'), {delay: null});
@@ -108,7 +109,7 @@ describe('Search', () => {
         })}
       />,
       {
-        context: TestStubs.routerContext(),
+        context: RouterContextFixture(),
       }
     );
 
@@ -147,7 +148,7 @@ describe('Search', () => {
         })}
       />,
       {
-        context: TestStubs.routerContext(),
+        context: RouterContextFixture(),
       }
     );
 
@@ -184,7 +185,7 @@ describe('Search', () => {
         })}
       />,
       {
-        context: TestStubs.routerContext(),
+        context: RouterContextFixture(),
       }
     );
 
@@ -207,7 +208,7 @@ describe('Search', () => {
         })}
       />,
       {
-        context: TestStubs.routerContext(),
+        context: RouterContextFixture(),
       }
     );
 

--- a/static/app/components/sidebar/sidebarDropdown/index.spec.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -9,7 +10,7 @@ function renderDropdown(props: any = {}) {
   const user = TestStubs.User();
   const config = TestStubs.Config();
   const organization = Organization({orgRole: 'member'});
-  const routerContext = TestStubs.routerContext([
+  const routerContext = RouterContextFixture([
     {
       organization,
     },

--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
@@ -1,11 +1,12 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {SwitchOrganization} from 'sentry/components/sidebar/sidebarDropdown/switchOrganization';
 
 describe('SwitchOrganization', function () {
-  const routerContext = TestStubs.routerContext();
+  const routerContext = RouterContextFixture();
   it('can list organizations', async function () {
     jest.useFakeTimers();
     render(
@@ -16,7 +17,7 @@ describe('SwitchOrganization', function () {
           Organization({name: 'Organization 2', slug: 'org2'}),
         ]}
       />,
-      {context: TestStubs.routerContext()}
+      {context: RouterContextFixture()}
     );
 
     await userEvent.hover(screen.getByTestId('sidebar-switch-org'), {delay: null});

--- a/static/app/components/stream/processingIssueHint.spec.tsx
+++ b/static/app/components/stream/processingIssueHint.spec.tsx
@@ -1,3 +1,5 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ProcessingIssueHint from 'sentry/components/stream/processingIssueHint';
@@ -27,7 +29,7 @@ describe('ProcessingIssueHint', function () {
         projectId={projectId}
         showProject={showProject}
       />,
-      {context: TestStubs.routerContext()}
+      {context: RouterContextFixture()}
     );
     container = result.container;
   }

--- a/static/app/components/tabs/index.spec.tsx
+++ b/static/app/components/tabs/index.spec.tsx
@@ -1,3 +1,5 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {TabList, TabPanels, Tabs} from 'sentry/components/tabs';
@@ -202,7 +204,7 @@ describe('Tabs', () => {
   });
 
   it('renders tab links', async () => {
-    const routerContext = TestStubs.routerContext();
+    const routerContext = RouterContextFixture();
     render(
       <Tabs>
         <TabList>

--- a/static/app/components/tag.spec.tsx
+++ b/static/app/components/tag.spec.tsx
@@ -1,10 +1,12 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import Tag from 'sentry/components/tag';
 import {IconFire} from 'sentry/icons';
 
 describe('Tag', () => {
-  const routerContext = TestStubs.routerContext();
+  const routerContext = RouterContextFixture();
   it('basic', () => {
     render(<Tag>Text</Tag>);
     expect(screen.getByText('Text')).toBeInTheDocument();

--- a/static/app/components/version.spec.tsx
+++ b/static/app/components/version.spec.tsx
@@ -1,3 +1,5 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import Version from 'sentry/components/version';
@@ -5,7 +7,7 @@ import Version from 'sentry/components/version';
 const VERSION = 'foo.bar.Baz@1.0.0+20200101';
 
 describe('Version', () => {
-  const context = TestStubs.routerContext();
+  const context = RouterContextFixture();
   afterEach(() => {
     jest.resetAllMocks();
   });

--- a/static/app/views/alerts/index.spec.tsx
+++ b/static/app/views/alerts/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -18,7 +19,7 @@ describe('AlertsContainer', function () {
           <SubView />
         </AlertsContainer>,
         {
-          context: TestStubs.routerContext([{organization}]),
+          context: RouterContextFixture([{organization}]),
           organization,
         }
       );
@@ -35,7 +36,7 @@ describe('AlertsContainer', function () {
           <SubView />
         </AlertsContainer>,
         {
-          context: TestStubs.routerContext([{organization}]),
+          context: RouterContextFixture([{organization}]),
           organization,
         }
       );

--- a/static/app/views/discover/index.spec.tsx
+++ b/static/app/views/discover/index.spec.tsx
@@ -1,5 +1,6 @@
 import selectEvent from 'react-select-event';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -110,7 +111,7 @@ describe('Discover > Landing', function () {
     const org = Organization({features});
 
     render(<DiscoverLanding organization={org} {...TestStubs.routeComponentProps()} />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
     });
 
     expect(screen.getByText('Discover')).toHaveAttribute(

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -3,6 +3,7 @@ import {Location} from 'history';
 import {Commit} from 'sentry-fixture/commit';
 import {CommitAuthor} from 'sentry-fixture/commitAuthor';
 import {Event as EventFixture} from 'sentry-fixture/event';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {SentryApp} from 'sentry-fixture/sentryApp';
 import {SentryAppComponent} from 'sentry-fixture/sentryAppComponent';
 
@@ -381,7 +382,7 @@ describe('groupEventDetails', () => {
       })
     );
 
-    const routerContext = TestStubs.routerContext();
+    const routerContext = RouterContextFixture();
     render(<TestComponent group={group} event={transaction} />, {
       organization: props.organization,
       context: routerContext,
@@ -431,7 +432,7 @@ describe('groupEventDetails', () => {
       })
     );
 
-    const routerContext = TestStubs.routerContext();
+    const routerContext = RouterContextFixture();
     render(<TestComponent group={group} event={transaction} />, {
       organization: props.organization,
       context: routerContext,
@@ -582,7 +583,7 @@ describe('Platform Integrations', () => {
         props.event,
         mockedTrace(props.project)
       );
-      const routerContext = TestStubs.routerContext();
+      const routerContext = RouterContextFixture();
 
       render(<TestComponent group={props.group} event={props.event} />, {
         organization: props.organization,
@@ -608,7 +609,7 @@ describe('Platform Integrations', () => {
         ...trace,
         performance_issues: [],
       });
-      const routerContext = TestStubs.routerContext();
+      const routerContext = RouterContextFixture();
 
       render(<TestComponent group={props.group} event={props.event} />, {
         organization: props.organization,

--- a/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Groups} from 'sentry-fixture/groups';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {
   render,
@@ -22,7 +23,7 @@ describe('Issues Similar View', function () {
     features: ['similarity-view'],
   });
 
-  const routerContext = TestStubs.routerContext([
+  const routerContext = RouterContextFixture([
     {
       router: {
         ...TestStubs.router(),

--- a/static/app/views/organizationStats/teamInsights/health.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {Team} from 'sentry-fixture/team';
 import {TeamAlertsTriggered} from 'sentry-fixture/teamAlertsTriggered';
 import {TeamResolutionTime} from 'sentry-fixture/teamResolutionTime';
@@ -173,7 +174,7 @@ describe('TeamStatsHealth', () => {
       teams,
       projects,
     });
-    const context = TestStubs.routerContext([{organization}]);
+    const context = RouterContextFixture([{organization}]);
     TeamStore.loadInitialData(teams, false, null);
 
     MockApiClient.addMockResponse({

--- a/static/app/views/organizationStats/teamInsights/index.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -12,7 +13,7 @@ describe('TeamInsightsContainer', () => {
 
   it('blocks access if org is missing flag', () => {
     const organization = Organization();
-    const context = TestStubs.routerContext([{organization}]);
+    const context = RouterContextFixture([{organization}]);
     render(
       <TeamInsightsContainer organization={organization}>
         <div>test</div>
@@ -25,7 +26,7 @@ describe('TeamInsightsContainer', () => {
   it('allows access for orgs with flag', () => {
     ProjectsStore.loadInitialData([TestStubs.Project()]);
     const organization = Organization({features: ['team-insights']});
-    const context = TestStubs.routerContext([{organization}]);
+    const context = RouterContextFixture([{organization}]);
     render(
       <TeamInsightsContainer organization={organization}>
         <div>test</div>
@@ -38,7 +39,7 @@ describe('TeamInsightsContainer', () => {
   it('shows message for users with no teams', () => {
     ProjectsStore.loadInitialData([]);
     const organization = Organization({features: ['team-insights']});
-    const context = TestStubs.routerContext([{organization}]);
+    const context = RouterContextFixture([{organization}]);
     render(<TeamInsightsContainer organization={organization} />, {context});
 
     expect(

--- a/static/app/views/organizationStats/teamInsights/issues.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {Team} from 'sentry-fixture/team';
 import {TeamIssuesBreakdown} from 'sentry-fixture/teamIssuesBreakdown';
 import {TeamResolutionTime} from 'sentry-fixture/teamResolutionTime';
@@ -141,7 +142,7 @@ describe('TeamStatsIssues', () => {
       teams,
       projects,
     });
-    const context = TestStubs.routerContext([{organization}]);
+    const context = RouterContextFixture([{organization}]);
     TeamStore.loadInitialData(teams, false, null);
 
     return render(<TeamStatsIssues {...routerProps} />, {

--- a/static/app/views/performance/transactionDetails/eventMetas.spec.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.spec.tsx
@@ -1,5 +1,6 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -11,7 +12,7 @@ describe('EventMetas', () => {
       dateReceived: '2017-05-21T18:01:48.762Z',
       dateCreated: '2017-05-21T18:02:48.762Z',
     });
-    const routerContext = TestStubs.routerContext([]);
+    const routerContext = RouterContextFixture([]);
     const organization = Organization({});
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.spec.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.spec.tsx
@@ -1,4 +1,5 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
@@ -10,7 +11,7 @@ import {
 import QuickTraceMeta from 'sentry/views/performance/transactionDetails/quickTraceMeta';
 
 describe('QuickTraceMeta', function () {
-  const routerContext = TestStubs.routerContext();
+  const routerContext = RouterContextFixture();
   const location = routerContext.context.location;
   const project = TestStubs.Project({platform: 'javascript'});
   const event = EventFixture({contexts: {trace: {trace_id: 'a'.repeat(32)}}});

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
@@ -1,5 +1,6 @@
 import {InjectedRouter} from 'react-router';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -148,7 +149,7 @@ describe('Transaction Summary Content', function () {
       transactionName,
       router,
     } = initialize(project, {});
-    const routerContext = TestStubs.routerContext([{organization}]);
+    const routerContext = RouterContextFixture([{organization}]);
 
     render(
       <WrappedComponent

--- a/static/app/views/performance/vitalDetail/index.spec.tsx
+++ b/static/app/views/performance/vitalDetail/index.spec.tsx
@@ -1,6 +1,7 @@
 import {browserHistory, InjectedRouter} from 'react-router';
 import {MetricsField} from 'sentry-fixture/metrics';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
@@ -277,7 +278,7 @@ describe('Performance > VitalDetail', function () {
       },
     };
 
-    const context = TestStubs.routerContext([
+    const context = RouterContextFixture([
       {
         organization,
         project,
@@ -331,7 +332,7 @@ describe('Performance > VitalDetail', function () {
       },
     };
 
-    const context = TestStubs.routerContext([
+    const context = RouterContextFixture([
       {
         organization,
         project,
@@ -386,7 +387,7 @@ describe('Performance > VitalDetail', function () {
       },
     };
 
-    const context = TestStubs.routerContext([
+    const context = RouterContextFixture([
       {
         organization,
         project,

--- a/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
+++ b/static/app/views/profiling/profileSummary/profileSummaryPage.spec.tsx
@@ -1,6 +1,7 @@
 import {Location} from 'history';
 import {GlobalSelection} from 'sentry-fixture/globalSelection';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -95,7 +96,7 @@ describe('ProfileSummaryPage', () => {
         organization: Organization({
           features: ['profiling-summary-redesign'],
         }),
-        context: TestStubs.routerContext(),
+        context: RouterContextFixture(),
       }
     );
 

--- a/static/app/views/projectDetail/projectFilters.spec.tsx
+++ b/static/app/views/projectDetail/projectFilters.spec.tsx
@@ -1,3 +1,5 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ProjectFilters from 'sentry/views/projectDetail/projectFilters';
@@ -28,7 +30,7 @@ describe('ProjectDetail > ProjectFilters', () => {
         tagValueLoader={tagValueLoader}
         relativeDateOptions={{}}
       />,
-      {context: TestStubs.routerContext()}
+      {context: RouterContextFixture()}
     );
 
     await userEvent.click(

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {MOCK_RESP_VERBOSE} from 'sentry-fixture/ruleConditions';
 import {Team} from 'sentry-fixture/team';
 
@@ -92,7 +93,7 @@ describe('CreateProject', function () {
 
   it('should block if you have access to no teams without team-roles', function () {
     render(<CreateProject />, {
-      context: TestStubs.routerContext([
+      context: RouterContextFixture([
         {
           organization: {
             id: '1',
@@ -117,7 +118,7 @@ describe('CreateProject', function () {
     TeamStore.loadUserTeams([Team({id: '2', slug: 'team-two', access: []})]);
 
     render(<CreateProject />, {
-      context: TestStubs.routerContext([
+      context: RouterContextFixture([
         {
           organization: {
             id: '1',
@@ -152,7 +153,7 @@ describe('CreateProject', function () {
       Team({id: '3', slug: 'team-three', access: ['team:admin']}),
     ]);
     render(<CreateProject />, {
-      context: TestStubs.routerContext([{organization}]),
+      context: RouterContextFixture([{organization}]),
       organization,
     });
 
@@ -170,7 +171,7 @@ describe('CreateProject', function () {
     });
 
     render(<CreateProject />, {
-      context: TestStubs.routerContext([
+      context: RouterContextFixture([
         {
           organization: {
             id: '1',
@@ -282,7 +283,7 @@ describe('CreateProject', function () {
       teamSlug: teamNoAccess.slug,
     });
     render(<CreateProject />, {
-      context: TestStubs.routerContext([
+      context: RouterContextFixture([
         {
           organization: {
             id: '1',

--- a/static/app/views/releases/detail/header/releaseActions.spec.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.spec.tsx
@@ -1,6 +1,7 @@
 import {browserHistory} from 'react-router';
 import {Location} from 'history';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {
   render,
@@ -130,7 +131,7 @@ describe('ReleaseActions', function () {
   });
 
   it('navigates to a next/prev release', function () {
-    const routerContext = TestStubs.routerContext();
+    const routerContext = RouterContextFixture();
     const {rerender} = render(
       <ReleaseActions
         organization={organization}

--- a/static/app/views/replays/list/listContent.spec.tsx
+++ b/static/app/views/replays/list/listContent.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -58,7 +59,7 @@ function getMockOrganization({features}: {features: string[]}) {
 }
 
 function getMockContext(mockOrg: TOrganization) {
-  return TestStubs.routerContext([{organization: mockOrg}]);
+  return RouterContextFixture([{organization: mockOrg}]);
 }
 
 describe('ReplayList', () => {

--- a/static/app/views/settings/account/accountAuthorizations.spec.tsx
+++ b/static/app/views/settings/account/accountAuthorizations.spec.tsx
@@ -1,3 +1,5 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {render} from 'sentry-test/reactTestingLibrary';
 
 import AccountAuthorizations from 'sentry/views/settings/account/accountAuthorizations';
@@ -25,7 +27,7 @@ describe('AccountAuthorizations', function () {
         router={router}
       />,
       {
-        context: TestStubs.routerContext(),
+        context: RouterContextFixture(),
       }
     );
   });

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.tsx
@@ -1,4 +1,5 @@
 import {Authenticators} from 'sentry-fixture/authenticators';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -21,7 +22,7 @@ describe('AccountSecurityEnroll', function () {
       ],
     });
 
-    const routerContext = TestStubs.routerContext([
+    const routerContext = RouterContextFixture([
       {
         router: {
           ...TestStubs.router(),
@@ -82,7 +83,7 @@ describe('AccountSecurityEnroll', function () {
       });
 
       const pushMock = jest.fn();
-      const routerContextWithMock = TestStubs.routerContext([
+      const routerContextWithMock = RouterContextFixture([
         {
           router: {
             ...TestStubs.router({push: pushMock}),

--- a/static/app/views/settings/account/accountSecurity/index.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.spec.tsx
@@ -1,6 +1,7 @@
 import {AccountEmails} from 'sentry-fixture/accountEmails';
 import {Authenticators} from 'sentry-fixture/authenticators';
 import {Organizations} from 'sentry-fixture/organizations';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {
   render,
@@ -65,7 +66,7 @@ describe('AccountSecurity', function () {
           params={{...router.params, authId: '15'}}
         />
       </AccountSecurityWrapper>,
-      {context: TestStubs.routerContext()}
+      {context: RouterContextFixture()}
     );
   }
 

--- a/static/app/views/settings/account/accountSecurity/sessionHistory/index.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/sessionHistory/index.spec.tsx
@@ -1,3 +1,5 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -35,7 +37,7 @@ describe('AccountSecuritySessionHistory', function () {
       ],
     });
 
-    render(<SessionHistory {...routerProps} />, {context: TestStubs.routerContext()});
+    render(<SessionHistory {...routerProps} />, {context: RouterContextFixture()});
 
     expect(screen.getByText('127.0.0.1')).toBeInTheDocument();
     expect(screen.getByText('192.168.0.1')).toBeInTheDocument();

--- a/static/app/views/settings/account/accountSubscriptions.spec.tsx
+++ b/static/app/views/settings/account/accountSubscriptions.spec.tsx
@@ -1,3 +1,4 @@
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {Subscriptions} from 'sentry-fixture/subscriptions';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -17,7 +18,7 @@ describe('AccountSubscriptions', function () {
       body: [],
     });
     render(<AccountSubscriptions />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
     });
   });
 

--- a/static/app/views/settings/account/apiNewToken.spec.tsx
+++ b/static/app/views/settings/account/apiNewToken.spec.tsx
@@ -1,4 +1,5 @@
 import selectEvent from 'react-select-event';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -7,13 +8,13 @@ import ApiNewToken from 'sentry/views/settings/account/apiNewToken';
 describe('ApiNewToken', function () {
   it('renders', function () {
     render(<ApiNewToken />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
     });
   });
 
   it('renders with disabled "Create Token" button', async function () {
     render(<ApiNewToken />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
     });
 
     expect(await screen.getByRole('button', {name: 'Create Token'})).toBeDisabled();
@@ -27,7 +28,7 @@ describe('ApiNewToken', function () {
     });
 
     render(<ApiNewToken />, {
-      context: TestStubs.routerContext(),
+      context: RouterContextFixture(),
     });
     const createButton = await screen.getByRole('button', {name: 'Create Token'});
 

--- a/static/app/views/settings/components/settingsSearch/index.spec.tsx
+++ b/static/app/views/settings/components/settingsSearch/index.spec.tsx
@@ -1,5 +1,6 @@
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {Team} from 'sentry-fixture/team';
 
 import {fireEvent, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -14,7 +15,7 @@ jest.mock('sentry/actionCreators/navigation');
 
 describe('SettingsSearch', function () {
   let orgsMock: jest.Mock;
-  const routerContext = TestStubs.routerContext([
+  const routerContext = RouterContextFixture([
     {
       router: TestStubs.router({
         params: {},

--- a/static/app/views/settings/organizationAuth/organizationAuthList.spec.tsx
+++ b/static/app/views/settings/organizationAuth/organizationAuthList.spec.tsx
@@ -1,5 +1,6 @@
 import {AuthProviders} from 'sentry-fixture/authProviders';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -28,7 +29,7 @@ describe('OrganizationAuthList', function () {
   });
 
   it('renders for members', function () {
-    const context = TestStubs.routerContext([
+    const context = RouterContextFixture([
       {organization: Organization({access: ['org:read']})},
     ]);
 
@@ -51,7 +52,7 @@ describe('OrganizationAuthList', function () {
 
     it('renders', function () {
       const organization = Organization({...require2fa, ...withSSO});
-      const context = TestStubs.routerContext([{organization}]);
+      const context = RouterContextFixture([{organization}]);
 
       render(
         <OrganizationAuthList
@@ -68,7 +69,7 @@ describe('OrganizationAuthList', function () {
 
     it('renders with saml available', function () {
       const organization = Organization({...require2fa, ...withSAML});
-      const context = TestStubs.routerContext([{organization}]);
+      const context = RouterContextFixture([{organization}]);
 
       render(
         <OrganizationAuthList
@@ -85,7 +86,7 @@ describe('OrganizationAuthList', function () {
 
     it('does not render without sso available', function () {
       const organization = Organization({...require2fa});
-      const context = TestStubs.routerContext([{organization}]);
+      const context = RouterContextFixture([{organization}]);
 
       render(
         <OrganizationAuthList
@@ -102,7 +103,7 @@ describe('OrganizationAuthList', function () {
 
     it('does not render with sso and require 2fa disabled', function () {
       const organization = Organization({...withSSO});
-      const context = TestStubs.routerContext([{organization}]);
+      const context = RouterContextFixture([{organization}]);
 
       render(
         <OrganizationAuthList
@@ -119,7 +120,7 @@ describe('OrganizationAuthList', function () {
 
     it('does not render with saml and require 2fa disabled', function () {
       const organization = Organization({...withSAML});
-      const context = TestStubs.routerContext([{organization}]);
+      const context = RouterContextFixture([{organization}]);
 
       render(
         <OrganizationAuthList

--- a/static/app/views/settings/organizationAuth/providerItem.spec.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.spec.tsx
@@ -1,5 +1,6 @@
 import {AuthProviders} from 'sentry-fixture/authProviders';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -11,7 +12,7 @@ describe('ProviderItem', function () {
   const org = Organization({
     features: [descopeFeatureName(provider.requiredFeature)],
   });
-  const routerContext = TestStubs.routerContext([{organization: org}]);
+  const routerContext = RouterContextFixture([{organization: org}]);
 
   it('renders', function () {
     render(<ProviderItem active={false} provider={provider} onConfigure={() => {}} />, {
@@ -34,7 +35,7 @@ describe('ProviderItem', function () {
   });
 
   it('renders a disabled Tag when disabled', function () {
-    const noFeatureRouterContext = TestStubs.routerContext();
+    const noFeatureRouterContext = RouterContextFixture();
     render(<ProviderItem active={false} provider={provider} onConfigure={() => {}} />, {
       context: noFeatureRouterContext,
     });

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -1,5 +1,6 @@
 import selectEvent from 'react-select-event';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {SentryApp} from 'sentry-fixture/sentryApp';
 import {SentryAppToken} from 'sentry-fixture/sentryAppToken';
 
@@ -35,7 +36,7 @@ describe('Sentry Application Details', function () {
           route={{path: 'new-public/'}}
           params={{}}
         />,
-        {context: TestStubs.routerContext([{organization: org}])}
+        {context: RouterContextFixture([{organization: org}])}
       );
     }
 
@@ -146,7 +147,7 @@ describe('Sentry Application Details', function () {
           route={{path: 'new-internal/'}}
           params={{}}
         />,
-        {context: TestStubs.routerContext([{organization: org}])}
+        {context: RouterContextFixture([{organization: org}])}
       );
     }
 
@@ -182,7 +183,7 @@ describe('Sentry Application Details', function () {
           params={{appSlug: sentryApp.slug}}
         />,
         {
-          context: TestStubs.routerContext([{organization: org}]),
+          context: RouterContextFixture([{organization: org}]),
         }
       );
     }
@@ -246,7 +247,7 @@ describe('Sentry Application Details', function () {
           params={{appSlug: sentryApp.slug}}
         />,
         {
-          context: TestStubs.routerContext([{organization: org}]),
+          context: RouterContextFixture([{organization: org}]),
         }
       );
     }
@@ -317,7 +318,7 @@ describe('Sentry Application Details', function () {
           params={{appSlug: sentryApp.slug}}
         />,
         {
-          context: TestStubs.routerContext([{organization: org}]),
+          context: RouterContextFixture([{organization: org}]),
         }
       );
     }
@@ -366,7 +367,7 @@ describe('Sentry Application Details', function () {
           params={{appSlug: sentryApp.slug}}
         />,
         {
-          context: TestStubs.routerContext([{organization: org}]),
+          context: RouterContextFixture([{organization: org}]),
         }
       );
     }
@@ -443,7 +444,7 @@ describe('Sentry Application Details', function () {
           params={{appSlug: sentryApp.slug}}
         />,
         {
-          context: TestStubs.routerContext([{organization: org}]),
+          context: RouterContextFixture([{organization: org}]),
         }
       );
     }
@@ -537,7 +538,7 @@ describe('Sentry Application Details', function () {
           params={{appSlug: sentryApp.slug}}
         />,
         {
-          context: TestStubs.routerContext([{organization: org}]),
+          context: RouterContextFixture([{organization: org}]),
         }
       );
     }

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -3,6 +3,7 @@ import selectEvent from 'react-select-event';
 import {AuthProvider} from 'sentry-fixture/authProvider';
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {Team} from 'sentry-fixture/team';
 
 import {
@@ -182,7 +183,7 @@ describe('OrganizationMembersList', function () {
     });
 
     render(<OrganizationMembersList {...defaultProps} />, {
-      context: TestStubs.routerContext([{organization}]),
+      context: RouterContextFixture([{organization}]),
     });
 
     await userEvent.click(screen.getAllByRole('button', {name: 'Remove'})[0]);
@@ -205,7 +206,7 @@ describe('OrganizationMembersList', function () {
     });
 
     render(<OrganizationMembersList {...defaultProps} />, {
-      context: TestStubs.routerContext([{organization}]),
+      context: RouterContextFixture([{organization}]),
     });
 
     await userEvent.click(screen.getAllByRole('button', {name: 'Remove'})[0]);
@@ -227,7 +228,7 @@ describe('OrganizationMembersList', function () {
     });
 
     render(<OrganizationMembersList {...defaultProps} />, {
-      context: TestStubs.routerContext([{organization}]),
+      context: RouterContextFixture([{organization}]),
     });
 
     await userEvent.click(screen.getAllByRole('button', {name: 'Leave'})[0]);
@@ -257,7 +258,7 @@ describe('OrganizationMembersList', function () {
     OrganizationsStore.addOrReplace(secondOrg);
 
     render(<OrganizationMembersList {...defaultProps} />, {
-      context: TestStubs.routerContext([{organization}]),
+      context: RouterContextFixture([{organization}]),
     });
 
     await userEvent.click(screen.getAllByRole('button', {name: 'Leave'})[0]);
@@ -283,7 +284,7 @@ describe('OrganizationMembersList', function () {
     });
 
     render(<OrganizationMembersList {...defaultProps} />, {
-      context: TestStubs.routerContext([{organization}]),
+      context: RouterContextFixture([{organization}]),
     });
 
     await userEvent.click(screen.getAllByRole('button', {name: 'Leave'})[0]);
@@ -308,7 +309,7 @@ describe('OrganizationMembersList', function () {
     });
 
     render(<OrganizationMembersList {...defaultProps} />, {
-      context: TestStubs.routerContext([{organization}]),
+      context: RouterContextFixture([{organization}]),
     });
 
     expect(inviteMock).not.toHaveBeenCalled();
@@ -327,7 +328,7 @@ describe('OrganizationMembersList', function () {
     });
 
     render(<OrganizationMembersList {...defaultProps} />, {
-      context: TestStubs.routerContext([{organization}]),
+      context: RouterContextFixture([{organization}]),
     });
 
     expect(inviteMock).not.toHaveBeenCalled();
@@ -342,7 +343,7 @@ describe('OrganizationMembersList', function () {
       body: [],
     });
 
-    const routerContext = TestStubs.routerContext();
+    const routerContext = RouterContextFixture();
 
     render(<OrganizationMembersList {...defaultProps} />, {
       context: routerContext,
@@ -370,7 +371,7 @@ describe('OrganizationMembersList', function () {
       url: '/organizations/org-slug/members/',
       body: [],
     });
-    const routerContext = TestStubs.routerContext();
+    const routerContext = RouterContextFixture();
     render(<OrganizationMembersList {...defaultProps} />, {
       context: routerContext,
     });
@@ -431,7 +432,7 @@ describe('OrganizationMembersList', function () {
   });
 
   it('can filter members with org roles from team membership', async function () {
-    const routerContext = TestStubs.routerContext();
+    const routerContext = RouterContextFixture();
     render(<OrganizationMembersList {...defaultProps} />, {
       context: routerContext,
     });
@@ -480,7 +481,7 @@ describe('OrganizationMembersList', function () {
       });
 
       render(<OrganizationMembersList {...defaultProps} organization={org} />, {
-        context: TestStubs.routerContext([{organization: org}]),
+        context: RouterContextFixture([{organization: org}]),
       });
 
       expect(screen.getByText('Pending Members')).toBeInTheDocument();
@@ -506,7 +507,7 @@ describe('OrganizationMembersList', function () {
       });
 
       render(<OrganizationMembersList {...defaultProps} />, {
-        context: TestStubs.routerContext([{organization: org}]),
+        context: RouterContextFixture([{organization: org}]),
       });
 
       expect(screen.getByText('Pending Members')).toBeInTheDocument();
@@ -544,7 +545,7 @@ describe('OrganizationMembersList', function () {
       });
 
       render(<OrganizationMembersList {...defaultProps} />, {
-        context: TestStubs.routerContext([{organization: org}]),
+        context: RouterContextFixture([{organization: org}]),
       });
 
       expect(screen.getByText('Pending Members')).toBeInTheDocument();
@@ -580,7 +581,7 @@ describe('OrganizationMembersList', function () {
       });
 
       render(<OrganizationMembersList {...defaultProps} />, {
-        context: TestStubs.routerContext([{organization: org}]),
+        context: RouterContextFixture([{organization: org}]),
       });
 
       await selectEvent.select(screen.getAllByRole('textbox')[1], ['Admin']);

--- a/static/app/views/settings/project/projectOwnership/index.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.spec.tsx
@@ -1,5 +1,6 @@
 import {GitHubIntegrationConfig} from 'sentry-fixture/integrationListDirectory';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -90,7 +91,7 @@ describe('Project Ownership', () => {
           organization={org}
           project={project}
         />,
-        {context: TestStubs.routerContext([{organization: org}])}
+        {context: RouterContextFixture([{organization: org}])}
       );
 
       // Renders button

--- a/static/app/views/settings/projectGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.spec.tsx
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router';
 import selectEvent from 'react-select-event';
 import {GroupingConfigs} from 'sentry-fixture/groupingConfigs';
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {
   act,
@@ -52,7 +53,7 @@ describe('projectGeneralSettings', function () {
 
   beforeEach(function () {
     jest.spyOn(window.location, 'assign');
-    routerContext = TestStubs.routerContext([
+    routerContext = RouterContextFixture([
       {
         router: TestStubs.router({
           params: {

--- a/static/app/views/settings/projectPlugins/projectPluginRow.spec.tsx
+++ b/static/app/views/settings/projectPlugins/projectPluginRow.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -9,7 +10,7 @@ describe('ProjectPluginRow', function () {
   const org = Organization({access: ['project:write']});
   const project = TestStubs.Project();
   const params = {orgId: org.slug, projectId: project.slug};
-  const routerContext = TestStubs.routerContext([{organization: org, project}]);
+  const routerContext = RouterContextFixture([{organization: org, project}]);
 
   it('renders', function () {
     render(<ProjectPluginRow {...params} {...plugin} project={project} />, {

--- a/tests/js/sentry-test/initializeOrg.tsx
+++ b/tests/js/sentry-test/initializeOrg.tsx
@@ -2,6 +2,7 @@ import type {RouteComponent, RouteComponentProps} from 'react-router';
 import type {Location} from 'history';
 import {Organization} from 'sentry-fixture/organization';
 import {OrgRoleList, TeamRoleList} from 'sentry-fixture/roleList';
+import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import type {Organization as TOrganization, Project} from 'sentry/types';
 
@@ -60,7 +61,7 @@ export function initializeOrg<RouterParams = {orgId: string; projectId: string}>
     },
   });
 
-  const routerContext: any = TestStubs.routerContext([
+  const routerContext: any = RouterContextFixture([
     {
       organization,
       project,


### PR DESCRIPTION
Relates to https://github.com/getsentry/frontend-tsc/issues/49