### PR TITLE
fix(crons): Don't mark muted monitors as missing

### DIFF
--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -212,7 +212,7 @@ class Monitor(Model):
     is_muted = models.BooleanField(default=False)
     """
     Monitor is operating normally but will not produce incidents or produce
-    occurences into the issues platform.
+    occurrences into the issues platform.
     """
 
     name = models.CharField(max_length=128)

--- a/src/sentry/monitors/models.py
+++ b/src/sentry/monitors/models.py
@@ -212,12 +212,12 @@ class Monitor(Model):
     is_muted = models.BooleanField(default=False)
     """
     Monitor is operating normally but will not produce incidents or produce
-    occurances into the issues platform.
+    occurences into the issues platform.
     """
 
     name = models.CharField(max_length=128)
     """
-    Human readible name of the monitor. Used for display purposes.
+    Human readable name of the monitor. Used for display purposes.
     """
 
     type = BoundedPositiveIntegerField(

--- a/src/sentry/monitors/tasks.py
+++ b/src/sentry/monitors/tasks.py
@@ -140,7 +140,7 @@ def try_monitor_tasks_trigger(ts: datetime, partition: int):
     # The scenario where the slowest_part_ts is older may happen when our
     # MONITOR_TASKS_PARTITION_CLOCKS set did not know about every partition the
     # topic is responsible for. Older check-ins may be processed after newer
-    # ones in diferent topics. This should only happen if redis loses state.
+    # ones in different topics. This should only happen if redis loses state.
     if precheck_last_ts is not None and precheck_last_ts >= slowest_part_ts:
         return
 
@@ -242,6 +242,9 @@ def check_missing(current_datetime: datetime):
                 ObjectStatus.PENDING_DELETION,
                 ObjectStatus.DELETION_IN_PROGRESS,
             ],
+        )
+        .exclude(
+            monitor__is_muted=True,  # Temporary test until we can move out of celery or reduce load
         )[:MONITOR_LIMIT]
     )
 
@@ -286,7 +289,7 @@ def mark_environment_missing(monitor_environment_id: int, ts: datetime):
     # happen. This takes advantage of the fact that the current reference time
     # will always be at least a minute after the last expected check-in.
     #
-    # Typically `expected_time` and this calculate time should be the same, but
+    # Typically `expected_time` and this calculated time should be the same, but
     # there are cases where it may not be:
     #
     #  1. We are guarding against a task having not run for every minute.


### PR DESCRIPTION
Excludes `is_muted` monitors from the `check_missing` task until we can reduce load or move out of celery, as our current workload is sensitive to celery slowdowns