### PR TITLE
ref(onboarding): [3/6] convert more backend platforms to new structure (tornado, flask, fastapi)

### DIFF
--- a/static/app/gettingStartedDocs/python/aiohttp.spec.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.spec.tsx
@@ -26,7 +26,7 @@ describe('aiohttp onboarding docs', function () {
 
     // Does not render config option
     expect(
-      screen.queryByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0,/))
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
     ).not.toBeInTheDocument();
 
     // Does not render config option

--- a/static/app/gettingStartedDocs/python/fastapi.spec.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.spec.tsx
@@ -28,7 +28,7 @@ describe('flask onboarding docs', function () {
 
     // Does not render config option
     expect(
-      screen.queryByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0,/))
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
     ).not.toBeInTheDocument();
 
     // Does not render config option

--- a/static/app/gettingStartedDocs/python/fastapi.spec.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.spec.tsx
@@ -1,18 +1,39 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './fastapi';
 
-import {GettingStartedWithFastApi, steps} from './fastapi';
-
-describe('GettingStartedWithFastApi', function () {
+describe('flask onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithFastApi dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({sentryInitContent: 'test-init-content'})) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[fastapi\]'/)
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders without performance monitoring', function () {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [],
+    });
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0,/))
+    ).not.toBeInTheDocument();
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profiles_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -1,167 +1,134 @@
 import ExternalLink from 'sentry/components/links/externalLink';
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
+import {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
-// Configuration Start
-const performanceConfiguration = `    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,`;
+type Params = DocsParams;
 
-const profilingConfiguration = `    # Set profiles_sample_rate to 1.0 to profile 100%
+const getSdkSetupSnippet = (params: Params) => `
+from fastapi import FastAPI
+import sentry_sdk
+
+sentry_sdk.init(
+    dsn="${params.dsn}",${
+      params.isPerformanceSelected
+        ? `
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,`
+        : ''
+    }${
+      params.isProfilingSelected
+        ? `
+    # Set profiles_sample_rate to 1.0 to profile 100%
     # of sampled transactions.
     # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,`;
-
-const introduction = (
-  <p>
-    {tct('The FastAPI integration adds support for the [link:FastAPI Framework].', {
-      link: <ExternalLink href="https://fastapi.tiangolo.com/" />,
-    })}
-  </p>
-);
-
-export const steps = ({
-  sentryInitContent,
-}: {
-  sentryInitContent: string;
-}): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: (
-      <p>
-        {tct(
-          'Install [sentrySdkCode:sentry-sdk] from PyPI with the [sentryFastApiCode:fastapi] extra:',
-          {
-            sentrySdkCode: <code />,
-            sentryFastApiCode: <code />,
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'bash',
-        code: "pip install --upgrade 'sentry-sdk[fastapi]'",
-      },
-    ],
-  },
-  {
-    type: StepType.CONFIGURE,
-    description: (
-      <p>
-        {tct(
-          'If you have the [codeFastAPI:fastapi] package in your dependencies, the FastAPI integration will be enabled automatically when you initialize the Sentry SDK. Initialize the Sentry SDK before your app has been initialized:',
-          {
-            codeFastAPI: <code />,
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `
-from fastapi import FastAPI
-
-import sentry_sdk
-
-sentry_sdk.init(
-${sentryInitContent}
+    profiles_sample_rate=1.0,`
+        : ''
+    }
 )
+`;
 
+const onboarding: OnboardingConfig = {
+  introduction: () =>
+    tct('The FastAPI integration adds support for the [link:FastAPI Framework].', {
+      link: <ExternalLink href="https://fastapi.tiangolo.com/" />,
+    }),
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'Install [sentrySdkCode:sentry-sdk] from PyPI with the [sentryFastApiCode:fastapi] extra:',
+        {
+          sentrySdkCode: <code />,
+          sentryFastApiCode: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: "pip install --upgrade 'sentry-sdk[fastapi]'",
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      description: tct(
+        'If you have the [codeFastAPI:fastapi] package in your dependencies, the FastAPI integration will be enabled automatically when you initialize the Sentry SDK. Initialize the Sentry SDK before your app has been initialized:',
+        {
+          codeFastAPI: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: `
+${getSdkSetupSnippet(params)}
 app = FastAPI()
       `,
-      },
-    ],
-    additionalInfo: (
-      <p>
-        {tct(
-          'The above configuration captures both error and performance data. To reduce the volume of performance data captured, change [code:traces_sample_rate] to a value between 0 and 1.',
-          {
-            code: <code />,
-          }
-        )}
-      </p>
-    ),
-  },
-  {
-    type: StepType.VERIFY,
-    description: t(
-      'You can easily verify your Sentry installation by creating a route that triggers an error:'
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `
-from fastapi import FastAPI
+        },
+      ],
+      additionalInfo: tct(
+        'The above configuration captures both error and performance data. To reduce the volume of performance data captured, change [code:traces_sample_rate] to a value between 0 and 1.',
+        {
+          code: <code />,
+        }
+      ),
+    },
+  ],
+  verify: (params: Params) => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'You can easily verify your Sentry installation by creating a route that triggers an error:'
+      ),
+      configurations: [
+        {
+          language: 'python',
 
-import sentry_sdk
-
-sentry_sdk.init(
-${sentryInitContent}
-)
-
+          code: `
+${getSdkSetupSnippet(params)}
 app = FastAPI()
 
 @app.get("/sentry-debug")
 async def trigger_error():
     division_by_zero = 1 / 0
       `,
-      },
-    ],
-    additionalInfo: (
-      <div>
-        <p>
-          {tct(
-            'When you point your browser to [link:http://localhost:8000/sentry-debug/] a transaction in the Performance section of Sentry will be created.',
-            {
-              link: <ExternalLink href="http://localhost:8000/sentry-debug/" />,
-            }
-          )}
-        </p>
-        <p>
-          {t(
-            'Additionally, an error event will be sent to Sentry and will be connected to the transaction.'
-          )}
-        </p>
-        <p>{t('It takes a couple of moments for the data to appear in Sentry.')}</p>
-      </div>
-    ),
-  },
-];
-// Configuration End
+        },
+      ],
+      additionalInfo: (
+        <div>
+          <p>
+            {tct(
+              'When you point your browser to [link:http://localhost:8000/sentry-debug/] a transaction in the Performance section of Sentry will be created.',
+              {
+                link: <ExternalLink href="http://localhost:8000/sentry-debug/" />,
+              }
+            )}
+          </p>
+          <p>
+            {t(
+              'Additionally, an error event will be sent to Sentry and will be connected to the transaction.'
+            )}
+          </p>
+          <p>{t('It takes a couple of moments for the data to appear in Sentry.')}</p>
+        </div>
+      ),
+    },
+  ],
+  nextSteps: () => [],
+};
 
