### PR TITLE
ref(relocation): Use separate filestore for relocations

### DIFF
--- a/src/sentry/data/config/config.yml.default
+++ b/src/sentry/data/config/config.yml.default
@@ -83,15 +83,23 @@ redis.clusters:
 filestore.backend: 'filesystem'
 filestore.options:
   location: '/tmp/sentry-files'
+filestore.relocation:
+  location: '/tmp/sentry-relocation-files'
 
 # NOTE: See docs/filestore for instructions on configuring the shell environment
 #       with authentication credentials for Google Cloud.
 # filestore.backend: 'gcs'
 # filestore.options:
-#   bucket_name: 's3-bucket-name'
+#   bucket_name: 'gcs-bucket-name'
+# filestore.relocation:
+#   bucket_name: 'gcs-relocation-bucket-name'
 
 # filestore.backend: 's3'
 # filestore.options:
 #   access_key: 'AKIXXXXXX'
 #   secret_key: 'XXXXXXX'
 #   bucket_name: 's3-bucket-name'
+# filestore.relocation:
+#   access_key: 'AKIXXXXXX'
+#   secret_key: 'XXXXXXX'
+#   bucket_name: 's3-relocation-bucket-name'

--- a/src/sentry/models/files/utils.py
+++ b/src/sentry/models/files/utils.py
@@ -118,7 +118,6 @@ class AssembleChecksumMismatch(Exception):
 
 
 def get_storage(config=None):
-
     if config is not None:
         backend = config["backend"]
         options = config["options"]
@@ -135,6 +134,25 @@ def get_storage(config=None):
 
     storage = get_storage_class(backend)
     return storage(**options)
+
+
+def get_relocation_storage(config=None):
+    if config is not None:
+        backend = config["backend"]
+        relocation = config["relocation"]
+    else:
+        from sentry import options as options_store
+
+        backend = options_store.get("filestore.backend")
+        relocation = options_store.get("filestore.relocation")
+
+    try:
+        backend = settings.SENTRY_FILESTORE_ALIASES[backend]
+    except KeyError:
+        pass
+
+    storage = get_storage_class(backend)
+    return storage(**relocation)
 
 
 def clear_cached_files(cache_path):

--- a/src/sentry/models/relocation.py
+++ b/src/sentry/models/relocation.py
@@ -186,12 +186,18 @@ class RelocationFile(DefaultFieldsModel):
         #
         # TODO(getsentry/team-ospo#216): Add a normalization step to the relocation flow
         NORMALIZED_USER_DATA = 2
-        # The global configuration we're going to validate against - pulled from the live Sentry
-        # instance, not supplied by the user.
+        # (Deprecated) The global configuration we're going to validate against - pulled from the
+        # live Sentry instance, not supplied by the user.
+        #
+        # TODO(getsentry/team-ospo#216): Deprecated, since we no longer store these in main bucket.
+        # Remove in the future.
         BASELINE_CONFIG_VALIDATION_DATA = 3
-        # The colliding users we're going to validate against - pulled from the live Sentry
-        # instance, not supplied by the user. However, to determine what is a "colliding user", we
-        # must inspect the user-provided data.
+        # (Deprecated) The colliding users we're going to validate against - pulled from the live
+        # Sentry instance, not supplied by the user. However, to determine what is a "colliding
+        # user", we must inspect the user-provided data.
+        #
+        # TODO(getsentry/team-ospo#216): Deprecated, since we no longer store these in main bucket.
+        # Remove in the future.
         COLLIDING_USERS_VALIDATION_DATA = 4
 
         # TODO(getsentry/team-ospo#190): Could we dedup this with a mixin in the future?

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -276,6 +276,9 @@ register("beacon.anonymous", type=Bool, flags=FLAG_REQUIRED)
 # Filestore (default)
 register("filestore.backend", default="filesystem", flags=FLAG_NOSTORE)
 register("filestore.options", default={"location": "/tmp/sentry-files"}, flags=FLAG_NOSTORE)
+register(
+    "filestore.relocation", default={"location": "/tmp/sentry-relocation-files"}, flags=FLAG_NOSTORE
+)
 
 # Filestore for control silo
 register("filestore.control.backend", default="", flags=FLAG_NOSTORE)

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -544,6 +544,7 @@ def apply_legacy_settings(settings: Any) -> None:
         ("MAILGUN_API_KEY", "mail.mailgun-api-key"),
         ("SENTRY_FILESTORE", "filestore.backend"),
         ("SENTRY_FILESTORE_OPTIONS", "filestore.options"),
+        ("SENTRY_FILESTORE_RELOCATION", "filestore.relocation"),
         ("GOOGLE_CLIENT_ID", "auth-google.client-id"),
         ("GOOGLE_CLIENT_SECRET", "auth-google.client-secret"),
     ):

--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -26,9 +26,8 @@ from sentry.backup.helpers import (
     unwrap_encrypted_export_tarball,
 )
 from sentry.backup.imports import import_in_organization_scope
-from sentry.filestore.gcs import GoogleCloudStorage
 from sentry.models.files.file import File
-from sentry.models.files.utils import get_storage
+from sentry.models.files.utils import get_relocation_storage, get_storage
 from sentry.models.importchunk import ControlImportChunkReplica, RegionImportChunk
 from sentry.models.lostpasswordhash import LostPasswordHash as LostPasswordHash
 from sentry.models.organization import Organization
@@ -50,14 +49,12 @@ from sentry.utils import json
 from sentry.utils.db import atomic_transaction
 from sentry.utils.env import gcp_project_id, log_gcp_credentials_details
 from sentry.utils.relocation import (
-    RELOCATION_BLOB_SIZE,
-    RELOCATION_FILE_TYPE,
     TASK_TO_STEP,
     LoggingPrinter,
     OrderedTask,
     create_cloudbuild_yaml,
     fail_relocation,
-    get_bucket_name,
+    get_relocations_bucket_name,
     retry_task_or_fail_relocation,
     send_relocation_update_email,
     start_relocation_task,
@@ -169,7 +166,6 @@ def uploading_complete(uuid: str) -> None:
             .first()
         )
         fp = raw_relocation_file.file.getfile()
