### PR TITLE
fix(integrations) Don't use `message` in logging context

### DIFF
--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -122,7 +122,7 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
                     "rule_id": rule_id,
                     "provider": provider,
                     "integration_id": integration.id,
-                    "message": str(e),
+                    "error_message": str(e),
                 },
             )
             metrics.incr(


### PR DESCRIPTION
Fixes SENTRY-2B42