### PR TITLE
feat(replay): Lazy load Replay previews

### DIFF
--- a/static/app/components/events/eventReplay/eventReplaySection.tsx
+++ b/static/app/components/events/eventReplay/eventReplaySection.tsx
@@ -1,11 +1,11 @@
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {t} from 'sentry/locale';
 
-type EventReplaySectionProps = {children: JSX.Element};
+type EventReplaySectionProps = {children: JSX.Element; className?: string};
 
-export function EventReplaySection({children}: EventReplaySectionProps) {
+export function EventReplaySection({className, children}: EventReplaySectionProps) {
   return (
-    <EventDataSection type="replay" title={t('Session Replay')}>
+    <EventDataSection type="replay" title={t('Session Replay')} className={className}>
       {children}
     </EventDataSection>
   );

--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -1,4 +1,6 @@
 import {useCallback} from 'react';
+import ReactLazyLoad from 'react-lazyload';
+import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {EventReplaySection} from 'sentry/components/events/eventReplay/eventReplaySection';
@@ -51,25 +53,27 @@ function EventReplayContent({
   const eventTimestampMs = timeOfEvent ? Math.floor(new Date(timeOfEvent).getTime()) : 0;
 
   return (
-    <EventReplaySection>
+    <ReplaySectionMinHeight>
       <ErrorBoundary mini>
-        <LazyLoad
-          component={replayPreview}
-          replaySlug={replayId}
-          orgSlug={organization.slug}
-          eventTimestampMs={eventTimestampMs}
-          buttonProps={{
-            analyticsEventKey: 'issue_details.open_replay_details_clicked',
-            analyticsEventName: 'Issue Details: Open Replay Details Clicked',
-            analyticsParams: {
-              ...getAnalyticsDataForEvent(event),
-              ...getAnalyticsDataForGroup(group),
-              organization,
-            },
-          }}
-        />
+        <ReactLazyLoad debounce={50} height={448} offset={0} once>
+          <LazyLoad
+            component={replayPreview}
+            replaySlug={replayId}
+            orgSlug={organization.slug}
+            eventTimestampMs={eventTimestampMs}
+            buttonProps={{
+              analyticsEventKey: 'issue_details.open_replay_details_clicked',
+              analyticsEventName: 'Issue Details: Open Replay Details Clicked',
+              analyticsParams: {
+                ...getAnalyticsDataForEvent(event),
+                ...getAnalyticsDataForGroup(group),
+                organization,
+              },
+            }}
+          />
+        </ReactLazyLoad>
       </ErrorBoundary>
-    </EventReplaySection>
+    </ReplaySectionMinHeight>
   );
 }
 
@@ -94,3 +98,8 @@ export default function EventReplay({event, group, projectSlug}: Props) {
 
   return null;
 }
+
+// The min-height here is due to max-height that is set in replayPreview.tsx
+const ReplaySectionMinHeight = styled(EventReplaySection)`
+  min-height: 508px;
+`;


### PR DESCRIPTION
This defers loading of Replay previews until the preview is in the viewport. This does not solve our performance issues with the previews due to count/extractDomNodes, but at least kicks it down the road a bit.
