### PR TITLE
feat(crons): Add cron monitor seat to data categories

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -309,6 +309,14 @@ export const DATA_CATEGORY_INFO = {
     titleName: t('Monitor Check-Ins'),
     uid: 10,
   },
+  [DataCategoryExact.MONITOR_SEAT]: {
+    name: DataCategoryExact.MONITOR_SEAT,
+    apiName: 'monitorSeat',
+    plural: 'monitorSeats',
+    displayName: 'cron monitors',
+    titleName: t('Cron Monitors'),
+    uid: 13,
+  },
 } as const satisfies Record<DataCategoryExact, DataCategoryInfo>;
 
 // Special Search characters

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -312,7 +312,7 @@ export const DATA_CATEGORY_INFO = {
   [DataCategoryExact.MONITOR_SEAT]: {
     name: DataCategoryExact.MONITOR_SEAT,
     apiName: 'monitorSeat',
-    plural: 'cron monitors',
+    plural: 'monitorSeats',
     displayName: 'cron monitors',
     titleName: t('Cron Monitors'),
     uid: 13,

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -312,9 +312,9 @@ export const DATA_CATEGORY_INFO = {
   [DataCategoryExact.MONITOR_SEAT]: {
     name: DataCategoryExact.MONITOR_SEAT,
     apiName: 'monitorSeat',
-    plural: 'monitorSeats',
+    plural: 'cron monitors',
     displayName: 'cron monitors',
-    titleName: t('Monitors'),
+    titleName: t('Cron Monitors'),
     uid: 13,
   },
 } as const satisfies Record<DataCategoryExact, DataCategoryInfo>;

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -314,7 +314,7 @@ export const DATA_CATEGORY_INFO = {
     apiName: 'monitorSeat',
     plural: 'monitorSeats',
     displayName: 'cron monitors',
-    titleName: t('Cron Monitors'),
+    titleName: t('Monitors'),
     uid: 13,
   },
 } as const satisfies Record<DataCategoryExact, DataCategoryInfo>;

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -95,6 +95,7 @@ export enum DataCategoryExact {
   TRANSACTION_PROCESSED = 'transaction_processed',
   TRANSACTION_INDEXED = 'transaction_indexed',
   MONITOR = 'monitor',
+  MONITOR_SEAT = 'monitorSeat',
 }
 
 export interface DataCategoryInfo {


### PR DESCRIPTION
Add monitor seat as a data category in preparation for the new checkout flow which will include cron monitors