### PR TITLE
fix(severity): Add is_new to high severity condition

### DIFF
--- a/src/sentry/rules/conditions/high_priority_issue.py
+++ b/src/sentry/rules/conditions/high_priority_issue.py
@@ -17,8 +17,8 @@ class HighPriorityIssueCondition(EventCondition):
     id = "sentry.rules.conditions.high_priority_issue.HighPriorityIssueCondition"
     label = "Sentry marks an issue as high priority"
 
-    def is_high_severity(self, state: EventState, group: Optional[Group]) -> bool:
-        if not group:
+    def is_new_high_severity(self, state: EventState, group: Optional[Group]) -> bool:
+        if not group or not state.is_new:
             return False
 
         try:
@@ -32,10 +32,10 @@ class HighPriorityIssueCondition(EventCondition):
         if not has_high_priority_issue_alerts(self.project):
             return False
 
-        is_high_severity = self.is_high_severity(state, event.group)
+        is_new_high_severity = self.is_new_high_severity(state, event.group)
         is_escalating = state.has_reappeared or state.has_escalated
 
-        return is_high_severity or is_escalating
+        return is_new_high_severity or is_escalating
 
     def get_activity(
         self, start: datetime, end: datetime, limit: int

--- a/tests/sentry/rules/conditions/test_high_priority_issue.py
+++ b/tests/sentry/rules/conditions/test_high_priority_issue.py
@@ -19,10 +19,13 @@ class HighPriorityIssueConditionTest(RuleTestCase):
         self.assertPasses(rule, event, has_reappeared=True, has_escalated=False)
         self.assertPasses(rule, event, has_reappeared=False, has_escalated=True)
         self.assertDoesNotPass(rule, event, has_reappeared=False, has_escalated=False)
+        self.assertDoesNotPass(rule, event, is_new=False, has_reappeared=False, has_escalated=False)
 
         event.group.data["metadata"] = {"severity": "0.7"}
-        self.assertPasses(rule, event, has_reappeared=False, has_escalated=False)
+        self.assertPasses(rule, event, is_new=True, has_reappeared=False, has_escalated=False)
+        self.assertDoesNotPass(rule, event, is_new=False, has_reappeared=False, has_escalated=False)
 
         event.group.data["metadata"] = {"severity": "0.0"}
-        self.assertPasses(rule, event, has_reappeared=False, has_escalated=True)
-        self.assertDoesNotPass(rule, event, has_reappeared=False, has_escalated=False)
+        self.assertPasses(rule, event, is_new=False, has_reappeared=False, has_escalated=True)
+        self.assertPasses(rule, event, is_new=False, has_reappeared=False, has_escalated=True)
+        self.assertDoesNotPass(rule, event, is_new=True, has_reappeared=False, has_escalated=False)


### PR DESCRIPTION
High severity events should only trigger an alert for the first event in a new group. 