-export function GettingStartedWithFastApi({
-  dsn,
-  activeProductSelection = [],
-  ...props
-}: ModuleProps) {
-  const otherConfigs: string[] = [];
+const docs: Docs = {
+  onboarding,
+  replayOnboardingJsLoader,
+};
 
-  let sentryInitContent: string[] = [`    dsn="${dsn}",`];
-
-  if (activeProductSelection.includes(ProductSolution.PERFORMANCE_MONITORING)) {
-    otherConfigs.push(performanceConfiguration);
-  }
-
-  if (activeProductSelection.includes(ProductSolution.PROFILING)) {
-    otherConfigs.push(profilingConfiguration);
-  }
-
-  sentryInitContent = sentryInitContent.concat(otherConfigs);
-
-  return (
-    <Layout
-      introduction={introduction}
-      steps={steps({
-        sentryInitContent: sentryInitContent.join('\n'),
-      })}
-      {...props}
-    />
-  );
-}
-
-export default GettingStartedWithFastApi;
+export default docs;

--- a/static/app/gettingStartedDocs/python/flask.spec.tsx
+++ b/static/app/gettingStartedDocs/python/flask.spec.tsx
@@ -1,18 +1,39 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './flask';
 
-import {GettingStartedWithFlask, steps} from './flask';
-
-describe('GettingStartedWithDjango', function () {
+describe('flask onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithFlask dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({sentryInitContent: 'test-init-content'})) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[flask\]'/)
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders without performance monitoring', function () {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [],
+    });
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0,/))
+    ).not.toBeInTheDocument();
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profiles_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/flask.spec.tsx
+++ b/static/app/gettingStartedDocs/python/flask.spec.tsx
@@ -28,7 +28,7 @@ describe('flask onboarding docs', function () {
 
     // Does not render config option
     expect(
-      screen.queryByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0,/))
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
     ).not.toBeInTheDocument();
 
     // Does not render config option

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -1,163 +1,133 @@
 import ExternalLink from 'sentry/components/links/externalLink';
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
+import {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
-// Configuration Start
-const performanceConfiguration = `    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,`;
+type Params = DocsParams;
 
-const profilingConfiguration = `    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,`;
-
-const introduction = (
-  <p>
-    {tct('The Flask integration adds support for the [link:Flask Framework].', {
-      link: <ExternalLink href="https://flask.palletsprojects.com" />,
-    })}
-  </p>
-);
-
-export const steps = ({
-  sentryInitContent,
-}: {
-  sentryInitContent: string;
-}): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: (
-      <p>
-        {tct(
-          'Install [sentrySdkCode:sentry-sdk] from PyPI with the [sentryFlaskCode:flask] extra:',
-          {
-            sentrySdkCode: <code />,
-            sentryFlaskCode: <code />,
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'bash',
-        code: "pip install --upgrade 'sentry-sdk[flask]'",
-      },
-    ],
-  },
-  {
-    type: StepType.CONFIGURE,
-    description: (
-      <p>
-        {tct(
-          'If you have the [codeFlask:flask] package in your dependencies, the Flask integration will be enabled automatically when you initialize the Sentry SDK. Initialize the Sentry SDK before your app has been initialized:',
-          {
-            codeFlask: <code />,
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `
+const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 from flask import Flask
 
 sentry_sdk.init(
-${sentryInitContent}
+    dsn="${params.dsn}",${
+      params.isPerformanceSelected
+        ? `
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,`
+        : ''
+    }${
+      params.isProfilingSelected
+        ? `
+    # Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production.
+    profiles_sample_rate=1.0,`
+        : ''
+    }
 )
+`;
 
+const onboarding: OnboardingConfig = {
+  introduction: () =>
+    tct('The Flask integration adds support for the [link:Flask Framework].', {
+      link: <ExternalLink href="https://flask.palletsprojects.com" />,
+    }),
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'Install [sentrySdkCode:sentry-sdk] from PyPI with the [sentryFlaskCode:flask] extra:',
+        {
+          sentrySdkCode: <code />,
+          sentryFlaskCode: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: "pip install --upgrade 'sentry-sdk[flask]'",
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      description: tct(
+        'If you have the [codeFlask:flask] package in your dependencies, the Flask integration will be enabled automatically when you initialize the Sentry SDK. Initialize the Sentry SDK before your app has been initialized:',
+        {
+          codeFlask: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: `
+${getSdkSetupSnippet(params)}
 app = Flask(__name__)
-        `,
-      },
-    ],
-    additionalInfo: (
-      <p>
-        {tct(
-          'The above configuration captures both error and performance data. To reduce the volume of performance data captured, change [code:traces_sample_rate] to a value between 0 and 1.',
-          {code: <code />}
-        )}
-      </p>
-    ),
-  },
-  {
-    type: StepType.VERIFY,
-    description: t(
-      'You can easily verify your Sentry installation by creating a route that triggers an error:'
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `from flask import Flask
-import sentry_sdk
+      `,
+        },
+      ],
+      additionalInfo: tct(
+        'The above configuration captures both error and performance data. To reduce the volume of performance data captured, change [code:traces_sample_rate] to a value between 0 and 1.',
+        {code: <code />}
+      ),
+    },
+  ],
+  verify: (params: Params) => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'You can easily verify your Sentry installation by creating a route that triggers an error:'
+      ),
+      configurations: [
+        {
+          language: 'python',
 
-sentry_sdk.init(
-${sentryInitContent}
-)
-
+          code: `
+${getSdkSetupSnippet(params)}
 app = Flask(__name__)
 
 @app.route("/")
 def hello_world():
-  1/0  # raises an error
-  return "<p>Hello, World!</p>"
+    1/0  # raises an error
+    return "<p>Hello, World!</p>"
         `,
-      },
-    ],
-    additionalInfo: (
-      <span>
-        <p>
-          {tct(
-            'When you point your browser to [link:http://localhost:5000/] a transaction in the Performance section of Sentry will be created.',
-            {
-              link: <ExternalLink href="http://localhost:5000/" />,
-            }
-          )}
-        </p>
-        <p>
-          {t(
-            'Additionally, an error event will be sent to Sentry and will be connected to the transaction.'
-          )}
-        </p>
-        <p>{t('It takes a couple of moments for the data to appear in Sentry.')}</p>
-      </span>
-    ),
-  },
-];
-// Configuration End
+        },
+      ],
+      additionalInfo: (
+        <span>
+          <p>
+            {tct(
+              'When you point your browser to [link:http://localhost:5000/] a transaction in the Performance section of Sentry will be created.',
+              {
+                link: <ExternalLink href="http://localhost:5000/" />,
+              }
+            )}
+          </p>
+          <p>
+            {t(
+              'Additionally, an error event will be sent to Sentry and will be connected to the transaction.'
+            )}
+          </p>
+          <p>{t('It takes a couple of moments for the data to appear in Sentry.')}</p>
+        </span>
+      ),
+    },
+  ],
+  nextSteps: () => [],
+};
 
