### PR TITLE
fix(investigation-bias): Fix event.type in the investigation bias and improve overall code

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -5,7 +5,9 @@ from collections import namedtuple
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from functools import reduce
-from typing import Any, List, Literal, Mapping, NamedTuple, Sequence, Set, Tuple, Union, cast
+from typing import Any, List, Literal, Mapping, NamedTuple
+from typing import Optional as PythonOptional
+from typing import Sequence, Set, Tuple, Union, cast
 
 from django.utils.functional import cached_property
 from parsimonious.exceptions import IncompleteParseError
@@ -1172,7 +1174,9 @@ QueryToken = Union[SearchFilter, QueryOp, ParenExpression]
 
 def parse_search_query(
     query, config=None, params=None, builder=None, config_overrides=None
-) -> Sequence[QueryToken]:
+) -> list[
+    SearchFilter
+]:  # TODO: use the `Sequence[QueryToken]` type and update the code that fails type checking.
     if config is None:
         config = default_config
 
@@ -1228,7 +1232,7 @@ def cleanup_search_query(tokens: Sequence[QueryToken]) -> Sequence[QueryToken]:
 
     # remove AND and OR operators that are next to each other
     ret_val = []
-    previous_token: Optional[QueryToken] = None
+    previous_token: PythonOptional[QueryToken] = None
 
     for token in removed_empty_parens:
         # this loop takes care of removing consecutive AND/OR operators (keeping only one of them)

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -5,9 +5,7 @@ from collections import namedtuple
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from functools import reduce
-from typing import Any, List, Literal, Mapping, NamedTuple
-from typing import Optional as PythonOptional
-from typing import Sequence, Set, Tuple, Union, cast
+from typing import Any, List, Literal, Mapping, NamedTuple, Sequence, Set, Tuple, Union
 
 from django.utils.functional import cached_property
 from parsimonious.exceptions import IncompleteParseError
@@ -1197,63 +1195,3 @@ def parse_search_query(
         config = SearchConfig.create_from(config, **config_overrides)
 
     return SearchVisitor(config, params=params, builder=builder).visit(tree)
-
-
-def cleanup_search_query(tokens: Sequence[QueryToken]) -> Sequence[QueryToken]:
-    """
-    Recreates a valid query from an original query that has had on demand search filters removed.
-
-    When removing filters from a query it is possible to create invalid queries.
-    For example removing the on demand filters from "transaction.duration:>=1s OR browser.version:1 AND environment:dev"
-    would result in "OR AND environment:dev" which is not a valid query this should be cleaned to "environment:dev.
-
-    "release:internal and browser.version:1 or os.name:android" => "release:internal or and os.name:android" which
-    would be cleaned to "release:internal or os.name:android"
-    """
-    tokens = list(tokens)
-
-    # remove empty parens
-    removed_empty_parens: List[QueryToken] = []
-    for token in tokens:
-        if not isinstance(token, ParenExpression):
-            removed_empty_parens.append(token)
-        else:
-            children = cleanup_search_query(token.children)
-            if len(children) > 0:
-                removed_empty_parens.append(ParenExpression(children))
-
-    # remove AND and OR operators at the start of the query
-    while len(removed_empty_parens) > 0 and isinstance(removed_empty_parens[0], str):
-        removed_empty_parens.pop(0)
-
-    # remove AND and OR operators at the end of the query
-    while len(removed_empty_parens) > 0 and isinstance(removed_empty_parens[-1], str):
-        removed_empty_parens.pop()
-
-    # remove AND and OR operators that are next to each other
-    ret_val = []
-    previous_token: PythonOptional[QueryToken] = None
-
-    for token in removed_empty_parens:
-        # this loop takes care of removing consecutive AND/OR operators (keeping only one of them)
-        if isinstance(token, str) and isinstance(previous_token, str):
-            token = cast(QueryOp, token.upper())
-            # this handles two AND/OR operators next to each other, we must drop one of them
-            # if we have an AND do nothing (AND will be merged in the previous token see comment below)
-            # if we have an OR the resulting operator will be an OR
-            # AND OR => OR
-            # OR OR => OR
-            # OR AND => OR
-            # AND AND => AND
-            if token == "OR":
-                previous_token = "OR"
-            continue
-        elif previous_token is not None:
-            ret_val.append(previous_token)
-        previous_token = token
-
-    # take care of the last token (if any)
-    if previous_token is not None:
-        ret_val.append(previous_token)
-
-    return ret_val

--- a/src/sentry/dynamic_sampling/rules/biases/custom_rule_bias.py
+++ b/src/sentry/dynamic_sampling/rules/biases/custom_rule_bias.py
@@ -31,4 +31,5 @@ class CustomRuleBias(Bias):
                     },
                 }
             )