-
         with fp:
             preprocessing_scan.delay(uuid)
 
@@ -315,7 +311,7 @@ def preprocessing_scan(uuid: str) -> None:
             relocation.want_usernames = sorted(usernames)
             relocation.save()
 
-            preprocessing_baseline_config.delay(uuid)
+            preprocessing_transfer.delay(uuid)
 
             # The user's import data looks basically okay - we can use this opportunity to send a
             # "your relocation request has been accepted and is in flight, please give it a few
@@ -328,6 +324,86 @@ def preprocessing_scan(uuid: str) -> None:
                     "orgs": relocation.want_org_slugs,
                 },
             )
+
+
+@instrumented_task(
+    name="sentry.relocation.preprocessing_transfer",
+    queue="relocation",
+    max_retries=MAX_FAST_TASK_RETRIES,
+    retry_backoff=RETRY_BACKOFF,
+    retry_backoff_jitter=True,
+    soft_time_limit=MEDIUM_TIME_LIMIT,
+    silo_mode=SiloMode.REGION,
+)
+def preprocessing_transfer(uuid: str) -> None:
+    """
+    We currently have the user's relocation data stored in the main filestore bucket, but we need to
+    move it to the relocation bucket. This task handles that transfer.
+
+    This function is meant to be idempotent, and should be retried with an exponential backoff.
+    """
+
+    relocation: Optional[Relocation]
+    attempts_left: int
+    (relocation, attempts_left) = start_relocation_task(
+        uuid=uuid,
+        task=OrderedTask.PREPROCESSING_TRANSFER,
+        allowed_task_attempts=MAX_FAST_TASK_ATTEMPTS,
+    )
+    if relocation is None:
+        return
+
+    with retry_task_or_fail_relocation(
+        relocation,
+        OrderedTask.PREPROCESSING_TRANSFER,
+        attempts_left,
+        ERR_PREPROCESSING_INTERNAL,
+    ):
+        relocation_storage = get_relocation_storage()
+
+        # Build the `cloudbuild.yaml` file we'll use for validation. CloudBuild requires the storage
+        # source to be zipped, even if it is only a single yaml file.
+        cloudbuild_yaml = BytesIO(create_cloudbuild_yaml(relocation))
+        cloudbuild_zip = BytesIO()
+        with ZipFile(cloudbuild_zip, "w") as zf:
+            zf.writestr("cloudbuild.yaml", cloudbuild_yaml.read())
+
+        # Save the ZIP archive to remote storage, so that we may build from it.
+        cloudbuild_yaml.seek(0)
+        cloudbuild_zip.seek(0)
+        relocation_storage.save(f"runs/{uuid}/conf/cloudbuild.yaml", cloudbuild_yaml)
+        relocation_storage.save(f"runs/{uuid}/conf/cloudbuild.zip", cloudbuild_zip)
+
+        # Upload the `key-config.json` file we'll use to identify the correct KMS resource use
+        # during validation.
+        log_gcp_credentials_details(logger)
+        kms_config_bytes = json.dumps(get_default_crypto_key_version()).encode("utf-8")
+        relocation_storage.save(f"runs/{uuid}/in/kms-config.json", BytesIO(kms_config_bytes))
+
+        # Now, upload the relocation data proper.
+        kind = RelocationFile.Kind.RAW_USER_DATA
+        raw_relocation_file = (
+            RelocationFile.objects.filter(
+                relocation=relocation,
+                kind=kind.value,
+            )
+            .select_related("file")
+            .prefetch_related("file__blobs")
+            .first()
+        )
+        if raw_relocation_file is None:
+            raise FileNotFoundError("User-supplied relocation data not found.")
+
+        file: File = raw_relocation_file.file
+        path = f'runs/{uuid}/in/{kind.to_filename("tar")}'
+
+        # Copy all of the files from Django's abstract filestore into an isolated,
+        # backend-specific filestore for relocation operations only.
+        fp = file.getfile()
+        fp.seek(0)
+        relocation_storage.save(path, fp)
+
+        preprocessing_baseline_config.delay(uuid)
 
 
 @instrumented_task(
@@ -362,6 +438,10 @@ def preprocessing_baseline_config(uuid: str) -> None:
         attempts_left,
         ERR_PREPROCESSING_INTERNAL,
     ):
+        kind = RelocationFile.Kind.BASELINE_CONFIG_VALIDATION_DATA
+        path = f'runs/{uuid}/in/{kind.to_filename("tar")}'
+        relocation_storage = get_relocation_storage()
+
         # TODO(getsentry/team-ospo#216): A very nice optimization here is to only pull this down
         # once a day - if we've already done a relocation today, we should just copy that file
         # instead of doing this (expensive!) global export again.
@@ -373,14 +453,7 @@ def preprocessing_baseline_config(uuid: str) -> None:
             printer=LoggingPrinter(uuid),
         )
         fp.seek(0)
-        kind = RelocationFile.Kind.BASELINE_CONFIG_VALIDATION_DATA
-        file = File.objects.create(name=kind.to_filename("tar"), type=RELOCATION_FILE_TYPE)
-        file.putfile(fp, blob_size=RELOCATION_BLOB_SIZE, logger=logger)
-        RelocationFile.objects.create(
-            relocation=relocation,
-            file=file,
-            kind=kind.value,
-        )
+        relocation_storage.save(path, fp)
 
         preprocessing_colliding_users.delay(uuid)
 
@@ -418,6 +491,9 @@ def preprocessing_colliding_users(uuid: str) -> None:
         attempts_left,
         ERR_PREPROCESSING_INTERNAL,
     ):
+        kind = RelocationFile.Kind.COLLIDING_USERS_VALIDATION_DATA
+        path = f'runs/{uuid}/in/{kind.to_filename("tar")}'
+        relocation_storage = get_relocation_storage()
         fp = BytesIO()
         log_gcp_credentials_details(logger)
         export_in_user_scope(
@@ -427,14 +503,7 @@ def preprocessing_colliding_users(uuid: str) -> None:
             printer=LoggingPrinter(uuid),
         )
         fp.seek(0)
