### PR TITLE
chore(api): Set API ownership for Performance & DnD private endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -150,7 +150,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
 @region_silo_endpoint
 class OrganizationDashboardVisitEndpoint(OrganizationDashboardBase):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
 
     def post(self, request: Request, organization, dashboard) -> Response:

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -14,7 +14,7 @@ from sentry.models.project import Project
 @region_silo_endpoint
 class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, organization, project_slug, event_id) -> Response:

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -16,7 +16,7 @@ from sentry.snuba import discover
 @region_silo_endpoint
 class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -39,7 +39,7 @@ DEFAULT_TAG_KEY_LIMIT = 5
 
 class OrganizationEventsFacetsPerformanceEndpointBase(OrganizationEventsV2EndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def has_feature(self, organization, request):
@@ -140,7 +140,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpoint(
     OrganizationEventsFacetsPerformanceEndpointBase
 ):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, organization) -> Response:
@@ -321,7 +321,6 @@ def query_top_tags(
     translated_aggregate_column = discover.resolve_discover_column(aggregate_column)
 
     with sentry_sdk.start_span(op="discover.discover", description="facets.top_tags"):
-
         if not orderby:
             orderby = ["-count"]
 

--- a/src/sentry/api/endpoints/organization_events_has_measurements.py
+++ b/src/sentry/api/endpoints/organization_events_has_measurements.py
@@ -50,7 +50,7 @@ class EventsHasMeasurementsQuerySerializer(serializers.Serializer):
 @region_silo_endpoint
 class OrganizationEventsHasMeasurementsEndpoint(OrganizationEventsV2EndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_events_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_histogram.py
@@ -44,7 +44,7 @@ class HistogramSerializer(serializers.Serializer):
 @region_silo_endpoint
 class OrganizationEventsHistogramEndpoint(OrganizationEventsV2EndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.PERFORMANCE
 

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -20,7 +20,7 @@ from sentry.snuba.referrer import Referrer
 @region_silo_endpoint
 class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, organization) -> Response:
@@ -48,7 +48,7 @@ UNESCAPED_QUOTE_RE = re.compile('(?<!\\\\)"')
 @region_silo_endpoint
 class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase, EnvironmentMixin):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -238,7 +238,7 @@ def fetch_geo_analysis_results(transaction_name, regression_breakpoint, params, 
 @region_silo_endpoint
 class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request, organization):

--- a/src/sentry/api/endpoints/organization_events_span_ops.py
+++ b/src/sentry/api/endpoints/organization_events_span_ops.py
@@ -21,11 +21,10 @@ class SpanOp(TypedDict):
 @region_silo_endpoint
 class OrganizationEventsSpanOpsEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, organization: Organization) -> Response:
-
         try:
             params = self.get_snuba_params(request, organization)
         except NoProjects:

--- a/src/sentry/api/endpoints/organization_events_spans_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_spans_histogram.py
@@ -37,7 +37,7 @@ class SpansHistogramSerializer(serializers.Serializer):
 @region_silo_endpoint
 class OrganizationEventsSpansHistogramEndpoint(OrganizationEventsV2EndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def has_feature(self, organization, request):

--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -148,11 +148,10 @@ class SpansPerformanceSerializer(serializers.Serializer):
 @region_silo_endpoint
 class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsSpansEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, organization: Organization) -> Response:
-
         try:
             params = self.get_snuba_params(request, organization)
         except NoProjects:
@@ -227,11 +226,10 @@ class SpanSerializer(serializers.Serializer):
 @region_silo_endpoint
 class OrganizationEventsSpansExamplesEndpoint(OrganizationEventsSpansEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, organization: Organization) -> Response:
-
         try:
             params = self.get_snuba_params(request, organization)
         except NoProjects:
@@ -312,11 +310,10 @@ class SpanExamplesPaginator:
 @region_silo_endpoint
 class OrganizationEventsSpansStatsEndpoint(OrganizationEventsSpansEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, organization: Organization) -> Response:
-
         serializer = SpanSerializer(data=request.GET)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -447,7 +447,7 @@ def query_trace_data(
 
 class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def has_feature(self, organization: Organization, request: HttpRequest) -> bool:
@@ -591,7 +591,7 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
 @region_silo_endpoint
 class OrganizationEventsTraceLightEndpoint(OrganizationEventsTraceEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     @staticmethod
@@ -674,7 +674,6 @@ class OrganizationEventsTraceLightEndpoint(OrganizationEventsTraceEndpointBase):
         root_id: Optional[str] = None
 
         with sentry_sdk.start_span(op="building.trace", description="light trace"):
-
             # Check if the event is an orphan_error
             if not snuba_event and not nodestore_event and allow_orphan_errors:
                 orphan_error = find_event(
@@ -1011,7 +1010,7 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
 @region_silo_endpoint
 class OrganizationEventsTraceMetaEndpoint(OrganizationEventsTraceEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: HttpRequest, organization: Organization, trace_id: str) -> HttpResponse:

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -34,9 +34,9 @@ class KeyTransactionPermission(OrganizationPermission):
 @region_silo_endpoint
 class KeyTransactionEndpoint(KeyTransactionBase):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (KeyTransactionPermission,)
 
@@ -146,7 +146,7 @@ class KeyTransactionEndpoint(KeyTransactionBase):
 @region_silo_endpoint
 class KeyTransactionListEndpoint(KeyTransactionBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (KeyTransactionPermission,)
 

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -119,7 +119,7 @@ from rest_framework.response import Response
 @region_silo_endpoint
 class DiscoverSavedQueryVisitEndpoint(OrganizationEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.DISCOVER_N_DASHBOARDS
     permission_classes = (DiscoverSavedQueryPermission,)


### PR DESCRIPTION
Categorized the endpoints as private for one or both of the following reasons:
1. we're likely going to have to deprecate them soon anyway as we move towards the spans model and a lot of these are based on the current transaction & trace model
2. they are just specializations of two of our more generic endpoints: events/ - already public and events-stats/ - we'd want to publicize.