### PR TITLE
fix(ui): Adjust icon sizes to match font sizes

### DIFF
--- a/static/app/components/button.stories.tsx
+++ b/static/app/components/button.stories.tsx
@@ -1,8 +1,8 @@
-import { Fragment, useState } from 'react';
+import {Fragment, useState} from 'react';
 
-import { Button, ButtonProps } from 'sentry/components/button';
-import Matrix, { PropMatrix } from 'sentry/components/stories/matrix';
-import { IconDelete } from 'sentry/icons';
+import {Button, ButtonProps} from 'sentry/components/button';
+import Matrix, {PropMatrix} from 'sentry/components/stories/matrix';
+import {IconDelete} from 'sentry/icons';
 import storyBook from 'sentry/stories/storyBook';
 
 export default storyBook('Button', story => {

--- a/static/app/components/button.stories.tsx
+++ b/static/app/components/button.stories.tsx
@@ -1,8 +1,8 @@
-import {Fragment, useState} from 'react';
+import { Fragment, useState } from 'react';
 
-import {Button, ButtonProps} from 'sentry/components/button';
-import Matrix, {PropMatrix} from 'sentry/components/stories/matrix';
-import {IconDelete} from 'sentry/icons';
+import { Button, ButtonProps } from 'sentry/components/button';
+import Matrix, { PropMatrix } from 'sentry/components/stories/matrix';
+import { IconDelete } from 'sentry/icons';
 import storyBook from 'sentry/stories/storyBook';
 
 export default storyBook('Button', story => {
@@ -21,13 +21,13 @@ export default storyBook('Button', story => {
   const propMatrix: PropMatrix<ButtonProps> = {
     borderless: [false, true],
     busy: [false, true],
-    children: ['Save', undefined],
+    children: ['Delete', undefined],
     icon: [undefined, <IconDelete key="" />],
     priority: ['default', 'primary', 'danger', 'link', undefined],
     size: ['md', 'sm', 'xs', 'zero'],
     disabled: [false, true],
     external: [false, true],
-    title: [undefined, 'Save Now'],
+    title: [undefined, 'Delete this'],
     translucentBorder: [false, true],
   };
   story('Props', () => (

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -202,7 +202,7 @@ const ICON_SIZES: Partial<
   Record<NonNullable<BaseButtonProps['size']>, SVGIconProps['size']>
 > = {
   xs: 'xs',
-  sm: 'xs',
+  sm: 'sm',
   md: 'sm',
 };
 

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -651,8 +651,8 @@ const generatePrismVariables = (
 
 const iconSizes = {
   xs: '12px',
-  sm: '16px',
-  md: '20px',
+  sm: '14px',
+  md: '18px',
   lg: '24px',
   xl: '32px',
   xxl: '72px',


### PR DESCRIPTION
See `/stories/?name=app/components/button.stories.tsx` for differences

| Before | After |
| --- | --- |
| <img width="174" alt="before" src="https://github.com/getsentry/sentry/assets/187460/a80b2328-b013-4644-851d-afa51983b0f8"> | <img width="169" alt="SCR-20240112-iogh" src="https://github.com/getsentry/sentry/assets/187460/e3541506-cd13-40f6-acce-db890bc10a21">