+
         return ret_val

--- a/src/sentry/models/dynamicsampling.py
+++ b/src/sentry/models/dynamicsampling.py
@@ -170,7 +170,6 @@ class CustomDynamicSamplingRule(Model):
         query: str,
         created_by_id: Optional[int] = None,
     ) -> "CustomDynamicSamplingRule":
-
         from sentry.models.organization import Organization
         from sentry.models.project import Project
 

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -394,6 +394,8 @@ def parse_search_query(
     edge cases.
     """
     tokens = cast(Sequence[QueryToken], event_search.parse_search_query(query))
+
+    # We might want to force the `event.type:transaction` to be in the query, as a validation step.
     if force_transaction_event_type:
         _check_event_type_transaction(tokens)
 

--- a/tests/sentry/api/endpoints/test_custom_rules.py
+++ b/tests/sentry/api/endpoints/test_custom_rules.py
@@ -436,9 +436,9 @@ class TestCustomRuleSerializerWithProjects(TestCase):
         (
             "hello world event.type:transaction",
             {
-                "op": "eq",
+                "op": "glob",
                 "name": "event.transaction",
-                "value": "hello world",
+                "value": ["*hello world*"],
             },
         ),
         (
@@ -447,7 +447,7 @@ class TestCustomRuleSerializerWithProjects(TestCase):
                 "op": "and",
                 "inner": [
                     {"op": "eq", "name": "event.environment", "value": "prod"},
-                    {"op": "eq", "name": "event.transaction", "value": "hello world"},
+                    {"op": "glob", "name": "event.transaction", "value": ["*hello world*"]},
                 ],
             },
         ),

--- a/tests/sentry/api/endpoints/test_custom_rules.py
+++ b/tests/sentry/api/endpoints/test_custom_rules.py
@@ -10,7 +10,7 @@ from sentry.api.endpoints.custom_rules import (
     CustomRulesInputSerializer,
     UnsupportedSearchQuery,
     UnsupportedSearchQueryReason,
-    get_condition,
+    get_rule_condition,
 )
 from sentry.models.dynamicsampling import CUSTOM_RULE_DATE_FORMAT, CustomDynamicSamplingRule
 from sentry.testutils.cases import APITestCase, TestCase
@@ -457,7 +457,7 @@ def test_get_condition(query, condition):
     """
     Test that the get_condition function works as expected
     """
-    actual_condition = get_condition(query)
+    actual_condition = get_rule_condition(query)
     assert actual_condition == condition
 
 
@@ -473,7 +473,7 @@ def test_get_condition(query, condition):
 )
 def test_get_condition_not_supported(query):
     with pytest.raises(UnsupportedSearchQuery) as excinfo:
-        get_condition(query)
+        get_rule_condition(query)
 
     assert excinfo.value.error_code == UnsupportedSearchQueryReason.NOT_TRANSACTION_QUERY.value
 
@@ -487,6 +487,6 @@ def test_get_condition_non_transaction_rule(query):
     Test that the get_condition function raises UnsupportedSearchQuery when event.type is not transaction
     """
     with pytest.raises(UnsupportedSearchQuery) as excinfo:
-        get_condition(query)
+        get_rule_condition(query)
 
     assert excinfo.value.error_code == UnsupportedSearchQueryReason.NOT_TRANSACTION_QUERY.value

--- a/tests/sentry/api/endpoints/test_custom_rules.py
+++ b/tests/sentry/api/endpoints/test_custom_rules.py
@@ -469,6 +469,7 @@ def test_get_condition(query, condition):
         "event.type:error environment:production",
         "",
         "hello world",
+        "http.status_code:GET AND (transaction.duration:>10 AND event.type:error)",
     ],
 )
 def test_get_condition_not_supported(query):

