### PR TITLE
feat(crons): Add disable button to monitor details

### DIFF
--- a/static/app/views/monitors/components/detailsSidebar.tsx
+++ b/static/app/views/monitors/components/detailsSidebar.tsx
@@ -57,7 +57,7 @@ export default function DetailsSidebar({monitorEnv, monitor}: Props) {
           )}
         </div>
         <div>
-          {monitorEnv?.nextCheckIn ? (
+          {monitor.status !== 'disabled' && monitorEnv?.nextCheckIn ? (
             <TimeSince
               unitStyle="regular"
               liveUpdateInterval="second"

--- a/static/app/views/monitors/components/monitorHeaderActions.tsx
+++ b/static/app/views/monitors/components/monitorHeaderActions.tsx
@@ -13,6 +13,8 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 import {Monitor} from '../types';
 
+import {StatusToggleButton} from './statusToggleButton';
+
 type Props = {
   monitor: Monitor;
   onUpdate: (data: Monitor) => void;
@@ -45,26 +47,28 @@ function MonitorHeaderActions({monitor, orgId, onUpdate}: Props) {
     onUpdate?.(resp);
   };
 
-  const toggleStatus = () => handleUpdate({isMuted: !monitor.isMuted});
+  const toggleMute = () => handleUpdate({isMuted: !monitor.isMuted});
+
+  const toggleStatus = () =>
+    handleUpdate({status: monitor.status === 'active' ? 'disabled' : 'active'});
 
   return (
     <ButtonBar gap={1}>
       <FeedbackWidgetButton />
+      <Button
+        size="sm"
+        icon={monitor.isMuted ? <IconSubscribed /> : <IconUnsubscribed />}
+        onClick={toggleMute}
+      >
+        {monitor.isMuted ? t('Unmute') : t('Mute')}
+      </Button>
+      <StatusToggleButton size="sm" onClick={toggleStatus} monitor={monitor} />
       <Confirm
         onConfirm={handleDelete}
         message={t('Are you sure you want to permanently delete this cron monitor?')}
       >
-        <Button size="sm" icon={<IconDelete />}>
-          {t('Delete')}
-        </Button>
+        <Button size="sm" icon={<IconDelete size="xs" />} aria-label={t('Delete')} />
       </Confirm>
-      <Button
-        size="sm"
-        icon={monitor.isMuted ? <IconSubscribed /> : <IconUnsubscribed />}
-        onClick={toggleStatus}
-      >
-        {monitor.isMuted ? t('Unmute') : t('Mute')}
-      </Button>
       <Button
         priority="primary"
         size="sm"

--- a/static/app/views/monitors/components/statusToggleButton.tsx
+++ b/static/app/views/monitors/components/statusToggleButton.tsx
@@ -1,0 +1,23 @@
+import {BaseButtonProps, Button} from 'sentry/components/button';
+import {IconPause, IconPlay} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {Monitor} from 'sentry/views/monitors/types';
+
+interface StatusToggleButtonProps extends BaseButtonProps {
+  monitor: Monitor;
+}
+
+function StatusToggleButton({monitor, ...props}: StatusToggleButtonProps) {
+  const {status} = monitor;
+  const isDisabeld = status === 'disabled';
+
+  const Icon = isDisabeld ? IconPlay : IconPause;
+
+  const label = isDisabeld
+    ? t('Reactive this monitor')
+    : t('Disable this monitor and discard incoming check-ins');
+
+  return <Button icon={<Icon />} aria-label={label} title={label} {...props} />;
+}
+
+export {StatusToggleButton};


### PR DESCRIPTION
Adds a button to the monitor header actions to toggle disabled / active state of a monitor.

Looks like this

![clipboard.png](https://i.imgur.com/iBfR6u2.png)

When disabled

![clipboard.png](https://i.imgur.com/ircrN4H.png)