### PR TITLE
chore(hybrid-cloud): Enable thread local cache in addition to memcache for Feature Handlers

### DIFF
--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -222,7 +222,7 @@ class FeatureManager(RegisteredFeatureManager):
         >>> FeatureManager.has('organizations:feature', organization, actor=request.user)
 
         """
-        from sentry.db.models.manager.base import BaseManager
+        from sentry.db.models.manager.base import BaseManager, flush_manager_local_cache
 
         # Use thread local cache to store any cached models such as Subscriptions in addition to Django's cache.
         # This helps shortcut around memcache's performance issues
@@ -250,6 +250,9 @@ class FeatureManager(RegisteredFeatureManager):
             except Exception:
                 logging.exception("Failed to run feature check")
                 return False
+
+        # Flush and clear the thread local cache
+        flush_manager_local_cache()
 
     def batch_has(
         self,


### PR DESCRIPTION
Using thread local cache in addition to memcache for Feature Handlers.

This was introduced in https://github.com/getsentry/sentry/pull/15148 to address performance issues with memcache (Django's cache backend).

And we may want to leverage the same approach for feature handlers.