### PR TITLE
fix(starfish): Fix incorrect domain selector loading behaviour

### DIFF
--- a/static/app/views/starfish/utils/useSpansQuery.tsx
+++ b/static/app/views/starfish/utils/useSpansQuery.tsx
@@ -117,8 +117,11 @@ function useWrappedDiscoverTimeseriesQuery<T>({
     ? defaultData
     : processDiscoverTimeseriesResult(result.data, eventView);
 
+  const pageLinks = result.response?.getResponseHeader('Link') ?? undefined;
+
   return {
     ...result,
+    pageLinks,
     data,
     meta: result.data?.meta,
   };

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.spec.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.spec.tsx
@@ -53,7 +53,9 @@ describe('DomainSelector', function () {
           },
         ],
       },
-
+      headers: {
+        Link: '<previous-data>; rel="previous"; results="false"; cursor="0:0:1", <next-data>; rel="next"; results="true"; cursor="0:100:0"',
+      },
       match: [MockApiClient.matchQuery({query: 'has:span.description span.module:db'})],
     });
   });

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.spec.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.spec.tsx
@@ -1,0 +1,61 @@
+import selectEvent from 'react-select-event';
+import {Organization} from 'sentry-fixture/organization';
+
+import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
+
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {ModuleName} from 'sentry/views/starfish/types';
+import {DomainSelector} from 'sentry/views/starfish/views/spans/selectors/domainSelector';
+
+jest.mock('sentry/utils/useOrganization');
+jest.mock('sentry/utils/usePageFilters');
+
+describe('DomainSelector', function () {
+  const organization = Organization();
+  jest.mocked(useOrganization).mockReturnValue(organization);
+
+  jest.mocked(usePageFilters).mockReturnValue({
+    isReady: true,
+    desyncedFilters: new Set(),
+    pinnedFilters: new Set(),
+    shouldPersist: true,
+    selection: {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+      environments: [],
+      projects: [],
+    },
+  });
+
+  it('allows selecting a domain', async function () {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [
+          {
+            'count()': 10,
+            'span.domain': 'sentry_user',
+          },
+          {
+            'count()': 9,
+            'span.domain': 'sentry_organization',
+          },
+        ],
+      },
+    });
+
+    render(<DomainSelector moduleName={ModuleName.DB} />);
+
+    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+
+    await selectEvent.openMenu(screen.getByText('All'));
+
+    expect(screen.getByText('sentry_user')).toBeInTheDocument();
+    expect(screen.getByText('sentry_organization')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -78,7 +78,9 @@ export function DomainSelector({
     referrer: 'api.starfish.get-span-domains',
   });
 
-  const incomingDomains = uniq(flatten(domainData?.map(row => row['span.domain'])));
+  const incomingDomains = uniq(
+    flatten(domainData?.map(row => row[SpanMetricsField.SPAN_DOMAIN]))
+  );
 
   // Cache for all previously seen domains
   const domainCache = useRef<DomainCacheValue>({
@@ -93,20 +95,18 @@ export function DomainSelector({
   }
 
   useEffect(() => {
-    // When caching the first domain data result, check if it had more data
+    // When caching the first domain data result, check if it had more data. If not, there's no point making any more requests when users update the search filter
     if (domainCache.current.loadCount === 0) {
       const {next} = parseLinkHeader(pageLinks ?? '');
       domainCache.current.initialLoadHadMoreData = next?.results ?? false;
     }
 
-    // Cache all known domains
     domainCache.current.loadCount += 1;
+
     incomingDomains?.forEach(domain => {
       domainCache.current.domains.add(domain);
     });
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [incomingDomains]);
+  }, [incomingDomains, pageLinks]);
 
   const emptyOption = {
     value: EMPTY_OPTION_VALUE,

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -94,19 +94,27 @@ export function DomainSelector({
     domainCache.current.domains.add(value);
   }
 
+  // Keep track of load count, so we can run some effects after exactly one load
   useEffect(() => {
-    // When caching the first domain data result, check if it had more data. If not, there's no point making any more requests when users update the search filter
-    if (domainCache.current.loadCount === 0) {
+    if (!isLoading) {
+      domainCache.current.loadCount += 1;
+    }
+  }, [isLoading]);
+
+  // When caching the first domain data result, check if it had more data. If not, there's no point making any more requests when users update the search filter
+  useEffect(() => {
+    if (domainCache.current.loadCount === 1) {
       const {next} = parseLinkHeader(pageLinks ?? '');
       domainCache.current.initialLoadHadMoreData = next?.results ?? false;
     }
+  }, [pageLinks]);
 
-    domainCache.current.loadCount += 1;
-
+  // Cache all known domains from previous requests
+  useEffect(() => {
     incomingDomains?.forEach(domain => {
       domainCache.current.domains.add(domain);
     });
-  }, [incomingDomains, pageLinks]);
+  }, [incomingDomains]);
 
   const emptyOption = {
     value: EMPTY_OPTION_VALUE,

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -36,7 +36,6 @@ interface DomainData {
 interface DomainCacheValue {
   domains: Set<string>;
   initialLoadHadMoreData: boolean;
-  loadCount: number;
 }
 
 export function DomainSelector({
@@ -86,7 +85,6 @@ export function DomainSelector({
   const domainCache = useRef<DomainCacheValue>({
     domains: new Set(),
     initialLoadHadMoreData: true,
-    loadCount: 0,
   });
 
   // The current selected table might not be in the cached set. Ensure it's always there
@@ -94,20 +92,14 @@ export function DomainSelector({
     domainCache.current.domains.add(value);
   }
 
-  // Keep track of load count, so we can run some effects after exactly one load
+  // When caching the unfiltered domain data result, check if it had more data. If not, there's no point making any more requests when users update the search filter that narrows the search
   useEffect(() => {
-    if (!isLoading) {
-      domainCache.current.loadCount += 1;
-    }
-  }, [isLoading]);
-
-  // When caching the first domain data result, check if it had more data. If not, there's no point making any more requests when users update the search filter
-  useEffect(() => {
-    if (domainCache.current.loadCount === 1) {
+    if (domainQuery === '' && !isLoading) {
       const {next} = parseLinkHeader(pageLinks ?? '');
+
       domainCache.current.initialLoadHadMoreData = next?.results ?? false;
     }
-  }, [pageLinks]);
+  }, [domainQuery, pageLinks, isLoading]);
 
   // Cache all known domains from previous requests
   useEffect(() => {


### PR DESCRIPTION
Tony reported that he can't find some of his tables in the table selector when typing into the field. The domain selector has some clever logic to side-load more data, but it had some deficiencies:

- the loading state wasn't reported, except for a "Loading..." message in the dropdown, as an option
- a logic problem in the code would prevent loading data if < 100 unique domains were returned

This wasn't working correctly, so I've made a few changes to fix the bug and improve UX:

- a loading spinner in the dropdown shows whenever more data is loading, whether it's on first load or when fetching more domains
- when we do the initial fetch (without a filter, to get the full list), check whether there is a `next` link in the header. If there is, that means there are more domains to be searched. In that case, when the user types into the dropdown, make a Discover call to fetch the domains from the server. If there _isn't_ a `next` link, there's no point making any more requests, so don't bother
- add a persistent cache of domains, so that even when the user is typing in new queries, we always show them all the tables we've seen until now

This simplified the component somewhat. Also added specs, which the selector didn't have before.

**e.g.,**

https://github.com/getsentry/sentry/assets/989898/95818be2-a786-4ea2-b8e8-92d0a70b5ed6

