### PR TITLE
feat(performance-tracing-details): Adding event details slideout panel.

### DIFF
--- a/static/app/components/events/eventDataSection.tsx
+++ b/static/app/components/events/eventDataSection.tsx
@@ -93,8 +93,8 @@ export function EventDataSection({
 
   return (
     <DataSection ref={scrollToSection} className={className || ''} {...props}>
-      {title && (
-        <SectionHeader id={type} data-test-id={`event-section-${type}`}>
+      <SectionHeader id={type} data-test-id={`event-section-${type}`}>
+        {title && (
           <Title>
             {showPermalink ? (
               <Permalink className="permalink">
@@ -110,9 +110,9 @@ export function EventDataSection({
               <QuestionTooltip size="xs" title={help} isHoverable={isHelpHoverable} />
             )}
           </Title>
-          {actions && <ActionContainer>{actions}</ActionContainer>}
-        </SectionHeader>
-      )}
+        )}
+        {actions && <ActionContainer>{actions}</ActionContainer>}
+      </SectionHeader>
       <SectionContents>{children}</SectionContents>
     </DataSection>
   );

--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -161,15 +161,19 @@ function partitionEntriesForReplay(entries: Entry[]) {
   return [entries.slice(0, replayIndex), entries.slice(replayIndex)];
 }
 
-function Entries({
+export function Entries({
   definedEvent,
   projectSlug,
   isShare,
   group,
   organization,
+  hideBeforeReplayEntries = false,
+  hideBreadCrumbs = false,
 }: {
   definedEvent: Event;
   projectSlug: string;
+  hideBeforeReplayEntries?: boolean;
+  hideBreadCrumbs?: boolean;
   isShare?: boolean;
 } & Pick<Props, 'group' | 'organization'>) {
   if (!Array.isArray(definedEvent.entries)) {
@@ -190,13 +194,18 @@ function Entries({
 
   return (
     <Fragment>
-      {beforeReplayEntries.map((entry, entryIdx) => (
-        <EventEntry key={entryIdx} entry={entry} {...eventEntryProps} />
-      ))}
+      {!hideBeforeReplayEntries &&
+        beforeReplayEntries.map((entry, entryIdx) => (
+          <EventEntry key={entryIdx} entry={entry} {...eventEntryProps} />
+        ))}
       {!isShare && <EventReplay {...eventEntryProps} />}
-      {afterReplayEntries.map((entry, entryIdx) => (
-        <EventEntry key={entryIdx} entry={entry} {...eventEntryProps} />
-      ))}
+      {afterReplayEntries.map((entry, entryIdx) => {
+        if (hideBreadCrumbs && entry.type === EntryType.BREADCRUMBS) {
+          return null;
+        }
+
+        return <EventEntry key={entryIdx} entry={entry} {...eventEntryProps} />;
+      })}
     </Fragment>
   );
 }

--- a/static/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -37,6 +37,7 @@ type Props = {
   };
   event: Event;
   organization: Organization;
+  hideTitle?: boolean;
 };
 
 enum BreadcrumbSort {
@@ -51,7 +52,7 @@ const sortOptions = [
   {label: t('Oldest'), value: BreadcrumbSort.OLDEST},
 ];
 
-function BreadcrumbsContainer({data, event, organization}: Props) {
+function BreadcrumbsContainer({data, event, organization, hideTitle = false}: Props) {
   const [searchTerm, setSearchTerm] = useState('');
   const [filterSelections, setFilterSelections] = useState<SelectOption<string>[]>([]);
   const [displayRelativeTime, setDisplayRelativeTime] = useState(false);
@@ -310,8 +311,9 @@ function BreadcrumbsContainer({data, event, organization}: Props) {
 
   return (
     <EventDataSection
+      showPermalink={!hideTitle}
       type={EntryType.BREADCRUMBS}
-      title={t('Breadcrumbs')}
+      title={hideTitle ? '' : t('Breadcrumbs')}
       actions={actions}
     >
       <ErrorBoundary>

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -296,7 +296,7 @@ export type EntryDebugMeta = {
   type: EntryType.DEBUGMETA;
 };
 
-type EntryBreadcrumbs = {
+export type EntryBreadcrumbs = {
   data: {
     values: Array<RawCrumb>;
   };
@@ -795,7 +795,13 @@ export interface EventTransaction
   endTimestamp: number;
   // EntryDebugMeta is required for profiles to render in the span
   // waterfall with the correct symbolication statuses
-  entries: (EntrySpans | EntryRequest | EntryDebugMeta | AggregateEntrySpans)[];
+  entries: (
+    | EntrySpans
+    | EntryRequest
+    | EntryDebugMeta
+    | AggregateEntrySpans
+    | EntryBreadcrumbs
+  )[];
   startTimestamp: number;
   type: EventOrGroupType.TRANSACTION;
   perfProblem?: PerformanceDetectorData;

--- a/static/app/views/performance/traceDetails/newTraceDetailsTraceView.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsTraceView.tsx
@@ -1,4 +1,4 @@
-import {createRef, Fragment, useEffect} from 'react';
+import {createRef, Fragment, memo, useEffect} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -44,7 +44,7 @@ import {
 } from 'sentry/views/performance/traceDetails/utils';
 
 import LimitExceededMessage from './limitExceededMessage';
-import {TraceType} from './newTraceDetailsContent';
+import {EventDetail, TraceType} from './newTraceDetailsContent';
 import TraceNotFound from './traceNotFound';
 
 type AccType = {
@@ -55,6 +55,7 @@ type AccType = {
 
 type Props = Pick<RouteComponentProps<{}, {}>, 'location'> & {
   meta: TraceMeta | null;
+  onRowClick: (detailKey: EventDetail | undefined) => void;
   organization: Organization;
   rootEvent: EventTransaction | undefined;
   traceEventView: EventView;
@@ -135,7 +136,7 @@ function generateBounds(traceInfo: TraceInfo) {
   });
 }
 
-export default function NewTraceView({
+function NewTraceView({
   location,
   meta,
   organization,
@@ -146,6 +147,7 @@ export default function NewTraceView({
   orphanErrors,
   traceType,
   handleLimitChange,
+  onRowClick,
   ...props
 }: Props) {
   const sentryTransaction = Sentry.getCurrentHub().getScope()?.getTransaction();
@@ -155,7 +157,6 @@ export default function NewTraceView({
   });
   const hasOrphanErrors = orphanErrors && orphanErrors.length > 0;
   const onlyOrphanErrors = hasOrphanErrors && (!traces || traces.length === 0);
-
   useEffect(() => {
     trackAnalytics('performance_views.trace_view.view', {
       organization,
@@ -230,6 +231,7 @@ export default function NewTraceView({
             numberOfHiddenErrorsAbove={0}
           />
           <TransactionGroup
+            onRowClick={onRowClick}
             location={location}
             traceViewRef={traceViewRef}
             organization={organization}
@@ -344,6 +346,7 @@ export default function NewTraceView({
             numberOfHiddenErrorsAbove={index > 0 ? currentHiddenCount : 0}
           />
           <TransactionGroup
+            onRowClick={onRowClick}
             location={location}
             organization={organization}
             traceViewRef={traceViewRef}
@@ -436,6 +439,7 @@ export default function NewTraceView({
                 </TraceViewHeaderContainer>
                 <TraceViewContainer ref={traceViewRef}>
                   <TransactionGroup
+                    onRowClick={onRowClick}
                     location={location}
                     organization={organization}
                     traceInfo={traceInfo}
@@ -487,6 +491,7 @@ export default function NewTraceView({
 
   return traceView;
 }
+export default memo(NewTraceView);
 
 export const StyledTracePanel = styled(Panel)`
   height: 100%;

--- a/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
@@ -191,8 +191,7 @@ function NewTraceDetailsTransactionBar(props: Props) {
       `/organizations/${props.organization.slug}/events/${transactionEvent?.project_slug}:${transactionEvent?.event_id}/`,
     ],
     {
-      staleTime: 0,
-      refetchOnWindowFocus: true,
+      staleTime: 2 * 60 * 1000,
       enabled: showEmbeddedChildren || isHighlighted,
     }
   );

--- a/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
@@ -94,7 +94,6 @@ type Props = {
   isOrphan: boolean;
   isVisible: boolean;
   location: Location;
-  onRowClick: (detailKey: EventDetail | undefined) => void;
   onWheel: (deltaX: number) => void;
   organization: Organization;
   removeContentSpanBarRef: (instance: HTMLDivElement | null) => void;
@@ -106,6 +105,7 @@ type Props = {
   isOrphanError?: boolean;
   measurements?: Map<number, VerticalMark>;
   numOfOrphanErrors?: number;
+  onRowClick?: (detailKey: EventDetail | undefined) => void;
   onlyOrphanErrors?: boolean;
 };
 
@@ -199,7 +199,7 @@ function NewTraceDetailsTransactionBar(props: Props) {
 
   useEffect(() => {
     if (isTraceTransaction(props.transaction)) {
-      if (isHighlighted) {
+      if (isHighlighted && props.onRowClick) {
         props.onRowClick({
           traceFullDetailedEvent: props.transaction,
           event: embeddedChildren,

--- a/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
@@ -2,6 +2,7 @@ import {createRef, Fragment, useCallback, useEffect, useState} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
+import omit from 'lodash/omit';
 import {Observer} from 'mobx-react';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
@@ -71,11 +72,12 @@ import {
 } from 'sentry/utils/performance/quickTrace/utils';
 import Projects from 'sentry/utils/projects';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import useRouter from 'sentry/utils/useRouter';
 import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
 import {ProfileContext, ProfilesProvider} from 'sentry/views/profiling/profilesProvider';
 
+import {EventDetail} from './newTraceDetailsContent';
 import {ProjectBadgeContainer} from './styles';
-import TransactionDetail from './transactionDetail';
 import {TraceInfo, TraceRoot, TreeDepth} from './types';
 import {shortenErrorTitle} from './utils';
 
@@ -92,6 +94,7 @@ type Props = {
   isOrphan: boolean;
   isVisible: boolean;
   location: Location;
+  onRowClick: (detailKey: EventDetail | undefined) => void;
   onWheel: (deltaX: number) => void;
   organization: Organization;
   removeContentSpanBarRef: (instance: HTMLDivElement | null) => void;
@@ -107,11 +110,17 @@ type Props = {
 };
 
 function NewTraceDetailsTransactionBar(props: Props) {
-  const [showDetail, setShowDetail] = useState(false);
+  const detail_id = props.location.query.detail;
+  const isHighlighted = !!(
+    isTraceTransaction(props.transaction) &&
+    detail_id &&
+    detail_id === props.transaction.event_id
+  );
   const [showEmbeddedChildren, setShowEmbeddedChildren] = useState(false);
   const transactionRowDOMRef = createRef<HTMLDivElement>();
   const transactionTitleRef = createRef<HTMLDivElement>();
   let spanContentRef: HTMLDivElement | null = null;
+  const router = useRouter();
 
   const handleWheel = useCallback(
     (event: WheelEvent) => {
@@ -141,7 +150,6 @@ function NewTraceDetailsTransactionBar(props: Props) {
     }
     const boundingRect = element.getBoundingClientRect();
     const offset = boundingRect.top + window.scrollY;
-    setShowDetail(true);
     window.scrollTo(0, offset);
   }, [transactionRowDOMRef]);
 
@@ -183,10 +191,22 @@ function NewTraceDetailsTransactionBar(props: Props) {
       `/organizations/${props.organization.slug}/events/${transactionEvent?.project_slug}:${transactionEvent?.event_id}/`,
     ],
     {
-      staleTime: 2 * 60 * 1000,
-      enabled: showEmbeddedChildren,
+      staleTime: 0,
+      refetchOnWindowFocus: true,
+      enabled: showEmbeddedChildren || isHighlighted,
     }
   );
+
+  useEffect(() => {
+    if (isTraceTransaction(props.transaction)) {
+      if (isHighlighted) {
+        props.onRowClick({
+          traceFullDetailedEvent: props.transaction,
+          event: embeddedChildren,
+        });
+      }
+    }
+  }, [isHighlighted, embeddedChildren, props, props.transaction]);
 
   const renderEmbeddedChildrenState = () => {
     if (showEmbeddedChildren) {
@@ -211,14 +231,19 @@ function NewTraceDetailsTransactionBar(props: Props) {
   };
 
   const handleRowCellClick = () => {
-    const {transaction, organization} = props;
+    const {transaction, organization, location} = props;
 
     if (isTraceError(transaction)) {
       browserHistory.push(generateIssueEventTarget(transaction, organization));
     }
 
     if (isTraceTransaction<TraceFullDetailed>(transaction)) {
-      setShowDetail(prev => !prev);
+      router.replace({
+        pathname: location.pathname,
+        query: isHighlighted
+          ? omit(router.location.query, 'detail')
+          : {...location.query, detail: transaction.event_id},
+      });
     }
   };
 
@@ -582,11 +607,11 @@ function NewTraceDetailsTransactionBar(props: Props) {
   const renderDivider = (
     dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
   ) => {
-    if (showDetail) {
+    if (isHighlighted) {
       // Mock component to preserve layout spacing
       return (
         <DividerLine
-          showDetail
+          showDetail={isHighlighted}
           style={{
             position: 'absolute',
           }}
@@ -703,7 +728,7 @@ function NewTraceDetailsTransactionBar(props: Props) {
                 left: startPercentage,
                 width: widthPercentage,
               })}
-              showDetail={showDetail}
+              showDetail={isHighlighted}
             >
               {getHumanDuration(duration)}
             </DurationPill>
@@ -754,7 +779,7 @@ function NewTraceDetailsTransactionBar(props: Props) {
     const hideDurationRectangle = isTraceRoot(transaction) && onlyOrphanErrors;
 
     return (
-      <RowCellContainer showDetail={showDetail}>
+      <RowCellContainer showDetail={isHighlighted}>
         <RowCell
           data-test-id="transaction-row-title"
           data-type="span-row-cell"
@@ -762,7 +787,7 @@ function NewTraceDetailsTransactionBar(props: Props) {
             width: `calc(${toPercent(dividerPosition)} - 0.5px)`,
             paddingTop: 0,
           }}
-          showDetail={showDetail}
+          showDetail={isHighlighted}
           onClick={handleRowCellClick}
           ref={transactionTitleRef}
         >
@@ -785,7 +810,7 @@ function NewTraceDetailsTransactionBar(props: Props) {
             paddingTop: 0,
             overflow: 'visible',
           }}
-          showDetail={showDetail}
+          showDetail={isHighlighted}
           onClick={handleRowCellClick}
         >
           <RowReplayTimeIndicators />
@@ -794,40 +819,19 @@ function NewTraceDetailsTransactionBar(props: Props) {
             {renderMeasurements()}
           </GuideAnchor>
         </RowCell>
-        {!showDetail && renderGhostDivider(dividerHandlerChildrenProps)}
+        {!isHighlighted && renderGhostDivider(dividerHandlerChildrenProps)}
       </RowCellContainer>
-    );
-  };
-
-  const renderDetail = () => {
-    const {location, organization, isVisible, transaction} = props;
-
-    if (isTraceError(transaction) || isTraceRoot(transaction)) {
-      return null;
-    }
-
-    if (!isVisible || !showDetail) {
-      return null;
-    }
-
-    return (
-      <TransactionDetail
-        location={location}
-        organization={organization}
-        transaction={transaction}
-        scrollIntoView={scrollIntoView}
-      />
     );
   };
 
   const {isVisible, transaction} = props;
 
   return (
-    <Fragment>
+    <Wrapper showingChildren={showEmbeddedChildren}>
       <StyledRow
         ref={transactionRowDOMRef}
         visible={isVisible}
-        showBorder={showDetail}
+        showBorder={isHighlighted}
         cursor={
           isTraceTransaction<TraceFullDetailed>(transaction) ? 'pointer' : 'default'
         }
@@ -844,11 +848,10 @@ function NewTraceDetailsTransactionBar(props: Props) {
             </DividerHandlerManager.Consumer>
           )}
         </ScrollbarManager.Consumer>
-        {renderDetail()}
       </StyledRow>
       {renderEmbeddedChildrenState()}
       {renderEmbeddedChildren()}
-    </Fragment>
+    </Wrapper>
   );
 }
 
@@ -863,6 +866,12 @@ const StyledRow = styled(Row)`
   ${RowCellContainer} {
     overflow: visible;
   }
+`;
+
+const Wrapper = styled('div')<{showingChildren: boolean}>`
+  ${p =>
+    p.showingChildren &&
+    'outline: 1px solid black; border-top: 1px solid black; border-bottom: 1px solid black; border-radius: 2px;'}
 `;
 
 const ErrorLink = styled(Link)`

--- a/static/app/views/performance/traceDetails/styles.tsx
+++ b/static/app/views/performance/traceDetails/styles.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
@@ -6,6 +7,7 @@ import {SecondaryHeader} from 'sentry/components/events/interfaces/spans/header'
 import Panel from 'sentry/components/panels/panel';
 import Pills from 'sentry/components/pills';
 import SearchBar from 'sentry/components/searchBar';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {defined} from 'sentry/utils';
@@ -77,26 +79,30 @@ const StyledPills = styled(Pills)`
 export function Tags({
   location,
   organization,
+  enableHiding,
   transaction,
 }: {
   location: Location;
   organization: Organization;
   transaction: TraceFullDetailed;
+  enableHiding?: boolean;
 }) {
   const {tags} = transaction;
+  const [showingAll, setShowingAll] = useState(enableHiding ? false : true);
 
   if (!tags || tags.length <= 0) {
     return null;
   }
 
   const orgSlug = organization.slug;
+  const renderText = showingAll ? t('Show less') : t('Show more') + '...';
 
   return (
     <tr>
       <td className="key">Tags</td>
       <td className="value">
         <StyledPills>
-          {tags.map((tag, index) => {
+          {tags.slice(0, showingAll ? tags.length : 5).map((tag, index) => {
             const {pathname: streamPath, query} = transactionSummaryRouteWithQuery({
               orgSlug,
               transaction: transaction.transaction,
@@ -119,6 +125,16 @@ export function Tags({
               />
             );
           })}
+          {tags.length > 5 && enableHiding && (
+            <div style={{position: 'relative', height: '20px'}}>
+              <a
+                style={{position: 'absolute', bottom: '0px', whiteSpace: 'nowrap'}}
+                onClick={() => setShowingAll(prev => !prev)}
+              >
+                {renderText}
+              </a>
+            </div>
+          )}
         </StyledPills>
       </td>
     </tr>

--- a/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
+++ b/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
@@ -1,0 +1,450 @@
+import {createRef, Fragment, useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+import omit from 'lodash/omit';
+
+import Alert from 'sentry/components/alert';
+import {Button} from 'sentry/components/button';
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import DateTime from 'sentry/components/dateTime';
+import {
+  isNotMarkMeasurement,
+  isNotPerformanceScoreMeasurement,
+  TraceEventCustomPerformanceMetric,
+} from 'sentry/components/events/eventCustomPerformanceMetrics';
+import {Breadcrumbs} from 'sentry/components/events/interfaces/breadcrumbs';
+import {getFormattedTimeRangeWithLeadingAndTrailingZero} from 'sentry/components/events/interfaces/spans/utils';
+import {generateStats} from 'sentry/components/events/opsBreakdown';
+import FileSize from 'sentry/components/fileSize';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import Link from 'sentry/components/links/link';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {
+  ErrorDot,
+  ErrorLevel,
+  ErrorMessageContent,
+  ErrorMessageTitle,
+  ErrorTitle,
+} from 'sentry/components/performance/waterfall/rowDetails';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import {generateIssueEventTarget} from 'sentry/components/quickTrace/utils';
+import {Tooltip} from 'sentry/components/tooltip';
+import {PAGE_URL_PARAM} from 'sentry/constants/pageFilters';
+import {IconChevron, IconOpen} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {EntryBreadcrumbs, EntryType, EventTransaction, Organization} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import getDynamicText from 'sentry/utils/getDynamicText';
+import {PageErrorProvider} from 'sentry/utils/performance/contexts/pageError';
+import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
+import Projects from 'sentry/utils/projects';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {isCustomMeasurement} from 'sentry/views/dashboards/utils';
+import DetailPanel from 'sentry/views/starfish/components/detailPanel';
+
+import {transactionSummaryRouteWithQuery} from '../transactionSummary/utils';
+
+import {EventDetail} from './newTraceDetailsContent';
+import {Row, Tags} from './styles';
+
+type DetailPanelProps = {
+  detail: EventDetail | undefined;
+  onClose: () => void;
+};
+
+type EventDetailProps = {
+  detail: EventDetail;
+  location: Location;
+  organization: Organization;
+};
+
+function OpsBreakdown({event}: {event: EventTransaction}) {
+  const [showingAll, setShowingAll] = useState(false);
+  const breakdown = event && generateStats(event, {type: 'no_filter'});
+
+  if (!breakdown) {
+    return null;
+  }
+
+  const renderText = showingAll ? t('Show less') : t('Show more') + '...';
+  return (
+    breakdown && (
+      <Row
+        title={
+          <FlexBox style={{gap: '5px'}}>
+            Ops Breakdown
+            <QuestionTooltip
+              title={t('Applicable to the children of this event only')}
+              size="xs"
+            />
+          </FlexBox>
+        }
+      >
+        <div style={{display: 'flex', flexDirection: 'column', gap: space(0.25)}}>
+          {breakdown.slice(0, showingAll ? breakdown.length : 5).map((currOp, index) => {
+            const {name, percentage, totalInterval} = currOp;
+
+            const operationName = typeof name === 'string' ? name : t('Other');
+            const durLabel = Math.round(totalInterval * 1000 * 100) / 100;
+            const pctLabel = isFinite(percentage) ? Math.round(percentage * 100) : '∞';
+
+            return (
+              <div key={index}>
+                {operationName}: {durLabel}ms ({pctLabel}%)
+              </div>
+            );
+          })}
+          {breakdown.length > 5 && (
+            <a onClick={() => setShowingAll(prev => !prev)}>{renderText}</a>
+          )}
+        </div>
+      </Row>
+    )
+  );
+}
+
+function BreadCrumbsSection({
+  event,
+  organization,
+}: {
+  event: EventTransaction;
+  organization: Organization;
+}) {
+  const [showBreadCrumbs, setShowBreadCrumbs] = useState(false);
+  const breadCrumbsContainerRef = createRef<HTMLDivElement>();
+
+  useEffect(() => {
+    setTimeout(() => {
+      breadCrumbsContainerRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'end',
+      });
+    }, 100);
+  }, [showBreadCrumbs, breadCrumbsContainerRef]);
+
+  const matchingEntry: EntryBreadcrumbs | undefined = event?.entries.find(
+    entry => entry.type === EntryType.BREADCRUMBS
+  ) as EntryBreadcrumbs;
+
+  if (!matchingEntry) {
+    return null;
+  }
+
+  const renderText = showBreadCrumbs ? t('Hide Breadcrumbs') : t('Show Breadcrumbs');
+  const chevron = showBreadCrumbs ? (
+    <IconChevron size="xs" direction="up" />
+  ) : (
+    <IconChevron size="xs" direction="down" />
+  );
+  return (
+    <Fragment>
+      <a
+        style={{display: 'flex', alignItems: 'center', gap: space(0.5)}}
+        onClick={() => {
+          setShowBreadCrumbs(prev => !prev);
+        }}
+      >
+        {renderText} {chevron}
+      </a>
+      <div ref={breadCrumbsContainerRef}>
+        {showBreadCrumbs && (
+          <Breadcrumbs
+            hideTitle
+            data={matchingEntry.data}
+            event={event}
+            organization={organization}
+          />
+        )}
+      </div>
+    </Fragment>
+  );
+}
+function EventDetails({detail, organization, location}: EventDetailProps) {
+  const eventJsonUrl = `/api/0/projects/${organization.slug}/${detail.traceFullDetailedEvent.project_slug}/events/${detail.traceFullDetailedEvent.event_id}/json/`;
+  const {errors, performance_issues} = detail.traceFullDetailedEvent;
+  const hasIssues = errors.length + performance_issues.length > 0;
+  const startTimestamp = Math.min(
+    detail.traceFullDetailedEvent.start_timestamp,
+    detail.traceFullDetailedEvent.timestamp
+  );
+  const endTimestamp = Math.max(
+    detail.traceFullDetailedEvent.start_timestamp,
+    detail.traceFullDetailedEvent.timestamp
+  );
+  const {start: startTimeWithLeadingZero, end: endTimeWithLeadingZero} =
+    getFormattedTimeRangeWithLeadingAndTrailingZero(startTimestamp, endTimestamp);
+  const duration = (endTimestamp - startTimestamp) * 1000;
+  const durationString = `${Number(duration.toFixed(3)).toLocaleString()}ms`;
+  const measurementNames = Object.keys(detail.traceFullDetailedEvent.measurements ?? {})
+    .filter(name => isCustomMeasurement(`measurements.${name}`))
+    .filter(isNotMarkMeasurement)
+    .filter(isNotPerformanceScoreMeasurement)
+    .sort();
+
+  const renderGoToProfileButton = () => {
+    if (!detail.traceFullDetailedEvent.profile_id) {
+      return null;
+    }
+
+    const target = generateProfileFlamechartRoute({
+      orgSlug: organization.slug,
+      projectSlug: detail.traceFullDetailedEvent.project_slug,
+      profileId: detail.traceFullDetailedEvent.profile_id,
+    });
+
+    function handleOnClick() {
+      trackAnalytics('profiling_views.go_to_flamegraph', {
+        organization,
+        source: 'performance.trace_view',
+      });
+    }
+
+    return (
+      <StyledButton size="xs" to={target} onClick={handleOnClick}>
+        {t('View Profile')}
+      </StyledButton>
+    );
+  };
+
+  return detail.event ? (
+    <Wrapper>
+      <Actions>
+        <Button
+          size="sm"
+          icon={<IconOpen />}
+          href={eventJsonUrl}
+          external
+          onClick={() =>
+            trackAnalytics('performance_views.event_details.json_button_click', {
+              organization,
+            })
+          }
+        >
+          {t('JSON')} (<FileSize bytes={detail.event?.size} />)
+        </Button>
+      </Actions>
+
+      <Title>
+        <Projects
+          orgId={organization.slug}
+          slugs={[detail.traceFullDetailedEvent.project_slug]}
+        >
+          {({projects}) => {
+            const project = projects.find(
+              p => p.slug === detail.traceFullDetailedEvent.project_slug
+            );
+            return (
+              <Tooltip title={detail.traceFullDetailedEvent.project_slug}>
+                <ProjectBadge
+                  project={
+                    project ? project : {slug: detail.traceFullDetailedEvent.project_slug}
+                  }
+                  avatarSize={50}
+                  hideName
+                />
+              </Tooltip>
+            );
+          }}
+        </Projects>
+        <div>
+          <div>{t('Event')}</div>
+          <TransactionOp>
+            {' '}
+            {detail.traceFullDetailedEvent['transaction.op']}
+          </TransactionOp>
+        </div>
+      </Title>
+
+      {hasIssues && (
+        <Alert
+          system
+          defaultExpanded
+          type="error"
+          expand={[
+            ...detail.traceFullDetailedEvent.errors,
+            ...detail.traceFullDetailedEvent.performance_issues,
+          ].map(error => (
+            <ErrorMessageContent key={error.event_id}>
+              <ErrorDot level={error.level} />
+              <ErrorLevel>{error.level}</ErrorLevel>
+              <ErrorTitle>
+                <Link to={generateIssueEventTarget(error, organization)}>
+                  {error.title}
+                </Link>
+              </ErrorTitle>
+            </ErrorMessageContent>
+          ))}
+        >
+          <ErrorMessageTitle>
+            {tn(
+              '%s issue occurred in this transaction.',
+              '%s issues occurred in this transaction.',
+              detail.traceFullDetailedEvent.errors.length +
+                detail.traceFullDetailedEvent.performance_issues.length
+            )}
+          </ErrorMessageTitle>
+        </Alert>
+      )}
+
+      <StyledTable className="table key-value">
+        <tbody>
+          <Row title={<TransactionIdTitle>{t('Event ID')}</TransactionIdTitle>}>
+            {detail.traceFullDetailedEvent.event_id}
+            <CopyToClipboardButton
+              borderless
+              size="zero"
+              iconSize="xs"
+              text={`${window.location.href.replace(window.location.hash, '')}#txn-${
+                detail.traceFullDetailedEvent.event_id
+              }`}
+            />
+          </Row>
+          <Row title={t('Description')}>
+            <Link
+              to={transactionSummaryRouteWithQuery({
+                orgSlug: organization.slug,
+                transaction: detail.traceFullDetailedEvent.transaction,
+                query: omit(location.query, Object.values(PAGE_URL_PARAM)),
+                projectID: String(detail.traceFullDetailedEvent.project_id),
+              })}
+            >
+              {detail.traceFullDetailedEvent.transaction}
+            </Link>
+          </Row>
+          {detail.traceFullDetailedEvent.profile_id && (
+            <Row title="Profile ID" extra={renderGoToProfileButton()}>
+              {detail.traceFullDetailedEvent.profile_id}
+            </Row>
+          )}
+          <Row title="Duration">{durationString}</Row>
+          <Row title="Date Range">
+            {getDynamicText({
+              fixed: 'Mar 19, 2021 11:06:27 AM UTC',
+              value: (
+                <Fragment>
+                  <DateTime date={startTimestamp * 1000} />
+                  {` (${startTimeWithLeadingZero})`}
+                </Fragment>
+              ),
+            })}
+            <br />
+            {getDynamicText({
+              fixed: 'Mar 19, 2021 11:06:28 AM UTC',
+              value: (
+                <Fragment>
+                  <DateTime date={endTimestamp * 1000} />
+                  {` (${endTimeWithLeadingZero})`}
+                </Fragment>
+              ),
+            })}
+          </Row>
+
+          <OpsBreakdown event={detail.event} />
+
+          <Tags
+            enableHiding
+            location={location}
+            organization={organization}
+            transaction={detail.traceFullDetailedEvent}
+          />
+
+          {measurementNames.length > 0 && (
+            <tr>
+              <td className="key">Custom Metrics</td>
+              <td className="value">
+                <Measurements>
+                  {measurementNames.map(name => {
+                    return (
+                      detail.event && (
+                        <TraceEventCustomPerformanceMetric
+                          key={name}
+                          event={detail.event}
+                          name={name}
+                          location={location}
+                          organization={organization}
+                          source={undefined}
+                          isHomepage={false}
+                        />
+                      )
+                    );
+                  })}
+                </Measurements>
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </StyledTable>
+      <BreadCrumbsSection event={detail.event} organization={organization} />
+    </Wrapper>
+  ) : (
+    <LoadingIndicator />
+  );
+}
+
+function TraceViewDetailPanel({detail, onClose}: DetailPanelProps) {
+  const organization = useOrganization();
+  const location = useLocation();
+  return (
+    <PageErrorProvider>
+      <DetailPanel detailKey={detail ? 'open' : undefined} onClose={onClose}>
+        {detail && (
+          <EventDetails location={location} organization={organization} detail={detail} />
+        )}
+      </DetailPanel>
+    </PageErrorProvider>
+  );
+}
+
+const Wrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(2)};
+`;
+
+const FlexBox = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+const Actions = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+`;
+
+const Title = styled(FlexBox)`
+  gap: ${space(2)};
+`;
+
+const TransactionOp = styled('div')`
+  font-size: 25px;
+  font-weight: bold;
+`;
+
+const TransactionIdTitle = styled('a')`
+  display: flex;
+  color: ${p => p.theme.textColor};
+  :hover {
+    color: ${p => p.theme.textColor};
+  }
+`;
+
+const Measurements = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${space(1)};
+  padding-top: 10px;
+`;
+
+const StyledButton = styled(Button)`
+  position: absolute;
+  top: ${space(0.75)};
+  right: ${space(0.5)};
+`;
+
+const StyledTable = styled('table')`
+  margin-bottom: 0;
+`;
+
+export default TraceViewDetailPanel;

--- a/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
+++ b/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
@@ -35,6 +35,7 @@ import {
   ErrorMessageTitle,
   ErrorTitle,
 } from 'sentry/components/performance/waterfall/rowDetails';
+import PerformanceDuration from 'sentry/components/performanceDuration';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {generateIssueEventTarget} from 'sentry/components/quickTrace/utils';
 import {Tooltip} from 'sentry/components/tooltip';
@@ -84,7 +85,7 @@ function OpsBreakdown({event}: {event: EventTransaction}) {
       <Row
         title={
           <FlexBox style={{gap: '5px'}}>
-            Ops Breakdown
+            {t('Ops Breakdown')}
             <QuestionTooltip
               title={t('Applicable to the children of this event only')}
               size="xs"
@@ -93,16 +94,16 @@ function OpsBreakdown({event}: {event: EventTransaction}) {
         }
       >
         <div style={{display: 'flex', flexDirection: 'column', gap: space(0.25)}}>
-          {breakdown.slice(0, showingAll ? breakdown.length : 5).map((currOp, index) => {
+          {breakdown.slice(0, showingAll ? breakdown.length : 5).map(currOp => {
             const {name, percentage, totalInterval} = currOp;
 
             const operationName = typeof name === 'string' ? name : t('Other');
-            const durLabel = Math.round(totalInterval * 1000 * 100) / 100;
             const pctLabel = isFinite(percentage) ? Math.round(percentage * 100) : '∞';
 
             return (
-              <div key={index}>
-                {operationName}: {durLabel}ms ({pctLabel}%)
+              <div key={operationName}>
+                {operationName}:{' '}
+                <PerformanceDuration seconds={totalInterval} abbreviation /> ({pctLabel}%)
               </div>
             );
           })}
@@ -137,19 +138,15 @@ function BreadCrumbsSection({
   }, [showBreadCrumbs, breadCrumbsContainerRef]);
 
   const matchingEntry: EntryBreadcrumbs | undefined = event?.entries.find(
-    entry => entry.type === EntryType.BREADCRUMBS
-  ) as EntryBreadcrumbs;
+    (entry): entry is EntryBreadcrumbs => entry.type === EntryType.BREADCRUMBS
+  );
 
   if (!matchingEntry) {
     return null;
   }
 
   const renderText = showBreadCrumbs ? t('Hide Breadcrumbs') : t('Show Breadcrumbs');
-  const chevron = showBreadCrumbs ? (
-    <IconChevron size="xs" direction="up" />
-  ) : (
-    <IconChevron size="xs" direction="down" />
-  );
+  const chevron = <IconChevron size="xs" direction={showBreadCrumbs ? 'up' : 'down'} />;
   return (
     <Fragment>
       <a
@@ -361,7 +358,7 @@ function EventDetails({detail, organization, location}: EventDetailProps) {
 
           {measurementNames.length > 0 && (
             <tr>
-              <td className="key">Custom Metrics</td>
+              <td className="key">{t('Custom Metrics')}</td>
               <td className="value">
                 <Measurements>
                   {measurementNames.map(name => {

--- a/static/app/views/performance/traceDetails/transactionGroup.tsx
+++ b/static/app/views/performance/traceDetails/transactionGroup.tsx
@@ -27,7 +27,6 @@ type Props = ScrollbarManagerChildrenProps & {
   isOrphan: boolean;
   isVisible: boolean;
   location: Location;
-  onRowClick: (detailKey: EventDetail | undefined) => void;
   organization: Organization;
   renderedChildren: React.ReactNode[];
   traceInfo: TraceInfo;
@@ -37,6 +36,7 @@ type Props = ScrollbarManagerChildrenProps & {
   isOrphanError?: boolean;
   measurements?: Map<number, VerticalMark>;
   numOfOrphanErrors?: number;
+  onRowClick?: (detailKey: EventDetail | undefined) => void;
   onlyOrphanErrors?: boolean;
 };
 

--- a/static/app/views/performance/traceDetails/transactionGroup.tsx
+++ b/static/app/views/performance/traceDetails/transactionGroup.tsx
@@ -13,6 +13,7 @@ import {
 import {Organization} from 'sentry/types';
 import {TraceError, TraceFullDetailed} from 'sentry/utils/performance/quickTrace/types';
 
+import {EventDetail} from './newTraceDetailsContent';
 import NewTraceDetailsTransactionBar from './newTraceDetailsTransactionBar';
 import TransactionBar from './transactionBar';
 import {TraceInfo, TraceRoot, TreeDepth} from './types';
@@ -26,6 +27,7 @@ type Props = ScrollbarManagerChildrenProps & {
   isOrphan: boolean;
   isVisible: boolean;
   location: Location;
+  onRowClick: (detailKey: EventDetail | undefined) => void;
   organization: Organization;
   renderedChildren: React.ReactNode[];
   traceInfo: TraceInfo;
@@ -80,6 +82,7 @@ class TransactionGroup extends Component<Props, State> {
       onlyOrphanErrors,
       isOrphanError,
       traceViewRef,
+      onRowClick,
     } = this.props;
     const {isExpanded} = this.state;
 
@@ -110,7 +113,11 @@ class TransactionGroup extends Component<Props, State> {
     return (
       <Fragment>
         {organization.features.includes('performance-trace-details') ? (
-          <NewTraceDetailsTransactionBar {...commonProps} traceViewRef={traceViewRef} />
+          <NewTraceDetailsTransactionBar
+            {...commonProps}
+            traceViewRef={traceViewRef}
+            onRowClick={onRowClick}
+          />
         ) : (
           <TransactionBar {...commonProps} />
         )}


### PR DESCRIPTION
This pr adds a slide out panel containing the major blocks of an event's detail, under the feature flag `organizations:performance-trace-details`.

- I used a simple `detail=${eventid}` query param to control the highlighted state across the trace. 
- I am aware that re-clicking a highlighted row doesn't get rid of the detail panel. Will fix that.

<img width="1507" alt="Screenshot 2023-12-13 at 11 09 35 AM" src="https://github.com/getsentry/sentry/assets/60121741/ba59081d-c1a9-4955-a871-6fd2dcc45cb7">

