### PR TITLE
feat(fonts): Increase font weight for Roboto Mono slightly for better readability

### DIFF
--- a/static/less/fonts.less
+++ b/static/less/fonts.less
@@ -102,7 +102,7 @@
 @font-face {
   font-family: 'Roboto Mono';
   font-style: normal;
-  font-weight: 400 600;
+  font-weight: 425 600;
   font-display: swap;
   src: url('../fonts/roboto-mono-variable.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
@@ -114,7 +114,7 @@
 @font-face {
   font-family: 'Roboto Mono';
   font-style: normal;
-  font-weight: 400 600;
+  font-weight: 425 600;
   font-display: swap;
   src: url('../fonts/roboto-mono-variable-latin-ext.woff2') format('woff2');
   unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
@@ -125,7 +125,7 @@
 @font-face {
   font-family: 'Roboto Mono';
   font-style: normal;
-  font-weight: 400 600;
+  font-weight: 425 600;
   font-display: swap;
   src: url('../fonts/roboto-mono-variable-vietnamese.woff2') format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1,
@@ -137,7 +137,7 @@
 @font-face {
   font-family: 'Roboto Mono';
   font-style: normal;
-  font-weight: 400 600;
+  font-weight: 425 600;
   font-display: swap;
   src: url('../fonts/roboto-mono-variable-greek.woff2') format('woff2');
   unicode-range: U+0370-03FF;
@@ -147,7 +147,7 @@
 @font-face {
   font-family: 'Roboto Mono';
   font-style: normal;
-  font-weight: 400 600;
+  font-weight: 425 600;
   font-display: swap;
   src: url('../fonts/roboto-mono-variable-cyrillic.woff2') format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
@@ -157,7 +157,7 @@
 @font-face {
   font-family: 'Roboto Mono';
   font-style: normal;
-  font-weight: 400 600;
+  font-weight: 425 600;
   font-display: swap;
   src: url('../fonts/roboto-mono-variable-cyrillic-ext.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;


### PR DESCRIPTION
This is a very slight difference that shouldn't be noticeable outside of a direct side-by-side comparison. But we hope this will make the mono font more readable, especially when syntax highlighting colors are added to smaller font sizes.

Before:

![CleanShot 2023-12-14 at 11 46 28](https://github.com/getsentry/sentry/assets/10888943/17931365-f25c-4116-bde9-fdce120e35af)

After:

![CleanShot 2023-12-14 at 11 46 45](https://github.com/getsentry/sentry/assets/10888943/f8a52c7b-318e-4dc9-9093-2d232a8d8f03)


