### PR TITLE
feat(ddm): Add ddm_view guide in FE

### DIFF
--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -297,6 +297,19 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
         },
       ],
     },
+    {
+      guide: 'ddm_view',
+      requiredTargets: ['create_scratchpad'],
+      steps: [
+        {
+          title: t('Save your charts'),
+          target: 'create_scratchpad',
+          description: t(
+            `Scratchpads are stored locally on your device. If you want to share them, simply send the URL to your teammates.`
+          ),
+        },
+      ],
+    },
   ];
 }
 

--- a/static/app/views/ddm/scratchpadSelector.tsx
+++ b/static/app/views/ddm/scratchpadSelector.tsx
@@ -296,11 +296,9 @@ function SaveAsDropdown({
 
   return (
     <div>
-      <GuideAnchor target="create-scratchpad" position="bottom">
-        <Button icon={isFork ? null : <IconStar isSolid={isFork} />} {...triggerProps}>
-          {isFork ? `${t('Duplicate as')}\u2026` : `${t('Save as')}\u2026`}
-        </Button>
-      </GuideAnchor>
+      <Button icon={isFork ? null : <IconStar isSolid={isFork} />} {...triggerProps}>
+        {isFork ? `${t('Duplicate as')}\u2026` : `${t('Save as')}\u2026`}
+      </Button>
       <AnimatePresence>
         {isOpen && (
           <FocusScope contain restoreFocus autoFocus>
@@ -314,15 +312,17 @@ function SaveAsDropdown({
                   size="sm"
                   onChange={({target}) => setName(target.value)}
                 />
-                <SaveAsButton
-                  priority="primary"
-                  disabled={!name}
-                  onClick={() => {
-                    save();
-                  }}
-                >
-                  {mode === 'fork' ? t('Fork') : t('Save')}
-                </SaveAsButton>
+                <GuideAnchor target="create_scratchpad" position="bottom">
+                  <SaveAsButton
+                    priority="primary"
+                    disabled={!name}
+                    onClick={() => {
+                      save();
+                    }}
+                  >
+                    {mode === 'fork' ? t('Fork') : t('Save')}
+                  </SaveAsButton>
+                </GuideAnchor>
               </StyledOverlay>
             </PositionWrapper>
           </FocusScope>

--- a/static/app/views/ddm/scratchpadSelector.tsx
+++ b/static/app/views/ddm/scratchpadSelector.tsx
@@ -6,6 +6,7 @@ import {uuid4} from '@sentry/utils';
 import {AnimatePresence} from 'framer-motion';
 import isEmpty from 'lodash/isEmpty';
 
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {Button} from 'sentry/components/button';
 import {CompactSelect} from 'sentry/components/compactSelect';
 import {openConfirmModal} from 'sentry/components/confirm';
@@ -270,9 +271,8 @@ function SaveAsDropdown({
     state: {setOpen},
   } = useOverlay({});
   const theme = useTheme();
-  const [name, setName] = useState('');
-
   const organization = useOrganization();
+  const [name, setName] = useState('');
 
   const save = useCallback(() => {
     trackAnalytics('ddm.scratchpad.save', {
@@ -296,9 +296,11 @@ function SaveAsDropdown({
 
   return (
     <div>
-      <Button icon={isFork ? null : <IconStar isSolid={isFork} />} {...triggerProps}>
-        {isFork ? `${t('Duplicate as')}\u2026` : `${t('Save as')}\u2026`}
-      </Button>
+      <GuideAnchor target="create-scratchpad" position="bottom">
+        <Button icon={isFork ? null : <IconStar isSolid={isFork} />} {...triggerProps}>
+          {isFork ? `${t('Duplicate as')}\u2026` : `${t('Save as')}\u2026`}
+        </Button>
+      </GuideAnchor>
       <AnimatePresence>
         {isOpen && (
           <FocusScope contain restoreFocus autoFocus>


### PR DESCRIPTION
Add `ddm_view` guide (explaining scratchpads).

- requires https://github.com/getsentry/sentry/pull/61745
- closes https://github.com/getsentry/sentry/issues/60794

![Screenshot 2023-12-14 at 13 33 15](https://github.com/getsentry/sentry/assets/7033940/438148e7-4aaa-4f52-a5f8-94cbcc054add)
