### PR TITLE
fix(starfish): Set unique cursors for mobile tables

### DIFF
--- a/static/app/views/starfish/views/screens/constants.ts
+++ b/static/app/views/starfish/views/screens/constants.ts
@@ -1,0 +1,11 @@
+export enum MobileCursors {
+  SPANS_TABLE = 'spansCursor',
+  SCREENS_TABLE = 'screensCursor',
+  RELEASE_1_EVENT_SAMPLE_TABLE = 'release1Cursor',
+  RELEASE_2_EVENT_SAMPLE_TABLE = 'release2Cursor',
+}
+
+export enum MobileSortKeys {
+  RELEASE_1_EVENT_SAMPLE_TABLE = 'release1Samples',
+  RELEASE_2_EVENT_SAMPLE_TABLE = 'release2Samples',
+}

--- a/static/app/views/starfish/views/screens/index.tsx
+++ b/static/app/views/starfish/views/screens/index.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -6,6 +7,7 @@ import Alert from 'sentry/components/alert';
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import LoadingContainer from 'sentry/components/loading/loadingContainer';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {CursorHandler} from 'sentry/components/pagination';
 import SearchBar from 'sentry/components/performance/searchBar';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -28,6 +30,7 @@ import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
+import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 import {ScreensBarChart} from 'sentry/views/starfish/views/screens/screenBarChart';
 import {
   ScreensTable,
@@ -109,6 +112,8 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
   const organization = useOrganization();
   const {query: locationQuery} = location;
 
+  const cursor = decodeScalar(location.query?.[MobileCursors.SCREENS_TABLE]);
+
   const yAxisCols = yAxes.map(val => YAXIS_COLUMNS[val]);
 
   const {
@@ -162,6 +167,7 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
     eventView: tableEventView,
     enabled: !isReleasesLoading,
     referrer: 'api.starfish.mobile-screen-table',
+    cursor,
   });
 
   const topTransactions =
@@ -241,6 +247,13 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
   const derivedQuery = getTransactionSearchQuery(location, tableEventView.query);
 
   const tableSearchFilters = new MutableSearch(['transaction.op:ui.load']);
+
+  const handleCursor: CursorHandler = (newCursor, pathname, query_) => {
+    browserHistory.push({
+      pathname,
+      query: {...query_, [MobileCursors.SCREENS_TABLE]: newCursor},
+    });
+  };
 
   return (
     <div data-test-id="starfish-mobile-view">
@@ -331,6 +344,7 @@ export function ScreensView({yAxes, additionalFilters, chartHeight}: Props) {
         data={topTransactionsData}
         isLoading={topTransactionsLoading}
         pageLinks={pageLinks}
+        onCursor={handleCursor}
       />
     </div>
   );

--- a/static/app/views/starfish/views/screens/screenLoadSpans/deviceClassSelector.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/deviceClassSelector.tsx
@@ -4,6 +4,7 @@ import {CompactSelect} from 'sentry/components/compactSelect';
 import {t} from 'sentry/locale';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
+import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 
 export function DeviceClassSelector() {
   const location = useLocation();
@@ -29,6 +30,8 @@ export function DeviceClassSelector() {
           query: {
             ...location.query,
             ['device.class']: newValue.value,
+            [MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE]: undefined,
+            [MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE]: undefined,
           },
         });
       }}

--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
@@ -23,6 +23,10 @@ import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/sta
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {
+  MobileCursors,
+  MobileSortKeys,
+} from 'sentry/views/starfish/views/screens/constants';
+import {
   ScreenCharts,
   YAxis,
 } from 'sentry/views/starfish/views/screens/screenLoadSpans/charts';
