### PR TITLE
ref(slack): Convert the text portion of issue alerts to use block kit

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1869,6 +1869,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:sourcemaps-upload-release-as-artifact-bundle": False,
     # Updated spike protection heuristic
     "organizations:spike-protection-decay-heuristic": False,
+    # Enable Slack messages using Block Kit
+    "organizations:slack-block-kit": False,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -225,7 +225,7 @@ default_manager.add("organizations:session-replay-new-zero-state", OrganizationF
 default_manager.add("organizations:session-replay-enable-canvas", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-overage-notifications", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:slack-block-kit", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:slack-block-kit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:stacktrace-processing-caching", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:starfish-view", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -225,6 +225,7 @@ default_manager.add("organizations:session-replay-new-zero-state", OrganizationF
 default_manager.add("organizations:session-replay-enable-canvas", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-overage-notifications", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:slack-block-kit", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:stacktrace-processing-caching", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:starfish-view", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/integrations/slack/message_builder/__init__.py
+++ b/src/sentry/integrations/slack/message_builder/__init__.py
@@ -3,7 +3,7 @@ from typing import Any, List, Mapping, Union
 # TODO(mgaeta): Continue fleshing out these types.
 SlackAttachment = Mapping[str, Any]
 SlackBlock = Mapping[str, Any]
-SlackBody = Union[SlackAttachment, List[SlackAttachment]]
+SlackBody = Union[SlackAttachment, SlackBlock, List[SlackAttachment]]
 
 # Attachment colors used for issues with no actions take.
 LEVEL_TO_COLOR = {
@@ -23,3 +23,13 @@ INCIDENT_COLOR_MAPPING = {
 }
 
 SLACK_URL_FORMAT = "<{url}|{text}>"
+
+LEVEL_TO_EMOJI = {
+    "_actioned_issue": ":white_check_mark:",
+    "_incident_resolved": ":green_circle:",
+    "debug": ":yellow_circle:",
+    "error": ":red_circle:",
+    "fatal": ":red_circle:",
+    "info": ":large_blue_circle:",
+    "warning": ":yellow_circle:",
+}

--- a/src/sentry/integrations/slack/message_builder/base/base.py
+++ b/src/sentry/integrations/slack/message_builder/base/base.py
@@ -5,7 +5,7 @@ from typing import Any, Mapping, MutableMapping, Sequence
 
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.message_builder import AbstractMessageBuilder
-from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR, SlackBody
+from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR, SlackAttachment, SlackBody
 from sentry.models.group import Group
 from sentry.notifications.utils.actions import MessageAction
 from sentry.utils.assets import get_asset_url
@@ -59,7 +59,7 @@ class SlackMessageBuilder(AbstractMessageBuilder, ABC):
         color: str | None = None,
         actions: Sequence[MessageAction] | None = None,
         **kwargs: Any,
-    ) -> SlackBody:
+    ) -> SlackAttachment:
         """
         Helper to DRY up Slack specific fields.
 

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC
+from datetime import datetime
 from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple, TypedDict
 
-from sentry.integrations.slack.message_builder import SlackBlock, SlackBody
+from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.base.base import SlackMessageBuilder
 
 
@@ -28,15 +29,49 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         return block
 
     @staticmethod
-    def get_markdown_block(text: str) -> SlackBlock:
+    def get_markdown_block(text: str, emoji: Optional[str] = None) -> SlackBlock:
+        if emoji:
+            text = f"{emoji} {text}"
         return {
             "type": "section",
             "text": {"type": "mrkdwn", "text": text},
         }
 
     @staticmethod
+    def get_tags_block(tags) -> SlackBlock:
+        fields = []
+        for tag in tags:
+            title = tag["title"]
+            value = tag["value"]
+            fields.append({"type": "mrkdwn", "text": f"*{title}:*\n{value}"})
+
+        return {"type": "section", "fields": fields}
+
+    @staticmethod
     def get_divider() -> SlackBlock:
         return {"type": "divider"}
+
+    @staticmethod
+    def get_static_action(action):
+        return {
+            "type": "static_select",
+            "placeholder": {"type": "plain_text", "text": action.label, "emoji": True},
+            "option_groups": [option for option in action.option_groups],
+            "action_id": action.name,
+        }
+
+    @staticmethod
+    def get_button_action(action):
+        button = {
+            "type": "button",
+            "action_id": action.value,
+            "text": {"type": "plain_text", "text": action.label},
+            "value": action.value,
+        }
+        if action.url:
+            button["url"] = action.url
+
+        return button
 
     @staticmethod
     def get_action_block(actions: Sequence[Tuple[str, Optional[str], str]]) -> SlackBlock:
@@ -59,9 +94,27 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         return action_block
 
     @staticmethod
+    def get_context_block(text: str, timestamp: Optional[datetime] = None) -> SlackBlock:
+        if timestamp:
+            time = timestamp.strftime("%b %d")
+            text += f" | {time}"
+        return {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": text,
+                }
+            ],
+        }
+
+    @staticmethod
     def _build_blocks(
-        *args: SlackBlock, fallback_text: Optional[str] = None, color: Optional[str] = None
-    ) -> SlackBody:
+        *args: SlackBlock,
+        fallback_text: Optional[str] = None,
+        color: Optional[str] = None,
+        block_id: Optional[dict[str, int]] = None,
+    ) -> SlackBlock:
         blocks: dict[str, Any] = {"blocks": list(args)}
 
         if fallback_text:
@@ -69,6 +122,10 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
 
         if color:
             blocks["color"] = color
+
+        # put the block_id into the first block
+        if block_id:
+            blocks["blocks"][0]["block_id"] = block_id
 
         return blocks
 

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence,
 
 from sentry.integrations.slack.message_builder import SlackBlock
 from sentry.integrations.slack.message_builder.base.base import SlackMessageBuilder
+from sentry.utils.dates import to_timestamp
 
 
 class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
@@ -96,7 +97,9 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
     @staticmethod
     def get_context_block(text: str, timestamp: Optional[datetime] = None) -> SlackBlock:
         if timestamp:
-            time = timestamp.strftime("%b %d")
+            time = "<!date^{:.0f}^ {} at {} | Sentry Issue>".format(
+                to_timestamp(timestamp), "{date_pretty}", "{time}"
+            )
             text += f" | {time}"
         return {
             "type": "context",

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -97,10 +97,11 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
     @staticmethod
     def get_context_block(text: str, timestamp: Optional[datetime] = None) -> SlackBlock:
         if timestamp:
-            time = "<!date^{:.0f}^ {} at {} | Sentry Issue>".format(
+            time = "<!date^{:.0f}^{} at {} | Sentry Issue>".format(
                 to_timestamp(timestamp), "{date_pretty}", "{time}"
             )
             text += f" | {time}"
+
         return {
             "type": "context",
             "elements": [

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -355,11 +355,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             blocks.append(self.get_tags_block(tags))
 
         # build footer block
-        footer = (
-            self.notification.build_notification_footer(self.recipient, ExternalProviders.SLACK)
-            if self.notification and self.recipient
-            else build_footer(self.group, project, self.rules, SLACK_URL_FORMAT)
-        )
         timestamp = None
         if not self.issue_details:
             ts = self.group.last_seen

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Sequence, Union
 
 from sentry import features, tagstore
 from sentry.eventstore.models import GroupEvent
@@ -14,8 +14,8 @@ from sentry.integrations.message_builder import (
     get_timestamp,
     get_title_link,
 )
-from sentry.integrations.slack.message_builder import SLACK_URL_FORMAT, SlackBody
-from sentry.integrations.slack.message_builder.base.base import SlackMessageBuilder
+from sentry.integrations.slack.message_builder import SLACK_URL_FORMAT, SlackAttachment, SlackBlock
+from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.utils.escape import escape_slack_text
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.actor import ActorTuple
@@ -99,6 +99,29 @@ def build_tag_fields(
                     "title": std_key.encode("utf-8"),
                     "value": labeled_value.encode("utf-8"),
                     "short": True,
+                }
+            )
+    return fields
+
+
+def get_tags(
+    event_for_tags: Any,
+    tags: set[str] | None = None,
+) -> Sequence[Mapping[str, str | bool]]:
+    """Get tag keys and values for block kit"""
+    fields = []
+    if tags:
+        event_tags = event_for_tags.tags if event_for_tags else []
+        for key, value in event_tags:
+            std_key = tagstore.get_standardized_key(key)
+            if std_key not in tags:
+                continue
+
+            labeled_value = tagstore.get_tag_value_label(key, value)
+            fields.append(
+                {
+                    "title": std_key,
+                    "value": labeled_value,
                 }
             )
     return fields
@@ -209,8 +232,8 @@ def build_actions(
     return action_list, text, color
 
 
-class SlackIssuesMessageBuilder(SlackMessageBuilder):
-    """We're keeping around this awkward interface so that we can share logic with unfurling."""
+class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
+    """Build an issue alert notification for Slack"""
 
     def __init__(
         self,
@@ -246,7 +269,7 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
         """
         return True
 
-    def build(self, notification_uuid: str | None = None) -> SlackBody:
+    def build(self, notification_uuid: str | None = None) -> Union[SlackBlock, SlackAttachment]:
         # XXX(dcramer): options are limited to 100 choices, even when nested
         text = build_attachment_text(self.group, self.event) or ""
 
@@ -285,26 +308,82 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
         if self.rules:
             rule_id = self.rules[0].id
 
-        return self._build(
-            actions=payload_actions,
-            callback_id=json.dumps({"issue": self.group.id}),
-            color=color,
-            fallback=self.build_fallback_text(obj, project.slug),
-            fields=fields,
-            footer=footer,
-            text=text,
-            title=build_attachment_title(obj),
-            title_link=get_title_link(
-                self.group,
-                self.event,
-                self.link_to_event,
-                self.issue_details,
-                self.notification,
-                ExternalProviders.SLACK,
-                rule_id,
-                notification_uuid=notification_uuid,
-            ),
-            ts=get_timestamp(self.group, self.event) if not self.issue_details else None,
+        if not features.has("organizations:slack-block-kit", self.group.project.organization):
+            return self._build(
+                actions=payload_actions,
+                callback_id=json.dumps({"issue": self.group.id}),
+                color=color,
+                fallback=self.build_fallback_text(obj, project.slug),
+                fields=fields,
+                footer=footer,
+                text=text,
+                title=build_attachment_title(obj),
+                title_link=get_title_link(
+                    self.group,
+                    self.event,
+                    self.link_to_event,
+                    self.issue_details,
+                    self.notification,
+                    ExternalProviders.SLACK,
+                    rule_id,
+                    notification_uuid=notification_uuid,
+                ),
+                ts=get_timestamp(self.group, self.event) if not self.issue_details else None,
+            )
+
+        # build up the blocks for newer issue alert formatting #
+
+        tags = get_tags(event_for_tags, self.tags)
+        # build title block
+        title_link = get_title_link(
+            self.group,
+            self.event,
+            self.link_to_event,
+            self.issue_details,
+            self.notification,
+            ExternalProviders.SLACK,
+            rule_id,
+            notification_uuid=notification_uuid,
+        )
+        blocks = [
+            self.get_markdown_block(
+                text=f"<{title_link}|*{escape_slack_text(build_attachment_title(obj))}*>  \n{text}",
+            )
+        ]
+        # build tags block
+        if tags:
+            blocks.append(self.get_tags_block(tags))
+
+        # build footer block
+        footer = (
+            self.notification.build_notification_footer(self.recipient, ExternalProviders.SLACK)
+            if self.notification and self.recipient
+            else build_footer(self.group, project, self.rules, SLACK_URL_FORMAT)
+        )
+        timestamp = None
+        if not self.issue_details:
+            ts = self.group.last_seen
+            timestamp = max(ts, self.event.datetime) if self.event else ts
+        blocks.append(self.get_context_block(text=footer, timestamp=timestamp))
+
+        # build actions
+        # actions = []
+        # for action in payload_actions:
+        #     if action.label in ("Archive", "Ignore", "Mark as Ongoing", "Stop Ignoring"):
+        #         actions.append(self.get_button_action(action))
+        #     elif action.label in ("Resolve", "Unresolve", "Resolve..."):
+        #         actions.append(self.get_button_action(action))
+        #     elif action.name == "assign":
+        #         actions.append(self.get_static_action(action))
+
+        # if actions:
+        #     action_block = {"type": "actions", "elements": [action for action in actions]}
+        #     blocks.append(action_block)
+
+        return self._build_blocks(
+            *blocks,
+            fallback_text=self.build_fallback_text(obj, project.slug),
+            block_id=json.dumps({"issue": self.group.id}),
         )
 
 
@@ -319,8 +398,8 @@ def build_group_attachment(
     issue_details: bool = False,
     is_unfurl: bool = False,
     notification_uuid: str | None = None,
-) -> SlackBody:
-    """@deprecated"""
+) -> Union[SlackBlock, SlackAttachment]:
+
     return SlackIssuesMessageBuilder(
         group,
         event,

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -366,20 +366,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             timestamp = max(ts, self.event.datetime) if self.event else ts
         blocks.append(self.get_context_block(text=footer, timestamp=timestamp))
 
-        # build actions
-        # actions = []
-        # for action in payload_actions:
-        #     if action.label in ("Archive", "Ignore", "Mark as Ongoing", "Stop Ignoring"):
-        #         actions.append(self.get_button_action(action))
-        #     elif action.label in ("Resolve", "Unresolve", "Resolve..."):
-        #         actions.append(self.get_button_action(action))
-        #     elif action.name == "assign":
-        #         actions.append(self.get_static_action(action))
-
-        # if actions:
-        #     action_block = {"type": "actions", "elements": [action for action in actions]}
-        #     blocks.append(action_block)
-
         return self._build_blocks(
             *blocks,
             fallback_text=self.build_fallback_text(obj, project.slug),

--- a/src/sentry/integrations/slack/message_builder/notifications/digest.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/digest.py
@@ -29,7 +29,7 @@ class DigestNotificationMessageBuilder(SlackNotificationsMessageBuilder):
         """
         digest: Digest = self.context.get("digest", {})
         return [
-            SlackIssuesMessageBuilder(  # type: ignore
+            SlackIssuesMessageBuilder(
                 group=group,
                 event=event,
                 rules=[rule],

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -61,7 +61,9 @@ def build_test_message_blocks(
     title_link += "/?referrer=slack"
     ts = group.last_seen
     timestamp = max(ts, event.datetime) if event else ts
-    event_date = timestamp.strftime("%b %d")
+    event_date = "<!date^{:.0f}^{} at {} | Sentry Issue>".format(
+        to_timestamp(timestamp), "{date_pretty}", "{time}"
+    )
     return {
         "blocks": [
             {

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -284,20 +284,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert isinstance(ret, dict)
         assert ret["actions"] != []
 
-    @with_feature("organizations:slack-block-kit")
-    def test_team_recipient_block_kit(self):
-        issue_alert_group = self.create_group(project=self.project)
-        ret = SlackIssuesMessageBuilder(
-            issue_alert_group, recipient=RpcActor.from_object(self.team)
-        ).build()
-        assert isinstance(ret, dict)
-        has_actions = False
-        for section in ret["blocks"]:
-            if section["type"] == "actions":
-                has_actions = True
-
-        assert has_actions
-
     # XXX(CEO): skipping replicating tests relating to color since there is no block kit equivalent
     def test_build_group_attachment_color_no_event_error_fallback(self):
         group_with_no_events = self.create_group(project=self.project)

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -29,6 +29,7 @@ from sentry.notifications.utils.actions import MessageAction
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.dates import to_timestamp
@@ -36,6 +37,45 @@ from sentry.utils.http import absolute_uri
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 pytestmark = [requires_snuba]
+
+
+def build_test_message_blocks(
+    teams: set[Team],
+    users: set[User],
+    timestamp: datetime,
+    group: Group,
+    event: Event | None = None,
+    link_to_event: bool = False,
+) -> dict[str, Any]:
+    project = group.project
+
+    title = group.title
+    title_link = f"http://testserver/organizations/{project.organization.slug}/issues/{group.id}"
+    formatted_title = title
+    if event:
+        title = event.title
+        if title == "<unlabeled event>":
+            formatted_title = "&lt;unlabeled event&gt;"
+        if link_to_event:
+            title_link += f"/events/{event.event_id}"
+    title_link += "/?referrer=slack"
+    ts = group.last_seen
+    timestamp = max(ts, event.datetime) if event else ts
+    event_date = timestamp.strftime("%b %d")
+    return {
+        "blocks": [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"<{title_link}|*{formatted_title}*>  \n"},
+                "block_id": f'{{"issue":{group.id}}}',
+            },
+            {
+                "type": "context",
+                "elements": [{"type": "mrkdwn", "text": f"BAR-{group.short_id} | {event_date}"}],
+            },
+        ],
+        "text": f"[{project.slug}] {title}",
+    }
 
 
 def build_test_message(
@@ -154,6 +194,56 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             ]
             assert SlackIssuesMessageBuilder(group).build() == test_message
 
+    @with_feature("organizations:slack-block-kit")
+    def test_build_group_block(self):
+        group = self.create_group(project=self.project)
+        assert SlackIssuesMessageBuilder(group).build() == build_test_message_blocks(
+            teams={self.team},
+            users={self.user},
+            timestamp=group.last_seen,
+            group=group,
+        )
+
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert SlackIssuesMessageBuilder(
+            group, event.for_group(group)
+        ).build() == build_test_message_blocks(
+            teams={self.team},
+            users={self.user},
+            timestamp=event.datetime,
+            group=group,
+            event=event,
+        )
+
+        assert SlackIssuesMessageBuilder(
+            group, event.for_group(group), link_to_event=True
+        ).build() == build_test_message_blocks(
+            teams={self.team},
+            users={self.user},
+            timestamp=event.datetime,
+            group=group,
+            event=event,
+            link_to_event=True,
+        )
+
+        with self.feature("organizations:escalating-issues"):
+            test_message = build_test_message_blocks(
+                teams={self.team},
+                users={self.user},
+                timestamp=group.last_seen,
+                group=group,
+            )
+
+            for section in test_message["blocks"]:
+                if section["type"] == "actions":
+                    for element in section["elements"]:
+                        if "ignore" in element["action_id"]:
+                            element["action_id"] = "ignored:until_escalating"
+                            element["value"] = "ignored:until_escalating"
+                            element["text"]["text"] = "Archive"
+
+            assert SlackIssuesMessageBuilder(group).build() == test_message
+
     @patch(
         "sentry.integrations.slack.message_builder.issues.get_option_groups",
         wraps=get_option_groups,
@@ -178,6 +268,14 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert isinstance(ret, dict)
         assert ret["actions"] == []
 
+    @with_feature("organizations:slack-block-kit")
+    def test_build_group_attachment_issue_alert_block_kit(self):
+        issue_alert_group = self.create_group(project=self.project)
+        ret = SlackIssuesMessageBuilder(issue_alert_group, issue_details=True).build()
+        assert isinstance(ret, dict)
+        for section in ret["blocks"]:
+            assert section["type"] != "actions"
+
     def test_team_recipient(self):
         issue_alert_group = self.create_group(project=self.project)
         ret = SlackIssuesMessageBuilder(
@@ -186,6 +284,21 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert isinstance(ret, dict)
         assert ret["actions"] != []
 
+    @with_feature("organizations:slack-block-kit")
+    def test_team_recipient_block_kit(self):
+        issue_alert_group = self.create_group(project=self.project)
+        ret = SlackIssuesMessageBuilder(
+            issue_alert_group, recipient=RpcActor.from_object(self.team)
+        ).build()
+        assert isinstance(ret, dict)
+        has_actions = False
+        for section in ret["blocks"]:
+            if section["type"] == "actions":
+                has_actions = True
+
+        assert has_actions
+
+    # XXX(CEO): skipping replicating tests relating to color since there is no block kit equivalent
     def test_build_group_attachment_color_no_event_error_fallback(self):
         group_with_no_events = self.create_group(project=self.project)
         ret = SlackIssuesMessageBuilder(group_with_no_events).build()
@@ -233,12 +346,41 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert attachments["fallback"] == f"[{self.project.slug}] {occurrence.issue_title}"
         assert attachments["color"] == "#2788CE"  # blue for info level
 
+    @with_feature("organizations:slack-block-kit")
+    def test_build_group_generic_issue_block(self):
+        """Test that a generic issue type's Slack alert contains the expected values"""
+        event = self.store_event(
+            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
+        )
+        group_event = event.for_group(event.groups[0])
+        occurrence = self.build_occurrence(level="info")
+        occurrence.save()
+        group_event.occurrence = occurrence
+
+        group_event.group.type = ProfileFileIOGroupType.type_id
+
+        blocks = SlackIssuesMessageBuilder(group=group_event.group, event=group_event).build()
+        assert isinstance(blocks, dict)
+        for section in blocks["blocks"]:
+            if section["type"] == "text":
+                assert occurrence.issue_title in section["text"]["text"]
+        assert occurrence.evidence_display[0].value in blocks["blocks"][0]["text"]["text"]
+        assert blocks["text"] == f"[{self.project.slug}] {occurrence.issue_title}"
+
     def test_build_error_issue_fallback_text(self):
         event = self.store_event(data={}, project_id=self.project.id)
         assert event.group is not None
         attachments = SlackIssuesMessageBuilder(event.group, event.for_group(event.group)).build()
         assert isinstance(attachments, dict)
         assert attachments["fallback"] == f"[{self.project.slug}] {event.group.title}"
+
+    @with_feature("organizations:slack-block-kit")
+    def test_build_error_issue_fallback_text_block_kit(self):
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+        blocks = SlackIssuesMessageBuilder(event.group, event.for_group(event.group)).build()
+        assert isinstance(blocks, dict)
+        assert blocks["text"] == f"[{self.project.slug}] {event.group.title}"
 
     def test_build_performance_issue(self):
         event = self.create_performance_issue()
@@ -252,6 +394,19 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         )
         assert attachments["fallback"] == f"[{self.project.slug}] N+1 Query"
         assert attachments["color"] == "#2788CE"  # blue for info level
+
+    @with_feature("organizations:slack-block-kit")
+    def test_build_performance_issue_block_kit(self):
+        event = self.create_performance_issue()
+        with self.feature("organizations:performance-issues"):
+            blocks = SlackIssuesMessageBuilder(event.group, event).build()
+        assert isinstance(blocks, dict)
+        assert "N+1 Query" in blocks["blocks"][0]["text"]["text"]
+        assert (
+            "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+            in blocks["blocks"][0]["text"]["text"]
+        )
+        assert blocks["text"] == f"[{self.project.slug}] N+1 Query"
 
     def test_build_performance_issue_color_no_event_passed(self):
         """This test doesn't pass an event to the SlackIssuesMessageBuilder to mimic what
@@ -272,6 +427,16 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         ret = SlackIssuesMessageBuilder(group, None).build()
         assert isinstance(ret, dict)
         assert ret["text"] == "&lt;https://example.com/|*Click Here*&gt;"
+
+    @with_feature("organizations:slack-block-kit")
+    def test_escape_slack_message_block_kit(self):
+        group = self.create_group(
+            project=self.project,
+            data={"type": "error", "metadata": {"value": "<https://example.com/|*Click Here*>"}},
+        )
+        ret = SlackIssuesMessageBuilder(group, None).build()
+        assert isinstance(ret, dict)
+        assert "&lt;https://example.com/|*Click Here*&gt;" in ret["blocks"][0]["text"]["text"]
 
 
 class BuildGroupAttachmentReplaysTest(TestCase):
@@ -302,6 +467,34 @@ class BuildGroupAttachmentReplaysTest(TestCase):
         assert (
             attachments["text"]
             == f"\n\n<http://testserver/organizations/baz/issues/{event.group.id}/replays/?referrer=slack|View Replays>"
+        )
+
+    @with_feature("organizations:slack-block-kit")
+    @patch("sentry.models.group.Group.has_replays")
+    def test_build_replay_issue_block_kit(self, has_replays):
+        replay1_id = "46eb3948be25448abd53fe36b5891ff2"
+        self.project.flags.has_replays = True
+        self.project.save()
+
+        event = self.store_event(
+            data={
+                "message": "Hello world",
+                "level": "error",
+                "contexts": {"replay": {"replay_id": replay1_id}},
+                "timestamp": iso_format(before_now(minutes=1)),
+            },
+            project_id=self.project.id,
+        )
+        assert event.group is not None
+
+        with self.feature(
+            ["organizations:session-replay", "organizations:session-replay-slack-new-issue"]
+        ):
+            blocks = SlackIssuesMessageBuilder(event.group, event.for_group(event.group)).build()
+        assert isinstance(blocks, dict)
+        assert (
+            f"\n\n<http://testserver/organizations/baz/issues/{event.group.id}/replays/?referrer=slack|View Replays>"
+            in blocks["blocks"][0]["text"]["text"]
         )
 
 
@@ -591,6 +784,11 @@ class ActionsTest(TestCase):
             group, self.project, "test txt", "red", [MessageAction(name="TEST")], MOCKIDENTITY
         ) == ([], "test txt\n", "_actioned_issue")
 
+        with self.feature("organizations:slack-block-kit"):
+            assert build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], MOCKIDENTITY
+            ) == ([], "test txt\n", "_actioned_issue")
+
     def _assert_message_actions_list(self, actions, expected):
         actions_dict = [
             {"name": a.name, "label": a.label, "type": a.type, "value": a.value} for a in actions
@@ -605,15 +803,24 @@ class ActionsTest(TestCase):
         res = build_actions(
             group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
         )
-
+        expected = {
+            "label": "Stop Ignoring",
+            "name": "status",
+            "type": "button",
+            "value": "unresolved:ongoing",
+        }
         self._assert_message_actions_list(
             res[0],
-            {
-                "label": "Stop Ignoring",
-                "name": "status",
-                "type": "button",
-                "value": "unresolved:ongoing",
-            },
+            expected,
+        )
+
+        with self.feature("organizations:slack-block-kit"):
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
+        self._assert_message_actions_list(
+            res[0],
+            expected,
         )
 
     def test_ignore_does_not_have_escalating(self):
@@ -626,15 +833,26 @@ class ActionsTest(TestCase):
                 group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
             )
 
+        expected = {
+            "label": "Mark as Ongoing",
+            "name": "status",
+            "type": "button",
+            "value": "unresolved:ongoing",
+        }
         self._assert_message_actions_list(
             res[0],
-            {
-                "label": "Mark as Ongoing",
-                "name": "status",
-                "type": "button",
-                "value": "unresolved:ongoing",
-            },
+            expected,
         )
+        with self.feature("organizations:escalating-issues"), self.feature(
+            "organizations:slack-block-kit"
+        ):
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
+            self._assert_message_actions_list(
+                res[0],
+                expected,
+            )
 
     def test_ignore_unresolved_no_escalating(self):
         group = self.create_group(project=self.project)
@@ -644,16 +862,25 @@ class ActionsTest(TestCase):
         res = build_actions(
             group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
         )
-
+        expected = {
+            "label": "Ignore",
+            "name": "status",
+            "type": "button",
+            "value": "ignored:forever",
+        }
         self._assert_message_actions_list(
             res[0],
-            {
-                "label": "Ignore",
-                "name": "status",
-                "type": "button",
-                "value": "ignored:forever",
-            },
+            expected,
         )
+
+        with self.feature("organizations:slack-block-kit"):
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
+            self._assert_message_actions_list(
+                res[0],
+                expected,
+            )
 
     def test_ignore_unresolved_has_escalating(self):
         group = self.create_group(project=self.project)
@@ -664,16 +891,26 @@ class ActionsTest(TestCase):
             res = build_actions(
                 group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
             )
-
+        expected = {
+            "label": "Archive",
+            "name": "status",
+            "type": "button",
+            "value": "ignored:until_escalating",
+        }
         self._assert_message_actions_list(
             res[0],
-            {
-                "label": "Archive",
-                "name": "status",
-                "type": "button",
-                "value": "ignored:until_escalating",
-            },
+            expected,
         )
+        with self.feature("organizations:slack-block-kit"), self.feature(
+            "organizations:escalating-issues"
+        ):
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
+            self._assert_message_actions_list(
+                res[0],
+                expected,
+            )
 
     def test_no_ignore_if_feedback(self):
         group = self.create_group(project=self.project, type=FeedbackGroup.type_id)
@@ -683,6 +920,13 @@ class ActionsTest(TestCase):
         # no ignore action if feedback issue, so only assign and resolve
         assert len(res[0]) == 2
 
+        with self.feature("organizations:slack-block-kit"):
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
+            # no ignore action if feedback issue, so only assign and resolve
+            assert len(res[0]) == 2
+
     def test_resolve_resolved(self):
         group = self.create_group(project=self.project)
         group.status = GroupStatus.RESOLVED
@@ -691,15 +935,15 @@ class ActionsTest(TestCase):
         res = build_actions(
             group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
         )
-
+        expected = {
+            "label": "Unresolve",
+            "name": "status",
+            "type": "button",
+            "value": "unresolved:ongoing",
+        }
         self._assert_message_actions_list(
             res[0],
-            {
-                "label": "Unresolve",
-                "name": "status",
-                "type": "button",
-                "value": "unresolved:ongoing",
-            },
+            expected,
         )
 
     def test_resolve_unresolved_no_releases(self):
@@ -759,3 +1003,12 @@ class ActionsTest(TestCase):
             res[0],
             {"label": "Select Assignee...", "name": "assign", "type": "select", "value": None},
         )
+        with self.feature("organizations:slack-block-kit"):
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
+
+            self._assert_message_actions_list(
+                res[0],
+                {"label": "Select Assignee...", "name": "assign", "type": "select", "value": None},
+            )


### PR DESCRIPTION
Breaking up https://github.com/getsentry/sentry/pull/61215 into smaller chunks - this PR is only the text portion of the issue alert (with no buttons). 

Here is the issue alert (note no buttons) built with block kit
<img width="426" alt="Screenshot 2023-12-14 at 12 18 50 PM" src="https://github.com/getsentry/sentry/assets/29959063/aaba88e3-b773-4c9d-81ac-4ab16d95076d">

