### PR TITLE
meta(endpoints): Update ingest endpoint visibility

### DIFF
--- a/src/sentry/api/endpoints/admin_project_configs.py
+++ b/src/sentry/api/endpoints/admin_project_configs.py
@@ -14,7 +14,7 @@ from sentry.relay import projectconfig_cache
 class AdminRelayProjectConfigsEndpoint(Endpoint):
     owner = ApiOwner.OWNERS_INGEST
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (SuperuserPermission,)
 

--- a/src/sentry/api/endpoints/organization_relay_usage.py
+++ b/src/sentry/api/endpoints/organization_relay_usage.py
@@ -14,7 +14,7 @@ from sentry.models.relay import RelayUsage
 class OrganizationRelayUsage(OrganizationEndpoint):
     owner = ApiOwner.OWNERS_INGEST
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (OrganizationPermission,)
 

--- a/src/sentry/api/endpoints/organization_relay_usage.py
+++ b/src/sentry/api/endpoints/organization_relay_usage.py
@@ -1,3 +1,6 @@
+from typing import List
+
+from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -7,18 +10,41 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.relay import OrganizationRelayResponse
+from sentry.apidocs.constants import RESPONSE_NOT_FOUND
+from sentry.apidocs.examples.organization_examples import OrganizationExamples
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.relay import RelayUsage
 
 
+@extend_schema(tags=["Organizations"])
 @region_silo_endpoint
 class OrganizationRelayUsage(OrganizationEndpoint):
     owner = ApiOwner.OWNERS_INGEST
     publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (OrganizationPermission,)
 
+    @extend_schema(
+        operation_id="List an Organization's trusted Relays",
+        parameters=[GlobalParams.ORG_SLUG],
+        request=None,
+        responses={
+            200: inline_sentry_response_serializer(
+                "OrganizationRelayResponse", List[OrganizationRelayResponse]
+            ),
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=OrganizationExamples.LIST_RELAYS,
+    )
     def get(self, request: Request, organization) -> Response:
+        """
+        Return a list of trusted relays bound to an organization.
+
+        If the organization doesn't have Relay usage enabled it returns a 404.
+        """
         has_relays = features.has("organizations:relay", organization, actor=request.user)
         if not has_relays:
             return Response(status=404)

--- a/src/sentry/api/endpoints/project_transaction_names.py
+++ b/src/sentry/api/endpoints/project_transaction_names.py
@@ -19,7 +19,7 @@ from sentry.ingest.transaction_clusterer.tree import TreeClusterer
 class ProjectTransactionNamesCluster(ProjectEndpoint):
     owner = ApiOwner.OWNERS_INGEST
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, project) -> Response:

--- a/src/sentry/api/endpoints/relay/details.py
+++ b/src/sentry/api/endpoints/relay/details.py
@@ -12,7 +12,7 @@ from sentry.models.relay import Relay
 @region_silo_endpoint
 class RelayDetailsEndpoint(Endpoint):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (SuperuserPermission,)
     owner = ApiOwner.OWNERS_INGEST

