### PR TITLE
feat(commit-context): Enable for GitHub Enterprise

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1138,7 +1138,7 @@ def process_commits(job: PostProcessJob) -> None:
 
                     org_integrations = integration_service.get_organization_integrations(
                         organization_id=event.project.organization_id,
-                        providers=["github", "gitlab"],
+                        providers=["github", "gitlab", "github_enterprise"],
                     )
                     has_integrations = len(org_integrations) > 0
                     # Cache the integrations check for 4 hours


### PR DESCRIPTION
## Objective:

GitHub Enterprise supports Suspect Commits with Commit Context. Add it to the list of supported providers.