### PR TITLE
feat(grouping): Do not include sentinel and prefix frames in latest config

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -279,38 +279,6 @@ module:java.lang.Runtime function:loadLibrary* category=load
 
 family:native function:pthread_mutex_lock category=lock
 
-# not interesting at all, if for some reason this gets picked as grouping
-# frame, add the next one too
-category:free +prefix
-category:malloc +prefix
-
-# lock: fails to get acquired/released
-category:lock +sentinel +prefix
-
-# load: dylib/module fails to get loaded
-category:load +sentinel +prefix
-
-# driver crash, similar reasoning as for GL
-category:driver +sentinel +prefix
-
-# UI: This is mostly interesting for ANR, where we need to pick interesting UI
-# frames to group by. Sometimes it can also happen that some UI framework
-# crashes without the (calling) app being at fault, that's where this also gets
-# useful.
-category:ui +sentinel +prefix
-
-# GL: We've observed that the same sequence of app
-# ("submit data buffer") frames triggers very different crashes in there.
-category:gl +sentinel
-
-# runtime: frames from a garbage collector, JIT or something else in the language
-# runtime. Only add frames to this category if you think their presence makes it
-# unlikely that app frames are relevant, e.g. because app frames can't call the
-# JIT/GC directly, or at least not this way and it's really the runtime being
-# buggy, not the app (or at least unlikely that it's the app code currently running).
-category:runtime +sentinel
-
-
 # Ignore driver frame if it is directly calling another driver frame. This
 # removes a lot of noise from the stack especially if most of the called frames
 # failed symbolication, stack scanning was done or to paper over differences in
@@ -324,10 +292,6 @@ category:driver | [ category:driver ] category=internals
 
 # Only group by top-level malloc op, not any helper function it may have called.
 [ category:malloc ] | category:malloc category=internals
-
-# abort() and exception raising is technically the culprit for crashes, but not
-# the thing we want to show.
-category:throw +prefix ^-group
 
 # On Windows, _purecall internally aborts when the function pointer is invalid.
 # We want to treat this the same as a segfault happening before calling

--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -293,6 +293,10 @@ category:driver | [ category:driver ] category=internals
 # Only group by top-level malloc op, not any helper function it may have called.
 [ category:malloc ] | category:malloc category=internals
 
+# abort() and exception raising is technically the culprit for crashes, but not
+# the thing we want to show.
+category:throw ^-group
+
 # On Windows, _purecall internally aborts when the function pointer is invalid.
 # We want to treat this the same as a segfault happening before calling
 # _purecall.

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/android_anr.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2023-12-12T13:53:09.636718Z'
+creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
@@ -70,7 +72,7 @@ app:
               "choreographer.java"
             function*
               "run"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.view.Choreographer"
             filename (module takes precedence)
@@ -98,7 +100,7 @@ app:
               "viewrootimpl.java"
             function*
               "run"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.view.ViewRootImpl"
             filename (module takes precedence)
@@ -133,7 +135,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -161,7 +163,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
@@ -196,7 +198,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -224,7 +226,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
@@ -259,7 +261,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -287,7 +289,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -315,7 +317,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -343,7 +345,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -371,7 +373,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -399,7 +401,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -427,7 +429,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -455,7 +457,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -483,7 +485,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
@@ -518,7 +520,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -546,7 +548,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -574,7 +576,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
@@ -609,7 +611,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -637,7 +639,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.LinearLayout"
             filename (module takes precedence)
@@ -672,7 +674,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "android.widget.FrameLayout"
             filename (module takes precedence)
@@ -700,7 +702,7 @@ app:
               "view.java"
             function*
               "layout"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)
@@ -1483,7 +1485,7 @@ system:
               "view.java"
             function*
               "layout"
