### PR TITLE
fix(stacktrace): Render native stack trace component when all frames are native

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
@@ -1,3 +1,5 @@
+import uniq from 'lodash/uniq';
+
 import EmptyMessage from 'sentry/components/emptyMessage';
 import {FrameSourceMapDebuggerData} from 'sentry/components/events/interfaces/sourceMapsDebuggerModal';
 import Panel from 'sentry/components/panels/panel';
@@ -29,6 +31,17 @@ type Props = {
   stackView?: StackView;
   threadId?: number;
 };
+
+// Render native stacktrace when:
+// 1. All frames have a native platform override in `frame.platform`, or
+// 2. The event platform is native
+function shouldRenderNativeContent({data, platform}: Pick<Props, 'data' | 'platform'>) {
+  const framePlatforms = uniq(data?.frames?.map(frame => frame.platform) ?? []);
+  const stackTracePlatform =
+    (framePlatforms.length === 1 ? framePlatforms[0] : null) ?? platform;
+
+  return isNativePlatform(stackTracePlatform);
+}
 
 function StackTrace({
   stackView,
@@ -76,7 +89,6 @@ function StackTrace({
   const includeSystemFrames =
     stackView === StackView.FULL ||
     (chainedException && data.frames?.every(frame => !frame.inApp));
-
   /**
    * Armin, Markus:
    * If all frames are in app, then no frame is in app.
@@ -86,7 +98,7 @@ function StackTrace({
    * It is easier to fix the UI logic to show a non-empty stack trace for chained exceptions
    */
 
-  if (isNativePlatform(platform)) {
+  if (shouldRenderNativeContent({data, platform})) {
     return (
       <NativeContent
         data={data}

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
@@ -1,5 +1,3 @@
-import uniq from 'lodash/uniq';
-
 import EmptyMessage from 'sentry/components/emptyMessage';
 import {FrameSourceMapDebuggerData} from 'sentry/components/events/interfaces/sourceMapsDebuggerModal';
 import Panel from 'sentry/components/panels/panel';
@@ -36,9 +34,9 @@ type Props = {
 // 1. All frames have a native platform override in `frame.platform`, or
 // 2. The event platform is native
 function shouldRenderNativeContent({data, platform}: Pick<Props, 'data' | 'platform'>) {
-  const framePlatforms = uniq(data?.frames?.map(frame => frame.platform) ?? []);
+  const framePlatforms = new Set(data?.frames?.map(frame => frame.platform));
   const stackTracePlatform =
-    (framePlatforms.length === 1 ? framePlatforms[0] : null) ?? platform;
+    (framePlatforms.size === 1 ? [...framePlatforms][0] : null) ?? platform;
 
   return isNativePlatform(stackTracePlatform);
 }

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -33,14 +33,12 @@ import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
 
 import DebugImage from '../debugMeta/debugImage';
 import {combineStatus} from '../debugMeta/utils';
-import {SymbolicatorStatus} from '../types';
 
 import Context from './context';
 import DefaultTitle from './defaultTitle';
-import PackageLink from './packageLink';
-import PackageStatus, {PackageStatusIcon} from './packageStatus';
-import Symbol, {FunctionNameToggleIcon} from './symbol';
-import TogglableAddress, {AddressToggleIcon} from './togglableAddress';
+import {PackageStatusIcon} from './packageStatus';
+import {FunctionNameToggleIcon} from './symbol';
+import {AddressToggleIcon} from './togglableAddress';
 import {
   getPlatform,
   hasAssembly,
@@ -163,17 +161,6 @@ export class DeprecatedLine extends Component<Props, State> {
       emptySourceNotation,
       isOnlyFrame,
     });
-  }
-
-  shouldShowLinkToImage() {
-    const {isHoverPreviewed, data} = this.props;
-    const {symbolicatorStatus} = data;
-
-    return (
-      !!symbolicatorStatus &&
-      symbolicatorStatus !== SymbolicatorStatus.UNKNOWN_IMAGE &&
-      !isHoverPreviewed
-    );
   }
 
   packageStatus() {
@@ -424,96 +411,6 @@ export class DeprecatedLine extends Component<Props, State> {
     );
   }
 
-  renderNativeLine() {
-    const {
-      data,
-      showingAbsoluteAddress,
-      onAddressToggle,
-      onFunctionNameToggle,
-      image,
-      maxLengthOfRelativeAddress,
-      includeSystemFrames,
-      isFrameAfterLastNonApp,
-      showCompleteFunctionName,
-      isHoverPreviewed,
-      isSubFrame,
-      hiddenFrameCount,
-    } = this.props;
-
-    const leadHint = this.renderLeadHint();
-    const packageStatus = this.packageStatus();
-
-    return (
-      <StrictClick onClick={this.isExpandable() ? this.toggleContext : undefined}>
-        <DefaultLine
-          className="title as-table"
-          data-test-id="title"
-          isSubFrame={!!isSubFrame}
-          hasToggle={!!hiddenFrameCount}
-        >
-          <NativeLineContent isFrameAfterLastNonApp={!!isFrameAfterLastNonApp}>
-            <PackageInfo>
-              {leadHint}
-              <PackageLink
-                includeSystemFrames={!!includeSystemFrames}
-                withLeadHint={leadHint !== null}
-                packagePath={data.package}
-                onClick={this.scrollToImage}
-                isClickable={this.shouldShowLinkToImage()}
-                isHoverPreviewed={isHoverPreviewed}
-              >
-                {!isHoverPreviewed && (
-                  <PackageStatus
-                    status={packageStatus}
-                    tooltip={t('Go to Images Loaded')}
-                  />
-                )}
-              </PackageLink>
-            </PackageInfo>
-            {data.instructionAddr && (
-              <TogglableAddress
-                address={data.instructionAddr}
-                startingAddress={image ? image.image_addr ?? null : null}
-                isAbsolute={!!showingAbsoluteAddress}
-                isFoundByStackScanning={this.isFoundByStackScanning()}
-                isInlineFrame={!!this.isInlineFrame()}
-                onToggle={onAddressToggle}
-                relativeAddressMaxlength={maxLengthOfRelativeAddress}
-                isHoverPreviewed={isHoverPreviewed}
-              />
-            )}
-            <Symbol
-              frame={data}
-              showCompleteFunctionName={!!showCompleteFunctionName}
-              onFunctionNameToggle={onFunctionNameToggle}
-              isHoverPreviewed={isHoverPreviewed}
-            />
-          </NativeLineContent>
-          <DefaultLineTagWrapper>
-            <DefaultLineTitleWrapper isInAppFrame={data.inApp}>
-              {this.renderExpander()}
-            </DefaultLineTitleWrapper>
-
-            {data.inApp ? <Tag type="info">{t('In App')}</Tag> : null}
-          </DefaultLineTagWrapper>
-        </DefaultLine>
-      </StrictClick>
-    );
-  }
-
-  renderLine() {
-    switch (this.getPlatform()) {
-      case 'objc':
-      // fallthrough
-      case 'cocoa':
-      // fallthrough
-      case 'native':
-        return this.renderNativeLine();
-      default:
-        return this.renderDefaultLine();
-    }
-  }
-
   render() {
     const data = this.props.data;
 
@@ -529,7 +426,7 @@ export class DeprecatedLine extends Component<Props, State> {
 
     return (
       <StyledLi data-test-id="line" {...props}>
-        {this.renderLine()}
+        {this.renderDefaultLine()}
         <Context
           frame={data}
           event={this.props.event}
@@ -553,16 +450,6 @@ export default withOrganization(
   withSentryAppComponents(DeprecatedLine, {componentType: 'stacktrace-link'})
 );
 
-const PackageInfo = styled('div')`
-  display: grid;
-  grid-template-columns: auto 1fr;
-  order: 2;
-  align-items: flex-start;
-  @media (min-width: ${props => props.theme.breakpoints.small}) {
-    order: 0;
-  }
-`;
-
 const RepeatedFrames = styled('div')`
   display: inline-block;
 `;
@@ -582,29 +469,6 @@ const LeftLineTitle = styled('div')`
 
 const RepeatedContent = styled(LeftLineTitle)`
   justify-content: center;
-`;
-
-const NativeLineContent = styled('div')<{isFrameAfterLastNonApp: boolean}>`
-  display: grid;
-  flex: 1;
-  gap: ${space(0.5)};
-  grid-template-columns: ${p =>
-    `minmax(${p.isFrameAfterLastNonApp ? '167px' : '117px'}, auto)  1fr`};
-  align-items: center;
-  justify-content: flex-start;
-
-  @media (min-width: ${props => props.theme.breakpoints.small}) {
-    grid-template-columns:
-      ${p => (p.isFrameAfterLastNonApp ? '200px' : '150px')} minmax(117px, auto)
-      1fr;
-  }
-
-  @media (min-width: ${props => props.theme.breakpoints.large}) and (max-width: ${props =>
-      props.theme.breakpoints.xlarge}) {
-    grid-template-columns:
-      ${p => (p.isFrameAfterLastNonApp ? '180px' : '140px')} minmax(117px, auto)
-      1fr;
-  }
 `;
 
 const DefaultLine = styled('div')<{


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/61572

See https://sentry-sdks.sentry.io/issues/4589159265

I thought that this code path wasn't being hit, but it turns out that it does when the event platform is non-native and the stack trace has frames that are native. I've deleted the native code paths in the non-native stack trace and check earlier whether or not we should render it.

Before:

![CleanShot 2023-12-11 at 15 50 50](https://github.com/getsentry/sentry/assets/10888943/fa39aaab-0f52-431d-9fd5-319e92b3ecd3)

After:

![CleanShot 2023-12-11 at 15 50 58](https://github.com/getsentry/sentry/assets/10888943/6af7cd46-bee2-4e8b-ba8c-ef5553f0a9cc)
