### PR TITLE
fix(user token): Hide API token after creation

### DIFF
--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -46,7 +46,7 @@ class ApiTokensEndpoint(Endpoint):
                 "application"
             )
         )
-
+        # Token value will NOT be present
         return Response(serialize(token_list, request.user))
 
     @method_decorator(never_cache)
@@ -74,7 +74,8 @@ class ApiTokensEndpoint(Endpoint):
 
             analytics.record("api_token.created", user_id=request.user.id)
 
-            return Response(serialize(token, request.user), status=201)
+            # This is THE ONLY TIME that the token is available
+            return Response(serialize(token, request.user, include_token=True), status=201)
         return Response(serializer.errors, status=400)
 
     @method_decorator(never_cache)

--- a/src/sentry/api/serializers/models/apitoken.py
+++ b/src/sentry/api/serializers/models/apitoken.py
@@ -4,7 +4,7 @@ from sentry.models.apitoken import ApiToken
 
 @register(ApiToken)
 class ApiTokenSerializer(Serializer):
-    def get_attrs(self, item_list, user):
+    def get_attrs(self, item_list, user, **kwargs):
         apps = {
             d["id"]: d
             for d in serialize({i.application for i in item_list if i.application_id}, user)
@@ -17,7 +17,7 @@ class ApiTokenSerializer(Serializer):
             }
         return attrs
 
-    def serialize(self, obj, attrs, user):
+    def serialize(self, obj, attrs, user, **kwargs):
         data = {
             "id": str(obj.id),
             "scopes": obj.get_scopes(),
@@ -27,6 +27,13 @@ class ApiTokenSerializer(Serializer):
             "state": attrs.get("state"),
         }
         if not attrs["application"]:
-            data["token"] = obj.token
+            include_token = kwargs.get("include_token", False)
+            if include_token:
+                data["token"] = obj.token
+
             data["refreshToken"] = obj.refresh_token
+
+        data["tokenLastCharacters"] = (
+            obj.token_last_characters if obj.token_last_characters else obj.token[:4]
+        )
         return data

--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -90,7 +90,8 @@ interface BaseApiToken {
 export interface InternalAppApiToken extends BaseApiToken {
   application: null;
   refreshToken: string;
-  token: string;
+  token?: string;
+  tokenLastCharacters?: string;
 }
 
 export type ApiApplication = {

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -8,14 +8,17 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
-import {Permissions} from 'sentry/types';
+import {InternalAppApiToken, Permissions} from 'sentry/types';
+import getDynamicText from 'sentry/utils/getDynamicText';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
+import ShowNewToken from 'sentry/views/settings/components/showNewToken';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import PermissionSelection from 'sentry/views/settings/organizationDeveloperSettings/permissionSelection';
 
 const API_INDEX_ROUTE = '/settings/account/api/auth-tokens/';
 type State = {
+  newToken: InternalAppApiToken | null;
   permissions: Permissions;
 };
 
@@ -31,6 +34,7 @@ export default class ApiNewToken extends Component<{}, State> {
         Release: 'no-access',
         Organization: 'no-access',
       },
+      newToken: null,
     };
   }
 
@@ -38,12 +42,14 @@ export default class ApiNewToken extends Component<{}, State> {
     browserHistory.push(normalizeUrl(API_INDEX_ROUTE));
   };
 
-  onSubmitSuccess = () => {
+  handleGoBack = () => {
     browserHistory.push(normalizeUrl(API_INDEX_ROUTE));
   };
 
   render() {
     const {permissions} = this.state;
+    const {newToken} = this.state;
+
     return (
       <SentryDocumentTitle title={t('Create User Auth Token')}>
         <div>
@@ -61,34 +67,46 @@ export default class ApiNewToken extends Component<{}, State> {
               }
             )}
           </TextBlock>
-          <Panel>
-            <PanelHeader>{t('Permissions')}</PanelHeader>
-            <ApiForm
-              apiMethod="POST"
-              apiEndpoint="/api-tokens/"
-              initialData={{scopes: []}}
-              onSubmitSuccess={this.onSubmitSuccess}
-              onCancel={this.onCancel}
-              footerStyle={{
-                marginTop: 0,
-                paddingRight: 20,
-              }}
-              submitDisabled={Object.values(permissions).every(
-                value => value === 'no-access'
-              )}
-              submitLabel={t('Create Token')}
-            >
-              <PanelBody>
-                <PermissionSelection
-                  appPublished={false}
-                  permissions={permissions}
-                  onChange={value => {
-                    this.setState({permissions: value});
-                  }}
-                />
-              </PanelBody>
-            </ApiForm>
-          </Panel>
+          {newToken ? (
+            <ShowNewToken
+              token={
+                getDynamicText({value: newToken.token, fixed: 'CI_AUTH_TOKEN'}) ||
+                'CI_AUTH_TOKEN'
+              }
+              handleGoBack={this.handleGoBack}
+            />
+          ) : (
+            <Panel>
+              <PanelHeader>{t('Permissions')}</PanelHeader>
+              <ApiForm
+                apiMethod="POST"
+                apiEndpoint="/api-tokens/"
+                initialData={{scopes: []}}
+                onSubmitSuccess={response => {
+                  this.setState({newToken: response});
+                }}
+                onCancel={this.onCancel}
+                footerStyle={{
+                  marginTop: 0,
+                  paddingRight: 20,
+                }}
+                submitDisabled={Object.values(permissions).every(
+                  value => value === 'no-access'
+                )}
+                submitLabel={t('Create Token')}
+              >
+                <PanelBody>
+                  <PermissionSelection
+                    appPublished={false}
+                    permissions={permissions}
+                    onChange={value => {
+                      this.setState({permissions: value});
+                    }}
+                  />
+                </PanelBody>
+              </ApiForm>
+            </Panel>
+          )}
         </div>
       </SentryDocumentTitle>
     );