-export function GettingStartedWithFlask({
-  dsn,
-  activeProductSelection = [],
-  ...props
-}: ModuleProps) {
-  const otherConfigs: string[] = [];
+const docs: Docs = {
+  onboarding,
+  replayOnboardingJsLoader,
+};
 
-  let sentryInitContent: string[] = [`    dsn="${dsn}",`];
-
-  if (activeProductSelection.includes(ProductSolution.PERFORMANCE_MONITORING)) {
-    otherConfigs.push(performanceConfiguration);
-  }
-
-  if (activeProductSelection.includes(ProductSolution.PROFILING)) {
-    otherConfigs.push(profilingConfiguration);
-  }
-
-  sentryInitContent = sentryInitContent.concat(otherConfigs);
-
-  return (
-    <Layout
-      introduction={introduction}
-      steps={steps({
-        sentryInitContent: sentryInitContent.join('\n'),
-      })}
-      {...props}
-    />
-  );
-}
-
-export default GettingStartedWithFlask;
+export default docs;

--- a/static/app/gettingStartedDocs/python/pyramid.spec.tsx
+++ b/static/app/gettingStartedDocs/python/pyramid.spec.tsx
@@ -1,18 +1,27 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './pyramid';
 
-import {GettingStartedWithPyramid, steps} from './pyramid';
-
-describe('GettingStartedWithPyramid', function () {
+describe('aiohttp onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithPyramid dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({sentryInitContent: 'test-init-content'})) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(textWithMarkupMatcher(/\$ pip install --upgrade sentry-sdk/))
+    ).toBeInTheDocument();
+  });
+
+  it('renders without performance monitoring', function () {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [],
+    });
   });
 });

