### PR TITLE
feat(issue-alerts): Add function that fetches the latest/earliest release for a group based on semver or date

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -61,6 +61,7 @@ from sentry.models.files.file import File
 from sentry.models.group import Group
 from sentry.models.grouphistory import GroupHistory
 from sentry.models.grouplink import GroupLink
+from sentry.models.grouprelease import GroupRelease
 from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
 from sentry.models.integrations.doc_integration import DocIntegration
 from sentry.models.integrations.external_actor import ExternalActor
@@ -580,6 +581,13 @@ class Factories:
             release.update(authors=[str(author.id)], commit_count=1, last_commit_id=commit.id)
 
         return release
+
+    def create_group_release(project: Project, group: Group, release: Release):
+        return GroupRelease.objects.create(
+            project_id=project.id,
+            group_id=group.id,
+            release_id=release.id,
+        )
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.REGION)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -582,7 +582,7 @@ class Factories:
 
         return release
 
-    def create_group_release(project: Project, group: Group, release: Release):
+    def create_group_release(project: Project, group: Group, release: Release) -> GroupRelease:
         return GroupRelease.objects.create(
             project_id=project.id,
             group_id=group.id,

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -189,6 +189,11 @@ class Fixtures:
             project = self.project
         return Factories.create_release(project=project, user=user, *args, **kwargs)
 
+    def create_group_release(self, project=None, *args, **kwargs):
+        if project is None:
+            project = self.project
+        return Factories.create_group_release(project, *args, **kwargs)
+
     def create_release_file(self, release_id=None, file=None, name=None, dist_id=None):
         if release_id is None:
             release_id = self.release.id

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -10,10 +10,12 @@ from sentry.eventstore.models import Event
 from sentry.incidents.models import IncidentActivityType
 from sentry.models.activity import Activity
 from sentry.models.actor import Actor, get_actor_id_for_user
+from sentry.models.grouprelease import GroupRelease
 from sentry.models.integrations.integration import Integration
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
+from sentry.models.project import Project
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.silo import SiloMode
@@ -189,7 +191,7 @@ class Fixtures:
             project = self.project
         return Factories.create_release(project=project, user=user, *args, **kwargs)
 
-    def create_group_release(self, project=None, *args, **kwargs):
+    def create_group_release(self, project: Project = None, *args, **kwargs) -> GroupRelease:
         if project is None:
             project = self.project
         return Factories.create_group_release(project, *args, **kwargs)

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -11,9 +11,11 @@ from sentry.search.base import ANY
 from sentry.search.utils import (
     DEVICE_CLASS,
     InvalidQuery,
+    LatestReleaseOrders,
     convert_user_tag_to_query,
     get_latest_release,
     get_numeric_field_value,
+    get_terminal_release_for_group,
     parse_duration,
     parse_query,
     tokenize_query,
@@ -800,6 +802,62 @@ class GetLatestReleaseTest(TestCase):
             release_2.version,
             release_1.version,
         ]
+
+
+@region_silo_test
+class GetTerminalReleaseForGroupTest(TestCase):
+    def test_date(self):
+        with pytest.raises(Release.DoesNotExist):
+            get_terminal_release_for_group(self.group, LatestReleaseOrders.DATE, True)
+
+        oldest = self.create_release(version="old")
+        self.create_group_release(group=self.group, release=oldest)
+        newest = self.create_release(
+            version="newest", date_released=oldest.date_added + timedelta(minutes=5)
+        )
+        self.create_group_release(group=self.group, release=newest)
+
+        assert newest == get_terminal_release_for_group(self.group, LatestReleaseOrders.DATE, True)
+        assert oldest == get_terminal_release_for_group(self.group, LatestReleaseOrders.DATE, False)
+
+        group_2 = self.create_group()
+        with pytest.raises(Release.DoesNotExist):
+            get_terminal_release_for_group(group_2, LatestReleaseOrders.DATE, True)
+        self.create_group_release(group=group_2, release=oldest)
+        assert oldest == get_terminal_release_for_group(group_2, LatestReleaseOrders.DATE, True)
+        assert oldest == get_terminal_release_for_group(group_2, LatestReleaseOrders.DATE, False)
+
+    def test_semver(self):
+        with pytest.raises(Release.DoesNotExist):
+            get_terminal_release_for_group(self.group, LatestReleaseOrders.SEMVER, True)
+
+        latest = self.create_release(version="test@2.0.0")
+        middle = self.create_release(version="test@1.3.2")
+        earliest = self.create_release(
+            version="test@1.0.0", date_released=latest.date_added + timedelta(minutes=5)
+        )
+        self.create_group_release(group=self.group, release=latest)
+        self.create_group_release(group=self.group, release=middle)
+        self.create_group_release(group=self.group, release=earliest)
+
+        assert latest == get_terminal_release_for_group(
+            self.group, LatestReleaseOrders.SEMVER, True
+        )
+        assert earliest == get_terminal_release_for_group(
+            self.group, LatestReleaseOrders.DATE, True
+        )
+        assert earliest == get_terminal_release_for_group(
+            self.group, LatestReleaseOrders.SEMVER, False
+        )
+        assert latest == get_terminal_release_for_group(self.group, LatestReleaseOrders.DATE, False)
+
+        group_2 = self.create_group()
+        with pytest.raises(Release.DoesNotExist):
+            get_terminal_release_for_group(group_2, LatestReleaseOrders.SEMVER, True)
+        self.create_group_release(group=group_2, release=latest)
+        self.create_group_release(group=group_2, release=middle)
+        assert latest == get_terminal_release_for_group(group_2, LatestReleaseOrders.SEMVER, True)
+        assert middle == get_terminal_release_for_group(group_2, LatestReleaseOrders.SEMVER, False)
 
 
 @control_silo_test

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -13,9 +13,9 @@ from sentry.search.utils import (
     InvalidQuery,
     LatestReleaseOrders,
     convert_user_tag_to_query,
+    get_first_last_release_for_group,
     get_latest_release,
     get_numeric_field_value,
-    get_terminal_release_for_group,
     parse_duration,
     parse_query,
     tokenize_query,
@@ -805,10 +805,10 @@ class GetLatestReleaseTest(TestCase):
 
 
 @region_silo_test
-class GetTerminalReleaseForGroupTest(TestCase):
+class GetFirstLastReleaseForGroupTest(TestCase):
     def test_date(self):
         with pytest.raises(Release.DoesNotExist):
-            get_terminal_release_for_group(self.group, LatestReleaseOrders.DATE, True)
+            get_first_last_release_for_group(self.group, LatestReleaseOrders.DATE, True)
 
         oldest = self.create_release(version="old")
         self.create_group_release(group=self.group, release=oldest)
@@ -817,19 +817,23 @@ class GetTerminalReleaseForGroupTest(TestCase):
         )
         self.create_group_release(group=self.group, release=newest)
 
-        assert newest == get_terminal_release_for_group(self.group, LatestReleaseOrders.DATE, True)
-        assert oldest == get_terminal_release_for_group(self.group, LatestReleaseOrders.DATE, False)
+        assert newest == get_first_last_release_for_group(
+            self.group, LatestReleaseOrders.DATE, True
+        )
+        assert oldest == get_first_last_release_for_group(
+            self.group, LatestReleaseOrders.DATE, False
+        )
 
         group_2 = self.create_group()
         with pytest.raises(Release.DoesNotExist):
-            get_terminal_release_for_group(group_2, LatestReleaseOrders.DATE, True)
+            get_first_last_release_for_group(group_2, LatestReleaseOrders.DATE, True)
         self.create_group_release(group=group_2, release=oldest)
-        assert oldest == get_terminal_release_for_group(group_2, LatestReleaseOrders.DATE, True)
-        assert oldest == get_terminal_release_for_group(group_2, LatestReleaseOrders.DATE, False)
+        assert oldest == get_first_last_release_for_group(group_2, LatestReleaseOrders.DATE, True)
+        assert oldest == get_first_last_release_for_group(group_2, LatestReleaseOrders.DATE, False)
 
     def test_semver(self):
         with pytest.raises(Release.DoesNotExist):
-            get_terminal_release_for_group(self.group, LatestReleaseOrders.SEMVER, True)
+            get_first_last_release_for_group(self.group, LatestReleaseOrders.SEMVER, True)
 
         latest = self.create_release(version="test@2.0.0")
         middle = self.create_release(version="test@1.3.2")
@@ -840,24 +844,28 @@ class GetTerminalReleaseForGroupTest(TestCase):
         self.create_group_release(group=self.group, release=middle)
         self.create_group_release(group=self.group, release=earliest)
 
-        assert latest == get_terminal_release_for_group(
+        assert latest == get_first_last_release_for_group(
             self.group, LatestReleaseOrders.SEMVER, True
         )
-        assert earliest == get_terminal_release_for_group(
+        assert earliest == get_first_last_release_for_group(
             self.group, LatestReleaseOrders.DATE, True
         )
-        assert earliest == get_terminal_release_for_group(
+        assert earliest == get_first_last_release_for_group(
             self.group, LatestReleaseOrders.SEMVER, False
         )
-        assert latest == get_terminal_release_for_group(self.group, LatestReleaseOrders.DATE, False)
+        assert latest == get_first_last_release_for_group(
+            self.group, LatestReleaseOrders.DATE, False
+        )
 
         group_2 = self.create_group()
         with pytest.raises(Release.DoesNotExist):
-            get_terminal_release_for_group(group_2, LatestReleaseOrders.SEMVER, True)
+            get_first_last_release_for_group(group_2, LatestReleaseOrders.SEMVER, True)
         self.create_group_release(group=group_2, release=latest)
         self.create_group_release(group=group_2, release=middle)
-        assert latest == get_terminal_release_for_group(group_2, LatestReleaseOrders.SEMVER, True)
-        assert middle == get_terminal_release_for_group(group_2, LatestReleaseOrders.SEMVER, False)
+        assert latest == get_first_last_release_for_group(group_2, LatestReleaseOrders.SEMVER, True)
+        assert middle == get_first_last_release_for_group(
+            group_2, LatestReleaseOrders.SEMVER, False
+        )
 
 
 @control_silo_test


### PR DESCRIPTION
We want to add a condition that compares the oldest release from a group to the latest adopted release from its project.

This adds a function to fetch the oldest release associated with a group. I've made it flexible so that it can fetch latest/newest, and also put in some guard rails so that we only consider up to 1000 group releases, since there are a small number of customers that have groups with 1m+ group releases.

Relies on https://github.com/getsentry/sentry/pull/61658