### PR TITLE
feat(ui): Add browser DDM

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -50,6 +50,9 @@ function getSentryIntegrations(routes?: Function) {
       // 6 is arbitrary, seems like a nice number
       depth: 6,
     }),
+
+    new Sentry.metrics.MetricsAggregator(),
+
     new BrowserTracing({
       ...(typeof routes === 'function'
         ? {

--- a/static/app/components/replays/replayProcessingError.tsx
+++ b/static/app/components/replays/replayProcessingError.tsx
@@ -18,7 +18,9 @@ export default function ReplayProcessingError({className, processingErrors}: Pro
       scope.setLevel('warning');
       scope.setFingerprint(['replay-processing-error']);
       processingErrors.forEach(error => {
-        Sentry.captureException(error);
+        Sentry.metrics.increment(
+          `replay.processing-error.${error.toLowerCase().replaceAll(' ', '-')}`
+        );
       });
     });
   }, [processingErrors]);

--- a/static/app/components/replays/replayProcessingError.tsx
+++ b/static/app/components/replays/replayProcessingError.tsx
@@ -21,7 +21,10 @@ export default function ReplayProcessingError({className, processingErrors}: Pro
         Sentry.metrics.increment(`replay.processing-error`, 1, {
           tags: {
             // There are only 2 different error types
-            type: error.toLowerCase().replaceAll(' ', '-'),
+            type:
+              error.toLowerCase() === 'missing meta frame'
+                ? 'missing-meta-frame'
+                : 'insufficient-replay-frames',
           },
         });
       });

--- a/static/app/components/replays/replayProcessingError.tsx
+++ b/static/app/components/replays/replayProcessingError.tsx
@@ -18,9 +18,12 @@ export default function ReplayProcessingError({className, processingErrors}: Pro
       scope.setLevel('warning');
       scope.setFingerprint(['replay-processing-error']);
       processingErrors.forEach(error => {
-        Sentry.metrics.increment(
-          `replay.processing-error.${error.toLowerCase().replaceAll(' ', '-')}`
-        );
+        Sentry.metrics.increment(`replay.processing-error`, 1, {
+          tags: {
+            // There are only 2 different error types
+            type: error.toLowerCase().replaceAll(' ', '-'),
+          },
+        });
       });
     });
   }, [processingErrors]);

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -123,6 +123,9 @@ jest.mock('@sentry/react', function sentryReact() {
     Scope: SentryReact.Scope,
     Severity: SentryReact.Severity,
     withProfiler: SentryReact.withProfiler,
+    metrics: {
+      MetricsAggregator: jest.fn().mockReturnValue({}),
+    },
     BrowserTracing: jest.fn().mockReturnValue({}),
     BrowserProfilingIntegration: jest.fn().mockReturnValue({}),
     addGlobalEventProcessor: jest.fn(),

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -125,6 +125,10 @@ jest.mock('@sentry/react', function sentryReact() {
     withProfiler: SentryReact.withProfiler,
     metrics: {
       MetricsAggregator: jest.fn().mockReturnValue({}),
+      increment: jest.fn(),
+      gauge: jest.fn(),
+      set: jest.fn(),
+      distribution: jest.fn(),
     },
     BrowserTracing: jest.fn().mockReturnValue({}),
     BrowserProfilingIntegration: jest.fn().mockReturnValue({}),


### PR DESCRIPTION
Replacing a feedback `captureException` as it is something we wanted to capture to keep an eye on and is not something we need (or have) a stacktrace of. We do not use it as an issue so this seems like a good candidate to use DDM on.

Docs: https://github.com/getsentry/sentry-javascript/releases/tag/7.88.0
