### PR TITLE
debug(crons): Log error for mismatched projects

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -97,6 +97,8 @@ def _ensure_monitor_with_config(
         )
         if created:
             signal_monitor_created(project, None, True)
+        if monitor.project_id != project.id:
+            logger.error("Monitor project + wrapper project do not match")
 
     # Update existing monitor
     if monitor and not created and monitor.config != validated_config:

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -97,8 +97,19 @@ def _ensure_monitor_with_config(
         )
         if created:
             signal_monitor_created(project, None, True)
+        # TODO(rjo100): Temporarily log to measure impact of a bug incorrectly scoping
+        # the Monitor lookups to the wrapper's project_id. This means that any consumer check-in
+        # will automatically get attached to a monitor with the given slug, regardless
+        # of the monitor's attached project.
         if monitor.project_id != project.id:
-            logger.error("Monitor project + wrapper project do not match")
+            logger.error(
+                "Monitor project + wrapper project do not match",
+                extra={
+                    "organization.id": project.organization_id,
+                    "monitor.project_id": monitor.project_id,
+                    "project.id": project.id,
+                },
+            )
 
     # Update existing monitor
     if monitor and not created and monitor.config != validated_config:

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -169,8 +169,19 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
 
                     if created:
                         signal_monitor_created(project, request.user, True)
+                    # TODO(rjo100): Temporarily log to measure impact of a bug incorrectly scoping
+                    # the Monitor lookups to the DSN's project_id. This means that any DSN check-in
+                    # will automatically get attached to a monitor with the given slug, regardless
+                    # of the monitor's attached project.
                     if monitor.project_id != project.id:
-                        logger.error("Monitor project + DSN project do not match")
+                        logger.error(
+                            "Monitor project + DSN project do not match",
+                            extra={
+                                "organization.id": project.organization_id,
+                                "monitor.project_id": monitor.project_id,
+                                "project.id": project.id,
+                            },
+                        )
 
             except MonitorLimitsExceeded as e:
                 return self.respond({type(e).__name__: str(e)}, status=400)

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import timedelta
 
 from django.db import router, transaction
@@ -38,6 +39,8 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import metrics
 
 from .base import MonitorIngestEndpoint
+
+logger = logging.getLogger(__name__)
 
 CHECKIN_QUOTA_LIMIT = 5
 CHECKIN_QUOTA_WINDOW = 60
@@ -166,6 +169,9 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
 
                     if created:
                         signal_monitor_created(project, request.user, True)
+                    if monitor.project_id != project.id:
+                        logger.error("Monitor project + DSN project do not match")
+
             except MonitorLimitsExceeded as e:
                 return self.respond({type(e).__name__: str(e)}, status=400)
 


### PR DESCRIPTION
Logs an error when the project for a given monitor (accessed via slug) doesn't match the project specified by the DSN or the consumer wrapper.

Allows us to measure the impact of https://github.com/getsentry/sentry/pull/61802