### PR TITLE
fix(crons): Properly scope project for MonitorEndpoint

### DIFF
--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -66,13 +66,13 @@ class MonitorEndpoint(Endpoint):
         except Organization.DoesNotExist:
             raise ResourceDoesNotExist
 
+        project = request.auth.project
+        if project.status != ObjectStatus.ACTIVE:
+            raise ResourceDoesNotExist
+
         try:
             monitor = Monitor.objects.get(organization_id=organization.id, slug=monitor_slug)
         except Monitor.DoesNotExist:
-            raise ResourceDoesNotExist
-
-        project = Project.objects.get_from_cache(id=monitor.project_id)
-        if project.status != ObjectStatus.ACTIVE:
             raise ResourceDoesNotExist
 
         self.check_object_permissions(request, project)


### PR DESCRIPTION
Pulls the project from the request auth instead of the monitor (accessed via slug)