### PR TITLE
ref(crons): Improve overflow menu icon size

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -64,8 +64,8 @@ export function TimelineTableRow({
                     <EnvActionButton
                       {...triggerProps}
                       aria-label={t('Monitor environment actions')}
-                      size="zero"
-                      icon={<IconEllipsis size="sm" />}
+                      size="xs"
+                      icon={<IconEllipsis />}
                     />
                   )}
                   items={[


### PR DESCRIPTION
Size xs makes more sense with the icon inheriting the size here

Before

![image](https://github.com/getsentry/sentry/assets/1421724/b6742d81-ea88-4765-8f21-259afb208d38)

After

![image](https://github.com/getsentry/sentry/assets/1421724/54fc3bcc-1901-430b-afe9-3d730ff37ecc)
