### PR TITLE
feat(app-start): Add warm and cold start charts

### DIFF
--- a/static/app/views/starfish/modules/mobile/appStartup.tsx
+++ b/static/app/views/starfish/modules/mobile/appStartup.tsx
@@ -46,7 +46,7 @@ export default function InitializationModule() {
                     <ReleaseComparisonSelector />
                   </Container>
                   <ErrorBoundary mini>
-                    <AppStartup />
+                    <AppStartup chartHeight={240} />
                   </ErrorBoundary>
                 </PageFiltersContainer>
               </Layout.Main>

--- a/static/app/views/starfish/views/screens/utils.tsx
+++ b/static/app/views/starfish/views/screens/utils.tsx
@@ -1,0 +1,64 @@
+import Color from 'color';
+
+import {Series, SeriesDataUnit} from 'sentry/types/echarts';
+import {defined} from 'sentry/utils';
+import {YAxis, YAXIS_COLUMNS} from 'sentry/views/starfish/views/screens';
+
+export function transformReleaseEvents({
+  yAxes,
+  primaryRelease,
+  secondaryRelease,
+  topTransactions,
+  colorPalette,
+  releaseEvents,
+}: {
+  colorPalette: string[];
+  releaseEvents: any;
+  topTransactions: any;
+  yAxes: YAxis[];
+  primaryRelease?: string;
+  secondaryRelease?: string;
+}): {
+  [yAxisName: string]: {
+    [releaseVersion: string]: Series;
+  };
+} {
+  const topTransactionsIndex = Object.fromEntries(topTransactions.map((e, i) => [e, i]));
+  const transformedReleaseEvents = yAxes.reduce(
+    (acc, yAxis) => ({...acc, [YAXIS_COLUMNS[yAxis]]: {}}),
+    {}
+  );
+
+  yAxes.forEach(val => {
+    [primaryRelease, secondaryRelease].filter(defined).forEach(release => {
+      transformedReleaseEvents[YAXIS_COLUMNS[val]][release] = {
+        seriesName: release,
+        data: Array(topTransactions.length).fill(0),
+      };
+    });
+  });
+
+  if (defined(releaseEvents) && defined(primaryRelease)) {
+    releaseEvents.data?.forEach(row => {
+      const release = row.release;
+      const isPrimary = release === primaryRelease;
+      const transaction = row.transaction;
+      const index = topTransactionsIndex[transaction];
+      yAxes.forEach(val => {
+        if (transformedReleaseEvents[YAXIS_COLUMNS[val]][release]) {
+          transformedReleaseEvents[YAXIS_COLUMNS[val]][release].data[index] = {
+            name: row.transaction,
+            value: row[YAXIS_COLUMNS[val]],
+            itemStyle: {
+              color: isPrimary
+                ? colorPalette[index]
+                : Color(colorPalette[index]).lighten(0.3).string(),
+            },
+          } as SeriesDataUnit;
+        }
+      });
+    });
+  }
+
+  return transformedReleaseEvents;
+}


### PR DESCRIPTION
Adds the cold and warm start charts to the app start overview page and filters down the screens so we're only seeing screens with cold/warm starts

<img width="1448" alt="Screenshot 2023-12-12 at 9 55 09 AM" src="https://github.com/getsentry/sentry/assets/22846452/4afd120a-730c-4cd8-886e-a916281c908e">

Also adds a small util for the code that formats the events data into release-specific series for the bar chart. The code was necessary here but since it was relatively complex, I decided to make it a util.