### PR TITLE
ref(hybrid-cloud): Consildate RPC calls to improve integration latency

### DIFF
--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -85,11 +85,19 @@ class SlackRequest:
         return False
 
     def _get_context(self):
+        team_id = None
+        user_id = None
+        # Let the intended validation methods handle the errors from reading these fields
+        try:
+            team_id = self.team_id
+            user_id = self.user_id
+        except Exception:
+            pass
         context = integration_service.get_integration_identity_context(
             integration_provider="slack",
-            integration_external_id=self.team_id,
-            identity_external_id=self.user_id,
-            identity_provider_external_id=self.team_id,
+            integration_external_id=team_id,
+            identity_external_id=user_id,
+            identity_provider_external_id=team_id,
         )
         if not context:
             return

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -8,6 +8,7 @@ from rest_framework.request import Request
 
 from sentry import options
 from sentry.services.hybrid_cloud.identity import RpcIdentity, identity_service
+from sentry.services.hybrid_cloud.identity.model import RpcIdentityProvider
 from sentry.services.hybrid_cloud.integration import RpcIntegration, integration_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
@@ -57,7 +58,9 @@ class SlackRequest:
     def __init__(self, request: Request) -> None:
         self.request = request
         self._integration: RpcIntegration | None = None
-        self._identity: RpcIdentity | None
+        self._identity: RpcIdentity | None = None
+        self._provider: RpcIdentityProvider | None = None
+        self._user: RpcUser | None = None
         self._data: MutableMapping[str, Any] = {}
 
     def validate(self) -> None:
