### PR TITLE
fix(hybridcloud) Remove limit on project query used in sdk wizard

### DIFF
--- a/src/sentry/services/hybrid_cloud/project/impl.py
+++ b/src/sentry/services/hybrid_cloud/project/impl.py
@@ -40,12 +40,11 @@ class DatabaseBackedProjectService(ProjectService):
         *,
         region_name: str,
         organization_ids: List[int],
-        limit: int = 100,
     ) -> List[RpcProject]:
         projects = Project.objects.filter(
             organization__in=organization_ids,
             status=ObjectStatus.ACTIVE,
-        ).order_by("-date_added")[:limit]
+        ).order_by("-date_added")
         return [serialize_project(p) for p in projects]
 
     def get_option(self, *, project: RpcProject, key: str) -> RpcProjectOptionValue:

--- a/src/sentry/services/hybrid_cloud/project/service.py
+++ b/src/sentry/services/hybrid_cloud/project/service.py
@@ -41,7 +41,6 @@ class ProjectService(RpcService):
         *,
         region_name: str,
         organization_ids: List[int],
-        limit: int = 100,
     ) -> List[RpcProject]:
         pass
 


### PR DESCRIPTION
Limiting these results can lead to users not being able to access the project they are looking for. We will need to revisit this as an unbounded result set in an RPC call is a trap