### PR TITLE
fix(hybridcloud) Improver provider regex to resolve jira issues

### DIFF
--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -95,9 +95,11 @@ class IntegrationClassification(BaseClassification):
             e.g. `/extensions/slack/commands/` -> `slack`
         """
         integration_prefix_regex = re.escape(self.integration_prefix)
-        provider_regex = rf"^{integration_prefix_regex}(\w+)"
+        provider_regex = rf"^{integration_prefix_regex}([^/]+)"
         result = re.search(provider_regex, request.path)
-        return result[1] if result else None
+        if not result:
+            return None
+        return result[1].replace("-", "_")
 
     def should_operate(self, request: HttpRequest) -> bool:
         return (

--- a/tests/sentry/middleware/integrations/test_classifications.py
+++ b/tests/sentry/middleware/integrations/test_classifications.py
@@ -86,7 +86,7 @@ class IntegrationClassificationTest(BaseClassificationTestCase):
     )
     def test_invalid_provider(self, mock_identify_provider):
         request = self.factory.post(f"{self.prefix}🔥🔥🔥/webhook/")
-        assert mock_identify_provider(request) is None
+        assert mock_identify_provider(request) == "🔥🔥🔥"
         self.validate_mock_ran_with_noop(request, mock_identify_provider)
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)

--- a/tests/sentry/middleware/integrations/test_integration_control.py
+++ b/tests/sentry/middleware/integrations/test_integration_control.py
@@ -9,6 +9,8 @@ from sentry.middleware.integrations.classifications import (
     PluginClassification,
 )
 from sentry.middleware.integrations.integration_control import IntegrationControlMiddleware
+from sentry.middleware.integrations.parsers.jira import JiraRequestParser
+from sentry.middleware.integrations.parsers.jira_server import JiraServerRequestParser
 from sentry.middleware.integrations.parsers.plugin import PluginRequestParser
 from sentry.middleware.integrations.parsers.slack import SlackRequestParser
 from sentry.silo import SiloMode
@@ -94,6 +96,36 @@ class IntegrationControlMiddlewareTest(TestCase):
         mock_parser_get_response.return_value = result
         response = self.middleware(self.factory.post("/extensions/slack/webhook/"))
         assert result == response
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @patch.object(JiraServerRequestParser, "get_response")
+    def test_returns_parser_get_response_jiraserver(self, mock_parser_get_response):
+        result = HttpResponse(status=204)
+        mock_parser_get_response.return_value = result
+        response = self.middleware(
+            self.factory.post("/extensions/jira_server/issue-updated/abc-123/")
+        )
+        assert result == response
+
+        # jira-server is the inflection used in URLS and should match
+        response = self.middleware(
+            self.factory.post("/extensions/jira-server/issue-updated/abc-123/")
+        )
+        assert result == response
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @patch.object(JiraRequestParser, "get_response")
+    def test_returns_parser_get_response_jira(self, mock_parser_get_response):
+        result = HttpResponse(status=204)
+        mock_parser_get_response.return_value = result
+        response = self.middleware(self.factory.post("/extensions/jira/issue-updated/abc-123/"))
+        assert result == response
+
+        # provider pattern should capture - and forward to jira server.
+        response = self.middleware(
+            self.factory.post("/extensions/jira-server/issue-updated/abc-123/")
+        )
+        assert result != response
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @patch.object(PluginRequestParser, "get_response")


### PR DESCRIPTION
We have been capturing `jira-server` and forwarding it to the jira integration which isn't correct. Instead `jira-server` should be captured and transformed to `jira_server` so that it matches the provider name in the classifications lookup. Without this, on-prem integrations like github-enterprise, jira-server and bitbucket-server won't be forwarded correctly.

Fixes HC-TEST-CONTROL-E9