### PR TITLE
fix(stacktrace): Fall back to symbolicator_status when debug image does not exist on the event

### DIFF
--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -187,10 +187,21 @@ function NativeFrame({
     return undefined;
   }
 
+  // this is the status of image that belongs to this frame
   function getStatus() {
-    // this is the status of image that belongs to this frame
+    // If a matching debug image doesn't exist, fall back to symbolicator_status
     if (!image) {
-      return undefined;
+      switch (frame.symbolicatorStatus) {
+        case SymbolicatorStatus.SYMBOLICATED:
+          return 'success';
+        case SymbolicatorStatus.MISSING:
+        case SymbolicatorStatus.MALFORMED:
+          return 'error';
+        case SymbolicatorStatus.MISSING_SYMBOL:
+        case SymbolicatorStatus.UNKNOWN_IMAGE:
+        default:
+          return undefined;
+      }
     }
 
     const combinedStatus = combineStatus(image.debug_status, image.unwind_status);
@@ -249,7 +260,11 @@ function NativeFrame({
                   'This frame has missing debug files and could not be symbolicated'
                 )}
               >
-                <IconFileBroken size="sm" color="errorText" />
+                <IconFileBroken
+                  size="sm"
+                  color="errorText"
+                  data-test-id="symbolication-error-icon"
+                />
               </Tooltip>
             ) : status === undefined ? (
               <Tooltip
@@ -257,7 +272,11 @@ function NativeFrame({
                   'This frame has an unknown problem and could not be symbolicated'
                 )}
               >
-                <IconWarning size="sm" color="warningText" />
+                <IconWarning
+                  size="sm"
+                  color="warningText"
+                  data-test-id="symbolication-warning-icon"
+                />
               </Tooltip>
             ) : null}
           </SymbolicatorIcon>


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/61605

For events that don't include debug images, but do have `symbolicator_status`, we should use that value to decide what to show as the frame status.