### PR TITLE
ref(crons): Move tolerance fields out in monitor form

### DIFF
--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -413,8 +413,42 @@ function MonitorForm({
             </PanelBody>
           </Panel>
         </InputGroup>
+        {hasIssuePlatform && (
+          <Fragment>
+            <StyledListItem>{t('Set tolerance')}</StyledListItem>
+            <ListItemSubText>
+              {t('Configure when an issue is created or resolved.')}
+            </ListItemSubText>
+            <InputGroup>
+              <Panel>
+                <PanelBody>
+                  <NumberField
+                    name="config.failure_issue_threshold"
+                    min={1}
+                    placeholder="1"
+                    help={t(
+                      'Create a new issue when this many consecutive missed or error check-ins are processed.'
+                    )}
+                    label={t('Failure Tolerance')}
+                  />
+                  <NumberField
+                    name="config.recovery_threshold"
+                    min={1}
+                    placeholder="1"
+                    help={t(
+                      'Resolve the issue when this many consecutive healthy check-ins are processed.'
+                    )}
+                    label={t('Recovery Tolerance')}
+                  />
+                </PanelBody>
+              </Panel>
+            </InputGroup>
+          </Fragment>
+        )}
         <StyledListItem>{t('Notifications')}</StyledListItem>
-        <ListItemSubText>{t('Configure who to notify and when.')}</ListItemSubText>
+        <ListItemSubText>
+          {t('Configure who to notify upon issue creation and when.')}
+        </ListItemSubText>
         <InputGroup>
           <Panel>
             <PanelBody>
@@ -436,28 +470,6 @@ function MonitorForm({
                 multiple
                 menuPlacement="auto"
               />
-              {hasIssuePlatform && (
-                <Fragment>
-                  <NumberField
-                    name="config.failure_issue_threshold"
-                    min={1}
-                    placeholder="1"
-                    help={t(
-                      'Create a new issue when this many consecutive missed or error check-ins are processed.'
-                    )}
-                    label={t('Failure Tolerance')}
-                  />
-                  <NumberField
-                    name="config.recovery_threshold"
-                    min={1}
-                    placeholder="1"
-                    help={t(
-                      'Resolve the issue when this many consecutive healthy check-ins are processed.'
-                    )}
-                    label={t('Recovery Tolerance')}
-                  />
-                </Fragment>
-              )}
               <SelectField
                 label={t('Environment')}
                 help={t('Only receive notifications from a specific environment.')}


### PR DESCRIPTION
These fields are a little buried into the notification section and should be taken out for better visibly and flow within the monitor form 

Before:
<img width="766" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/fb6f4686-b747-4e03-9703-3f3dbf4cab3e">


After:
<img width="712" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/6f0aeb89-0984-4592-9b7f-61a85b5c9a63">
