### PR TITLE
feat(relocation): Enable globally for superusers

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1798,7 +1798,7 @@ register(
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Relocation
+# Relocation: whether or not the self-serve API for the feature is enabled.
 register(
     "relocation.enabled",
     default=False,
@@ -1806,21 +1806,23 @@ register(
     # FLAG_AUTOMATOR_MODIFIABLE`, to enforce it only being toggled from code.
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "relocation.self-serve",
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
+
+# Relocation: globally limits the number of small (<=10MB) relocations allowed per silo per day.
 register(
     "relocation.daily-limit.small",
     default=0,
     flags=FLAG_ADMIN_MODIFIABLE | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Relocation: globally limits the number of medium (>10MB && <=100MB) relocations allowed per silo
+# per day.
 register(
     "relocation.daily-limit.medium",
     default=0,
     flags=FLAG_ADMIN_MODIFIABLE | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Relocation: globally limits the number of large (>100MB) relocations allowed per silo per day.
 register(
     "relocation.daily-limit.large",
     default=0,

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -7,10 +7,12 @@ from uuid import UUID
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
+from rest_framework import status
 
 from sentry.api.endpoints.relocations import ERR_FEATURE_DISABLED
 from sentry.api.endpoints.relocations.index import (
     ERR_INVALID_ORG_SLUG,
+    ERR_INVALID_OWNER,
     ERR_OWNER_NOT_FOUND,
     ERR_UNKNOWN_RELOCATION_STATUS,
 )
@@ -105,14 +107,14 @@ class GetRelocationsTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(f"{self.path}")
 
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 4
 
     def test_good_status_in_progress(self):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(f"{self.path}?status={Relocation.Status.IN_PROGRESS.name}")
 
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
         assert response.data[0]["status"] == Relocation.Status.IN_PROGRESS.name
 
@@ -120,7 +122,7 @@ class GetRelocationsTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(f"{self.path}?status={Relocation.Status.PAUSE.name}")
 
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
         assert response.data[0]["status"] == Relocation.Status.PAUSE.name
 
@@ -128,7 +130,7 @@ class GetRelocationsTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(f"{self.path}?status={Relocation.Status.SUCCESS.name}")
 
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
         assert response.data[0]["status"] == Relocation.Status.SUCCESS.name
 
@@ -136,7 +138,7 @@ class GetRelocationsTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(f"{self.path}?status={Relocation.Status.FAILURE.name}")
 
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
         assert response.data[0]["status"] == Relocation.Status.FAILURE.name
 
@@ -144,7 +146,7 @@ class GetRelocationsTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(f"{self.path}?query=ccef828a")
 
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
         assert response.data[0]["status"] == Relocation.Status.IN_PROGRESS.name
 
@@ -154,7 +156,7 @@ class GetRelocationsTest(APITestCase):
             f"{self.path}?query=af3d45ee%2Dce76%2D4de0%2D90c1%2Dfc739da29523"
         )
 
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
         assert response.data[0]["status"] == Relocation.Status.PAUSE.name
 
@@ -162,7 +164,7 @@ class GetRelocationsTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(f"{self.path}?query=foo")
 
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 2
         assert response.data[0]["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data[1]["status"] == Relocation.Status.SUCCESS.name
@@ -171,7 +173,7 @@ class GetRelocationsTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(f"{self.path}?query=alice")
 
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 2
         assert response.data[0]["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data[1]["status"] == Relocation.Status.FAILURE.name
@@ -180,7 +182,7 @@ class GetRelocationsTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(f"{self.path}?query=b")
 
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 3
         assert response.data[0]["status"] == Relocation.Status.IN_PROGRESS.name
         assert response.data[1]["status"] == Relocation.Status.PAUSE.name
@@ -190,7 +192,7 @@ class GetRelocationsTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(f"{self.path}?query=foo%20alice")
 
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
         assert response.data[0]["status"] == Relocation.Status.IN_PROGRESS.name
 
@@ -198,7 +200,7 @@ class GetRelocationsTest(APITestCase):
         self.login_as(user=self.superuser, superuser=True)
         response = self.client.get(f"{self.path}?status=nonexistent")
 
-        assert response.status_code == 400
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_UNKNOWN_RELOCATION_STATUS.substitute(
             status="nonexistent"
@@ -207,11 +209,23 @@ class GetRelocationsTest(APITestCase):
     def test_bad_no_auth(self):
         response = self.client.get(f"{self.path}")
 
-        assert response.status_code == 401
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_bad_regular_user(self):
+        self.login_as(user=self.owner, superuser=False)
+        response = self.client.get(f"{self.path}")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_bad_no_superuser(self):
+        self.login_as(user=self.superuser, superuser=False)
+        response = self.client.get(f"{self.path}")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @region_silo_test
-class PostRelocationTest(APITestCase):
+class PostRelocationsTest(APITestCase):
     endpoint = "sentry-api-0-relocations-index"
 
     def setUp(self):
@@ -237,7 +251,7 @@ class PostRelocationTest(APITestCase):
 
     @patch("sentry.tasks.relocation.uploading_complete.delay")
     def test_success_simple(self, uploading_complete_mock):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.owner, superuser=False)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
 
@@ -267,11 +281,76 @@ class PostRelocationTest(APITestCase):
                         format="multipart",
                     )
 
-        assert response.status_code == 201
+        assert response.status_code == status.HTTP_201_CREATED
         assert Relocation.objects.count() == relocation_count + 1
         assert RelocationFile.objects.count() == relocation_file_count + 1
         assert Relocation.objects.get(owner_id=self.owner.id).want_org_slugs == ["testing"]
         assert uploading_complete_mock.call_count == 1
+
+    @patch("sentry.tasks.relocation.uploading_complete.delay")
+    def test_success_with_superuser_when_feature_disabled(self, uploading_complete_mock):
+        self.login_as(user=self.superuser, superuser=True)
+        relocation_count = Relocation.objects.count()
+        relocation_file_count = RelocationFile.objects.count()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with self.options(
+                {
+                    "relocation.enabled": False,
+                    "relocation.daily-limit.small": 1,
+                }
+            ), open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    response = self.client.post(
+                        reverse(self.endpoint),
+                        {
+                            "owner": self.owner.username,
+                            "file": SimpleUploadedFile(
+                                "export.tar",
+                                create_encrypted_export_tarball(
+                                    data, LocalFileEncryptor(p)
+                                ).getvalue(),
+                                content_type="application/tar",
+                            ),
+                            "orgs": "testing",
+                        },
+                        format="multipart",
+                    )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert Relocation.objects.count() == relocation_count + 1
+        assert RelocationFile.objects.count() == relocation_file_count + 1
+        assert Relocation.objects.get(owner_id=self.owner.id).want_org_slugs == ["testing"]
+        assert uploading_complete_mock.call_count == 1
+
+    def test_fail_without_superuser_when_feature_disabled(self):
+        self.login_as(user=self.owner, superuser=False)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    response = self.client.post(
+                        reverse(self.endpoint),
+                        {
+                            "owner": self.owner.username,
+                            "file": SimpleUploadedFile(
+                                "export.tar",
+                                create_encrypted_export_tarball(
+                                    data, LocalFileEncryptor(p)
+                                ).getvalue(),
+                                content_type="application/tar",
+                            ),
+                            "orgs": "testing, foo",
+                        },
+                        format="multipart",
+                    )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.data.get("detail") is not None
+        assert response.data.get("detail") == ERR_FEATURE_DISABLED
 
     # pytest parametrize does not work in TestCase subclasses, so hack around this
     for org_slugs, expected in [
@@ -285,7 +364,7 @@ class PostRelocationTest(APITestCase):
         def test_success_good_org_slugs(
             self, uploading_complete_mock, org_slugs=org_slugs, expected=expected
         ):
-            self.login_as(user=self.superuser, superuser=True)
+            self.login_as(user=self.owner, superuser=False)
             relocation_count = Relocation.objects.count()
             relocation_file_count = RelocationFile.objects.count()
 
@@ -312,7 +391,7 @@ class PostRelocationTest(APITestCase):
                             format="multipart",
                         )
 
-            assert response.status_code == 201
+            assert response.status_code == status.HTTP_201_CREATED
             assert Relocation.objects.count() == relocation_count + 1
             assert RelocationFile.objects.count() == relocation_file_count + 1
             assert Relocation.objects.get(owner_id=self.owner.id).want_org_slugs == expected
@@ -329,7 +408,7 @@ class PostRelocationTest(APITestCase):
         def test_fail_bad_org_slugs(
             self, uploading_complete_mock, org_slugs=org_slugs, invalid_org_slug=invalid_org_slug
         ):
-            self.login_as(user=self.superuser, superuser=True)
+            self.login_as(user=self.owner, superuser=False)
             relocation_count = Relocation.objects.count()
             relocation_file_count = RelocationFile.objects.count()
 
@@ -356,7 +435,7 @@ class PostRelocationTest(APITestCase):
                             format="multipart",
                         )
 
-            assert response.status_code == 400
+            assert response.status_code == status.HTTP_400_BAD_REQUEST
             assert response.data.get("detail") is not None
             assert response.data.get("detail") == ERR_INVALID_ORG_SLUG.substitute(
                 org_slug=invalid_org_slug
@@ -365,7 +444,7 @@ class PostRelocationTest(APITestCase):
             assert RelocationFile.objects.count() == relocation_file_count
 
     def test_success_relocation_for_same_owner_already_completed(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.owner, superuser=False)
         Relocation.objects.create(
             creator_id=self.superuser.id,
             owner_id=self.owner.id,
@@ -409,39 +488,12 @@ class PostRelocationTest(APITestCase):
                         format="multipart",
                     )
 
-        assert response.status_code == 201
+        assert response.status_code == status.HTTP_201_CREATED
         assert Relocation.objects.count() == relocation_count + 1
         assert RelocationFile.objects.count() == relocation_file_count + 1
 
-    def test_fail_feature_disabled(self):
-        self.login_as(user=self.superuser, superuser=True)
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
-            with open(FRESH_INSTALL_PATH) as f:
-                data = json.load(f)
-                with open(tmp_pub_key_path, "rb") as p:
-                    response = self.client.post(
-                        reverse(self.endpoint),
-                        {
-                            "owner": self.owner.username,
-                            "file": SimpleUploadedFile(
-                                "export.tar",
-                                create_encrypted_export_tarball(
-                                    data, LocalFileEncryptor(p)
-                                ).getvalue(),
-                                content_type="application/tar",
-                            ),
-                            "orgs": "testing, foo",
-                        },
-                        format="multipart",
-                    )
-
-        assert response.status_code == 400
-        assert response.data.get("detail") is not None
-        assert response.data.get("detail") == ERR_FEATURE_DISABLED
-
     def test_fail_missing_file(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.owner, superuser=False)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
             with self.options(
@@ -459,12 +511,12 @@ class PostRelocationTest(APITestCase):
                     format="multipart",
                 )
 
-        assert response.status_code == 400
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data.get("file") is not None
         assert response.data.get("file")[0].code == "required"
 
     def test_fail_missing_orgs(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.owner, superuser=False)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
             with self.options(
@@ -490,12 +542,12 @@ class PostRelocationTest(APITestCase):
                         format="multipart",
                     )
 
-        assert response.status_code == 400
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data.get("orgs") is not None
         assert response.data.get("orgs")[0].code == "required"
 
     def test_fail_missing_owner(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.owner, superuser=False)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
             with self.options(
@@ -521,7 +573,7 @@ class PostRelocationTest(APITestCase):
                         format="multipart",
                     )
 
-        assert response.status_code == 400
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data.get("owner") is not None
         assert response.data.get("owner")[0].code == "required"
 
@@ -553,14 +605,46 @@ class PostRelocationTest(APITestCase):
                         format="multipart",
                     )
 
-        assert response.status_code == 400
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_OWNER_NOT_FOUND.substitute(
             owner_username="doesnotexist"
         )
 
+    def test_fail_owner_not_self(self):
+        self.login_as(user=self.owner, superuser=False)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with self.options(
+                {
+                    "relocation.enabled": True,
+                    "relocation.daily-limit.small": 1,
+                }
+            ), open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    response = self.client.post(
+                        reverse(self.endpoint),
+                        {
+                            "owner": "other",
+                            "file": SimpleUploadedFile(
+                                "export.tar",
+                                create_encrypted_export_tarball(
+                                    data, LocalFileEncryptor(p)
+                                ).getvalue(),
+                                content_type="application/tar",
+                            ),
+                            "orgs": "testing, foo",
+                        },
+                        format="multipart",
+                    )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data.get("detail") is not None
+        assert response.data.get("detail") == ERR_INVALID_OWNER.substitute(creator_username="owner")
+
     def test_fail_relocation_for_same_owner_already_in_progress(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.owner, superuser=False)
         Relocation.objects.create(
             creator_id=self.superuser.id,
             owner_id=self.owner.id,
@@ -594,9 +678,73 @@ class PostRelocationTest(APITestCase):
                         format="multipart",
                     )
 
-        assert response.status_code == 409
+        assert response.status_code == status.HTTP_409_CONFLICT
 
     def test_fail_throttle_if_daily_limit_reached(self):
+        self.login_as(user=self.owner, superuser=False)
+        relocation_count = Relocation.objects.count()
+        relocation_file_count = RelocationFile.objects.count()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
+            with self.options(
+                {
+                    "relocation.enabled": True,
+                    "relocation.daily-limit.small": 1,
+                }
+            ), open(FRESH_INSTALL_PATH) as f:
+                data = json.load(f)
+                with open(tmp_pub_key_path, "rb") as p:
+                    initial_response = self.client.post(
+                        reverse(self.endpoint),
+                        {
+                            "owner": self.owner.username,
+                            "file": SimpleUploadedFile(
+                                "export.tar",
+                                create_encrypted_export_tarball(
+                                    data, LocalFileEncryptor(p)
+                                ).getvalue(),
+                                content_type="application/tar",
+                            ),
+                            "orgs": "testing, foo",
+                        },
+                        format="multipart",
+                    )
+
+                    # Simulate completion of relocation job
+                    relocation = Relocation.objects.all()[0]
+                    relocation.status = Relocation.Status.SUCCESS.value
+                    relocation.save()
+                    relocation.refresh_from_db()
+
+                with open(tmp_pub_key_path, "rb") as p:
+                    throttled_response = self.client.post(
+                        reverse(self.endpoint),
+                        {
+                            "owner": self.owner.username,
+                            "file": SimpleUploadedFile(
+                                "export.tar",
+                                create_encrypted_export_tarball(
+                                    data, LocalFileEncryptor(p)
+                                ).getvalue(),
+                                content_type="application/tar",
+                            ),
+                            "orgs": "testing, foo",
+                        },
+                        format="multipart",
+                    )
+
+        assert initial_response.status_code == status.HTTP_201_CREATED
+        assert throttled_response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert throttled_response.data.get("detail") is not None
+        assert (
+            throttled_response.data.get("detail")
+            == "We've reached our daily limit of relocations - please try again tomorrow or contact support."
+        )
+        assert Relocation.objects.count() == relocation_count + 1
+        assert RelocationFile.objects.count() == relocation_file_count + 1
+
+    def test_success_no_throttle_for_superuser(self):
         self.login_as(user=self.superuser, superuser=True)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
@@ -650,18 +798,13 @@ class PostRelocationTest(APITestCase):
                         format="multipart",
                     )
 
-        assert initial_response.status_code == 201
-        assert throttled_response.status_code == 429
-        assert throttled_response.data.get("detail") is not None
-        assert (
-            throttled_response.data.get("detail")
-            == "We've reached our daily limit of relocations - please try again tomorrow or contact support."
-        )
-        assert Relocation.objects.count() == relocation_count + 1
-        assert RelocationFile.objects.count() == relocation_file_count + 1
+        assert initial_response.status_code == status.HTTP_201_CREATED
+        assert throttled_response.status_code == status.HTTP_201_CREATED
+        assert Relocation.objects.count() == relocation_count + 2
+        assert RelocationFile.objects.count() == relocation_file_count + 2
 
     def test_success_no_throttle_different_bucket_relocations(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.owner, superuser=False)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
 
@@ -699,7 +842,7 @@ class PostRelocationTest(APITestCase):
                     relocation.refresh_from_db()
 
                 with open(tmp_pub_key_path, "rb") as p:
-                    throttled_response = self.client.post(
+                    unthrottled_response = self.client.post(
                         reverse(self.endpoint),
                         {
                             "owner": self.owner.username,
@@ -716,13 +859,13 @@ class PostRelocationTest(APITestCase):
                         format="multipart",
                     )
 
-        assert initial_response.status_code == 201
-        assert throttled_response.status_code == 201
+        assert initial_response.status_code == status.HTTP_201_CREATED
+        assert unthrottled_response.status_code == status.HTTP_201_CREATED
         assert Relocation.objects.count() == relocation_count + 2
         assert RelocationFile.objects.count() == relocation_file_count + 2
 
     def test_success_no_throttle_relocation_over_multiple_days(self):
-        self.login_as(user=self.superuser, superuser=True)
+        self.login_as(user=self.owner, superuser=False)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
 
@@ -761,9 +904,9 @@ class PostRelocationTest(APITestCase):
                 frozen_time.shift(timedelta(days=1, minutes=1))
 
                 # Re-login since session has expired
-                self.login_as(user=self.superuser, superuser=True)
+                self.login_as(user=self.owner, superuser=False)
                 with open(tmp_pub_key_path, "rb") as p:
-                    throttled_response = self.client.post(
+                    unthrottled_response = self.client.post(
                         reverse(self.endpoint),
                         {
                             "owner": self.owner.username,
@@ -779,12 +922,11 @@ class PostRelocationTest(APITestCase):
                         format="multipart",
                     )
 
-        assert initial_response.status_code == 201
-        assert throttled_response.status_code == 201
+        assert initial_response.status_code == status.HTTP_201_CREATED
+        assert unthrottled_response.status_code == status.HTTP_201_CREATED
         assert Relocation.objects.count() == relocation_count + 2
         assert RelocationFile.objects.count() == relocation_file_count + 2
 
-    # TODO(getsentry/team-ospo#214): Add test for non-superusers to be able to create relocations.
     def test_bad_no_auth(self):
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
@@ -812,6 +954,6 @@ class PostRelocationTest(APITestCase):
                         format="multipart",
                     )
 
-        assert response.status_code == 401
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert Relocation.objects.count() == relocation_count
         assert RelocationFile.objects.count() == relocation_file_count


### PR DESCRIPTION
Superusers (aka admins) will now be able to hit the relocation endpoint successfully in all deployments. The `relocation:enabled` flag, and the `relocation.enabled` option that controls it, will instead refer only to the self-serve endpoint, which will remain contained to the test region for now.

This means that admins can now trigger relocations in any region for any user, and are not throttled when they do so. Regular users may only trigger relocations for themselves in regions where `relocations.enabled` is set to `True`, and are subject to the global daily throttles.

Issue: getsentry/team-ospo#214