### PR TITLE
fix(hybridcloud) Fix cross-silo queries in jira server

### DIFF
--- a/src/sentry/integrations/jira_server/utils/api.py
+++ b/src/sentry/integrations/jira_server/utils/api.py
@@ -77,6 +77,7 @@ def handle_status_change(
     for oi in org_integrations:
         installation = integration.get_installation(oi.organization_id)
 
-        installation.sync_status_inbound(
-            issue_key, {"changelog": changelog, "issue": data["issue"]}
-        )
+        if hasattr(installation, "sync_status_inbound"):
+            installation.sync_status_inbound(
+                issue_key, {"changelog": changelog, "issue": data["issue"]}
+            )

--- a/src/sentry/integrations/jira_server/utils/api.py
+++ b/src/sentry/integrations/jira_server/utils/api.py
@@ -4,6 +4,8 @@ import logging
 from typing import TYPE_CHECKING, Any, Mapping
 
 from sentry.integrations.utils import sync_group_assignee_inbound
+from sentry.services.hybrid_cloud.integration.model import RpcIntegration
+from sentry.services.hybrid_cloud.integration.service import integration_service
 
 if TYPE_CHECKING:
     from sentry.models.integrations.integration import Integration
@@ -12,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_assignee_email(
-    integration: Integration,
+    integration: RpcIntegration | Integration,
     assignee: Mapping[str, str],
 ) -> str | None:
     """Get email from `assignee`."""
@@ -20,7 +22,7 @@ def get_assignee_email(
 
 
 def handle_assignee_change(
-    integration: Integration,
+    integration: RpcIntegration | Integration,
     data: Mapping[str, Any],
 ) -> None:
     assignee_changed = any(
@@ -50,7 +52,9 @@ def handle_assignee_change(
     sync_group_assignee_inbound(integration, email, issue_key, assign=True)
 
 
-def handle_status_change(integration, data):
+def handle_status_change(
+    integration: RpcIntegration | Integration, data: Mapping[str, Any]
+) -> None:
     status_changed = any(item for item in data["changelog"]["items"] if item["field"] == "status")
     if not status_changed:
         return
@@ -66,8 +70,12 @@ def handle_status_change(integration, data):
         )
         return
 
-    for org_id in integration.organizationintegration_set.values_list("organization_id", flat=True):
-        installation = integration.get_installation(org_id)
+    org_integrations = integration_service.get_organization_integrations(
+        integration_id=integration.id,
+        providers=[integration.provider],
+    )
+    for oi in org_integrations:
+        installation = integration.get_installation(oi.organization_id)
 
         installation.sync_status_inbound(
             issue_key, {"changelog": changelog, "issue": data["issue"]}

--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -7,17 +9,18 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, control_silo_endpoint
+from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.integrations.jira_server.utils import handle_assignee_change, handle_status_change
 from sentry.integrations.utils.scope import clear_tags_and_context
-from sentry.models.integrations.integration import Integration
+from sentry.services.hybrid_cloud.integration.model import RpcIntegration
+from sentry.services.hybrid_cloud.integration.service import integration_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import jwt, metrics
 
 logger = logging.getLogger(__name__)
 
 
-def get_integration_from_token(token):
+def get_integration_from_token(token: str | None) -> RpcIntegration:
     """
     When we create a jira server integration we create a webhook that contains
     a JWT in the URL. We use that JWT to locate the matching sentry integration later
@@ -32,9 +35,9 @@ def get_integration_from_token(token):
         raise ValueError("Could not decode JWT token")
     if "id" not in unvalidated:
         raise ValueError("Token did not contain `id`")
-    try:
-        integration = Integration.objects.get(provider="jira_server", external_id=unvalidated["id"])
-    except Integration.DoesNotExist:
+
+    integration = integration_service.get_integration(external_id=unvalidated["id"])
+    if not integration:
         raise ValueError("Could not find integration for token")
     try:
         jwt.decode(token, integration.metadata["webhook_secret"])
@@ -44,7 +47,7 @@ def get_integration_from_token(token):
     return integration
 
 
-@control_silo_endpoint
+@region_silo_endpoint
 class JiraServerIssueUpdatedWebhook(Endpoint):
     owner = ApiOwner.INTEGRATIONS
     publish_status = {

--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -13,6 +13,7 @@ from rest_framework import status
 from sentry.models.integrations import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.outbox import ControlOutbox, WebhookProviderIdentifier
+from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.services.hybrid_cloud.organization import RpcOrganizationSummary
 from sentry.services.hybrid_cloud.organization_mapping import organization_mapping_service
 from sentry.silo import SiloLimit, SiloMode
@@ -180,7 +181,7 @@ class BaseRequestParser(abc.ABC):
     # Optional Overrides
 
     def get_organizations_from_integration(
-        self, integration: Optional[Integration] = None
+        self, integration: Optional[Integration | RpcIntegration] = None
     ) -> Sequence[RpcOrganizationSummary]:
         """
         Use the get_integration_from_request() method to identify organizations associated with

--- a/tests/sentry/integrations/jira_server/test_webhooks.py
+++ b/tests/sentry/integrations/jira_server/test_webhooks.py
@@ -6,6 +6,7 @@ from requests.exceptions import ConnectionError
 
 from sentry.integrations.jira_server.integration import JiraServerIntegration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
+from sentry.services.hybrid_cloud.integration.serial import serialize_integration
 from sentry.testutils.cases import APITestCase
 
 from . import EXAMPLE_PAYLOAD, get_integration, link_group
@@ -71,8 +72,9 @@ class JiraServerWebhookEndpointTest(APITestCase):
             "issue": {"fields": {"assignee": {"emailAddress": "bob@example.org"}}, "key": "APP-1"},
         }
         self.get_success_response(self.jwt_token, **payload)
+        rpc_integration = serialize_integration(self.integration)
 
-        mock_sync.assert_called_with(self.integration, "bob@example.org", "APP-1", assign=True)
+        mock_sync.assert_called_with(rpc_integration, "bob@example.org", "APP-1", assign=True)
 
     @patch.object(JiraServerIntegration, "sync_status_inbound")
     def test_post_update_status(self, mock_sync):

--- a/tests/sentry/middleware/integrations/parsers/test_jira_server.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira_server.py
@@ -9,7 +9,6 @@ from django.urls import reverse
 from sentry.middleware.integrations.parsers.jira_server import JiraServerRequestParser
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.outbox import WebhookProviderIdentifier
-from sentry.services.hybrid_cloud.organization_mapping.service import organization_mapping_service
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import assert_webhook_outboxes
@@ -33,7 +32,6 @@ class JiraServerRequestParserTest(TestCase):
         self.integration = self.create_integration(
             organization=self.organization, external_id="jira_server:1", provider="jira_server"
         )
-        organization_mapping_service
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_routing_endpoint_no_integration(self):


### PR DESCRIPTION
- Assign webhook endpoint to be a region endpoint as it needs to spawn tasks that can only be run in region.
- Replace queries with service calls.

Refs HC-1023