-          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame*
             module*
               "androidx.recyclerview.widget.RecyclerView"
             filename (module takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:07.751949Z'
+created: '2023-12-12T13:53:16.104124Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,7 +18,7 @@ app:
           frame (non app frame)
             function*
               "UIApplicationMain"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             function*
               "-[UIApplication _run]"
           frame (non app frame)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:06.277778Z'
+created: '2023-12-12T13:53:13.957393Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -26,7 +26,7 @@ app:
           frame (non app frame)
             function*
               "UIApplicationMain"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             function*
               "-[UIApplication _run]"
           frame (non app frame)
@@ -102,7 +102,7 @@ system:
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
-          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame*
             function*
               "-[UIApplication _run]"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:03.397605Z'
+created: '2023-12-12T14:07:26.922870Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,13 +18,13 @@ app:
           frame (non app frame)
             function*
               "UIApplicationMain"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             function*
               "-[UIApplication _run]"
           frame (non app frame)
             function*
               "GSEventRunModal"
-          frame (marked as prefix frame by stack trace rule (category:free +prefix))
+          frame (non app frame)
             function*
               "objc_release"
         type*
@@ -45,13 +45,13 @@ system:
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
-          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame*
             function*
               "-[UIApplication _run]"
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "GSEventRunModal"
-          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
+          frame*
             function*
               "objc_release"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:21:59.369986Z'
+created: '2023-12-12T13:53:07.554820Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -119,7 +119,7 @@ app:
           frame (non app frame)
             function*
               "_CFBundleDlfcnLoadBundle"
-          frame (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "dlopen"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -258,7 +258,7 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "_CFBundleDlfcnLoadBundle"
-          frame* (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "dlopen"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:05.603596Z'
+created: '2023-12-12T14:07:28.313265Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -45,7 +45,7 @@ app:
           frame (non app frame)
             function*
               "destructor'"
-          frame (marked as prefix frame by stack trace rule (category:free +prefix))
+          frame (non app frame)
             function*
               "RtlFreeHeap"
           frame (non app frame)
@@ -57,7 +57,7 @@ app:
           frame (non app frame)
             function*
               "RtlpFreeUserBlockToHeap"
-          frame (marked as prefix frame by stack trace rule (category:free +prefix))
+          frame (non app frame)
             function*
               "RtlFreeHeap"
           frame (non app frame)
@@ -128,7 +128,7 @@ system:
           frame*
             function*
               "destructor'"
-          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
+          frame*
             function*
               "RtlFreeHeap"
           frame (ignored by stack trace rule (category:internals -group))
@@ -140,7 +140,7 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "RtlpFreeUserBlockToHeap"
-          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
+          frame*
             function*
               "RtlFreeHeap"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:05.318316Z'
+created: '2023-12-12T14:07:27.737598Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -53,7 +53,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+          frame (non app frame)
             function*
               "glDeleteTextures_Exec"
           frame (non app frame)
@@ -71,7 +71,7 @@ app:
           frame (non app frame)
             function*
               "gpusSubmitDataBuffers"
-          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame (non app frame)
             function*
               "gldCreateDevice"
           frame (non app frame)
@@ -80,7 +80,7 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -144,7 +144,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+          frame*
             function*
               "glDeleteTextures_Exec"
           frame (ignored by stack trace rule (category:internals -group))
@@ -162,7 +162,7 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "gpusSubmitDataBuffers"
-          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame*
             function*
               "gldCreateDevice"
           frame (ignored by stack trace rule (category:telemetry -group))
@@ -171,13 +171,13 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:27.737598Z'
+created: '2023-12-12T15:27:59.106711Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -174,10 +174,10 @@ system:
           frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__abort"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:27.611086Z'
+created: '2023-12-12T15:27:58.915158Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -144,7 +144,7 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "ba708cc62a8c075bf5ba767c5332dba6"
+  hash: "49b6f72b6635cb43190c57ee56b026b0"
   component:
     system*
       exception*
@@ -262,19 +262,19 @@ system:
           frame* (marked out of app by stack trace rule (family:native function:std::* -app))
             function*
               "std::terminate"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "std::__terminate"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "default_terminate_handler"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "abort_message"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:04.267297Z'
+created: '2023-12-12T14:07:27.611086Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -72,7 +72,7 @@ app:
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame (marked as prefix frame by stack trace rule (category:malloc +prefix))
+          frame (marked out of app by stack trace rule (family:native function:std::* -app))
             filename*
               "memory"
             function*
@@ -119,7 +119,7 @@ app:
           frame (marked out of app by stack trace rule (family:native function:std::* -app))
             function*
               "std::__1::thread::~thread"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (marked out of app by stack trace rule (family:native function:std::* -app))
             function*
               "std::terminate"
           frame (marked out of app by stack trace rule (family:native function:std::* -app))
@@ -131,7 +131,7 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort_message"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -144,7 +144,7 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "49b6f72b6635cb43190c57ee56b026b0"
+  hash: "ba708cc62a8c075bf5ba767c5332dba6"
   component:
     system*
       exception*
@@ -212,7 +212,7 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
+          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
             filename*
               "memory"
             function*
@@ -259,22 +259,22 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::__1::thread::~thread"
-          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
             function*
               "std::terminate"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::__terminate"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "default_terminate_handler"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "abort_message"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:06.540670Z'
+created: '2023-12-12T14:07:30.131130Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -88,7 +88,7 @@ app:
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame (marked as prefix frame by stack trace rule (category:malloc +prefix))
+          frame (marked out of app by stack trace rule (family:native function:std::* -app))
             filename*
               "memory"
             function*
@@ -132,7 +132,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (marked out of app by stack trace rule (family:native function:std::* -app))
             function*
               "std::terminate"
           frame (marked out of app by stack trace rule (family:native function:std::* -app))
@@ -144,7 +144,7 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort_message"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -159,7 +159,7 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "49b6f72b6635cb43190c57ee56b026b0"
+  hash: "ba708cc62a8c075bf5ba767c5332dba6"
   component:
     system*
       exception*
@@ -243,7 +243,7 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
+          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
             filename*
               "memory"
             function*
@@ -287,25 +287,25 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
             function*
               "std::terminate"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::__terminate"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "demangling_terminate_handler"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "abort_message"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:30.131130Z'
+created: '2023-12-12T15:28:00.451600Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -159,7 +159,7 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "ba708cc62a8c075bf5ba767c5332dba6"
+  hash: "49b6f72b6635cb43190c57ee56b026b0"
   component:
     system*
       exception*
@@ -290,22 +290,22 @@ system:
           frame* (marked out of app by stack trace rule (family:native function:std::* -app))
             function*
               "std::terminate"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "std::__terminate"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "demangling_terminate_handler"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "abort_message"
-          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__abort"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:06.826856Z'
+created: '2023-12-12T14:07:30.638127Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -158,7 +158,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "dlopen"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -177,7 +177,7 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "__report_load.cold.1"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -346,7 +346,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "dlopen"
           frame (ignored by stack trace rule (category:indirection -group))
@@ -365,13 +365,13 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "__report_load.cold.1"
-          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:30.638127Z'
+created: '2023-12-12T15:28:00.792724Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -368,10 +368,10 @@ system:
           frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__abort"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:06.989168Z'
+created: '2023-12-12T14:07:30.777122Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -155,7 +155,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "dlopen"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -182,7 +182,7 @@ app:
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "__report_load"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -348,7 +348,7 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "dlopen"
           frame (ignored by stack trace rule (category:internals -group))
@@ -375,13 +375,13 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "__report_load"
-          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:30.777122Z'
+created: '2023-12-12T15:28:01.041311Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -378,10 +378,10 @@ system:
           frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__abort"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:00.175091Z'
+created: '2023-12-12T14:07:23.514672Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -81,7 +81,7 @@ app:
           frame (non app frame)
             function*
               "-[NSOpenGLContext flushBuffer]"
-          frame (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+          frame (non app frame)
             function*
               "CGLFlushDrawable"
           frame (non app frame)
@@ -99,7 +99,7 @@ app:
           frame (non app frame)
             function*
               "IntelCommandBuffer::getNew"
-          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame (non app frame)
             function*
               "gpusSubmitDataBuffers"
           frame (non app frame)
@@ -111,7 +111,7 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
           frame (non app frame)
@@ -153,7 +153,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+          frame (non app frame)
             function*
               "CGLTexImageIOSurface2D"
           frame (non app frame)
@@ -171,7 +171,7 @@ app:
           frame (non app frame)
             function*
               "IntelCommandBuffer::getNew"
-          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame (non app frame)
             function*
               "gpusSubmitDataBuffers"
           frame (non app frame)
@@ -183,7 +183,7 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -195,7 +195,7 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "7e64037e487c78ce0439f750a2ef503f"
+  hash: "7ffa495d1ad08294df8cbd53880b5142"
   component:
     system*
       exception*
@@ -272,7 +272,7 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "-[NSOpenGLContext flushBuffer]"
-          frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+          frame*
             function*
               "CGLFlushDrawable"
           frame (ignored by stack trace rule (category:internals -group))
@@ -290,7 +290,7 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "IntelCommandBuffer::getNew"
-          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame*
             function*
               "gpusSubmitDataBuffers"
           frame (ignored by stack trace rule (category:telemetry -group))
@@ -302,16 +302,16 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame*
             function*
               "stripped_application_code"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "_sigtramp"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
@@ -320,64 +320,64 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "NSRunAlertPanel"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "_NSTryRunModal"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "CA::Transaction::commit"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "CA::Context::commit_transaction"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "CA::Layer::display_if_needed"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "CGLTexImageIOSurface2D"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "CGLDescribeRenderer"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "gliSetInteger"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "gldFlushObject"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "intelSubmitCommands"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "IntelCommandBuffer::getNew"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "gpusSubmitDataBuffers"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "gpusKillClientExt"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:23.514672Z'
+created: '2023-12-12T15:27:56.059424Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -195,7 +195,7 @@ app:
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 system:
-  hash: "7ffa495d1ad08294df8cbd53880b5142"
+  hash: "7e64037e487c78ce0439f750a2ef503f"
   component:
     system*
       exception*
@@ -305,13 +305,13 @@ system:
           frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame*
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "stripped_application_code"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "_sigtramp"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
@@ -320,64 +320,64 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "NSRunAlertPanel"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "_NSTryRunModal"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "CA::Transaction::commit"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "CA::Context::commit_transaction"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "CA::Layer::display_if_needed"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "CGLTexImageIOSurface2D"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "CGLDescribeRenderer"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "gliSetInteger"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "gldFlushObject"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "intelSubmitCommands"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "IntelCommandBuffer::getNew"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "gpusSubmitDataBuffers"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "gpusKillClientExt"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:23.859708Z'
+created: '2023-12-12T15:27:56.301049Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -240,10 +240,10 @@ system:
           frame*
             function*
               "abort"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "raise"
-          frame (ignored by stack trace rule (category:telemetry -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:00.360259Z'
+created: '2023-12-12T14:07:23.859708Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -112,7 +112,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (non app frame)
             function*
               "abort"
           frame (non app frame)
@@ -237,13 +237,13 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame*
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "raise"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:telemetry -group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:23.292995Z'
+created: '2023-12-12T15:27:55.917350Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -240,10 +240,10 @@ system:
           frame*
             function*
               "abort"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "raise"
-          frame (ignored by stack trace rule (category:telemetry -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:21:59.988672Z'
+created: '2023-12-12T14:07:23.292995Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -112,7 +112,7 @@ app:
           frame (non app frame)
             function*
               "stripped_application_code"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (non app frame)
             function*
               "abort"
           frame (non app frame)
@@ -237,13 +237,13 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame*
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "raise"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:telemetry -group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:21:59.198550Z'
+created: '2023-12-12T14:07:20.542892Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -136,7 +136,7 @@ app:
           frame (non app frame)
             function*
               "abort"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (non app frame)
             function*
               "raise"
           frame (non app frame)
@@ -282,10 +282,10 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "abort"
-          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame*
             function*
               "raise"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:telemetry -group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:20.542892Z'
+created: '2023-12-12T15:27:54.534928Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -285,7 +285,7 @@ system:
           frame*
             function*
               "raise"
-          frame (ignored by stack trace rule (category:telemetry -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             filename*
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:07.216273Z'
+created: '2023-12-12T13:53:15.232494Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -20,7 +20,7 @@ app:
           frame (non app frame)
             function*
               "UIApplicationMain"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             function*
               "-[UIApplication _run]"
           frame (non app frame)
@@ -64,7 +64,7 @@ app:
               "<compiler-generated>"
             function*
               "TableView.layoutSubviews"
-          frame (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame (non app frame)
             function*
               "-[UITableView layoutSubviews]"
           frame (non app frame)
@@ -165,7 +165,7 @@ system:
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             function*
               "UIApplicationMain"
-          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame*
             function*
               "-[UIApplication _run]"
           frame (ignored by stack trace rule (category:internals -group))
@@ -209,7 +209,7 @@ system:
               "<compiler-generated>"
             function*
               "TableView.layoutSubviews"
-          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+          frame*
             function*
               "-[UITableView layoutSubviews]"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:24.669831Z'
+created: '2023-12-12T15:27:56.927636Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -303,7 +303,7 @@ system:
           frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:01.017659Z'
+created: '2023-12-12T14:07:24.669831Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -126,7 +126,7 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+          frame (non app frame)
             function*
               "glTexSubImage2D"
           frame (non app frame)
@@ -139,14 +139,14 @@ app:
           frame (non app frame)
             function*
               "gpusSubmitDataBuffers"
-          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame (non app frame)
           frame (non app frame)
             function*
               "gpusGenerateCrashLog"
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -280,7 +280,7 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+          frame*
             function*
               "glTexSubImage2D"
           frame (ignored by stack trace rule (category:internals -group))
@@ -293,17 +293,17 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "gpusSubmitDataBuffers"
-          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame
           frame (ignored by stack trace rule (category:telemetry -group))
             function*
               "gpusGenerateCrashLog"
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:02.978272Z'
+created: '2023-12-12T14:07:26.800755Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -74,7 +74,7 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+          frame (non app frame)
             function*
               "CGLTexImageIOSurface2D"
           frame (non app frame)
@@ -92,7 +92,7 @@ app:
           frame (non app frame)
             function*
               "IntelCommandBuffer::getNew"
-          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame (non app frame)
             function*
               "gpusSubmitDataBuffers"
           frame (non app frame)
@@ -104,7 +104,7 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
           frame (non app frame)
@@ -144,7 +144,7 @@ app:
           frame (non app frame)
             function*
               "code"
-          frame (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+          frame (non app frame)
             function*
               "CGLTexImageIOSurface2D"
           frame (non app frame)
@@ -162,7 +162,7 @@ app:
           frame (non app frame)
             function*
               "IntelCommandBuffer::getNew"
-          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame (non app frame)
             function*
               "gpusSubmitDataBuffers"
           frame (non app frame)
@@ -174,7 +174,7 @@ app:
           frame (non app frame)
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -256,7 +256,7 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+          frame*
             function*
               "CGLTexImageIOSurface2D"
           frame (ignored by stack trace rule (category:internals -group))
@@ -274,7 +274,7 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "IntelCommandBuffer::getNew"
-          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame*
             function*
               "gpusSubmitDataBuffers"
           frame (ignored by stack trace rule (category:telemetry -group))
@@ -286,14 +286,14 @@ system:
           frame (ignored by stack trace rule (category:indirection -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "abort"
           frame
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "_sigtramp"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "code"
           frame (ignored due to recursion)
@@ -302,64 +302,64 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "NSRunAlertPanel"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "_NSTryRunModal"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "CA::Transaction::commit"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "CA::Context::commit_transaction"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "CA::Layer::display_if_needed"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "code"
           frame (ignored due to recursion)
             function*
               "code"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "CGLTexImageIOSurface2D"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "CGLDescribeRenderer"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "gliSetInteger"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "gldFlushObject"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "intelSubmitCommands"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "IntelCommandBuffer::getNew"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "gpusSubmitDataBuffers"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "gpusKillClientExt"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:handler ^-group -group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:26.800755Z'
+created: '2023-12-12T15:27:58.522542Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -290,10 +290,10 @@ system:
             function*
               "abort"
           frame
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "_sigtramp"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "code"
           frame (ignored due to recursion)
@@ -302,64 +302,64 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "NSRunAlertPanel"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "_NSTryRunModal"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "CA::Transaction::commit"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "CA::Context::commit_transaction"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "CA::Layer::display_if_needed"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "code"
           frame (ignored due to recursion)
             function*
               "code"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "CGLTexImageIOSurface2D"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "CGLDescribeRenderer"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "gliSetInteger"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "gldFlushObject"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "intelSubmitCommands"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "IntelCommandBuffer::getNew"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "gpusSubmitDataBuffers"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "gpusKillClientExt"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "gpusGenerateCrashLog"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "gpusGenerateCrashLog.cold.1"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:handler ^-group -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T14:07:31.390126Z'
+created: '2023-12-12T15:28:01.679476Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -182,10 +182,10 @@ system:
           frame*
             function*
               "abort"
-          frame (ignored by stack trace rule (category:indirection -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "pthread_kill"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (category:throw ^-group))
             function*
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:07.372589Z'
+created: '2023-12-12T14:07:31.390126Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -75,16 +75,16 @@ app:
           frame (marked out of app by stack trace rule (family:native function:std::* -app))
             function*
               "std::__1::basic_string<T>::~basic_string"
-          frame (marked as prefix frame by stack trace rule (category:free +prefix))
+          frame (non app frame)
             function*
               "free"
-          frame (marked as prefix frame by stack trace rule (category:malloc +prefix))
+          frame (non app frame)
             function*
               "malloc_report"
           frame (non app frame)
             function*
               "malloc_vreport"
-          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame (non app frame)
             function*
               "abort"
           frame (non app frame)
@@ -170,22 +170,22 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::__1::basic_string<T>::~basic_string"
-          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
+          frame*
             function*
               "free"
-          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
+          frame*
             function*
               "malloc_report"
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "malloc_vreport"
-          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+          frame*
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:indirection -group))
             function*
               "pthread_kill"
-          frame (ignored by stack trace rule (category:throw +prefix ^-group))
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:06.354055Z'
+created: '2023-12-12T13:53:14.096424Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -27,7 +27,7 @@ app:
           frame (non app frame)
             function*
               "OpenAdapter10"
-          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame (non app frame)
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value*
@@ -57,7 +57,7 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "OpenAdapter10"
-          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:01.158167Z'
+created: '2023-12-12T13:53:10.012806Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app:
             function*
               "OpenAdapter10"
           frame (non app frame)
-          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame (non app frame)
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value*
@@ -47,7 +47,7 @@ system:
             function*
               "OpenAdapter10"
           frame
-          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame (ignored due to recursion)
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:03.508061Z'
+created: '2023-12-12T13:53:11.913366Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -28,7 +28,7 @@ app:
           frame (non app frame)
             function*
               "OpenAdapter12"
-          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame (non app frame)
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value*
@@ -59,7 +59,7 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "OpenAdapter12"
-          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+          frame
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-02-01T08:22:05.694657Z'
+created: '2023-12-12T14:07:28.469899Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,7 +12,7 @@ app:
           frame (non app frame)
             function*
               "application_frame"
-          frame (marked as prefix frame by stack trace rule (category:malloc +prefix))
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "malloc_zone_malloc"
           frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
@@ -41,7 +41,7 @@ system:
           frame*
             function*
               "application_frame"
-          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
+          frame* (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
             function*
               "malloc_zone_malloc"
           frame (ignored by stack trace rule (category:internals -group))


### PR DESCRIPTION
Sentinel and prefix frames are only used for hierarchical grouping (which we won't be shipping). Customers who are using the hierarchical grouping will not be affected by this since I'm only changing the rules for the latest config.