### PR TITLE
chore: remove lodash usages

### DIFF
--- a/static/app/chartcuterie/discover.tsx
+++ b/static/app/chartcuterie/discover.tsx
@@ -1,5 +1,4 @@
 import type {SeriesOption} from 'echarts';
-import isArray from 'lodash/isArray';
 
 import XAxis from 'sentry/components/charts/components/xAxis';
 import AreaSeries from 'sentry/components/charts/series/areaSeries';
@@ -29,7 +28,7 @@ discoverCharts.push({
       | {seriesName: string; stats: EventsStats}
       | {stats: Record<string, EventsStats>; seriesName?: string}
   ) => {
-    if (isArray(data.stats.data)) {
+    if (Array.isArray(data.stats.data)) {
       const color = theme.charts.getColorPalette(data.stats.data.length - 2);
       const areaSeries = AreaSeries({
         name: data.seriesName,
@@ -87,7 +86,7 @@ discoverCharts.push({
       | {seriesName: string; stats: EventsStats}
       | {stats: Record<string, EventsStats>; seriesName?: string}
   ) => {
-    if (isArray(data.stats.data)) {
+    if (Array.isArray(data.stats.data)) {
       const color = theme.charts.getColorPalette(data.stats.data.length - 2);
 
       const barSeries = BarSeries({
@@ -147,7 +146,7 @@ discoverCharts.push({
   getOption: (
     data: {stats: Record<string, EventsStats>} | {stats: EventsStats; seriesName?: string}
   ) => {
-    if (isArray(data.stats.data)) {
+    if (Array.isArray(data.stats.data)) {
       const color = theme.charts.getColorPalette(data.stats.data.length - 2);
 
       const areaSeries = AreaSeries({
@@ -204,7 +203,7 @@ discoverCharts.push({
   getOption: (
     data: {stats: Record<string, EventsStats>} | {stats: EventsStats; seriesName?: string}
   ) => {
-    if (isArray(data.stats.data)) {
+    if (Array.isArray(data.stats.data)) {
       const color = theme.charts.getColorPalette(data.stats.data.length - 2);
 
       const lineSeries = LineSeries({
@@ -260,7 +259,7 @@ discoverCharts.push({
   getOption: (
     data: {stats: Record<string, EventsStats>} | {stats: EventsStats; seriesName?: string}
   ) => {
-    if (isArray(data.stats.data)) {
+    if (Array.isArray(data.stats.data)) {
       const color = theme.charts.getColorPalette(data.stats.data.length - 2);
 
       const areaSeries = AreaSeries({
@@ -318,7 +317,7 @@ discoverCharts.push({
       | {seriesName: string; stats: EventsStats}
       | {stats: Record<string, EventsStats>; seriesName?: string}
   ) => {
-    if (isArray(data.stats.data)) {
+    if (Array.isArray(data.stats.data)) {
       const dataMiddleIndex = Math.floor(data.stats.data.length / 2);
       const current = data.stats.data.slice(dataMiddleIndex);
       const previous = data.stats.data.slice(0, dataMiddleIndex);

--- a/static/app/components/contextData/index.tsx
+++ b/static/app/components/contextData/index.tsx
@@ -1,8 +1,6 @@
 import {isValidElement} from 'react';
 import styled from '@emotion/styled';
-import isArray from 'lodash/isArray';
 import isNumber from 'lodash/isNumber';
-import isString from 'lodash/isString';
 
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -60,7 +58,7 @@ function walk({
     );
   }
 
-  if (isString(value)) {
+  if (typeof value === 'string') {
     const valueInfo = analyzeStringForRepr(value);
 
     const valueToBeReturned = withAnnotatedText ? (
@@ -103,7 +101,7 @@ function walk({
     return <span>{valueToBeReturned}</span>;
   }
 
-  if (isArray(value)) {
+  if (Array.isArray(value)) {
     for (i = 0; i < value.length; i++) {
       children.push(
         <span className="val-array-item" key={i}>

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -2,7 +2,6 @@ import {browserHistory} from 'react-router';
 import {Theme} from '@emotion/react';
 import {Location} from 'history';
 import isNumber from 'lodash/isNumber';
-import isString from 'lodash/isString';
 import maxBy from 'lodash/maxBy';
 import set from 'lodash/set';
 import moment from 'moment';
@@ -39,7 +38,7 @@ import {
 } from './types';
 
 export const isValidSpanID = (maybeSpanID: any) =>
-  isString(maybeSpanID) && maybeSpanID.length > 0;
+  typeof maybeSpanID === 'string' && maybeSpanID.length > 0;
 
 export type SpanBoundsType = {endTimestamp: number; startTimestamp: number};
 export type SpanGeneratedBoundsType =

--- a/static/app/components/events/interfaces/utils.tsx
+++ b/static/app/components/events/interfaces/utils.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react';
-import isString from 'lodash/isString';
 import partition from 'lodash/partition';
 import * as qs from 'query-string';
 
@@ -157,7 +156,7 @@ export function getCurlCommand(data: EntryRequest['data']) {
         break;
 
       default:
-        if (isString(data.data)) {
+        if (typeof data.data === 'string') {
           result += ' \\\n --data "' + escapeBashString(data.data) + '"';
         } else if (Object.keys(data.data).length === 0) {
           // Do nothing with empty object data.
@@ -175,7 +174,7 @@ export function getCurlCommand(data: EntryRequest['data']) {
 }
 
 export function stringifyQueryList(query: string | [key: string, value: string][]) {
-  if (isString(query)) {
+  if (typeof query === 'string') {
     return query;
   }
 

--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
 import isNumber from 'lodash/isNumber';
-import isString from 'lodash/isString';
 import moment from 'moment-timezone';
 
 import {Tooltip} from 'sentry/components/tooltip';
@@ -11,7 +10,7 @@ import getDynamicText from 'sentry/utils/getDynamicText';
 import {ColorOrAlias} from 'sentry/utils/theme';
 
 function getDateObj(date: RelaxedDateType): Date {
-  return isString(date) || isNumber(date) ? new Date(date) : date;
+  return typeof date === 'string' || isNumber(date) ? new Date(date) : date;
 }
 
 type RelaxedDateType = string | number | Date;

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -2,7 +2,6 @@ import {cloneElement, Fragment, isValidElement} from 'react';
 import * as Sentry from '@sentry/react';
 import Jed from 'jed';
 import isObject from 'lodash/isObject';
-import isString from 'lodash/isString';
 import {sprintf} from 'sprintf-js';
 
 import localStorage from 'sentry/utils/localStorage';
@@ -98,7 +97,7 @@ function formatForReact(formatString: string, args: FormatArg[]): React.ReactNod
 
   // always re-parse, do not cache, because we change the match
   sprintf.parse(formatString).forEach((match: any, idx: number) => {
-    if (isString(match)) {
+    if (typeof match === 'string') {
       nodes.push(match);
       return;
     }
@@ -249,7 +248,7 @@ export function renderTemplate(
     const group = template[groupKey] || [];
 
     for (const item of group) {
-      if (isString(item)) {
+      if (typeof item === 'string') {
         children.push(<Fragment key={idx++}>{item}</Fragment>);
       } else {
         children.push(renderGroup(item.group));

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -1,7 +1,5 @@
 import {Query} from 'history';
-import isArray from 'lodash/isArray';
 import isObject from 'lodash/isObject';
-import isString from 'lodash/isString';
 
 import ConfigStore from 'sentry/stores/configStore';
 import {Project} from 'sentry/types';
@@ -31,7 +29,7 @@ export function valueIsEqual(value?: any, other?: any, deep?: boolean): boolean 
   if (value === other) {
     return true;
   }
-  if (isArray(value) || isArray(other)) {
+  if (Array.isArray(value) || Array.isArray(other)) {
     if (arrayIsEqual(value, other, deep)) {
       return true;
     }
@@ -135,8 +133,7 @@ export function nl2br(str: string): string {
  */
 export function isUrl(str: any): boolean {
   return (
-    !!str &&
-    isString(str) &&
+    typeof str === 'string' &&
     (str.indexOf('http://') === 0 || str.indexOf('https://') === 0)
   );
 }

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -1,7 +1,6 @@
 import {Location, Query} from 'history';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
-import isString from 'lodash/isString';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 import uniqBy from 'lodash/uniqBy';
@@ -188,7 +187,7 @@ export const fromSorts = (sorts: string | string[] | undefined): Array<Sort> => 
     return [];
   }
 
-  sorts = isString(sorts) ? [sorts] : sorts;
+  sorts = typeof sorts === 'string' ? [sorts] : sorts;
 
   // NOTE: sets are iterated in insertion order
   const uniqueSorts = [...new Set(sorts)];

--- a/static/app/utils/queryString.tsx
+++ b/static/app/utils/queryString.tsx
@@ -1,4 +1,3 @@
-import isString from 'lodash/isString';
 import * as qs from 'query-string';
 
 import {escapeDoubleQuotes} from 'sentry/utils';
@@ -41,7 +40,11 @@ export function appendTagCondition(
   key: string,
   value: null | string
 ): string {
-  let currentQuery = Array.isArray(query) ? query.pop() : isString(query) ? query : '';
+  let currentQuery = Array.isArray(query)
+    ? query.pop()
+    : typeof query === 'string'
+    ? query
+    : '';
 
   if (typeof value === 'string' && /[:\s\(\)\\"]/g.test(value)) {
     value = `"${escapeDoubleQuotes(value)}"`;
@@ -60,7 +63,11 @@ export function appendExcludeTagValuesCondition(
   key: string,
   values: string[]
 ): string {
-  let currentQuery = Array.isArray(query) ? query.pop() : isString(query) ? query : '';
+  let currentQuery = Array.isArray(query)
+    ? query.pop()
+    : typeof query === 'string'
+    ? query
+    : '';
   const filteredValuesCondition = `[${values
     .map(value => {
       if (typeof value === 'string' && /[\s"]/g.test(value)) {
@@ -89,17 +96,17 @@ export function decodeScalar(value: QueryValue, fallback?: string): string | und
   const unwrapped =
     Array.isArray(value) && value.length > 0
       ? value[0]
-      : isString(value)
+      : typeof value === 'string'
       ? value
       : fallback;
-  return isString(unwrapped) ? unwrapped : fallback;
+  return typeof unwrapped === 'string' ? unwrapped : fallback;
 }
 
 export function decodeList(value: string[] | string | undefined | null): string[] {
   if (!value) {
     return [];
   }
-  return Array.isArray(value) ? value : isString(value) ? [value] : [];
+  return Array.isArray(value) ? value : typeof value === 'string' ? [value] : [];
 }
 
 // This function has multiple signatures to help with typing in callers.

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -1,7 +1,6 @@
 import {browserHistory, InjectedRouter} from 'react-router';
 import {urlEncode} from '@sentry/utils';
 import {Location, Query} from 'history';
-import isString from 'lodash/isString';
 import * as Papa from 'papaparse';
 
 import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
@@ -745,7 +744,7 @@ export function getTargetForTransactionSummaryLink(
   let projectID: string | string[] | undefined;
   const filterProjects = location?.query.project;
 
-  if (isString(filterProjects) && filterProjects !== '-1') {
+  if (typeof filterProjects === 'string' && filterProjects !== '-1') {
     // Project selector in discover has just one selected project
     projectID = filterProjects;
   } else {

--- a/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
+++ b/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
@@ -1,7 +1,6 @@
 import {Component} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import isString from 'lodash/isString';
 
 import {Client, ResponseMeta} from 'sentry/api';
 import {Alert} from 'sentry/components/alert';
@@ -81,7 +80,7 @@ class ProjectDetailsInner extends Component<DetailsProps, DetailsState> {
 
   hasProjectId() {
     const projectID = this.getProjectId();
-    return isString(projectID) && projectID.length > 0;
+    return typeof projectID === 'string' && projectID.length > 0;
   }
 
   getOrganizationId() {


### PR DESCRIPTION
Removes unnecessary Lodash usages. More information can be found from [You don't need Lodash](https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore) repository.

Removed usages:

- `lodash/isArray`
- `lodash/isString`