### PR TITLE
fix(stats-detectors): Use full fingerprint in regression group

### DIFF
--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -16,14 +16,13 @@ from sentry.seer.utils import BreakpointData
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.discover import zerofill
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
-from sentry.statistical_detectors.detector import DetectorPayload, TrendType
+from sentry.statistical_detectors.detector import DetectorPayload, TrendType, generate_fingerprint
 from sentry.tasks.statistical_detectors import (
     detect_function_change_points,
     detect_function_trends,
     detect_transaction_change_points,
     detect_transaction_trends,
     emit_function_regression_issue,
-    generate_fingerprint,
     limit_regressions_by_project,
     query_functions,
     query_transactions,

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -17,7 +17,6 @@ from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.discover import zerofill
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.statistical_detectors.detector import DetectorPayload, TrendType
-from sentry.statistical_detectors.issue_platform_adapter import fingerprint_regression
 from sentry.tasks.statistical_detectors import (
     detect_function_change_points,
     detect_function_trends,
@@ -357,7 +356,7 @@ def test_detect_transaction_trends_auto_resolution(
             version=1,
             active=True,
             project_id=project.id,
-            fingerprint=fingerprint_regression("/123"),
+            fingerprint=generate_fingerprint(RegressionType.ENDPOINT, "/123"),
             baseline=100,
             regressed=300,
         )
@@ -365,7 +364,7 @@ def test_detect_transaction_trends_auto_resolution(
             detect_transaction_trends([project.organization.id], [project.id], ts)
 
     status_change = StatusChangeMessage(
-        fingerprint=[fingerprint_regression("/123", full=True)],
+        fingerprint=[generate_fingerprint(RegressionType.ENDPOINT, "/123")],
         project_id=project.id,
         new_status=GroupStatus.RESOLVED,
         new_substatus=None,
@@ -566,18 +565,7 @@ def test_redirect_escalations(
                 project_id=project.id,
                 fingerprint=generate_fingerprint(
                     regression_type,
-                    {
-                        "absolute_percentage_change": 5.0,
-                        "aggregate_range_1": 100000000.0,
-                        "aggregate_range_2": 500000000.0,
-                        "breakpoint": 1687323600,
-                        "project": str(project.id),
-                        "transaction": transaction,
-                        "trend_difference": 400000000.0,
-                        "trend_percentage": 5.0,
-                        "unweighted_p_value": 0.0,
-                        "unweighted_t_value": -float("inf"),
-                    },
+                    transaction,
                 ),
                 baseline=100000000.0,
                 regressed=500000000.0,


### PR DESCRIPTION
There's no way to map the regression group to the issue group right now. Change to use the full fingerprint then we'll be able to do so by looking for `md5(fingerprint)` in GroupHash and mapping that to the group.