### PR TITLE
fix(agg-spans): Append env filter to nodestore backend query

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_aggregation.py
+++ b/src/sentry/api/endpoints/organization_spans_aggregation.py
@@ -376,6 +376,12 @@ class OrganizationSpansAggregationEndpoint(OrganizationEventsEndpointBase):
         if http_method is not None:
             conditions.append(["http.method", "=", http_method])
 
+        environments = params.get("environment", None)
+        if environments and len(environments) > 1:
+            conditions.append(["environment", "IN", environments])
+        elif environments and len(environments) == 1:
+            conditions.append(["environment", "=", environments[0]])
+
         events = eventstore.backend.get_events(
             filter=eventstore.Filter(
                 conditions=conditions,


### PR DESCRIPTION
Honour the environment filter in agg waterfall.
Note, once we move to just using the indexed spans
backend, all this filter construction logic can be
removed