### PR TITLE
feat(issue-alerts): Add latest adopted release filter

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import itertools
 import logging
 import re
+from collections import namedtuple
 from dataclasses import dataclass
 from time import time
 from typing import ClassVar, List, Mapping, Optional, Sequence, Union
@@ -66,6 +67,12 @@ class UnsafeReleaseDeletion(Exception):
 
 
 class ReleaseCommitError(Exception):
+    pass
+
+
+class SemverVersion(
+    namedtuple("SemverVersion", "major minor patch revision prerelease_case prerelease")
+):
     pass
 
 
@@ -636,8 +643,8 @@ class Release(Model):
         return False
 
     @property
-    def semver_tuple(self):
-        return (
+    def semver_tuple(self) -> SemverVersion:
+        return SemverVersion(
             self.major,
             self.minor,
             self.patch,

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -635,6 +635,17 @@ class Release(Model):
 
         return False
 
+    @property
+    def semver_tuple(self):
+        return (
+            self.major,
+            self.minor,
+            self.patch,
+            self.revision,
+            1 if self.prerelease == "" else 0,
+            self.prerelease,
+        )
+
     @classmethod
     def get_cache_key(cls, organization_id, version):
         return f"release:3:{organization_id}:{md5_text(version).hexdigest()}"

--- a/src/sentry/rules/age.py
+++ b/src/sentry/rules/age.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import operator
+
+
+class ModelAgeType:
+    OLDEST = "oldest"
+    NEWEST = "newest"
+
+
+model_age_choices = [(ModelAgeType.OLDEST, "oldest"), (ModelAgeType.NEWEST, "newest")]
+
+
+class AgeComparisonType:
+    OLDER = "older"
+    NEWER = "newer"
+
+
+age_comparison_choices = [(AgeComparisonType.OLDER, "older"), (AgeComparisonType.NEWER, "newer")]
+age_comparison_map = {AgeComparisonType.OLDER: operator.lt, AgeComparisonType.NEWER: operator.gt}

--- a/src/sentry/rules/filters/age_comparison.py
+++ b/src/sentry/rules/filters/age_comparison.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import operator
 from datetime import datetime, timedelta
 from typing import Any, Dict, Sequence, Tuple
 
@@ -10,14 +9,9 @@ from django.utils import timezone
 from sentry.eventstore.models import GroupEvent
 from sentry.models.group import Group
 from sentry.rules import EventState
+from sentry.rules.age import AgeComparisonType, age_comparison_choices, age_comparison_map
 from sentry.rules.filters.base import EventFilter
 from sentry.types.condition_activity import ConditionActivity
-
-
-class AgeComparisonType:
-    OLDER = "older"
-    NEWER = "newer"
-
 
 timeranges = {
     "minute": ("minute(s)", timedelta(minutes=1)),
@@ -25,10 +19,6 @@ timeranges = {
     "day": ("day(s)", timedelta(days=1)),
     "week": ("week(s)", timedelta(days=7)),
 }
-
-age_comparison_choices = [(AgeComparisonType.OLDER, "older"), (AgeComparisonType.NEWER, "newer")]
-
-age_comparison_map = {AgeComparisonType.OLDER: operator.lt, AgeComparisonType.NEWER: operator.gt}
 
 
 def get_timerange_choices() -> Sequence[Tuple[str, str]]:

--- a/src/sentry/rules/filters/latest_adopted_release_filter.py
+++ b/src/sentry/rules/filters/latest_adopted_release_filter.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from typing import Any
+
+from django import forms
+from django.db.models.signals import post_delete, post_save
+
+from sentry.eventstore.models import GroupEvent
+from sentry.models.environment import Environment
+from sentry.models.grouprelease import GroupRelease
+from sentry.models.release import Release, follows_semver_versioning_scheme
+from sentry.models.releaseenvironment import ReleaseEnvironment
+from sentry.rules import EventState
+from sentry.rules.age import (
+    AgeComparisonType,
+    ModelAgeType,
+    age_comparison_choices,
+    model_age_choices,
+)
+from sentry.rules.filters.base import EventFilter
+from sentry.search.utils import (
+    LatestReleaseOrders,
+    get_latest_release,
+    get_terminal_release_for_group,
+)
+from sentry.utils.cache import cache
+
+
+class LatestAdoptedReleaseForm(forms.Form):
+    release_age_type = forms.ChoiceField(choices=list(model_age_choices))
+    age_comparison = forms.ChoiceField(choices=list(age_comparison_choices))
+    environment_id = forms.CharField(required=False)
+
+    def __init__(self, project, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.project = project
+
+    def clean_environment_id(self):
+        environment_id = self.cleaned_data.get("environment_id")
+        if environment_id == "None":
+            environment_id = None
+        if environment_id:
+            try:
+                environment_id = int(environment_id)
+            except ValueError:
+                raise forms.ValidationError("environmentId must be an integer")
+            if not Environment.objects.filter(
+                environment_id=environment_id, organization_id=self.project.organization_id
+            ).exists():
+                raise forms.ValidationError(
+                    "environmentId does not exist or is not associated with this organization"
+                )
+        return environment_id
+
+
+class LatestAdoptedReleaseFilter(EventFilter):
+    id = "sentry.rules.filters.latest_adopted_release_filter.LatestAdoptedReleaseFilter"
+    form_cls = LatestAdoptedReleaseForm
+    label = "The {release_age_type} release associated with the event's issue is {age_comparison} than the latest release in the {environmentId} environment"
+
+    form_fields = {
+        "release_age_type": {"type": "choice", "choices": list(model_age_choices)},
+        "age_comparison": {"type": "choice", "choices": list(age_comparison_choices)},
+        "environment_id": {"type": "string", "placeholder": "value"},
+    }
+
+    def get_latest_release_for_env(self, event: GroupEvent, environment_id: int) -> Release | None:
+        cache_key = get_project_release_cache_key(event.project_id, environment_id)
+        latest_release = cache.get(cache_key)
+        if latest_release is None:
+            organization_id = event.organization.id
+            environments = [Environment.objects.get(id=environment_id)]
+            try:
+                latest_release_versions = get_latest_release(
+                    [event.project],
+                    environments,
+                    organization_id,
+                    adopted=True,
+                )
+            except Release.DoesNotExist:
+                return None
+            latest_release = Release.objects.get(
+                version=latest_release_versions[0], organization_id=organization_id
+            )
+
+            if latest_release:
+                cache.set(cache_key, latest_release, 600)
+            else:
+                cache.set(cache_key, False, 600)
+        return latest_release
+
+    def get_terminal_release_for_env(
+        self, event: GroupEvent, release_age_type: str, order_type: LatestReleaseOrders
+    ) -> Release | None:
+        group = event.group
+        cache_key = get_terminal_release_for_group_cache_key(group.id, release_age_type)
+        release = cache.get(cache_key)
+        if release is None:
+
+            try:
+                release = get_terminal_release_for_group(
+                    group, order_type, release_age_type == ModelAgeType.NEWEST
+                )
+            except Release.DoesNotExist:
+                release = None
+
+            if release:
+                cache.set(cache_key, release, 600)
+            else:
+                cache.set(cache_key, False, 600)
+
+        return release
+
+    def passes(self, event: GroupEvent, state: EventState) -> bool:
+        release_age_type = self.get_option("release_age_type")
+        age_comparison = self.get_option("age_comparison")
+        environment_id = self.get_option("environment_id")
+
+        if follows_semver_versioning_scheme(event.organization.id, event.project_id):
+            order_type = LatestReleaseOrders.SEMVER
+        else:
+            order_type = LatestReleaseOrders.DATE
+
+        latest_project_release = self.get_latest_release_for_env(event, int(environment_id))
+        if not latest_project_release:
+            return False
+
+        release = self.get_terminal_release_for_env(event, release_age_type, order_type)
+        if not release:
+            return False
+
+        if age_comparison == AgeComparisonType.NEWER:
+            return is_newer_release(release, latest_project_release, order_type)
+        elif age_comparison == AgeComparisonType.OLDER:
+            return is_newer_release(latest_project_release, release, order_type)
+
+        return False
+
+    def get_form_instance(self) -> forms.Form:
+        form: forms.Form = self.form_cls(self.project, self.data)
+        return form
+
+
+def is_newer_release(
+    release: Release, comparison_release: Release, order_type: LatestReleaseOrders
+):
+    if order_type == LatestReleaseOrders.SEMVER:
+        if not release.is_semver_release or not comparison_release.is_semver_release:
+            # Error?
+            pass
+        return release.semver_tuple > comparison_release.semver_tuple
+    else:
+        release_date = release.date_released if release.date_released else release.date_added
+        comparison_date = (
+            comparison_release.date_released
+            if comparison_release.date_released
+            else comparison_release.date_added
+        )
+        return release_date > comparison_date
+
+
+def get_terminal_release_for_group_cache_key(group_id: int, release_age_type: str) -> str:
+    return f"group:{group_id}:age_type:{release_age_type}:terminal_release"
+
+
+def clear_get_terminal_release_for_group_cache(instance: GroupRelease, **kwargs: Any) -> None:
+    cache.delete_many(
+        [
+            get_terminal_release_for_group_cache_key(instance.group_id, release_age_type)
+            for release_age_type in [ModelAgeType.NEWEST, ModelAgeType.OLDEST]
+        ]
+    )
+
+
+def get_project_release_cache_key(project_id: int, environment_id: int) -> str:
+    return f"project:{project_id}:env:{environment_id}:latest_release_adopted"
+
+
+def clear_release_environment_project_cache(instance: ReleaseEnvironment, **kwargs: Any) -> None:
+    try:
+        release_project_ids = instance.release.projects.values_list("id", flat=True)
+    except Release.DoesNotExist:
+        # This can happen during deletions as release projects are removed before the release is.
+        return
+
+    cache.delete_many(
+        [
+            get_project_release_cache_key(proj_id, instance.environment_id)
+            for proj_id in release_project_ids
+        ]
+    )
+
+
+post_save.connect(clear_get_terminal_release_for_group_cache, sender=GroupRelease, weak=False)
+post_delete.connect(clear_get_terminal_release_for_group_cache, sender=GroupRelease, weak=False)
+
+post_save.connect(clear_release_environment_project_cache, sender=ReleaseEnvironment, weak=False)
+post_delete.connect(clear_release_environment_project_cache, sender=ReleaseEnvironment, weak=False)

--- a/src/sentry/rules/match.py
+++ b/src/sentry/rules/match.py
@@ -3,8 +3,10 @@ class MatchType:
     ENDS_WITH = "ew"
     EQUAL = "eq"
     GREATER_OR_EQUAL = "gte"
+    GREATER = "gt"
     IS_SET = "is"
     LESS_OR_EQUAL = "lte"
+    LESS = "lt"
     NOT_CONTAINS = "nc"
     NOT_ENDS_WITH = "new"
     NOT_EQUAL = "ne"
@@ -17,6 +19,12 @@ LEVEL_MATCH_CHOICES = {
     MatchType.EQUAL: "equal to",
     MatchType.GREATER_OR_EQUAL: "greater than or equal to",
     MatchType.LESS_OR_EQUAL: "less than or equal to",
+}
+
+RELEASE_MATCH_CHOICES = {
+    MatchType.EQUAL: "equal to",
+    MatchType.GREATER: "greater than",
+    MatchType.LESS: "less than",
 }
 
 MATCH_CHOICES = {

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -480,7 +480,7 @@ def get_first_last_release_for_group(
     group: Group,
     query_type: LatestReleaseOrders,
     last: bool,
-) -> Sequence[str]:
+) -> Release:
     """
     Fetches the first or last release associated with a group. `query_type` determines whether we use semver or date
     ordering to order the releases.

--- a/tests/sentry/rules/filters/test_latest_adopted_release.py
+++ b/tests/sentry/rules/filters/test_latest_adopted_release.py
@@ -35,9 +35,13 @@ class LatestAdoptedReleaseFilterTest(RuleTestCase):
             environments=[prod],
             adopted=now,
         )
+        # Test no release
+        data = {"release_age_type": "oldest", "age_comparison": "newer", "environment_id": prod.id}
+        rule = self.get_rule(data=data)
+        self.assertDoesNotPass(rule, event)
+
         self.create_group_release(group=self.event.group, release=newest_release)
 
-        data = {"release_age_type": "oldest", "age_comparison": "newer", "environment_id": prod.id}
         rule = self.get_rule(data=data)
         self.assertPasses(rule, event)
 

--- a/tests/sentry/rules/filters/test_latest_adopted_release.py
+++ b/tests/sentry/rules/filters/test_latest_adopted_release.py
@@ -1,0 +1,121 @@
+from datetime import datetime, timedelta
+
+from sentry.rules.filters.latest_adopted_release_filter import LatestAdoptedReleaseFilter
+from sentry.testutils.cases import RuleTestCase
+
+
+class LatestAdoptedReleaseFilterTest(RuleTestCase):
+    rule_cls = LatestAdoptedReleaseFilter
+
+    def test_semver(self):
+        event = self.get_event()
+        now = datetime.now()
+        prod = self.create_environment(name="prod")
+        test = self.create_environment(name="test")
+        newest_release = self.create_release(
+            project=event.group.project,
+            version="test@2.0",
+            date_added=now - timedelta(days=2),
+            environments=[test],
+            adopted=now - timedelta(days=2),
+        )
+
+        oldest_release = self.create_release(
+            project=event.group.project,
+            version="test@1.0",
+            date_added=now - timedelta(days=1),
+            environments=[prod],
+            adopted=now - timedelta(days=1),
+        )
+
+        middle_release = self.create_release(
+            project=event.group.project,
+            version="test@1.5",
+            date_added=now,
+            environments=[prod],
+            adopted=now,
+        )
+        self.create_group_release(group=self.event.group, release=newest_release)
+
+        data = {"release_age_type": "oldest", "age_comparison": "newer", "environment_id": prod.id}
+        rule = self.get_rule(data=data)
+        self.assertPasses(rule, event)
+
+        event_2 = self.store_event(data={"fingerprint": ["group2"]}, project_id=self.project.id)
+        group_2 = event_2.group
+
+        self.create_group_release(group=group_2, release=newest_release)
+        self.create_group_release(group=group_2, release=oldest_release)
+        self.assertDoesNotPass(rule, event_2)
+
+        event_3 = self.store_event(data={"fingerprint": ["group3"]}, project_id=self.project.id)
+        group_3 = event_3.group
+
+        self.create_group_release(group=group_3, release=middle_release)
+        self.assertDoesNotPass(rule, event_3)
+
+        # Check that the group cache invalidation works by adding an older release to the first group
+        self.create_group_release(group=self.event.group, release=oldest_release)
+        self.assertDoesNotPass(rule, event)
+
+        # Check that the project cache invalidation works by adding a newer release to the project
+        event_4 = self.store_event(data={"fingerprint": ["group4"]}, project_id=self.project.id)
+        group_4 = event_4.group
+        self.create_group_release(group=group_4, release=newest_release)
+        self.assertPasses(rule, event_4)
+
+        self.create_release(
+            project=event.group.project,
+            version="test@3.0",
+            date_added=now - timedelta(days=5),
+            environments=[prod],
+            adopted=now - timedelta(days=2),
+        )
+        self.assertDoesNotPass(rule, event_4)
+
+    def test_date(self):
+        event = self.get_event()
+        now = datetime.now()
+        prod = self.create_environment(name="prod")
+        test = self.create_environment(name="test")
+        oldest_release = self.create_release(
+            project=event.group.project,
+            version="1",
+            date_added=now - timedelta(days=2),
+            environments=[prod],
+            adopted=now - timedelta(days=2),
+        )
+
+        middle_release = self.create_release(
+            project=event.group.project,
+            version="2",
+            date_added=now - timedelta(days=1),
+            environments=[prod],
+            adopted=now - timedelta(days=1),
+        )
+
+        newest_release = self.create_release(
+            project=event.group.project,
+            version="3",
+            date_added=now,
+            environments=[test],
+            adopted=now,
+        )
+        self.create_group_release(group=self.event.group, release=newest_release)
+
+        data = {"release_age_type": "oldest", "age_comparison": "newer", "environment_id": prod.id}
+        rule = self.get_rule(data=data)
+        self.assertPasses(rule, event)
+
+        event_2 = self.store_event(data={"fingerprint": ["group2"]}, project_id=self.project.id)
+        group_2 = event_2.group
+
+        self.create_group_release(group=group_2, release=newest_release)
+        self.create_group_release(group=group_2, release=oldest_release)
+        self.assertDoesNotPass(rule, event_2)
+
+        event_3 = self.store_event(data={"fingerprint": ["group3"]}, project_id=self.project.id)
+        group_3 = event_3.group
+
+        self.create_group_release(group=group_3, release=middle_release)
+        self.assertDoesNotPass(rule, event_3)


### PR DESCRIPTION
This adds a new filter to issue alerts. It's rather similar to the latest release filter, but there are a couple of differences:
 - It allows us to filter to the latest release from a specific environment. The release must also be `adopted` but not `unadopted`.
 - The comparison release isn't the release from the event, but instead, the oldest release associated with the event's group
 - Instead of matching to an exact release, we can specify that the group release can be older/newer than the environment release

Also worth noting is the definition of newest/oldest here will be semver if the project uses semver, otherwise, we'll use our standard date comparison.

This doesn't add the filter actually to be displayed yet, I will follow up with that separately.

