### PR TITLE
fix(jira) Respond with 409 when we get undeliverable hooks

### DIFF
--- a/src/sentry/integrations/jira/webhooks/base.py
+++ b/src/sentry/integrations/jira/webhooks/base.py
@@ -47,7 +47,7 @@ class JiraWebhookBase(Endpoint, abc.ABC):
         scope = scope or Scope()
 
         if isinstance(exc, (AtlassianConnectValidationError, JiraTokenError)):
-            return self.respond(status=status.HTTP_400_BAD_REQUEST)
+            return self.respond(status=status.HTTP_409_CONFLICT)
 
         # Atlassian has an automated tool which tests to make sure integrations with Jira
         # (like ours) pass certain security requirements, which leads them to probe certain

--- a/tests/sentry/integrations/jira/test_installed.py
+++ b/tests/sentry/integrations/jira/test_installed.py
@@ -75,13 +75,13 @@ class JiraInstalledTest(APITestCase):
         )
 
     def test_missing_token(self):
-        self.get_error_response(**self.body(), status_code=status.HTTP_400_BAD_REQUEST)
+        self.get_error_response(**self.body(), status_code=status.HTTP_409_CONFLICT)
 
     def test_invalid_token(self):
         self.get_error_response(
             **self.body(),
             extra_headers=dict(HTTP_AUTHORIZATION="invalid"),
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_409_CONFLICT,
         )
 
     @patch(
@@ -95,7 +95,7 @@ class JiraInstalledTest(APITestCase):
         self.get_error_response(
             **self.body(),
             extra_headers=dict(HTTP_AUTHORIZATION="JWT " + self.jwt_token_cdn()),
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_409_CONFLICT,
         )
 
     @patch("sentry_sdk.set_tag")

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -210,7 +210,7 @@ class JiraWebhookBaseTest(TestCase):
             request = self.make_request(method="GET")
             response = mock_endpoint(request)
 
-            assert response.status_code == status.HTTP_400_BAD_REQUEST
+            assert response.status_code == status.HTTP_409_CONFLICT
             # This kind of error shouldn't be sent to Sentry
             assert mock_capture_exception.call_count == 0
 


### PR DESCRIPTION
When a webhook can't be delivered because the JWT is invalid, or expired we need to use a 409 status code so that webhook forwarding from control can consider the hook as delivered.

In a monolith environment the 409 will be returned to Jira triggering a retry in jira. This should be ok though as we rarely get the problematic conditions in production.
