### PR TITLE
feat(spotlight): Remove `sentryConfig.environment` condition

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -169,12 +169,10 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
     },
   });
 
-  if (process.env.NODE_ENV !== 'production') {
-    if (sentryConfig.environment === 'development') {
-      import('@spotlightjs/spotlight').then(Spotlight => {
-        /* #__PURE__ */ Spotlight.init();
-      });
-    }
+  if (process.env.NODE_ENV === 'development') {
+    import('@spotlightjs/spotlight').then(Spotlight => {
+      /* #__PURE__ */ Spotlight.init({injectImmediately: true});
+    });
   }
 
   // Event processor to fill the debug_meta field with debug IDs based on the


### PR DESCRIPTION
`yarn dev-ui` will receive the prod sentry config, so spotlight is not enabled for `dev-ui`. Also we probably want to inject it into UI?
