### PR TITLE
fix(superuser): use OrganizationStore in isActiveSuperuser

### DIFF
--- a/static/app/components/acl/role.spec.tsx
+++ b/static/app/components/acl/role.spec.tsx
@@ -1,4 +1,3 @@
-import Cookies from 'js-cookie';
 import {Organization} from 'sentry-fixture/organization';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
@@ -6,6 +5,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {Role} from 'sentry/components/acl/role';
 import ConfigStore from 'sentry/stores/configStore';
+import OrganizationStore from 'sentry/stores/organizationStore';
 
 describe('Role', function () {
   const organization = Organization({
@@ -46,6 +46,7 @@ describe('Role', function () {
   describe('as render prop', function () {
     const childrenMock = jest.fn().mockReturnValue(null);
     beforeEach(function () {
+      OrganizationStore.init();
       childrenMock.mockClear();
     });
 
@@ -68,20 +69,14 @@ describe('Role', function () {
     });
 
     it('gives access to a superuser with insufficient role', function () {
-      ConfigStore.config.user = TestStubs.User({isSuperuser: true});
-      Cookies.set = jest.fn();
+      organization.access = ['org:superuser'];
+      OrganizationStore.onUpdate(organization, {replace: true});
 
       render(<Role role="owner">{childrenMock}</Role>, {context: routerContext});
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasRole: true,
       });
-      expect(Cookies.set).toHaveBeenCalledWith(
-        'su-test-cookie',
-        'set-in-isActiveSuperuser',
-        {domain: '.sentry.io'}
-      );
-      ConfigStore.config.user = TestStubs.User({isSuperuser: false});
     });
 
     it('does not give access to a made up role', function () {

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -116,7 +116,7 @@ function Sidebar({organization}: Props) {
 
   const collapsed = !!preferences.collapsed;
   const horizontal = useMedia(`(max-width: ${theme.breakpoints.medium})`);
-  const hasSuperuserSession = isActiveSuperuser(organization);
+  const hasSuperuserSession = isActiveSuperuser();
 
   useOpenOnboardingSidebar();
 

--- a/static/app/utils/isActiveSuperuser.tsx
+++ b/static/app/utils/isActiveSuperuser.tsx
@@ -1,7 +1,7 @@
 import Cookies from 'js-cookie';
 
 import ConfigStore from 'sentry/stores/configStore';
-import {Organization} from 'sentry/types/organization';
+import OrganizationStore from 'sentry/stores/organizationStore';
 
 const SUPERUSER_COOKIE_NAME = window.superUserCookieName ?? 'su';
 const SUPERUSER_COOKIE_DOMAIN = window.superUserCookieDomain;
@@ -16,7 +16,9 @@ const SUPERUSER_COOKIE_DOMAIN = window.superUserCookieDomain;
  *
  * Documented here: https://getsentry.atlassian.net/browse/ER-1602
  */
-export function isActiveSuperuser(organization?: Organization) {
+export function isActiveSuperuser() {
+  const {organization} = OrganizationStore.getState();
+
   if (organization) {
     return organization.access.includes('org:superuser');
   }

--- a/static/app/views/settings/projectSourceMaps/projectSourceMapsArtifacts.spec.tsx
+++ b/static/app/views/settings/projectSourceMaps/projectSourceMapsArtifacts.spec.tsx
@@ -1,3 +1,4 @@
+import {Organization} from 'sentry-fixture/organization';
 import {SourceMapArchive} from 'sentry-fixture/sourceMapArchive';
 import {SourceMapArtifact} from 'sentry-fixture/sourceMapArtifact';
 import {SourceMapsDebugIDBundlesArtifacts} from 'sentry-fixture/sourceMapsDebugIDBundlesArtifacts';
@@ -13,6 +14,7 @@ import {
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import ConfigStore from 'sentry/stores/configStore';
+import OrganizationStore from 'sentry/stores/organizationStore';
 import {ProjectSourceMapsArtifacts} from 'sentry/views/settings/projectSourceMaps/projectSourceMapsArtifacts';
 
 function renderReleaseBundlesMockRequests({
@@ -78,9 +80,16 @@ function renderDebugIdBundlesMockRequests({
 }
 
 describe('ProjectSourceMapsArtifacts', function () {
+  beforeEach(function () {
+    OrganizationStore.init();
+  });
+
   describe('Release Bundles', function () {
     it('renders default state', async function () {
       const {organization, routerContext, project, routerProps} = initializeOrg({
+        organization: Organization({
+          access: ['org:superuser'],
+        }),
         router: {
           location: {
             query: {},
@@ -88,6 +97,8 @@ describe('ProjectSourceMapsArtifacts', function () {
           params: {},
         },
       });
+
+      OrganizationStore.onUpdate(organization, {replace: true});
 
       ConfigStore.config = {
         ...ConfigStore.config,
@@ -174,6 +185,9 @@ describe('ProjectSourceMapsArtifacts', function () {
   describe('Artifact Bundles', function () {
     it('renders default state', async function () {
       const {organization, project, routerProps, routerContext} = initializeOrg({
+        organization: Organization({
+          access: ['org:superuser', 'project:releases'],
+        }),
         router: {
           location: {
             pathname: `/settings/${initializeOrg().organization.slug}/projects/${
@@ -184,6 +198,8 @@ describe('ProjectSourceMapsArtifacts', function () {
           params: {},
         },
       });
+
+      OrganizationStore.onUpdate(organization, {replace: true});
 
       ConfigStore.config = {
         ...ConfigStore.config,


### PR DESCRIPTION
Instead of forcing call sites of `isActiveSuperuser` to pass in an organization we can use `OrganizationStore` to fetch the org.