-        kind = RelocationFile.Kind.COLLIDING_USERS_VALIDATION_DATA
-        file = File.objects.create(name=kind.to_filename("tar"), type=RELOCATION_FILE_TYPE)
-        file.putfile(fp, blob_size=RELOCATION_BLOB_SIZE, logger=logger)
-        RelocationFile.objects.create(
-            relocation=relocation,
-            file=file,
-            kind=kind.value,
-        )
+        relocation_storage.save(path, fp)
 
         preprocessing_complete.delay(uuid)
 
@@ -450,9 +519,10 @@ def preprocessing_colliding_users(uuid: str) -> None:
 )
 def preprocessing_complete(uuid: str) -> None:
     """
-    Creates a "composite object" from the uploaded tarball, which could have many pieces. Because
-    creating a composite object in this manner is a synchronous operation, we don't need a follow-up
-    step confirming success.
+    This task ensures that every file CloudBuild will need to do its work is actually present and
+    available. Even if we've "finished" our uploads from the previous step, they may still not (yet)
+    be available on the read side, so this final step just gives us a bit of buffer to ensure that
+    this is the case.
 
     This function is meant to be idempotent, and should be retried with an exponential backoff.
     """
@@ -473,53 +543,17 @@ def preprocessing_complete(uuid: str) -> None:
         attempts_left,
         ERR_PREPROCESSING_INTERNAL,
     ):
-        storage = get_storage()
-
-        # Build the `cloudbuild.yaml` file we'll use for validation. CloudBuild requires the storage
-        # source to be zipped, even if it is only a single yaml file.
-        cloudbuild_yaml = BytesIO(create_cloudbuild_yaml(relocation))
-        cloudbuild_zip = BytesIO()
-        with ZipFile(cloudbuild_zip, "w") as zf:
-            zf.writestr("cloudbuild.yaml", cloudbuild_yaml.read())
-
-        # Save the ZIP archive to remote storage, so that we may build from it.
-        cloudbuild_yaml.seek(0)
-        cloudbuild_zip.seek(0)
-        storage.save(f"relocations/runs/{uuid}/conf/cloudbuild.yaml", cloudbuild_yaml)
-        storage.save(f"relocations/runs/{uuid}/conf/cloudbuild.zip", cloudbuild_zip)
-
-        # Upload the `key-config.json` file we'll use to identify the correct KMS resource use
-        # during validation.
-        log_gcp_credentials_details(logger)
-        kms_config_bytes = json.dumps(get_default_crypto_key_version()).encode("utf-8")
-        storage.save(f"relocations/runs/{uuid}/in/kms-config.json", BytesIO(kms_config_bytes))
-
-        # Upload the exports we'll be validating.
+        relocation_storage = get_relocation_storage()
+        if not relocation_storage.exists(f"runs/{uuid}/conf/cloudbuild.yaml"):
+            raise FileNotFoundError("Could not locate `cloudbuild.yaml` in relocation bucket.")
+        if not relocation_storage.exists(f"runs/{uuid}/conf/cloudbuild.zip"):
+            raise FileNotFoundError("Could not locate `cloudbuild.zip` in relocation bucket.")
+        if not relocation_storage.exists(f"runs/{uuid}/in/kms-config.json"):
+            raise FileNotFoundError("Could not locate `kms-config.json` in relocation bucket.")
         for kind in RELOCATION_FILES_TO_BE_VALIDATED:
