### PR TITLE
docs(stories): Categorize Zoom in/out icon in the Action sections of icons.stories.tsx

### DIFF
--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -999,6 +999,18 @@ const SECTIONS: TSection[] = [
         name: 'KeyDown',
         defaultProps: {},
       },
+      {
+        id: 'zoom-out',
+        keywords: [],
+        name: 'Zoom',
+        defaultProps: {isZoomIn: false},
+      },
+      {
+        id: 'zoom-in',
+        keywords: [],
+        name: 'Zoom',
+        defaultProps: {isZoomIn: true},
+      },
     ],
   },
   {


### PR DESCRIPTION
<img width="964" alt="SCR-20231211-kiaw" src="https://github.com/getsentry/sentry/assets/187460/89f1482a-c2bd-4277-9b13-e91d5e16da0b">
