### PR TITLE
chore(vscode): Use new Code Actions on Save and Auto

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,12 +17,8 @@
   "files.trimFinalNewlines": true,
   "files.insertFinalNewline": true,
 
-  "files.associations": {
-    "*.jsx": "javascriptreact"
-  },
-
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
 
   "[javascript]": {
@@ -60,8 +56,8 @@
   "[python]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true,
-      "source.fixAll.eslint": false
+      "source.organizeImports": "explicit",
+      "source.fixAll.eslint": "never"
     },
     "editor.defaultFormatter": "ms-python.black-formatter"
   },


### PR DESCRIPTION
Every time I open vscode it corrects these values to the new ones.

**The options are:**
explicit - Triggers Code Actions when explicitly saved. Same as true.   
always - Triggers Code Actions when explicitly saved and on Auto Saves from window or focus changes.  
never - Never triggers Code Actions on save. Same as false. 

https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto
