### PR TITLE
chore(pagerduty) Align pagerduty config implementation with opsgenie

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1381,9 +1381,12 @@ def get_alert_rule_trigger_action_pagerduty_service(
     input_channel_id=None,
     integrations=None,
 ):
-    service = integration_service.find_pagerduty_service(
-        organization_id=organization.id, integration_id=integration_id, service_id=target_value
+    from sentry.integrations.pagerduty.utils import get_service
+
+    org_integration = integration_service.get_organization_integration(
+        integration_id=integration_id, organization_id=organization.id
     )
+    service = get_service(target_value, org_integration)
     if not service:
         raise InvalidTriggerActionError("No PagerDuty service found.")
 
@@ -1416,6 +1419,7 @@ def get_alert_rule_trigger_action_opsgenie_team(
         integration=integration,
         integration_key=integration_key,
         org_integration_id=oi.id,
+        keyid=team["id"],
     )
     try:
         client.authorize_integration(type="sentry")

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -38,7 +38,6 @@ from sentry.incidents.models import (
     TriggerStatus,
 )
 from sentry.models.actor import Actor
-from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.notificationaction import ActionService, ActionTarget
 from sentry.models.project import Project
 from sentry.relay.config.metric_extraction import on_demand_metrics_feature_flags
@@ -1386,7 +1385,7 @@ def get_alert_rule_trigger_action_pagerduty_service(
     org_integration = integration_service.get_organization_integration(
         integration_id=integration_id, organization_id=organization.id
     )
-    service = get_service(target_value, org_integration)
+    service = get_service(org_integration, target_value)
     if not service:
         raise InvalidTriggerActionError("No PagerDuty service found.")
 
@@ -1477,12 +1476,12 @@ def get_available_action_integrations_for_org(organization) -> List[RpcIntegrati
 
 
 def get_pagerduty_services(organization_id, integration_id) -> List[Tuple[int, str]]:
+    from sentry.integrations.pagerduty.utils import get_services
+
     org_int = integration_service.get_organization_integration(
         organization_id=organization_id, integration_id=integration_id
     )
-    if org_int is None:
-        return []
-    services = OrganizationIntegration.services_in(org_int.config)
+    services = get_services(org_int)
     return [(s["id"], s["service_name"]) for s in services]
 
 

--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -11,6 +11,7 @@ from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.integration.model import RpcOrganizationIntegration
+from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.shared_integrations.client.proxy import infer_org_integration
 from sentry.shared_integrations.exceptions import ApiError
 
@@ -26,6 +27,7 @@ class PagerDutyServiceDict(TypedDict):
     id: int
 
 
+@control_silo_function
 def add_service(
     organization_integration: OrganizationIntegration, integration_key: str, service_name: str
 ) -> PagerDutyServiceDict:

--- a/src/sentry/models/integrations/organization_integration.py
+++ b/src/sentry/models/integrations/organization_integration.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, ClassVar, List, Mapping, TypedDict
+from typing import Any, ClassVar, Mapping
 
-from django.db import models, router, transaction
+from django.db import models
 from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
@@ -59,55 +59,3 @@ class OrganizationIntegration(ReplicatedControlModel):
         payload: Mapping[str, Any] | None,
     ) -> None:
         pass
-
-    @staticmethod
-    def services_in(config: Mapping[str, Any]) -> List[PagerDutyServiceDict]:
-        return config.get("pagerduty_services", [])
-
-    def set_services(self, services: List[PagerDutyServiceDict]) -> None:
-        self.config["pagerduty_services"] = services
-
-    @staticmethod
-    def find_service(config: Mapping[str, Any], id: int | str) -> PagerDutyServiceDict | None:
-        try:
-            return next(
-                pds
-                for pds in OrganizationIntegration.services_in(config)
-                if str(pds["id"]) == str(id)
-            )
-        except StopIteration:
-            return None
-
-    def add_pagerduty_service(
-        self, integration_key: str, service_name: str
-    ) -> PagerDutyServiceDict:
-        with transaction.atomic(router.db_for_write(OrganizationIntegration)):
-            OrganizationIntegration.objects.filter(id=self.id).select_for_update()
-
-            with transaction.get_connection(
-                router.db_for_write(OrganizationIntegration)
-            ).cursor() as cursor:
-                cursor.execute(
-                    "SELECT nextval(%s)", [f"{OrganizationIntegration._meta.db_table}_id_seq"]
-                )
-                next_id: int = cursor.fetchone()[0]
-
-            service: PagerDutyServiceDict = {
-                "id": next_id,
-                "integration_key": integration_key,
-                "service_name": service_name,
-                "integration_id": self.integration_id,
-            }
-
-            existing: list[PagerDutyServiceDict] = OrganizationIntegration.services_in(self.config)
-            new_services: list[PagerDutyServiceDict] = existing + [service]
-            self.config["pagerduty_services"] = new_services
-            self.save()
-        return service
-
-
-class PagerDutyServiceDict(TypedDict):
-    integration_id: int
-    integration_key: str
-    service_name: str
-    id: int

--- a/src/sentry/models/integrations/organization_integration.py
+++ b/src/sentry/models/integrations/organization_integration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, ClassVar, Mapping
+from typing import TYPE_CHECKING, Any, ClassVar, Mapping
 
 from django.db import models
 from django.utils import timezone
@@ -16,6 +16,9 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 from sentry.db.models.fields.jsonfield import JSONField
 from sentry.db.models.outboxes import ControlOutboxProducingManager, ReplicatedControlModel
 from sentry.models.outbox import OutboxCategory
+
+if TYPE_CHECKING:
+    from sentry.integrations.pagerduty.utils import PagerDutyServiceDict
 
 
 @control_silo_only_model
@@ -59,3 +62,18 @@ class OrganizationIntegration(ReplicatedControlModel):
         payload: Mapping[str, Any] | None,
     ) -> None:
         pass
+
+    def add_pagerduty_service(
+        self, integration_key: str, service_name: str
+    ) -> PagerDutyServiceDict:
+        # TODO(mark) remove this shim code once getsentry is updated.
+        from sentry.integrations.pagerduty.utils import add_service
+
+        return add_service(self, integration_key=integration_key, service_name=service_name)
+
+    @classmethod
+    def services_in(cls, config: dict[str, Any]) -> list[PagerDutyServiceDict]:
+        # TODO(mark) remove this shim code once getsentry is updated.
+        if not config:
+            return []
+        return config.get("pagerduty_services", [])

--- a/src/sentry/services/hybrid_cloud/integration/service.py
+++ b/src/sentry/services/hybrid_cloud/integration/service.py
@@ -5,12 +5,8 @@
 
 from abc import abstractmethod
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
-from sentry.models.integrations.organization_integration import (
-    OrganizationIntegration,
-    PagerDutyServiceDict,
-)
 from sentry.services.hybrid_cloud.integration import RpcIntegration, RpcOrganizationIntegration
 from sentry.services.hybrid_cloud.integration.model import RpcIntegrationExternalProject
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
@@ -131,19 +127,6 @@ class IntegrationService(RpcService):
             integration_id=integration_id, organization_id=organization_id, limit=1
         )
         return ois[0] if len(ois) > 0 else None
