### PR TITLE
ref: upgrade nodeenv

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -102,7 +102,7 @@ msgpack==1.0.4
 msgpack-types==0.2.0
 mypy==1.7.1
 mypy-extensions==1.0.0
-nodeenv==1.6.0
+nodeenv==1.8.0
 oauthlib==3.1.0
 openai==1.3.5
 openapi-core==0.14.2


### PR DESCRIPTION
fix flaky IncompleteRead setting up js environments

```
An unexpected error has occurred: CalledProcessError: command: ('/Users/runner/work/getsentry/getsentry/.venv/bin/python', '-mnodeenv', '--prebuilt', '--clean-src', '/Users/runner/.cache/pre-commit/repo6sv2ontx/node_env-default')
return code: 1
stdout: (none)
stderr:
    /Users/runner/work/getsentry/getsentry/.venv/lib/python3.8/site-packages/nodeenv.py:48: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
      from pkg_resources import parse_version
     * Install prebuilt node (21.4.0) .Incomplete read while readingfrom https://nodejs.org/download/release/v21.4.0/node-v21.4.0-darwin-x64.tar.gz
    .
    Traceback (most recent call last):
      File "/Users/runner/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/runpy.py", line 194, in _run_module_as_main
        return _run_code(code, main_globals, None,
      File "/Users/runner/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "/Users/runner/work/getsentry/getsentry/.venv/lib/python3.8/site-packages/nodeenv.py", line 1494, in <module>
        main()
      File "/Users/runner/work/getsentry/getsentry/.venv/lib/python3.8/site-packages/nodeenv.py", line 1079, in main
        create_environment(env_dir, opt)
      File "/Users/runner/work/getsentry/getsentry/.venv/lib/python3.8/site-packages/nodeenv.py", line 956, in create_environment
        install_node(env_dir, src_dir, opt)
      File "/Users/runner/work/getsentry/getsentry/.venv/lib/python3.8/site-packages/nodeenv.py", line 721, in install_node
        install_node_wrapped(env_dir, src_dir, opt)
      File "/Users/runner/work/getsentry/getsentry/.venv/lib/python3.8/site-packages/nodeenv.py", line 743, in install_node_wrapped
        download_node_src(node_url, src_dir, opt)
      File "/Users/runner/work/getsentry/getsentry/.venv/lib/python3.8/site-packages/nodeenv.py", line 586, in download_node_src
        with ctx as archive:
      File "/Users/runner/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/contextlib.py", line 113, in __enter__
        return next(self.gen)
      File "/Users/runner/work/getsentry/getsentry/.venv/lib/python3.8/site-packages/nodeenv.py", line 557, in tarfile_open
        tf = tarfile.open(*args, **kwargs)
      File "/Users/runner/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/tarfile.py", line 1781, in open
        saved_pos = fileobj.tell()
    AttributeError: 'bytes' object has no attribute 'tell'
```
<!-- Describe your PR here. -->