### PR TITLE
chore(hybrid-cloud): Simplify Discord API client

### DIFF
--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -227,7 +227,11 @@ Required if **service_type** is `slack` or `opsgenie`.
         # If we've only received a channel name, ask slack for its id
         generic_error_message = f"Could not fetch channel id from Slack for '{channel_name}'. Try providing the channel id, or try again later."
         try:
-            _prefix, channel_id, timed_out, = get_channel_id(
+            (
+                _prefix,
+                channel_id,
+                timed_out,
+            ) = get_channel_id(
                 organization=self.context["organization"],
                 integration=self.integration,
                 channel_name=channel_name,
@@ -276,7 +280,6 @@ Required if **service_type** is `slack` or `opsgenie`.
             validate_channel_id(
                 channel_id=channel_id,
                 guild_id=self.integration.external_id,
-                integration_id=self.integration.id,
                 guild_name=self.integration.name,
             )
         except Exception as e:

--- a/src/sentry/api/serializers/rest_framework/notification_action.py
+++ b/src/sentry/api/serializers/rest_framework/notification_action.py
@@ -227,11 +227,7 @@ Required if **service_type** is `slack` or `opsgenie`.
         # If we've only received a channel name, ask slack for its id
         generic_error_message = f"Could not fetch channel id from Slack for '{channel_name}'. Try providing the channel id, or try again later."
         try:
-            (
-                _prefix,
-                channel_id,
-                timed_out,
-            ) = get_channel_id(
+            (_prefix, channel_id, timed_out,) = get_channel_id(
                 organization=self.context["organization"],
                 integration=self.integration,
                 channel_name=channel_name,

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1339,7 +1339,6 @@ def get_alert_rule_trigger_action_discord_channel_id(
         validate_channel_id(
             channel_id=name,
             guild_id=integration.external_id,
-            integration_id=integration.id,
             guild_name=integration.name,
         )
     except ValidationError as e:

--- a/src/sentry/integrations/discord/actions/issue_alert/form.py
+++ b/src/sentry/integrations/discord/actions/issue_alert/form.py
@@ -50,7 +50,6 @@ class DiscordNotifyServiceForm(forms.Form):
                 validate_channel_id(
                     channel_id=channel,
                     guild_id=integration.external_id,
-                    integration_id=integration.id,
                     guild_name=integration.name,
                 )
                 cleaned_data["channel_id"] = channel

--- a/src/sentry/integrations/discord/actions/issue_alert/notification.py
+++ b/src/sentry/integrations/discord/actions/issue_alert/notification.py
@@ -45,7 +45,7 @@ class DiscordNotifyServiceAction(IntegrationEventAction):
             rules = [f.rule for f in futures]
             message = DiscordIssuesMessageBuilder(event.group, event=event, tags=tags, rules=rules)
 
-            client = DiscordClient(integration_id=integration.id)
+            client = DiscordClient()
             try:
                 client.send_message(channel_id, message, notification_uuid=notification_uuid)
             except ApiError as e:

--- a/src/sentry/integrations/discord/actions/metric_alert.py
+++ b/src/sentry/integrations/discord/actions/metric_alert.py
@@ -49,7 +49,7 @@ def send_incident_alert_notification(
         chart_url=chart_url,
     )
 
-    client = DiscordClient(integration_id=incident.identifier)
+    client = DiscordClient()
     try:
         client.send_message(channel, message)
     except ApiError as error:

--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -16,7 +16,7 @@ from sentry.integrations import (
     IntegrationMetadata,
     IntegrationProvider,
 )
-from sentry.integrations.discord.client import DiscordClient, DiscordNonProxyClient
+from sentry.integrations.discord.client import DiscordClient
 from sentry.models.integrations.integration import Integration
 from sentry.pipeline.views.base import PipelineView
 from sentry.services.hybrid_cloud.organization.model import RpcOrganizationSummary
@@ -72,12 +72,7 @@ metadata = IntegrationMetadata(
 
 class DiscordIntegration(IntegrationInstallation):
     def get_client(self) -> DiscordClient:
-        org_integration_id = self.org_integration.id if self.org_integration else None
-
-        return DiscordClient(
-            integration_id=self.model.id,
-            org_integration_id=org_integration_id,
-        )
+        return DiscordClient()
 
     def uninstall(self) -> None:
         # If this is the only org using this Discord server, we should remove
@@ -155,7 +150,7 @@ class DiscordIntegrationProvider(IntegrationProvider):
         self.public_key = options.get("discord.public-key")
         self.bot_token = options.get("discord.bot-token")
         self.client_secret = options.get("discord.client-secret")
-        self.client = DiscordNonProxyClient()
+        self.client = DiscordClient()
         self.setup_url = absolute_uri("extensions/discord/setup/")
         super().__init__()
 

--- a/src/sentry/integrations/discord/utils/channel.py
+++ b/src/sentry/integrations/discord/utils/channel.py
@@ -35,14 +35,12 @@ SUPPORTED_CHANNEL_TYPES = {
 }
 
 
-def validate_channel_id(
-    channel_id: str, guild_id: str, integration_id: int | None, guild_name: str | None
-) -> None:
+def validate_channel_id(channel_id: str, guild_id: str, guild_name: str | None) -> None:
     """
     Make sure that for this integration, the channel exists, belongs to this
     integration, and our bot has access to it.
     """
-    client = DiscordClient(integration_id=integration_id)
+    client = DiscordClient()
     try:
         result = client.get_channel(channel_id)
     except ApiError as e:

--- a/tests/sentry/integrations/discord/test_client.py
+++ b/tests/sentry/integrations/discord/test_client.py
@@ -1,10 +1,22 @@
 import responses
-from django.test import override_settings
+from responses import matchers
 
 from sentry import options
-from sentry.integrations.discord.client import GUILD_URL, DiscordClient
-from sentry.silo.base import SiloMode
-from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
+from sentry.integrations.discord.client import (
+    APPLICATION_COMMANDS_URL,
+    CHANNEL_URL,
+    GUILD_URL,
+    MESSAGE_URL,
+    USERS_GUILD_URL,
+    DiscordClient,
+)
+from sentry.integrations.discord.message_builder.base.base import DiscordMessageBuilder
+from sentry.integrations.discord.message_builder.base.flags import (
+    EPHEMERAL_FLAG,
+    LOADING_FLAG,
+    SUPPRESS_NOTIFICATIONS_FLAG,
+    DiscordMessageFlags,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -20,18 +32,39 @@ class DiscordClientTest(TestCase):
             name="Cool server",
             provider="discord",
         )
-        self.discord_client = DiscordClient(self.integration.id)
+        self.discord_client = DiscordClient()
+
+    def test_prepare_auth_header(self):
+        expected = {"Authorization": f"Bot {self.bot_token}"}
+        assert self.discord_client.prepare_auth_header() == expected
 
     @responses.activate
-    def test_authorize_request(self):
+    def test_set_application_command(self):
+        responses.add(
+            responses.POST,
+            url=f"{DiscordClient.base_url}{APPLICATION_COMMANDS_URL.format(application_id=self.application_id)}",
+            status=204,
+            match=[
+                matchers.header_matcher({"Authorization": f"Bot {self.bot_token}"}),
+                matchers.json_params_matcher({"command": "test"}),
+            ],
+        )
+
+        self.discord_client.set_application_command(command={"command": "test"})
+
+    @responses.activate
+    def test_has_application_commands(self):
         responses.add(
             responses.GET,
-            url=f"{DiscordClient.base_url}/",
-            json={},
+            url=f"{DiscordClient.base_url}{APPLICATION_COMMANDS_URL.format(application_id=self.application_id)}",
+            status=200,
+            json=[{"name": "test"}],
+            match=[
+                matchers.header_matcher({"Authorization": f"Bot {self.bot_token}"}),
+            ],
         )
-        self.discord_client.get("/")
-        request = responses.calls[0].request
-        assert request.headers["Authorization"] == f"Bot {self.bot_token}"
+
+        assert self.discord_client.has_application_commands() is True
 
     @responses.activate
     def test_get_guild_name(self):
@@ -45,84 +78,66 @@ class DiscordClientTest(TestCase):
                 "id": guild_id,
                 "name": server_name,
             },
+            match=[matchers.header_matcher({"Authorization": f"Bot {self.bot_token}"})],
         )
 
         guild_name = self.discord_client.get_guild_name(guild_id)
         assert guild_name == "Cool server"
 
+    @responses.activate
+    def test_leave_guild(self):
+        guild_id = self.integration.external_id
 
-control_address = "http://controlserver"
-secret = "secret-has-6-letters"
-
-
-@override_settings(
-    SENTRY_CONTROL_ADDRESS=control_address,
-    SENTRY_SUBNET_SECRET=secret,
-)
-class DiscordProxyClientTest(TestCase):
-    def setUp(self):
-        self.integration = self.create_integration(
-            organization=self.organization,
-            provider="discord",
-            name="Cool server",
-            external_id="1234567890",
+        responses.add(
+            responses.DELETE,
+            url=f"{DiscordClient.base_url}{USERS_GUILD_URL.format(guild_id=guild_id)}",
+            status=204,
+            match=[matchers.header_matcher({"Authorization": f"Bot {self.bot_token}"})],
         )
-        self.installation = self.integration.get_installation(organization_id=self.organization.id)
-        self.discord_client = DiscordClient(self.integration.id)
+
+        self.discord_client.leave_guild(guild_id)
 
     @responses.activate
-    def test_integration_proxy_is_active(self):
-        class DiscordProxyTestClient(DiscordClient):
-            _use_proxy_url_for_tests = True
-
-            def assert_proxy_request(self, request, is_proxy=True):
-                assert (PROXY_BASE_PATH in request.url) == is_proxy
-                assert (PROXY_OI_HEADER in request.headers) == is_proxy
-                assert (PROXY_SIGNATURE_HEADER in request.headers) == is_proxy
-                # The discord bot token shouldn't yet be in the request
-                assert ("Authorization" in request.headers) != is_proxy
-                if is_proxy:
-                    assert request.headers[PROXY_OI_HEADER] is not None
-
+    def test_get_channel(self):
+        channel_id = "channel-id"
         responses.add(
-            method=responses.GET,
-            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=self.integration.external_id)}",
-            json={"guild_id": "1234567890", "name": "Cool server"},
+            responses.GET,
+            url=f"{DiscordClient.base_url}{CHANNEL_URL.format(channel_id=channel_id)}",
             status=200,
+            json={"id": channel_id},
+            match=[matchers.header_matcher({"Authorization": f"Bot {self.bot_token}"})],
         )
 
+        response = self.discord_client.get_channel(channel_id=channel_id)
+        assert response == {"id": "channel-id"}
+
+    @responses.activate
+    def test_send_message(self):
+        channel_id = "channel-id"
         responses.add(
-            method=responses.GET,
-            url=f"{control_address}{PROXY_BASE_PATH}{GUILD_URL.format(guild_id=self.integration.external_id)}",
-            json={"guild_id": "1234567890", "name": "Cool server"},
+            responses.POST,
+            url=f"{DiscordClient.base_url}{MESSAGE_URL.format(channel_id=channel_id)}",
             status=200,
+            json={"id": channel_id},
+            match=[
+                matchers.header_matcher({"Authorization": f"Bot {self.bot_token}"}),
+                matchers.json_params_matcher(
+                    {
+                        "components": [],
+                        "content": "test",
+                        "embeds": [],
+                        "flags": EPHEMERAL_FLAG | LOADING_FLAG | SUPPRESS_NOTIFICATIONS_FLAG,
+                    }
+                ),
+            ],
         )
 
-        with override_settings(SILO_MODE=SiloMode.MONOLITH):
-            client = DiscordProxyTestClient(integration_id=self.integration.id)
-            client.get_guild_name(self.integration.external_id)
-            request = responses.calls[0].request
+        message = DiscordMessageBuilder(
+            content="test",
+            flags=DiscordMessageFlags().set_loading().set_ephemeral().set_suppress_notifications(),
+        )
 
-            assert GUILD_URL.format(guild_id=self.integration.external_id) in request.url
-            assert client.base_url in request.url
-            client.assert_proxy_request(request, is_proxy=False)
-
-        responses.calls.reset()
-        with override_settings(SILO_MODE=SiloMode.CONTROL):
-            client = DiscordProxyTestClient(integration_id=self.integration.id)
-            client.get_guild_name(self.integration.external_id)
-            request = responses.calls[0].request
-
-            assert GUILD_URL.format(guild_id=self.integration.external_id) in request.url
-            assert client.base_url in request.url
-            client.assert_proxy_request(request, is_proxy=False)
-
-        responses.calls.reset()
-        with override_settings(SILO_MODE=SiloMode.REGION):
-            client = DiscordProxyTestClient(integration_id=self.integration.id)
-            client.get_guild_name(self.integration.external_id)
-            request = responses.calls[0].request
-
-            assert GUILD_URL.format(guild_id=self.integration.external_id) in request.url
-            assert client.base_url not in request.url
-            client.assert_proxy_request(request, is_proxy=True)
+        self.discord_client.send_message(
+            channel_id=channel_id,
+            message=message,
+        )

--- a/tests/sentry/integrations/discord/test_integration.py
+++ b/tests/sentry/integrations/discord/test_integration.py
@@ -29,7 +29,7 @@ class DiscordIntegrationTest(IntegrationTestCase):
         options.set("discord.bot-token", self.bot_token)
         options.set("discord.client-secret", self.client_secret)
 
-    @mock.patch("sentry.integrations.discord.client.DiscordNonProxyClient.set_application_command")
+    @mock.patch("sentry.integrations.discord.client.DiscordClient.set_application_command")
     def assert_setup_flow(
         self,
         mock_set_application_command,
@@ -250,7 +250,7 @@ class DiscordIntegrationTest(IntegrationTestCase):
         with pytest.raises(IntegrationError):
             provider._get_discord_user_id("auth_code")
 
-    @mock.patch("sentry.integrations.discord.client.DiscordNonProxyClient.set_application_command")
+    @mock.patch("sentry.integrations.discord.client.DiscordClient.set_application_command")
     def test_post_install_missing_credentials(self, mock_set_application_command):
         provider = self.provider()
         provider.application_id = None

--- a/tests/sentry/integrations/discord/test_utils.py
+++ b/tests/sentry/integrations/discord/test_utils.py
@@ -41,71 +41,55 @@ class ValidateChannelTest(TestCase):
     @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
     def test_happy_path(self, mock_get_channel):
         mock_get_channel.return_value = {"guild_id": self.guild_id, "type": self.channel_type}
-        validate_channel_id(self.channel_id, self.guild_id, self.integration_id, self.guild_name)
+        validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
 
     @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
     def test_404(self, mock_get_channel):
         mock_get_channel.side_effect = ApiError(code=404, text="")
         with raises(ValidationError):
-            validate_channel_id(
-                self.channel_id, self.guild_id, self.integration_id, self.guild_name
-            )
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
 
     @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
     def test_403(self, mock_get_channel):
         mock_get_channel.side_effect = ApiError(code=403, text="")
         with raises(ValidationError):
-            validate_channel_id(
-                self.channel_id, self.guild_id, self.integration_id, self.guild_name
-            )
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
 
     @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
     def test_400(self, mock_get_channel):
         mock_get_channel.side_effect = ApiError(code=400, text="")
         with raises(ValidationError):
-            validate_channel_id(
-                self.channel_id, self.guild_id, self.integration_id, self.guild_name
-            )
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
 
     @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
     def test_api_error(self, mock_get_channel):
         mock_get_channel.side_effect = ApiError(code=401, text="")
         with raises(IntegrationError):
-            validate_channel_id(
-                self.channel_id, self.guild_id, self.integration_id, self.guild_name
-            )
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
 
     @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
     def test_bad_response(self, mock_get_channel):
         mock_get_channel.return_value = ""
         with raises(IntegrationError):
-            validate_channel_id(
-                self.channel_id, self.guild_id, self.integration_id, self.guild_name
-            )
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
 
     @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
     def test_not_guild_member(self, mock_get_channel):
         mock_get_channel.return_value = {"guild_id": "not-my-guild", "type": self.channel_type}
         with raises(ValidationError):
-            validate_channel_id(
-                self.channel_id, self.guild_id, self.integration_id, self.guild_name
-            )
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
 
     @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
     def test_timeout(self, mock_get_channel):
         mock_get_channel.side_effect = Timeout("foo")
         with raises(ApiTimeoutError):
-            validate_channel_id(
-                self.channel_id, self.guild_id, self.integration_id, self.guild_name
-            )
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
 
     @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
     def test_not_supported_type(self, mock_get_channel):
         mock_get_channel.return_value = {"guild_id": self.guild_id, "type": ChannelType.DM.value}
         with raises(ValidationError):
-            validate_channel_id(
-                self.channel_id, self.guild_id, self.integration_id, self.guild_name
-            )
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
 
 
 class GetChannelIdFromUrl(TestCase):


### PR DESCRIPTION
The Discord API client has no business being an integration proxy API client since it doesn't rely on any token refresh dance, nor any dependence on any integration database records on the Control silo.

This refactor lets the Discord API client to make Discord API calls from within the Region silo itself, rather than performing it at the control silo.