### PR TITLE
fix(stats-detectors): Link regression sample events to event details

### DIFF
--- a/static/app/views/issueDetails/allEventsTable.tsx
+++ b/static/app/views/issueDetails/allEventsTable.tsx
@@ -81,14 +81,14 @@ function AllEventsTable(props: Props) {
 
   eventView.statsPeriod = '90d';
 
+  const isRegressionIssue =
+    group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION ||
+    group.issueType === IssueType.PERFORMANCE_ENDPOINT_REGRESSION;
+
   let idQuery = `issue.id:${issueId}`;
   if (group.issueCategory === IssueCategory.PERFORMANCE && !groupIsOccurrenceBacked) {
     idQuery = `performance.issue_ids:${issueId} event.type:transaction`;
-  } else if (
-    (group.issueType === IssueType.PERFORMANCE_DURATION_REGRESSION ||
-      group.issueType === IssueType.PERFORMANCE_ENDPOINT_REGRESSION) &&
-    groupIsOccurrenceBacked
-  ) {
+  } else if (isRegressionIssue && groupIsOccurrenceBacked) {
     const {transaction, aggregateRange2, breakpoint} =
       data?.occurrence?.evidenceData ?? {};
 
@@ -118,6 +118,7 @@ function AllEventsTable(props: Props) {
       eventView={eventView}
       location={location}
       issueId={issueId}
+      isRegressionIssue={isRegressionIssue}
       organization={organization}
       routes={routes}
       excludedTags={excludedTags}

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -73,6 +73,7 @@ type Props = {
   customColumns?: ('attachments' | 'minidump')[];
   excludedTags?: string[];
   isEventLoading?: boolean;
+  isRegressionIssue?: boolean;
   issueId?: string;
   projectSlug?: string;
   referrer?: string;
@@ -158,11 +159,11 @@ class EventsTable extends Component<Props, State> {
     }
 
     if (field === 'id' || field === 'trace') {
-      const {issueId} = this.props;
+      const {issueId, isRegressionIssue} = this.props;
       const isIssue: boolean = !!issueId;
       let target: LocationDescriptor = {};
       // TODO: set referrer properly
-      if (isIssue && field === 'id') {
+      if (isIssue && !isRegressionIssue && field === 'id') {
         target.pathname = `/organizations/${organization.slug}/issues/${issueId}/events/${dataRow.id}/`;
       } else {
         const generateLink = field === 'id' ? generateTransactionLink : generateTraceLink;


### PR DESCRIPTION
The id currently links to the particular occurrence of the issue. But for regression events, we want to link to the event details.