### PR TITLE
ref(replays): add js loader instructions to more BE platforms

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -299,13 +299,16 @@ export const releaseHealth: PlatformKey[] = [
 ];
 
 // These are the backend platforms that can set up replay -- e.g. they can be set up via a linked JS framework or via JS loader.
-// Note: not currently comprehensive -- only included ones that are also in the `backend` platforms listed above
-// TODO: add all the platforms
 const replayBackendPlatforms: readonly PlatformKey[] = [
   'bun',
   'dotnet-aspnetcore',
   'dotnet-aspnet',
   'elixir',
+  'go-echo',
+  'go-fasthttp',
+  'go-gin',
+  'go-iris',
+  'go-martini',
   'java-spring',
   'java-spring-boot',
   'node',

--- a/static/app/gettingStartedDocs/dotnet/aspnet.tsx
+++ b/static/app/gettingStartedDocs/dotnet/aspnet.tsx
@@ -11,6 +11,7 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
@@ -179,6 +180,7 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  replayOnboardingJsLoader,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/go/echo.tsx
+++ b/static/app/gettingStartedDocs/go/echo.tsx
@@ -9,6 +9,7 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
@@ -209,6 +210,7 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  replayOnboardingJsLoader,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/go/fasthttp.tsx
+++ b/static/app/gettingStartedDocs/go/fasthttp.tsx
@@ -9,6 +9,7 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
@@ -213,6 +214,7 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  replayOnboardingJsLoader,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/go/gin.tsx
+++ b/static/app/gettingStartedDocs/go/gin.tsx
@@ -9,6 +9,7 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
@@ -201,6 +202,7 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  replayOnboardingJsLoader,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/go/iris.tsx
+++ b/static/app/gettingStartedDocs/go/iris.tsx
@@ -9,6 +9,7 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
@@ -199,6 +200,7 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  replayOnboardingJsLoader,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/go/martini.tsx
+++ b/static/app/gettingStartedDocs/go/martini.tsx
@@ -9,6 +9,7 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
@@ -196,6 +197,7 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  replayOnboardingJsLoader,
 };
 
 export default docs;


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry/issues/61069

<details><summary> The rest of the platforms still need to be converted to the new structure:</summary>

-   node
-   node-express
-   php
-   php-laravel
-   php-symfony
-   python-aiohttp
-   python-bottle
-   python-django
-   python-falcon
-   python-fastapi
-   python-flask
-   python-pyramid
-   python-quart
-   python-sanic
-   python-starlette
-   python-tornado
-   ruby-rails
 
</details>