--- a/static/app/views/settings/account/apiTokenRow.tsx
+++ b/static/app/views/settings/account/apiTokenRow.tsx
@@ -3,12 +3,12 @@ import styled from '@emotion/styled';
 import {Button} from 'sentry/components/button';
 import DateTime from 'sentry/components/dateTime';
 import PanelItem from 'sentry/components/panels/panelItem';
-import TextCopyInput from 'sentry/components/textCopyInput';
 import {IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {InternalAppApiToken} from 'sentry/types';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import {tokenPreview} from 'sentry/views/settings/organizationAuthTokens';
 
 type Props = {
   onRemove: (token: InternalAppApiToken) => void;
@@ -19,17 +19,24 @@ function ApiTokenRow({token, onRemove}: Props) {
   return (
     <StyledPanelItem>
       <Controls>
-        <InputWrapper>
-          <TextCopyInput>
-            {getDynamicText({value: token.token, fixed: 'CI_AUTH_TOKEN'})}
-          </TextCopyInput>
-        </InputWrapper>
-        <Button
-          onClick={() => onRemove(token)}
-          icon={<IconSubtract isCircled size="xs" />}
-        >
-          {t('Remove')}
-        </Button>
+        {token.tokenLastCharacters && (
+          <TokenPreview aria-label={t('Token preview')}>
+            {tokenPreview(
+              getDynamicText({
+                value: token.tokenLastCharacters,
+                fixed: 'ABCD',
+              })
+            )}
+          </TokenPreview>
+        )}
+        <ButtonWrapper>
+          <Button
+            onClick={() => onRemove(token)}
+            icon={<IconSubtract isCircled size="xs" />}
+          >
+            {t('Remove')}
+          </Button>
+        </ButtonWrapper>
       </Controls>
 
       <Details>
@@ -64,12 +71,6 @@ const Controls = styled('div')`
   margin-bottom: ${space(1)};
 `;
 
-const InputWrapper = styled('div')`
-  font-size: ${p => p.theme.fontSizeRelativeSmall};
-  flex: 1;
-  margin-right: ${space(1)};
-`;
-
 const Details = styled('div')`
   display: flex;
   margin-top: ${space(1)};
@@ -94,6 +95,20 @@ const Heading = styled('div')`
   text-transform: uppercase;
   color: ${p => p.theme.subText};
   margin-bottom: ${space(1)};
+`;
+
+const TokenPreview = styled('div')`
+  color: ${p => p.theme.gray300};
+`;
+
+const ButtonWrapper = styled('div')`
+  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: flex-end;
+  font-size: ${p => p.theme.fontSizeSmall};
+  gap: ${space(1)};
 `;
 
 export default ApiTokenRow;

--- a/static/app/views/settings/components/showNewToken.tsx
+++ b/static/app/views/settings/components/showNewToken.tsx
@@ -1,0 +1,66 @@
+import {MouseEventHandler} from 'react';
+import styled from '@emotion/styled';
+
+import Alert from 'sentry/components/alert';
+import {Button} from 'sentry/components/button';
+import FieldGroup from 'sentry/components/forms/fieldGroup';
+import PanelItem from 'sentry/components/panels/panelItem';
+import TextCopyInput from 'sentry/components/textCopyInput';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+function ShowNewToken({
+  token,
+  handleGoBack,
+}: {
+  handleGoBack: MouseEventHandler;
+  token: string;
+}) {
+  return (
+    <div>
+      <Alert type="warning" showIcon system>
+        {t("Please copy this token to a safe place — it won't be shown again!")}
+      </Alert>
+
+      <PanelItem>
+        <InputWrapper>
+          <FieldGroupNoPadding
+            label={t('Token')}
+            help={t('You can only view this token when it was created.')}
+            inline
+            flexibleControlStateSize
+          >
+            <TextCopyInput aria-label={t('Generated token')}>{token}</TextCopyInput>
+          </FieldGroupNoPadding>
+        </InputWrapper>
+      </PanelItem>
+
+      <PanelItem>
+        <ButtonWrapper>
+          <Button onClick={handleGoBack} priority="primary">
+            {t('Done')}
+          </Button>
+        </ButtonWrapper>
+      </PanelItem>
+    </div>
+  );
+}
+
+const InputWrapper = styled('div')`
+  flex: 1;
+`;
+
+const FieldGroupNoPadding = styled(FieldGroup)`
+  padding: 0;
+`;
+
+const ButtonWrapper = styled('div')`
+  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-size: ${p => p.theme.fontSizeSmall};
+  gap: ${space(1)};
+`;
+
+export default ShowNewToken;

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
@@ -7,8 +7,6 @@ import {
   addLoadingMessage,
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
-import Alert from 'sentry/components/alert';
-import {Button} from 'sentry/components/button';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import TextField from 'sentry/components/forms/fields/textField';
 import Form from 'sentry/components/forms/form';
@@ -16,11 +14,8 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
-import PanelItem from 'sentry/components/panels/panelItem';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {Organization, OrgAuthToken} from 'sentry/types';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
@@ -30,6 +25,7 @@ import useApi from 'sentry/utils/useApi';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withOrganization from 'sentry/utils/withOrganization';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
+import ShowNewToken from 'sentry/views/settings/components/showNewToken';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import {makeFetchOrgAuthTokensForOrgQueryKey} from 'sentry/views/settings/organizationAuthTokens';
 
@@ -132,55 +128,16 @@ function AuthTokenCreateForm({
   );
 }
 
-function ShowNewToken({
-  token,
-  organization,
-}: {
-  organization: Organization;
-  token: OrgAuthTokenWithToken;
-}) {
-  const handleGoBack = useCallback(() => {
-    browserHistory.push(normalizeUrl(`/settings/${organization.slug}/auth-tokens/`));
-  }, [organization.slug]);
-
-  return (
-    <div>
-      <Alert type="warning" showIcon system>
-        {t("Please copy this token to a safe place — it won't be shown again!")}
-      </Alert>
-
-      <PanelItem>
-        <InputWrapper>
-          <FieldGroupNoPadding
-            label={t('Token')}
-            help={t('You can only view this token when it was created.')}
-            inline
-            flexibleControlStateSize
-          >
-            <TextCopyInput aria-label={t('Generated token')}>
-              {getDynamicText({value: token.token, fixed: 'ORG_AUTH_TOKEN'})}
-            </TextCopyInput>
-          </FieldGroupNoPadding>
-        </InputWrapper>
-      </PanelItem>
-
-      <PanelItem>
-        <ButtonWrapper>
-          <Button onClick={handleGoBack} priority="primary">
-            {t('Done')}
-          </Button>
-        </ButtonWrapper>
-      </PanelItem>
-    </div>
-  );
-}
-
 export function OrganizationAuthTokensNewAuthToken({
   organization,
 }: {
   organization: Organization;
 }) {
   const [newToken, setNewToken] = useState<OrgAuthTokenWithToken | null>(null);
+
+  const handleGoBack = useCallback(() => {
+    browserHistory.push(normalizeUrl(`/settings/${organization.slug}/auth-tokens/`));
+  }, [organization.slug]);
 
   return (
     <div>
@@ -205,7 +162,10 @@ export function OrganizationAuthTokensNewAuthToken({
 
         <PanelBody>
           {newToken ? (
-            <ShowNewToken token={newToken} organization={organization} />
+            <ShowNewToken
+              token={getDynamicText({value: newToken.token, fixed: 'ORG_AUTH_TOKEN'})}
+              handleGoBack={handleGoBack}
+            />
           ) : (
             <AuthTokenCreateForm
               organization={organization}
@@ -219,23 +179,6 @@ export function OrganizationAuthTokensNewAuthToken({
 }
 
 export default withOrganization(OrganizationAuthTokensNewAuthToken);
-
-const InputWrapper = styled('div')`
-  flex: 1;
-`;
-
-const ButtonWrapper = styled('div')`
-  margin-left: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  font-size: ${p => p.theme.fontSizeSmall};
-  gap: ${space(1)};
-`;
-
-const FieldGroupNoPadding = styled(FieldGroup)`
-  padding: 0;
-`;
 
 const ScopeHelpText = styled('div')`
   color: ${p => p.theme.gray300};


### PR DESCRIPTION
Hide the user API token after it's been created. Currently the API token in user settings can always be seen, even after creation. This experience also deviates from the org auth tokens. To keep both experiences consistent, and increase security around tokens from leaking, we are updating the API token contract and UI.

- The GET endpoint for /api-tokens will no longer include the actual value of the token
- The API contract for /api-tokens will include a new field of `tokenLastCharacters`
- A general component for showing new tokens has been created and utilized to keep token experiences consistent

Fixes ENTERPRISE-1


https://github.com/getsentry/sentry/assets/5581484/6b1e1512-8859-4477-bb9d-3cfef59e2766