--- a/static/app/gettingStartedDocs/python/pyramid.tsx
+++ b/static/app/gettingStartedDocs/python/pyramid.tsx
@@ -1,78 +1,74 @@
 import ExternalLink from 'sentry/components/links/externalLink';
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
-// Configuration Start
-const introduction = (
-  <p>
-    {tct('The Pyramid integration adds support for the [link:Pyramid Web Framework].', {
-      link: <ExternalLink href="https://trypyramid.com/" />,
-    })}
-  </p>
-);
+type Params = DocsParams;
 
-export const steps = ({
-  sentryInitContent,
-}: {
-  sentryInitContent: string;
-}): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: <p>{tct('Install [code:sentry-sdk] from PyPI:', {code: <code />})}</p>,
-    configurations: [
-      {
-        language: 'bash',
-        code: '$ pip install --upgrade sentry-sdk',
-      },
-    ],
-  },
-  {
-    type: StepType.CONFIGURE,
-    description: (
-      <p>
-        {tct(
-          'If you have the [codePyramid:pyramid] package in your dependencies, the Pyramid integration will be enabled automatically when you initialize the Sentry SDK. Initialize the Sentry SDK before your app has been initialized:',
-          {
-            codePyramid: <code />,
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `
+const getSdkSetupSnippet = (params: Params) => `
 from pyramid.config import Configurator
 import sentry_sdk
 
 sentry_sdk.init(
-${sentryInitContent}
+    dsn="${params.dsn}",
 )
+`;
 
+const onboarding: OnboardingConfig = {
+  introduction: () =>
+    tct('The Pyramid integration adds support for the [link:Pyramid Web Framework].', {
+      link: <ExternalLink href="https://trypyramid.com/" />,
+    }),
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct('Install [code:sentry-sdk] from PyPI:', {code: <code />}),
+      configurations: [
+        {
+          language: 'bash',
+          code: '$ pip install --upgrade sentry-sdk',
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      description: tct(
+        'If you have the [codePyramid:pyramid] package in your dependencies, the Pyramid integration will be enabled automatically when you initialize the Sentry SDK. Initialize the Sentry SDK before your app has been initialized:',
+        {
+          codePyramid: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: `
+${getSdkSetupSnippet(params)}
 with Configurator() as config:
     # ...
-      `,
-      },
-    ],
-  },
-  {
-    type: StepType.VERIFY,
-    description: t(
-      'You can easily verify your Sentry installation by creating a view that triggers an error:'
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `from wsgiref.simple_server import make_server
-from pyramid.config import Configurator
-from pyramid.response import Response
+        `,
+        },
+      ],
+    },
+  ],
+  verify: (params: Params) => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'You can easily verify your Sentry installation by creating a route that triggers an error:'
+      ),
+      configurations: [
+        {
+          language: 'python',
 
-sentry_sdk.init(
-${sentryInitContent}
-)
-
+          code: `from wsgiref.simple_server import make_server
+from pyramid.response import Response${getSdkSetupSnippet(params)}
 def hello_world(request):
     1/0  # raises an error
     return Response('Hello World!')
@@ -85,39 +81,23 @@ if __name__ == '__main__':
 
     server = make_server('0.0.0.0', 6543, app)
     server.serve_forever()
-        `,
-      },
-    ],
-    additionalInfo: (
-      <p>
-        {tct(
-          'When you point your browser to [link:http://localhost:6543/] an error event will be sent to Sentry.',
-          {
-            link: <ExternalLink href="http://localhost:6543/" />,
-          }
-        )}
-      </p>
-    ),
-  },
-];
-// Configuration End
+              `,
+        },
+      ],
+      additionalInfo: tct(
+        'When you point your browser to [link:http://localhost:6543/] an error event will be sent to Sentry.',
+        {
+          link: <ExternalLink href="http://localhost:6543/" />,
+        }
+      ),
+    },
+  ],
+  nextSteps: () => [],
+};
 
-export function GettingStartedWithPyramid({dsn, ...props}: ModuleProps) {
-  const otherConfigs: string[] = [];
+const docs: Docs = {
+  onboarding,
+  replayOnboardingJsLoader,
+};
 
-  let sentryInitContent: string[] = [`    dsn="${dsn}",`];
-
-  sentryInitContent = sentryInitContent.concat(otherConfigs);
-
-  return (
-    <Layout
-      introduction={introduction}
-      steps={steps({
-        sentryInitContent: sentryInitContent.join('\n'),
-      })}
-      {...props}
-    />
-  );
-}
-
-export default GettingStartedWithPyramid;
+export default docs;

--- a/static/app/gettingStartedDocs/python/quart.spec.tsx
+++ b/static/app/gettingStartedDocs/python/quart.spec.tsx
@@ -28,7 +28,7 @@ describe('quart onboarding docs', function () {
 
     // Does not render config option
     expect(
-      screen.queryByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0,/))
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
     ).not.toBeInTheDocument();
 
     // Does not render config option


### PR DESCRIPTION
refactor work for https://github.com/getsentry/sentry/issues/61069