### PR TITLE
ref: disable migrations by default under test (part 2: sentry)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: run tests
         run: |
-          MIGRATIONS_TEST_MIGRATE=1 PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations" make test-python-ci
+          PYTEST_ADDOPTS="$PYTEST_ADDOPTS -m migrations --migrations" make test-python-ci
 
       # Upload coverage data even if running the tests step fails since
       # it reduces large coverage fluctuations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ skip = "migrations"
 python_files = "test_*.py sentry/testutils/*"
 # note: When updating the traceback format, make sure to update .github/pytest.json
 # We don't use the celery pytest plugin.
-addopts = "-ra --tb=short --strict-markers -p no:celery"
+addopts = "-ra --tb=short --strict-markers -p no:celery --nomigrations"
 # TODO: --import-mode=importlib will become the default soon,
 # currently we have a few relative imports that don't work with that.
 markers = [

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3524,10 +3524,6 @@ SOUTH_MIGRATION_CONVERSIONS = (
     ),
 )
 
-# Whether to use Django migrations to create the database, or just build it based off
-# of models, similar to how syncdb used to work. The former is more correct, the latter
-# is much faster.
-MIGRATIONS_TEST_MIGRATE = os.environ.get("MIGRATIONS_TEST_MIGRATE", "0") == "1"
 # Specifies the list of django apps to include in the lockfile. If Falsey then include
 # all apps with migrations
 MIGRATIONS_LOCKFILE_APP_WHITELIST = (

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2407,7 +2407,7 @@ class TestMigrations(TransactionTestCase):
     """
     From https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/
 
-    Note that when running these tests locally you will need to set the `MIGRATIONS_TEST_MIGRATE=1`
+    Note that when running these tests locally you will need to set the `--migrations`
     environmental variable for these to pass.
     """
 
@@ -2441,8 +2441,7 @@ class TestMigrations(TransactionTestCase):
         matching_migrations = [m for m in executor.loader.applied_migrations if m[0] == self.app]
         if not matching_migrations:
             raise AssertionError(
-                "no migrations detected!\n\n"
-                "try running this test with `MIGRATIONS_TEST_MIGRATE=1 pytest ...`"
+                "no migrations detected!\n\ntry running this test with `pytest --migrations ...`"
             )
         self.current_migration = [max(matching_migrations)]
         old_apps = executor.loader.project_state(migrate_from).apps

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -54,7 +54,7 @@ def pytest_configure(config: pytest.Config) -> None:
         category=UnsupportedBackend,
     )
 
-    config.addinivalue_line("markers", "migrations: requires MIGRATIONS_TEST_MIGRATE=1")
+    config.addinivalue_line("markers", "migrations: requires --migrations")
 
     if sys.platform == "darwin" and shutil.which("colima"):
         # This is the only way other than pytest --basetemp to change
@@ -250,13 +250,6 @@ def pytest_configure(config: pytest.Config) -> None:
     patcher = mock.patch("socket.getfqdn", return_value="localhost")
     patcher.start()
 
-    if not settings.MIGRATIONS_TEST_MIGRATE:
-        # Migrations for the "sentry" app take a long time to run, which makes test startup time slow in dev.
-        # This is a hack to force django to sync the database state from the models rather than use migrations.
-        settings.MIGRATION_MODULES["sentry"] = None  # type: ignore[assignment]
-        settings.MIGRATION_MODULES["hybridcloud"] = None  # type: ignore[assignment]
-        settings.MIGRATION_MODULES["feedback"] = None  # type: ignore[assignment]
-
     asset_version_patcher = mock.patch(
         "sentry.runner.initializer.get_asset_version", return_value="{version}"
     )
@@ -308,10 +301,10 @@ def register_extensions() -> None:
 
 
 def pytest_runtest_setup(item: pytest.Item) -> None:
-    if not settings.MIGRATIONS_TEST_MIGRATE and any(
+    if item.config.getvalue("nomigrations") and any(
         mark for mark in item.iter_markers(name="migrations")
     ):
-        pytest.skip("migrations are not enabled, run with MIGRATIONS_TEST_MIGRATE=1 pytest ...")
+        pytest.skip("migrations are not enabled, run with `pytest --migrations ...`")
 
 
 def pytest_runtest_teardown(item: pytest.Item) -> None:

--- a/tests/sentry/db/postgres/schema/safe_migrations/integration/test_migrations.py
+++ b/tests/sentry/db/postgres/schema/safe_migrations/integration/test_migrations.py
@@ -15,7 +15,9 @@ class BaseSafeMigrationTest(TestCase):
     migrate_to: str
 
     def run_migration(self):
-        with override_settings(INSTALLED_APPS=(f"{self.BASE_PATH}.{self.app}",)):
+        with override_settings(
+            INSTALLED_APPS=(f"{self.BASE_PATH}.{self.app}",), MIGRATION_MODULES={}
+        ):
             migrate_from = [(self.app, self.migrate_from)]
             migrate_to = [(self.app, self.migrate_to)]
             executor = MigrationExecutor(connection)


### PR DESCRIPTION
<!-- Describe your PR here. -->

this also speeds up tests by 3-5 seconds \o/ -- already applied in getsentry

part 3 is removing compat in getsentry