### PR TITLE
feat(grouping): Add metric for number of hashing calculations done

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -564,6 +564,10 @@ class EventManager:
         ), metrics.timer("event_manager.calculate_event_grouping", tags=metric_tags):
             hashes = _calculate_event_grouping(project, job["event"], grouping_config)
 
+        # Track the total number of grouping calculations done overall, so we can divide by the
+        # count to get an average number of calculations per event
+        metrics.incr("grouping.hashes_calculated", amount=2 if secondary_hashes else 1)
+
         # Because this logic is not complex enough we want to special case the situation where we
         # migrate from a hierarchical hash to a non hierarchical hash.  The reason being that
         # `_save_aggregate` needs special logic to not create orphaned hashes in migration cases

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import logging
 import uuid
 from time import time
 from unittest import mock
+from unittest.mock import MagicMock
 
 from sentry import tsdb
 from sentry.event_manager import EventManager
@@ -25,6 +28,10 @@ def make_event(**kwargs):
     }
     result.update(kwargs)
     return result
+
+
+def get_relevant_metrics_calls(mock_fn: MagicMock, key: str) -> list[mock._Call]:
+    return [call for call in mock_fn.call_args_list if call.args[0] == key]
 
 
 @region_silo_test
@@ -355,3 +362,36 @@ class EventManagerGroupingTest(TestCase):
             event = manager.save(self.project.id)
 
         assert event.group
+
+
+@region_silo_test
+class EventManagerGroupingMetricsTest(TestCase):
+    @mock.patch("sentry.event_manager.metrics.incr")
+    def test_records_num_calculations(self, mock_metrics_incr: MagicMock):
+        project = self.project
+        project.update_option("sentry:grouping_config", "legacy:2019-03-12")
+        project.update_option("sentry:secondary_grouping_config", None)
+
+        manager = EventManager(make_event(message="dogs are great"))
+        manager.normalize()
+        manager.save(project.id)
+
+        hashes_calculated_calls = get_relevant_metrics_calls(
+            mock_metrics_incr, "grouping.hashes_calculated"
+        )
+        assert len(hashes_calculated_calls) == 1
+        assert hashes_calculated_calls[0].kwargs["amount"] == 1
+
+        project.update_option("sentry:grouping_config", "newstyle:2023-01-11")
+        project.update_option("sentry:secondary_grouping_config", "legacy:2019-03-12")
+        project.update_option("sentry:secondary_grouping_expiry", time() + 3600)
+
+        manager = EventManager(make_event(message="dogs are great"))
+        manager.normalize()
+        manager.save(project.id)
+
+        hashes_calculated_calls = get_relevant_metrics_calls(
+            mock_metrics_incr, "grouping.hashes_calculated"
+        )
+        assert len(hashes_calculated_calls) == 2
+        assert hashes_calculated_calls[1].kwargs["amount"] == 2


### PR DESCRIPTION
This adds a metric tracking how many hashing calculations we do in the process of ingesting an event. Right now, it should be 2 in almost all cases, but should go down to 1 in most cases once we switch to only calculating the secondary hash if needed.

Ref: https://github.com/getsentry/sentry/issues/61651