### PR TITLE
fix(stacktrace): Fix crash when context lines have newline characters

### DIFF
--- a/static/app/components/events/interfaces/frame/context.spec.tsx
+++ b/static/app/components/events/interfaces/frame/context.spec.tsx
@@ -1,10 +1,12 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {GitHubIntegration} from 'sentry-fixture/githubIntegration';
 import {Organization} from 'sentry-fixture/organization';
+import {Project} from 'sentry-fixture/project';
 import {Repository} from 'sentry-fixture/repository';
 import {RepositoryProjectPathConfig} from 'sentry-fixture/repositoryProjectPathConfig';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
-import {render} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {Coverage, Frame, LineCoverage} from 'sentry/types';
@@ -13,9 +15,9 @@ import Context, {getLineCoverage} from './context';
 
 describe('Frame - Context', function () {
   const org = Organization();
-  const project = TestStubs.Project({});
+  const project = Project({});
   const event = EventFixture({projectID: project.id});
-  const integration = TestStubs.GitHubIntegration();
+  const integration = GitHubIntegration();
   const repo = Repository({integrationId: integration.id});
   const frame = {filename: '/sentry/app.py', lineNo: 233} as Frame;
   const config = RepositoryProjectPathConfig({project, repo, integration});
@@ -67,10 +69,52 @@ describe('Frame - Context', function () {
       {
         context: RouterContextFixture([{organization: org}]),
         organization: org,
-        project,
       }
     );
 
     expect(mock).not.toHaveBeenCalled();
+  });
+
+  describe('syntax highlighting', function () {
+    it('renders code correctly when context lines end in newline characters', function () {
+      MockApiClient.addMockResponse({
+        url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
+        body: {
+          config,
+          sourceUrl: null,
+          integrations: [integration],
+        },
+      });
+
+      const testFrame: Frame = {
+        ...frame,
+        lineNo: 2,
+        context: [
+          [1, 'this is line 1\n'],
+          [2, 'this is line 2\n'],
+          [3, 'this is line 3\n'],
+        ],
+      };
+
+      render(
+        <Context
+          isExpanded
+          hasContextSource
+          frame={testFrame}
+          event={event}
+          organization={Organization({
+            features: ['issue-details-stacktrace-syntax-highlighting'],
+          })}
+          registers={{}}
+          components={[]}
+        />
+      );
+
+      expect(screen.getAllByTestId('context-line')).toHaveLength(3);
+
+      expect(screen.getByText('this is line 1')).toBeInTheDocument();
+      expect(screen.getByText('this is line 2')).toBeInTheDocument();
+      expect(screen.getByText('this is line 3')).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -136,7 +136,9 @@ function Context({
 
   const fileExtension = getFileExtension(frame.filename || '') ?? '';
   const lines = usePrismTokens({
-    code: contextLines?.map(([, code]) => code).join('\n') ?? '',
+    // Some events have context lines with newline characters at the end,
+    // so we need to remove them to be consistent.
+    code: contextLines?.map(([, code]) => code.replaceAll(/\r?\n/g, '')).join('\n') ?? '',
     language: fileExtension,
   });
 
@@ -173,7 +175,7 @@ function Context({
 
                 return (
                   <Fragment key={i}>
-                    <ContextLineWrapper isActive={isActive}>
+                    <ContextLineWrapper isActive={isActive} data-test-id="context-line">
                       <ContextLineNumber
                         lineNumber={contextLine[0]}
                         isActive={isActive}


### PR DESCRIPTION
Fixes JAVASCRIPT-2Q8N
Fixes JAVASCRIPT-2Q8P

This problem was introduced by the syntax highlighting change which is still being tested internally: https://github.com/getsentry/sentry/pull/60807

The reason for the crash here is that some events have context lines that end in newline characters, like so:

```json
"pre_context": ["const foo = 1\n", "const foo = 2\n"]
```

When combining those into a single string to be fed into `usePrismTokens()`, the number of lines doubled due to the extra newline characters. By removing those characters prior to joining, we can prevent this and make things consistent.