### PR TITLE
fix(database): Improve missing data message

### DIFF
--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -107,6 +107,16 @@ export function DatabaseLandingPage() {
     'api.starfish.span-landing-page-metrics-chart'
   );
 
+  const isCriticalDataLoading =
+    isThroughputDataLoading || isDurationDataLoading || queryListResponse.isLoading;
+
+  const isAnyCriticalDataAvailable =
+    (queryListResponse.data ?? []).length > 0 ||
+    durationData[`${selectedAggregate}(span.self_time)`].data?.some(
+      ({value}) => value > 0
+    ) ||
+    throughputData['spm()'].data?.some(({value}) => value > 0);
+
   useSynchronizeCharts([!isThroughputDataLoading && !isDurationDataLoading]);
 
   return (
@@ -132,7 +142,12 @@ export function DatabaseLandingPage() {
 
       <Layout.Body>
         <Layout.Main fullWidth>
-          {!onboardingProject && <NoDataMessage Wrapper={AlertBanner} />}
+          {!onboardingProject && !isCriticalDataLoading && (
+            <NoDataMessage
+              Wrapper={AlertBanner}
+              isDataAvailable={isAnyCriticalDataAvailable}
+            />
+          )}
           <FloatingFeedbackWidget />
           <PaddedContainer>
             <PageFilterBar condensed>

--- a/static/app/views/performance/database/noDataMessage.spec.tsx
+++ b/static/app/views/performance/database/noDataMessage.spec.tsx
@@ -100,39 +100,28 @@ describe('NoDataMessage', () => {
     );
   });
 
-  it('shows a list of denylisted projects if any are are set', async function () {
-    const sdkMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/sdk-updates/',
-      body: [],
-    });
-
+  it('shows a list of denylisted projects if any are are set even if data is available', async function () {
     ProjectsStore.loadInitialData([
-      Project({name: 'Terrible API', slug: 'terrible-api', features: []}),
-      Project({name: 'Awful API', slug: 'awful-api', features: []}),
+      Project({
+        name: 'Awful API',
+        slug: 'awful-api',
+        features: [],
+      }),
     ]);
 
-    render(<NoDataMessage isDataAvailable={false} />);
+    render(<NoDataMessage isDataAvailable />);
 
-    await waitFor(() => expect(sdkMock).toHaveBeenCalled());
     await tick(); // There is no visual indicator, this awaits the promise resolve
 
     expect(
-      screen.queryByText(textWithMarkupMatcher('No queries found.'))
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(
-        textWithMarkupMatcher('You may be missing data due to outdated SDKs')
-      )
-    ).not.toBeInTheDocument();
-    expect(
       screen.getByText(
         textWithMarkupMatcher(
-          'Some of your projects have been omitted from metrics extraction'
+          'Some of your projects have been omitted from database metrics extraction'
         )
       )
     ).toBeInTheDocument();
 
-    expect(screen.getAllByRole('link')[2]).toHaveAttribute(
+    expect(screen.getAllByRole('link')[1]).toHaveAttribute(
       'href',
       '/organizations/org-slug/projects/awful-api/'
     );

--- a/static/app/views/performance/database/noDataMessage.spec.tsx
+++ b/static/app/views/performance/database/noDataMessage.spec.tsx
@@ -121,7 +121,7 @@ describe('NoDataMessage', () => {
       )
     ).toBeInTheDocument();
 
-    expect(screen.getAllByRole('link')[1]).toHaveAttribute(
+    expect(screen.getAllByRole('link')[0]).toHaveAttribute(
       'href',
       '/organizations/org-slug/projects/awful-api/'
     );

--- a/static/app/views/performance/database/noDataMessage.spec.tsx
+++ b/static/app/views/performance/database/noDataMessage.spec.tsx
@@ -116,7 +116,7 @@ describe('NoDataMessage', () => {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          'Some of your projects have been omitted from database metrics extraction'
+          'Some of your projects have been omitted from query performance analysis'
         )
       )
     ).toBeInTheDocument();

--- a/static/app/views/performance/database/noDataMessage.spec.tsx
+++ b/static/app/views/performance/database/noDataMessage.spec.tsx
@@ -31,47 +31,17 @@ describe('NoDataMessage', () => {
     }));
   });
 
-  it('does not show anything while data is loading', async function () {
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/sdk-updates/',
-      body: [],
-    });
-
-    const eventsMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
-      body: {
-        data: [],
-      },
-    });
-
-    render(<NoDataMessage />);
-
-    await waitFor(() => expect(eventsMock).toHaveBeenCalled());
-
-    expect(
-      screen.queryByText(textWithMarkupMatcher('No queries found.'))
-    ).not.toBeInTheDocument();
-
-    await tick();
+  afterEach(() => {
+    ProjectsStore.reset();
   });
 
