### PR TITLE
fix(suspect-commits): Correct GitLab file paths with leading slashes before making request

### DIFF
--- a/src/sentry/integrations/gitlab/blame.py
+++ b/src/sentry/integrations/gitlab/blame.py
@@ -81,9 +81,12 @@ def _fetch_file_blame(
     client: BaseApiClient, file: SourceLineInfo, extra: Mapping[str, Any]
 ) -> Tuple[Optional[CommitInfo], Optional[GitLabRateLimitInfo]]:
     project_id = file.repo.config.get("project_id")
-    encoded_path = quote(file.path, safe="")
+
+    # GitLab returns an invalid file path error if there are leading or trailing slashes
+    encoded_path = quote(file.path.strip("/"), safe="")
     request_path = GitLabApiClientPath.blame.format(project=project_id, path=encoded_path)
     params = {"ref": file.ref, "range[start]": file.lineno, "range[end]": file.lineno}
+
     cache_key = client.get_cache_key(request_path, json.dumps(params))
     response = client.check_cache(cache_key)
     if response:

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -361,7 +361,7 @@ class GitLabBlameForFilesTest(GitLabClientTest):
         )
 
     def make_blame_request(self, file: SourceLineInfo) -> str:
-        return f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/{quote(file.path, safe='')}/blame?ref={file.ref}&range[start]={file.lineno}&range[end]={file.lineno}"
+        return f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/{quote(file.path.strip('/'), safe='')}/blame?ref={file.ref}&range[start]={file.lineno}&range[end]={file.lineno}"
 
     def make_blame_response(self, **kwargs) -> list[GitLabFileBlameResponseItem]:
         return [


### PR DESCRIPTION
GitLab treats leading slashes as an invalid file path which seems to be a common error when setting up code mappings. It is easily corrected, so we should just trim them when present. We already do this with the GitHub client here: https://github.com/getsentry/sentry/blob/b8bb9963140a517ff9710a9e8a4e43cfb9e05a38/src/sentry/integrations/github/blame.py#L270

To see how this GitLab endpoint treats leading slashes, see https://gitlab.com/api/v4/projects/278964/repository/files/%2FLICENSE/raw?ref=master vs https://gitlab.com/api/v4/projects/278964/repository/files/LICENSE/raw?ref=master

Hopefully after merging this, we will see the numbers for this Sentry issue go down: https://sentry.sentry.io/issues/4707726778/