### PR TITLE
ref(feedback): update github & jira pre-filled ticket for feedback linked issues

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.mixins.issues import MAX_CHAR, IssueBasicMixin
+from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.organization import Organization
@@ -26,6 +27,16 @@ class GitHubIssueBasic(IssueBasicMixin):
         repo, issue_id = key.split("#")
         return f"https://{domain_name}/{repo}/issues/{issue_id}"
 
+    def get_feedback_issue_body(self, event: GroupEvent) -> str:
+        body = "|  |  |\n"
+        body += "| ------------- | --------------- |\n"
+        for evidence in sorted(
+            event.occurrence.evidence_display, key=attrgetter("important"), reverse=True
+        ):
+            body += f"| **{evidence.name}** | {evidence.value} |\n"
+
+        return body[:-2]
+
     def get_generic_issue_body(self, event: GroupEvent) -> str:
         body = "|  |  |\n"
         body += "| ------------- | --------------- |\n"
@@ -40,7 +51,11 @@ class GitHubIssueBasic(IssueBasicMixin):
         output = self.get_group_link(group, **kwargs)
 
         if isinstance(event, GroupEvent) and event.occurrence is not None:
-            body = self.get_generic_issue_body(event)
+            body = ""
+            if group.issue_category == GroupCategory.FEEDBACK:
+                body = self.get_feedback_issue_body(event)
+            else:
+                body = self.get_generic_issue_body(event)
             output.extend([body])
         else:
             body = self.get_group_body(group, event)

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -28,14 +28,24 @@ class GitHubIssueBasic(IssueBasicMixin):
         return f"https://{domain_name}/{repo}/issues/{issue_id}"
 
     def get_feedback_issue_body(self, event: GroupEvent) -> str:
-        body = "|  |  |\n"
+        messages = [
+            evidence for evidence in event.occurrence.evidence_display if evidence.name == "message"
+        ]
+        others = [
+            evidence for evidence in event.occurrence.evidence_display if evidence.name != "message"
+        ]
+
+        body = ""
+        for message in messages:
+            body += message.value
+            body += "\n\n"
+
+        body += "|  |  |\n"
         body += "| ------------- | --------------- |\n"
-        for evidence in sorted(
-            event.occurrence.evidence_display, key=attrgetter("important"), reverse=True
-        ):
+        for evidence in sorted(others, key=attrgetter("important"), reverse=True):
             body += f"| **{evidence.name}** | {evidence.value} |\n"
 
-        return body[:-2]
+        return body[:-1]  # remove the last new line
 
     def get_generic_issue_body(self, event: GroupEvent) -> str:
         body = "|  |  |\n"

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -45,7 +45,7 @@ class GitHubIssueBasic(IssueBasicMixin):
         for evidence in sorted(others, key=attrgetter("important"), reverse=True):
             body += f"| **{evidence.name}** | {evidence.value} |\n"
 
-        return body[:-1]  # remove the last new line
+        return body.rstrip("\n")  # remove the last new line
 
     def get_generic_issue_body(self, event: GroupEvent) -> str:
         body = "|  |  |\n"

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from typing import Any, ClassVar, Dict, List, Mapping, Sequence
 
 from sentry.integrations.utils import where_should_sync
+from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
 from sentry.models.integrations.external_issue import ExternalIssue
@@ -78,6 +79,14 @@ class IssueBasicMixin:
         params = {}
         if kwargs.get("link_referrer"):
             params["referrer"] = kwargs.get("link_referrer")
+
+        if group.issue_category == GroupCategory.FEEDBACK:
+            return [
+                "Sentry Feedback: [{}]({})".format(
+                    group.qualified_short_id, absolute_uri(group.get_absolute_url(params=params))
+                )
+            ]
+
         return [
             "Sentry Issue: [{}]({})".format(
                 group.qualified_short_id, absolute_uri(group.get_absolute_url(params=params))


### PR DESCRIPTION
For both GH and Jira linked issues created from feedback:
- move the feedback message out of the table
- change the issue title to be "Sentry Feedback" rather than "Sentry Issue"

closes https://github.com/getsentry/sentry/issues/61631