### PR TITLE
fix(stats-detectors): Should auto resolve condition is backwards

### DIFF
--- a/src/sentry/statistical_detectors/algorithm.py
+++ b/src/sentry/statistical_detectors/algorithm.py
@@ -59,7 +59,7 @@ class MovingAverageDetectorState(DetectorState):
     def should_auto_resolve(self, target: float, rel_threshold: float) -> bool:
         value = self.moving_avg_long
 
-        rel_change = (target - value) / target
+        rel_change = (value - target) / target
         if rel_change < rel_threshold:
             return True
 

--- a/tests/sentry/statistical_detectors/test_algorithm.py
+++ b/tests/sentry/statistical_detectors/test_algorithm.py
@@ -200,10 +200,10 @@ def test_moving_average_detector_state_should_auto_resolve(baseline, rel_thresho
     state = MovingAverageDetectorState(
         timestamp=datetime(2023, 8, 31, 11, 28, 52),
         count=10,
-        moving_avg_short=100,
-        moving_avg_long=100,
+        moving_avg_short=baseline,
+        moving_avg_long=baseline,
     )
-    assert state.should_auto_resolve(baseline, rel_threshold) == auto_resolve
+    assert state.should_auto_resolve(100, rel_threshold) == auto_resolve
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The subtraction order is backwards here. Should be current average - target so if average is greater than target, the rel change is positive.