-  it('does not show anything if there is recent data', async function () {
+  it('does not show anything if there is recent data', function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/sdk-updates/',
       body: [],
     });
 
-    const eventsMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
-      body: {
-        data: [{'project.id': 2, 'count()': 1}],
-      },
-    });
-
-    render(<NoDataMessage />);
-
-    await waitFor(() => expect(eventsMock).toHaveBeenCalled());
-    await tick(); // There is no visual indicator, this awaits the promise resolve
+    render(<NoDataMessage isDataAvailable />);
 
     expect(
       screen.queryByText(textWithMarkupMatcher('No queries found.'))
@@ -79,21 +49,13 @@ describe('NoDataMessage', () => {
   });
 
   it('shows a no data message if there is no recent data', async function () {
-    MockApiClient.addMockResponse({
+    const sdkMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/sdk-updates/',
       body: [],
     });
 
-    const eventsMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
-      body: {
-        data: [],
-      },
-    });
-
-    render(<NoDataMessage />);
-
-    await waitFor(() => expect(eventsMock).toHaveBeenCalled());
+    render(<NoDataMessage isDataAvailable={false} />);
+    await waitFor(() => expect(sdkMock).toHaveBeenCalled());
     await tick(); // There is no visual indicator, this awaits the promise resolve
 
     expect(
@@ -112,16 +74,8 @@ describe('NoDataMessage', () => {
       body: [ProjectSdkUpdates({projectId: '2'})],
     });
 
-    const eventsMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
-      body: {
-        data: [],
-      },
-    });
+    render(<NoDataMessage isDataAvailable={false} />);
 
-    render(<NoDataMessage />);
-
-    await waitFor(() => expect(eventsMock).toHaveBeenCalled());
     await waitFor(() => expect(sdkMock).toHaveBeenCalled());
     await tick(); // There is no visual indicator, this awaits the promise resolve
 

--- a/static/app/views/performance/database/noDataMessage.tsx
+++ b/static/app/views/performance/database/noDataMessage.tsx
@@ -34,19 +34,17 @@ export function NoDataMessage({Wrapper = DivWrapper, isDataAvailable}: Props) {
       projectId: selectedProjectIds,
     });
 
