### PR TITLE
test: Add event exception None test

### DIFF
--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -342,3 +342,16 @@ class EventManagerGroupingTest(TestCase):
             )[event1.group.id]
             == 1
         )
+
+    def test_none_exception(self):
+        """Test that when the exception is None, the group is still formed."""
+        manager = EventManager(
+            make_event(
+                exception=None,
+            )
+        )
+        with self.tasks():
+            manager.normalize()
+            event = manager.save(self.project.id)
+
+        assert event.group


### PR DESCRIPTION
This https://github.com/getsentry/sentry/pull/60885 caused an error since event.data["exception"] could be None. Add a test to make sure this is tested

closes https://github.com/getsentry/sentry/issues/61798