### PR TITLE
ref(ui): Allow icon sizes to inherit for buttons

### DIFF
--- a/static/app/components/acl/featureDisabled.tsx
+++ b/static/app/components/acl/featureDisabled.tsx
@@ -82,7 +82,7 @@ function FeatureDisabled({
             }
           )}
         </HelpText>
-        <CopyButton borderless icon={<IconCopy size="xs" />} onClick={onClick} size="xs">
+        <CopyButton borderless icon={<IconCopy />} onClick={onClick} size="xs">
           {t('Copy to Clipboard')}
         </CopyButton>
         <Pre onClick={e => selectText(e.target as HTMLElement)}>

--- a/static/app/components/acl/featureDisabledModal.tsx
+++ b/static/app/components/acl/featureDisabledModal.tsx
@@ -33,7 +33,7 @@ export function FeatureDisabledModal({
         />
       </Body>
       <Footer>
-        <Button size="md" priority="primary" onClick={closeModal}>
+        <Button priority="primary" onClick={closeModal}>
           {t('Got it')}
         </Button>
       </Footer>

--- a/static/app/components/actions/archive.tsx
+++ b/static/app/components/actions/archive.tsx
@@ -157,7 +157,7 @@ function ArchiveActions({
             {...triggerProps}
             aria-label={t('Archive options')}
             size={size}
-            icon={<IconChevron direction="down" size="xs" />}
+            icon={<IconChevron direction="down" />}
             disabled={disabled}
           />
         )}

--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -269,7 +269,7 @@ function IgnoreActions({
             {...triggerProps}
             aria-label={t('Ignore options')}
             size={size}
-            icon={<IconChevron direction="down" size="xs" />}
+            icon={<IconChevron direction="down" />}
             disabled={disabled}
           />
         )}

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -233,7 +233,7 @@ function ResolveActions({
             size={size}
             priority={priority}
             aria-label={t('More resolve options')}
-            icon={<IconChevron direction="down" size="xs" />}
+            icon={<IconChevron direction="down" />}
             disabled={isDisabled}
           />
         )}

--- a/static/app/components/activity/note/header.tsx
+++ b/static/app/components/activity/note/header.tsx
@@ -31,7 +31,7 @@ function NoteHeader({authorName, user, onEdit, onDelete}: Props) {
             size: 'xs',
             showChevron: false,
             borderless: true,
-            icon: <IconEllipsis size="xs" />,
+            icon: <IconEllipsis />,
             'aria-label': t('Comment Actions'),
           }}
           items={[

--- a/static/app/components/alerts/onDemandMetricAlert.tsx
+++ b/static/app/components/alerts/onDemandMetricAlert.tsx
@@ -58,7 +58,7 @@ export function OnDemandMetricAlert({
         <DismissButton
           priority="link"
           size="sm"
-          icon={<IconClose size="xs" />}
+          icon={<IconClose />}
           aria-label={t('Close Alert')}
           onClick={dismiss}
         />

--- a/static/app/components/alerts/snoozeAlert.tsx
+++ b/static/app/components/alerts/snoozeAlert.tsx
@@ -181,7 +181,7 @@ function SnoozeAlert({
               {...triggerProps}
               size="sm"
               aria-label={t('Mute alert options')}
-              icon={<IconChevron direction="down" size="xs" />}
+              icon={<IconChevron direction="down" />}
             />
           )}
           items={dropdownItems}

--- a/static/app/components/carousel.tsx
+++ b/static/app/components/carousel.tsx
@@ -100,7 +100,7 @@ function Carousel({children, visibleRatio = 0.8}: CarouselProps) {
           onClick={scrollLeft}
           direction="left"
           aria-label={t('Scroll left')}
-          icon={<IconArrow size="sm" direction="left" />}
+          icon={<IconArrow direction="left" />}
         />
       )}
       {!isAtEnd && (
@@ -108,7 +108,7 @@ function Carousel({children, visibleRatio = 0.8}: CarouselProps) {
           onClick={scrollRight}
           direction="right"
           aria-label={t('Scroll right')}
-          icon={<IconArrow size="sm" direction="right" />}
+          icon={<IconArrow direction="right" />}
         />
       )}
     </CarouselContainer>

--- a/static/app/components/dynamicSampling/investigationRule.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.tsx
@@ -266,7 +266,7 @@ function InvestigationRuleCreationInternal(props: PropsInternal) {
         priority="primary"
         {...props.buttonProps}
         onClick={() => createInvestigationRule({organization, period, projects, query})}
-        icon={<IconStack size="xs" />}
+        icon={<IconStack />}
       >
         {t('Get Samples')}
       </Button>

--- a/static/app/components/events/aiSuggestedSolution/suggestion.tsx
+++ b/static/app/components/events/aiSuggestedSolution/suggestion.tsx
@@ -182,7 +182,7 @@ export function Suggestion({onHideSuggestion, projectSlug, event}: Props) {
             <strong>{t('Was this helpful?')}</strong>
             <ButtonBar gap={1}>
               <Button
-                icon={<IconSad color="red300" size="xs" />}
+                icon={<IconSad color="red300" />}
                 size="xs"
                 onClick={() => {
                   trackAnalytics(
@@ -201,7 +201,7 @@ export function Suggestion({onHideSuggestion, projectSlug, event}: Props) {
                 {t('Nope')}
               </Button>
               <Button
-                icon={<IconMeh color="yellow300" size="xs" />}
+                icon={<IconMeh color="yellow300" />}
                 size="xs"
                 onClick={() => {
                   trackAnalytics(
@@ -220,7 +220,7 @@ export function Suggestion({onHideSuggestion, projectSlug, event}: Props) {
                 {t('Kinda')}
               </Button>
               <Button
-                icon={<IconHappy color="green300" size="xs" />}
+                icon={<IconHappy color="green300" />}
                 size="xs"
                 onClick={() => {
                   trackAnalytics(

--- a/static/app/components/events/eventAttachmentActions.tsx
+++ b/static/app/components/events/eventAttachmentActions.tsx
@@ -41,7 +41,7 @@ function EventAttachmentActions({
       >
         <Button
           size="xs"
-          icon={<IconDelete size="xs" />}
+          icon={<IconDelete />}
           aria-label={t('Delete')}
           disabled={!url}
           title={!url ? t('Insufficient permissions to delete attachments') : undefined}
@@ -50,7 +50,7 @@ function EventAttachmentActions({
 
       <DownloadButton
         size="xs"
-        icon={<IconDownload size="xs" />}
+        icon={<IconDownload />}
         href={url ? `${url}?download=1` : ''}
         disabled={!url}
         title={!url ? t('Insufficient permissions to download attachments') : undefined}
@@ -62,7 +62,7 @@ function EventAttachmentActions({
           size="xs"
           disabled={!url || !hasPreview}
           priority={previewIsOpen ? 'primary' : 'default'}
-          icon={<IconShow size="xs" />}
+          icon={<IconShow />}
           onClick={handlePreview}
           title={
             !url

--- a/static/app/components/events/eventStatisticalDetector/eventDifferentialFlamegraph.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventDifferentialFlamegraph.tsx
@@ -359,14 +359,14 @@ function DifferentialFlamegraphTransactionToolbar(
       )}
       <ButtonBar merged>
         <DifferentialFlamegraphPaginationButton
-          icon={<IconChevron direction="left" size="xs" />}
+          icon={<IconChevron direction="left" />}
           aria-label={t('Previous Transaction')}
           size="xs"
           disabled={!props.onPreviousTransactionClick}
           onClick={props.onPreviousTransactionClick}
         />
         <DifferentialFlamegraphPaginationButton
-          icon={<IconChevron direction="right" size="xs" />}
+          icon={<IconChevron direction="right" />}
           aria-label={t('Next Transaction')}
           size="xs"
           disabled={!props.onNextTransactionClick}
@@ -708,14 +708,14 @@ function DifferentialFlamegraphChangedFunctionsTitle(props: {
           size="xs"
           disabled={!props.onPreviousPageClick}
           onClick={props.onPreviousPageClick}
-          icon={<IconChevron direction="left" size="xs" />}
+          icon={<IconChevron direction="left" />}
           aria-label={t('Previous page')}
         />
         <DifferentialFlamegraphPaginationButton
           size="xs"
           disabled={!props.onNextPageClick}
           onClick={props.onNextPageClick}
-          icon={<IconChevron direction="right" size="xs" />}
+          icon={<IconChevron direction="right" />}
           aria-label={t('Next page')}
         />
       </ButtonBar>

--- a/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
+++ b/static/app/components/events/eventStatisticalDetector/regressionMessage.tsx
@@ -111,11 +111,7 @@ function EventStatisticalDetectorRegressedPerformanceMessage({
               'The current date is over 14 days from the breakpoint. Open the Transaction Summary to see the most up to date transaction behaviour.'
             )}
           >
-            <LinkButton
-              to={transactionSummaryLink}
-              size="xs"
-              icon={<IconOpen size="xs" />}
-            >
+            <LinkButton to={transactionSummaryLink} size="xs" icon={<IconOpen />}>
               {t('Go to Summary')}
             </LinkButton>
           </Tooltip>

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
@@ -67,7 +67,7 @@ function Screenshot({
               disabled={screenshotInFocus === 0}
               aria-label={t('Previous Screenshot')}
               onClick={onPrevious}
-              icon={<IconChevron direction="left" size="xs" />}
+              icon={<IconChevron direction="left" />}
               size="xs"
             />
             {tct('[currentScreenshot] of [totalScreenshots]', {
@@ -78,7 +78,7 @@ function Screenshot({
               disabled={screenshotInFocus + 1 === totalScreenshots}
               aria-label={t('Next Screenshot')}
               onClick={onNext}
-              icon={<IconChevron direction="right" size="xs" />}
+              icon={<IconChevron direction="right" />}
               size="xs"
             />
           </StyledPanelHeader>
@@ -123,7 +123,7 @@ function Screenshot({
                 offset={4}
                 triggerProps={{
                   showChevron: false,
-                  icon: <IconEllipsis size="xs" />,
+                  icon: <IconEllipsis />,
                   'aria-label': t('More screenshot actions'),
                 }}
                 size="xs"

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotPagination.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotPagination.tsx
@@ -25,7 +25,7 @@ function ScreenshotPagination({
   return (
     <Wrapper lightText>
       <Button
-        icon={<IconChevron direction="left" size="xs" />}
+        icon={<IconChevron direction="left" />}
         aria-label={t('Previous')}
         size="xs"
         disabled={previousDisabled}
@@ -33,7 +33,7 @@ function ScreenshotPagination({
       />
       <span data-test-id="pagination-header-text">{headerText}</span>
       <Button
-        icon={<IconChevron direction="right" size="xs" />}
+        icon={<IconChevron direction="right" />}
         aria-label={t('Next')}
         size="xs"
         disabled={nextDisabled}

--- a/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
+++ b/static/app/components/events/interfaces/crons/cronTimelineSection.tsx
@@ -80,7 +80,7 @@ export function CronTimelineSection({event, organization}: Props) {
     <ButtonBar gap={1}>
       <LinkButton
         size="xs"
-        icon={<IconOpen size="xs" />}
+        icon={<IconOpen />}
         to={`/organizations/${organization.slug}/crons/${monitorSlug}`}
       >
         {t('View in Monitor Details')}

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidate/actions.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidate/actions.tsx
@@ -64,7 +64,7 @@ function Actions({
                   <ActionButton
                     aria-label={t('Actions')}
                     disabled={deleted}
-                    icon={<IconEllipsis size="sm" />}
+                    icon={<IconEllipsis />}
                   />
                 }
                 anchorRight
@@ -99,7 +99,7 @@ function Actions({
                 <Tooltip disabled={hasRole} title={noPermissionToDownloadDebugFilesInfo}>
                   <Button
                     size="xs"
-                    icon={<IconDownload size="xs" />}
+                    icon={<IconDownload />}
                     href={downloadUrl}
                     disabled={!hasRole}
                   >
@@ -115,7 +115,7 @@ function Actions({
                   >
                     <Button
                       priority="danger"
-                      icon={<IconDelete size="xs" />}
+                      icon={<IconDelete />}
                       size="xs"
                       disabled={!hasAccess}
                       aria-label={t('Delete')}

--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -184,7 +184,7 @@ export function SpanProfileDetails({
         <SpanDetailsItem>
           <ButtonBar merged>
             <Button
-              icon={<IconChevron direction="left" size="xs" />}
+              icon={<IconChevron direction="left" />}
               aria-label={t('Previous')}
               size="xs"
               disabled={!hasPrevious}
@@ -193,7 +193,7 @@ export function SpanProfileDetails({
               }}
             />
             <Button
-              icon={<IconChevron direction="right" size="xs" />}
+              icon={<IconChevron direction="right" />}
               aria-label={t('Next')}
               size="xs"
               disabled={!hasNext}

--- a/static/app/components/events/profileEventEvidence.tsx
+++ b/static/app/components/events/profileEventEvidence.tsx
@@ -61,7 +61,7 @@ export function ProfileEventEvidence({event, projectSlug}: ProfileEvidenceProps)
                     referrer: 'issue',
                   },
                 })}
-                icon={<IconProfiling size="xs" />}
+                icon={<IconProfiling />}
               >
                 {t('View Profile')}
               </Button>

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -401,7 +401,7 @@ export function TraceEventDataSection({
             )}
             <CompactSelect
               triggerProps={{
-                icon: <IconSort size="xs" />,
+                icon: <IconSort />,
                 size: 'xs',
                 title: sortByTooltip,
               }}
@@ -418,7 +418,7 @@ export function TraceEventDataSection({
             />
             <CompactSelect
               triggerProps={{
-                icon: <IconEllipsis size="xs" />,
+                icon: <IconEllipsis />,
                 size: 'xs',
                 showChevron: false,
                 'aria-label': t('Options'),

--- a/static/app/components/feedback/list/feedbackListBulkSelection.tsx
+++ b/static/app/components/feedback/list/feedbackListBulkSelection.tsx
@@ -52,7 +52,7 @@ export default function FeedbackListBulkSelection({
             position="bottom-end"
             triggerProps={{
               'aria-label': t('Read Menu'),
-              icon: <IconEllipsis size="xs" />,
+              icon: <IconEllipsis />,
               showChevron: false,
               size: 'xs',
             }}

--- a/static/app/components/forms/fields/choiceMapperField.tsx
+++ b/static/app/components/forms/fields/choiceMapperField.tsx
@@ -183,7 +183,7 @@ export default class ChoiceMapperField extends Component<ChoiceMapperFieldProps>
       >
         {({isOpen}) => (
           <DropdownButton
-            icon={<IconAdd size="xs" isCircled />}
+            icon={<IconAdd isCircled />}
             isOpen={isOpen}
             size="xs"
             disabled={disabled}

--- a/static/app/components/forms/fields/projectMapperField.tsx
+++ b/static/app/components/forms/fields/projectMapperField.tsx
@@ -257,7 +257,7 @@ export class RenderField extends Component<RenderProps, State> {
               <Button
                 size="sm"
                 priority="primary"
-                icon={<IconOpen size="xs" />}
+                icon={<IconOpen />}
                 disabled={!existingValues.length}
                 href={nextUrl}
                 title={DISABLED_TOOLTIP_TEXT}

--- a/static/app/components/forms/fields/tableField.tsx
+++ b/static/app/components/forms/fields/tableField.tsx
@@ -101,12 +101,7 @@ export default class TableField extends Component<InputFieldProps> {
     const disabled = typeof rawDisabled === 'function' ? false : rawDisabled;
 
     const button = (
-      <Button
-        icon={<IconAdd size="xs" isCircled />}
-        onClick={addRow}
-        size="xs"
-        disabled={disabled}
-      >
+      <Button icon={<IconAdd isCircled />} onClick={addRow} size="xs" disabled={disabled}>
         {addButtonText}
       </Button>
     );

--- a/static/app/components/modals/demoSignUp.tsx
+++ b/static/app/components/modals/demoSignUp.tsx
@@ -28,7 +28,7 @@ function DemoSignUpModal({closeModal}: Props) {
   return (
     <HighlightCornerContainer>
       <CloseButton
-        icon={<IconClose size="xs" />}
+        icon={<IconClose />}
         size="xs"
         aria-label={t('Close')}
         onClick={() => {

--- a/static/app/components/modals/importDashboardFromFileModal.tsx
+++ b/static/app/components/modals/importDashboardFromFileModal.tsx
@@ -97,7 +97,6 @@ function ImportDashboardFromFileModal({
         <Wrapper>
           <Button
             onClick={handleUploadClick}
-            size="md"
             disabled={!validated}
             priority="primary"
             icon={<IconUpload />}

--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -391,7 +391,7 @@ class InviteMembersModal extends DeprecatedAsyncComponent<
           size="sm"
           borderless
           onClick={this.addInviteRow}
-          icon={<IconAdd size="xs" isCircled />}
+          icon={<IconAdd isCircled />}
         >
           {t('Add another')}
         </AddButton>

--- a/static/app/components/navigationButtonGroup.tsx
+++ b/static/app/components/navigationButtonGroup.tsx
@@ -39,7 +39,7 @@ function NavigationButtonGroup({
         to={links[0]}
         disabled={!hasPrevious}
         aria-label={t('Oldest')}
-        icon={<IconPrevious size="xs" />}
+        icon={<IconPrevious />}
         onClick={onOldestClick}
       />
       <Button size={size} to={links[1]} disabled={!hasPrevious} onClick={onOlderClick}>
@@ -53,7 +53,7 @@ function NavigationButtonGroup({
         to={links[3]}
         disabled={!hasNext}
         aria-label={t('Newest')}
-        icon={<IconNext size="xs" />}
+        icon={<IconNext />}
         onClick={onNewestClick}
       />
     </ButtonBar>

--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -284,11 +284,8 @@ export function FrameworkSuggestionModal({
       </Body>
       <Footer>
         <Actions>
-          <Button size="md" onClick={handleSkip}>
-            {t('Skip')}
-          </Button>
+          <Button onClick={handleSkip}>{t('Skip')}</Button>
           <Button
-            size="md"
             priority="primary"
             onClick={handleConfigure}
             disabled={!selectedFramework}

--- a/static/app/components/organizations/projectPageFilter/menuFooter.tsx
+++ b/static/app/components/organizations/projectPageFilter/menuFooter.tsx
@@ -51,7 +51,7 @@ function ProjectPageFilterMenuFooter({
         size="xs"
         aria-label={t('Add Project')}
         to={`/organizations/${organization.slug}/projects/new/`}
-        icon={<IconAdd size="xs" isCircled />}
+        icon={<IconAdd isCircled />}
       >
         {t('Project')}
       </Button>

--- a/static/app/components/pagination.tsx
+++ b/static/app/components/pagination.tsx
@@ -67,7 +67,7 @@ function Pagination({
       {caption && <PaginationCaption>{caption}</PaginationCaption>}
       <ButtonBar merged>
         <Button
-          icon={<IconChevron direction="left" size="sm" />}
+          icon={<IconChevron direction="left" />}
           aria-label={t('Previous')}
           size={size}
           disabled={previousDisabled}
@@ -77,7 +77,7 @@ function Pagination({
           }}
         />
         <Button
-          icon={<IconChevron direction="right" size="sm" />}
+          icon={<IconChevron direction="right" />}
           aria-label={t('Next')}
           size={size}
           disabled={nextDisabled}

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -236,7 +236,7 @@ const ClearButton = styled(Button)`
 `;
 
 ClearButton.defaultProps = {
-  icon: <IconClose isCircled size="xs" />,
+  icon: <IconClose isCircled />,
   borderless: true,
   size: 'xs',
 };

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/differentialFlamegraphSettingsButton.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/differentialFlamegraphSettingsButton.tsx
@@ -42,7 +42,7 @@ export function DifferentialFlamegraphSettingsButton(
     <Fragment>
       <Button
         ref={setButtonRef}
-        icon={<IconSettings size="xs" />}
+        icon={<IconSettings />}
         size="xs"
         aria-label={t('Differential Flamegraph Settings')}
         onClick={onToggleMenu}

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphOptionsMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphOptionsMenu.tsx
@@ -40,7 +40,7 @@ function FlamegraphOptionsMenu({
       </Button>
       <CompactSelect
         triggerLabel={t('Color Coding')}
-        triggerProps={{icon: <IconSliders size="xs" />, size: 'xs'}}
+        triggerProps={{icon: <IconSliders />, size: 'xs'}}
         options={colorCodingOptions}
         position="bottom-end"
         value={colorCoding}

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.tsx
@@ -73,7 +73,7 @@ function FlamegraphThreadSelector({
   return (
     <StyledCompactSelect
       triggerProps={{
-        icon: <IconList size="xs" />,
+        icon: <IconList />,
         size: 'xs',
       }}
       options={[

--- a/static/app/components/replays/pageBanner.tsx
+++ b/static/app/components/replays/pageBanner.tsx
@@ -35,7 +35,7 @@ export default function PageBanner({
       {onDismiss && (
         <CloseButton
           onClick={onDismiss}
-          icon={<IconClose size="xs" />}
+          icon={<IconClose />}
           aria-label={t('Hide')}
           size="xs"
         />

--- a/static/app/components/replays/playerDOMAlert.tsx
+++ b/static/app/components/replays/playerDOMAlert.tsx
@@ -23,7 +23,7 @@ function PlayerDOMAlert() {
         <DismissButton
           priority="link"
           size="sm"
-          icon={<IconClose size="xs" />}
+          icon={<IconClose />}
           aria-label={t('Close Alert')}
           onClick={dismiss}
         />

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -63,7 +63,6 @@ function ReplayPlayPauseBar() {
       />
       {isFinished ? (
         <Button
-          size="md"
           title={t('Restart Replay')}
           icon={<IconPrevious size="md" />}
           onClick={restart}
@@ -72,7 +71,6 @@ function ReplayPlayPauseBar() {
         />
       ) : (
         <Button
-          size="md"
           title={isPlaying ? t('Pause') : t('Play')}
           icon={isPlaying ? <IconPause size="md" /> : <IconPlay size="md" />}
           onClick={() => togglePlayPause(!isPlaying)}
@@ -155,7 +153,7 @@ function TimelineSizeBar() {
       <Button
         size="xs"
         title={t('Zoom out')}
-        icon={<IconSubtract size="xs" />}
+        icon={<IconSubtract />}
         borderless
         onClick={() => setTimelineScale(Math.max(timelineScale - 1, 1))}
         aria-label={t('Zoom out')}
@@ -168,7 +166,7 @@ function TimelineSizeBar() {
       <Button
         size="xs"
         title={t('Zoom in')}
-        icon={<IconAdd size="xs" />}
+        icon={<IconAdd />}
         borderless
         onClick={() => setTimelineScale(Math.min(timelineScale + 1, maxScale))}
         aria-label={t('Zoom in')}

--- a/static/app/components/repositoryRow.tsx
+++ b/static/app/components/repositoryRow.tsx
@@ -83,7 +83,7 @@ function RepositoryRow({
       >
         <StyledButton
           size="xs"
-          icon={<IconDelete size="xs" />}
+          icon={<IconDelete />}
           aria-label={t('delete')}
           disabled={!hasAccess}
         />

--- a/static/app/components/sidebar/serviceIncidents.tsx
+++ b/static/app/components/sidebar/serviceIncidents.tsx
@@ -102,7 +102,7 @@ function ServiceIncidents({
             <SidebarPanelItem title={incident.name} key={incident.id}>
               <LinkButton
                 size="xs"
-                icon={<IconOpen size="xs" />}
+                icon={<IconOpen />}
                 priority="link"
                 href={incident.url}
                 external

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -2030,7 +2030,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
                   {...props}
                   size="sm"
                   aria-label={t('Show more')}
-                  icon={<VerticalEllipsisIcon size="xs" />}
+                  icon={<VerticalEllipsisIcon />}
                 />
               )}
               triggerLabel={t('Show more')}

--- a/static/app/components/timeRangeSelector/index.tsx
+++ b/static/app/components/timeRangeSelector/index.tsx
@@ -439,7 +439,7 @@ export function TimeRangeSelector({
                             <Button
                               size="xs"
                               borderless
-                              icon={<IconArrow size="xs" direction="left" />}
+                              icon={<IconArrow direction="left" />}
                               onClick={() => setShowAbsoluteSelector(false)}
                             >
                               {t('Back')}

--- a/static/app/views/admin/adminEnvironment.tsx
+++ b/static/app/views/admin/adminEnvironment.tsx
@@ -42,7 +42,7 @@ export default class AdminEnvironment extends DeprecatedAsyncView<{}, State> {
               {version.upgradeAvailable && (
                 <Button
                   href="https://github.com/getsentry/sentry/releases"
-                  icon={<IconUpgrade size="xs" />}
+                  icon={<IconUpgrade />}
                   size="xs"
                   external
                 >

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -408,7 +408,7 @@ function RuleListRow({
               triggerProps={{
                 'aria-label': t('Actions'),
                 size: 'xs',
-                icon: <IconEllipsis size="xs" />,
+                icon: <IconEllipsis />,
                 showChevron: false,
               }}
               disabledKeys={hasAccess && canEdit ? [] : ['delete']}

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -367,7 +367,7 @@ function RuleNode({
       return (
         <Button
           size="sm"
-          icon={<IconSettings size="xs" />}
+          icon={<IconSettings />}
           onClick={() =>
             openModal(deps => (
               <TicketRuleModal
@@ -392,7 +392,7 @@ function RuleNode({
       return (
         <Button
           size="sm"
-          icon={<IconSettings size="xs" />}
+          icon={<IconSettings />}
           disabled={Boolean(data.disabled) || disabled}
           onClick={() => {
             openModal(

--- a/static/app/views/alerts/rules/metric/details/errorMigrationWarning.tsx
+++ b/static/app/views/alerts/rules/metric/details/errorMigrationWarning.tsx
@@ -114,7 +114,7 @@ export function ErrorMigrationWarning({project, rule}: ErrorMigrationWarningProp
               query: {migration: '1'},
             }}
             size="xs"
-            icon={<IconEdit size="xs" />}
+            icon={<IconEdit />}
           >
             {t('Exclude archived issues')}
           </LinkButton>

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/deleteActionButton.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/deleteActionButton.tsx
@@ -19,7 +19,7 @@ export default function DeleteActionButton(
   return (
     <Button
       size="sm"
-      icon={<IconDelete size="xs" />}
+      icon={<IconDelete />}
       aria-label={t('Remove action')}
       {...props}
       onClick={handleClick}

--- a/static/app/views/auth/loginForm.tsx
+++ b/static/app/views/auth/loginForm.tsx
@@ -29,17 +29,17 @@ function LoginProviders({
     <ProviderWrapper>
       <ProviderHeading>{t('External Account Login')}</ProviderHeading>
       {googleLoginLink && (
-        <Button size="sm" icon={<IconGoogle size="xs" />} href={googleLoginLink}>
+        <Button size="sm" icon={<IconGoogle />} href={googleLoginLink}>
           {t('Sign in with Google')}
         </Button>
       )}
       {githubLoginLink && (
-        <Button size="sm" icon={<IconGithub size="xs" />} href={githubLoginLink}>
+        <Button size="sm" icon={<IconGithub />} href={githubLoginLink}>
           {t('Sign in with GitHub')}
         </Button>
       )}
       {vstsLoginLink && (
-        <Button size="sm" icon={<IconVsts size="xs" />} href={vstsLoginLink}>
+        <Button size="sm" icon={<IconVsts />} href={vstsLoginLink}>
           {t('Sign in with Azure DevOps')}
         </Button>
       )}

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -494,7 +494,7 @@ class Dashboard extends Component<Props, State> {
             className={DRAG_RESIZE_CLASS}
             size="xs"
             borderless
-            icon={<IconResize size="xs" />}
+            icon={<IconResize />}
           />
         }
         useCSSTransforms={false}

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -130,7 +130,7 @@ function WidgetCardContextMenu({
                   aria-label={t('Open Widget Viewer')}
                   borderless
                   size="xs"
-                  icon={<IconExpand size="xs" />}
+                  icon={<IconExpand />}
                   onClick={() => {
                     (seriesData || tableData) &&
                       setData({
@@ -272,7 +272,7 @@ function WidgetCardContextMenu({
                 aria-label={t('Open Widget Viewer')}
                 borderless
                 size="xs"
-                icon={<IconExpand size="xs" />}
+                icon={<IconExpand />}
                 onClick={() => {
                   setData({
                     seriesData,

--- a/static/app/views/ddm/trayContent.tsx
+++ b/static/app/views/ddm/trayContent.tsx
@@ -47,7 +47,7 @@ export function TrayContent() {
         <ToggleButton
           size="xs"
           isMinimized={trayIsMinimized}
-          icon={<IconChevron size="xs" />}
+          icon={<IconChevron />}
           onClick={trayIsMinimized ? resetSize : maximiseSize}
           aria-label={trayIsMinimized ? t('show') : t('hide')}
         />

--- a/static/app/views/discover/table/columnEditCollection.tsx
+++ b/static/app/views/discover/table/columnEditCollection.tsx
@@ -621,7 +621,7 @@ class ColumnEditCollection extends Component<Props, State> {
                 onClick={this.handleAddColumn}
                 title={title}
                 disabled={!canAdd}
-                icon={<IconAdd isCircled size="xs" />}
+                icon={<IconAdd isCircled />}
               >
                 {t('Add a Column')}
               </Button>
@@ -632,7 +632,7 @@ class ColumnEditCollection extends Component<Props, State> {
                   onClick={this.handleAddEquation}
                   title={title}
                   disabled={!canAdd}
-                  icon={<IconAdd isCircled size="xs" />}
+                  icon={<IconAdd isCircled />}
                 >
                   {t('Add an Equation')}
                 </Button>

--- a/static/app/views/discover/table/tableActions.tsx
+++ b/static/app/views/discover/table/tableActions.tsx
@@ -65,7 +65,7 @@ function renderBrowserExportButton(canEdit: boolean, props: Props) {
       disabled={disabled}
       onClick={onClick}
       data-test-id="grid-download-csv"
-      icon={<IconDownload size="xs" />}
+      icon={<IconDownload />}
       title={t(
         "There aren't that many results, start your export and it'll download immediately."
       )}
@@ -85,7 +85,7 @@ function renderAsyncExportButton(canEdit: boolean, props: Props) {
         queryInfo: eventView.getEventsAPIPayload(location),
       }}
       disabled={disabled}
-      icon={<IconDownload size="xs" />}
+      icon={<IconDownload />}
     >
       {t('Export All')}
     </DataExport>
@@ -103,7 +103,7 @@ function renderEditButton(canEdit: boolean, props: Props) {
         disabled={!canEdit}
         onClick={onClick}
         data-test-id="grid-edit-enable"
-        icon={<IconSliders size="xs" />}
+        icon={<IconSliders />}
       >
         {t('Columns')}
       </Button>
@@ -115,7 +115,7 @@ function renderEditButton(canEdit: boolean, props: Props) {
 
 function renderSummaryButton({onChangeShowTags, showTags}: Props) {
   return (
-    <Button size="sm" onClick={onChangeShowTags} icon={<IconTag size="xs" />}>
+    <Button size="sm" onClick={onChangeShowTags} icon={<IconTag />}>
       {showTags ? t('Hide Tags') : t('Show Tags')}
     </Button>
   );

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -371,7 +371,7 @@ export function Actions(props: Props) {
       <DropdownMenu
         triggerProps={{
           'aria-label': t('More Actions'),
-          icon: <IconEllipsis size="xs" />,
+          icon: <IconEllipsis />,
           showChevron: false,
           size: 'sm',
         }}

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -278,7 +278,7 @@ export function GroupEventActions({event, group, projectSlug}: GroupEventActions
         position="bottom-end"
         triggerProps={{
           'aria-label': t('Event Actions Menu'),
-          icon: <IconEllipsis size="xs" />,
+          icon: <IconEllipsis />,
           showChevron: false,
           size: BUTTON_SIZE,
         }}

--- a/static/app/views/issueDetails/groupTagValues.tsx
+++ b/static/app/views/issueDetails/groupTagValues.tsx
@@ -224,7 +224,7 @@ function GroupTagValues({baseUrl, project, group, environments}: Props) {
               triggerProps={{
                 size: 'xs',
                 showChevron: false,
-                icon: <IconEllipsis size="xs" />,
+                icon: <IconEllipsis />,
                 'aria-label': t('More'),
               }}
               items={[

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -298,7 +298,7 @@ function ActionSet({
         items={menuItems}
         triggerProps={{
           'aria-label': t('More issue actions'),
-          icon: <IconEllipsis size="xs" />,
+          icon: <IconEllipsis />,
           showChevron: false,
           size: 'xs',
         }}

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -54,7 +54,7 @@ function IssueListSortOptions({onSelect, sort, query}: Props) {
       value={sortKey}
       triggerProps={{
         size: 'xs',
-        icon: <IconSort size="xs" />,
+        icon: <IconSort />,
       }}
     />
   );

--- a/static/app/views/issueList/header.tsx
+++ b/static/app/views/issueList/header.tsx
@@ -126,7 +126,7 @@ function IssueListHeader({
             data-test-id="real-time"
             title={realtimeTitle}
             aria-label={realtimeTitle}
-            icon={realtimeActive ? <IconPause size="xs" /> : <IconPlay size="xs" />}
+            icon={realtimeActive ? <IconPause /> : <IconPlay />}
             onClick={() => onRealtimeChange(!realtimeActive)}
           />
         </ButtonBar>

--- a/static/app/views/issueList/savedIssueSearches.tsx
+++ b/static/app/views/issueList/savedIssueSearches.tsx
@@ -215,7 +215,7 @@ function SavedIssueSearches({
             aria-label={t('Collapse sidebar')}
             borderless
             onClick={() => setIsOpen(false)}
-            icon={<IconClose size="sm" />}
+            icon={<IconClose />}
           />
         </HeadingContainer>
         <CreateSavedSearchWrapper>

--- a/static/app/views/monitors/components/cronsLandingPanel.tsx
+++ b/static/app/views/monitors/components/cronsLandingPanel.tsx
@@ -173,7 +173,7 @@ export function CronsLandingPanel() {
   return (
     <Panel>
       <BackButton
-        icon={<IconChevron size="sm" direction="left" />}
+        icon={<IconChevron direction="left" />}
         onClick={() => navigateToPlatformGuide(null)}
         borderless
       >

--- a/static/app/views/monitors/components/monitorCheckIns.tsx
+++ b/static/app/views/monitors/components/monitorCheckIns.tsx
@@ -179,7 +179,7 @@ function MonitorCheckIns({monitor, monitorEnvs, orgSlug}: Props) {
                   <div>
                     <Button
                       size="xs"
-                      icon={<IconDownload size="xs" />}
+                      icon={<IconDownload />}
                       href={generateDownloadUrl(checkIn)}
                     >
                       {t('Attachment')}

--- a/static/app/views/monitors/components/monitorHeaderActions.tsx
+++ b/static/app/views/monitors/components/monitorHeaderActions.tsx
@@ -54,15 +54,13 @@ function MonitorHeaderActions({monitor, orgId, onUpdate}: Props) {
         onConfirm={handleDelete}
         message={t('Are you sure you want to permanently delete this cron monitor?')}
       >
-        <Button size="sm" icon={<IconDelete size="xs" />}>
+        <Button size="sm" icon={<IconDelete />}>
           {t('Delete')}
         </Button>
       </Confirm>
       <Button
         size="sm"
-        icon={
-          monitor.isMuted ? <IconSubscribed size="xs" /> : <IconUnsubscribed size="xs" />
-        }
+        icon={monitor.isMuted ? <IconSubscribed /> : <IconUnsubscribed />}
         onClick={toggleStatus}
       >
         {monitor.isMuted ? t('Unmute') : t('Mute')}
@@ -70,7 +68,7 @@ function MonitorHeaderActions({monitor, orgId, onUpdate}: Props) {
       <Button
         priority="primary"
         size="sm"
-        icon={<IconEdit size="xs" />}
+        icon={<IconEdit />}
         to={{
           pathname: `/organizations/${orgId}/crons/${monitor.slug}/edit/`,
           // TODO(davidenwang): Right now we have to pass the environment

--- a/static/app/views/monitors/overview.tsx
+++ b/static/app/views/monitors/overview.tsx
@@ -87,7 +87,7 @@ export default function Monitors() {
             <ButtonBar gap={1}>
               <FeedbackWidgetButton />
               {showAddMonitor && (
-                <NewMonitorButton size="sm" icon={<IconAdd isCircled size="xs" />}>
+                <NewMonitorButton size="sm" icon={<IconAdd isCircled />}>
                   {t('Add Monitor')}
                 </NewMonitorButton>
               )}

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -536,7 +536,7 @@ const Back = styled(({className, animate, ...props}: BackButtonProps) => (
       },
     }}
   >
-    <Button {...props} icon={<IconArrow direction="left" size="sm" />} priority="link">
+    <Button {...props} icon={<IconArrow direction="left" />} priority="link">
       {t('Back')}
     </Button>
   </motion.div>

--- a/static/app/views/performance/browser/webVitals/pagePerformanceTable.tsx
+++ b/static/app/views/performance/browser/webVitals/pagePerformanceTable.tsx
@@ -314,14 +314,12 @@ export function PagePerformanceTable() {
           <Wrapper>
             <ButtonBar merged>
               <Button
-                icon={<IconChevron direction="left" size="sm" />}
-                size="md"
+                icon={<IconChevron direction="left" />}
                 disabled
                 aria-label={t('Previous')}
               />
               <Button
-                icon={<IconChevron direction="right" size="sm" />}
-                size="md"
+                icon={<IconChevron direction="right" />}
                 disabled
                 aria-label={t('Next')}
               />

--- a/static/app/views/performance/browser/webVitals/pageSamplePerformanceTable.tsx
+++ b/static/app/views/performance/browser/webVitals/pageSamplePerformanceTable.tsx
@@ -341,14 +341,12 @@ export function PageSamplePerformanceTable({
           <Wrapper>
             <ButtonBar merged>
               <Button
-                icon={<IconChevron direction="left" size="sm" />}
-                size="md"
+                icon={<IconChevron direction="left" />}
                 disabled
                 aria-label={t('Previous')}
               />
               <Button
-                icon={<IconChevron direction="right" size="sm" />}
-                size="md"
+                icon={<IconChevron direction="right" />}
                 disabled
                 aria-label={t('Next')}
               />

--- a/static/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.tsx
@@ -189,7 +189,7 @@ class EventMetas extends Component<Props, State> {
                 ))}
               {hasReplay && (
                 <ReplayButtonContainer>
-                  <Button href="#replay" size="sm" icon={<IconPlay size="xs" />}>
+                  <Button href="#replay" size="sm" icon={<IconPlay />}>
                     {t('Replay')}
                   </Button>
                 </ReplayButtonContainer>

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -487,7 +487,7 @@ function TrendsListItem(props: TrendsListItemProps) {
           title={
             <StyledButton
               size="xs"
-              icon={<IconEllipsis data-test-id="trends-item-action" size="xs" />}
+              icon={<IconEllipsis data-test-id="trends-item-action" />}
               aria-label={t('Actions')}
             />
           }

--- a/static/app/views/projectInstall/components/platformHeaderButtonBar.tsx
+++ b/static/app/views/projectInstall/components/platformHeaderButtonBar.tsx
@@ -11,11 +11,7 @@ type Props = {
 export default function PlatformHeaderButtonBar({gettingStartedLink, docsLink}: Props) {
   return (
     <ButtonBar gap={1}>
-      <Button
-        size="sm"
-        icon={<IconChevron size="xs" direction="left" />}
-        to={gettingStartedLink}
-      >
+      <Button size="sm" icon={<IconChevron direction="left" />} to={gettingStartedLink}>
         {t('Back')}
       </Button>
       <Button size="sm" href={docsLink} external>

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -153,7 +153,7 @@ function Dashboard({teams, organization, loadingTeams, error, router, location}:
           <ButtonBar gap={1}>
             <Button
               size="sm"
-              icon={<IconUser size="xs" />}
+              icon={<IconUser />}
               title={
                 canJoinTeam ? undefined : t('You do not have permission to join a team.')
               }
@@ -173,7 +173,7 @@ function Dashboard({teams, organization, loadingTeams, error, router, location}:
                   : undefined
               }
               to={`/organizations/${organization.slug}/projects/new/`}
-              icon={<IconAdd size="xs" isCircled />}
+              icon={<IconAdd isCircled />}
               data-test-id="create-project"
             >
               {t('Create Project')}

--- a/static/app/views/releases/detail/header/releaseActions.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.tsx
@@ -207,7 +207,7 @@ function ReleaseActions({
         items={menuItems}
         triggerProps={{
           showChevron: false,
-          icon: <IconEllipsis size="xs" />,
+          icon: <IconEllipsis />,
           'aria-label': t('Actions'),
         }}
         position="bottom-end"

--- a/static/app/views/relocation/encryptBackup.tsx
+++ b/static/app/views/relocation/encryptBackup.tsx
@@ -57,7 +57,7 @@ export function EncryptBackup(props: StepProps) {
           <mark>{'/path/to/encrypted/backup/output/file.tar'}</mark>
           {t('file that will be uploaded in the next step')}
         </p>
-        <ContinueButton size="md" priority="primary" onClick={() => props.onComplete()}>
+        <ContinueButton priority="primary" onClick={() => props.onComplete()}>
           {t('Continue')}
         </ContinueButton>
       </motion.div>

--- a/static/app/views/relocation/getStarted.tsx
+++ b/static/app/views/relocation/getStarted.tsx
@@ -66,7 +66,6 @@ function GetStarted(props: StepProps) {
           )}
           <ContinueButton
             disabled={!orgSlugs || !regionUrl}
-            size="md"
             priority="primary"
             type="submit"
           >

--- a/static/app/views/relocation/publicKey.tsx
+++ b/static/app/views/relocation/publicKey.tsx
@@ -41,7 +41,7 @@ export function PublicKey({publicKey, onComplete}: StepProps) {
       >
         {publicKey}
       </RelocationCodeBlock>
-      <ContinueButton size="md" priority="primary" type="submit" onClick={handleContinue}>
+      <ContinueButton priority="primary" type="submit" onClick={handleContinue}>
         {t('Continue')}
       </ContinueButton>
     </motion.div>

--- a/static/app/views/relocation/relocation.tsx
+++ b/static/app/views/relocation/relocation.tsx
@@ -298,7 +298,7 @@ const Back = styled(({className, animate, ...props}: BackButtonProps) => (
       },
     }}
   >
-    <Button {...props} icon={<IconArrow direction="left" size="sm" />} priority="link">
+    <Button {...props} icon={<IconArrow direction="left" />} priority="link">
       {t('Back')}
     </Button>
   </motion.div>

--- a/static/app/views/relocation/uploadBackup.tsx
+++ b/static/app/views/relocation/uploadBackup.tsx
@@ -139,7 +139,6 @@ export function UploadBackup(__props: StepProps) {
               <a onClick={() => setFile(undefined)}>{t('Remove file')}</a>
             </div>
             <StartRelocationButton
-              size="md"
               priority="primary"
               onClick={handleStartRelocation}
               icon={<IconUpload className="upload-icon" size="xs" />}

--- a/static/app/views/replays/detail/noRowRenderer.tsx
+++ b/static/app/views/replays/detail/noRowRenderer.tsx
@@ -19,11 +19,7 @@ function NoRowRenderer({children, unfilteredItems, clearSearchTerm}: Props) {
   ) : (
     <EmptyState>
       <p>{t('No results found')}</p>
-      <Button
-        icon={<IconClose color="gray500" size="sm" isCircled />}
-        onClick={clearSearchTerm}
-        size="md"
-      >
+      <Button icon={<IconClose color="gray500" isCircled />} onClick={clearSearchTerm}>
         {t('Clear filters')}
       </Button>
     </EmptyState>

--- a/static/app/views/settings/account/apiApplications/details.tsx
+++ b/static/app/views/settings/account/apiApplications/details.tsx
@@ -107,11 +107,7 @@ class ApiApplicationsDetails extends DeprecatedAsyncView<Props, State> {
                   ) : (
                     <ClientSecret>
                       <HiddenSecret>{t('hidden')}</HiddenSecret>
-                      <Button
-                        size="md"
-                        onClick={this.rotateClientSecret}
-                        priority="danger"
-                      >
+                      <Button onClick={this.rotateClientSecret} priority="danger">
                         Rotate client secret
                       </Button>
                     </ClientSecret>

--- a/static/app/views/settings/account/apiApplications/index.tsx
+++ b/static/app/views/settings/account/apiApplications/index.tsx
@@ -66,7 +66,7 @@ class ApiApplications extends DeprecatedAsyncView<Props, State> {
               priority="primary"
               size="sm"
               onClick={this.handleCreateApplication}
-              icon={<IconAdd size="xs" isCircled />}
+              icon={<IconAdd isCircled />}
             >
               {t('Create New Application')}
             </Button>

--- a/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
@@ -253,7 +253,6 @@ function NotificationSettingsByEntity({
           />
           <Button
             disabled={!selectedEntityId || !selectedValue}
-            size="md"
             priority="primary"
             onClick={handleAdd}
             icon={<IconAdd />}

--- a/static/app/views/settings/components/dataScrubbing/organizationRules.tsx
+++ b/static/app/views/settings/components/dataScrubbing/organizationRules.tsx
@@ -90,7 +90,7 @@ export class OrganizationRules extends Component<Props, State> {
                 ? t('Expand Organization Rules')
                 : t('Collapse Organization Rules')
             }
-            icon={<IconChevron size="xs" direction={isCollapsed ? 'down' : 'up'} />}
+            icon={<IconChevron direction={isCollapsed ? 'down' : 'up'} />}
             size="xs"
             aria-label={t('Toggle Organization Rules')}
           />

--- a/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
+++ b/static/app/views/settings/components/teamSelect/teamSelectForMember.tsx
@@ -185,7 +185,7 @@ function TeamRow({
       <div>
         <Button
           size="xs"
-          icon={<IconSubtract isCircled size="xs" />}
+          icon={<IconSubtract isCircled />}
           title={buttonHelpText}
           disabled={isRemoveDisabled}
           onClick={() => onRemoveTeam(team.slug)}

--- a/static/app/views/settings/components/teamSelect/teamSelectForProject.tsx
+++ b/static/app/views/settings/components/teamSelect/teamSelectForProject.tsx
@@ -134,7 +134,7 @@ function TeamRow({
         onConfirm={() => onRemoveTeam(team.slug)}
         disabled={disabled}
       >
-        <Button size="xs" icon={<IconSubtract isCircled size="xs" />} disabled={disabled}>
+        <Button size="xs" icon={<IconSubtract isCircled />} disabled={disabled}>
           {t('Remove')}
         </Button>
       </Confirm>

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
@@ -53,7 +53,7 @@ function OrganizationApiKeysList({
     <Button
       priority="primary"
       size="sm"
-      icon={<IconAdd size="xs" isCircled />}
+      icon={<IconAdd isCircled />}
       busy={busy}
       disabled={busy}
       onClick={onAddApiKey}

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -272,13 +272,13 @@ export default class RequestLog extends DeprecatedAsyncComponent<Props, State> {
 
         <PaginationButtons>
           <Button
-            icon={<IconChevron direction="left" size="sm" />}
+            icon={<IconChevron direction="left" />}
             onClick={this.handlePrevPage}
             disabled={!this.hasPrevPage}
             aria-label={t('Previous page')}
           />
           <Button
-            icon={<IconChevron direction="right" size="sm" />}
+            icon={<IconChevron direction="right" />}
             onClick={this.handleNextPage}
             disabled={!this.hasNextPage}
             aria-label={t('Next page')}

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -447,7 +447,7 @@ class SentryApplicationDetails extends DeprecatedAsyncView<Props, State> {
                 {t('Tokens')}
                 <Button
                   size="xs"
-                  icon={<IconAdd size="xs" isCircled />}
+                  icon={<IconAdd isCircled />}
                   onClick={evt => this.onAddToken(evt)}
                   data-test-id="token-add"
                 >

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -236,7 +236,7 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
             <Button
               priority="primary"
               size="sm"
-              icon={<IconAdd size="xs" isCircled />}
+              icon={<IconAdd isCircled />}
               onClick={() => onClick()}
             >
               {t('Add Services')}
@@ -292,7 +292,7 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
                 handleJiraMigration();
               }}
             >
-              <Button priority="primary" size="md" disabled={!hasAccess}>
+              <Button priority="primary" disabled={!hasAccess}>
                 {t('Migrate Plugin')}
               </Button>
             </Confirm>
@@ -335,7 +335,7 @@ function ConfigureIntegration({params, router, routes, location}: Props) {
                 handleOpsgenieMigration();
               }}
             >
-              <Button priority="primary" size="md" disabled={!hasAccess}>
+              <Button priority="primary" disabled={!hasAccess}>
                 {t('Migrate Plugin')}
               </Button>
             </Confirm>

--- a/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -89,7 +89,7 @@ class DocIntegrationDetailedView extends AbstractIntegrationDetailedView<
           size="sm"
           priority="primary"
           style={{marginLeft: space(1)}}
-          icon={<StyledIconOpen size="xs" />}
+          icon={<StyledIconOpen />}
         >
           {t('Learn More')}
         </LearnMoreButton>

--- a/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
@@ -242,7 +242,7 @@ class IntegrationCodeMappings extends DeprecatedAsyncComponent<Props, State> {
                   data-test-id="add-mapping-button"
                   onClick={() => this.openModal()}
                   size="xs"
-                  icon={<IconAdd size="xs" isCircled />}
+                  icon={<IconAdd isCircled />}
                 >
                   {t('Add Code Mapping')}
                 </Button>

--- a/static/app/views/settings/organizationIntegrations/integrationExternalMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalMappings.tsx
@@ -200,7 +200,7 @@ class IntegrationExternalMappings extends DeprecatedAsyncComponent<Props, State>
               data-test-id="add-mapping-button"
               onClick={() => onCreate()}
               size="xs"
-              icon={<IconAdd size="xs" isCircled />}
+              icon={<IconAdd isCircled />}
             >
               {tct('Add [type] Mapping', {type})}
             </AddButton>,

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -336,7 +336,7 @@ class OrganizationMemberDetail extends DeprecatedAsyncView<Props, State> {
                     {canResend && (
                       <Button
                         data-test-id="resend-invite"
-                        icon={<IconRefresh size="sm" />}
+                        icon={<IconRefresh />}
                         title={t('Generate a new invite link and send a new email.')}
                         onClick={() => this.handleInvite(true)}
                       >

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -183,7 +183,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
               >
                 <Button
                   data-test-id="remove"
-                  icon={<IconSubtract isCircled size="xs" />}
+                  icon={<IconSubtract isCircled />}
                   size="sm"
                   busy={this.state.busy}
                 >
@@ -205,7 +205,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
                     ? t('You cannot make changes to this partner-provisioned user.')
                     : t('You do not have access to remove members')
                 }
-                icon={<IconSubtract isCircled size="xs" />}
+                icon={<IconSubtract isCircled />}
               >
                 {t('Remove')}
               </Button>
@@ -218,7 +218,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
                 })}
                 onConfirm={this.handleLeave}
               >
-                <Button priority="danger" size="sm" icon={<IconClose size="xs" />}>
+                <Button priority="danger" size="sm" icon={<IconClose />}>
                   {t('Leave')}
                 </Button>
               </Confirm>
@@ -227,7 +227,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
             {showLeaveButton && !memberCanLeave && (
               <Button
                 size="sm"
-                icon={<IconClose size="xs" />}
+                icon={<IconClose />}
                 disabled
                 title={
                   isIdpProvisioned

--- a/static/app/views/settings/organizationProjects/createProjectButton.tsx
+++ b/static/app/views/settings/organizationProjects/createProjectButton.tsx
@@ -17,7 +17,7 @@ export default function CreateProjectButton() {
         !canCreateProject ? t('You do not have permission to create projects') : undefined
       }
       to={`/organizations/${organization.slug}/projects/new/`}
-      icon={<IconAdd size="xs" isCircled />}
+      icon={<IconAdd isCircled />}
     >
       {t('Create Project')}
     </Button>

--- a/static/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/static/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -167,7 +167,7 @@ class RelayWrapper extends DeprecatedAsyncView<Props, State> {
               }
               priority="primary"
               size="sm"
-              icon={<IconAdd size="xs" isCircled />}
+              icon={<IconAdd isCircled />}
               onClick={this.handleOpenAddDialog}
               disabled={disabled}
             >

--- a/static/app/views/settings/organizationTeams/organizationTeams.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.tsx
@@ -63,7 +63,7 @@ function OrganizationTeams({
           organization,
         })
       }
-      icon={<IconAdd size="xs" isCircled />}
+      icon={<IconAdd isCircled />}
     >
       {t('Create Team')}
     </Button>

--- a/static/app/views/settings/organizationTeams/teamMembersRow.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembersRow.tsx
@@ -77,7 +77,7 @@ function RemoveButton(props: {
       <Button
         size="xs"
         disabled
-        icon={<IconSubtract size="xs" isCircled />}
+        icon={<IconSubtract isCircled />}
         aria-label={t('Remove')}
         title={t('You do not have permission to remove a member from this team.')}
       >
@@ -94,7 +94,7 @@ function RemoveButton(props: {
       <Button
         size="xs"
         disabled
-        icon={<IconSubtract size="xs" isCircled />}
+        icon={<IconSubtract isCircled />}
         aria-label={t('Remove')}
         title={buttonHelpText}
       >
@@ -109,7 +109,7 @@ function RemoveButton(props: {
       data-test-id={`button-remove-${member.id}`}
       size="xs"
       disabled={!canRemoveMember}
-      icon={<IconSubtract size="xs" isCircled />}
+      icon={<IconSubtract isCircled />}
       onClick={onClick}
       aria-label={buttonRemoveText}
     >

--- a/static/app/views/settings/organizationTeams/teamProjects.tsx
+++ b/static/app/views/settings/organizationTeams/teamProjects.tsx
@@ -162,7 +162,7 @@ function TeamProjects({team, location, params}: TeamProjectsProps) {
                   <Button
                     size="sm"
                     disabled={!hasWriteAccess}
-                    icon={<IconSubtract isCircled size="xs" />}
+                    icon={<IconSubtract isCircled />}
                     aria-label={t('Remove')}
                     onClick={() => {
                       handleLinkProject(project, 'remove');

--- a/static/app/views/settings/project/projectFilters/groupTombstones.tsx
+++ b/static/app/views/settings/project/projectFilters/groupTombstones.tsx
@@ -68,7 +68,7 @@ function GroupTombstoneRow({data, disabled, onUndiscard}: GroupTombstoneRowProps
                 : t('Undiscard')
             }
             size="xs"
-            icon={<IconDelete size="xs" />}
+            icon={<IconDelete />}
             disabled={disabled}
           />
         </Confirm>

--- a/static/app/views/settings/project/projectKeys/list/index.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.tsx
@@ -187,7 +187,7 @@ class ProjectKeys extends DeprecatedAsyncView<Props, State> {
               onClick={this.handleCreateKey}
               size="sm"
               priority="primary"
-              icon={<IconAdd size="xs" isCircled />}
+              icon={<IconAdd isCircled />}
               disabled={!hasAccess}
             >
               {t('Generate New Key')}

--- a/static/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/static/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -82,7 +82,7 @@ function KeyRow({
               'Are you sure you want to remove this key? This action is irreversible.'
             )}
           >
-            <Button size="xs" icon={<IconDelete size="xs" />} aria-label={t('Delete')} />
+            <Button size="xs" icon={<IconDelete />} aria-label={t('Delete')} />
           </Confirm>
         </Controls>
       </PanelHeader>

--- a/static/app/views/settings/project/projectOwnership/codeOwnerFileTable.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeOwnerFileTable.tsx
@@ -149,7 +149,7 @@ export function CodeOwnerFileTable({
               triggerProps={{
                 'aria-label': t('Actions'),
                 size: 'xs',
-                icon: <IconEllipsis size="xs" />,
+                icon: <IconEllipsis />,
                 showChevron: false,
                 disabled,
               }}

--- a/static/app/views/settings/project/projectOwnership/codeowners.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeowners.tsx
@@ -75,7 +75,7 @@ class CodeOwnersPanel extends Component<Props> {
             controls={[
               <Button
                 key="sync"
-                icon={<IconSync size="xs" />}
+                icon={<IconSync />}
                 size="xs"
                 onClick={() => this.handleSync(codeowner)}
                 disabled={disabled}
@@ -89,7 +89,7 @@ class CodeOwnersPanel extends Component<Props> {
               >
                 <Button
                   key="delete"
-                  icon={<IconDelete size="xs" />}
+                  icon={<IconDelete />}
                   aria-label={t('Delete')}
                   size="xs"
                 />

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -155,7 +155,7 @@ tags.sku_class:enterprise #enterprise`;
                 <Button
                   type="button"
                   size="sm"
-                  icon={<IconEdit size="xs" />}
+                  icon={<IconEdit />}
                   priority="primary"
                   onClick={() =>
                     openEditOwnershipRules({

--- a/static/app/views/settings/project/projectServiceHooks.tsx
+++ b/static/app/views/settings/project/projectServiceHooks.tsx
@@ -160,7 +160,7 @@ class ProjectServiceHooks extends DeprecatedAsyncView<Props, State> {
                 to={`/settings/${organization.slug}/projects/${params.projectId}/hooks/new/`}
                 size="sm"
                 priority="primary"
-                icon={<IconAdd size="xs" isCircled />}
+                icon={<IconAdd isCircled />}
               >
                 {t('Create New Hook')}
               </Button>

--- a/static/app/views/settings/projectDebugFiles/debugFileRow.tsx
+++ b/static/app/views/settings/projectDebugFiles/debugFileRow.tsx
@@ -104,7 +104,7 @@ function DebugFileRow({
               >
                 <Button
                   size="xs"
-                  icon={<IconDownload size="xs" />}
+                  icon={<IconDownload />}
                   href={downloadUrl}
                   disabled={!hasRole}
                 >
@@ -127,7 +127,7 @@ function DebugFileRow({
                 >
                   <Button
                     priority="danger"
-                    icon={<IconDelete size="xs" />}
+                    icon={<IconDelete />}
                     size="xs"
                     disabled={!hasAccess}
                     data-test-id="delete-dif"

--- a/static/app/views/settings/projectTags/index.tsx
+++ b/static/app/views/settings/projectTags/index.tsx
@@ -136,7 +136,7 @@ function ProjectTags(props: Props) {
                                 : t('You do not have permission to remove tags.')
                             }
                             aria-label={t('Remove tag')}
-                            icon={<IconDelete size="xs" />}
+                            icon={<IconDelete />}
                             data-test-id="delete"
                           />
                         </Confirm>


### PR DESCRIPTION
This is a follow up to GH-61791. Buttons will now tell icons now big to be based on the size of the button, so in all these cases we no longer need to specify the button size