--- a/src/sentry/api/endpoints/relay/health_check.py
+++ b/src/sentry/api/endpoints/relay/health_check.py
@@ -9,7 +9,7 @@ from sentry.api.base import Endpoint, region_silo_endpoint
 @region_silo_endpoint
 class RelayHealthCheck(Endpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     """
     Endpoint checked by downstream Relay when a suspected network error is encountered.

--- a/src/sentry/api/endpoints/relay/index.py
+++ b/src/sentry/api/endpoints/relay/index.py
@@ -14,7 +14,7 @@ from sentry.models.relay import Relay
 @region_silo_endpoint
 class RelayIndexEndpoint(Endpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (SuperuserPermission,)
     owner = ApiOwner.OWNERS_INGEST

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -36,7 +36,7 @@ def _sample_apm():
 @region_silo_endpoint
 class RelayProjectConfigsEndpoint(Endpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.OWNERS_INGEST
     authentication_classes = (RelayAuthentication,)

--- a/src/sentry/api/endpoints/relay/project_ids.py
+++ b/src/sentry/api/endpoints/relay/project_ids.py
@@ -12,7 +12,7 @@ from sentry.models.projectkey import ProjectKey
 @region_silo_endpoint
 class RelayProjectIdsEndpoint(Endpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     authentication_classes = (RelayAuthentication,)
     permission_classes = (RelayPermission,)

--- a/src/sentry/api/endpoints/relay/public_keys.py
+++ b/src/sentry/api/endpoints/relay/public_keys.py
@@ -12,7 +12,7 @@ from sentry.models.relay import Relay
 @region_silo_endpoint
 class RelayPublicKeysEndpoint(Endpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     authentication_classes = (RelayAuthentication,)
     permission_classes = (RelayPermission,)

--- a/src/sentry/api/endpoints/relay/register_challenge.py
+++ b/src/sentry/api/endpoints/relay/register_challenge.py
@@ -24,7 +24,7 @@ class RelayRegisterChallengeSerializer(RelayIdSerializer):
 @region_silo_endpoint
 class RelayRegisterChallengeEndpoint(Endpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     authentication_classes = ()
     permission_classes = ()

--- a/src/sentry/api/endpoints/relay/register_response.py
+++ b/src/sentry/api/endpoints/relay/register_response.py
@@ -26,7 +26,7 @@ class RelayRegisterResponseSerializer(RelayIdSerializer):
 @region_silo_endpoint
 class RelayRegisterResponseEndpoint(Endpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.OWNERS_INGEST
     authentication_classes = ()

--- a/src/sentry/api/serializers/models/relay.py
+++ b/src/sentry/api/serializers/models/relay.py
@@ -1,10 +1,20 @@
+from typing_extensions import TypedDict
+
 from sentry.api.serializers import Serializer, register
 from sentry.models.relay import Relay
 
 
+class OrganizationRelayResponse(TypedDict):
+    id: str
+    relayId: str
+    publicKey: str
+    firstSeen: str
+    lastSeen: str
+
+
 @register(Relay)
 class RelaySerializer(Serializer):
-    def serialize(self, obj, attrs, user):
+    def serialize(self, obj, attrs, user) -> OrganizationRelayResponse:
         return {
             "id": str(obj.id),
             "relayId": str(obj.relay_id),

--- a/src/sentry/api/serializers/models/relay.py
+++ b/src/sentry/api/serializers/models/relay.py
@@ -5,8 +5,8 @@ from sentry.models.relay import Relay
 
 
 class OrganizationRelayResponse(TypedDict):
-    id: str
     relayId: str
+    version: str
     publicKey: str
     firstSeen: str
     lastSeen: str
@@ -16,8 +16,8 @@ class OrganizationRelayResponse(TypedDict):
 class RelaySerializer(Serializer):
     def serialize(self, obj, attrs, user) -> OrganizationRelayResponse:
         return {
-            "id": str(obj.id),
             "relayId": str(obj.relay_id),
+            "version": str(obj.version),
             "publicKey": obj.public_key,
             "firstSeen": obj.first_seen,
             "lastSeen": obj.last_seen,

--- a/src/sentry/api/serializers/models/relay.py
+++ b/src/sentry/api/serializers/models/relay.py
@@ -14,7 +14,7 @@ class OrganizationRelayResponse(TypedDict):
 
 @register(Relay)
 class RelaySerializer(Serializer):
-    def serialize(self, obj, attrs, user) -> OrganizationRelayResponse:
+    def serialize(self, obj, attrs, user):
         return {
             "relayId": str(obj.relay_id),
             "version": str(obj.version),

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -351,3 +351,19 @@ class OrganizationExamples:
             response_only=True,
         )
     ]
+
+    LIST_RELAYS = [
+        OpenApiExample(
+            "List an organization's trusted relays",
+            value=[
+                {
+                    "relayId": "0123abcd-4567-efgh-ij89-012aaa456bbb",
+                    "version": "23.11.2",
+                    "firstSeen": "2023-12-10T00:00:00.000000Z",
+                    "lastSeen": "2023-12-20T22:22:22.222222Z",
+                    "publicKey": "asdfa54g9987ga9dfha0f8adfhkj324-dafd78321-I",
+                }
+            ],
+            status_codes=["200"],
+        ),
+    ]

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -365,5 +365,6 @@ class OrganizationExamples:
                 }
             ],
             status_codes=["200"],
+            response_only=True,
         ),
     ]


### PR DESCRIPTION
Relay-related endpoints should not be publicly accessible and only used internally. This PR updates the visibility of such endpoints. It also includes `ProjectTransactionNamesCluster`, used internally for getting insights into the clusterer for debugging purposes.

`OrganizationRelayUsage` is the exception: this endpoint allows querying trusted relays for an organization and should be public.

### Docs screenshots

<img width="272" alt="image" src="https://github.com/getsentry/sentry/assets/32816711/41a07c5f-6e6b-428b-a6a8-85127374e79b">
<img width="1047" alt="image" src="https://github.com/getsentry/sentry/assets/32816711/6c6f75f3-e53d-4780-b498-0efe72accee0">
<img width="496" alt="image" src="https://github.com/getsentry/sentry/assets/32816711/b8f0d530-ab5d-491f-80f5-0a36b95053c3">
