### PR TITLE
feat(hybrid-cloud): Introduce Virtual Silo Modes

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -582,7 +582,9 @@ class ReleaseAnalyticsMixin:
 
 class EndpointSiloLimit(SiloLimit):
     def modify_endpoint_class(self, decorated_class: Type[Endpoint]) -> type:
-        dispatch_override = self.create_override(decorated_class.dispatch)
+        dispatch_override = self.create_override(
+            self.create_override_with_virtual_mode(decorated_class.dispatch)
+        )
         new_class = type(
             decorated_class.__name__,
             (decorated_class,),
@@ -595,7 +597,7 @@ class EndpointSiloLimit(SiloLimit):
         return new_class
 
     def modify_endpoint_method(self, decorated_method: Callable[..., Any]) -> Callable[..., Any]:
-        return self.create_override(decorated_method)
+        return self.create_override(self.create_override_with_virtual_mode(decorated_method))
 
     def handle_when_unavailable(
         self,

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -495,7 +495,12 @@ class _RemoteSiloCall:
             if use_test_client:
                 response = self._fire_test_request(headers, data)
             else:
-                response = self._fire_request(headers, data)
+                if self.region:
+                    target_mode = SiloMode.REGION
+                else:
+                    target_mode = SiloMode.CONTROL
+                with SiloMode.enter_virtual_single_process_silo_context(target_mode):
+                    response = self._fire_request(headers, data)
             metrics.incr(
                 "hybrid_cloud.dispatch_rpc.response_code",
                 tags=self._metrics_tags(status=response.status_code),

--- a/src/sentry/silo/base.py
+++ b/src/sentry/silo/base.py
@@ -219,7 +219,7 @@ class SiloLimit(abc.ABC):
         functools.update_wrapper(override, original_method)
         return override
 
-    def create_override_with_virtual_mode(self, original_func: Callable[..., Any]) -> None:
+    def create_override_with_virtual_mode(self, original_func: Callable[..., Any]) -> Any:
         if len(self.modes) == 1:
             virtual_silo_mode = next(iter(self.modes))
 

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -55,7 +55,9 @@ audit_logger = logging.getLogger("sentry.audit.ui")
 
 class ViewSiloLimit(SiloLimit):
     def modify_endpoint_class(self, decorated_class: Type[View]) -> type:
-        dispatch_override = self.create_override(decorated_class.dispatch)
+        dispatch_override = self.create_override(
+            self.create_override_with_virtual_mode(decorated_class.dispatch)
+        )
         new_class = type(
             decorated_class.__name__,
             (decorated_class,),
@@ -68,7 +70,7 @@ class ViewSiloLimit(SiloLimit):
         return new_class
 
     def modify_endpoint_method(self, decorated_method: Callable[..., Any]) -> Callable[..., Any]:
-        return self.create_override(decorated_method)
+        return self.create_override(self.create_override_with_virtual_mode(decorated_method))
 
     def handle_when_unavailable(
         self,


### PR DESCRIPTION
Virtual silo mode idea.

Need this in `dev.py` in `getsentry`:

```
################
# Hybrid Cloud #
################
RPC_SHARED_SECRET = ["a-long-value-that-is-shared-but-also-secret"]
SENTRY_SUBNET_SECRET = "a-long-value-that-is-shared-but-also-secret"
SENTRY_CONTROL_ADDRESS = "http://dev.getsentry.net:8000"
RPC_TIMEOUT = 100000
```