-            raw_relocation_file = (
-                RelocationFile.objects.filter(
-                    relocation=relocation,
-                    kind=kind.value,
-                )
-                .select_related("file")
-                .prefetch_related("file__blobs")
-                .first()
-            )
-
-            file = raw_relocation_file.file
-            path = f'relocations/runs/{uuid}/in/{kind.to_filename("tar")}'
-            if isinstance(storage, GoogleCloudStorage):
-                # If we're using GCS, rather than performing an expensive copy of the file, just
-                # create a composite object.
-                storage.client.bucket(storage.bucket_name).blob(path).compose(
-                    [b.getfile().blob for b in file.blobs.all()]
-                )
-            else:
-                # In S3 or the local filesystem, no "composite object" API exists, so we do a manual
-                # concatenation then copying instead.
-                fp = file.getfile()
-                fp.seek(0)
-                storage.save(path, fp)
+            filename = kind.to_filename("tar")
+            if not relocation_storage.exists(f"runs/{uuid}/in/{filename}"):
+                raise FileNotFoundError(f"Could not locate `{filename}` in relocation bucket.")
 
         with atomic_transaction(
             using=(router.db_for_write(Relocation), router.db_for_write(RelocationValidation))
@@ -719,8 +753,8 @@ def validating_start(uuid: str) -> None:
         build = Build(
             source={
                 "storage_source": {
-                    "bucket": get_bucket_name(),
-                    "object_": f"relocations/runs/{uuid}/conf/cloudbuild.zip",
+                    "bucket": get_relocations_bucket_name(),
+                    "object_": f"runs/{uuid}/conf/cloudbuild.zip",
                 }
             },
             steps=convert_dict_key_case(cb_conf["steps"], camel_to_snake_keep_underscores),
@@ -886,13 +920,13 @@ def validating_complete(uuid: str, build_id: str) -> None:
     ):
         storage = get_storage()
         final_status = ValidationStatus.VALID
-        (_, findings_files) = storage.listdir(f"relocations/runs/{uuid}/findings")
+        (_, findings_files) = storage.listdir(f"runs/{uuid}/findings")
         for file in sorted(findings_files, reverse=True):
             # Ignore files prefixed with `artifacts-`, as these are generated by CloudBuild.
             if file.startswith("artifacts-"):
                 continue
 
-            findings_file = storage.open(f"relocations/runs/{uuid}/findings/{file}")
+            findings_file = storage.open(f"runs/{uuid}/findings/{file}")
             with findings_file:
                 findings = json.load(findings_file)
                 if len(findings) > 0:
@@ -1179,6 +1213,7 @@ TASK_MAP: dict[OrderedTask, Task] = {
     OrderedTask.NONE: Task(),
     OrderedTask.UPLOADING_COMPLETE: uploading_complete,
     OrderedTask.PREPROCESSING_SCAN: preprocessing_scan,
+    OrderedTask.PREPROCESSING_TRANSFER: preprocessing_transfer,
     OrderedTask.PREPROCESSING_BASELINE_CONFIG: preprocessing_baseline_config,
     OrderedTask.PREPROCESSING_COLLIDING_USERS: preprocessing_colliding_users,
     OrderedTask.PREPROCESSING_COMPLETE: preprocessing_complete,

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -213,6 +213,7 @@ def test_apply_legacy_settings(settings):
     settings.SENTRY_OPTIONS = {"system.secret-key": "secret-key", "mail.from": "mail-from"}
     settings.SENTRY_FILESTORE = "some-filestore"
     settings.SENTRY_FILESTORE_OPTIONS = {"filestore-foo": "filestore-bar"}
+    settings.SENTRY_FILESTORE_RELOCATION = {"relocation-baz": "relocation-qux"}
     with pytest.warns(DeprecatedSettingWarning) as warninfo:
         apply_legacy_settings(settings)
     assert settings.CELERY_ALWAYS_EAGER is False
@@ -228,6 +229,7 @@ def test_apply_legacy_settings(settings):
         "mail.mailgun-api-key": "mailgun-api-key",
         "filestore.backend": "some-filestore",
         "filestore.options": {"filestore-foo": "filestore-bar"},
+        "filestore.relocation": {"relocation-baz": "relocation-qux"},
     }
     assert settings.DEFAULT_FROM_EMAIL == "mail-from"
     assert settings.ALLOWED_HOSTS == ["*"]
@@ -241,6 +243,7 @@ def test_apply_legacy_settings(settings):
             ("SENTRY_ENABLE_EMAIL_REPLIES", "SENTRY_OPTIONS['mail.enable-replies']"),
             ("SENTRY_FILESTORE", "SENTRY_OPTIONS['filestore.backend']"),
             ("SENTRY_FILESTORE_OPTIONS", "SENTRY_OPTIONS['filestore.options']"),
+            ("SENTRY_FILESTORE_RELOCATION", "SENTRY_OPTIONS['filestore.relocation']"),
             ("SENTRY_REDIS_OPTIONS", 'SENTRY_OPTIONS["redis.clusters"]'),
             ("SENTRY_SMTP_HOSTNAME", "SENTRY_OPTIONS['mail.reply-hostname']"),
             ("SENTRY_SYSTEM_MAX_EVENTS_PER_MINUTE", "SENTRY_OPTIONS['system.rate-limit']"),

--- a/tests/sentry/tasks/snapshots/PreprocessingTransferTest/test_success.pysnap
+++ b/tests/sentry/tasks/snapshots/PreprocessingTransferTest/test_success.pysnap
@@ -5,7 +5,7 @@ source: tests/sentry/tasks/test_relocation.py
 ---
 artifacts:
   objects:
-    location: gs://<BUCKET>/relocations/runs/<UUID>/findings/
+    location: gs://<BUCKET>/runs/<UUID>/findings/
     paths:
     - /workspace/findings/**
 options:
@@ -16,7 +16,7 @@ steps:
 - args:
   - cp
   - -r
-  - gs://<BUCKET>/relocations/runs/<UUID>/in
+  - gs://<BUCKET>/runs/<UUID>/in
   - .
   id: copy-inputs-being-validated
   name: gcr.io/cloud-builders/gsutil
@@ -295,7 +295,7 @@ steps:
   - cp
   - -r
   - /workspace/out
-  - gs://<BUCKET>/relocations/runs/<UUID>/out
+  - gs://<BUCKET>/runs/<UUID>/out
   id: copy-out-dir
   name: gcr.io/cloud-builders/gsutil
   timeout: 30s

--- a/tests/sentry/tasks/test_relocation.py
+++ b/tests/sentry/tasks/test_relocation.py
@@ -24,7 +24,7 @@ from sentry.backup.helpers import (
 )
 from sentry.backup.imports import import_in_organization_scope
 from sentry.models.files.file import File
-from sentry.models.files.utils import get_storage
+from sentry.models.files.utils import get_relocation_storage, get_storage
 from sentry.models.importchunk import (
     ControlImportChunk,
     ControlImportChunkReplica,
@@ -70,6 +70,7 @@ from sentry.tasks.relocation import (
     preprocessing_colliding_users,
     preprocessing_complete,
     preprocessing_scan,
+    preprocessing_transfer,
     uploading_complete,
     validating_complete,
     validating_poll,
@@ -267,7 +268,7 @@ class UploadingCompleteTest(RelocationTaskTestCase):
     new_callable=lambda: FakeKeyManagementServiceClient,
 )
 @patch("sentry.utils.relocation.MessageBuilder")
-@patch("sentry.tasks.relocation.preprocessing_baseline_config.delay")
+@patch("sentry.tasks.relocation.preprocessing_transfer.delay")
 class PreprocessingScanTest(RelocationTaskTestCase):
     def setUp(self):
         super().setUp()
@@ -277,7 +278,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
 
     def test_success_admin_assisted_relocation(
         self,
-        preprocessing_baseline_config_mock: Mock,
+        preprocessing_transfer_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: FakeKeyManagementServiceClient,
     ):
@@ -295,7 +296,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        assert preprocessing_baseline_config_mock.call_count == 1
+        assert preprocessing_transfer_mock.call_count == 1
 
         relocation: Relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.want_usernames == [
@@ -306,7 +307,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
 
     def test_success_self_service_relocation(
         self,
-        preprocessing_baseline_config_mock: Mock,
+        preprocessing_transfer_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: FakeKeyManagementServiceClient,
     ):
@@ -323,7 +324,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_message_builder.call_args.kwargs["type"] == "relocation.started"
         fake_message_builder.return_value.send_async.assert_called_once_with(to=[self.owner.email])
 
-        assert preprocessing_baseline_config_mock.call_count == 1
+        assert preprocessing_transfer_mock.call_count == 1
 
         relocation: Relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.want_usernames == [
@@ -334,7 +335,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
 
     def test_pause(
         self,
-        preprocessing_baseline_config_mock: Mock,
+        preprocessing_transfer_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: FakeKeyManagementServiceClient,
     ):
@@ -348,7 +349,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_kms_client.asymmetric_decrypt.call_count == 0
         assert fake_kms_client.get_public_key.call_count == 0
         assert fake_message_builder.call_count == 0
-        assert preprocessing_baseline_config_mock.call_count == 0
+        assert preprocessing_transfer_mock.call_count == 0
 
         relocation: Relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.PAUSE.value
@@ -358,7 +359,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
 
     def test_retry_if_attempts_left(
         self,
-        preprocessing_baseline_config_mock: Mock,
+        preprocessing_transfer_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: FakeKeyManagementServiceClient,
     ):
@@ -373,7 +374,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert fake_kms_client.asymmetric_decrypt.call_count == 0
         assert fake_kms_client.get_public_key.call_count == 0
         assert fake_message_builder.call_count == 0
-        assert preprocessing_baseline_config_mock.call_count == 0
+        assert preprocessing_transfer_mock.call_count == 0
 
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.IN_PROGRESS.value
@@ -382,7 +383,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
 
     def test_fail_if_no_attempts_left(
         self,
-        preprocessing_baseline_config_mock: Mock,
+        preprocessing_transfer_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: FakeKeyManagementServiceClient,
     ):
@@ -405,7 +406,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        assert preprocessing_baseline_config_mock.call_count == 0
+        assert preprocessing_transfer_mock.call_count == 0
 
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
@@ -414,7 +415,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
 
     def test_fail_invalid_tarball(
         self,
-        preprocessing_baseline_config_mock: Mock,
+        preprocessing_transfer_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: FakeKeyManagementServiceClient,
     ):
@@ -432,7 +433,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        assert preprocessing_baseline_config_mock.call_count == 0
+        assert preprocessing_transfer_mock.call_count == 0
 
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
@@ -441,7 +442,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
 
     def test_fail_decryption_failure(
         self,
-        preprocessing_baseline_config_mock: Mock,
+        preprocessing_transfer_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: FakeKeyManagementServiceClient,
     ):
@@ -466,7 +467,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         )
 
         assert fake_kms_client.asymmetric_decrypt.call_count == 1
-        assert preprocessing_baseline_config_mock.call_count == 0
+        assert preprocessing_transfer_mock.call_count == 0
 
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
@@ -475,7 +476,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
 
     def test_fail_invalid_json(
         self,
-        preprocessing_baseline_config_mock: Mock,
+        preprocessing_transfer_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: FakeKeyManagementServiceClient,
     ):
@@ -492,7 +493,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        assert preprocessing_baseline_config_mock.call_count == 0
+        assert preprocessing_transfer_mock.call_count == 0
 
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
@@ -501,7 +502,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
 
     def test_fail_no_users(
         self,
-        preprocessing_baseline_config_mock: Mock,
+        preprocessing_transfer_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: FakeKeyManagementServiceClient,
     ):
@@ -518,7 +519,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        assert preprocessing_baseline_config_mock.call_count == 0
+        assert preprocessing_transfer_mock.call_count == 0
 
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
@@ -528,7 +529,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
     @patch("sentry.tasks.relocation.MAX_USERS_PER_RELOCATION", 0)
     def test_fail_too_many_users(
         self,
-        preprocessing_baseline_config_mock: Mock,
+        preprocessing_transfer_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: FakeKeyManagementServiceClient,
     ):
@@ -543,7 +544,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        assert preprocessing_baseline_config_mock.call_count == 0
+        assert preprocessing_transfer_mock.call_count == 0
 
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
@@ -552,7 +553,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
 
     def test_fail_no_orgs(
         self,
-        preprocessing_baseline_config_mock: Mock,
+        preprocessing_transfer_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: FakeKeyManagementServiceClient,
     ):
@@ -569,7 +570,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        assert preprocessing_baseline_config_mock.call_count == 0
+        assert preprocessing_transfer_mock.call_count == 0
 
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
@@ -579,7 +580,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
     @patch("sentry.tasks.relocation.MAX_ORGS_PER_RELOCATION", 0)
     def test_fail_too_many_orgs(
         self,
-        preprocessing_baseline_config_mock: Mock,
+        preprocessing_transfer_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: FakeKeyManagementServiceClient,
     ):
@@ -594,7 +595,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        assert preprocessing_baseline_config_mock.call_count == 0
+        assert preprocessing_transfer_mock.call_count == 0
 
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
@@ -603,7 +604,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
 
     def test_fail_missing_orgs(
         self,
-        preprocessing_baseline_config_mock: Mock,
+        preprocessing_transfer_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: FakeKeyManagementServiceClient,
     ):
@@ -622,7 +623,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
             to=[self.owner.email, self.superuser.email]
         )
 
-        assert preprocessing_baseline_config_mock.call_count == 0
+        assert preprocessing_transfer_mock.call_count == 0
 
         relocation = Relocation.objects.get(uuid=self.uuid)
         assert relocation.status == Relocation.Status.FAILURE.value
@@ -630,6 +631,112 @@ class PreprocessingScanTest(RelocationTaskTestCase):
         assert relocation.failure_reason == ERR_PREPROCESSING_MISSING_ORGS.substitute(
             orgs=",".join(orgs)
         )
+
+
+@region_silo_test
+@patch("sentry.utils.relocation.MessageBuilder")
+@patch("sentry.tasks.relocation.preprocessing_baseline_config.delay")
+class PreprocessingTransferTest(RelocationTaskTestCase):
+    def setUp(self):
+        super().setUp()
+        self.relocation.step = Relocation.Step.PREPROCESSING.value
+        self.relocation.latest_task = OrderedTask.PREPROCESSING_SCAN.name
+        self.relocation.want_usernames = ["importing"]
+        self.relocation.save()
+        self.create_user("importing")
+        self.relocation_storage = get_relocation_storage()
+
+    def test_success(
+        self,
+        preprocessing_baseline_config_mock: Mock,
+        fake_message_builder: Mock,
+    ):
+        self.mock_message_builder(fake_message_builder)
+        assert not self.relocation_storage.exists(f"runs/{self.uuid}")
+
+        preprocessing_transfer(self.uuid)
+
+        assert fake_message_builder.call_count == 0
+        assert preprocessing_baseline_config_mock.call_count == 1
+
+        (_, files) = self.relocation_storage.listdir(f"runs/{self.uuid}/conf")
+        assert len(files) == 2
+        assert "cloudbuild.yaml" in files
+        assert "cloudbuild.zip" in files
+
+        cb_yaml_file = self.relocation_storage.open(f"runs/{self.uuid}/conf/cloudbuild.yaml")
+        with cb_yaml_file:
+            cb_conf = yaml.safe_load(cb_yaml_file)
+            assert cb_conf is not None
+
+        # These entries in the generated `cloudbuild.yaml` depend on the UUID, so check them
+        # separately then replace them for snapshotting.
+        in_path = cb_conf["steps"][0]["args"][2]
+        findings_path = cb_conf["artifacts"]["objects"]["location"]
+        assert in_path == f"gs://default/runs/{self.uuid}/in"
+        assert findings_path == f"gs://default/runs/{self.uuid}/findings/"
+
+        # Do a snapshot test of the cloudbuild config.
+        cb_conf["steps"][0]["args"][2] = "gs://<BUCKET>/runs/<UUID>/in"
+        cb_conf["artifacts"]["objects"]["location"] = "gs://<BUCKET>/runs/<UUID>/findings/"
+        cb_conf["steps"][12]["args"][3] = "gs://<BUCKET>/runs/<UUID>/out"
+        self.insta_snapshot(cb_conf)
+
+        (_, files) = self.relocation_storage.listdir(f"runs/{self.uuid}/in")
+        assert len(files) == 2
+        assert "kms-config.json" in files
+        assert "raw-relocation-data.tar" in files
+
+        kms_file = self.relocation_storage.open(f"runs/{self.uuid}/in/kms-config.json")
+        with kms_file:
+            json.load(kms_file)
+
+    def test_retry_if_attempts_left(
+        self,
+        preprocessing_baseline_config_mock: Mock,
+        fake_message_builder: Mock,
+    ):
+        RelocationFile.objects.filter(relocation=self.relocation).delete()
+        self.mock_message_builder(fake_message_builder)
+
+        # An exception being raised will trigger a retry in celery.
+        with pytest.raises(Exception):
+            preprocessing_transfer(self.uuid)
+
+        assert fake_message_builder.call_count == 0
+        assert preprocessing_baseline_config_mock.call_count == 0
+
+        relocation = Relocation.objects.get(uuid=self.uuid)
+        assert relocation.status == Relocation.Status.IN_PROGRESS.value
+        assert relocation.latest_notified != Relocation.EmailKind.FAILED.value
+        assert not relocation.failure_reason
+
+    def test_fail_if_no_attempts_left(
+        self,
+        preprocessing_baseline_config_mock: Mock,
+        fake_message_builder: Mock,
+    ):
+        self.relocation.latest_task = OrderedTask.PREPROCESSING_TRANSFER.name
+        self.relocation.latest_task_attempts = MAX_FAST_TASK_RETRIES
+        self.relocation.save()
+        RelocationFile.objects.filter(relocation=self.relocation).delete()
+        self.mock_message_builder(fake_message_builder)
+
+        with pytest.raises(Exception):
+            preprocessing_transfer(self.uuid)
+
+        assert fake_message_builder.call_count == 1
+        assert fake_message_builder.call_args.kwargs["type"] == "relocation.failed"
+        fake_message_builder.return_value.send_async.assert_called_once_with(
+            to=[self.owner.email, self.superuser.email]
+        )
+
+        assert preprocessing_baseline_config_mock.call_count == 0
+
+        relocation = Relocation.objects.get(uuid=self.uuid)
+        assert relocation.status == Relocation.Status.FAILURE.value
+        assert relocation.latest_notified == Relocation.EmailKind.FAILED.value
+        assert relocation.failure_reason == ERR_PREPROCESSING_INTERNAL
 
 
 @region_silo_test
@@ -643,8 +750,9 @@ class PreprocessingBaselineConfigTest(RelocationTaskTestCase):
     def setUp(self):
         super().setUp()
         self.relocation.step = Relocation.Step.PREPROCESSING.value
-        self.relocation.latest_task = OrderedTask.PREPROCESSING_SCAN.name
+        self.relocation.latest_task = OrderedTask.PREPROCESSING_TRANSFER.name
         self.relocation.save()
+        self.relocation_storage = get_relocation_storage()
 
     def test_success(
         self,
@@ -662,17 +770,11 @@ class PreprocessingBaselineConfigTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 0
         assert preprocessing_colliding_users_mock.call_count == 1
 
-        relocation_file = (
-            RelocationFile.objects.filter(
-                relocation=self.relocation,
-                kind=RelocationFile.Kind.BASELINE_CONFIG_VALIDATION_DATA.value,
-            )
-            .select_related("file")
-            .first()
-        )
-        assert relocation_file.file.name == "baseline-config.tar"
+        (_, files) = self.relocation_storage.listdir(f"runs/{self.uuid}/in")
+        assert len(files) == 1
+        assert "baseline-config.tar" in files
 
-        with relocation_file.file.getfile() as fp:
+        with self.relocation_storage.open(f"runs/{self.uuid}/in/baseline-config.tar") as fp:
             json_models = json.loads(
                 decrypt_encrypted_tarball(fp, LocalFileDecryptor.from_bytes(self.priv_key_pem))
             )
@@ -763,6 +865,8 @@ class PreprocessingCollidingUsersTest(RelocationTaskTestCase):
         self.create_user("d")
         self.create_user("e")
 
+        self.relocation_storage = get_relocation_storage()
+
     def test_success(
         self,
         preprocessing_complete_mock: Mock,
@@ -779,17 +883,11 @@ class PreprocessingCollidingUsersTest(RelocationTaskTestCase):
         assert fake_message_builder.call_count == 0
         assert preprocessing_complete_mock.call_count == 1
 
-        relocation_file = (
-            RelocationFile.objects.filter(
-                relocation=self.relocation,
-                kind=RelocationFile.Kind.COLLIDING_USERS_VALIDATION_DATA.value,
-            )
-            .select_related("file")
-            .first()
-        )
-        assert relocation_file.file.name == "colliding-users.tar"
+        (_, files) = self.relocation_storage.listdir(f"runs/{self.uuid}/in")
+        assert len(files) == 1
+        assert "colliding-users.tar" in files
 
-        with relocation_file.file.getfile() as fp:
+        with self.relocation_storage.open(f"runs/{self.uuid}/in/colliding-users.tar") as fp:
             json_models = json.loads(
                 decrypt_encrypted_tarball(fp, LocalFileDecryptor.from_bytes(self.priv_key_pem))
             )
@@ -872,25 +970,14 @@ class PreprocessingCompleteTest(RelocationTaskTestCase):
         self.relocation.want_usernames = ["importing"]
         self.relocation.save()
         self.create_user("importing")
-        self.storage = get_storage()
+        self.relocation_storage = get_relocation_storage()
 
-        file = File.objects.create(name="baseline-config.tar", type=RELOCATION_FILE_TYPE)
-        self.swap_file(file, "single-option.json", blob_size=16384)  # No chunking
-        RelocationFile.objects.create(
-            relocation=self.relocation,
-            file=file,
-            kind=RelocationFile.Kind.BASELINE_CONFIG_VALIDATION_DATA.value,
-        )
-        assert file.blobs.count() == 1  # So small that chunking is unnecessary.
-
-        file = File.objects.create(name="colliding-users.tar", type=RELOCATION_FILE_TYPE)
-        self.swap_file(file, "user-with-maximum-privileges.json", blob_size=8192)  # Forces chunks
-        RelocationFile.objects.create(
-            relocation=self.relocation,
-            file=file,
-            kind=RelocationFile.Kind.COLLIDING_USERS_VALIDATION_DATA.value,
-        )
-        assert file.blobs.count() > 1  # A bit bigger, so we get chunks.
+        self.relocation_storage.save(f"runs/{self.uuid}/conf/cloudbuild.yaml", BytesIO())
+        self.relocation_storage.save(f"runs/{self.uuid}/conf/cloudbuild.zip", BytesIO())
+        self.relocation_storage.save(f"runs/{self.uuid}/in/kms-config.json", BytesIO())
+        self.relocation_storage.save(f"runs/{self.uuid}/in/raw-relocation-data.tar", BytesIO())
+        self.relocation_storage.save(f"runs/{self.uuid}/in/baseline-config.tar", BytesIO())
+        self.relocation_storage.save(f"runs/{self.uuid}/in/colliding-users.tar", BytesIO())
 
     def test_success(
         self,
@@ -898,48 +985,11 @@ class PreprocessingCompleteTest(RelocationTaskTestCase):
         fake_message_builder: Mock,
     ):
         self.mock_message_builder(fake_message_builder)
-        assert not self.storage.exists(f"relocations/runs/{self.uuid}")
 
         preprocessing_complete(self.uuid)
 
         assert fake_message_builder.call_count == 0
         assert validating_start_mock.call_count == 1
-
-        (_, files) = self.storage.listdir(f"relocations/runs/{self.uuid}/conf")
-        assert len(files) == 2
-        assert "cloudbuild.yaml" in files
-        assert "cloudbuild.zip" in files
-
-        cb_yaml_file = self.storage.open(f"relocations/runs/{self.uuid}/conf/cloudbuild.yaml")
-        with cb_yaml_file:
-            cb_conf = yaml.safe_load(cb_yaml_file)
-            assert cb_conf is not None
-
-        # These entries in the generated `cloudbuild.yaml` depend on the UUID, so check them
-        # separately then replace them for snapshotting.
-        in_path = cb_conf["steps"][0]["args"][2]
-        findings_path = cb_conf["artifacts"]["objects"]["location"]
-        assert in_path == f"gs://default/relocations/runs/{self.uuid}/in"
-        assert findings_path == f"gs://default/relocations/runs/{self.uuid}/findings/"
-
-        # Do a snapshot test of the cloudbuild config.
-        cb_conf["steps"][0]["args"][2] = "gs://<BUCKET>/relocations/runs/<UUID>/in"
-        cb_conf["artifacts"]["objects"][
-            "location"
-        ] = "gs://<BUCKET>/relocations/runs/<UUID>/findings/"
-        cb_conf["steps"][12]["args"][3] = "gs://<BUCKET>/relocations/runs/<UUID>/out"
-        self.insta_snapshot(cb_conf)
-
-        (_, files) = self.storage.listdir(f"relocations/runs/{self.uuid}/in")
-        assert len(files) == 4
-        assert "kms-config.json" in files
-        assert "raw-relocation-data.tar" in files
-        assert "baseline-config.tar" in files
-        assert "colliding-users.tar" in files
-
-        kms_file = self.storage.open(f"relocations/runs/{self.uuid}/in/kms-config.json")
-        with kms_file:
-            json.load(kms_file)
 
         self.relocation.refresh_from_db()
         assert self.relocation.step == Relocation.Step.VALIDATING.value
@@ -950,7 +1000,7 @@ class PreprocessingCompleteTest(RelocationTaskTestCase):
         validating_start_mock: Mock,
         fake_message_builder: Mock,
     ):
-        RelocationFile.objects.filter(relocation=self.relocation).delete()
+        self.relocation_storage.delete(f"runs/{self.uuid}/conf/cloudbuild.yaml")
         self.mock_message_builder(fake_message_builder)
 
         # An exception being raised will trigger a retry in celery.
@@ -973,7 +1023,7 @@ class PreprocessingCompleteTest(RelocationTaskTestCase):
         self.relocation.latest_task = OrderedTask.PREPROCESSING_COMPLETE.name
         self.relocation.latest_task_attempts = MAX_FAST_TASK_RETRIES
         self.relocation.save()
-        RelocationFile.objects.filter(relocation=self.relocation).delete()
+        self.relocation_storage.delete(f"runs/{self.uuid}/in/raw-relocation-data.tar")
         self.mock_message_builder(fake_message_builder)
 
         with pytest.raises(Exception):
@@ -991,6 +1041,46 @@ class PreprocessingCompleteTest(RelocationTaskTestCase):
         assert relocation.status == Relocation.Status.FAILURE.value
         assert relocation.latest_notified == Relocation.EmailKind.FAILED.value
         assert relocation.failure_reason == ERR_PREPROCESSING_INTERNAL
+
+    def test_fail_missing_cloudbuild_zip(
+        self,
+        validating_start_mock: Mock,
+        fake_message_builder: Mock,
+    ):
+        self.relocation_storage.delete(f"runs/{self.uuid}/conf/cloudbuild.zip")
+        self.mock_message_builder(fake_message_builder)
+
+        # An exception being raised will trigger a retry in celery.
+        with pytest.raises(Exception):
+            preprocessing_complete(self.uuid)
+
+        assert fake_message_builder.call_count == 0
+        assert validating_start_mock.call_count == 0
+
+        relocation = Relocation.objects.get(uuid=self.uuid)
+        assert relocation.status == Relocation.Status.IN_PROGRESS.value
+        assert relocation.latest_notified != Relocation.EmailKind.FAILED.value
+        assert not relocation.failure_reason
+
+    def test_fail_missing_kms_config(
+        self,
+        validating_start_mock: Mock,
+        fake_message_builder: Mock,
+    ):
+        self.relocation_storage.delete(f"runs/{self.uuid}/in/kms-config.json")
+        self.mock_message_builder(fake_message_builder)
+
+        # An exception being raised will trigger a retry in celery.
+        with pytest.raises(Exception):
+            preprocessing_complete(self.uuid)
+
+        assert fake_message_builder.call_count == 0
+        assert validating_start_mock.call_count == 0
+
+        relocation = Relocation.objects.get(uuid=self.uuid)
+        assert relocation.status == Relocation.Status.IN_PROGRESS.value
+        assert relocation.latest_notified != Relocation.EmailKind.FAILED.value
+        assert not relocation.failure_reason
 
 
 @region_silo_test
@@ -1344,7 +1434,7 @@ class ValidatingPollTest(RelocationTaskTestCase):
 
 def mock_invalid_finding(storage: Storage, uuid: str):
     storage.save(
-        f"relocations/runs/{uuid}/findings/import-baseline-config.json",
+        f"runs/{uuid}/findings/import-baseline-config.json",
         BytesIO(
             b"""
 [
@@ -1391,7 +1481,7 @@ class ValidatingCompleteTest(RelocationTaskTestCase):
 
         self.storage = get_storage()
         self.storage.save(
-            f"relocations/runs/{self.uuid}/findings/artifacts-prefixes-are-ignored.json",
+            f"runs/{self.uuid}/findings/artifacts-prefixes-are-ignored.json",
             BytesIO(b"invalid-json"),
         )
         files = [
@@ -1406,7 +1496,7 @@ class ValidatingCompleteTest(RelocationTaskTestCase):
             "compare-colliding-users.json",
         ]
         for file in files:
-            self.storage.save(f"relocations/runs/{self.uuid}/findings/{file}", BytesIO(b"[]"))
+            self.storage.save(f"runs/{self.uuid}/findings/{file}", BytesIO(b"[]"))
 
     def test_valid(
         self,
@@ -1463,7 +1553,7 @@ class ValidatingCompleteTest(RelocationTaskTestCase):
     ):
         self.mock_message_builder(fake_message_builder)
         self.storage.save(
-            f"relocations/runs/{self.uuid}/findings/null.json",
+            f"runs/{self.uuid}/findings/null.json",
             BytesIO(b"invalid-json"),
         )
 
@@ -1488,9 +1578,7 @@ class ValidatingCompleteTest(RelocationTaskTestCase):
         self.relocation.latest_task = OrderedTask.VALIDATING_COMPLETE.name
         self.relocation.latest_task_attempts = MAX_FAST_TASK_RETRIES
         self.relocation.save()
-        self.storage.save(
-            f"relocations/runs/{self.uuid}/findings/null.json", BytesIO(b"invalid-json")
-        )
+        self.storage.save(f"runs/{self.uuid}/findings/null.json", BytesIO(b"invalid-json"))
 
         with pytest.raises(Exception):
             validating_complete(self.uuid, self.relocation_validation_attempt.build_id)
@@ -1991,9 +2079,7 @@ class EndToEndTest(RelocationTaskTestCase, TransactionTestCase):
             "compare-colliding-users.json",
         ]
         for file in files:
-            self.storage.save(
-                f"relocations/runs/{self.relocation.uuid}/findings/{file}", BytesIO(b"[]")
-            )
+            self.storage.save(f"runs/{self.relocation.uuid}/findings/{file}", BytesIO(b"[]"))
 
     def mock_max_retries(
         self,


### PR DESCRIPTION
Previously, relocations were stored in the same filestore (local directory, GCP/S3 bucket, etc) as all other Django-tracked files, but in a special `/relocation` top-level directory. For operational reasons, we've decided to move relocation data into an entirely separate store. Thus, we make the following changes:

1. The `filestore` configuration now has an extra property, `filestore.relocation`. This closely mirrors the existing `filetore.options`: where the latter is used to configure the storage backend for regular Django-tracked files, this new config object does the same for the relocation bucket. A new storage getter called `get_relocation_storage` is created to provide access to this bespoke bucket in the same manner we use `get_storage` to directly access the main bucket today.
2. The `baseline-config.tar` and `colliding-users.tar` exports are no longer tracked in the Django FS. Instead, we write them directly to the new relocation bucket at creation time, and forego entering them into the DB-bakced filesystem altogether.
3. A new preprocessing step, `PREPROCESSING_TRANSFER`, is added directly after the completion of the scan. This copies the user-supplied `raw-relocation.tar` from the DB-backed filesystem into the relocation bucket. The `PREPROCESSING_COMPLETE` task is modified to just do a quick check ensuring that all necessary files are gettable by CloudBuild (ie, not only has the write finished, but they are available for read as well).

Issue: getsentry/team-ospo#214