--- a/tests/sentry/api/endpoints/test_custom_rules.py
+++ b/tests/sentry/api/endpoints/test_custom_rules.py
@@ -427,7 +427,7 @@ class TestCustomRuleSerializerWithProjects(TestCase):
     [
         (
             "event.type:transaction",
-            {},
+            {"inner": [], "op": "and"},
         ),
         (
             "environment:prod event.type:transaction",

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -10,10 +10,12 @@ from django.utils import timezone
 from sentry.api.event_search import (
     AggregateFilter,
     AggregateKey,
+    ParenExpression,
     SearchConfig,
     SearchFilter,
     SearchKey,
     SearchValue,
+    cleanup_search_query,
     parse_search_query,
 )
 from sentry.constants import MODULE_ROOT
@@ -705,3 +707,45 @@ def test_search_value_to_query_string(value, expected_query_string):
     actual = search_value.to_query_string()
 
     assert actual == expected_query_string
+
+
+@pytest.mark.parametrize(
+    "dirty, clean",
+    [
+        ("release:initial OR os.name:android", "release:initial OR os.name:android"),
+        ("OR AND OR release:initial OR os.name:android", "release:initial OR os.name:android"),
+        ("release:initial OR os.name:android AND OR AND ", "release:initial OR os.name:android"),
+        (
+            "release:initial AND (AND OR) (OR )os.name:android ",
+            "release:initial AND os.name:android",
+        ),
+        (
+            " AND ((AND OR (OR ))) release:initial (((AND OR  (AND)))) AND os.name:android  (AND OR) ",
+            "release:initial AND os.name:android",
+        ),
+        (" (AND) And (And) Or release:initial or (and) or", "release:initial"),
+    ],
+)
+def test_cleanup_query(dirty, clean):
+    dirty_tokens = parse_search_query(dirty)
+    clean_tokens = parse_search_query(clean)
+    actual_clean = cleanup_search_query(dirty_tokens)
+
+    assert actual_clean == clean_tokens
+
+
+def test_cleanup_query_with_empty_parens():
+    """
+    Separate test with empty parens because we can't parse a string with empty parens correctly
+    """
+    paren = ParenExpression
+    dirty_tokens = (
+        [paren([paren(["AND", "OR", paren([])])])]
+        + parse_search_query("release:initial AND (AND OR) (OR)")  # ((AND OR (OR ())))
+        + [paren([])]
+        + parse_search_query("os.name:android")  # ()
+        + [paren([paren([paren(["AND", "OR", paren([])])])])]  # ((()))
+    )
+    clean_tokens = parse_search_query("release:initial AND os.name:android")
+    actual_clean = cleanup_search_query(dirty_tokens)
+    assert actual_clean == clean_tokens

--- a/tests/sentry/dynamic_sampling/rules/biases/snapshots/test_custom_rule_bias/test_custom_rule_bias.pysnap
+++ b/tests/sentry/dynamic_sampling/rules/biases/snapshots/test_custom_rule_bias/test_custom_rule_bias.pysnap
@@ -4,9 +4,9 @@ creator: sentry
 source: tests/sentry/dynamic_sampling/rules/biases/test_custom_rule_bias.py
 ---
 - condition:
-    name: environment
-    op: equals
-    value: prod1
+    name: event.transaction
+    op: eq
+    value: /hello
   id: 3001
   samplingValue:
     limit: 100
@@ -16,9 +16,8 @@ source: tests/sentry/dynamic_sampling/rules/biases/test_custom_rule_bias.py
     start: '2023-09-19T09:00:00.000000Z'
   type: transaction
 - condition:
-    name: environment
-    op: equals
-    value: prod2
+    inner: []
+    op: and
   id: 3002
   samplingValue:
     limit: 101

--- a/tests/sentry/dynamic_sampling/rules/biases/snapshots/test_custom_rule_bias/test_custom_rule_bias_with_invalid_condition.pysnap
+++ b/tests/sentry/dynamic_sampling/rules/biases/snapshots/test_custom_rule_bias/test_custom_rule_bias_with_invalid_condition.pysnap
@@ -1,0 +1,6 @@
+---
+created: '2023-09-19T10:00:00Z'
+creator: sentry
+source: tests/sentry/dynamic_sampling/rules/biases/test_custom_rule_bias.py
+---
+[]

--- a/tests/sentry/dynamic_sampling/rules/biases/test_custom_rule_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_custom_rule_bias.py
@@ -13,7 +13,7 @@ from sentry.testutils.helpers.datetime import freeze_time
 @mock.patch("sentry.models.CustomDynamicSamplingRule.get_project_rules")
 def test_custom_rule_bias(custom_dynamic_sampling_rule_mock, insta_snapshot):
     """
-    Test that the custom rule bias transforms the rules from the model into the expected format
+    Test that the custom rule bias transforms the rules from the model into the expected format.
     """
     p = Project(id=1)  # no need to save since I'm using as a mock parameter
     now = timezone.now()
@@ -22,7 +22,7 @@ def test_custom_rule_bias(custom_dynamic_sampling_rule_mock, insta_snapshot):
             start_date=now - timedelta(hours=1),
             end_date=now + timedelta(hours=1),
             rule_id=1,
-            condition='{"op": "equals", "name": "environment", "value": "prod1"}',
+            condition='{"op": "eq", "name": "event.transaction", "value": "/hello"}',
             sample_rate=0.5,
             num_samples=100,
         ),
@@ -30,15 +30,46 @@ def test_custom_rule_bias(custom_dynamic_sampling_rule_mock, insta_snapshot):
             start_date=now - timedelta(hours=1),
             end_date=now + timedelta(hours=1),
             rule_id=2,
-            condition='{"op": "equals", "name": "environment", "value": "prod2"}',
+            condition='{"op": "and", "inner": []}',
             sample_rate=0.6,
             num_samples=101,
         ),
     ]
 
     bias = CustomRuleBias()
