### PR TITLE
feat(hybridcloud) Add a grace_period expired filter to integration service

### DIFF
--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -177,7 +177,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         status: int | None = None,
         providers: List[str] | None = None,
         has_grace_period: bool | None = None,
-        grace_period_expired: bool | None = None,
+        grace_period_expired: Optional[bool] = None,
         limit: int | None = None,
     ) -> List[RpcOrganizationIntegration]:
         oi_kwargs: Dict[str, Any] = {}

--- a/src/sentry/services/hybrid_cloud/integration/impl.py
+++ b/src/sentry/services/hybrid_cloud/integration/impl.py
@@ -177,6 +177,7 @@ class DatabaseBackedIntegrationService(IntegrationService):
         status: int | None = None,
         providers: List[str] | None = None,
         has_grace_period: bool | None = None,
+        grace_period_expired: bool | None = None,
         limit: int | None = None,
     ) -> List[RpcOrganizationIntegration]:
         oi_kwargs: Dict[str, Any] = {}
@@ -194,6 +195,9 @@ class DatabaseBackedIntegrationService(IntegrationService):
             oi_kwargs["integration__provider__in"] = providers
         if has_grace_period is not None:
             oi_kwargs["grace_period_end__isnull"] = not has_grace_period
+        if grace_period_expired:
+            # Used by getsentry
+            oi_kwargs["grace_period_end__lte"] = timezone.now()
 
         if not oi_kwargs:
             return []

--- a/src/sentry/services/hybrid_cloud/integration/service.py
+++ b/src/sentry/services/hybrid_cloud/integration/service.py
@@ -110,7 +110,7 @@ class IntegrationService(RpcService):
         status: Optional[int] = None,
         providers: Optional[List[str]] = None,
         has_grace_period: Optional[bool] = None,
-        grace_period_expired: bool | None = None,
+        grace_period_expired: Optional[bool] = None,
         limit: Optional[int] = None,
     ) -> List[RpcOrganizationIntegration]:
         """

--- a/src/sentry/services/hybrid_cloud/integration/service.py
+++ b/src/sentry/services/hybrid_cloud/integration/service.py
@@ -110,6 +110,7 @@ class IntegrationService(RpcService):
         status: Optional[int] = None,
         providers: Optional[List[str]] = None,
         has_grace_period: Optional[bool] = None,
+        grace_period_expired: bool | None = None,
         limit: Optional[int] = None,
     ) -> List[RpcOrganizationIntegration]:
         """


### PR DESCRIPTION
We'll need this to fix a silo violation query in a getsentry task that disables integrations after trials complete.

Refs HC-1034
