### PR TITLE
feat(ddm): Implement org abuse limits for metrics

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -862,7 +862,7 @@ register(
 # Drop delete_old_primary_hash messages for a particular project.
 register("reprocessing2.drop-delete-old-primary-hash", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# BEGIN PROJECT ABUSE QUOTAS
+# BEGIN ABUSE QUOTAS
 
 # Example:
 # >>> org = Organization.objects.get(slug='foo')
@@ -943,7 +943,15 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# END PROJECT ABUSE QUOTAS
+
+register(
+    "organization-abuse-quota.metric-bucket-limit",
+    type=Int,
+    default=0,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# END ABUSE QUOTAS
 
 # Send event messages for specific project IDs to random partitions in Kafka
 # contents are a list of project IDs to message types to be randomly assigned

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -388,6 +388,13 @@ class Quota(Service):
                 categories=[DataCategory.SESSION],
                 scope=QuotaScope.PROJECT,
             ),
+            AbuseQuota(
+                id="oam",
+                option="organization-abuse-quota.metric-bucket-limit",
+                compat_options=None,
+                categories=[DataCategory.METRIC_BUCKET],
+                scope=QuotaScope.ORGANIZATION,
+            ),
         ]
 
         # XXX: These reason codes are hardcoded in getsentry:

--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -53,7 +53,7 @@ class RedisQuota(Quota):
         if key:
             key.project = project
 
-        results = [*self.get_project_abuse_quotas(project.organization)]
+        results = [*self.get_abuse_quotas(project.organization)]
 
         with sentry_sdk.start_span(op="redis.get_quotas.get_project_quota") as span:
             span.set_tag("project.id", project.id)


### PR DESCRIPTION
Relay has a new quota category `METRIC_BUCKET`, this adds a org abuse limit for this category.

Relay: https://github.com/getsentry/relay/pull/2836
Epic: https://github.com/getsentry/relay/issues/2716

I checked in getsentry, `get_project_abuse_quotas` is not called, it can be renamed.