### PR TITLE
fix(integrations) Don't capture exceptions for jira request failures

### DIFF
--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -13,7 +13,9 @@ from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.services.hybrid_cloud.integration.model import RpcIntegration
 from sentry.services.hybrid_cloud.integration.service import integration_service
 from sentry.services.hybrid_cloud.util import region_silo_function
+from sentry.shared_integrations.exceptions import IntegrationFormError
 from sentry.types.rules import RuleFuture
+from sentry.utils import metrics
 
 logger = logging.getLogger("sentry.rules")
 
@@ -102,7 +104,7 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
         if ExternalIssue.objects.has_linked_issue(event, integration):
             logger.info(
                 "%s.rule_trigger.link_already_exists",
-                integration.provider,
+                provider,
                 extra={
                     "rule_id": rule_id,
                     "project_id": event.group.project.id,
@@ -110,7 +112,26 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
                 },
             )
             return
-        response = installation.create_issue(data)
+        try:
+            response = installation.create_issue(data)
+        except IntegrationFormError as e:
+            logger.info(
+                "%s.rule_trigger.create_ticket.failure",
+                provider,
+                extra={
+                    "rule_id": rule_id,
+                    "provider": provider,
+                    "integration_id": integration.id,
+                    "message": str(e),
+                },
+            )
+            metrics.incr(
+                f"{provider}.rule_trigger.create_ticket.failure",
+                tags={
+                    "provider": provider,
+                },
+            )
+            return
 
         if not event.get_tag("sample_event") == "yes":
             create_link(integration, installation, event, response)


### PR DESCRIPTION
When a request to a jira instance fails for validation errors we don't need to be alerted about it. Instead we can log the failure and record metrics to have visibility into what is happening.

Fixes SENTRY-12JM