### PR TITLE
ref(ui): remove box shadow on feedback list `ProjectAvatar`

### DIFF
--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -111,6 +111,7 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
                   project={feedbackItem.project}
                   size={12}
                   title={feedbackItem.project.slug}
+                  style={{boxShadow: 'none'}}
                 />
                 <TextOverflow>{feedbackItem.shortId}</TextOverflow>
               </Row>

--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -107,11 +107,10 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
 
             <BottomGrid style={{gridArea: 'bottom'}}>
               <Row justify="flex-start" gap={space(0.75)}>
-                <ProjectAvatar
+                <StyledProjectAvatar
                   project={feedbackItem.project}
                   size={12}
                   title={feedbackItem.project.slug}
-                  style={{boxShadow: 'none'}}
                 />
                 <TextOverflow>{feedbackItem.shortId}</TextOverflow>
               </Row>
@@ -188,6 +187,12 @@ const BottomGrid = styled('div')`
   gap: ${space(1)};
 
   overflow: hidden;
+`;
+
+const StyledProjectAvatar = styled(ProjectAvatar)`
+  && img {
+    box-shadow: none;
+  }
 `;
 
 export default FeedbackListItem;

--- a/static/app/components/platformList.tsx
+++ b/static/app/components/platformList.tsx
@@ -29,7 +29,6 @@ type Props = {
    * Platform icon size in pixels
    */
   size?: number;
-  style?: React.CSSProperties;
 };
 
 type WrapperProps = Required<
@@ -44,7 +43,6 @@ function PlatformList({
   consistentWidth = false,
   showCounter = false,
   className,
-  style,
 }: Props) {
   const visiblePlatforms = platforms.slice(0, max);
   const numNotVisiblePlatforms = platforms.length - visiblePlatforms.length;
@@ -52,7 +50,7 @@ function PlatformList({
 
   function renderContent() {
     if (!platforms.length) {
-      return <StyledPlatformIcon size={size} platform="default" style={style} />;
+      return <StyledPlatformIcon size={size} platform="default" />;
     }
 
     const platformIcons = visiblePlatforms.slice().reverse();
@@ -67,11 +65,7 @@ function PlatformList({
                 title={getPlatformName(visiblePlatform)}
                 containerDisplayMode="inline-flex"
               >
-                <StyledPlatformIcon
-                  platform={visiblePlatform}
-                  size={size}
-                  style={style}
-                />
+                <StyledPlatformIcon platform={visiblePlatform} size={size} />
               </Tooltip>
             ))}
           </PlatformIcons>
@@ -96,7 +90,6 @@ function PlatformList({
             key={visiblePlatform + index}
             platform={visiblePlatform}
             size={size}
-            style={style}
           />
         ))}
       </PlatformIcons>

--- a/static/app/components/platformList.tsx
+++ b/static/app/components/platformList.tsx
@@ -29,6 +29,7 @@ type Props = {
    * Platform icon size in pixels
    */
   size?: number;
+  style?: React.CSSProperties;
 };
 
 type WrapperProps = Required<
@@ -43,6 +44,7 @@ function PlatformList({
   consistentWidth = false,
   showCounter = false,
   className,
+  style,
 }: Props) {
   const visiblePlatforms = platforms.slice(0, max);
   const numNotVisiblePlatforms = platforms.length - visiblePlatforms.length;
@@ -50,7 +52,7 @@ function PlatformList({
 
   function renderContent() {
     if (!platforms.length) {
-      return <StyledPlatformIcon size={size} platform="default" />;
+      return <StyledPlatformIcon size={size} platform="default" style={style} />;
     }
 
     const platformIcons = visiblePlatforms.slice().reverse();
@@ -65,7 +67,11 @@ function PlatformList({
                 title={getPlatformName(visiblePlatform)}
                 containerDisplayMode="inline-flex"
               >
-                <StyledPlatformIcon platform={visiblePlatform} size={size} />
+                <StyledPlatformIcon
+                  platform={visiblePlatform}
+                  size={size}
+                  style={style}
+                />
               </Tooltip>
             ))}
           </PlatformIcons>
@@ -90,6 +96,7 @@ function PlatformList({
             key={visiblePlatform + index}
             platform={visiblePlatform}
             size={size}
+            style={style}
           />
         ))}
       </PlatformIcons>


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/61705

Now we can do this:
<img width="104" alt="SCR-20231214-jfqb" src="https://github.com/getsentry/sentry/assets/56095982/ee55495c-1360-4ab3-a73d-4c210aa08bcf">

Instead of having this :( 
![image](https://github.com/getsentry/sentry/assets/56095982/1d10a4fd-71b5-4643-8a57-5b951aed1f03)