-
-    def find_pagerduty_service(
-        self, *, organization_id: int, integration_id: int, service_id: Union[str, int]
-    ) -> Optional[PagerDutyServiceDict]:
-        org_integration = self.get_organization_integration(
-            integration_id=integration_id, organization_id=organization_id
-        )
-        if not org_integration:
-            return None
-        try:
-            return OrganizationIntegration.find_service(org_integration.config, service_id)
-        except StopIteration:
-            return None
 
     @rpc_method
     @abstractmethod

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_details.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_details.py
@@ -4,6 +4,7 @@ import responses
 from rest_framework import serializers, status
 
 from sentry.api.serializers.base import serialize
+from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.notificationaction import (
     ActionRegistration,
     ActionService,
@@ -293,7 +294,9 @@ class NotificationActionsDetailsEndpointTest(APITestCase):
         )
         assert "Did not recieve PagerDuty service id" in str(response.data["targetIdentifier"])
         with assume_test_silo_mode(SiloMode.CONTROL):
-            service = second_integration.organizationintegration_set.first().add_pagerduty_service(
+            org_integration = second_integration.organizationintegration_set.first()
+            service = add_service(
+                org_integration,
                 service_name=service_name,
                 integration_key="abc",
             )
@@ -307,7 +310,9 @@ class NotificationActionsDetailsEndpointTest(APITestCase):
         )
         assert "ensure Sentry has access" in str(response.data["targetIdentifier"])
         with assume_test_silo_mode(SiloMode.CONTROL):
