### PR TITLE
fix(cleanup) Convert id collections to list

### DIFF
--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -261,7 +261,7 @@ def bulk_delete_objects(
         if column.endswith("__in"):
             column, _ = column.split("__")
             query.append(f"{quote_name(column)} = ANY(%s)")
-            params.append(value)
+            params.append(list(value))
         else:
             query.append(f"{quote_name(column)} = %s")
             params.append(value)

--- a/tests/sentry/utils/test_query.py
+++ b/tests/sentry/utils/test_query.py
@@ -79,6 +79,26 @@ class BulkDeleteObjectsTest(TestCase):
         assert result, "Could be more work to do"
         assert len(UserReport.objects.all()) == 0
 
+    def test_basic_tuple(self):
+        total = 10
+        records = []
+        for i in range(total):
+            records.append(self.create_userreport(project=self.project, event_id=str(i) * 32))
+
+        result = bulk_delete_objects(UserReport, id__in=tuple([r.id for r in records]))
+        assert result, "Could be more work to do"
+        assert len(UserReport.objects.all()) == 0
+
+    def test_basic_set(self):
+        total = 10
+        records = []
+        for i in range(total):
+            records.append(self.create_userreport(project=self.project, event_id=str(i) * 32))
+
+        result = bulk_delete_objects(UserReport, id__in={r.id for r in records})
+        assert result, "Could be more work to do"
+        assert len(UserReport.objects.all()) == 0
+
     def test_limiting(self):
         total = 10
         records = []


### PR DESCRIPTION
pyscopg will convert lists to ARRAY[] but not other container types. Casting collections to list prevents SQL syntax errors.

Fixes SENTRY-2b2x