### PR TITLE
feat(app-start): Add App Start Breakdown widget to Summary page

### DIFF
--- a/static/app/components/charts/barChart.tsx
+++ b/static/app/components/charts/barChart.tsx
@@ -40,8 +40,5 @@ export function BarChart({series, stacked, xAxis, animation, ...props}: BarChart
     return option;
   }, [xAxis]);
 
-  console.log('transformed series', transformedSeries);
-  console.log('props', props);
-  console.log('axis', xAxisOptions);
   return <BaseChart {...props} xAxis={xAxisOptions} series={transformedSeries} />;
 }

--- a/static/app/components/charts/barChart.tsx
+++ b/static/app/components/charts/barChart.tsx
@@ -40,5 +40,8 @@ export function BarChart({series, stacked, xAxis, animation, ...props}: BarChart
     return option;
   }, [xAxis]);
 
+  console.log('transformed series', transformedSeries);
+  console.log('props', props);
+  console.log('axis', xAxisOptions);
   return <BaseChart {...props} xAxis={xAxisOptions} series={transformedSeries} />;
 }

--- a/static/app/views/starfish/views/appStartup/appStartBreakdown.tsx
+++ b/static/app/views/starfish/views/appStartup/appStartBreakdown.tsx
@@ -7,15 +7,25 @@ import {space} from 'sentry/styles/space';
 import toPercent from 'sentry/utils/number/toPercent';
 import toRoundedPercent from 'sentry/utils/number/toRoundedPercent';
 
-const COLD_START_COLOR = '#F58C46';
-const WARM_START_COLOR = '#F2B712';
+export const COLD_START_COLOR = '#F58C46';
+export const WARM_START_COLOR = '#F2B712';
 
 interface Row {
   'count_starts(measurements.app_start_cold)': number;
   'count_starts(measurements.app_start_warm)': number;
 }
 
