### PR TITLE
fix(metrics): Move metrics calculations back to client

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -189,9 +189,9 @@ class IndexerBatch:
         self.__message_tags_len_max[use_case_id] = max(
             len(parsed_payload.get("tags", {})), self.__message_tags_len_max[use_case_id]
         )
-        self.__message_tags_len_max[use_case_id] = max(
+        self.__message_value_len_max[use_case_id] = max(
             len(parsed_payload["value"]) if isinstance(parsed_payload["value"], Iterable) else 1,
-            self.__message_tags_len_max[use_case_id],
+            self.__message_value_len_max[use_case_id],
         )
 
         return parsed_payload
@@ -517,41 +517,54 @@ class IndexerBatch:
                 tags={"use_case_id": use_case_id.value},
             )
             metrics.distribution(
-                "metrics_consumer.process_message.message.size",
-                self.__message_bytes[use_case_id],
+                "metrics_consumer.process_message.message.avg_size_in_batch",
+                self.__message_bytes[use_case_id] / self.__message_count[use_case_id],
                 tags={"use_case_id": use_case_id.value},
                 unit="byte",
             )
             metrics.distribution(
-                "metrics_consumer.process_message.message.tags_len",
-                self.__message_tags_len[use_case_id],
+                "metrics_consumer.process_message.message.avg_tags_len_in_batch",
+                self.__message_tags_len[use_case_id] / self.__message_count[use_case_id],
                 tags={"use_case_id": use_case_id.value},
                 unit="int",
             )
             metrics.distribution(
-                "metrics_consumer.process_message.message.value_len",
-                self.__message_value_len[use_case_id],
+                "metrics_consumer.process_message.message.avg_value_len_in_batch",
+                self.__message_value_len[use_case_id] / self.__message_count[use_case_id],
                 tags={"use_case_id": use_case_id.value},
                 unit="int",
             )
             metrics.gauge(
-                "metrics_consumer.process_message.message.max_size",
-                self.__message_bytes[use_case_id],
+                "metrics_consumer.process_message.message.max_size_in_batch",
+                self.__message_bytes_max[use_case_id],
                 tags={"use_case_id": use_case_id.value},
                 unit="byte",
             )
             metrics.gauge(
-                "metrics_consumer.process_message.message.max_tags_len",
-                self.__message_tags_len[use_case_id],
+                "metrics_consumer.process_message.message.max_tags_len_in_batch",
+                self.__message_tags_len_max[use_case_id],
                 tags={"use_case_id": use_case_id.value},
                 unit="int",
             )
             metrics.gauge(
-                "metrics_consumer.process_message.message.max_value_len",
-                self.__message_value_len[use_case_id],
+                "metrics_consumer.process_message.message.max_value_len_in_batch",
+                self.__message_value_len_max[use_case_id],
                 tags={"use_case_id": use_case_id.value},
                 unit="int",
             )
+        num_messages = sum(self.__message_count.values())
+        metrics.gauge(
+            "metrics_consumer.process_message.message.avg_size_in_batch",
+            sum(self.__message_bytes.values()) / num_messages,
+        )
+        metrics.gauge(
+            "metrics_consumer.process_message.message.avg_tags_len_in_batch",
+            sum(self.__message_tags_len.values()) / num_messages,
+        )
+        metrics.gauge(
+            "metrics_consumer.process_message.message.avg_value_len_in_batch",
+            sum(self.__message_value_len.values()) / num_messages,
+        )
 
         return IndexerOutputMessageBatch(
             new_messages,


### PR DESCRIPTION
### Overview

The previous changes made to the metrics that the indexer emit is not as good as I like. It suffers from 2 problems:
1. During deployment the metrics becomes really spiky, which causes the graph to not be very useful when zooming out to see values over the last few days.
2. The average values are broken because we are emitting the sum over a batch

This pr moves the calculation to client side