### PR TITLE
fix(provisioning): restricted member should not be deletable

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -286,7 +286,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
 
     def update_flags(self, *, organization_id: int, flags: RpcOrganizationFlagsUpdate) -> None:
         updates: F | CombinedExpression = models.F("flags")
-        for (name, value) in flags.items():
+        for name, value in flags.items():
             if value is True:
                 updates = updates.bitor(getattr(Organization.flags, name))
             elif value is False:
@@ -306,6 +306,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
             flags.member_limit__restricted,
             flags.idp__provisioned,
             flags.idp__role_restricted,
+            flags.partnership__restricted,
         )
 
     def add_organization_member(


### PR DESCRIPTION
We added the `partnership:restricted` flag a while back to ensure that partner users cannot be kicked out of the org. This was not working because the flag was lost during serialization. This PR fixes the issue.

![Screenshot 2023-12-12 at 11 09 57 AM](https://github.com/getsentry/sentry/assets/132939361/ec4aad3a-720a-48e6-8016-e58cb2d1569b)

