### PR TITLE
fix(flamegraph): Allow flamegraph filters when searching fingerprint

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -80,9 +80,13 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
                 span_group,
             )
         elif "fingerprint" in request.query_params:
-            function_fingerprint = int(request.query_params["fingerprint"])
+            function_fingerprint = int(request.GET.get["fingerprint"])
             profile_ids = get_profiles_with_function(
-                organization.id, project_ids[0], function_fingerprint, params
+                organization.id,
+                project_ids[0],
+                function_fingerprint,
+                params,
+                request.GET.get("query", ""),
             )
         else:
             profile_ids = get_profile_ids(params, request.query_params.get("query", None))

--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -79,8 +79,8 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
                 params,
                 span_group,
             )
-        elif "fingerprint" in request.query_params:
-            function_fingerprint = int(request.GET.get["fingerprint"])
+        elif request.query_params.get("fingerprint"):
+            function_fingerprint = int(request.query_params["fingerprint"])
             profile_ids = get_profiles_with_function(
                 organization.id,
                 project_ids[0],

--- a/src/sentry/search/events/datasets/profile_functions.py
+++ b/src/sentry/search/events/datasets/profile_functions.py
@@ -17,6 +17,7 @@ from sentry.search.events.datasets.base import DatasetConfig
 from sentry.search.events.fields import (
     ColumnArg,
     Combinator,
+    IntArg,
     InvalidFunctionArgument,
     NumberRange,
     NumericColumn,
@@ -305,6 +306,29 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                                     Function("groupUniqArrayMerge(5)", [SnQLColumn("examples")]),
                                     Function("argMaxMerge", [SnQLColumn("worst")]),
                                 ],
+                            ),
+                        ],
+                        alias,
+                    ),
+                    default_result_type="string",  # TODO: support array type
+                ),
+                SnQLFunction(
+                    "unique_examples",
+                    optional_args=[
+                        with_default(5, IntArg("count", negative=False)),
+                    ],
+                    snql_aggregate=lambda args, alias: Function(
+                        "arrayMap",
+                        [
+                            # TODO: should this transform be moved to snuba?
+                            Lambda(
+                                ["x"],
+                                Function(
+                                    "replaceAll", [Function("toString", [Identifier("x")]), "-", ""]
+                                ),
+                            ),
+                            Function(
+                                f"groupUniqArrayMerge({args['count']})", [SnQLColumn("examples")]
                             ),
                         ],
                         alias,

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -888,6 +888,23 @@ class NullColumn(FunctionArg):
         return None
 
 
+class IntArg(FunctionArg):
+    def __init__(self, name: str, negative: bool):
+        super().__init__(name)
+        self.negative = negative
+
+    def normalize(self, value: str, params: ParamsType, combinator: Optional[Combinator]) -> int:
+        try:
+            normalized_value = int(value)
+        except ValueError:
+            raise InvalidFunctionArgument(f"{value} is not an integer")
+
+        if not self.negative and normalized_value < 0:
+            raise InvalidFunctionArgument(f"{value} must be non negative")
+
+        return normalized_value
+
+
 class NumberRange(FunctionArg):
     def __init__(self, name: str, start: Optional[float], end: Optional[float]):
         super().__init__(name)

--- a/tests/sentry/profiles/test_flamegraph.py
+++ b/tests/sentry/profiles/test_flamegraph.py
@@ -1,0 +1,94 @@
+from datetime import timedelta, timezone
+
+from sentry.profiles.flamegraph import get_profiles_with_function
+from sentry.testutils.cases import ProfilesSnubaTestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.silo import region_silo_test
+from sentry.utils.samples import load_data
+
+
+@region_silo_test
+class GetProfileWithFunctionTest(ProfilesSnubaTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.now = before_now(minutes=10)
+        self.hour_ago = (self.now - timedelta(hours=1)).replace(
+            minute=0, second=0, microsecond=0, tzinfo=timezone.utc
+        )
+
+        for _ in range(3):
+            self.store_functions(
+                [
+                    {
+                        "self_times_ns": [100 for _ in range(10)],
+                        "package": "foo",
+                        "function": "foo",
+                        "in_app": True,
+                    },
+                ],
+                project=self.project,
+                timestamp=self.hour_ago,
+            )
+
+        transaction = load_data("transaction", timestamp=before_now(minutes=10))
+        transaction["transaction"] = "foobar"
+
+        self.store_functions(
+            [
+                {
+                    "self_times_ns": [100 for _ in range(10)],
+                    "package": "foo",
+                    "function": "foo",
+                    "in_app": True,
+                },
+            ],
+            project=self.project,
+            timestamp=self.hour_ago,
+            transaction=transaction,
+        )
+
+    def test_get_profile_with_function(self):
+        profile_ids = get_profiles_with_function(
+            self.organization.id,
+            self.project.id,
+            self.function_fingerprint({"package": "foo", "function": "foo"}),
+            {
+                "organization_id": self.organization.id,
+                "project_id": [self.project.id],
+                "start": before_now(days=1),
+                "end": self.now,
+            },
+            "",
+        )
+        assert len(profile_ids["profile_ids"]) == 4, profile_ids
+
+    def test_get_profile_with_function_with_transaction_filter(self):
+        profile_ids = get_profiles_with_function(
+            self.organization.id,
+            self.project.id,
+            self.function_fingerprint({"package": "foo", "function": "foo"}),
+            {
+                "organization_id": self.organization.id,
+                "project_id": [self.project.id],
+                "start": before_now(days=1),
+                "end": self.now,
+            },
+            "transaction:foobar",
+        )
+        assert len(profile_ids["profile_ids"]) == 1, profile_ids
+
+    def test_get_profile_with_function_no_match(self):
+        profile_ids = get_profiles_with_function(
+            self.organization.id,
+            self.project.id,
+            self.function_fingerprint({"package": "foo", "function": "foo"}),
+            {
+                "organization_id": self.organization.id,
+                "project_id": [self.project.id],
+                "start": before_now(days=1),
+                "end": self.now,
+            },
+            "transaction:foo",
+        )
+        assert len(profile_ids["profile_ids"]) == 0, profile_ids


### PR DESCRIPTION
Passes the `query` from the query parameter to the query builder and ensure it is used in the filters.