### PR TITLE
feat(crons): Add 'View Environment' item in overview overflow menu

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -40,6 +40,8 @@ export function TimelineTableRow({
   onDeleteEnvironment,
   ...timelineProps
 }: Props) {
+  const organization = useOrganization();
+
   const [isExpanded, setExpanded] = useState(
     monitor.environments.length <= MAX_SHOWN_ENVIRONMENTS
   );
@@ -69,6 +71,11 @@ export function TimelineTableRow({
                     />
                   )}
                   items={[
+                    {
+                      label: t('View Environment'),
+                      key: 'view',
+                      to: `/organizations/${organization.slug}/crons/${monitor.slug}/?environment=${name}`,
+                    },
                     {
                       label: t('Delete Environment'),
                       key: 'delete',


### PR DESCRIPTION
Looks like this. Useful to quickly get into the details for the
environment

![clipboard.png](https://i.imgur.com/fNG8gdv.png)