### PR TITLE
feat(crons): Remove joins from monitor-stats query

### DIFF
--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -135,7 +135,7 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
                 "monitor_environment_id",
                 "status",
             )
-            .order_by("monitor_id", "bucket")
+            .order_by("bucket")
             .annotate(count=Count("*"))
             .values_list(
                 "monitor_id",

--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -14,7 +14,13 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import StatsMixin, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.helpers.environments import get_environments
-from sentry.monitors.models import CheckInStatus, Monitor, MonitorCheckIn
+from sentry.monitors.models import (
+    CheckInStatus,
+    Environment,
+    Monitor,
+    MonitorCheckIn,
+    MonitorEnvironment,
+)
 from sentry.utils.dates import to_timestamp
 
 
@@ -56,22 +62,56 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
             CheckInStatus.TIMEOUT,
         ]
 
-        monitor_ids = Monitor.objects.filter(
-            organization_id=organization.id,
-            slug__in=monitor_slugs,
-        ).values("id")
+        # Pre-fetch the monitor-ids and their slugs. This is an optimization to eliminate a join
+        # against the monitor table which significantly inflates the size of the aggregation
+        # states.
+        #
+        # The ids are used to explicitly scope the query and the slugs are returned as display
+        # data. The slugs have to be fetched (even though we already have them in memory) so we
+        # can maintain a correct mapping of id -> slug.
+        monitor_map = dict(
+            Monitor.objects.filter(organization_id=organization.id, slug__in=monitor_slugs)
+            .values_list("id", "slug")
+            .all()
+        )
+
+        # We only care about the name but we don't want to join to get it. So we're maintaining
+        # this map until the very end where we'll map from monitor_environment to environment to
+        # name.
+        #
+        # If no environments were found then every environment must be fetched. This could return
+        # a lot of rows. A better alternative would be to denormalize the environment name onto
+        # the check-in table.
+        environments = get_environments(request, organization)
+        if not environments:
+            environments = Environment.objects.filter(organization_id=organization.id).all()
+
+        environment_map = {env.id: env.name for env in environments}
+
+        # Pre-fetch the monitor environments. This is an optimization to eliminate a join against
+        # the monitor-environment table and environment table which significantly inflates the
+        # size of the aggregation states.
+        #
+        # This could return a lot of rows. A better alternative would be to denormalize the
+        # environment name onto the check-in table.
+        monitor_environment_map = dict(
+            MonitorEnvironment.objects.filter(
+                monitor_id__in=monitor_map.keys(),
+                environment_id__in=environment_map.keys(),
+            )
+            .values_list("id", "environment_id")
+            .all()
+        )
 
         check_ins = MonitorCheckIn.objects.filter(
-            monitor_id__in=monitor_ids,
+            monitor_id__in=monitor_map.keys(),
             status__in=tracked_statuses,
             date_added__gt=args["start"],
             date_added__lte=args["end"],
         )
 