-  // Hide message while fetching outdated projects or denylisted projects
-  if (areOutdatedProjectsFetching || areDenylistProjectsFetching) {
+  const isDataFetching = areOutdatedProjectsFetching || areDenylistProjectsFetching;
+
+  if (isDataFetching) {
     return null;
   }
 
-  // Hide message if all conditions are satisfied
-  if (
-    isDataAvailable &&
-    !areOutdatedProjectsFetching &&
-    !areDenylistProjectsFetching &&
-    outdatedProjects.length === 0 &&
-    denylistedProjects.length === 0
-  ) {
+  const hasAnyProblematicProjects =
+    (!areOutdatedProjectsFetching && outdatedProjects.length > 0) ||
+    (!areDenylistProjectsFetching && denylistedProjects.length > 0);
+
+  if (isDataAvailable && !hasAnyProblematicProjects) {
     return null;
   }
 

--- a/static/app/views/performance/database/noDataMessage.tsx
+++ b/static/app/views/performance/database/noDataMessage.tsx
@@ -1,7 +1,9 @@
 import {Fragment} from 'react';
 
+import {openHelpSearchModal} from 'sentry/actionCreators/modal';
+import {Button} from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {Project} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -19,6 +21,7 @@ function DivWrapper(props) {
 }
 
 export function NoDataMessage({Wrapper = DivWrapper, isDataAvailable}: Props) {
+  const organization = useOrganization();
   const {selection, isReady: pageFilterIsReady} = usePageFilters();
 
   const selectedProjectIds = selection.projects.map(projectId => projectId.toString());
@@ -65,10 +68,12 @@ export function NoDataMessage({Wrapper = DivWrapper, isDataAvailable}: Props) {
         })}{' '}
       {denylistedProjects.length > 0 &&
         tct(
-          'Some of your projects have been omitted from query performance analysis. Please contact [support]. Omitted projects: [projectList].',
+          'Some of your projects have been omitted from query performance analysis. Please [supportLink]. Omitted projects: [projectList].',
           {
-            support: (
-              <ExternalLink href="https://sentry.io/support/">support</ExternalLink>
+            supportLink: (
+              <Button priority="link" onClick={() => openHelpSearchModal({organization})}>
+                {t('contact support')}
+              </Button>
             ),
             projectList: <ProjectList projects={denylistedProjects} />,
           }

--- a/static/app/views/performance/database/noDataMessage.tsx
+++ b/static/app/views/performance/database/noDataMessage.tsx
@@ -72,7 +72,7 @@ export function NoDataMessage({Wrapper = DivWrapper, isDataAvailable}: Props) {
           {
             supportLink: (
               <Button priority="link" onClick={() => openHelpSearchModal({organization})}>
-                {t('contact support')}
+                {t('Contact Support')}
               </Button>
             ),
             projectList: <ProjectList projects={denylistedProjects} />,

--- a/static/app/views/performance/database/noDataMessage.tsx
+++ b/static/app/views/performance/database/noDataMessage.tsx
@@ -5,7 +5,7 @@ import {t, tct} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
-import {useIneligibleProjects} from 'sentry/views/performance/database/useIneligibleProjects';
+import {useOutdatedSDKProjects} from 'sentry/views/performance/database/useOutdatedSDKProjects';
 
 interface Props {
   Wrapper?: React.ComponentType;
@@ -21,18 +21,18 @@ export function NoDataMessage({Wrapper = DivWrapper, isDataAvailable}: Props) {
 
   const selectedProjectIds = selection.projects.map(projectId => projectId.toString());
 
-  const {ineligibleProjects, isFetching: areIneligibleProjectsFetching} =
-    useIneligibleProjects({
+  const {projects: outdatedProjects, isFetching: areOutdatedProjectsFetching} =
+    useOutdatedSDKProjects({
       projectId: selectedProjectIds,
       enabled: pageFilterIsReady && !isDataAvailable,
     });
 
   const organization = useOrganization();
 
-  const hasMoreIneligibleProjectsThanVisible =
-    ineligibleProjects.length > MAX_LISTED_PROJECTS;
+  const hasMoreOutdatedProjectsThanVisible =
+    outdatedProjects.length > MAX_LISTED_PROJECTS;
 
-  if (areIneligibleProjectsFetching) {
+  if (areOutdatedProjectsFetching) {
     return null;
   }
 
@@ -40,7 +40,7 @@ export function NoDataMessage({Wrapper = DivWrapper, isDataAvailable}: Props) {
     return null;
   }
 
-  const firstIneligibleProjects = ineligibleProjects.slice(0, MAX_LISTED_PROJECTS + 1);
+  const firstOutdatedProjects = outdatedProjects.slice(0, MAX_LISTED_PROJECTS + 1);
 
   return (
     <Wrapper>
@@ -53,14 +53,14 @@ export function NoDataMessage({Wrapper = DivWrapper, isDataAvailable}: Props) {
           ),
         }
       )}{' '}
-      {ineligibleProjects.length > 0 &&
+      {outdatedProjects.length > 0 &&
         tct('You may also be missing data due to outdated SDKs: [projectList]', {
           documentation: (
             <ExternalLink href="https://docs.sentry.io/product/performance/query-insights/" />
           ),
           projectList: (
             <Fragment>
-              {firstIneligibleProjects.map((project, projectIndex) => {
+              {firstOutdatedProjects.map((project, projectIndex) => {
                 return (
                   <span key={project.id}>
                     <a
@@ -70,16 +70,16 @@ export function NoDataMessage({Wrapper = DivWrapper, isDataAvailable}: Props) {
                     >
                       {project.name}
                     </a>
-                    {projectIndex < firstIneligibleProjects.length - 1 && ', '}
+                    {projectIndex < firstOutdatedProjects.length - 1 && ', '}
                   </span>
                 );
               })}
             </Fragment>
           ),
         })}
-      {hasMoreIneligibleProjectsThanVisible &&
+      {hasMoreOutdatedProjectsThanVisible &&
         tct(' and [count] more.', {
-          count: ineligibleProjects.length - MAX_LISTED_PROJECTS,
+          count: outdatedProjects.length - MAX_LISTED_PROJECTS,
         })}{' '}
     </Wrapper>
   );

--- a/static/app/views/performance/database/noDataMessage.tsx
+++ b/static/app/views/performance/database/noDataMessage.tsx
@@ -29,18 +29,21 @@ export function NoDataMessage({Wrapper = DivWrapper, isDataAvailable}: Props) {
       enabled: pageFilterIsReady && !isDataAvailable,
     });
 
-  const {projects: denylistedProjects} = useDenylistedProjects({
-    projectId: selectedProjectIds,
-  });
+  const {projects: denylistedProjects, isFetching: areDenylistProjectsFetching} =
+    useDenylistedProjects({
+      projectId: selectedProjectIds,
+    });
 
-  // Hide message while fetching outdated projects
-  if (areOutdatedProjectsFetching) {
+  // Hide message while fetching outdated projects or denylisted projects
+  if (areOutdatedProjectsFetching || areDenylistProjectsFetching) {
     return null;
   }
 
   // Hide message if all conditions are satisfied
   if (
     isDataAvailable &&
+    !areOutdatedProjectsFetching &&
+    !areDenylistProjectsFetching &&
     outdatedProjects.length === 0 &&
     denylistedProjects.length === 0
   ) {
@@ -59,14 +62,16 @@ export function NoDataMessage({Wrapper = DivWrapper, isDataAvailable}: Props) {
           }
         )}{' '}
       {outdatedProjects.length > 0 &&
-        tct('You may be missing data due to outdated SDKs: [projectList]', {
+        tct('You may be missing data due to outdated SDKs: [projectList].', {
           projectList: <ProjectList projects={outdatedProjects} />,
         })}{' '}
       {denylistedProjects.length > 0 &&
         tct(
-          'Some of your projects have been omitted from metrics extraction. Please contact [support]. Omitted projects: [projectList]',
+          'Some of your projects have been omitted from database metrics extraction. Please contact [support]. Omitted projects: [projectList].',
           {
-            support: <ExternalLink href="https://sentry.io/support/" />,
+            support: (
+              <ExternalLink href="https://sentry.io/support/">support</ExternalLink>
+            ),
             projectList: <ProjectList projects={denylistedProjects} />,
           }
         )}

--- a/static/app/views/performance/database/noDataMessage.tsx
+++ b/static/app/views/performance/database/noDataMessage.tsx
@@ -67,7 +67,7 @@ export function NoDataMessage({Wrapper = DivWrapper, isDataAvailable}: Props) {
         })}{' '}
       {denylistedProjects.length > 0 &&
         tct(
-          'Some of your projects have been omitted from database metrics extraction. Please contact [support]. Omitted projects: [projectList].',
+          'Some of your projects have been omitted from query performance analysis. Please contact [support]. Omitted projects: [projectList].',
           {
             support: (
               <ExternalLink href="https://sentry.io/support/">support</ExternalLink>

--- a/static/app/views/performance/database/useDenylistedProjects.tsx
+++ b/static/app/views/performance/database/useDenylistedProjects.tsx
@@ -1,7 +1,6 @@
 import useProjects from 'sentry/utils/useProjects';
 
 interface Options {
-  enabled?: boolean;
   projectId?: string[];
 }
 

--- a/static/app/views/performance/database/useDenylistedProjects.tsx
+++ b/static/app/views/performance/database/useDenylistedProjects.tsx
@@ -21,7 +21,7 @@ export function useDenylistedProjects(options: Options = {}) {
 
   const projectsToCheck = shouldCheckAllProjects
     ? projects
-    : projects.filter(project => options?.projectId?.includes(project.id.toString()));
+    : projects.filter(project => projectId.includes(project.id.toString()));
 
   const denylistedProjects = projectsToCheck
     .filter(project => {

--- a/static/app/views/performance/database/useDenylistedProjects.tsx
+++ b/static/app/views/performance/database/useDenylistedProjects.tsx
@@ -24,7 +24,7 @@ export function useDenylistedProjects(options?: Options) {
 
   const denylistedProjects = projectsToCheck
     .filter(project => {
-      return !project?.features.includes('span-metrics-extraction');
+      return !project.features.includes('span-metrics-extraction');
     })
     .filter((item): item is NonNullable<typeof item> => Boolean(item));
 

--- a/static/app/views/performance/database/useDenylistedProjects.tsx
+++ b/static/app/views/performance/database/useDenylistedProjects.tsx
@@ -12,11 +12,12 @@ interface Options {
  * @param options.projectId List of project IDs to check against. If omitted, checks all organization projects
  * @returns List of projects
  */
-export function useDenylistedProjects(options?: Options) {
+export function useDenylistedProjects(options: Options = {}) {
   const {projects, fetching} = useProjects();
 
-  const shouldCheckAllProjects =
-    options?.projectId?.length === 0 || options?.projectId?.includes('-1');
+  const {projectId = []} = options;
+
+  const shouldCheckAllProjects = projectId.length === 0 || projectId.includes('-1');
 
   const projectsToCheck = shouldCheckAllProjects
     ? projects

--- a/static/app/views/performance/database/useDenylistedProjects.tsx
+++ b/static/app/views/performance/database/useDenylistedProjects.tsx
@@ -1,0 +1,29 @@
+import ProjectsStore from 'sentry/stores/projectsStore';
+
+interface Options {
+  enabled?: boolean;
+  projectId?: string[];
+}
+
+/**
+ * Returns a list of projects that are not eligible for span metrics
+ * because they were denylisted.
+ *
+ * @param options Additional options
+ * @param options.projectId List of project IDs to check against. If omitted, checks all organization projects
+ * @returns List of projects
+ */
+export function useDenylistedProjects(options?: Options) {
+  const projects = (options?.projectId ?? [])
+    .map(projectId => {
+      return ProjectsStore.getById(projectId);
+    })
+    .filter(project => {
+      return !project?.features.includes('span-metrics-extraction');
+    })
+    .filter((item): item is NonNullable<typeof item> => Boolean(item));
+
+  return {
+    projects,
+  };
+}

--- a/static/app/views/performance/database/useOutdatedSDKProjects.tsx
+++ b/static/app/views/performance/database/useOutdatedSDKProjects.tsx
@@ -16,11 +16,11 @@ interface Options {
  * @param options.projectId List of project IDs to check against. If omitted, checks all organization projects
  * @returns List of projects
  */
-export function useIneligibleProjects(options?: Options) {
+export function useOutdatedSDKProjects(options?: Options) {
   const response = useOrganizationSDKUpdates(options ?? {});
   const {data: availableUpdates} = response;
 
-  const ineligibleProjects = (availableUpdates ?? [])
+  const projects = (availableUpdates ?? [])
     .filter(update => {
       const platform = removeFlavorFromSDKName(update.sdkName);
       const minimumRequiredVersion = MIN_SDK_VERSION_BY_PLATFORM[platform];
@@ -41,7 +41,7 @@ export function useIneligibleProjects(options?: Options) {
 
   return {
     ...response,
-    ineligibleProjects,
+    projects,
   };
 }
 

--- a/static/app/views/performance/database/useOutdatedSDKProjects.tsx
+++ b/static/app/views/performance/database/useOutdatedSDKProjects.tsx
@@ -1,3 +1,5 @@
+import uniqBy from 'lodash/uniqBy';
+
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {useOrganizationSDKUpdates} from 'sentry/utils/useOrganizationSDKUpdates';
 import {semverCompare} from 'sentry/utils/versions';
@@ -41,7 +43,7 @@ export function useOutdatedSDKProjects(options?: Options) {
 
   return {
     ...response,
-    projects,
+    projects: uniqBy(projects, 'id'),
   };
 }
 

--- a/static/app/views/performance/landing/widgets/components/selectableList.tsx
+++ b/static/app/views/performance/landing/widgets/components/selectableList.tsx
@@ -96,7 +96,7 @@ export function TimeSpentInDatabaseWidgetEmptyStateWarning() {
     <StyledEmptyStateWarning>
       <PrimaryMessage>{t('No results found')}</PrimaryMessage>
       <SecondaryMessage>
-        <NoDataMessage Wrapper={Fragment} />
+        <NoDataMessage Wrapper={Fragment} isDataAvailable={false} />
       </SecondaryMessage>
     </StyledEmptyStateWarning>
   );


### PR DESCRIPTION
Several important improvements to the "No queries found" banner in the Database overview.

1. The "No queries found" message _only shows up if there's no data on the screen_. Previously, it did it's own check. This was portable, but it was inconsistent. People were seeing the banner even though there's data below. Now, the banner component is told by the parent whether there's data or not
2. Small improvements to copy and UI. Prevents duplicate projects in the lists, extracts some components, improves grammar, removes unused code.
3. New "You have omitted projects" message for those who have been denylisted, so they can contact support. Checks the metrics ingestion flag, since that's a 1:1 proxy for our denylisting.
4. The "No queries found", "You have outdated SDKs" and "Your projects were omitted" messages are now more independent. The omission message _always_ show up if true, even if there's data! The SDK message only shows up if there's no data. The "No data" messages shows up if there's no data
