### PR TITLE
ref(slack): Handle getsentry billing attachment in block kit

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1874,7 +1874,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Updated spike protection heuristic
     "organizations:spike-protection-decay-heuristic": False,
     # Enable Slack messages using Block Kit
-    "organizations:slack-block-kit": False,
+    "organizations:slack-block-kit": True,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1874,7 +1874,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Updated spike protection heuristic
     "organizations:spike-protection-decay-heuristic": False,
     # Enable Slack messages using Block Kit
-    "organizations:slack-block-kit": True,
+    "organizations:slack-block-kit": False,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -55,7 +55,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
 
         def send_notification(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             rules = [f.rule for f in futures]
-            # TODO: handle additional_attachments for block kit
             if features.has("organizations:slack-block-kit", event.group.project.organization):
                 blocks = build_group_attachment(
                     event.group,
@@ -64,6 +63,12 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     rules=rules,
                     notification_uuid=notification_uuid,
                 )
+                additional_attachment = get_additional_attachment(
+                    integration, self.project.organization
+                )
+                if additional_attachment:
+                    for block in additional_attachment:
+                        blocks["blocks"].append(block)
 
                 if blocks.get("blocks"):
                     payload = {

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -87,8 +87,8 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
             "accessory": {
                 "type": "button",
                 "text": {"type": "plain_text", "text": action.name, "emoji": True},
-                "style": "primary",
-                "value": "click_me_123",
+                "style": action.style,
+                "value": action.value,
                 "url": action.url,
             },
         }

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -76,6 +76,7 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
 
         return button
 
+    @staticmethod
     def get_link_button(action):
         return {
             "type": "section",

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -76,6 +76,22 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
 
         return button
 
+    def get_link_button(action):
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": action.label,
+            },
+            "accessory": {
+                "type": "button",
+                "text": {"type": "plain_text", "text": action.name, "emoji": True},
+                "style": "primary",
+                "value": "click_me_123",
+                "url": action.url,
+            },
+        }
+
     @staticmethod
     def get_action_block(actions: Sequence[Tuple[str, Optional[str], str]]) -> SlackBlock:
         class SlackBlockType(TypedDict):

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -500,8 +500,8 @@ class SlackActionEndpoint(Endpoint):
 
         action_option = self.get_action_option(slack_request=slack_request)
 
-        # If a user is just clicking our auto response in the messages tab we just return a 200
-        if action_option == "sentry_docs_link_clicked":
+        # If a user is just clicking a button link we return a 200
+        if action_option in ("sentry_docs_link_clicked", "grace_period_warning"):
             return self.respond()
 
         if action_option in UNFURL_ACTION_OPTIONS:


### PR DESCRIPTION
If getsentry adds a billing attachment to Slack, add it to the blocks.

[Here](https://github.com/getsentry/getsentry/pull/12401) is the companion getsentry PR, but this one needs to be merged first.

Closes #61457 