### PR TITLE
fix(ddm): Dashboard widget name and missing MRIs

### DIFF
--- a/static/app/utils/metrics/dashboard.spec.tsx
+++ b/static/app/utils/metrics/dashboard.spec.tsx
@@ -23,7 +23,7 @@ describe('convertToDashboardWidget', () => {
         MetricDisplayType.AREA
       )
     ).toEqual({
-      title: 'DDM Widget',
+      title: 'p95(login)',
       displayType: DisplayType.AREA,
       widgetType: 'custom-metrics',
       limit: 10,
@@ -60,7 +60,7 @@ describe('convertToDashboardWidget', () => {
         MetricDisplayType.BAR
       )
     ).toEqual({
-      title: 'DDM Widget',
+      title: 'p95(measurements.duration)',
       displayType: DisplayType.BAR,
       widgetType: 'discover',
       limit: 1,

--- a/static/app/utils/metrics/dashboard.tsx
+++ b/static/app/utils/metrics/dashboard.tsx
@@ -6,6 +6,7 @@ import {
   MetricDisplayType,
   MetricsQuery,
 } from 'sentry/utils/metrics';
+import {formatMRI} from 'sentry/utils/metrics/mri';
 import {DashboardWidgetSource, Widget, WidgetType} from 'sentry/views/dashboards/types';
 
 export function convertToDashboardWidget(
@@ -15,7 +16,7 @@ export function convertToDashboardWidget(
   const isCustomMetricQuery = isCustomMetric(metricsQuery);
 
   return {
-    title: 'DDM Widget',
+    title: `${metricsQuery.op}(${formatMRI(metricsQuery.mri)})`,
     // @ts-expect-error this is a valid widget type
     displayType,
     widgetType: isCustomMetricQuery ? WidgetType.METRICS : WidgetType.DISCOVER,

--- a/static/app/views/dashboards/datasetConfig/metrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/metrics.tsx
@@ -136,6 +136,15 @@ function getFields(
     })
     .then(metaReponse => {
       const groupedByOp = groupByOp(metaReponse);
+      const typesByOp: Record<string, Set<string>> = Object.entries(groupedByOp).reduce(
+        (acc, [operation, fields]) => {
+          const types = new Set();
+          fields.forEach(field => types.add(field.type));
+          acc[operation] = types;
+          return acc;
+        },
+        {}
+      );
 
       const fieldOptions: Record<string, any> = {};
       Object.entries(groupedByOp).forEach(([operation, fields]) => {
@@ -148,7 +157,7 @@ function getFields(
               parameters: [
                 {
                   kind: 'column',
-                  columnTypes: [fields[0].type],
+                  columnTypes: [...typesByOp[operation]],
                   defaultValue: fields[0].mri,
                   required: true,
                 },


### PR DESCRIPTION
Pass MRI and op as name when creating dashboard widget
Fix MRI filter logic in dashboard widget builder

**Note:** for our own organization with over 700 MRIs for the operation `sum` the select field becomes a bit slow (at least in dev build). IMHO slow is better than missing data, but we should improve performance in the near future.