-
     rules = bias.generate_rules(p, 0.5)
 
     assert len(rules) == 2
+    insta_snapshot(rules)
+
+
+@freeze_time("2023-09-19 10:00:00")
+@mock.patch("sentry.models.CustomDynamicSamplingRule.get_project_rules")
+def test_custom_rule_bias_with_invalid_condition(custom_dynamic_sampling_rule_mock, insta_snapshot):
+    """
+    Test that the custom rule bias throws an error if the condition is invalid.
+    """
+    p = Project(id=1)  # no need to save since I'm using as a mock parameter
+    now = timezone.now()
+
+    invalid_rules = []
+    for invalid_condition in ("", "{}", '{"op": "and"}'):
+        invalid_rules.append(
+            CustomDynamicSamplingRule(
+                start_date=now - timedelta(hours=1),
+                end_date=now + timedelta(hours=1),
+                rule_id=2,
+                condition=invalid_condition,
+                sample_rate=0.6,
+                num_samples=101,
+            ),
+        )
+
+    custom_dynamic_sampling_rule_mock.return_value = invalid_rules
+
+    bias = CustomRuleBias()
+    rules = bias.generate_rules(p, 0.5)
+
+    # We expect no rules to be generated.
+    assert len(rules) == 0
     insta_snapshot(rules)

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -2,12 +2,11 @@ from unittest.mock import patch
 
 import pytest
 