@@ -66,6 +69,7 @@ class SlackRequest:
         """
         self.request.body
         self._log_request()
+        self._get_context()
         self.authorize()
         self._validate_data()
         self.validate_integration()
@@ -79,6 +83,21 @@ class SlackRequest:
 
     def is_challenge(self) -> bool:
         return False
+
+    def _get_context(self):
+        context = integration_service.get_integration_identity_context(
+            integration_provider="slack",
+            integration_external_id=self.team_id,
+            identity_external_id=self.user_id,
+            identity_provider_external_id=self.team_id,
+        )
+        if not context:
+            return
+
+        self._integration = context["integration"]
+        self._provider = context["identity_provider"]
+        self._identity = context["identity"]
+        self._user = context["user"]
 
     @property
     def integration(self) -> RpcIntegration:
@@ -126,27 +145,34 @@ class SlackRequest:
         return {k: v for k, v in data.items() if v}
 
     def get_identity(self) -> RpcIdentity | None:
-        if not hasattr(self, "_identity"):
-            provider = identity_service.get_provider(
+        if self._identity is not None:
+            return self._identity
+
+        if self._provider is None:
+            self._provider = identity_service.get_provider(
                 provider_type="slack", provider_ext_id=self.team_id
             )
-            self._identity = (
-                identity_service.get_identity(
-                    filter={
-                        "provider_id": provider.id,
-                        "identity_ext_id": self.user_id,
-                    }
-                )
-                if provider
-                else None
+
+        if self._provider is not None:
+            self._identity = identity_service.get_identity(
+                filter={
+                    "provider_id": self._provider.id,
+                    "identity_ext_id": self.user_id,
+                }
             )
+
         return self._identity
 
     def get_identity_user(self) -> RpcUser | None:
+        if self._user:
+            return self._user
+
         identity = self.get_identity()
         if not identity:
             return None
-        return user_service.get_user(identity.user_id)
+
+        self._user = user_service.get_user(identity.user_id)
+        return self._user
 
     def _validate_data(self) -> None:
         try:
@@ -183,9 +209,11 @@ class SlackRequest:
         return self.data.get("token") == verification_token
 
     def validate_integration(self) -> None:
-        self._integration = integration_service.get_integration(
-            provider="slack", external_id=self.team_id
-        )
+        if not self._integration:
+            self._integration = integration_service.get_integration(
+                provider="slack", external_id=self.team_id
+            )
+
         if not self._integration:
             self._info("slack.action.invalid-team-id")
             raise SlackRequestError(status=status_.HTTP_403_FORBIDDEN)

--- a/src/sentry/integrations/slack/requests/base.py
+++ b/src/sentry/integrations/slack/requests/base.py
@@ -93,11 +93,10 @@ class SlackRequest:
         )
         if not context:
             return
-
-        self._integration = context["integration"]
-        self._provider = context["identity_provider"]
-        self._identity = context["identity"]
-        self._user = context["user"]
+        self._integration = context.integration
+        self._provider = context.identity_provider
+        self._identity = context.identity
+        self._user = context.user
 
     @property
     def integration(self) -> RpcIntegration:

--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -439,10 +439,10 @@ class DatabaseBackedIntegrationService(IntegrationService):
     def get_integration_identity_context(
         self,
         *,
-        integration_provider: str,
-        integration_external_id: str,
-        identity_external_id: str,
-        identity_provider_external_id: str,
+        integration_provider: str | None = None,
+        integration_external_id: str | None = None,
+        identity_external_id: str | None = None,
+        identity_provider_external_id: str | None = None,
     ) -> RpcIntegrationIdentityContext:
         from sentry.services.hybrid_cloud.identity.service import identity_service
         from sentry.services.hybrid_cloud.user.service import user_service

--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -22,7 +22,10 @@ from sentry.services.hybrid_cloud.integration import (
     RpcIntegration,
     RpcOrganizationIntegration,
 )
-from sentry.services.hybrid_cloud.integration.model import RpcIntegrationExternalProject
+from sentry.services.hybrid_cloud.integration.model import (
+    RpcIntegrationExternalProject,
+    RpcIntegrationIdentityContext,
+)
 from sentry.services.hybrid_cloud.integration.serial import (
     serialize_integration,
     serialize_integration_external_project,
@@ -432,3 +435,40 @@ class DatabaseBackedIntegrationService(IntegrationService):
         if external_project is None:
             return None
         return serialize_integration_external_project(external_project)
+
+    def get_integration_identity_context(
+        self,
+        *,
+        integration_provider: str,
+        integration_external_id: str,
+        identity_external_id: str,
+        identity_provider_external_id: str,
+    ) -> RpcIntegrationIdentityContext:
+        from sentry.services.hybrid_cloud.identity.service import identity_service
+        from sentry.services.hybrid_cloud.user.service import user_service
+
+        integration = self.get_integration(
+            provider=integration_provider,
+            external_id=integration_external_id,
+        )
+        identity_provider = identity_service.get_provider(
+            provider_type=integration_provider,
+            provider_ext_id=identity_provider_external_id,
+        )
+        identity = (
+            identity_service.get_identity(
+                filter={
+                    "provider_id": identity_provider.id,
+                    "identity_ext_id": identity_external_id,
+                }
+            )
+            if identity_provider
+            else None
+        )
+        user = user_service.get_user(identity.user_id) if identity else None
+        return {
+            "integration": integration,
+            "identity_provider": identity_provider,
+            "identity": identity,
+            "user": user,
+        }

--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -466,9 +466,9 @@ class DatabaseBackedIntegrationService(IntegrationService):
             else None
         )
         user = user_service.get_user(identity.user_id) if identity else None
-        return {
-            "integration": integration,
-            "identity_provider": identity_provider,
-            "identity": identity,
-            "user": user,
-        }
+        return RpcIntegrationIdentityContext(
+            integration=integration,
+            identity_provider=identity_provider,
+            identity=identity,
+            user=user,
+        )

--- a/src/sentry/services/hybrid_cloud/integration/model.py
+++ b/src/sentry/services/hybrid_cloud/integration/model.py
@@ -6,6 +6,8 @@
 from datetime import datetime
 from typing import Any, Dict, Optional
 
+from typing_extensions import TypedDict
+
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import (
     IntegrationFeatures,
@@ -13,6 +15,8 @@ from sentry.integrations.base import (
     IntegrationProvider,
 )
 from sentry.services.hybrid_cloud import RpcModel
+from sentry.services.hybrid_cloud.identity.model import RpcIdentity, RpcIdentityProvider
+from sentry.services.hybrid_cloud.user.model import RpcUser
 
 
 class RpcIntegration(RpcModel):
@@ -74,3 +78,10 @@ class RpcIntegrationExternalProject(RpcModel):
     external_id: str
     resolved_status: str
     unresolved_status: str
+
+
+class RpcIntegrationIdentityContext(TypedDict):
+    integration: Optional[RpcIntegration]
+    identity_provider: Optional[RpcIdentityProvider]
+    identity: Optional[RpcIdentity]
+    user: Optional[RpcUser]

--- a/src/sentry/services/hybrid_cloud/integration/model.py
+++ b/src/sentry/services/hybrid_cloud/integration/model.py
@@ -6,8 +6,6 @@
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-from typing_extensions import TypedDict
-
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import (
     IntegrationFeatures,
@@ -80,7 +78,7 @@ class RpcIntegrationExternalProject(RpcModel):
     unresolved_status: str
 
 
-class RpcIntegrationIdentityContext(TypedDict):
+class RpcIntegrationIdentityContext(RpcModel):
     integration: Optional[RpcIntegration]
     identity_provider: Optional[RpcIdentityProvider]
     identity: Optional[RpcIdentity]

--- a/src/sentry/services/hybrid_cloud/integration/service.py
+++ b/src/sentry/services/hybrid_cloud/integration/service.py
@@ -295,10 +295,10 @@ class IntegrationService(RpcService):
     def get_integration_identity_context(
         self,
         *,
-        integration_provider: str,
-        integration_external_id: str,
-        identity_external_id: str,
-        identity_provider_external_id: str,
+        integration_provider: Optional[str] = None,
+        integration_external_id: Optional[str] = None,
+        identity_external_id: Optional[str] = None,
+        identity_provider_external_id: Optional[str] = None,
     ) -> RpcIntegrationIdentityContext:
         pass
 

--- a/src/sentry/services/hybrid_cloud/integration/service.py
+++ b/src/sentry/services/hybrid_cloud/integration/service.py
@@ -12,7 +12,10 @@ from sentry.models.integrations.organization_integration import (
     PagerDutyServiceDict,
 )
 from sentry.services.hybrid_cloud.integration import RpcIntegration, RpcOrganizationIntegration
-from sentry.services.hybrid_cloud.integration.model import RpcIntegrationExternalProject
+from sentry.services.hybrid_cloud.integration.model import (
+    RpcIntegrationExternalProject,
+    RpcIntegrationIdentityContext,
+)
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.services.hybrid_cloud.pagination import RpcPaginationArgs, RpcPaginationResult
 from sentry.services.hybrid_cloud.rpc import RpcService, rpc_method
@@ -285,6 +288,18 @@ class IntegrationService(RpcService):
     def get_integration_external_project(
         self, *, organization_id: int, integration_id: int, external_id: str
     ) -> Optional[RpcIntegrationExternalProject]:
+        pass
+
+    @rpc_method
+    @abstractmethod
+    def get_integration_identity_context(
+        self,
+        *,
+        integration_provider: str,
+        integration_external_id: str,
+        identity_external_id: str,
+        identity_provider_external_id: str,
+    ) -> RpcIntegrationIdentityContext:
         pass
 
 


### PR DESCRIPTION
This PR attempts to resolve some of the latency issues we have with integrations and proxying. Slack and Discord both have timeout constraints of 3s which makes it difficult to test in the underprovisioned test regions.

Rather than figuring out an async pipeline, I've consildated the calls to hopefully quick fix the perf issues. If this doesn't allow slack testing, we can figure that out in a future PR.

This has been tested for slack and discord