### PR TITLE
highlight release tab on the release-thresholds page still

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -265,7 +265,8 @@ export function isItemActive(
     (item?.label === 'Settings' && location.pathname.startsWith('/settings/')) ||
     (item?.label === 'Alerts' &&
       location.pathname.includes('/alerts/') &&
-      !location.pathname.startsWith('/settings/'))
+      !location.pathname.startsWith('/settings/')) ||
+    (item?.label === 'Releases' && location.pathname.includes('/release-thresholds/'))
   );
 }
 


### PR DESCRIPTION
Updates:
- Highlight Release tab in sidebar nav when you're on the release-thresholds routes