### PR TITLE
fix(ddm-dashboards): Sorting of chart table in details modal

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -42,6 +42,7 @@ import {
   isEquation,
   isEquationAlias,
 } from 'sentry/utils/discover/fields';
+import {formatMRIField} from 'sentry/utils/metrics/mri';
 import {createOnDemandFilterWarning} from 'sentry/utils/onDemandMetrics';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
@@ -691,6 +692,44 @@ function WidgetViewerModal(props: Props) {
     );
   };
 
+  const renderMetricsTable: MetricWidgetQueries['props']['children'] = ({
+    tableResults,
+    loading,
+    pageLinks,
+  }) => {
+    const links = parseLinkHeader(pageLinks ?? null);
+    const isFirstPage = links.previous?.results === false;
+    const data = tableResults?.[0]?.data ?? [];
+
+    // For now we only support one aggregate in metric widgets, once we support multiple aggregates we will need to do the sorting on the backend
+    const mainField = props.widget.queries[0].aggregates[0];
+    const sortedData = [...data].sort(
+      (a, b) => Number(a[mainField]) - Number(b[mainField])
+    );
+
+    return (
+      <Fragment>
+        <GridEditable
+          isLoading={loading}
+          data={sortedData}
+          columnOrder={columnOrder}
+          columnSortBy={columnSortBy}
+          grid={{
+            renderHeadCell: column => formatMRIField(column.name),
+            renderBodyCell: renderGridBodyCell({
+              ...props,
+              location,
+              tableData: tableResults?.[0],
+              isFirstPage,
+            }),
+            onResizeColumn,
+          }}
+          location={location}
+        />
+      </Fragment>
+    );
+  };
+
   const onZoom: AugmentedEChartDataZoomHandler = (evt, chart) => {
     // @ts-expect-error getModel() is private but we need this to retrieve datetime values of zoomed in region
     const model = chart.getModel();
@@ -794,7 +833,7 @@ function WidgetViewerModal(props: Props) {
         );
       case WidgetType.METRICS:
         if (tableData && chartUnmodified && widget.displayType === DisplayType.TABLE) {
-          return renderReleaseTable({
+          return renderMetricsTable({
             tableResults: tableData,
             loading: false,
             pageLinks: defaultPageLinks,
@@ -815,7 +854,7 @@ function WidgetViewerModal(props: Props) {
             dashboardFilters={dashboardFilters}
           >
             {/* TODO(ddm): Check if we need to use a diffrent implementation, for now we fallback to release table */}
-            {renderReleaseTable}
+            {renderMetricsTable}
           </MetricWidgetQueries>
         );
       case WidgetType.DISCOVER:

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -853,7 +853,6 @@ function WidgetViewerModal(props: Props) {
             cursor={cursor}
             dashboardFilters={dashboardFilters}
           >
-            {/* TODO(ddm): Check if we need to use a diffrent implementation, for now we fallback to release table */}
             {renderMetricsTable}
           </MetricWidgetQueries>
         );


### PR DESCRIPTION
Remove sorting and pagination controls as the API does not support it yet.
Sort returned data by the queried metric.
Format MRI in table header.

![Screenshot 2023-12-15 at 11 33 41](https://github.com/getsentry/sentry/assets/7033940/aea2b6ef-2497-401e-8e53-e0c09cc939bb)

- closes https://github.com/getsentry/sentry/issues/61830