### PR TITLE
feat(stacktrace): Add platform icons to native stack traces

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/index.tsx
@@ -64,6 +64,7 @@ export function StackTraceContent({
           groupingCurrentLevel={groupingCurrentLevel}
           meta={meta}
           inlined={inlined}
+          hideIcon={inlined}
           maxDepth={maxDepth}
         />
       </ErrorBoundary>

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
@@ -1,9 +1,9 @@
 import {cloneElement, Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
+import StacktracePlatformIcon from 'sentry/components/events/interfaces/crashContent/stackTrace/platformIcon';
 import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {Frame, Group, PlatformKey} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {StacktraceType} from 'sentry/types/stacktrace';
@@ -16,6 +16,7 @@ import {
   getLastFrameIndex,
   isRepeatedFrame,
   parseAddress,
+  stackTracePlatformIcon,
 } from '../../utils';
 
 type Props = {
@@ -25,6 +26,7 @@ type Props = {
   expandFirstFrame?: boolean;
   groupingCurrentLevel?: Group['metadata']['current_level'];
   hiddenFrameCount?: number;
+  hideIcon?: boolean;
   includeSystemFrames?: boolean;
   inlined?: boolean;
   isHoverPreviewed?: boolean;
@@ -36,12 +38,14 @@ type Props = {
 };
 
 export function NativeContent({
+  className,
   data,
   platform,
   event,
   newestFirst,
   isHoverPreviewed,
   inlined,
+  hideIcon,
   groupingCurrentLevel,
   includeSystemFrames = true,
   expandFirstFrame = true,
@@ -248,9 +252,9 @@ export function NativeContent({
     })
     .filter(frame => !!frame) as React.ReactElement[];
 
-  const className = `traceback ${
+  const wrapperClassName = `traceback ${
     includeSystemFrames ? 'full-traceback' : 'in-app-traceback'
-  }`;
+  } ${className}`;
 
   if (convertedFrames.length > 0 && registers) {
     const lastFrame = convertedFrames.length - 1;
@@ -264,12 +268,14 @@ export function NativeContent({
   }
 
   return (
-    <Wrapper className={className}>
-      <Frames
-        isHoverPreviewed={isHoverPreviewed}
-        inlined={inlined}
-        data-test-id="stack-trace"
-      >
+    <Wrapper className={wrapperClassName}>
+      {hideIcon ? null : (
+        <StacktracePlatformIcon
+          platform={stackTracePlatformIcon(platform, data.frames ?? [])}
+        />
+      )}
+
+      <Frames data-test-id="stack-trace">
         {!newestFirst ? convertedFrames : [...convertedFrames].reverse()}
       </Frames>
     </Wrapper>
@@ -277,39 +283,10 @@ export function NativeContent({
 }
 
 const Wrapper = styled(Panel)`
-  && {
-    border-top-left-radius: 0;
-    position: relative;
-    border: 0;
-  }
+  position: relative;
+  border-top-left-radius: 0;
 `;
 
-export const Frames = styled('ul')<{inlined?: boolean; isHoverPreviewed?: boolean}>`
-  background: ${p => p.theme.background};
-  border-radius: ${p => p.theme.borderRadius};
-  border: 1px ${p => 'solid ' + p.theme.border};
-  box-shadow: ${p => p.theme.dropShadowMedium};
-  margin-bottom: ${space(2)};
-  position: relative;
-  display: grid;
-  overflow: hidden;
-  font-size: ${p => p.theme.fontSizeSmall};
-  line-height: 16px;
-  color: ${p => p.theme.gray500};
-  ${p =>
-    p.isHoverPreviewed &&
-    `
-      border: 0;
-      border-radius: 0;
-      box-shadow: none;
-      margin-bottom: 0;
-    `}
-
-  ${p =>
-    p.inlined &&
-    `
-      border-radius: 0;
-      border-left: 0;
-      border-right: 0;
-    `}
+export const Frames = styled('ul')`
+  list-style: none;
 `;

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.tsx
@@ -23,6 +23,7 @@ type Props = {
   data: StacktraceType;
   event: Event;
   platform: PlatformKey;
+  className?: string;
   expandFirstFrame?: boolean;
   groupingCurrentLevel?: Group['metadata']['current_level'];
   hiddenFrameCount?: number;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -486,6 +486,12 @@ const StackTraceFrame = styled('li')`
       border-bottom-left-radius: 5px;
     }
   }
+
+  &:first-child {
+    ${RowHeader} {
+      border-top-right-radius: 5px;
+    }
+  }
 `;
 
 const SymbolicatorIcon = styled('div')`

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -479,6 +479,13 @@ const StackTraceFrame = styled('li')`
       border-bottom: 1px solid ${p => p.theme.border};
     }
   }
+
+  &:last-child {
+    ${RowHeader} {
+      border-bottom-right-radius: 5px;
+      border-bottom-left-radius: 5px;
+    }
+  }
 `;
 
 const SymbolicatorIcon = styled('div')`


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/61577

In order to place the platform icon consistently in both normal and native stack traces, I needed to make some CSS changes so that both were styled similarly at the top level. Was able to delete a bunch of CSS without any visual changes (that I could find, anyway).

Before:

![CleanShot 2023-12-14 at 15 38 34](https://github.com/getsentry/sentry/assets/10888943/0b496d65-1031-41fa-bd5e-abe2564aaa80)

After:

![CleanShot 2023-12-14 at 15 38 15](https://github.com/getsentry/sentry/assets/10888943/6157ed28-286e-43bd-84ab-df3a7ef37d45)


Confirmed that the inline stack trace still looks good:

![CleanShot 2023-12-14 at 15 37 44](https://github.com/getsentry/sentry/assets/10888943/7178c611-d549-45e6-8bfc-31aea32c9633)
