### PR TITLE
feat(ddm): Duplicate and delete widgets

### DIFF
--- a/static/app/views/ddm/context.tsx
+++ b/static/app/views/ddm/context.tsx
@@ -13,6 +13,8 @@ import {DEFAULT_SORT_STATE} from 'sentry/views/ddm/constants';
 
 interface DDMContextValue {
   addWidget: () => void;
+  duplicateWidget: (index: number) => void;
+  removeWidget: (index: number) => void;
   selectedWidgetIndex: number;
   setSelectedWidgetIndex: (index: number) => void;
   updateWidget: (index: number, data: Partial<MetricWidgetQueryParams>) => void;
@@ -24,6 +26,8 @@ export const DDMContext = createContext<DDMContextValue>({
   setSelectedWidgetIndex: () => {},
   addWidget: () => {},
   updateWidget: () => {},
+  removeWidget: () => {},
+  duplicateWidget: () => {},
   widgets: [],
 });
 
@@ -63,37 +67,65 @@ export function useMetricWidgets() {
     });
   }, [router.location.query.widgets]);
 
+  const setWidgets = useCallback(
+    (newWidgets: MetricWidgetQueryParams[]) => {
+      updateQuery(router, {
+        widgets: JSON.stringify(newWidgets),
+      });
+    },
+    [router]
+  );
+
   const updateWidget = useCallback(
     (index: number, data: Partial<MetricWidgetQueryParams>) => {
       const widgetsCopy = [...widgets];
       widgetsCopy[index] = {...widgets[index], ...data};
 
-      updateQuery(router, {
-        widgets: JSON.stringify(widgetsCopy),
-      });
+      setWidgets(widgetsCopy);
     },
-    [widgets, router]
+    [widgets, setWidgets]
   );
 
   const addWidget = useCallback(() => {
     const widgetsCopy = [...widgets];
     widgetsCopy.push(emptyWidget);
 
-    updateQuery(router, {
-      widgets: JSON.stringify(widgetsCopy),
-    });
-  }, [widgets, router]);
+    setWidgets(widgetsCopy);
+  }, [widgets, setWidgets]);
+
+  const removeWidget = useCallback(
+    (index: number) => {
+      const widgetsCopy = [...widgets];
+      widgetsCopy.splice(index, 1);
+
+      setWidgets(widgetsCopy);
+    },
+    [setWidgets, widgets]
+  );
+
+  const duplicateWidget = useCallback(
+    (index: number) => {
+      const widgetsCopy = [...widgets];
+      widgetsCopy.splice(index, 0, widgets[index]);
+
+      setWidgets(widgetsCopy);
+    },
+    [setWidgets, widgets]
+  );
 
   return {
     widgets,
     updateWidget,
     addWidget,
+    removeWidget,
+    duplicateWidget,
   };
 }
 
 export function DDMContextProvider({children}: {children: React.ReactNode}) {
   const [selectedWidgetIndex, setSelectedWidgetIndex] = useState(0);
-  const {widgets, updateWidget, addWidget} = useMetricWidgets();
+  const {widgets, updateWidget, addWidget, removeWidget, duplicateWidget} =
+    useMetricWidgets();
 
   const handleAddWidget = useCallback(() => {
     addWidget();
@@ -108,6 +140,14 @@ export function DDMContextProvider({children}: {children: React.ReactNode}) {
     [updateWidget]
   );
 
+  const handleDuplicate = useCallback(
+    (index: number) => {
+      duplicateWidget(index);
+      setSelectedWidgetIndex(index + 1);
+    },
+    [duplicateWidget]
+  );
+
   const contextValue = useMemo<DDMContextValue>(
     () => ({
       addWidget: handleAddWidget,
@@ -115,9 +155,18 @@ export function DDMContextProvider({children}: {children: React.ReactNode}) {
         selectedWidgetIndex > widgets.length - 1 ? 0 : selectedWidgetIndex,
       setSelectedWidgetIndex,
       updateWidget: handleUpdateWidget,
+      removeWidget,
+      duplicateWidget: handleDuplicate,
       widgets,
     }),
-    [handleAddWidget, handleUpdateWidget, selectedWidgetIndex, widgets]
+    [
+      handleAddWidget,
+      handleDuplicate,
+      handleUpdateWidget,
+      removeWidget,
+      selectedWidgetIndex,
+      widgets,
+    ]
   );
 
   return <DDMContext.Provider value={contextValue}>{children}</DDMContext.Provider>;

--- a/static/app/views/ddm/contextMenu.tsx
+++ b/static/app/views/ddm/contextMenu.tsx
@@ -52,12 +52,6 @@ export function MetricWidgetContextMenu({
         onAction: () => duplicateWidget(widgetIndex),
       },
       {
-        leadingItems: [<IconDelete key="icon" />],
-        key: 'delete',
-        label: t('Delete'),
-        onAction: () => removeWidget(widgetIndex),
-      },
-      {
         leadingItems: [<IconSiren key="icon" />],
         key: 'add-alert',
         label: t('Create Alert'),
@@ -70,6 +64,12 @@ export function MetricWidgetContextMenu({
         label: t('Add to Dashboard'),
         disabled: !createDashboardWidget,
         onAction: createDashboardWidget,
+      },
+      {
+        leadingItems: [<IconDelete key="icon" />],
+        key: 'delete',
+        label: t('Delete'),
+        onAction: () => removeWidget(widgetIndex),
       },
     ],
     [createAlert, createDashboardWidget, duplicateWidget, removeWidget, widgetIndex]

--- a/static/app/views/ddm/trayContent.tsx
+++ b/static/app/views/ddm/trayContent.tsx
@@ -9,7 +9,7 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconChevron, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {isCustomMetric} from 'sentry/utils/metrics';
+import {isCustomMetric, MetricWidgetQueryParams} from 'sentry/utils/metrics';
 import {formatMRI} from 'sentry/utils/metrics/mri';
 import {CodeLocations} from 'sentry/views/ddm/codeLocations';
 import {useDDMContext} from 'sentry/views/ddm/context';
@@ -26,9 +26,11 @@ export function TrayContent() {
   const {isMaximized, maximiseSize, resetSize} = useContext(SplitPanelContext);
   // the tray is minimized when the main content is maximized
   const trayIsMinimized = isMaximized;
-  const selectedWidget = widgets[selectedWidgetIndex];
+  const selectedWidget = widgets[selectedWidgetIndex] as
+    | MetricWidgetQueryParams
+    | undefined;
   const isCodeLocationsDisabled =
-    selectedWidget.mri && !isCustomMetric({mri: selectedWidget.mri});
+    selectedWidget?.mri && !isCustomMetric({mri: selectedWidget.mri});
 
   if (isCodeLocationsDisabled && selectedTab === Tab.CODE_LOCATIONS) {
     setSelectedTab(Tab.SAMPLES);

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -82,6 +82,7 @@ export const MetricWidget = memo(
               powerUserMode={widget.powerUserMode}
             />
             <MetricWidgetContextMenu
+              widgetIndex={index}
               metricsQuery={metricsQuery}
               displayType={widget.displayType}
             />


### PR DESCRIPTION
Add context menu actions for deleting and duplicating widgets.
 
<img width="348" alt="Screenshot 2023-12-14 at 07 30 31" src="https://github.com/getsentry/sentry/assets/7033940/5d78c4bf-e27a-468d-a7c0-6abaff0b21b0">

- closes https://github.com/getsentry/sentry/issues/59713
- closes https://github.com/getsentry/sentry/issues/59711