### PR TITLE
feat(performance-trace-details): Adding trace level information.

### DIFF
--- a/static/app/components/events/interfaces/spans/newTraceDetailsHeader.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsHeader.tsx
@@ -1,0 +1,199 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {generateStats} from 'sentry/components/events/opsBreakdown';
+import {DividerSpacer} from 'sentry/components/performance/waterfall/miniHeader';
+import {t} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
+import {space} from 'sentry/styles/space';
+import {EventTransaction, Organization} from 'sentry/types';
+import {getDuration} from 'sentry/utils/formatters';
+import toPercent from 'sentry/utils/number/toPercent';
+import useProjects from 'sentry/utils/useProjects';
+import {TraceType} from 'sentry/views/performance/traceDetails/newTraceDetailsContent';
+import {TraceInfo} from 'sentry/views/performance/traceDetails/types';
+import {
+  platformToPerformanceType,
+  ProjectPerformanceType,
+} from 'sentry/views/performance/utils';
+
+import ReplayPreview from '../../eventReplay/replayPreview';
+
+import * as DividerHandlerManager from './dividerHandlerManager';
+
+type PropType = {
+  event: EventTransaction | undefined;
+  organization: Organization;
+  traceInfo: TraceInfo;
+  traceType: TraceType;
+  traceViewHeaderRef: React.RefObject<HTMLDivElement>;
+};
+
+function ServiceBreakdown({
+  rootEvent,
+  displayBreakdown,
+}: {
+  displayBreakdown: boolean;
+  rootEvent: EventTransaction;
+}) {
+  if (!displayBreakdown) {
+    return (
+      <BreakDownWrapper>
+        <BreakDownRow>
+          <div>{t('server side')}</div>
+          <FlexBox>
+            <span>{'N/A'}</span>
+          </FlexBox>
+        </BreakDownRow>
+        <BreakDownRow>
+          <div>{t('client side')}</div>
+          <FlexBox>
+            <span>{'N/A'}</span>
+          </FlexBox>
+        </BreakDownRow>
+      </BreakDownWrapper>
+    );
+  }
+
+  const totalDuration = rootEvent.endTimestamp - rootEvent.startTimestamp;
+  const breakdown = generateStats(rootEvent, {type: 'no_filter'});
+  const httpOp = breakdown.find(obj => obj.name === 'http.client');
+  const httpDuration = httpOp?.totalInterval ?? 0;
+  const serverSidePct = ((httpDuration / totalDuration) * 100).toFixed();
+  const clientSidePct = 100 - Number(serverSidePct);
+
+  return httpDuration ? (
+    <BreakDownWrapper>
+      <BreakDownRow>
+        <div>{t('server side')}</div>
+        <FlexBox>
+          <Dur>{getDuration(httpDuration, 2, true)}</Dur>
+          <Pct>{serverSidePct}%</Pct>
+        </FlexBox>
+      </BreakDownRow>
+      <BreakDownRow>
+        <div>{t('client side')}</div>
+        <FlexBox>
+          <Dur>{getDuration(totalDuration - httpDuration, 2, true)}</Dur>
+          <Pct>{clientSidePct}%</Pct>
+        </FlexBox>
+      </BreakDownRow>
+    </BreakDownWrapper>
+  ) : null;
+}
+
+function TraceViewHeader(props: PropType) {
+  const {projects} = useProjects();
+
+  const {event} = props;
+  if (!event) {
+    return null;
+  }
+
+  const projectSlug = event.projectSlug;
+  const project = projects.find(proj => proj.slug === projectSlug);
+
+  const isFrontendRoot =
+    project &&
+    platformToPerformanceType(projects, [Number(project?.id)]) ===
+      ProjectPerformanceType.FRONTEND &&
+    props.traceType === TraceType.ONE_ROOT;
+
+  return (
+    <HeaderContainer ref={props.traceViewHeaderRef} hasProfileMeasurementsChart={false}>
+      <DividerHandlerManager.Consumer>
+        {dividerHandlerChildrenProps => {
+          const {dividerPosition} = dividerHandlerChildrenProps;
+          return (
+            <Fragment>
+              <OperationsBreakdown
+                style={{
+                  width: `calc(${toPercent(dividerPosition)} - 0.5px)`,
+                }}
+              >
+                {props.event && (
+                  <ServiceBreakdown
+                    displayBreakdown={!!isFrontendRoot}
+                    rootEvent={props.event}
+                  />
+                )}
+              </OperationsBreakdown>
+              <DividerSpacer
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: `calc(${toPercent(dividerPosition)} - 0.5px)`,
+                  height: `100px`,
+                }}
+              />
+              <div
+                style={{
+                  overflow: 'hidden',
+                  position: 'relative',
+                  height: '100px',
+                  width: `calc(${toPercent(1 - dividerPosition)} - 0.5px)`,
+                  left: `calc(${toPercent(dividerPosition)} + 0.5px)`,
+                }}
+              >
+                {event.contexts.replay?.replay_id && (
+                  <ReplayPreview
+                    replaySlug={event.contexts.replay?.replay_id ?? ''}
+                    orgSlug={props.organization.slug}
+                    eventTimestampMs={props.traceInfo.startTimestamp}
+                  />
+                )}
+              </div>
+            </Fragment>
+          );
+        }}
+      </DividerHandlerManager.Consumer>
+    </HeaderContainer>
+  );
+}
+
+const HeaderContainer = styled('div')<{hasProfileMeasurementsChart: boolean}>`
+  width: 100%;
+  left: 0;
+  top: ${p => (ConfigStore.get('demoMode') ? p.theme.demo.headerSize : 0)};
+  z-index: ${p => p.theme.zIndex.traceView.minimapContainer};
+  background-color: ${p => p.theme.background};
+  border-bottom: 1px solid ${p => p.theme.border};
+  height: 100px;
+  border-top-left-radius: ${p => p.theme.borderRadius};
+  border-top-right-radius: ${p => p.theme.borderRadius};
+`;
+
+const OperationsBreakdown = styled('div')`
+  height: 100px;
+  position: absolute;
+  left: 0;
+  top: 0;
+  overflow: hidden;
+`;
+
+const Dur = styled('div')`
+  color: ${p => p.theme.gray300};
+  font-variant-numeric: tabular-nums;
+`;
+
+const Pct = styled('div')`
+  min-width: 40px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+`;
+
+const FlexBox = styled('div')`
+  display: flex;
+`;
+
+const BreakDownWrapper = styled(FlexBox)`
+  flex-direction: column;
+  padding: ${space(2)};
+`;
+
+const BreakDownRow = styled(FlexBox)`
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export default TraceViewHeader;

--- a/static/app/components/events/interfaces/spans/newTraceDetailsHeader.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsHeader.tsx
@@ -9,13 +9,8 @@ import {space} from 'sentry/styles/space';
 import {EventTransaction, Organization} from 'sentry/types';
 import {getDuration} from 'sentry/utils/formatters';
 import toPercent from 'sentry/utils/number/toPercent';
-import useProjects from 'sentry/utils/useProjects';
 import {TraceType} from 'sentry/views/performance/traceDetails/newTraceDetailsContent';
 import {TraceInfo} from 'sentry/views/performance/traceDetails/types';
-import {
-  platformToPerformanceType,
-  ProjectPerformanceType,
-} from 'sentry/views/performance/utils';
 
 import ReplayPreview from '../../eventReplay/replayPreview';
 
@@ -83,21 +78,14 @@ function ServiceBreakdown({
 }
 
 function TraceViewHeader(props: PropType) {
-  const {projects} = useProjects();
-
   const {event} = props;
   if (!event) {
     return null;
   }
 
-  const projectSlug = event.projectSlug;
-  const project = projects.find(proj => proj.slug === projectSlug);
-
-  const isFrontendRoot =
-    project &&
-    platformToPerformanceType(projects, [Number(project?.id)]) ===
-      ProjectPerformanceType.FRONTEND &&
-    props.traceType === TraceType.ONE_ROOT;
+  const opsBreakdown = generateStats(event, {type: 'no_filter'});
+  const httpOp = opsBreakdown.find(obj => obj.name === 'http.client');
+  const hasServiceBreakdown = httpOp && props.traceType === TraceType.ONE_ROOT;
 
   return (
     <HeaderContainer ref={props.traceViewHeaderRef} hasProfileMeasurementsChart={false}>
@@ -113,7 +101,7 @@ function TraceViewHeader(props: PropType) {
               >
                 {props.event && (
                   <ServiceBreakdown
-                    displayBreakdown={!!isFrontendRoot}
+                    displayBreakdown={!!hasServiceBreakdown}
                     rootEvent={props.event}
                   />
                 )}

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -562,7 +562,7 @@ export class SpanBar extends Component<SpanBarProps, SpanBarState> {
             // TODO Abdullah Khan: A little bit hacky, but ensures that the toggled tree aligns
             // with the rest of the span tree, in the trace view.
             if (this.props.fromTraceView) {
-              this.props.updateHorizontalScrollState(1);
+              this.props.updateHorizontalScrollState(0.5);
             }
           }}
         >

--- a/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
@@ -58,6 +58,7 @@ export enum TraceType {
   MULTIPLE_ROOTS = 'multiple_roots',
   BROKEN_SUBTRACES = 'broken_subtraces',
   ONLY_ERRORS = 'only_errors',
+  EMPTY_TRACE = 'empty_trace',
 }
 
 function NewTraceDetailsContent(props: Props) {
@@ -170,7 +171,15 @@ function NewTraceDetailsContent(props: Props) {
       return TraceType.ONLY_ERRORS;
     }
 
-    return TraceType.ONE_ROOT;
+    if (roots === 1) {
+      return TraceType.ONE_ROOT;
+    }
+
+    if (roots === 0 && orphans === 0) {
+      return TraceType.EMPTY_TRACE;
+    }
+
+    throw new Error('Unknown trace type');
   };
 
   const renderTraceWarnings = () => {

--- a/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
@@ -10,25 +10,25 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import TimeSince from 'sentry/components/timeSince';
-import {t, tct, tn} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {Organization} from 'sentry/types';
+import {EventTransaction, Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
 import {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
 import {getDuration} from 'sentry/utils/formatters';
-import getDynamicText from 'sentry/utils/getDynamicText';
 import {
   TraceError,
   TraceFullDetailed,
   TraceMeta,
 } from 'sentry/utils/performance/quickTrace/types';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
 import {MetaData} from 'sentry/views/performance/transactionDetails/styles';
 
-import {TraceDetailHeader} from './styles';
+import {BrowserDisplay} from '../transactionDetails/eventMetas';
+
 import TraceNotFound from './traceNotFound';
 import TraceView from './traceView';
 import {TraceInfo} from './types';
@@ -47,7 +47,27 @@ type Props = Pick<RouteComponentProps<{traceSlug: string}, {}>, 'params' | 'loca
   orphanErrors?: TraceError[];
 };
 
+export enum TraceType {
+  ONE_ROOT = 'one_root',
+  NO_ROOT = 'no_root',
+  MULTIPLE_ROOTS = 'multiple_roots',
+  BROKEN_SUBTRACES = 'broken_subtraces',
+  ONLY_ERRORS = 'only_errors',
+}
+
 function NewTraceDetailsContent(props: Props) {
+  const root = props.traces && props.traces[0];
+  const {data: rootEvent, isLoading: isRootEventLoading} = useApiQuery<EventTransaction>(
+    [
+      `/organizations/${props.organization.slug}/events/${root?.project_slug}:${root?.event_id}/`,
+    ],
+    {
+      staleTime: Infinity,
+      retry: true,
+      enabled: !!(props.traces && props.traces.length > 0),
+    }
+  );
+
   const renderTraceLoading = () => {
     return (
       <LoadingContainer>
@@ -67,46 +87,54 @@ function NewTraceDetailsContent(props: Props) {
     const performanceIssues =
       meta?.performance_issues ?? traceInfo.performanceIssues.size;
     return (
-      <TraceDetailHeader>
-        <GuideAnchor target="trace_view_guide_breakdown">
+      <TraceHeaderContainer>
+        {rootEvent && (
+          <TraceHeaderRow>
+            <MetaData
+              headingText={t('User')}
+              tooltipText=""
+              bodyText={rootEvent?.user?.email ?? rootEvent?.user?.name ?? '\u2014'}
+              subtext={null}
+            />
+            <MetaData
+              headingText={t('Browser')}
+              tooltipText=""
+              bodyText={<BrowserDisplay event={rootEvent} showVersion />}
+              subtext={null}
+            />
+          </TraceHeaderRow>
+        )}
+        <TraceHeaderRow>
+          <GuideAnchor target="trace_view_guide_breakdown">
+            <MetaData
+              headingText={t('Events')}
+              tooltipText=""
+              bodyText={meta?.transactions ?? traceInfo.transactions.size}
+              subtext={null}
+            />
+          </GuideAnchor>
           <MetaData
-            headingText={t('Event Breakdown')}
-            tooltipText={t(
-              'The number of transactions and issues there are in this trace.'
-            )}
-            bodyText={tct('[transactions]  |  [errors]', {
-              transactions: tn(
-                '%s Transaction',
-                '%s Transactions',
-                meta?.transactions ?? traceInfo.transactions.size
-              ),
-              errors: tn('%s Issue', '%s Issues', errors + performanceIssues),
-            })}
-            subtext={tn(
-              'Across %s project',
-              'Across %s projects',
-              meta?.projects ?? traceInfo.projects.size
-            )}
+            headingText={t('Issues')}
+            tooltipText=""
+            bodyText={errors + performanceIssues}
+            subtext={null}
           />
-        </GuideAnchor>
-        <MetaData
-          headingText={t('Total Duration')}
-          tooltipText={t('The time elapsed between the start and end of this trace.')}
-          bodyText={getDuration(
-            traceInfo.endTimestamp - traceInfo.startTimestamp,
-            2,
-            true
-          )}
-          subtext={getDynamicText({
-            value: <TimeSince date={(traceInfo.endTimestamp || 0) * 1000} />,
-            fixed: '5 days ago',
-          })}
-        />
-      </TraceDetailHeader>
+          <MetaData
+            headingText={t('Total Duration')}
+            tooltipText=""
+            bodyText={getDuration(
+              traceInfo.endTimestamp - traceInfo.startTimestamp,
+              2,
+              true
+            )}
+            subtext={null}
+          />
+        </TraceHeaderRow>
+      </TraceHeaderContainer>
     );
   };
 
-  const renderTraceWarnings = () => {
+  const getTraceType = (): TraceType => {
     const {traces, orphanErrors} = props;
 
     const {roots, orphans} = (traces ?? []).reduce(
@@ -121,49 +149,76 @@ function NewTraceDetailsContent(props: Props) {
       {roots: 0, orphans: 0}
     );
 
-    let warning: React.ReactNode = null;
-
     if (roots === 0 && orphans > 0) {
-      warning = (
-        <Alert type="info" showIcon>
-          <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#orphan-traces-and-broken-subtraces">
-            {t(
-              'A root transaction is missing. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
+      return TraceType.NO_ROOT;
+    }
+
+    if (roots === 1 && orphans > 0) {
+      return TraceType.BROKEN_SUBTRACES;
+    }
+
+    if (roots > 1) {
+      return TraceType.MULTIPLE_ROOTS;
+    }
+
+    if (orphanErrors && orphanErrors.length > 1) {
+      return TraceType.ONLY_ERRORS;
+    }
+
+    return TraceType.ONE_ROOT;
+  };
+
+  const renderTraceWarnings = () => {
+    let warning: React.ReactNode = null;
+    const traceType = getTraceType();
+
+    switch (traceType) {
+      case TraceType.NO_ROOT:
+        warning = (
+          <Alert type="info" showIcon>
+            <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#orphan-traces-and-broken-subtraces">
+              {t(
+                'A root transaction is missing. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
+              )}
+            </ExternalLink>
+          </Alert>
+        );
+        break;
+      case TraceType.BROKEN_SUBTRACES:
+        warning = (
+          <Alert type="info" showIcon>
+            <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#orphan-traces-and-broken-subtraces">
+              {t(
+                'This trace has broken subtraces. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
+              )}
+            </ExternalLink>
+          </Alert>
+        );
+        break;
+      case TraceType.MULTIPLE_ROOTS:
+        warning = (
+          <Alert type="info" showIcon>
+            <ExternalLink href="https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#multiple-roots">
+              {t('Multiple root transactions have been found with this trace ID.')}
+            </ExternalLink>
+          </Alert>
+        );
+        break;
+      case TraceType.ONLY_ERRORS:
+        warning = (
+          <Alert type="info" showIcon>
+            {tct(
+              "The good news is we know these errors are related to each other. The bad news is that we can't tell you more than that. If you haven't already, [tracingLink: configure performance monitoring for your SDKs] to learn more about service interactions.",
+              {
+                tracingLink: (
+                  <ExternalLink href="https://docs.sentry.io/product/performance/getting-started/" />
+                ),
+              }
             )}
-          </ExternalLink>
-        </Alert>
-      );
-    } else if (roots === 1 && orphans > 0) {
-      warning = (
-        <Alert type="info" showIcon>
-          <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#orphan-traces-and-broken-subtraces">
-            {t(
-              'This trace has broken subtraces. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
-            )}
-          </ExternalLink>
-        </Alert>
-      );
-    } else if (roots > 1) {
-      warning = (
-        <Alert type="info" showIcon>
-          <ExternalLink href="https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#multiple-roots">
-            {t('Multiple root transactions have been found with this trace ID.')}
-          </ExternalLink>
-        </Alert>
-      );
-    } else if (orphanErrors && orphanErrors.length > 1) {
-      warning = (
-        <Alert type="info" showIcon>
-          {tct(
-            "The good news is we know these errors are related to each other. The bad news is that we can't tell you more than that. If you haven't already, [tracingLink: configure performance monitoring for your SDKs] to learn more about service interactions.",
-            {
-              tracingLink: (
-                <ExternalLink href="https://docs.sentry.io/product/performance/getting-started/" />
-              ),
-            }
-          )}
-        </Alert>
-      );
+          </Alert>
+        );
+        break;
+      default:
     }
 
     return warning;
@@ -186,7 +241,7 @@ function NewTraceDetailsContent(props: Props) {
     if (!dateSelected) {
       return renderTraceRequiresDateRangeSelection();
     }
-    if (isLoading) {
+    if (isLoading || isRootEventLoading) {
       return renderTraceLoading();
     }
 
@@ -212,6 +267,8 @@ function NewTraceDetailsContent(props: Props) {
         <Margin>
           <VisuallyCompleteWithData id="PerformanceDetails-TraceView" hasData={hasData}>
             <TraceView
+              traceType={getTraceType()}
+              rootEvent={rootEvent}
               traceInfo={traceInfo}
               location={location}
               organization={organization}
@@ -274,6 +331,18 @@ const LoadingContainer = styled('div')`
   font-size: ${p => p.theme.fontSizeLarge};
   color: ${p => p.theme.subText};
   text-align: center;
