### PR TITLE
ref(crons): Use `is_muted` over monitor.status

### DIFF
--- a/static/app/views/monitors/components/monitorHeaderActions.tsx
+++ b/static/app/views/monitors/components/monitorHeaderActions.tsx
@@ -11,7 +11,7 @@ import useApi from 'sentry/utils/useApi';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
-import {Monitor, MonitorObjectStatus} from '../types';
+import {Monitor} from '../types';
 
 type Props = {
   monitor: Monitor;
@@ -45,13 +45,7 @@ function MonitorHeaderActions({monitor, orgId, onUpdate}: Props) {
     onUpdate?.(resp);
   };
 
-  const toggleStatus = () =>
-    handleUpdate({
-      status:
-        monitor.status === MonitorObjectStatus.MUTED
-          ? MonitorObjectStatus.ACTIVE
-          : MonitorObjectStatus.MUTED,
-    });
+  const toggleStatus = () => handleUpdate({isMuted: !monitor.isMuted});
 
   return (
     <ButtonBar gap={1}>
@@ -67,15 +61,11 @@ function MonitorHeaderActions({monitor, orgId, onUpdate}: Props) {
       <Button
         size="sm"
         icon={
-          monitor.status !== MonitorObjectStatus.MUTED ? (
-            <IconUnsubscribed size="xs" />
-          ) : (
-            <IconSubscribed size="xs" />
-          )
+          monitor.isMuted ? <IconSubscribed size="xs" /> : <IconUnsubscribed size="xs" />
         }
         onClick={toggleStatus}
       >
-        {monitor.status !== MonitorObjectStatus.MUTED ? t('Mute') : t('Unmute')}
+        {monitor.isMuted ? t('Unmute') : t('Mute')}
       </Button>
       <Button
         priority="primary"

--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -12,7 +12,7 @@ import {t, tct} from 'sentry/locale';
 import {fadeIn} from 'sentry/styles/animations';
 import {space} from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
-import {Monitor, MonitorObjectStatus, MonitorStatus} from 'sentry/views/monitors/types';
+import {Monitor, MonitorStatus} from 'sentry/views/monitors/types';
 import {scheduleAsText} from 'sentry/views/monitors/utils';
 import {statusIconColorMap} from 'sentry/views/monitors/utils/constants';
 
@@ -53,10 +53,7 @@ export function TimelineTableRow({
       {!singleMonitorView && <MonitorDetails monitor={monitor} />}
       <MonitorEnvContainer>
         {environments.map(({name, status}) => {
-          const envStatus =
-            monitor.status === MonitorObjectStatus.MUTED
-              ? MonitorStatus.DISABLED
-              : status;
+          const envStatus = monitor.isMuted ? MonitorStatus.DISABLED : status;
           const {label, icon} = statusIconColorMap[envStatus];
           return (
             <EnvWithStatus key={name}>

--- a/static/app/views/monitors/types.tsx
+++ b/static/app/views/monitors/types.tsx
@@ -20,7 +20,6 @@ export enum ScheduleType {
 
 export enum MonitorObjectStatus {
   ACTIVE = 'active',
-  MUTED = 'muted',
 }
 
 export enum MonitorStatus {
@@ -89,6 +88,7 @@ export interface Monitor {
   dateCreated: string;
   environments: MonitorEnvironment[];
   id: string;
+  isMuted: boolean;
   name: string;
   project: Project;
   slug: string;


### PR DESCRIPTION
Updates the cron monitor details page to use the `is_muted` field over
changing the status