### PR TITLE
ref(billing): Add const assertion to DATA_CATEGORY_INFO

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -309,7 +309,7 @@ export const DATA_CATEGORY_INFO = {
     titleName: t('Monitor Check-Ins'),
     uid: 10,
   },
-} satisfies Record<DataCategoryExact, DataCategoryInfo>;
+} as const satisfies Record<DataCategoryExact, DataCategoryInfo>;
 
 // Special Search characters
 export const NEGATION_OPERATOR = '!';


### PR DESCRIPTION
Use a const assertion here so that in this PR: https://github.com/getsentry/getsentry/pull/12375 we may be able to restrict the string literals of `.plural` to just include the plural data category literals (`errors`, `attachments`, `monitor check-ins`, etc...)