### PR TITLE
fix(profiling): handle concurrent spans in tree rendering

### DIFF
--- a/static/app/utils/profiling/spanChart.spec.tsx
+++ b/static/app/utils/profiling/spanChart.spec.tsx
@@ -297,7 +297,7 @@ describe('spanChart', () => {
     );
 
     const chart = new SpanChart(tree);
-    expect(chart.spanTrees.length).toBe(1);
+    expect(chart.spanTrees.length).toBe(2);
   });
 
   it('creates a new tree from orphaned spans', () => {


### PR DESCRIPTION
Concurrent spans can exceed parent span lengths, meaning they need to be draw in the next line. We were not handling this behavior previously and would just break out of the loop once we detected that the newly generated tree had not consumed any of the spans compared to the previous tree.