### PR TITLE
fix(stats-v2): Correct documentation of category filter

### DIFF
--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -98,7 +98,7 @@ class OrgStatsQueryParamsSerializer(serializers.Serializer):
     )
 
     category = serializers.ChoiceField(
-        ("error", "transaction", "attachment", "replays", "profiles"),
+        ("error", "transaction", "attachment", "replay", "profile"),
         required=False,
         help_text=(
             "If filtering by attachments, you cannot filter by any other category due to quantity values becoming nonsensical (combining bytes and event counts).\n\n"


### PR DESCRIPTION
These should NOT be plurarl. They map to relays `DataCategory` constant.