### PR TITLE
fix(dashboards): Fix alignment for equation headers

### DIFF
--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -82,6 +82,7 @@ export function decodeColumnOrder(fields: Readonly<Field[]>): TableColumn<string
     if (isEquation(f.field)) {
       column.key = f.field;
       column.name = getEquation(columnName);
+      column.type = 'number';
     } else {
       column.key = columnName;
       column.name = columnName;


### PR DESCRIPTION
When building a table widget in Dashboards, the equation column headers would be misaligned. This is because the column was not properly having its type set to `number` for equations, and had the default value of `never`.

### Before
![image](https://github.com/getsentry/sentry/assets/16740047/ee82123e-ec5c-45ce-9a54-3b5861486921)


### After
![image](https://github.com/getsentry/sentry/assets/16740047/cdcaeb80-2c1b-4810-908d-faf77c0cbff4)
