### PR TITLE
chore(hybrid-cloud): Remove dead code

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3861,10 +3861,6 @@ SHOW_LOGIN_BANNER = False
 # }
 SLICED_KAFKA_TOPICS: Mapping[tuple[str, int], Mapping[str, Any]] = {}
 
-# Used by silo tests -- when requests pass through decorated endpoints, switch the server silo mode to match that
-# decorator.
-SINGLE_SERVER_SILO_MODE = False
-
 # Used by silo tests -- activate all silo mode test decorators even if not marked stable
 FORCE_SILOED_TESTS = os.environ.get("SENTRY_FORCE_SILOED_TESTS", False)
 

--- a/src/sentry/silo/base.py
+++ b/src/sentry/silo/base.py
@@ -42,10 +42,6 @@ class SiloMode(Enum):
         return str(self.value)
 
     @classmethod
-    def single_process_silo_mode(cls) -> bool:
-        return bool(settings.SINGLE_SERVER_SILO_MODE)
-
-    @classmethod
     @contextlib.contextmanager
     def enter_single_process_silo_context(
         cls, mode: SiloMode, region: Region | None = None


### PR DESCRIPTION
`single_process_silo_mode()` and `SINGLE_SERVER_SILO_MODE` are not used and are dead code

Either of these didn't show any usage via `grep`.