### PR TITLE
feat(crons): Validate that a monitor may be assigned a seat

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_details.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_details.py
@@ -117,7 +117,11 @@ class OrganizationMonitorDetailsEndpoint(MonitorEndpoint):
                 "config": monitor.config,
                 "project": project,
             },
-            context={"organization": organization, "access": request.access},
+            context={
+                "organization": organization,
+                "access": request.access,
+                "monitor": monitor,
+            },
         )
         if not validator.is_valid():
             return self.respond(validator.errors, status=400)

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import IntEnum, unique
 from typing import TYPE_CHECKING, Any, Optional, Tuple
 
@@ -177,6 +178,18 @@ def _limit_from_settings(x: Any) -> int | None:
     """
 
     return int(x or 0) or None
+
+
+@dataclass
+class SeatAssignmentResult:
+    assignable: bool
+    """
+    Can the seat assignment be made?
+    """
+    reason: Optional[str] = None
+    """
+    The human readable reason the assignment can be made or not.
+    """
 
 
 def index_data_category(event_type: Optional[str], organization) -> DataCategory:
@@ -497,12 +510,18 @@ class Quota(Service):
         :param volume: The volume of transaction of the given project.
         """
 
-    def assign_monitor_seat(
-        self,
-        monitor: Monitor,
-    ) -> int:
+    def check_assign_monitor_seat(self, monitor: Monitor) -> SeatAssignmentResult:
         """
-        Determines if a monitor seat assignment is accepted or rate limited.
+        Determines if a monitor can be assigned a seat. If it is not possible
+        to assign a monitor a seat, a reason will be included in the response
+        """
+        return SeatAssignmentResult(assignable=True)
+
+    def assign_monitor_seat(self, monitor: Monitor) -> int:
+        """
+        Assigns a monitor a seat if possible, resulting in a Outcome.ACCEPTED.
+        If the monitor cannot be assigned a seat it will be
+        Outcome.RATE_LIMITED.
         """
         from sentry.utils.outcomes import Outcome
 

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_details.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 import pytest
 
@@ -17,6 +18,7 @@ from sentry.monitors.models import (
     ScheduleType,
 )
 from sentry.monitors.utils import get_timeout_at
+from sentry.quotas.base import SeatAssignmentResult
 from sentry.testutils.cases import MonitorTestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import region_silo_test
@@ -566,6 +568,41 @@ class UpdateMonitorTest(MonitorTestCase):
         assert (
             resp.data["detail"]["message"] == "existing monitors may not be moved between projects"
         ), resp.content
+
+    @patch("sentry.quotas.backend.check_assign_monitor_seat")
+    def test_activate_monitor_success(self, check_assign_monitor_seat):
+        check_assign_monitor_seat.return_value = SeatAssignmentResult(assignable=True)
+
+        monitor = self._create_monitor()
+        monitor.update(status=ObjectStatus.DISABLED)
+
+        self.get_success_response(
+            self.organization.slug, monitor.slug, method="PUT", **{"status": "active"}
+        )
+
+        monitor = Monitor.objects.get(id=monitor.id)
+        assert monitor.status == ObjectStatus.ACTIVE
+
+    @patch("sentry.quotas.backend.check_assign_monitor_seat")
+    def test_activate_monitor_invalid(self, check_assign_monitor_seat):
+        result = SeatAssignmentResult(
+            assignable=False,
+            reason="Over quota",
+        )
+        check_assign_monitor_seat.return_value = result
+
+        monitor = self._create_monitor()
+        monitor.update(status=ObjectStatus.DISABLED)
+
+        resp = self.get_error_response(
+            self.organization.slug,
+            monitor.slug,
+            method="PUT",
+            status_code=400,
+            **{"status": "active"},
+        )
+
+        assert resp.data["status"][0] == result.reason
 
 
 @region_silo_test()


### PR DESCRIPTION
Introduces a new `check_assign_monitor_seat` quota method.

This allows the monitor details validator to determine if the monitor status change is valid or not.