-            service = integration.organizationintegration_set.first().add_pagerduty_service(
+            org_integration = integration.organizationintegration_set.first()
+            service = add_service(
+                org_integration,
                 service_name=service_name,
                 integration_key="def",
             )

--- a/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
+++ b/tests/sentry/api/endpoints/notifications/test_notification_actions_index.py
@@ -4,6 +4,7 @@ import responses
 from rest_framework import serializers, status
 
 from sentry.api.serializers.base import serialize
+from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.notificationaction import (
     ActionRegistration,
     ActionService,
@@ -338,7 +339,9 @@ class NotificationActionsIndexEndpointTest(APITestCase):
         )
         assert "Did not recieve PagerDuty service id" in str(response.data["targetIdentifier"])
         with assume_test_silo_mode(SiloMode.CONTROL):
-            service = second_integration.organizationintegration_set.first().add_pagerduty_service(
+            org_integration = second_integration.organizationintegration_set.first()
+            service = add_service(
+                org_integration,
                 service_name=service_name,
                 integration_key="abc",
             )
@@ -351,7 +354,9 @@ class NotificationActionsIndexEndpointTest(APITestCase):
         )
         assert "ensure Sentry has access" in str(response.data["targetIdentifier"])
         with assume_test_silo_mode(SiloMode.CONTROL):
-            service = integration.organizationintegration_set.first().add_pagerduty_service(
+            org_integration = integration.organizationintegration_set.first()
+            service = add_service(
+                org_integration,
                 service_name=service_name,
                 integration_key="def",
             )

--- a/tests/sentry/hybridcloud/test_integration.py
+++ b/tests/sentry/hybridcloud/test_integration.py
@@ -5,6 +5,7 @@ from typing import List
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationFeatures
+from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.services.hybrid_cloud.integration import (
@@ -261,11 +262,13 @@ class OrganizationIntegrationServiceTest(BaseIntegrationServiceTest):
             org_integration = OrganizationIntegration.objects.get(
                 organization_id=self.organization.id, integration_id=integration.id
             )
-            pds = org_integration.add_pagerduty_service(
+            pds = add_service(
+                org_integration,
                 integration_key="key1",
                 service_name="service1",
             )
-            pds2 = org_integration.add_pagerduty_service(
+            pds2 = add_service(
+                org_integration,
                 integration_key="key2",
                 service_name="service1",
             )

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -6,6 +6,7 @@ import responses
 from sentry.incidents.action_handlers import PagerDutyActionHandler
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models import AlertRuleTriggerAction, IncidentStatus, IncidentStatusMethod
+from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.integrations.integration import Integration
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils import json
@@ -31,9 +32,10 @@ class PagerDutyActionHandlerTest(FireTest):
             external_id="example-pagerduty",
             metadata={"service": service},
         )
-        self.integration.add_organization(self.organization, self.user)
+        org_integration = self.integration.add_organization(self.organization, self.user)
 
-        self.service = self.integration.organizationintegration_set.first().add_pagerduty_service(
+        self.service = add_service(
+            org_integration,
             service_name=service[0]["service_name"],
             integration_key=service[0]["integration_key"],
         )
@@ -117,7 +119,9 @@ class PagerDutyActionHandlerTest(FireTest):
                 "service_name": "meowmeowfuntime",
             },
         ]
-        self.integration.organizationintegration_set.first().add_pagerduty_service(
+        org_integration = self.integration.organizationintegration_set.first()
+        add_service(
+            org_integration,
             service_name=service[0]["service_name"],
             integration_key=service[0]["integration_key"],
         )

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -5,6 +5,7 @@ from sentry.incidents.endpoints.organization_alert_rule_available_action_index i
     build_action_response,
 )
 from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.integrations import SentryAppComponent, SentryAppInstallation
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
@@ -96,8 +97,9 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
                 external_id="example-pagerduty",
                 metadata={"services": SERVICES},
             )
-            integration.add_organization(self.organization, self.user)
-            service = integration.organizationintegration_set.first().add_pagerduty_service(
+            org_integration = integration.add_organization(self.organization, self.user)
+            service = add_service(
+                org_integration,
                 service_name=service_name,
                 integration_key=SERVICES[0]["integration_key"],
             )

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -68,6 +68,7 @@ from sentry.incidents.models import (
     TriggerStatus,
 )
 from sentry.integrations.discord.utils.channel import ChannelType
+from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.actor import ActorTuple, get_actor_for_user, get_actor_id_for_user
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
@@ -1434,8 +1435,9 @@ class CreateAlertRuleTriggerActionTest(BaseAlertRuleTriggerActionTest, TestCase)
             external_id="example-pagerduty",
             metadata={"services": services},
         )
-        integration.add_organization(self.organization, self.user)
-        service = integration.organizationintegration_set.first().add_pagerduty_service(
+        org_integration = integration.add_organization(self.organization, self.user)
+        service = add_service(
+            org_integration,
             service_name=services[0]["service_name"],
             integration_key=services[0]["integration_key"],
         )
@@ -1726,8 +1728,9 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
             external_id="example-pagerduty",
             metadata={"services": services},
         )
-        integration.add_organization(self.organization, self.user)
-        service = integration.organizationintegration_set.first().add_pagerduty_service(
+        org_integration = integration.add_organization(self.organization, self.user)
+        service = add_service(
+            org_integration,
             service_name=services[0]["service_name"],
             integration_key=services[0]["integration_key"],
         )

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -205,7 +205,7 @@ class PagerDutyProxyApiClientTest(APITestCase):
             client = PagerDutyProxyApiTestClient(
                 org_integration_id=self.installation.org_integration.id,
                 integration_key=self.service["integration_key"],
-                keyid=self.service["id"],
+                keyid=str(self.service["id"]),
             )
             client.send_trigger(event)
 
@@ -220,7 +220,7 @@ class PagerDutyProxyApiClientTest(APITestCase):
             client = PagerDutyProxyApiTestClient(
                 org_integration_id=self.installation.org_integration.id,
                 integration_key=self.service["integration_key"],
-                keyid=self.service["id"],
+                keyid=str(self.service["id"]),
             )
             client.send_trigger(event)
 
@@ -235,7 +235,7 @@ class PagerDutyProxyApiClientTest(APITestCase):
             client = PagerDutyProxyApiTestClient(
                 org_integration_id=self.installation.org_integration.id,
                 integration_key=self.service["integration_key"],
-                keyid=self.service["id"],
+                keyid=str(self.service["id"]),
             )
             client.send_trigger(event)
 

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -9,6 +9,7 @@ from responses import matchers
 
 from sentry.api.serializers import ExternalEventSerializer, serialize
 from sentry.integrations.pagerduty.client import PagerDutyProxyClient
+from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.integrations.integration import Integration
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
@@ -48,7 +49,8 @@ class PagerDutyProxyClientTest(APITestCase):
             metadata={"services": SERVICES},
         )
         self.integration.add_organization(self.organization, self.user)
-        self.service = self.integration.organizationintegration_set.first().add_pagerduty_service(
+        self.service = add_service(
+            self.integration.organizationintegration_set.first(),
             service_name=SERVICES[0]["service_name"],
             integration_key=SERVICES[0]["integration_key"],
         )
@@ -149,7 +151,8 @@ class PagerDutyProxyApiClientTest(APITestCase):
             metadata={"services": SERVICES},
         )
         self.integration.add_organization(self.organization, self.user)
-        self.service = self.integration.organizationintegration_set.first().add_pagerduty_service(
+        self.service = add_service(
+            self.integration.organizationintegration_set.first(),
             service_name=SERVICES[0]["service_name"],
             integration_key=SERVICES[0]["integration_key"],
         )

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import responses
 
 from sentry.integrations.pagerduty.actions.notification import PagerDutyNotifyServiceAction
+from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.silo import SiloMode
@@ -43,9 +44,11 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
             )
             self.integration.add_organization(self.organization, self.user)
         with assume_test_silo_mode(SiloMode.CONTROL):
-            self.service = OrganizationIntegration.objects.get(
+            org_integration = OrganizationIntegration.objects.get(
                 integration_id=self.integration.id, organization_id=self.organization.id
-            ).add_pagerduty_service(
+            )
+            self.service = add_service(
+                org_integration,
                 service_name=SERVICES[0]["service_name"],
                 integration_key=SERVICES[0]["integration_key"],
             )
@@ -203,7 +206,8 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.add_organization(new_org, self.user)
             oi = OrganizationIntegration.objects.get(organization_id=new_org.id)
-            new_service = oi.add_pagerduty_service(
+            new_service = add_service(
+                oi,
                 service_name="New Service",
                 integration_key="new_service_key",
             )
@@ -239,9 +243,11 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
                 metadata={"services": [service_info]},
             )
             integration.add_organization(self.organization, self.user)
-            service = OrganizationIntegration.objects.get(
+            org_integration = OrganizationIntegration.objects.get(
                 integration_id=integration.id, organization_id=self.organization.id
-            ).add_pagerduty_service(
+            )
+            service = add_service(
+                org_integration,
                 service_name=service_info["service_name"],
                 integration_key=service_info["integration_key"],
             )
@@ -285,7 +291,9 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
                 metadata={"services": [service_info]},
             )
             integration.add_organization(self.organization, self.user)
-            service = integration.organizationintegration_set.first().add_pagerduty_service(
+            org_integration = integration.organizationintegration_set.first()
+            service = add_service(
+                org_integration,
                 service_name=service_info["service_name"],
                 integration_key=service_info["integration_key"],
             )


### PR DESCRIPTION
The opsgenie integration uses module functions to manage its keyring data. Align pagerduty with this implementation so that we don't have a handful of pagerduty methods attached to OrganizationIntegration.

Longer term I'd like to normalize the logic that opsgenie and pagerduty as it is largely the same outside of naming conventions.
