### PR TITLE
fix(superuser): pass organization into isActiveSuperuser

### DIFF
--- a/static/app/components/acl/role.spec.tsx
+++ b/static/app/components/acl/role.spec.tsx
@@ -1,4 +1,3 @@
-import Cookies from 'js-cookie';
 import {Organization} from 'sentry-fixture/organization';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
@@ -68,20 +67,22 @@ describe('Role', function () {
     });
 
     it('gives access to a superuser with insufficient role', function () {
-      ConfigStore.config.user = TestStubs.User({isSuperuser: true});
-      Cookies.set = jest.fn();
+      const org = Organization({
+        ...organization,
+        access: [...organization.access, 'org:superuser'],
+      });
 
-      render(<Role role="owner">{childrenMock}</Role>, {context: routerContext});
+      const orgRouterContext = RouterContextFixture([
+        {
+          organization: org,
+        },
+      ]);
+
+      render(<Role role="owner">{childrenMock}</Role>, {context: orgRouterContext});
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasRole: true,
       });
-      expect(Cookies.set).toHaveBeenCalledWith(
-        'su-test-cookie',
-        'set-in-isActiveSuperuser',
-        {domain: '.sentry.io'}
-      );
-      ConfigStore.config.user = TestStubs.User({isSuperuser: false});
     });
 
     it('does not give access to a made up role', function () {

--- a/static/app/components/acl/role.tsx
+++ b/static/app/components/acl/role.tsx
@@ -17,7 +17,7 @@ function checkUserRole(user: User, organization: Organization, role: RoleProps['
     return false;
   }
 
-  if (isActiveSuperuser()) {
+  if (isActiveSuperuser(organization)) {
     return true;
   }
 

--- a/static/app/components/events/aiSuggestedSolution/suggestion.tsx
+++ b/static/app/components/events/aiSuggestedSolution/suggestion.tsx
@@ -14,7 +14,7 @@ import {IconFile, IconFlag, IconHappy, IconMeh, IconSad} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
-import {Event, Project} from 'sentry/types';
+import {Event, Organization, Project} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getAnalyticsDataForEvent} from 'sentry/utils/events';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
@@ -34,7 +34,7 @@ type Props = {
 
 function ErrorDescription({
   restriction,
-  organizationSlug,
+  organization,
   onRefetch,
   onSetIndividualConsent,
   onHideSuggestion,
@@ -42,7 +42,7 @@ function ErrorDescription({
   onHideSuggestion: () => void;
   onRefetch: () => void;
   onSetIndividualConsent: (consent: boolean) => void;
-  organizationSlug: string;
+  organization: Organization;
   restriction?: 'subprocessor' | 'individual_consent';
 }) {
   if (restriction === 'subprocessor') {
@@ -56,7 +56,7 @@ function ErrorDescription({
         action={
           <ButtonBar gap={2}>
             <Button onClick={onHideSuggestion}>{t('Dismiss')}</Button>
-            <Button priority="primary" to={`/settings/${organizationSlug}/legal/`}>
+            <Button priority="primary" to={`/settings/${organization.slug}/legal/`}>
               {t('Accept in Settings')}
             </Button>
           </ButtonBar>
@@ -77,7 +77,7 @@ function ErrorDescription({
           'By using this feature, you agree that OpenAI is a subprocessor and may process the data that you’ve chosen to submit. Sentry makes no guarantees as to the accuracy of the feature’s AI-generated recommendations.'
         );
 
-    const activeSuperUser = isActiveSuperuser();
+    const activeSuperUser = isActiveSuperuser(organization);
     return (
       <EmptyMessage
         icon={<IconFlag size="xl" />}
@@ -158,7 +158,7 @@ export function Suggestion({onHideSuggestion, projectSlug, event}: Props) {
         ) : dataIsError ? (
           <ErrorDescription
             onRefetch={dataRefetch}
-            organizationSlug={organization.slug}
+            organization={organization}
             onSetIndividualConsent={() =>
               setSuggestedSolutionLocalConfig({individualConsent: true})
             }

--- a/static/app/components/organizations/environmentPageFilter/index.tsx
+++ b/static/app/components/organizations/environmentPageFilter/index.tsx
@@ -75,7 +75,7 @@ export function EnvironmentPageFilter({
   } = usePageFilters();
 
   const environments = useMemo<string[]>(() => {
-    const isSuperuser = isActiveSuperuser();
+    const isSuperuser = isActiveSuperuser(organization);
 
     const unsortedEnvironments = projects.flatMap(project => {
       const projectId = parseInt(project.id, 10);
@@ -102,7 +102,7 @@ export function EnvironmentPageFilter({
       !envPageFilterValue.includes(env),
       env,
     ]);
-  }, [projects, projectPageFilterValue, envPageFilterValue]);
+  }, [projects, projectPageFilterValue, envPageFilterValue, organization]);
 
   /**
    * Validated values that only includes the currently available environments

--- a/static/app/utils/isActiveSuperuser.tsx
+++ b/static/app/utils/isActiveSuperuser.tsx
@@ -16,7 +16,7 @@ const SUPERUSER_COOKIE_DOMAIN = window.superUserCookieDomain;
  *
  * Documented here: https://getsentry.atlassian.net/browse/ER-1602
  */
-export function isActiveSuperuser(organization?: Organization) {
+export function isActiveSuperuser(organization?: Organization | null) {
   if (organization) {
     return organization.access.includes('org:superuser');
   }

--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -359,7 +359,7 @@ export function useTeams({limit, slugs, provideUserTeams}: Options = {}) {
     }
   }, [shouldLoadUserTeams, loadUserTeams]);
 
-  const isSuperuser = isActiveSuperuser();
+  const isSuperuser = isActiveSuperuser(organization);
 
   const filteredTeams = useMemo(() => {
     return slugs

--- a/static/app/utils/useUserTeams.tsx
+++ b/static/app/utils/useUserTeams.tsx
@@ -52,7 +52,7 @@ export function useUserTeams(): UseTeamsResult {
     }
   }, [additionalTeams]);
 
-  const isSuperuser = isActiveSuperuser();
+  const isSuperuser = isActiveSuperuser(organization);
   const teams = useMemo<Team[]>(() => {
     return isSuperuser ? storeState.teams : storeState.teams.filter(t => t.isMember);
   }, [storeState.teams, isSuperuser]);

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1131,7 +1131,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
       !rule || !rule.environment ? ALL_ENVIRONMENTS_KEY : rule.environment;
 
     const canCreateAlert = hasEveryAccess(['alerts:write'], {organization, project});
-    const disabled = loading || !(canCreateAlert || isActiveSuperuser());
+    const disabled = loading || !(canCreateAlert || isActiveSuperuser(organization));
     const displayDuplicateError =
       detailedError?.name?.some(str => isExactDuplicateExp.test(str)) ?? false;
 

--- a/static/app/views/alerts/rules/utils.tsx
+++ b/static/app/views/alerts/rules/utils.tsx
@@ -52,7 +52,7 @@ export function getProjectOptions({
     },
   ];
 
-  return hasOpenMembership || hasOrgWrite || isActiveSuperuser()
+  return hasOpenMembership || hasOrgWrite || isActiveSuperuser(organization)
     ? openMembershipProjects
     : myProjectOptions;
 }

--- a/static/app/views/monitors/components/monitorCreateForm.tsx
+++ b/static/app/views/monitors/components/monitorCreateForm.tsx
@@ -192,7 +192,7 @@ export default function MonitorCreateForm() {
     ? projects.find(p => p.id === selectedProjectId + '')
     : null;
 
-  const isSuperuser = isActiveSuperuser();
+  const isSuperuser = isActiveSuperuser(organization);
   const filteredProjects = projects.filter(project => isSuperuser || project.isMember);
 
   function onCreateMonitor(data: Monitor) {

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -211,7 +211,7 @@ function MonitorForm({
     ? projects.find(p => p.id === selectedProjectId + '')
     : null;
 
-  const isSuperuser = isActiveSuperuser();
+  const isSuperuser = isActiveSuperuser(organization);
   const filteredProjects = projects.filter(project => isSuperuser || project.isMember);
 
   const alertRuleTarget = monitor?.alertRule?.targets.map(

--- a/static/app/views/organizationStats/teamInsights/controls.tsx
+++ b/static/app/views/organizationStats/teamInsights/controls.tsx
@@ -59,7 +59,7 @@ function TeamStatsControls({
     slugs: currentTeam?.projects?.map(project => project.slug) ?? [],
   });
   const organization = useOrganization();
-  const isSuperuser = isActiveSuperuser();
+  const isSuperuser = isActiveSuperuser(organization);
   const theme = useTheme();
 
   const query = location?.query ?? {};

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -822,7 +822,7 @@ class ProjectPerformance extends DeprecatedAsyncView<Props, State> {
     const params = {orgId: organization.slug, projectId: project.slug};
     const projectEndpoint = this.getProjectEndpoint(params);
     const performanceIssuesEndpoint = this.getPerformanceIssuesEndpoint(params);
-    const isSuperUser = isActiveSuperuser();
+    const isSuperUser = isActiveSuperuser(organization);
 
     return (
       <Fragment>

--- a/static/app/views/settings/projectSourceMaps/projectSourceMapsArtifacts.spec.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMapsArtifacts.spec.tsx
@@ -1,3 +1,4 @@
+import {Organization} from 'sentry-fixture/organization';
 import {SourceMapArchive} from 'sentry-fixture/sourceMapArchive';
 import {SourceMapArtifact} from 'sentry-fixture/sourceMapArtifact';
 import {SourceMapsDebugIDBundlesArtifacts} from 'sentry-fixture/sourceMapsDebugIDBundlesArtifacts';
@@ -81,6 +82,9 @@ describe('ProjectSourceMapsArtifacts', function () {
   describe('Release Bundles', function () {
     it('renders default state', async function () {
       const {organization, routerContext, project, routerProps} = initializeOrg({
+        organization: Organization({
+          access: ['org:superuser'],
+        }),
         router: {
           location: {
             query: {},
@@ -174,6 +178,9 @@ describe('ProjectSourceMapsArtifacts', function () {
   describe('Artifact Bundles', function () {
     it('renders default state', async function () {
       const {organization, project, routerProps, routerContext} = initializeOrg({
+        organization: Organization({
+          access: ['org:superuser', 'project:releases'],
+        }),
         router: {
           location: {
             pathname: `/settings/${initializeOrg().organization.slug}/projects/${


### PR DESCRIPTION
`isActiveSuperuser` now takes in an `organization` argument. We added the `org:superuser` scope to `organization.access` when somebody is in active superuser mode (#61391).