### PR TITLE
ref(relocation): Organize options a bit

### DIFF
--- a/src/sentry/api/endpoints/relocations/index.py
+++ b/src/sentry/api/endpoints/relocations/index.py
@@ -65,7 +65,7 @@ def should_throttle_relocation(relocation_bucket_size) -> bool:
         0,
     )
     if num_recent_same_size_relocation_files < get(
-        f"relocation.daily-limit-{relocation_bucket_size}"
+        f"relocation.daily-limit.{relocation_bucket_size}"
     ):
         return False
     return True

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3,6 +3,7 @@ import os
 from sentry.logging import LoggingFormat
 from sentry.options import register
 from sentry.options.manager import (
+    FLAG_ADMIN_MODIFIABLE,
     FLAG_ALLOW_EMPTY,
     FLAG_AUTOMATOR_MODIFIABLE,
     FLAG_CREDENTIAL,
@@ -1784,9 +1785,30 @@ register(
 )
 
 # Relocation
-register("relocation.enabled", default=False)
-
-# Throttling limits for relocation requests
-register("relocation.daily-limit-small", default=0)
-register("relocation.daily-limit-medium", default=0)
-register("relocation.daily-limit-large", default=0)
+register(
+    "relocation.enabled",
+    default=False,
+    # TODO(getsentry/team-ospo#214): Eventually change this to `FLAG_BOOL |
+    # FLAG_AUTOMATOR_MODIFIABLE`, to enforce it only being toggled from code.
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "relocation.self-serve",
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "relocation.daily-limit.small",
+    default=0,
+    flags=FLAG_ADMIN_MODIFIABLE | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "relocation.daily-limit.medium",
+    default=0,
+    flags=FLAG_ADMIN_MODIFIABLE | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "relocation.daily-limit.large",
+    default=0,
+    flags=FLAG_ADMIN_MODIFIABLE | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -246,7 +246,7 @@ class PostRelocationTest(APITestCase):
             with self.options(
                 {
                     "relocation.enabled": True,
-                    "relocation.daily-limit-small": 1,
+                    "relocation.daily-limit.small": 1,
                 }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
@@ -292,7 +292,7 @@ class PostRelocationTest(APITestCase):
             with tempfile.TemporaryDirectory() as tmp_dir:
                 (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
                 with self.options(
-                    {"relocation.enabled": True, "relocation.daily-limit-small": 1}
+                    {"relocation.enabled": True, "relocation.daily-limit.small": 1}
                 ), open(FRESH_INSTALL_PATH) as f:
                     data = json.load(f)
                     with open(tmp_pub_key_path, "rb") as p:
@@ -336,7 +336,7 @@ class PostRelocationTest(APITestCase):
             with tempfile.TemporaryDirectory() as tmp_dir:
                 (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
                 with self.options(
-                    {"relocation.enabled": True, "relocation.daily-limit-small": 1}
+                    {"relocation.enabled": True, "relocation.daily-limit.small": 1}
                 ), open(FRESH_INSTALL_PATH) as f:
                     data = json.load(f)
                     with open(tmp_pub_key_path, "rb") as p:
@@ -388,7 +388,7 @@ class PostRelocationTest(APITestCase):
             with self.options(
                 {
                     "relocation.enabled": True,
-                    "relocation.daily-limit-small": 1,
+                    "relocation.daily-limit.small": 1,
                 }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
@@ -447,7 +447,7 @@ class PostRelocationTest(APITestCase):
             with self.options(
                 {
                     "relocation.enabled": True,
-                    "relocation.daily-limit-small": 1,
+                    "relocation.daily-limit.small": 1,
                 }
             ):
                 response = self.client.post(
@@ -470,7 +470,7 @@ class PostRelocationTest(APITestCase):
             with self.options(
                 {
                     "relocation.enabled": True,
-                    "relocation.daily-limit-small": 1,
+                    "relocation.daily-limit.small": 1,
                 }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
@@ -501,7 +501,7 @@ class PostRelocationTest(APITestCase):
             with self.options(
                 {
                     "relocation.enabled": True,
-                    "relocation.daily-limit-small": 1,
+                    "relocation.daily-limit.small": 1,
                 }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
@@ -532,7 +532,7 @@ class PostRelocationTest(APITestCase):
             with self.options(
                 {
                     "relocation.enabled": True,
-                    "relocation.daily-limit-small": 1,
+                    "relocation.daily-limit.small": 1,
                 }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
@@ -573,7 +573,7 @@ class PostRelocationTest(APITestCase):
             with self.options(
                 {
                     "relocation.enabled": True,
-                    "relocation.daily-limit-small": 1,
+                    "relocation.daily-limit.small": 1,
                 }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
@@ -606,7 +606,7 @@ class PostRelocationTest(APITestCase):
             with self.options(
                 {
                     "relocation.enabled": True,
-                    "relocation.daily-limit-small": 1,
+                    "relocation.daily-limit.small": 1,
                 }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
@@ -670,8 +670,8 @@ class PostRelocationTest(APITestCase):
             with self.options(
                 {
                     "relocation.enabled": True,
-                    "relocation.daily-limit-small": 1,
-                    "relocation.daily-limit-medium": 1,
+                    "relocation.daily-limit.small": 1,
+                    "relocation.daily-limit.medium": 1,
                 }
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
@@ -731,7 +731,7 @@ class PostRelocationTest(APITestCase):
             with self.options(
                 {
                     "relocation.enabled": True,
-                    "relocation.daily-limit-small": 1,
+                    "relocation.daily-limit.small": 1,
                 }
             ), open(FRESH_INSTALL_PATH) as f, freeze_time("2023-11-28 00:00:00") as frozen_time:
                 data = json.load(f)
@@ -792,7 +792,7 @@ class PostRelocationTest(APITestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
             with self.feature("relocation:enabled"), self.options(
-                {"relocation.daily-limit-small": 1}
+                {"relocation.daily-limit.small": 1}
             ), open(FRESH_INSTALL_PATH) as f:
                 data = json.load(f)
                 with open(tmp_pub_key_path, "rb") as p:


### PR DESCRIPTION
This PR introduces a `relocation.self-serve` option, but it is currently unused. Future PRs will gate the self-serve UI on it, separating the self-service toggle from the global feature toggle.

Issue: getsentry/team-ospo#214