### PR TITLE
fix(feedback): formatting tweaks for github and jira linked tickets

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -341,10 +341,8 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             body += message.value
             body += "\n\n"
 
-        body += "|  |  |\n"
-        body += "| ------------- | --------------- |\n"
         for evidence in sorted(others, key=attrgetter("important"), reverse=True):
-            body += f"| **{evidence.name}** | {evidence.value} |\n"
+            body += f"| *{evidence.name}* | {evidence.value} |\n"
 
         return body.rstrip("\n")  # remove the last new line
 
@@ -362,7 +360,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         output = []
         if group.issue_category == GroupCategory.FEEDBACK:
             output = [
-                "Sentry Feedback: [{}|{}]".format(
+                "Sentry Feedback: [{}|{}]\n".format(
                     group.qualified_short_id,
                     group.get_absolute_url(params={"referrer": "jira_integration"}),
                 )

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -82,7 +82,7 @@ class IssueBasicMixin:
 
         if group.issue_category == GroupCategory.FEEDBACK:
             return [
-                "Sentry Feedback: [{}]({})".format(
+                "Sentry Feedback: [{}]({})\n".format(
                     group.qualified_short_id, absolute_uri(group.get_absolute_url(params=params))
                 )
             ]


### PR DESCRIPTION
couple copy paste tweaks:
- newline after Sentry Feedback and before message
- extraneous jira formatting removed