-        environments = get_environments(request, organization)
-
-        if environments:
-            check_ins = check_ins.filter(monitor_environment__environment__in=environments)
+        if monitor_environment_map:
+            check_ins = check_ins.filter(monitor_environment_id__in=monitor_environment_map.keys())
 
         # Use postgres' `date_bin` to bucket rounded to our rollups
         bucket = Func(
@@ -91,16 +131,16 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
             .annotate(bucket=bucket)
             .values(
                 "bucket",
-                "monitor__slug",
-                "monitor_environment__environment",
+                "monitor_id",
+                "monitor_environment_id",
                 "status",
             )
-            .order_by("monitor__slug", "bucket")
+            .order_by("monitor_id", "bucket")
             .annotate(count=Count("*"))
             .values_list(
-                "monitor__slug",
+                "monitor_id",
                 "bucket",
-                "monitor_environment__environment__name",
+                "monitor_environment_id",
                 "status",
                 "count",
             )
@@ -129,7 +169,16 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
                 stats[slug][ts] = defaultdict(status_obj_factory)
                 ts += args["rollup"]
 
-        for slug, ts, env_name, status, count in history.iterator():
+        for mid, ts, meid, status, count in history.iterator():
+            slug = monitor_map[mid]
+
+            # Monitor environments can be null.  If we find a null monitor environment we
+            # default to "production" by convention.
+            if meid not in monitor_environment_map:
+                env_name = "production"
+            else:
+                env_name = environment_map[monitor_environment_map[meid]]
+
             named_status = status_to_name[status]
             stats[slug][ts][env_name][named_status] = count
 

--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -178,7 +178,7 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
                 env_name = environment_map[monitor_environment_map[meid]]
 
             named_status = status_to_name[status]
-            stats[slug][ts][env_name][named_status] = count
+            stats[slug][ts][env_name][named_status] = count  # type: ignore
 
         # Flatten the timestamp to env mapping dict into a tuple list, this
         # maintains the ordering

--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -163,6 +163,8 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
                 stats[slug][ts] = defaultdict(status_obj_factory)
                 ts += args["rollup"]
 
+        # We manually sort the response output by slug and bucket. This is fine because the set
+        # of slugs is known (they're provided as a query parameter) and there is no pagination.
         for mid, ts, meid, status, count in sorted(
             list(history), key=lambda k: (monitor_map[k[0]], k[1])
         ):
@@ -179,10 +181,7 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
             stats[slug][ts][env_name][named_status] = count
 
         # Flatten the timestamp to env mapping dict into a tuple list, this
-        # maintains the ordering.
-        #
-        # We manually sort the response output by slug. This is fine because the set of slugs is
-        # known (they're provided as a query parameter) and there is no pagination.
+        # maintains the ordering
         stats_list = {
             slug: [[ts, env_mapping] for ts, env_mapping in ts_to_envs.items()]
             for slug, ts_to_envs in stats.items()

--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -65,9 +65,9 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
         # data. The slugs have to be fetched (even though we already have them in memory) so we
         # can maintain a correct mapping of id -> slug.
         monitor_map = dict(
-            Monitor.objects.filter(organization_id=organization.id, slug__in=monitor_slugs)
-            .values_list("id", "slug")
-            .all()
+            Monitor.objects.filter(
+                organization_id=organization.id, slug__in=monitor_slugs
+            ).values_list("id", "slug")
         )
 
         # We only care about the name but we don't want to join to get it. So we're maintaining
@@ -93,9 +93,7 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
             MonitorEnvironment.objects.filter(
                 monitor_id__in=monitor_map.keys(),
                 environment_id__in=environment_map.keys(),
-            )
-            .values_list("id", "environment_id")
-            .all()
+            ).values_list("id", "environment_id")
         )
 
         check_ins = MonitorCheckIn.objects.filter(

--- a/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index_stats.py
@@ -183,10 +183,13 @@ class OrganizationMonitorIndexStatsEndpoint(OrganizationEndpoint, StatsMixin):
             stats[slug][ts][env_name][named_status] = count
 
         # Flatten the timestamp to env mapping dict into a tuple list, this
-        # maintains the ordering
+        # maintains the ordering.
+        #
+        # We manually sort the response output by slug. This is fine because the set of slugs is
+        # known (they're provided as a query parameter) and there is no pagination.
         stats_list = {
             slug: [[ts, env_mapping] for ts, env_mapping in ts_to_envs.items()]
-            for slug, ts_to_envs in stats.items()
+            for slug, ts_to_envs in sorted(stats.items(), key=lambda k: k[0])
         }
 
         return Response(stats_list)


### PR DESCRIPTION
This is an experiment to improve performance on the monitor-stats endpoint.  Instead of making one large analytics query with multiple joins we'll make two smaller queries and pass the ids to the analytics query.  This should significantly reduce the amount of work postgres has to do to aggregate the check-ins.

The old plan:

```
GroupAggregate  (cost=25.33..25.37 rows=1 width=316)
  Group Key: sentry_monitor.slug, (EXTRACT(epoch FROM (date_bin('01:00:00'::interval, sentry_monitorcheckin.date_added, '2022-03-21 07:00:00+00'::timestamp with time zone) AT TIME ZONE 'UTC'::text))), sentry_monitorenvironment.environment_id, sentry_monitorcheckin.status, sentry_environment.name
  ->  Sort  (cost=25.33..25.34 rows=1 width=308)
        Sort Key: sentry_monitor.slug, (EXTRACT(epoch FROM (date_bin('01:00:00'::interval, sentry_monitorcheckin.date_added, '2022-03-21 07:00:00+00'::timestamp with time zone) AT TIME ZONE 'UTC'::text))), sentry_monitorenvironment.environment_id, sentry_monitorcheckin.status, sentry_environment.name
        ->  Nested Loop Left Join  (cost=0.73..25.32 rows=1 width=308)
              ->  Nested Loop  (cost=0.44..16.91 rows=1 width=138)
                    ->  Nested Loop  (cost=0.29..16.43 rows=1 width=134)
                          ->  Index Scan using sentry_monitor_organization_id_27f5b6ee on sentry_monitor u0  (cost=0.14..8.16 rows=1 width=8)
                                Index Cond: (organization_id = '4549556814217216'::bigint)
                                Filter: ((slug)::text = ANY ('{e98acdbc7198,1a213306e410}'::text[]))
                          ->  Index Scan using sentry_monitor_pkey on sentry_monitor  (cost=0.14..8.16 rows=1 width=126)
                                Index Cond: (id = u0.id)
                    ->  Index Scan using sentry_moni_monitor_0a49ce_idx on sentry_monitorcheckin  (cost=0.15..0.48 rows=1 width=28)
                          Index Cond: ((monitor_id = sentry_monitor.id) AND (date_added > '2022-03-21 07:57:00+00'::timestamp with time zone) AND (date_added <= '2022-03-21 09:57:00+00'::timestamp with time zone))
                          Filter: (status = ANY ('{3,1,2,4,5}'::integer[]))
              ->  Nested Loop Left Join  (cost=0.30..8.39 rows=1 width=162)
                    ->  Index Scan using sentry_monitorenvironment_pkey on sentry_monitorenvironment  (cost=0.15..8.17 rows=1 width=16)
                          Index Cond: (id = sentry_monitorcheckin.monitor_environment_id)
                    ->  Index Scan using sentry_environment_pkey on sentry_environment  (cost=0.15..0.22 rows=1 width=154)
                          Index Cond: (id = sentry_monitorenvironment.environment_id)
```

The new plan:

```
GroupAggregate  (cost=9.55..9.59 rows=1 width=60)
  Group Key: monitor_id, (EXTRACT(epoch FROM (date_bin('01:00:00'::interval, date_added, '2022-03-21 07:00:00+00'::timestamp with time zone) AT TIME ZONE 'UTC'::text))), monitor_environment_id, status
  ->  Sort  (cost=9.55..9.56 rows=1 width=52)
        Sort Key: monitor_id, (EXTRACT(epoch FROM (date_bin('01:00:00'::interval, date_added, '2022-03-21 07:00:00+00'::timestamp with time zone) AT TIME ZONE 'UTC'::text))), monitor_environment_id, status
        ->  Bitmap Heap Scan on sentry_monitorcheckin  (cost=4.17..9.54 rows=1 width=52)
              Recheck Cond: ((date_added > '2022-03-21 07:57:00+00'::timestamp with time zone) AND (date_added <= '2022-03-21 09:57:00+00'::timestamp with time zone))
              Filter: ((monitor_id = ANY ('{5,6}'::bigint[])) AND (monitor_environment_id = ANY ('{5,6}'::bigint[])) AND (status = ANY ('{3,1,2,4,5}'::integer[])))
              ->  Bitmap Index Scan on sentry_monitorcheckin_date_added_23c78113  (cost=0.00..4.17 rows=2 width=0)
                    Index Cond: ((date_added > '2022-03-21 07:57:00+00'::timestamp with time zone) AND (date_added <= '2022-03-21 09:57:00+00'::timestamp with time zone))
```