-from sentry.api.event_search import ParenExpression, parse_search_query
+from sentry.api.event_search import parse_search_query
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import (
     OnDemandMetricSpec,
     SearchQueryConverter,
-    _cleanup_query,
     apdex_tag_spec,
     failure_tag_spec,
     query_tokens_to_string,
@@ -733,49 +732,6 @@ def test_query_tokens_to_string(query):
 @pytest.mark.parametrize(
     "dirty, clean",
     [
-        ("release:initial OR os.name:android", "release:initial OR os.name:android"),
-        ("OR AND OR release:initial OR os.name:android", "release:initial OR os.name:android"),
-        ("release:initial OR os.name:android AND OR AND ", "release:initial OR os.name:android"),
-        (
-            "release:initial AND (AND OR) (OR )os.name:android ",
-            "release:initial AND os.name:android",
-        ),
-        (
-            " AND ((AND OR (OR ))) release:initial (((AND OR  (AND)))) AND os.name:android  (AND OR) ",
-            "release:initial AND os.name:android",
-        ),
-        (" (AND) And (And) Or release:initial or (and) or", "release:initial"),
-    ],
-)
-def test_cleanup_query(dirty, clean):
-    dirty_tokens = parse_search_query(dirty)
-    clean_tokens = parse_search_query(clean)
-    actual_clean = _cleanup_query(dirty_tokens)
-
-    assert actual_clean == clean_tokens
-
-
-def test_cleanup_query_with_empty_parens():
-    """
-    Separate test with empty parens because we can't parse a string with empty parens correctly
-    """
-
-    paren = ParenExpression
-    dirty_tokens = (
-        [paren([paren(["AND", "OR", paren([])])])]
-        + parse_search_query("release:initial AND (AND OR) (OR)")  # ((AND OR (OR ())))
-        + [paren([])]
-        + parse_search_query("os.name:android")  # ()
-        + [paren([paren([paren(["AND", "OR", paren([])])])])]  # ((()))
-    )
-    clean_tokens = parse_search_query("release:initial AND os.name:android")
-    actual_clean = _cleanup_query(dirty_tokens)
-    assert actual_clean == clean_tokens
-
-
-@pytest.mark.parametrize(
-    "dirty, clean",
-    [
         ("transaction.duration:>=1 ", ""),
         ("transaction.duration:>=1 and geo.city:Vienna ", ""),
         ("transaction.duration:>=1 and geo.city:Vienna or os.name:android", "os.name:android"),
@@ -814,4 +770,5 @@ def test_search_query_converter(query, expected):
     tokens = parse_search_query(query)
     converter = SearchQueryConverter(tokens)
     condition = converter.convert()
+
     assert expected == condition

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -2,12 +2,13 @@ from unittest.mock import patch
 
 import pytest
 
-from sentry.api.event_search import parse_search_query
+from sentry.api.event_search import ParenExpression, parse_search_query
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.extraction import (
     OnDemandMetricSpec,
     SearchQueryConverter,
     apdex_tag_spec,
+    cleanup_search_query,
     failure_tag_spec,
     query_tokens_to_string,
     should_use_on_demand_metrics,
@@ -772,3 +773,45 @@ def test_search_query_converter(query, expected):
     condition = converter.convert()
 
     assert expected == condition
+
+
+@pytest.mark.parametrize(
+    "dirty, clean",
+    [
+        ("release:initial OR os.name:android", "release:initial OR os.name:android"),
+        ("OR AND OR release:initial OR os.name:android", "release:initial OR os.name:android"),
+        ("release:initial OR os.name:android AND OR AND ", "release:initial OR os.name:android"),
+        (
+            "release:initial AND (AND OR) (OR )os.name:android ",
+            "release:initial AND os.name:android",
+        ),
+        (
+            " AND ((AND OR (OR ))) release:initial (((AND OR  (AND)))) AND os.name:android  (AND OR) ",
+            "release:initial AND os.name:android",
+        ),
+        (" (AND) And (And) Or release:initial or (and) or", "release:initial"),
+    ],
+)
+def test_cleanup_query(dirty, clean):
+    dirty_tokens = parse_search_query(dirty)
+    clean_tokens = parse_search_query(clean)
+    actual_clean = cleanup_search_query(dirty_tokens)
+
+    assert actual_clean == clean_tokens
+
+
+def test_cleanup_query_with_empty_parens():
+    """
+    Separate test with empty parens because we can't parse a string with empty parens correctly
+    """
+    paren = ParenExpression
+    dirty_tokens = (
+        [paren([paren(["AND", "OR", paren([])])])]
+        + parse_search_query("release:initial AND (AND OR) (OR)")  # ((AND OR (OR ())))
+        + [paren([])]
+        + parse_search_query("os.name:android")  # ()
+        + [paren([paren([paren(["AND", "OR", paren([])])])])]  # ((()))
+    )
+    clean_tokens = parse_search_query("release:initial AND os.name:android")
+    actual_clean = cleanup_search_query(dirty_tokens)
+    assert actual_clean == clean_tokens


### PR DESCRIPTION
This PR fixes a problem with the investigation bias which was not scraping away `event.type:x` from the query, resulting in a spec being generated that would not match any incoming transaction. In addition to this fix, it adds some validation before the rule is generated and sent to Relay.

Closes https://github.com/getsentry/sentry/issues/61676