### PR TITLE
ref(replays): add alert about enabling session replay for loader instructions

### DIFF
--- a/static/app/gettingStartedDocs/javascript/jsLoader/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/jsLoader/javascript.tsx
@@ -1,5 +1,7 @@
 import beautify from 'js-beautify';
 
+import Alert from 'sentry/components/alert';
+import Link from 'sentry/components/links/link';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   DocsParams,
@@ -9,7 +11,7 @@ import {
   getReplayConfigureDescription,
   getReplayJsLoaderSdkSetupSnippet,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
 
@@ -23,6 +25,18 @@ const getInstallConfig = (params: Params) => [
         code: beautify.html(
           `<script src="${params.cdn}" crossorigin="anonymous"></script>`,
           {indent_size: 2, wrap_attributes: 'force-expand-multiline'}
+        ),
+        additionalInfo: (
+          <Alert type="info" showIcon style={{margin: 0}}>
+            {tct(
+              'Make sure that Session Replay is enabled in your [link:project settings].',
+              {
+                link: (
+                  <Link to={`/settings/projects/${params.projectSlug}/loader-script/`} />
+                ),
+              }
+            )}
+          </Alert>
         ),
       },
     ],

--- a/static/app/gettingStartedDocs/javascript/jsLoader/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/jsLoader/javascript.tsx
@@ -1,7 +1,7 @@
 import beautify from 'js-beautify';
 
 import Alert from 'sentry/components/alert';
-import Link from 'sentry/components/links/link';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   DocsParams,
@@ -12,6 +12,7 @@ import {
   getReplayJsLoaderSdkSetupSnippet,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {t, tct} from 'sentry/locale';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 type Params = DocsParams;
 
@@ -32,7 +33,11 @@ const getInstallConfig = (params: Params) => [
               'Make sure that Session Replay is enabled in your [link:project settings].',
               {
                 link: (
-                  <Link to={`/settings/projects/${params.projectSlug}/loader-script/`} />
+                  <ExternalLink
+                    href={normalizeUrl(
+                      `/settings/projects/${params.projectSlug}/loader-script/`
+                    )}
+                  />
                 ),
               }
             )}

--- a/static/app/gettingStartedDocs/javascript/jsLoader/javascript.tsx
+++ b/static/app/gettingStartedDocs/javascript/jsLoader/javascript.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import beautify from 'js-beautify';
 
 import Alert from 'sentry/components/alert';
@@ -28,7 +29,7 @@ const getInstallConfig = (params: Params) => [
           {indent_size: 2, wrap_attributes: 'force-expand-multiline'}
         ),
         additionalInfo: (
-          <Alert type="info" showIcon style={{margin: 0}}>
+          <StyledAlert type="info" showIcon>
             {tct(
               'Make sure that Session Replay is enabled in your [link:project settings].',
               {
@@ -41,7 +42,7 @@ const getInstallConfig = (params: Params) => [
                 ),
               }
             )}
-          </Alert>
+          </StyledAlert>
         ),
       },
     ],
@@ -68,5 +69,9 @@ const replayOnboardingJsLoaderJavascript: OnboardingConfig = {
   verify: () => [],
   nextSteps: () => [],
 };
+
+const StyledAlert = styled(Alert)`
+  margin: 0;
+`;
 
 export default replayOnboardingJsLoaderJavascript;


### PR DESCRIPTION
In the future, this may be replaced with a toggle in the setup itself to enable session replay.

<img width="531" alt="SCR-20231213-lqmo" src="https://github.com/getsentry/sentry/assets/56095982/f0bdae22-6062-4654-84c1-3019afd07f76">
