### PR TITLE
fix(webvitals): fix issue where score columns are sortable when using frontend calculated scores

### DIFF
--- a/static/app/views/performance/browser/webVitals/pagePerformanceTable.tsx
+++ b/static/app/views/performance/browser/webVitals/pagePerformanceTable.tsx
@@ -34,6 +34,7 @@ import {useTransactionWebVitalsQuery} from 'sentry/views/performance/browser/web
 import {
   Row,
   SORTABLE_FIELDS,
+  SORTABLE_SCORE_FIELDS,
 } from 'sentry/views/performance/browser/webVitals/utils/types';
 import {useStoredScoresSetting} from 'sentry/views/performance/browser/webVitals/utils/useStoredScoresSetting';
 import {useWebVitalsSort} from 'sentry/views/performance/browser/webVitals/utils/useWebVitalsSort';
@@ -133,8 +134,10 @@ export function PagePerformanceTable() {
         query: {...location.query, sort: newSort},
       };
     }
-
-    const canSort = (SORTABLE_FIELDS as unknown as string[]).includes(col.key);
+    const sortableFields = shouldUseStoredScores
+      ? SORTABLE_FIELDS
+      : SORTABLE_FIELDS.filter(field => !SORTABLE_SCORE_FIELDS.includes(field));
+    const canSort = (sortableFields as unknown as string[]).includes(col.key);
 
     if (canSort && !['score', 'opportunity'].includes(col.key)) {
       return (

--- a/static/app/views/performance/browser/webVitals/pageSamplePerformanceTable.tsx
+++ b/static/app/views/performance/browser/webVitals/pageSamplePerformanceTable.tsx
@@ -36,8 +36,10 @@ import {useTransactionSamplesWebVitalsQuery} from 'sentry/views/performance/brow
 import {
   DEFAULT_INDEXED_SORT,
   SORTABLE_INDEXED_FIELDS,
+  SORTABLE_INDEXED_SCORE_FIELDS,
   TransactionSampleRow,
 } from 'sentry/views/performance/browser/webVitals/utils/types';
+import {useStoredScoresSetting} from 'sentry/views/performance/browser/webVitals/utils/useStoredScoresSetting';
 import {useWebVitalsSort} from 'sentry/views/performance/browser/webVitals/utils/useWebVitalsSort';
 import {generateReplayLink} from 'sentry/views/performance/transactionSummary/utils';
 
@@ -78,9 +80,17 @@ export function PageSamplePerformanceTable({
   const organization = useOrganization();
   const routes = useRoutes();
   const router = useRouter();
+  const shouldUseStoredScores = useStoredScoresSetting();
+
+  const sortableFields = shouldUseStoredScores
+    ? SORTABLE_INDEXED_FIELDS
+    : SORTABLE_INDEXED_FIELDS.filter(
+        field => !SORTABLE_INDEXED_SCORE_FIELDS.includes(field)
+      );
+
   const sort = useWebVitalsSort({
     defaultSort: DEFAULT_INDEXED_SORT,
-    sortableFields: SORTABLE_INDEXED_FIELDS as unknown as string[],
+    sortableFields: sortableFields as unknown as string[],
   });
   const replayLinkGenerator = generateReplayLink(routes);
 
@@ -126,7 +136,7 @@ export function PageSamplePerformanceTable({
       };
     }
 
-    const canSort = (SORTABLE_INDEXED_FIELDS as ReadonlyArray<string>).includes(col.key);
+    const canSort = (sortableFields as ReadonlyArray<string>).includes(col.key);
 
     if (
       [

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawSamplesWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawSamplesWebVitalsQuery.tsx
@@ -10,9 +10,11 @@ import {calculatePerformanceScore} from 'sentry/views/performance/browser/webVit
 import {
   DEFAULT_INDEXED_SORT,
   SORTABLE_INDEXED_FIELDS,
+  SORTABLE_INDEXED_SCORE_FIELDS,
   TransactionSampleRowWithScore,
   WebVitals,
 } from 'sentry/views/performance/browser/webVitals/utils/types';
+import {useStoredScoresSetting} from 'sentry/views/performance/browser/webVitals/utils/useStoredScoresSetting';
 import {useWebVitalsSort} from 'sentry/views/performance/browser/webVitals/utils/useWebVitalsSort';
 
 type Props = {
@@ -37,11 +39,18 @@ export const useTransactionRawSamplesWebVitalsQuery = ({
   const organization = useOrganization();
   const pageFilters = usePageFilters();
   const location = useLocation();
+  const shouldUseStoredScores = useStoredScoresSetting();
+
+  const filteredSortableFields = shouldUseStoredScores
+    ? SORTABLE_INDEXED_FIELDS
+    : SORTABLE_INDEXED_FIELDS.filter(
+        field => !SORTABLE_INDEXED_SCORE_FIELDS.includes(field)
+      );
 
   const sort = useWebVitalsSort({
     sortName,
     defaultSort: DEFAULT_INDEXED_SORT,
-    sortableFields: SORTABLE_INDEXED_FIELDS as unknown as string[],
+    sortableFields: filteredSortableFields as unknown as string[],
   });
 
   const eventView = EventView.fromNewQueryWithPageFilters(

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionSamplesWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionSamplesWebVitalsScoresQuery.tsx
@@ -9,9 +9,11 @@ import {mapWebVitalToOrderBy} from 'sentry/views/performance/browser/webVitals/u
 import {
   DEFAULT_INDEXED_SORT,
   SORTABLE_INDEXED_FIELDS,
+  SORTABLE_INDEXED_SCORE_FIELDS,
   TransactionSampleRowWithScore,
   WebVitals,
 } from 'sentry/views/performance/browser/webVitals/utils/types';
+import {useStoredScoresSetting} from 'sentry/views/performance/browser/webVitals/utils/useStoredScoresSetting';
 import {useWebVitalsSort} from 'sentry/views/performance/browser/webVitals/utils/useWebVitalsSort';
 
 type Props = {
@@ -38,11 +40,18 @@ export const useTransactionSamplesWebVitalsScoresQuery = ({
   const organization = useOrganization();
   const pageFilters = usePageFilters();
   const location = useLocation();
+  const shouldUseStoredScores = useStoredScoresSetting();
+
+  const filteredSortableFields = shouldUseStoredScores
+    ? SORTABLE_INDEXED_FIELDS
+    : SORTABLE_INDEXED_FIELDS.filter(
+        field => !SORTABLE_INDEXED_SCORE_FIELDS.includes(field)
+      );
 
   const sort = useWebVitalsSort({
     sortName,
     defaultSort: DEFAULT_INDEXED_SORT,
-    sortableFields: SORTABLE_INDEXED_FIELDS as unknown as string[],
+    sortableFields: filteredSortableFields as unknown as string[],
   });
 
   const eventView = EventView.fromNewQueryWithPageFilters(

--- a/static/app/views/performance/browser/webVitals/utils/types.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/types.tsx
@@ -51,6 +51,13 @@ export type TransactionSampleRowWithScore = TransactionSampleRow & Score;
 export type WebVitals = 'lcp' | 'fcp' | 'cls' | 'ttfb' | 'fid';
 
 // TODO: Refactor once stored scores are GA'd
+export const SORTABLE_SCORE_FIELDS = [
+  'score',
+  'opportunity',
+  'avg(measurements.score.total)',
+  'opportunity_score(measurements.score.total)',
+];
+
 export const SORTABLE_FIELDS = [
   'count()',
   'p75(measurements.cls)',
@@ -58,11 +65,10 @@ export const SORTABLE_FIELDS = [
   'p75(measurements.fid)',
   'p75(measurements.lcp)',
   'p75(measurements.ttfb)',
-  'score',
-  'opportunity',
-  'avg(measurements.score.total)',
-  'opportunity_score(measurements.score.total)',
+  ...SORTABLE_SCORE_FIELDS,
 ] as const;
+
+export const SORTABLE_INDEXED_SCORE_FIELDS = ['score', 'measurements.score.total'];
 
 export const SORTABLE_INDEXED_FIELDS = [
   'measurements.lcp',
@@ -70,8 +76,7 @@ export const SORTABLE_INDEXED_FIELDS = [
   'measurements.cls',
   'measurements.ttfb',
   'measurements.fid',
-  'score',
-  'measurements.score.total',
+  ...SORTABLE_INDEXED_SCORE_FIELDS,
 ] as const;
 
 export const DEFAULT_SORT: Sort = {

--- a/static/app/views/performance/browser/webVitals/utils/useWebVitalsSort.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/useWebVitalsSort.tsx
@@ -5,7 +5,9 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {
   DEFAULT_SORT,
   SORTABLE_FIELDS,
+  SORTABLE_SCORE_FIELDS,
 } from 'sentry/views/performance/browser/webVitals/utils/types';
+import {useStoredScoresSetting} from 'sentry/views/performance/browser/webVitals/utils/useStoredScoresSetting';
 
 export function useWebVitalsSort({
   sortName = 'sort',
@@ -17,10 +19,14 @@ export function useWebVitalsSort({
   sortableFields?: string[];
 } = {}) {
   const location = useLocation();
+  const shouldUseStoredScores = useStoredScoresSetting();
+  const filteredSortableFields = shouldUseStoredScores
+    ? sortableFields
+    : sortableFields.filter(field => !SORTABLE_SCORE_FIELDS.includes(field));
 
   const sort =
     fromSorts(decodeScalar(location.query[sortName])).filter(s =>
-      (sortableFields as unknown as string[]).includes(s.field)
+      (filteredSortableFields as unknown as string[]).includes(s.field)
     )[0] ?? defaultSort;
 
   return sort;


### PR DESCRIPTION
Perf score and opportunity columns should only be sortable when using scores sourced from the backend