### PR TITLE
fix(stacktrace): Improve platform icon logic for mixed-platform stack traces

### DIFF
--- a/fixtures/js-stubs/eventStacktraceFrame.ts
+++ b/fixtures/js-stubs/eventStacktraceFrame.ts
@@ -1,0 +1,75 @@
+import {Frame} from 'sentry/types';
+
+export function EventStacktraceFrame(params = {}): Frame {
+  return {
+    filename: 'raven/base.py',
+    absPath: '/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/base.py',
+    module: 'raven.base',
+    package: null,
+    platform: null,
+    instructionAddr: null,
+    symbolAddr: null,
+    function: 'build_msg',
+    rawFunction: null,
+    symbol: null,
+    context: [
+      [298, '                frames = stack'],
+      [299, ''],
+      [300, '            data.update({'],
+      [301, "                'sentry.interfaces.Stacktrace': {"],
+      [302, "                    'frames': get_stack_info(frames,"],
+      [303, '                        transformer=self.transform)'],
+      [304, '                },'],
+      [305, '            })'],
+      [306, ''],
+      [307, "        if 'sentry.interfaces.Stacktrace' in data:"],
+      [308, '            if self.include_paths:'],
+    ],
+    lineNo: 303,
+    colNo: null,
+    inApp: true,
+    trust: null,
+    vars: {
+      "'culprit'": null,
+      "'data'": {
+        "'message'": "u'This is a test message generated using ``raven test``'",
+        "'sentry.interfaces.Message'": {
+          "'message'": "u'This is a test message generated using ``raven test``'",
+          "'params'": [],
+        },
+      },
+      "'date'": 'datetime.datetime(2013, 8, 13, 3, 8, 24, 880386)',
+      "'event_id'": "'54a322436e1b47b88e239b78998ae742'",
+      "'event_type'": "'raven.events.Message'",
+      "'extra'": {
+        "'go_deeper'": [['{"\'bar\'":["\'baz\'"],"\'foo\'":"\'bar\'"}']],
+        "'loadavg'": [0.37255859375, 0.5341796875, 0.62939453125],
+        "'user'": "'dcramer'",
+      },
+      "'frames'": '<generator object iter_stack_frames at 0x107bcc3c0>',
+      "'handler'": '<raven.events.Message object at 0x107bd0890>',
+      "'k'": "'sentry.interfaces.Message'",
+      "'kwargs'": {
+        "'level'": 20,
+        "'message'": "'This is a test message generated using ``raven test``'",
+      },
+      "'public_key'": null,
+      "'result'": {
+        "'message'": "u'This is a test message generated using ``raven test``'",
+        "'sentry.interfaces.Message'": {
+          "'message'": "u'This is a test message generated using ``raven test``'",
+          "'params'": [],
+        },
+      },
+      "'self'": '<raven.base.Client object at 0x107bb8210>',
+      "'stack'": true,
+      "'tags'": null,
+      "'time_spent'": null,
+      "'v'": {
+        "'message'": "u'This is a test message generated using ``raven test``'",
+        "'params'": [],
+      },
+    },
+    ...params,
+  };
+}

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
@@ -1,5 +1,6 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {EventEntryStacktrace} from 'sentry-fixture/eventEntryStacktrace';
+import {EventStacktraceFrame} from 'sentry-fixture/eventStacktraceFrame';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -415,6 +416,84 @@ describe('StackTrace', function () {
         'Occurred in non-app: raven/scripts/runner.py in main at line 112'
       );
       expect(frameTitles[1]).toHaveTextContent('raven/base.py in build_msg at line 303');
+    });
+  });
+
+  describe('platform icons', function () {
+    it('uses the top in-app frame file extension for mixed stack trace platforms', function () {
+      renderedComponent({
+        data: {
+          ...data,
+          frames: [
+            EventStacktraceFrame({
+              inApp: true,
+              filename: 'foo.cs',
+            }),
+            EventStacktraceFrame({
+              inApp: true,
+              filename: 'foo.py',
+            }),
+            EventStacktraceFrame({
+              inApp: true,
+              filename: 'foo',
+            }),
+            EventStacktraceFrame({
+              inApp: false,
+              filename: 'foo.rb',
+            }),
+          ],
+        },
+      });
+
+      // foo.py is the most recent in-app frame with a valid file extension
+      expect(screen.getByTestId('platform-icon-python')).toBeInTheDocument();
+    });
+
+    it('uses frame.platform if file extension does not work', function () {
+      renderedComponent({
+        data: {
+          ...data,
+          frames: [
+            EventStacktraceFrame({
+              inApp: true,
+              filename: 'foo.cs',
+            }),
+            EventStacktraceFrame({
+              inApp: true,
+              filename: 'foo',
+              platform: 'node',
+            }),
+            EventStacktraceFrame({
+              inApp: true,
+              filename: 'foo',
+            }),
+            EventStacktraceFrame({
+              inApp: false,
+              filename: 'foo.rb',
+            }),
+          ],
+        },
+      });
+
+      expect(screen.getByTestId('platform-icon-node')).toBeInTheDocument();
+    });
+
+    it('falls back to the event platform if there is no other information', function () {
+      renderedComponent({
+        data: {
+          ...data,
+          frames: [
+            EventStacktraceFrame({
+              inApp: true,
+              filename: 'foo',
+              platform: null,
+            }),
+          ],
+        },
+        platform: 'python',
+      });
+
+      expect(screen.getByTestId('platform-icon-python')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/53132

Previously, we looked to see if all file extensions in the stack trace were the same. If so, we returned the icon for that file extension. Otherwise, we returned the event platform. For platforms like react native, this did not work very well.

This modifies the logic to look at the most recent in-app frames and return the first match we find. It also takes into account `frame.platform` which was not used before.

Before:

![CleanShot 2023-12-11 at 13 31 04](https://github.com/getsentry/sentry/assets/10888943/d8ef7fa3-281e-42cf-a278-9ff04ada72f7)

After:

![CleanShot 2023-12-11 at 13 30 41](https://github.com/getsentry/sentry/assets/10888943/a5125a61-1ab7-4e69-882e-bc0c38dac946)
