### PR TITLE
fix(stats-detector): Lazily create redis client

### DIFF
--- a/src/sentry/statistical_detectors/redis.py
+++ b/src/sentry/statistical_detectors/redis.py
@@ -26,7 +26,16 @@ class RedisDetectorStore(DetectorStore):
     ):
         self.detector_type = detector_type
         self.ttl = ttl
-        self.client = self.get_redis_client() if client is None else client
+        self._client: RedisCluster | StrictRedis | None = None
+
+    @property
+    def client(
+        self,
+        client: RedisCluster | StrictRedis | None = None,
+    ):
+        if self._client is None:
+            self._client = self.get_redis_client() if client is None else client
+        return self._client
 
     def bulk_read_states(
         self, payloads: List[DetectorPayload]


### PR DESCRIPTION
Just in case, do not create the client right away. It'll be created when it's needed.