-function TooltipContents({row, total}: {row: Row; total: number}) {
+function TooltipContents({
+  row,
+  total,
+  coldStartKey,
+  warmStartKey,
+}: {
+  coldStartKey: string;
+  row: Row;
+  total: number;
+  warmStartKey: string;
+}) {
   return (
     <TooltipContentWrapper>
       <StartupType>
@@ -23,34 +33,49 @@ function TooltipContents({row, total}: {row: Row; total: number}) {
           <StartupDot style={{backgroundColor: COLD_START_COLOR}} />
           <StartupName>{t('Cold Start')}</StartupName>
         </StartupNameContainer>
-        {toRoundedPercent(row['count_starts(measurements.app_start_cold)'] / total)}
+        {toRoundedPercent(row[coldStartKey] / total)}
       </StartupType>
       <StartupType>
         <StartupNameContainer>
           <StartupDot style={{backgroundColor: WARM_START_COLOR}} />
           <StartupName>{t('Warm Start')}</StartupName>
         </StartupNameContainer>
-        {toRoundedPercent(row['count_starts(measurements.app_start_warm)'] / total)}
+        {toRoundedPercent(row[warmStartKey] / total)}
       </StartupType>
     </TooltipContentWrapper>
   );
 }
 
-function AppStartBreakdown({row}: {row: Row}) {
-  const total =
-    row['count_starts(measurements.app_start_cold)'] +
-    row['count_starts(measurements.app_start_warm)'];
+function AppStartBreakdown({
+  row,
+  coldStartKey = 'count_starts(measurements.app_start_cold)',
+  warmStartKey = 'count_starts(measurements.app_start_warm)',
+}: {
+  row: Row;
+  coldStartKey?: string;
+  warmStartKey?: string;
+}) {
+  const total = row[coldStartKey] + row[warmStartKey];
 
   if (total === 0) {
     return null;
   }
   return (
-    <Tooltip title={<TooltipContents row={row} total={total} />}>
+    <Tooltip
+      title={
+        <TooltipContents
+          row={row}
+          total={total}
+          coldStartKey={coldStartKey}
+          warmStartKey={warmStartKey}
+        />
+      }
+    >
       <RelativeOpsBreakdown>
         <div
           key="cold-start"
           style={{
-            width: toPercent(row['count_starts(measurements.app_start_cold)'] / total),
+            width: toPercent(row[coldStartKey] / total),
           }}
         >
           <RectangleRelativeOpsBreakdown
@@ -62,7 +87,7 @@ function AppStartBreakdown({row}: {row: Row}) {
         <div
           key="warm-start"
           style={{
-            width: toPercent(row['count_starts(measurements.app_start_warm)'] / total),
+            width: toPercent(row[warmStartKey] / total),
           }}
         >
           <RectangleRelativeOpsBreakdown

--- a/static/app/views/starfish/views/appStartup/appStartBreakdown.tsx
+++ b/static/app/views/starfish/views/appStartup/appStartBreakdown.tsx
@@ -11,8 +11,7 @@ export const COLD_START_COLOR = '#F58C46';
 export const WARM_START_COLOR = '#F2B712';
 
 interface Row {
-  'count_starts(measurements.app_start_cold)': number;
-  'count_starts(measurements.app_start_warm)': number;
+  [index: string]: number | undefined;
 }
 
 function TooltipContents({
@@ -33,14 +32,14 @@ function TooltipContents({
           <StartupDot style={{backgroundColor: COLD_START_COLOR}} />
           <StartupName>{t('Cold Start')}</StartupName>
         </StartupNameContainer>
-        {toRoundedPercent(row[coldStartKey] / total)}
+        {toRoundedPercent((row[coldStartKey] ?? 0) / total)}
       </StartupType>
       <StartupType>
         <StartupNameContainer>
           <StartupDot style={{backgroundColor: WARM_START_COLOR}} />
           <StartupName>{t('Warm Start')}</StartupName>
         </StartupNameContainer>
-        {toRoundedPercent(row[warmStartKey] / total)}
+        {toRoundedPercent((row[warmStartKey] ?? 0) / total)}
       </StartupType>
     </TooltipContentWrapper>
   );
@@ -55,7 +54,7 @@ function AppStartBreakdown({
   coldStartKey?: string;
   warmStartKey?: string;
 }) {
-  const total = row[coldStartKey] + row[warmStartKey];
+  const total = (row[coldStartKey] ?? 0) + (row[warmStartKey] ?? 0);
 
   if (total === 0) {
     return null;
@@ -75,7 +74,7 @@ function AppStartBreakdown({
         <div
           key="cold-start"
           style={{
-            width: toPercent(row[coldStartKey] / total),
+            width: toPercent((row[coldStartKey] ?? 0) / total),
           }}
         >
           <RectangleRelativeOpsBreakdown
@@ -87,7 +86,7 @@ function AppStartBreakdown({
         <div
           key="warm-start"
           style={{
-            width: toPercent(row[warmStartKey] / total),
+            width: toPercent((row[warmStartKey] ?? 0) / total),
           }}
         >
           <RectangleRelativeOpsBreakdown

--- a/static/app/views/starfish/views/appStartup/screenSummary/appStartBreakdownWidget.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/appStartBreakdownWidget.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {getInterval} from 'sentry/components/charts/utils';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {OpsDot} from 'sentry/components/events/opsBreakdown';
 import LoadingContainer from 'sentry/components/loading/loadingContainer';
 import TextOverflow from 'sentry/components/textOverflow';
@@ -74,7 +75,11 @@ function AppStartBreakdownWidget({additionalFilters}) {
   }
 
   if (!data) {
-    return null;
+    return (
+      <EmptyStateWarning small>
+        <p>{t('There was no app start data found for these two releases')}</p>
+      </EmptyStateWarning>
+    );
   }
 
   const startsByReleaseSeries = data.data.reduce((acc, row) => {
@@ -87,7 +92,6 @@ function AppStartBreakdownWidget({additionalFilters}) {
   return (
     <MiniChartPanel
       title={t('App Start')}
-      // button={<div style={{position: 'absolute'}}>potato</div>}
       subtitle={
         primaryRelease
           ? t(

--- a/static/app/views/starfish/views/appStartup/screenSummary/appStartBreakdownWidget.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/appStartBreakdownWidget.tsx
@@ -47,7 +47,11 @@ function AppStartBreakdownWidget({additionalFilters}) {
     query.addStringFilter(prepareQueryForLandingPage(searchQuery, false));
   }
 
-  const queryString = appendReleaseFilters(query, primaryRelease, secondaryRelease);
+  const queryString = `${appendReleaseFilters(
+    query,
+    primaryRelease,
+    secondaryRelease
+  )} span.description:["Cold Start","Warm Start"]`;
 
   const {data, isLoading} = useTableQuery({
     eventView: EventView.fromNewQueryWithPageFilters(

--- a/static/app/views/starfish/views/appStartup/screenSummary/appStartBreakdownWidget.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/appStartBreakdownWidget.tsx
@@ -1,0 +1,194 @@
+import omit from 'lodash/omit';
+
+import {BarChart} from 'sentry/components/charts/barChart';
+import BaseChart from 'sentry/components/charts/baseChart';
+import {getInterval} from 'sentry/components/charts/utils';
+import LoadingContainer from 'sentry/components/loading/loadingContainer';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {formatVersion} from 'sentry/utils/formatters';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {prepareQueryForLandingPage} from 'sentry/views/performance/data';
+import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
+import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
+import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
+import AppStartBreakdown, {
+  COLD_START_COLOR,
+  WARM_START_COLOR,
+} from 'sentry/views/starfish/views/appStartup/appStartBreakdown';
+import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
+
+const BAR_WIDTH = '20px';
+
+function AppStartBreakdownWidget({height}) {
+  const pageFilter = usePageFilters();
+  const {selection} = pageFilter;
+  const location = useLocation();
+  const {query: locationQuery} = location;
+
+  const {
+    primaryRelease,
+    secondaryRelease,
+    isLoading: isReleasesLoading,
+  } = useReleaseSelection();
+
+  const query = new MutableSearch([
+    // 'event.type:transaction',
+    // 'transaction.op:ui.load',
+    // ...(additionalFilters ?? []),
+  ]);
+
+  const searchQuery = decodeScalar(locationQuery.query, '');
+  if (searchQuery) {
+    query.addStringFilter(prepareQueryForLandingPage(searchQuery, false));
+  }
+
+  const queryString = appendReleaseFilters(query, primaryRelease, secondaryRelease);
+
+  const {data, isLoading, isError} = useTableQuery({
+    eventView: EventView.fromNewQueryWithPageFilters(
+      {
+        name: '',
+        fields: ['release', 'span.op', 'count()'],
+        topEvents: '2',
+        query: `${queryString} span.op:[app.start.warm,app.start.cold]`,
+        dataset: DiscoverDatasets.SPANS_METRICS,
+        version: 2,
+        interval: getInterval(
+          pageFilter.selection.datetime,
+          STARFISH_CHART_INTERVAL_FIDELITY
+        ),
+      },
+      pageFilter.selection
+    ),
+    enabled: !isReleasesLoading,
+    referrer: 'api.starfish.mobile-startup-breakdown',
+    initialData: {data: []},
+  });
+
+  if (isLoading) {
+    return <LoadingContainer isLoading />;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  console.log(data);
+  // const startsByReleaseSeries = data.data.reduce((acc, row) => {
+  //   if (!acc['span.op']) {
+  //     acc['span.op']
+  //   }
+
+  //   return acc;
+  // }, {});
+
+  // const series = data.data.reduce((acc, row) => {
+  //   if (!acc[row['span.op']]) {
+  //     // set up the default bar series
+  //     acc[row['span.op']] = {
+  //       name: row['span.op'],
+  //       color: row['span.op'] === 'app.start.cold' ? COLD_START_COLOR : WARM_START_COLOR,
+  //       type: 'bar',
+  //       stack: 'stack',
+  //       barWidth: BAR_WIDTH,
+  //       emphasis: {
+  //         focus: 'series',
+  //       },
+  //       data: [],
+  //     };
+  //   }
+
+  //   acc[row['span.op']].data.push({name: row.release, value: row['count()']});
+
+  //   return acc;
+  // }, {});
+
+  // console.log(startsByRelease);
+
+  // const keys = {coldStartKey: 'app.start.cold', warmStartKey: 'app.start.warm'};
+
+  const yAxisLabels: string[] = [];
+  if (secondaryRelease) {
+    yAxisLabels.push(secondaryRelease);
+  }
+  if (primaryRelease) {
+    yAxisLabels.push(primaryRelease);
+  }
+
+  console.log(yAxisLabels);
+  return (
+    <MiniChartPanel
+      title={t('App Start')}
+      subtitle={
+        primaryRelease
+          ? t(
+              '%s v. %s',
+              formatVersionAndCenterTruncate(primaryRelease, 12),
+              secondaryRelease ? formatVersionAndCenterTruncate(secondaryRelease, 12) : ''
+            )
+          : ''
+      }
+    >
+      <BaseChart
+        showTimeInTooltip={false}
+        yAxis={{
+          type: 'category',
+          data: yAxisLabels,
+          axisLabel: {
+            formatter: value => formatVersion(value),
+          },
+        }}
+        xAxis={{type: 'value'}}
+        legend={{show: true, right: 0}}
+        height={height}
+        grid={{
+          left: '20px',
+          right: '0',
+          top: '8px',
+          bottom: '0',
+          containLabel: true,
+        }}
+        series={[
+          {
+            name: 'app.start.cold',
+            color: COLD_START_COLOR,
+            type: 'bar',
+            stack: 'stack',
+            barWidth: BAR_WIDTH,
+            emphasis: {
+              focus: 'series',
+            },
+            data: [
+              {name: secondaryRelease ?? '', value: 0.7},
+              {name: primaryRelease ?? '', value: 0.3},
+            ],
+          },
+          {
+            name: 'app.start.warm',
+            color: WARM_START_COLOR,
+            type: 'bar',
+            stack: 'stack',
+            emphasis: {
+              focus: 'series',
+            },
+            barWidth: BAR_WIDTH,
+            data: [
+              {name: secondaryRelease ?? '', value: 0.3},
+              {name: primaryRelease ?? '', value: 0.7},
+            ],
+          },
+        ]}
+      />
+    </MiniChartPanel>
+  );
+}
+
+export default AppStartBreakdownWidget;

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -85,7 +85,7 @@ function ScreenSummary() {
                   <ReleaseComparisonSelector />
                 </Container>
                 <ErrorBoundary mini>
-                  <AppStartWidgets />
+                  <AppStartWidgets additionalFilters={[]} />
                 </ErrorBoundary>
               </PageFiltersContainer>
             </Layout.Main>

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -23,6 +23,8 @@ import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releas
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 
+import AppStartWidgets from './widgets';
+
 type Query = {
   primaryRelease: string;
   project: string;
@@ -82,7 +84,9 @@ function ScreenSummary() {
                   </PageFilterBar>
                   <ReleaseComparisonSelector />
                 </Container>
-                <ErrorBoundary mini>Screen detail page content</ErrorBoundary>
+                <ErrorBoundary mini>
+                  <AppStartWidgets />
+                </ErrorBoundary>
               </PageFiltersContainer>
             </Layout.Main>
           </Layout.Body>

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -85,7 +85,9 @@ function ScreenSummary() {
                   <ReleaseComparisonSelector />
                 </Container>
                 <ErrorBoundary mini>
-                  <AppStartWidgets additionalFilters={[]} />
+                  <AppStartWidgets
+                    additionalFilters={[`transaction:${transactionName}`]}
+                  />
                 </ErrorBoundary>
               </PageFiltersContainer>
             </Layout.Main>

--- a/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
@@ -1,28 +1,42 @@
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 
-function SummaryWidgets() {
+import AppStartBreakdownWidget from './appStartBreakdownWidget';
+
+const {TRANSACTION} = SpanMetricsField;
+
+const YAXIS_COLS = [
+  // 'count_start(measurements.app_start_cold)',
+  // 'count_start(measurements.app_start_warm)',
+  'count()',
+];
+
+function SummaryWidgets({additionalFilters}) {
   return (
     <WidgetLayout>
-      <WidgetPosition style={{gridArea: '1 / 1 / 1 / 1'}}>App Start</WidgetPosition>
-      <WidgetPosition style={{gridArea: '2 / 1 / 2 / 1'}}>Count</WidgetPosition>
+      <WidgetPosition style={{gridArea: '1 / 1 / 1 / 1'}}>
+        <AppStartBreakdownWidget height={140} />
+      </WidgetPosition>
+
+      {/* TODO: these are the new widgets that will populate the grid */}
+      {/* <WidgetPosition style={{gridArea: '2 / 1 / 2 / 1'}}>
+        System v Application
+      </WidgetPosition>
       <WidgetPosition style={{gridArea: '1 / 2 / 1 / 2'}}>Cold Start</WidgetPosition>
       <WidgetPosition style={{gridArea: '2 / 2 / 2 / 2'}}>Warm Start</WidgetPosition>
-      <WidgetPosition style={{gridArea: '1 / 3 / 3 / 3'}}>
-        Framework Initializer functions
+      <WidgetPosition style={{gridArea: '1 / 3 / 2 / 3'}}>
+        Dynamically loaded libraries
       </WidgetPosition>
+      <WidgetPosition style={{gridArea: '2 / 3 / 3 / 3'}}>Count</WidgetPosition> */}
     </WidgetLayout>
   );
 }
 
 export default SummaryWidgets;
 
-const WidgetPosition = styled('div')`
-  background: lightgray;
-  border: 1px solid black;
-  border-radius: 4px;
-`;
+const WidgetPosition = styled('div')``;
 
 const WidgetLayout = styled('div')`
   display: grid;

--- a/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
@@ -1,23 +1,14 @@
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
 
 import AppStartBreakdownWidget from './appStartBreakdownWidget';
-
-const {TRANSACTION} = SpanMetricsField;
-
-const YAXIS_COLS = [
-  // 'count_start(measurements.app_start_cold)',
-  // 'count_start(measurements.app_start_warm)',
-  'count()',
-];
 
 function SummaryWidgets({additionalFilters}) {
   return (
     <WidgetLayout>
       <WidgetPosition style={{gridArea: '1 / 1 / 1 / 1'}}>
-        <AppStartBreakdownWidget height={140} />
+        <AppStartBreakdownWidget additionalFilters={additionalFilters} />
       </WidgetPosition>
 
       {/* TODO: these are the new widgets that will populate the grid */}

--- a/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
@@ -7,27 +7,14 @@ import AppStartBreakdownWidget from './appStartBreakdownWidget';
 function SummaryWidgets({additionalFilters}) {
   return (
     <WidgetLayout>
-      <WidgetPosition style={{gridArea: '1 / 1 / 1 / 1'}}>
+      <div style={{gridArea: '1 / 1 / 1 / 1'}}>
         <AppStartBreakdownWidget additionalFilters={additionalFilters} />
-      </WidgetPosition>
-
-      {/* TODO: these are the new widgets that will populate the grid */}
-      {/* <WidgetPosition style={{gridArea: '2 / 1 / 2 / 1'}}>
-        System v Application
-      </WidgetPosition>
-      <WidgetPosition style={{gridArea: '1 / 2 / 1 / 2'}}>Cold Start</WidgetPosition>
-      <WidgetPosition style={{gridArea: '2 / 2 / 2 / 2'}}>Warm Start</WidgetPosition>
-      <WidgetPosition style={{gridArea: '1 / 3 / 2 / 3'}}>
-        Dynamically loaded libraries
-      </WidgetPosition>
-      <WidgetPosition style={{gridArea: '2 / 3 / 3 / 3'}}>Count</WidgetPosition> */}
+      </div>
     </WidgetLayout>
   );
 }
 
 export default SummaryWidgets;
-
-const WidgetPosition = styled('div')``;
 
 const WidgetLayout = styled('div')`
   display: grid;

--- a/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+import {space} from 'sentry/styles/space';
+
+function SummaryWidgets() {
+  return (
+    <WidgetLayout>
+      <WidgetPosition style={{gridArea: '1 / 1 / 1 / 1'}}>App Start</WidgetPosition>
+      <WidgetPosition style={{gridArea: '2 / 1 / 2 / 1'}}>Count</WidgetPosition>
+      <WidgetPosition style={{gridArea: '1 / 2 / 1 / 2'}}>Cold Start</WidgetPosition>
+      <WidgetPosition style={{gridArea: '2 / 2 / 2 / 2'}}>Warm Start</WidgetPosition>
+      <WidgetPosition style={{gridArea: '1 / 3 / 3 / 3'}}>
+        Framework Initializer functions
+      </WidgetPosition>
+    </WidgetLayout>
+  );
+}
+
+export default SummaryWidgets;
+
+const WidgetPosition = styled('div')`
+  background: lightgray;
+  border: 1px solid black;
+  border-radius: 4px;
+`;
+
+const WidgetLayout = styled('div')`
+  display: grid;
+  grid-template-columns: 33% 33% 33%;
+  grid-template-rows: 140px 140px;
+  gap: ${space(1)};
+`;


### PR DESCRIPTION
Reuses the App Start Breakdown component in the overview table to render a breakdown of app starts for each release.

<img width="831" alt="Screenshot 2023-12-15 at 4 01 30 PM" src="https://github.com/getsentry/sentry/assets/22846452/ddf65dde-b2d5-45ab-a697-a2ed0619c09e">

To make the component generalizable, I needed to pass keys for accessing an object with count data for each kind of start as opposed to hardcoding them.