### PR TITLE
feat(crons): Improve mark_failed to check future check-ins

### DIFF
--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -37,7 +37,7 @@ def mark_failed(
 
     The provided `ts` is the reference time for when the next check-in time is
     calculated from. This typically would be the failed check-in's `date_added`
-    or completion time. Though for the missed and timedout tasks this may be
+    or completion time. Though for the missed and timeout tasks this may be
     computed based on the tasks reference time.
     """
     monitor_env = failed_checkin.monitor_environment


### PR DESCRIPTION
Looks at future check-ins during `mark_failed` to better account for timeouts that occur at the beginning of a failed sequence.

Closes https://github.com/getsentry/sentry/issues/60123