@@ -114,8 +118,8 @@ function ScreenLoadSpans() {
                   <SampleContainerItem>
                     <ScreenLoadEventSamples
                       release={primaryRelease}
-                      sortKey="release1Samples"
-                      cursorName="release1Cursor"
+                      sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
+                      cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
                       transaction={transactionName}
                       showDeviceClassSelector
                     />
@@ -123,8 +127,8 @@ function ScreenLoadSpans() {
                   <SampleContainerItem>
                     <ScreenLoadEventSamples
                       release={secondaryRelease}
-                      sortKey="release2Samples"
-                      cursorName="release2Cursor"
+                      sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
+                      cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
                       transaction={transactionName}
                     />
                   </SampleContainerItem>

--- a/static/app/views/starfish/views/screens/screenLoadSpans/spanOpSelector.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/spanOpSelector.tsx
@@ -13,6 +13,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
+import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
 type Props = {
@@ -79,6 +80,7 @@ export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: 
           query: {
             ...location.query,
             [SpanMetricsField.SPAN_OP]: newValue.value,
+            [MobileCursors.SPANS_TABLE]: undefined,
           },
         });
       }}

--- a/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
@@ -10,7 +11,7 @@ import GridEditable, {
 import SortLink from 'sentry/components/gridEditable/sortLink';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
-import Pagination from 'sentry/components/pagination';
+import Pagination, {CursorHandler} from 'sentry/components/pagination';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import {NewQuery} from 'sentry/types';
@@ -37,6 +38,7 @@ import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/center
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
+import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
 import {SpanOpSelector} from 'sentry/views/starfish/views/screens/screenLoadSpans/spanOpSelector';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
@@ -57,6 +59,7 @@ export function ScreenLoadSpansTable({
   const location = useLocation();
   const {selection} = usePageFilters();
   const organization = useOrganization();
+  const cursor = decodeScalar(location.query?.[MobileCursors.SPANS_TABLE]);
 
   const spanOp = decodeScalar(location.query[SpanMetricsField.SPAN_OP]) ?? '';
   const truncatedPrimary = formatVersionAndCenterTruncate(primaryRelease ?? '', 15);
@@ -117,6 +120,7 @@ export function ScreenLoadSpansTable({
     eventView,
     enabled: true,
     referrer: 'api.starfish.mobile-span-table',
+    cursor,
   });
 
   const columnNameMap = {
@@ -305,6 +309,13 @@ export function ScreenLoadSpansTable({
 
   const columnSortBy = eventView.getSorts();
 
+  const handleCursor: CursorHandler = (newCursor, pathname, query) => {
+    browserHistory.push({
+      pathname,
+      query: {...query, [MobileCursors.SPANS_TABLE]: newCursor},
+    });
+  };
+
   return (
     <Fragment>
       <SpanOpSelector
@@ -334,7 +345,7 @@ export function ScreenLoadSpansTable({
           renderBodyCell,
         }}
       />
-      <Pagination pageLinks={pageLinks} />
+      <Pagination pageLinks={pageLinks} onCursor={handleCursor} />
     </Fragment>
   );
 }

--- a/static/app/views/starfish/views/screens/screensTable.tsx
+++ b/static/app/views/starfish/views/screens/screensTable.tsx
@@ -5,7 +5,7 @@ import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
 import SortLink from 'sentry/components/gridEditable/sortLink';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
-import Pagination from 'sentry/components/pagination';
+import Pagination, {CursorHandler} from 'sentry/components/pagination';
 import {Tooltip} from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
 import {
@@ -35,9 +35,10 @@ type Props = {
   eventView: EventView;
   isLoading: boolean;
   pageLinks: string | undefined;
+  onCursor?: CursorHandler;
 };
 
-export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
+export function ScreensTable({data, eventView, isLoading, pageLinks, onCursor}: Props) {
   const location = useLocation();
   const {selection} = usePageFilters();
   const {projects} = useProjects();
@@ -219,7 +220,7 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
           renderBodyCell,
         }}
       />
-      <Pagination pageLinks={pageLinks} />
+      <Pagination pageLinks={pageLinks} onCursor={onCursor} />
     </Fragment>
   );
 }


### PR DESCRIPTION
We make a ton of table queries on the mobile
pages, giving them all unique cursor names
so they don't conflict.