+`;
+
+const TraceHeaderContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const TraceHeaderRow = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(2)};
 `;
 
 const Margin = styled('div')`

--- a/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
@@ -34,8 +34,8 @@ import {MetaData} from 'sentry/views/performance/transactionDetails/styles';
 
 import {BrowserDisplay} from '../transactionDetails/eventMetas';
 
+import NewTraceView from './newTraceDetailsTraceView';
 import TraceNotFound from './traceNotFound';
-import TraceView from './traceView';
 import {TraceInfo} from './types';
 import {getTraceInfo, hasTraceData, isRootTransaction} from './utils';
 
@@ -313,7 +313,7 @@ function NewTraceDetailsContent(props: Props) {
         {traceInfo && renderTraceHeader(traceInfo)}
         <Margin>
           <VisuallyCompleteWithData id="PerformanceDetails-TraceView" hasData={hasData}>
-            <TraceView
+            <NewTraceView
               traceType={getTraceType()}
               rootEvent={rootEvent}
               traceInfo={traceInfo}
@@ -324,7 +324,6 @@ function NewTraceDetailsContent(props: Props) {
               traces={traces || []}
               meta={meta}
               orphanErrors={orphanErrors || []}
-              handleLimitChange={props.handleLimitChange}
             />
           </VisuallyCompleteWithData>
         </Margin>

--- a/static/app/views/performance/traceDetails/newTraceDetailsTraceView.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsTraceView.tsx
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/react';
 
 import * as DividerHandlerManager from 'sentry/components/events/interfaces/spans/dividerHandlerManager';
 import MeasurementsPanel from 'sentry/components/events/interfaces/spans/measurementsPanel';
+import TraceViewHeader from 'sentry/components/events/interfaces/spans/newTraceDetailsHeader';
 import * as ScrollbarManager from 'sentry/components/events/interfaces/spans/scrollbarManager';
 import {
   boundsGenerator,
@@ -20,7 +21,7 @@ import {
 } from 'sentry/components/performance/waterfall/miniHeader';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import {tct} from 'sentry/locale';
-import {Organization} from 'sentry/types';
+import {EventTransaction, Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
 import toPercent from 'sentry/utils/number/toPercent';
@@ -43,6 +44,7 @@ import {
 } from 'sentry/views/performance/traceDetails/utils';
 
 import LimitExceededMessage from './limitExceededMessage';
+import {TraceType} from './newTraceDetailsContent';
 import TraceNotFound from './traceNotFound';
 
 type AccType = {
@@ -54,8 +56,10 @@ type AccType = {
 type Props = Pick<RouteComponentProps<{}, {}>, 'location'> & {
   meta: TraceMeta | null;
   organization: Organization;
+  rootEvent: EventTransaction | undefined;
   traceEventView: EventView;
   traceSlug: string;
+  traceType: TraceType;
   traces: TraceFullDetailed[];
   filteredEventIds?: Set<string>;
   handleLimitChange?: (newLimit: number) => void;
@@ -131,7 +135,7 @@ function generateBounds(traceInfo: TraceInfo) {
   });
 }
 
-export default function TraceView({
+export default function NewTraceView({
   location,
   meta,
   organization,
@@ -140,6 +144,7 @@ export default function TraceView({
   traceEventView,
   filteredEventIds,
   orphanErrors,
+  traceType,
   handleLimitChange,
   ...props
 }: Props) {
@@ -383,6 +388,13 @@ export default function TraceView({
               isEmbedded
             >
               <StyledTracePanel>
+                <TraceViewHeader
+                  traceInfo={traceInfo}
+                  traceType={traceType}
+                  traceViewHeaderRef={traceViewRef}
+                  organization={organization}
+                  event={props.rootEvent}
+                />
                 <TraceViewHeaderContainer>
                   <ScrollbarManager.Consumer>
                     {({virtualScrollbarRef, scrollBarAreaRef, onDragStart, onScroll}) => {

--- a/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
@@ -772,7 +772,9 @@ function NewTraceDetailsTransactionBar(props: Props) {
         </RowCell>
         <DividerContainer>
           {renderDivider(dividerHandlerChildrenProps)}
-          {!isTraceRoot(transaction) && renderEmbeddedTransactionsBadge()}
+          {!isTraceRoot(transaction) &&
+            !isTraceError(transaction) &&
+            renderEmbeddedTransactionsBadge()}
         </DividerContainer>
         <RowCell
           data-test-id="transaction-row-duration"

--- a/static/app/views/performance/traceDetails/traceView.tsx
+++ b/static/app/views/performance/traceDetails/traceView.tsx
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/react';
 
 import * as DividerHandlerManager from 'sentry/components/events/interfaces/spans/dividerHandlerManager';
 import MeasurementsPanel from 'sentry/components/events/interfaces/spans/measurementsPanel';
+import TraceViewHeader from 'sentry/components/events/interfaces/spans/newTraceDetailsHeader';
 import * as ScrollbarManager from 'sentry/components/events/interfaces/spans/scrollbarManager';
 import {
   boundsGenerator,
@@ -20,7 +21,7 @@ import {
 } from 'sentry/components/performance/waterfall/miniHeader';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import {tct} from 'sentry/locale';
-import {Organization} from 'sentry/types';
+import {EventTransaction, Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
 import toPercent from 'sentry/utils/number/toPercent';
@@ -43,6 +44,7 @@ import {
 } from 'sentry/views/performance/traceDetails/utils';
 
 import LimitExceededMessage from './limitExceededMessage';
+import {TraceType} from './newTraceDetailsContent';
 import TraceNotFound from './traceNotFound';
 
 type AccType = {
@@ -54,8 +56,10 @@ type AccType = {
 type Props = Pick<RouteComponentProps<{}, {}>, 'location'> & {
   meta: TraceMeta | null;
   organization: Organization;
+  rootEvent: EventTransaction | undefined;
   traceEventView: EventView;
   traceSlug: string;
+  traceType: TraceType;
   traces: TraceFullDetailed[];
   filteredEventIds?: Set<string>;
   handleLimitChange?: (newLimit: number) => void;
@@ -140,6 +144,7 @@ export default function TraceView({
   traceEventView,
   filteredEventIds,
   orphanErrors,
+  traceType,
   handleLimitChange,
   ...props
 }: Props) {
@@ -383,6 +388,13 @@ export default function TraceView({
               isEmbedded
             >
               <StyledTracePanel>
+                <TraceViewHeader
+                  traceInfo={traceInfo}
+                  traceType={traceType}
+                  traceViewHeaderRef={traceViewRef}
+                  organization={organization}
+                  event={props.rootEvent}
+                />
                 <TraceViewHeaderContainer>
                   <ScrollbarManager.Consumer>
                     {({virtualScrollbarRef, scrollBarAreaRef, onDragStart, onScroll}) => {

--- a/static/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.tsx
@@ -230,7 +230,13 @@ const IconContainer = styled('div')`
   margin-top: ${space(0.25)};
 `;
 
-function BrowserDisplay({event}: {event: Event}) {
+export function BrowserDisplay({
+  event,
+  showVersion = false,
+}: {
+  event: Event;
+  showVersion?: boolean;
+}) {
   const icon = generateIconName(
     event.contexts.browser?.name,
     event.contexts.browser?.version
@@ -240,7 +246,9 @@ function BrowserDisplay({event}: {event: Event}) {
       <IconContainer>
         <ContextIcon name={icon} />
       </IconContainer>
-      <span>{event.contexts.browser?.name}</span>
+      <span>
+        {event.contexts.browser?.name} {showVersion && event.contexts.browser?.version}
+      </span>
     </BrowserCenter>
   );
 }

--- a/static/app/views/performance/transactionDetails/styles.tsx
+++ b/static/app/views/performance/transactionDetails/styles.tsx
@@ -9,8 +9,8 @@ type MetaDataProps = {
   bodyText: React.ReactNode;
   headingText: string;
   subtext: React.ReactNode;
-  tooltipText: string;
   badge?: 'alpha' | 'beta' | 'new';
+  tooltipText?: string;
 };
 
 export function MetaData({
@@ -24,12 +24,14 @@ export function MetaData({
     <HeaderInfo>
       <StyledSectionHeading>
         {headingText}
-        <QuestionTooltip
-          position="top"
-          size="xs"
-          containerDisplayMode="block"
-          title={tooltipText}
-        />
+        {tooltipText && (
+          <QuestionTooltip
+            position="top"
+            size="xs"
+            containerDisplayMode="block"
+            title={tooltipText}
+          />
+        )}
         {badge && <StyledFeatureBadge type={badge} />}
       </StyledSectionHeading>
       <SectionBody>{bodyText}</SectionBody>


### PR DESCRIPTION
This pr adds trace level information under the feature flag `organizations:performance-trace-details`:
- User info + browser
- Event/Issues/Total Duration
- Web vitals (will add CTAs later)
- Trace level tag summary (we can add show tags functionality later)
- Service breakdown + replay preview



