### PR TITLE
feat(crons): Implement calls to monitor seat assignment toggles

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -527,6 +527,12 @@ class Quota(Service):
 
         return Outcome.ACCEPTED
 
+    def disable_monitor_seat(self, monitor: Monitor) -> None:
+        """
+        Removes a monitor from it's assigned seat.
+        """
+        pass
+
     def check_accept_monitor_checkin(self, project_id: int, monitor_slug: str):
         """
         Will return a `PermitCheckInStatus`.


### PR DESCRIPTION
Triggers the seat assignment and unassignment quota methods when
changing the status of a monitor.