### PR TITLE
fix(metrics-extraction): Update task to iterate over all widgets

### DIFF
--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -115,7 +115,7 @@ def schedule_on_demand_check() -> None:
 
     for (widget_query_id,) in RangeQuerySetWrapper(
         DashboardWidgetQuery.objects.filter(
-            widget__widget_type=DashboardWidgetTypes.DISCOVER, columns__len__gt=0
+            widget__widget_type=DashboardWidgetTypes.DISCOVER
         )
         .exclude(conditions__contains="event.type:error")
         .values_list("id"),

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -114,9 +114,7 @@ def schedule_on_demand_check() -> None:
     dashboard_widget_count = 0
 
     for (widget_query_id,) in RangeQuerySetWrapper(
-        DashboardWidgetQuery.objects.filter(
-            widget__widget_type=DashboardWidgetTypes.DISCOVER
-        )
+        DashboardWidgetQuery.objects.filter(widget__widget_type=DashboardWidgetTypes.DISCOVER)
         .exclude(conditions__contains="event.type:error")
         .values_list("id"),
         result_value_getter=lambda item: item[0],


### PR DESCRIPTION
Previously this task was just for cardinality checks, but since this now includes iterating over all widgets to check for cardinality, we should remove the columns clause. Will opt in another ~100k queries.
