### PR TITLE
feat(grouping): _block_invoke: Do not -group when in_app=true

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -151,7 +151,7 @@ family:native package:libAudioToolboxUtility.dylib category=av
 family:native function:std::_* category=internals
 family:native function:__swift_* category=internals
 family:native function:block_destroy_helper* category=internals
-family:native function:*_block_invoke* category=internals
+family:native function:*_block_invoke* app:no category=internals
 
 family:native package:/usr/lib/system/** function:start category=threadbase
 family:native package:libdyld.dylib function:start category=threadbase

--- a/tests/sentry/grouping/grouping_inputs/block_invoke.json
+++ b/tests/sentry/grouping/grouping_inputs/block_invoke.json
@@ -1,0 +1,38 @@
+{
+  "platform": "cocoa",
+  "message": "Foo",
+  "grouping_config": {
+    "enhancements": "eJybzDRxc15qeXFJZU6qlZGBkbGugaGuoeHsSRNXp_nkp6enFunl5KdPOcvCcJaZ4SwL41lmxkkTN6a5OAElQxKB8imuRUX5RWgK1kIUOJb4pJal5qBJLoNIooluAYo6FhenFpXgNnYnUI1zRmpyNiGFNxVwqvRNLS5OTE9F07Abm-0UK92S5paZk-qcmJyRijMsl6SlJFVMOcsKFmMFiQEAtd-T3A",
+    "id": "newstyle:2023-01-11"
+  },
+  "threads": {
+    "values": [
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2",
+              "package": "/private/var/containers/Bundle/Application/9B2E1C43-8839-4525-9586-FC58F0534940/Foobar.app/Foobar",
+              "note": "Because it's in_app it will be considered for grouping even though it uses _block_invoke.",
+              "in_app": true
+            },
+            {
+              "function": "__99+[Something else]_block_invoke_2",
+              "package": "/private/var/containers/Bundle/Application/9B2E1C43-8839-4525-9586-FC58F0534940/Foobar.app/Foobar",
+              "note": "A rule will make this frame as in_app, thus, it will be considered for grouping even though it uses _block_invoke.",
+              "in_app": false
+            },
+            {
+              "function": "__00+[Something else]_block_invoke_2",
+              "note": "No rule turns this into in_app and it uses _block_invoke, thus, ignore for grouping.",
+              "in_app": false
+            }
+          ]
+        },
+        "crashed": false,
+        "current": true,
+        "main": true
+      }
+    ]
+  }
+}

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/block_invoke.pysnap
@@ -1,0 +1,43 @@
+---
+created: '2023-12-12T18:45:37.447995Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (logentry takes precedence)
+      threads
+        stacktrace
+          frame
+            function (function name is not used if module or filename are available)
+              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
+          frame (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function (function name is not used if module or filename are available)
+              "__99+[Something else]_block_invoke_2"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "__00+[Something else]_block_invoke_2"
+--------------------------------------------------------------------------
+default:
+  hash: "1356c67d7ad1638d816bfb822dd2c25d"
+  component:
+    default*
+      message*
+        "Foo"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system (logentry takes precedence)
+      threads
+        stacktrace
+          frame
+            function (function name is not used if module or filename are available)
+              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
+          frame (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function (function name is not used if module or filename are available)
+              "__99+[Something else]_block_invoke_2"
+          frame
+            function (function name is not used if module or filename are available)
+              "__00+[Something else]_block_invoke_2"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/block_invoke.pysnap
@@ -1,0 +1,47 @@
+---
+created: '2023-12-12T18:45:55.265873Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app-depth-1:
+  hash: null
+  component:
+    app-depth-1 (logentry takes precedence)
+      threads
+        stacktrace
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__00+[Something else]_block_invoke_2"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: null
+  component:
+    app-depth-max (logentry takes precedence)
+      threads
+        stacktrace
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__00+[Something else]_block_invoke_2"
+--------------------------------------------------------------------------
+default:
+  hash: "1356c67d7ad1638d816bfb822dd2c25d"
+  component:
+    default*
+      message*
+        "Foo"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system (logentry takes precedence)
+      threads
+        stacktrace
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__99+[Something else]_block_invoke_2"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__00+[Something else]_block_invoke_2"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/block_invoke.pysnap
@@ -1,0 +1,43 @@
+---
+created: '2023-12-12T18:46:11.097452Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
+  component:
+    app*
+      threads*
+        stacktrace*
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__99+[Something else]_block_invoke_2"
+          frame (non app frame)
+            function*
+              "__00+[Something else]_block_invoke_2"
+--------------------------------------------------------------------------
+default:
+  hash: null
+  component:
+    default (threads of app/system take precedence)
+      message (threads of app/system take precedence)
+        "Foo"
+--------------------------------------------------------------------------
+system:
+  hash: "cff360e554b4acecd9fd2534d9051870"
+  component:
+    system*
+      threads*
+        stacktrace*
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__99+[Something else]_block_invoke_2"
+          frame*
+            function*
+              "__00+[Something else]_block_invoke_2"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/block_invoke.pysnap
@@ -1,0 +1,43 @@
+---
+created: '2023-12-12T18:46:17.496488Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
+  component:
+    app*
+      threads*
+        stacktrace*
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__99+[Something else]_block_invoke_2"
+          frame (non app frame)
+            function*
+              "__00+[Something else]_block_invoke_2"
+--------------------------------------------------------------------------
+default:
+  hash: null
+  component:
+    default (threads of app/system take precedence)
+      message (threads of app/system take precedence)
+        "Foo"
+--------------------------------------------------------------------------
+system:
+  hash: "cff360e554b4acecd9fd2534d9051870"
+  component:
+    system*
+      threads*
+        stacktrace*
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__99+[Something else]_block_invoke_2"
+          frame*
+            function*
+              "__00+[Something else]_block_invoke_2"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/block_invoke.pysnap
@@ -1,0 +1,43 @@
+---
+created: '2023-12-12T18:45:42.493182Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
+  component:
+    app*
+      threads*
+        stacktrace*
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__99+[Something else]_block_invoke_2"
+          frame (non app frame)
+            function*
+              "__00+[Something else]_block_invoke_2"
+--------------------------------------------------------------------------
+default:
+  hash: null
+  component:
+    default (threads of app/system take precedence)
+      message (threads of app/system take precedence)
+        "Foo"
+--------------------------------------------------------------------------
+system:
+  hash: "cff360e554b4acecd9fd2534d9051870"
+  component:
+    system*
+      threads*
+        stacktrace*
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__99+[Something else]_block_invoke_2"
+          frame*
+            function*
+              "__00+[Something else]_block_invoke_2"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/block_invoke.pysnap
@@ -1,0 +1,43 @@
+---
+created: '2023-12-12T18:45:48.154315Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
+  component:
+    app*
+      threads*
+        stacktrace*
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__99+[Something else]_block_invoke_2"
+          frame (non app frame)
+            function*
+              "__00+[Something else]_block_invoke_2"
+--------------------------------------------------------------------------
+default:
+  hash: null
+  component:
+    default (threads of app/system take precedence)
+      message (threads of app/system take precedence)
+        "Foo"
+--------------------------------------------------------------------------
+system:
+  hash: "cff360e554b4acecd9fd2534d9051870"
+  component:
+    system*
+      threads*
+        stacktrace*
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__99+[Something else]_block_invoke_2"
+          frame*
+            function*
+              "__00+[Something else]_block_invoke_2"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,0 +1,43 @@
+---
+created: '2023-12-12T18:43:32.477116Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (threads of system take precedence)
+      threads (ignored because hash matches system variant)
+        stacktrace*
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__99+[Something else]_block_invoke_2"
+          frame (non app frame)
+            function*
+              "__00+[Something else]_block_invoke_2"
+--------------------------------------------------------------------------
+default:
+  hash: null
+  component:
+    default (threads of system take precedence)
+      message (threads of system take precedence)
+        "Foo"
+--------------------------------------------------------------------------
+system:
+  hash: "ff6c4ee7c54f118a9647ee86f0c2b0b0"
+  component:
+    system*
+      threads*
+        stacktrace*
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__46+[FudgeGlobalHandler setupGlobalHandlersIfNeeded]_block_invoke_2"
+          frame* (marked in-app by stack trace rule (family:native package:**/containers/bundle/application/** +app))
+            function*
+              "__99+[Something else]_block_invoke_2"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__00+[Something else]_block_invoke_2"


### PR DESCRIPTION
Any frames using `*_block_invoke*` get marked as category internals which then get excluded from grouping (see snippet below). Adding `app:no` will allow in-app frames to be left alone.

```
family:native function:*_block_invoke* app:no category=internals
category:internals -group
```