### PR TITLE
feat(stacktrace-link): Implement new Stacktrace Link designs

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -2,7 +2,10 @@ import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiC
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {EventEntryExceptionGroup as EventEntryExceptionGroupFixture} from 'sentry-fixture/eventEntryExceptionGroup';
 import {EventStacktraceFrame} from 'sentry-fixture/eventStacktraceFrame';
-import {Project, Project as ProjectFixture} from 'sentry-fixture/project';
+import {Organization} from 'sentry-fixture/organization';
+import {Project} from 'sentry-fixture/project';
+import {Repository} from 'sentry-fixture/repository';
+import {RepositoryProjectPathConfig} from 'sentry-fixture/repositoryProjectPathConfig';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
@@ -14,14 +17,25 @@ import {EntryType} from 'sentry/types';
 import {StackType, StackView} from 'sentry/types/stacktrace';
 
 describe('Exception Content', function () {
+  const organization = Organization();
+  const project = Project({});
+  const integration = TestStubs.GitHubIntegration();
+  const repo = Repository({integrationId: integration.id});
+  const config = RepositoryProjectPathConfig({project, repo, integration});
+
   beforeEach(function () {
+    MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: `/prompts-activity/`,
     });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/stacktrace-link/`,
+      body: {config, sourceUrl: 'https://something.io', integrations: [integration]},
+    });
+    ProjectsStore.loadInitialData([project]);
   });
 
   it('display redacted values from exception entry', async function () {
-    const project = Project({id: '0'});
     const projectDetails = Project({
       ...project,
       relayPiiConfig: JSON.stringify(DataScrubbingRelayPiiConfig()),
@@ -30,11 +44,14 @@ describe('Exception Content', function () {
       url: `/projects/org-slug/${project.slug}/`,
       body: projectDetails,
     });
-    ProjectsStore.loadInitialData([project]);
 
-    const {organization, router, routerContext} = initializeOrg({
+    const {
+      organization: org,
+      router,
+      routerContext,
+    } = initializeOrg({
       router: {
-        location: {query: {project: '0'}},
+        location: {query: {project: project.id}},
       },
       projects: [project],
     });
@@ -127,7 +144,7 @@ describe('Exception Content', function () {
         meta={event._meta!.entries[0].data.values}
         projectSlug={project.slug}
       />,
-      {organization, router, context: routerContext}
+      {organization: org, router, context: routerContext}
     );
 
     expect(screen.getAllByText(/redacted/)).toHaveLength(2);
@@ -159,6 +176,7 @@ describe('Exception Content', function () {
 
   it('respects platform overrides in stacktrace frames', function () {
     const event = EventFixture({
+      projectID: project.id,
       platform: 'python',
       entries: [
         {
@@ -188,7 +206,7 @@ describe('Exception Content', function () {
         stackView={StackView.APP}
         event={event}
         values={event.entries[0].data.values}
-        projectSlug="project-slug"
+        projectSlug={project.slug}
       />
     );
 
@@ -200,9 +218,14 @@ describe('Exception Content', function () {
   });
 
   describe('exception groups', function () {
-    const event = EventFixture({entries: [EventEntryExceptionGroupFixture()]});
-    const project = ProjectFixture();
+    const event = EventFixture({
+      entries: [EventEntryExceptionGroupFixture()],
+      projectID: project.id,
+    });
+
     beforeEach(() => {
+      MockApiClient.clearMockResponses();
+
       const promptResponse = {
         dismissed_ts: undefined,
         snoozed_ts: undefined,
@@ -211,6 +234,11 @@ describe('Exception Content', function () {
         url: '/prompts-activity/',
         body: promptResponse,
       });
+      MockApiClient.addMockResponse({
+        url: `/projects/${organization.slug}/${project.slug}/stacktrace-link/`,
+        body: {config, sourceUrl: 'https://something.io', integrations: [integration]},
+      });
+      ProjectsStore.loadInitialData([project]);
     });
 
     const defaultProps = {

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
@@ -1,15 +1,29 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {EventEntryStacktrace} from 'sentry-fixture/eventEntryStacktrace';
 import {EventStacktraceFrame} from 'sentry-fixture/eventStacktraceFrame';
+import {Organization} from 'sentry-fixture/organization';
+import {Project as ProjectFixture} from 'sentry-fixture/project';
+import {Repository} from 'sentry-fixture/repository';
+import {RepositoryProjectPathConfig} from 'sentry-fixture/repositoryProjectPathConfig';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import StackTraceContent from 'sentry/components/events/interfaces/crashContent/stackTrace/content';
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {EventOrGroupType} from 'sentry/types';
 import {StacktraceType} from 'sentry/types/stacktrace';
 
+const organization = Organization();
+const project = ProjectFixture({});
+
+const integration = TestStubs.GitHubIntegration();
+const repo = Repository({integrationId: integration.id});
+
+const config = RepositoryProjectPathConfig({project, repo, integration});
+
 const eventEntryStacktrace = EventEntryStacktrace();
 const event = EventFixture({
+  projectID: project.id,
   entries: [eventEntryStacktrace],
   type: EventOrGroupType.ERROR,
 });
@@ -34,6 +48,8 @@ function renderedComponent(
 
 describe('StackTrace', function () {
   beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
     const promptResponse = {
       dismissed_ts: undefined,
       snoozed_ts: undefined,
@@ -42,6 +58,11 @@ describe('StackTrace', function () {
       url: '/prompts-activity/',
       body: promptResponse,
     });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/stacktrace-link/`,
+      body: {config, sourceUrl: 'https://something.io', integrations: [integration]},
+    });
+    ProjectsStore.loadInitialData([project]);
   });
   it('renders', function () {
     renderedComponent({});

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -88,12 +88,12 @@ function Context({
     organization?.features?.includes('issue-details-stacktrace-syntax-highlighting') ??
     false;
 
-  const hasStacktraceLinkFeatureFlag =
+  const hasStacktraceLinkInFrameFeatureFlag =
     organization?.features?.includes('issue-details-stacktrace-link-in-frame') ?? false;
 
   // This is the old design. Only show if the feature flag is not enabled for this organization.
   const hasStacktraceLink =
-    frame.inApp && !!frame.filename && isExpanded && !hasStacktraceLinkFeatureFlag;
+    frame.inApp && !!frame.filename && isExpanded && !hasStacktraceLinkInFrameFeatureFlag;
 
   const {projects} = useProjects();
   const project = useMemo(

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -3,9 +3,7 @@ import styled from '@emotion/styled';
 import keyBy from 'lodash/keyBy';
 
 import ClippedBox from 'sentry/components/clippedBox';
-import ErrorBoundary from 'sentry/components/errorBoundary';
 import ContextLine from 'sentry/components/events/interfaces/frame/contextLine';
-import {StacktraceLink} from 'sentry/components/events/interfaces/frame/stacktraceLink';
 import {IconFlag} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -15,8 +13,6 @@ import {
   Frame,
   LineCoverage,
   Organization,
-  SentryAppComponent,
-  SentryAppSchemaStacktraceLink,
 } from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
@@ -32,11 +28,9 @@ import {Assembly} from './assembly';
 import ContextLineNumber from './contextLineNumber';
 import {FrameRegisters} from './frameRegisters';
 import {FrameVariables} from './frameVariables';
-import {OpenInContextLine} from './openInContextLine';
 import useStacktraceLink from './useStacktraceLink';
 
 type Props = {
-  components: SentryAppComponent<SentryAppSchemaStacktraceLink>[];
   event: Event;
   frame: Frame;
   registers: {[key: string]: string};
@@ -76,7 +70,6 @@ function Context({
   hasAssembly = false,
   emptySourceNotation = false,
   registers,
-  components,
   frame,
   event,
   organization,
@@ -154,7 +147,6 @@ function Context({
   }
 
   const startLineNo = hasContextSource ? frame.context[0][0] : 0;
-  const hasStacktraceLink = frame.inApp && !!frame.filename && isExpanded;
 
   const prismClassName = fileExtension ? `language-${fileExtension}` : '';
 
@@ -172,8 +164,6 @@ function Context({
               {lines.map((line, i) => {
                 const contextLine = contextLines[i];
                 const isActive = activeLineNumber === contextLine[0];
-                const hasComponents = isActive && components.length > 0;
-                const showStacktraceLink = hasStacktraceLink && isActive;
 
                 return (
                   <Fragment key={i}>
@@ -191,26 +181,6 @@ function Context({
                         ))}
                       </ContextLineCode>
                     </ContextLineWrapper>
-                    {hasComponents && (
-                      <ErrorBoundary mini>
-                        <OpenInContextLine
-                          key={i}
-                          lineNo={contextLine[0]}
-                          filename={frame.filename || ''}
-                          components={components}
-                        />
-                      </ErrorBoundary>
-                    )}
-                    {showStacktraceLink && (
-                      <ErrorBoundary customComponent={null}>
-                        <StacktraceLink
-                          key={i}
-                          line={contextLine[1]}
-                          frame={frame}
-                          event={event}
-                        />
-                      </ErrorBoundary>
-                    )}
                   </Fragment>
                 );
               })}
@@ -222,8 +192,6 @@ function Context({
       {frame.context && !hasSyntaxHighlighting
         ? contextLines.map((line, index) => {
             const isActive = activeLineNumber === line[0];
-            const hasComponents = isActive && components.length > 0;
-            const showStacktraceLink = hasStacktraceLink && isActive;
 
             return (
               <ContextLine
@@ -231,28 +199,7 @@ function Context({
                 line={line}
                 isActive={isActive}
                 coverage={lineCoverage[index]}
-              >
-                {hasComponents && (
-                  <ErrorBoundary mini>
-                    <OpenInContextLine
-                      key={index}
-                      lineNo={line[0]}
-                      filename={frame.filename || ''}
-                      components={components}
-                    />
-                  </ErrorBoundary>
-                )}
-                {showStacktraceLink && (
-                  <ErrorBoundary customComponent={null}>
-                    <StacktraceLink
-                      key={index}
-                      line={line[1]}
-                      frame={frame}
-                      event={event}
-                    />
-                  </ErrorBoundary>
-                )}
-              </ContextLine>
+              />
             );
           })
         : null}

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -1,7 +1,6 @@
 import {Component, Fragment} from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
-import debounce from 'lodash/debounce';
 import scrollToElement from 'scroll-to-element';
 
 import {openModal} from 'sentry/actionCreators/modal';
@@ -136,13 +135,13 @@ export class DeprecatedLine extends Component<Props, State> {
     isHovering: false,
   };
 
-  handleMouseEnter = debounce(() => {
+  handleMouseEnter = () => {
     this.setState({isHovering: true});
-  }, 100);
+  };
 
-  handleMouseLeave = debounce(() => {
+  handleMouseLeave = () => {
     this.setState({isHovering: false});
-  }, 100);
+  };
 
   toggleContext = evt => {
     evt && evt.preventDefault();

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -348,9 +348,12 @@ export class DeprecatedLine extends Component<Props, State> {
     const activeLineNumber = data.lineNo;
     const contextLine = data.context.find(l => l[0] === activeLineNumber);
     const hasStacktraceLink = data.inApp && !!data.filename && (isHovering || isExpanded);
-    const showStacktraceLink = hasStacktraceLink && contextLine;
-    const hasSentryAppStacktraceLink =
-      hasStacktraceLink && contextLine && this.props.components.length > 0;
+    const hasStacktraceLinkFeatureFlag =
+      organization?.features?.includes('issue-details-stacktrace-link-in-frame') ?? false;
+    const showStacktraceLink =
+      hasStacktraceLink && contextLine && hasStacktraceLinkFeatureFlag;
+    const showSentryAppStacktraceLink =
+      showStacktraceLink && this.props.components.length > 0;
 
     return (
       <StrictClick onClick={this.isExpandable() ? this.toggleContext : undefined}>
@@ -427,7 +430,7 @@ export class DeprecatedLine extends Component<Props, State> {
                 </SourceMapDebuggerModalButton>
               </Fragment>
             ) : null}
-            {hasSentryAppStacktraceLink && (
+            {showSentryAppStacktraceLink && (
               <ErrorBoundary mini>
                 <OpenInContextLine
                   lineNo={contextLine[0]}
@@ -473,6 +476,7 @@ export class DeprecatedLine extends Component<Props, State> {
           frame={data}
           event={this.props.event}
           registers={this.props.registers}
+          components={this.props.components}
           hasContextSource={hasContextSource(data)}
           hasContextVars={hasContextVars(data)}
           hasContextRegisters={hasContextRegisters(this.props.registers)}

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -345,7 +345,7 @@ export class DeprecatedLine extends Component<Props, State> {
     };
 
     const activeLineNumber = data.lineNo;
-    const contextLine = data.context.find(l => l[0] === activeLineNumber);
+    const contextLine = (data?.context || []).find(l => l[0] === activeLineNumber);
     const hasStacktraceLink = data.inApp && !!data.filename && (isHovering || isExpanded);
     const hasStacktraceLinkInFrameFeatureFlag =
       organization?.features?.includes('issue-details-stacktrace-link-in-frame') ?? false;

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -39,10 +39,10 @@ import {combineStatus} from '../debugMeta/utils';
 
 import Context from './context';
 import DefaultTitle from './defaultTitle';
+import {OpenInContextLine} from './openInContextLine';
 import {PackageStatusIcon} from './packageStatus';
 import {FunctionNameToggleIcon} from './symbol';
 import {AddressToggleIcon} from './togglableAddress';
-import {OpenInContextLine} from './openInContextLine';
 import {
   getPlatform,
   hasAssembly,
@@ -430,21 +430,21 @@ export class DeprecatedLine extends Component<Props, State> {
                 </SourceMapDebuggerModalButton>
               </Fragment>
             ) : null}
-            {showSentryAppStacktraceLink && (
-              <ErrorBoundary mini>
-                <OpenInContextLine
-                  lineNo={contextLine[0]}
-                  filename={data.filename || ''}
-                  components={this.props.components}
-                />
-              </ErrorBoundary>
-            )}
             {showStacktraceLink && (
               <ErrorBoundary>
                 <StacktraceLink
                   frame={data}
                   line={contextLine[1]}
                   event={this.props.event}
+                />
+              </ErrorBoundary>
+            )}
+            {showSentryAppStacktraceLink && (
+              <ErrorBoundary mini>
+                <OpenInContextLine
+                  lineNo={contextLine[0]}
+                  filename={data.filename || ''}
+                  components={this.props.components}
                 />
               </ErrorBoundary>
             )}

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -350,7 +350,7 @@ export class DeprecatedLine extends Component<Props, State> {
     const hasStacktraceLinkInFrameFeatureFlag =
       organization?.features?.includes('issue-details-stacktrace-link-in-frame') ?? false;
     const showStacktraceLinkInFrame =
-      hasStacktraceLink && contextLine && hasStacktraceLinkInFrameFeatureFlag;
+      hasStacktraceLink && hasStacktraceLinkInFrameFeatureFlag;
     const showSentryAppStacktraceLinkInFrame =
       showStacktraceLinkInFrame && this.props.components.length > 0;
 
@@ -433,7 +433,7 @@ export class DeprecatedLine extends Component<Props, State> {
               <ErrorBoundary>
                 <StacktraceLink
                   frame={data}
-                  line={contextLine[1]}
+                  line={contextLine ? contextLine[1] : ''}
                   event={this.props.event}
                 />
               </ErrorBoundary>
@@ -441,7 +441,7 @@ export class DeprecatedLine extends Component<Props, State> {
             {showSentryAppStacktraceLinkInFrame && (
               <ErrorBoundary mini>
                 <OpenInContextLine
-                  lineNo={contextLine[0]}
+                  lineNo={data.lineNo}
                   filename={data.filename || ''}
                   components={this.props.components}
                 />

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -347,12 +347,12 @@ export class DeprecatedLine extends Component<Props, State> {
     const activeLineNumber = data.lineNo;
     const contextLine = data.context.find(l => l[0] === activeLineNumber);
     const hasStacktraceLink = data.inApp && !!data.filename && (isHovering || isExpanded);
-    const hasStacktraceLinkFeatureFlag =
+    const hasStacktraceLinkInFrameFeatureFlag =
       organization?.features?.includes('issue-details-stacktrace-link-in-frame') ?? false;
-    const showStacktraceLink =
-      hasStacktraceLink && contextLine && hasStacktraceLinkFeatureFlag;
-    const showSentryAppStacktraceLink =
-      showStacktraceLink && this.props.components.length > 0;
+    const showStacktraceLinkInFrame =
+      hasStacktraceLink && contextLine && hasStacktraceLinkInFrameFeatureFlag;
+    const showSentryAppStacktraceLinkInFrame =
+      showStacktraceLinkInFrame && this.props.components.length > 0;
 
     return (
       <StrictClick onClick={this.isExpandable() ? this.toggleContext : undefined}>
@@ -429,7 +429,7 @@ export class DeprecatedLine extends Component<Props, State> {
                 </SourceMapDebuggerModalButton>
               </Fragment>
             ) : null}
-            {showStacktraceLink && (
+            {showStacktraceLinkInFrame && (
               <ErrorBoundary>
                 <StacktraceLink
                   frame={data}
@@ -438,7 +438,7 @@ export class DeprecatedLine extends Component<Props, State> {
                 />
               </ErrorBoundary>
             )}
-            {showSentryAppStacktraceLink && (
+            {showSentryAppStacktraceLinkInFrame && (
               <ErrorBoundary mini>
                 <OpenInContextLine
                   lineNo={contextLine[0]}

--- a/static/app/components/events/interfaces/frame/line/index.tsx
+++ b/static/app/components/events/interfaces/frame/line/index.tsx
@@ -4,8 +4,13 @@ import classNames from 'classnames';
 
 import ListItem from 'sentry/components/list/listItem';
 import StrictClick from 'sentry/components/strictClick';
-import {PlatformKey} from 'sentry/types';
+import {
+  PlatformKey,
+  SentryAppComponent,
+  SentryAppSchemaStacktraceLink,
+} from 'sentry/types';
 import {Event} from 'sentry/types/event';
+import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
 
 import Context from '../context';
 import {PackageStatusIcon} from '../packageStatus';
@@ -31,6 +36,7 @@ type Props = Omit<
     React.ComponentProps<typeof Default>,
     'onToggleContext' | 'isExpandable' | 'leadsToApp' | 'hasGroupingBadge'
   > & {
+    components: SentryAppComponent<SentryAppSchemaStacktraceLink>[];
     event: Event;
     registers: Record<string, string>;
     emptySourceNotation?: boolean;
@@ -52,6 +58,7 @@ function Line({
   registers,
   isOnlyFrame,
   event,
+  components,
   frameMeta,
   registersMeta,
   emptySourceNotation = false,
@@ -148,6 +155,7 @@ function Line({
         frame={frame}
         event={event}
         registers={registers}
+        components={components}
         hasContextSource={hasContextSource(frame)}
         hasContextVars={hasContextVars(frame)}
         hasContextRegisters={hasContextRegisters(registers)}
@@ -161,7 +169,7 @@ function Line({
   );
 }
 
-export default Line;
+export default withSentryAppComponents(Line, {componentType: 'stacktrace-link'});
 
 const StyleListItem = styled(ListItem)`
   overflow: hidden;

--- a/static/app/components/events/interfaces/frame/line/index.tsx
+++ b/static/app/components/events/interfaces/frame/line/index.tsx
@@ -4,13 +4,8 @@ import classNames from 'classnames';
 
 import ListItem from 'sentry/components/list/listItem';
 import StrictClick from 'sentry/components/strictClick';
-import {
-  PlatformKey,
-  SentryAppComponent,
-  SentryAppSchemaStacktraceLink,
-} from 'sentry/types';
+import {PlatformKey} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
 
 import Context from '../context';
 import {PackageStatusIcon} from '../packageStatus';
@@ -36,7 +31,6 @@ type Props = Omit<
     React.ComponentProps<typeof Default>,
     'onToggleContext' | 'isExpandable' | 'leadsToApp' | 'hasGroupingBadge'
   > & {
-    components: SentryAppComponent<SentryAppSchemaStacktraceLink>[];
     event: Event;
     registers: Record<string, string>;
     emptySourceNotation?: boolean;
@@ -58,7 +52,6 @@ function Line({
   registers,
   isOnlyFrame,
   event,
-  components,
   frameMeta,
   registersMeta,
   emptySourceNotation = false,
@@ -155,7 +148,6 @@ function Line({
         frame={frame}
         event={event}
         registers={registers}
-        components={components}
         hasContextSource={hasContextSource(frame)}
         hasContextVars={hasContextVars(frame)}
         hasContextRegisters={hasContextRegisters(registers)}
@@ -169,7 +161,7 @@ function Line({
   );
 }
 
-export default withSentryAppComponents(Line, {componentType: 'stacktrace-link'});
+export default Line;
 
 const StyleListItem = styled(ListItem)`
   overflow: hidden;

--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -16,7 +16,7 @@ import withOrganization from 'sentry/utils/withOrganization';
 type Props = {
   components: SentryAppComponent<SentryAppSchemaStacktraceLink>[];
   filename: string;
-  lineNo: number;
+  lineNo: number | null;
 };
 
 function OpenInContextLine({lineNo, filename, components}: Props) {
@@ -80,7 +80,7 @@ const OpenInContainer = withOrganization(styled('div')<{
       ? css`
           color: ${p.theme.linkColor};
           animation: ${fadeIn} 0.2s ease-in-out forwards;
-          padding: ${space(0)} ${space(0)};
+          padding: ${space(0)};
         `
       : css`
           color: ${p.theme.subText};

--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -1,4 +1,4 @@
-import {keyframes} from '@emotion/react';
+import {css, keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -77,18 +77,18 @@ const OpenInContainer = withOrganization(styled('div')<{
   white-space: nowrap;
   ${p =>
     p.organization?.features?.includes('issue-details-stacktrace-link-in-frame')
-      ? `
-   color: ${p.theme.linkColor};
-   animation: ${fadeIn} 0.2s ease-in-out forwards;
-   padding: ${space(0)} ${space(0)};
-   `
-      : `
-  color: ${p.theme.subText};
-  background-color: ${p.theme.background};
-  border-bottom: 1px solid ${p.theme.border};
-  padding: ${space(0.25)} ${space(3)};
-  box-shadow: ${p.theme.dropShadowLight};
-   `}
+      ? css`
+          color: ${p.theme.linkColor};
+          animation: ${fadeIn} 0.2s ease-in-out forwards;
+          padding: ${space(0)} ${space(0)};
+        `
+      : css`
+          color: ${p.theme.subText};
+          background-color: ${p.theme.background};
+          border-bottom: 1px solid ${p.theme.border};
+          padding: ${space(0.25)} ${space(3)};
+          box-shadow: ${p.theme.dropShadowLight};
+        `}
 `);
 
 const OpenInLink = withOrganization(styled(ExternalLink)<{organization: Organization}>`

--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -76,7 +76,7 @@ const OpenInContainer = withOrganization(styled('div')<{
   overflow: auto;
   white-space: nowrap;
   ${p =>
-    p.organization.features.includes('issue-details-stacktrace-link-in-frame')
+    p.organization?.features?.includes('issue-details-stacktrace-link-in-frame')
       ? `
    color: ${p.theme.linkColor};
    animation: ${fadeIn} 0.2s ease-in-out forwards;
@@ -96,14 +96,14 @@ const OpenInLink = withOrganization(styled(ExternalLink)<{organization: Organiza
   gap: ${space(0.75)};
   align-items: center;
   ${p =>
-    p.organization.features.includes('issue-details-stacktrace-link-in-frame')
+    p.organization?.features?.includes('issue-details-stacktrace-link-in-frame')
       ? ``
       : `color: ${p.theme.gray300};`}
 `);
 
 export const OpenInName = withOrganization(styled('span')<{organization: Organization}>`
   ${p =>
-    p.organization.features.includes('issue-details-stacktrace-link-in-frame')
+    p.organization?.features?.includes('issue-details-stacktrace-link-in-frame')
       ? `
     &:hover {
       text-decoration: underline;

--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -4,9 +4,14 @@ import styled from '@emotion/styled';
 import ExternalLink from 'sentry/components/links/externalLink';
 import SentryAppComponentIcon from 'sentry/components/sentryAppComponentIcon';
 import {space} from 'sentry/styles/space';
-import {SentryAppComponent, SentryAppSchemaStacktraceLink} from 'sentry/types';
+import {
+  Organization,
+  SentryAppComponent,
+  SentryAppSchemaStacktraceLink,
+} from 'sentry/types';
 import {addQueryParamsToExistingUrl} from 'sentry/utils/queryString';
 import {recordInteraction} from 'sentry/utils/recordSentryAppInteraction';
+import withOrganization from 'sentry/utils/withOrganization';
 
 type Props = {
   components: SentryAppComponent<SentryAppSchemaStacktraceLink>[];
@@ -58,30 +63,53 @@ const fadeIn = keyframes`
   to { opacity: 1; }
 `;
 
-const OpenInContainer = styled('div')<{columnQuantity: number}>`
+const OpenInContainer = withOrganization(styled('div')<{
+  columnQuantity: number;
+  organization: Organization;
+}>`
   display: flex;
   gap: ${space(1)};
   align-items: center;
   z-index: 1;
-  color: ${p => p.theme.linkColor};
   font-family: ${p => p.theme.text.family};
-  padding: ${space(0)} ${space(0)};
   text-indent: initial;
   overflow: auto;
   white-space: nowrap;
-  animation: ${fadeIn} 0.2s ease-in-out forwards;
-`;
+  ${p =>
+    p.organization.features.includes('issue-details-stacktrace-link-in-frame')
+      ? `
+   color: ${p.theme.linkColor};
+   animation: ${fadeIn} 0.2s ease-in-out forwards;
+   padding: ${space(0)} ${space(0)};
+   `
+      : `
+  color: ${p.theme.subText};
+  background-color: ${p.theme.background};
+  border-bottom: 1px solid ${p.theme.border};
+  padding: ${space(0.25)} ${space(3)};
+  box-shadow: ${p.theme.dropShadowLight};
+   `}
+`);
 
-const OpenInLink = styled(ExternalLink)`
+const OpenInLink = withOrganization(styled(ExternalLink)<{organization: Organization}>`
   display: flex;
   gap: ${space(0.75)};
   align-items: center;
-`;
+  ${p =>
+    p.organization.features.includes('issue-details-stacktrace-link-in-frame')
+      ? ``
+      : `color: ${p.theme.gray300};`}
+`);
 
-export const OpenInName = styled('span')`
-  &:hover {
-    text-decoration: underline;
-    text-decoration-color: ${p => p.theme.linkUnderline};
-    text-underline-offset: ${space(0.5)};
-  }
-`;
+export const OpenInName = withOrganization(styled('span')<{organization: Organization}>`
+  ${p =>
+    p.organization.features.includes('issue-details-stacktrace-link-in-frame')
+      ? `
+    &:hover {
+      text-decoration: underline;
+      text-decoration-color: ${p.theme.linkUnderline};
+      text-underline-offset: ${space(0.5)};
+    }
+    `
+      : ``}
+`);

--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -1,8 +1,8 @@
+import {keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import ExternalLink from 'sentry/components/links/externalLink';
 import SentryAppComponentIcon from 'sentry/components/sentryAppComponentIcon';
-import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {SentryAppComponent, SentryAppSchemaStacktraceLink} from 'sentry/types';
 import {addQueryParamsToExistingUrl} from 'sentry/utils/queryString';
@@ -29,7 +29,6 @@ function OpenInContextLine({lineNo, filename, components}: Props) {
 
   return (
     <OpenInContainer columnQuantity={components.length + 1}>
-      <div>{t('Open this line in')}</div>
       {components.map(component => {
         const url = getUrl(component.schema.url);
         const {slug} = component.sentryApp;
@@ -54,30 +53,35 @@ function OpenInContextLine({lineNo, filename, components}: Props) {
 
 export {OpenInContextLine};
 
+const fadeIn = keyframes`
+  from { opacity: 0; }
+  to { opacity: 1; }
+`;
+
 const OpenInContainer = styled('div')<{columnQuantity: number}>`
   display: flex;
   gap: ${space(1)};
   align-items: center;
   z-index: 1;
-  color: ${p => p.theme.subText};
-  background-color: ${p => p.theme.background};
+  color: ${p => p.theme.linkColor};
   font-family: ${p => p.theme.text.family};
-  border-bottom: 1px solid ${p => p.theme.border};
-  padding: ${space(0.25)} ${space(3)};
-  box-shadow: ${p => p.theme.dropShadowLight};
+  padding: ${space(0)} ${space(0)};
   text-indent: initial;
   overflow: auto;
   white-space: nowrap;
+  animation: ${fadeIn} 0.2s ease-in-out forwards;
 `;
 
 const OpenInLink = styled(ExternalLink)`
   display: flex;
   gap: ${space(0.75)};
   align-items: center;
-  color: ${p => p.theme.gray300};
 `;
 
-export const OpenInName = styled('strong')`
-  color: ${p => p.theme.subText};
-  font-weight: 700;
+export const OpenInName = styled('span')`
+  &:hover {
+    text-decoration: underline;
+    text-decoration-color: ${p => p.theme.linkUnderline};
+    text-underline-offset: ${space(0.5)};
+  }
 `;

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -422,7 +422,7 @@ const StacktraceLinkWrapper = withOrganization(styled('div')<{
   font-family: ${p => p.theme.text.family};
 
   ${p =>
-    p.organization.features.includes('issue-details-stacktrace-link-in-frame')
+    p.organization?.features?.includes('issue-details-stacktrace-link-in-frame')
       ? `
       padding: ${space(0)} ${space(1)};
     `
@@ -440,7 +440,7 @@ const FixMappingButton = withOrganization(styled(Button)<{organization: Organiza
   color: ${p => p.theme.subText};
 
   ${p =>
-    p.organization.features.includes('issue-details-stacktrace-link-in-frame')
+    p.organization?.features?.includes('issue-details-stacktrace-link-in-frame')
       ? `
       &:hover {
         color: ${p.theme.subText};
@@ -470,7 +470,7 @@ const LinkStyles = css`
 const OpenInLink = withOrganization(styled(ExternalLink)<{organization: Organization}>`
   ${LinkStyles}
   ${p =>
-    p.organization.features.includes('issue-details-stacktrace-link-in-frame')
+    p.organization?.features?.includes('issue-details-stacktrace-link-in-frame')
       ? `
       color: ${p.theme.linkColor};
       animation: ${fadeIn} 0.2s ease-in-out forwards;

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -218,8 +218,6 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
       timer = setTimeout(() => {
         setIsQueryEnabled(true);
       }, 100); // Delay of 100ms
-    } else {
-      setIsQueryEnabled(true);
     }
     return () => timer && clearTimeout(timer);
   }, [hasStacktraceLinkFeatureFlag]); // Empty dependency array to run only on mount

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -1,5 +1,5 @@
 import {useMemo} from 'react';
-import {css} from '@emotion/react';
+import {css, keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
@@ -158,7 +158,8 @@ function CodecovLink({
     return null;
   }
 
-  const onOpenCodecovLink = () => {
+  const onOpenCodecovLink = e => {
+    e.stopPropagation();
     trackAnalytics('integrations.stacktrace_codecov_link_clicked', {
       view: 'stacktrace_issue_details',
       organization,
@@ -170,7 +171,7 @@ function CodecovLink({
   return (
     <OpenInLink href={coverageUrl} openInNewTab onClick={onOpenCodecovLink}>
       <StyledIconWrapper>{getIntegrationIcon('codecov', 'sm')}</StyledIconWrapper>
-      {t('Open in Codecov')}
+      {t('Codecov')}
     </OpenInLink>
   );
 }
@@ -235,7 +236,8 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
       : {}
   );
 
-  const onOpenLink = () => {
+  const onOpenLink = e => {
+    e.stopPropagation();
     const provider = match!.config?.provider;
     if (provider) {
       trackAnalytics(
@@ -259,7 +261,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
   if (isLoading || !match) {
     return (
       <StacktraceLinkWrapper>
-        <Placeholder height="24px" width="120px" />
+        <Placeholder height="14px" width="171px" />
       </StacktraceLinkWrapper>
     );
   }
@@ -280,7 +282,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
           <StyledIconWrapper>
             {getIntegrationIcon(match.config.provider.key, 'sm')}
           </StyledIconWrapper>
-          {t('Open this line in %s', match.config.provider.name)}
+          {match.config.provider.name}
         </OpenInLink>
         {shouldShowCodecovFeatures(organization, match) ? (
           <CodecovLink
@@ -307,7 +309,6 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
     event.platform === 'csharp' &&
     frame.sourceLink?.startsWith('https://www.github.com/');
   const hideErrors = isMinifiedJsError || isUnsupportedPlatform;
-
   // for .NET projects, if there is no match found but there is a GitHub source link, use that
   if (
     frame.sourceLink &&
@@ -318,7 +319,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
       <StacktraceLinkWrapper>
         <OpenInLink onClick={onOpenLink} href={frame.sourceLink} openInNewTab>
           <StyledIconWrapper>{getIntegrationIcon('github', 'sm')}</StyledIconWrapper>
-          {t('Open this line in GitHub')}
+          {t('GitHub')}
         </OpenInLink>
         {shouldShowCodecovFeatures(organization, match) ? (
           <CodecovLink
@@ -395,21 +396,29 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
   );
 }
 
+const fadeIn = keyframes`
+  from { opacity: 0; }
+  to { opacity: 1; }
+`;
+
 const StacktraceLinkWrapper = styled('div')`
   display: flex;
   gap: ${space(2)};
   align-items: center;
   color: ${p => p.theme.subText};
-  background-color: ${p => p.theme.background};
   font-family: ${p => p.theme.text.family};
-  border-bottom: 1px solid ${p => p.theme.border};
-  padding: ${space(0.25)} ${space(3)};
-  box-shadow: ${p => p.theme.dropShadowLight};
-  min-height: 28px;
+  padding: ${space(0)} ${space(1)};
 `;
 
 const FixMappingButton = styled(Button)`
   color: ${p => p.theme.subText};
+
+  &:hover {
+    color: ${p => p.theme.subText};
+    text-decoration: underline;
+    text-decoration-color: ${p => p.theme.subText};
+    text-underline-offset: ${space(0.5)};
+  }
 `;
 
 const CloseButton = styled(Button)`
@@ -429,7 +438,14 @@ const LinkStyles = css`
 
 const OpenInLink = styled(ExternalLink)`
   ${LinkStyles}
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.linkColor};
+  animation: ${fadeIn} 0.2s ease-in-out forwards;
+
+  &:hover {
+    text-decoration: underline;
+    text-decoration-color: ${p => p.theme.linkUnderline};
+    text-underline-offset: ${space(0.5)};
+  }
 `;
 
 const StyledLink = styled(Link)`

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -439,6 +439,8 @@ const StacktraceLinkWrapper = withOrganization(styled('div')<{
     p.organization?.features?.includes('issue-details-stacktrace-link-in-frame')
       ? `
       padding: ${space(0)} ${space(1)};
+      flex-wrap: wrap;
+      gap: ${space(1)}
     `
       : `
       background-color: ${p.theme.background};

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -487,18 +487,18 @@ const OpenInLink = withOrganization(styled(ExternalLink)<{organization: Organiza
   ${LinkStyles}
   ${p =>
     p.organization?.features?.includes('issue-details-stacktrace-link-in-frame')
-      ? `
-      color: ${p.theme.linkColor};
-      animation: ${fadeIn} 0.2s ease-in-out forwards;
-      &:hover {
-        text-decoration: underline;
-        text-decoration-color: ${p.theme.linkUnderline};
-        text-underline-offset: ${space(0.5)};
-      }
-    `
-      : `
-      color: ${p.theme.gray300};
-      `}
+      ? css`
+          color: ${p.theme.linkColor};
+          animation: ${fadeIn} 0.2s ease-in-out forwards;
+          &:hover {
+            text-decoration: underline;
+            text-decoration-color: ${p.theme.linkUnderline};
+            text-underline-offset: ${space(0.5)};
+          }
+        `
+      : css`
+          color: ${p.theme.gray300};
+        `}
 `);
 
 const StyledLink = styled(Link)`

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -148,11 +148,12 @@ function NativeFrame({
   const [isHovering, setHovering] = useState(false);
 
   const contextLine = frame.context.find(l => l[0] === frame.lineNo);
-  const hasStacktraceLink = frame.inApp && !!frame.filename && (isHovering || expanded);
+  const hasStacktraceLink =
+    frame.inApp && !!frame.filename && frame.lineNo && (isHovering || expanded);
   const hasStacktraceLinkInFrameFeatureFlag =
     organization?.features?.includes('issue-details-stacktrace-link-in-frame') ?? false;
   const showStacktraceLinkInFrame =
-    hasStacktraceLink && contextLine && hasStacktraceLinkInFrameFeatureFlag;
+    hasStacktraceLink && hasStacktraceLinkInFrameFeatureFlag;
   const showSentryAppStacktraceLinkInFrame =
     showStacktraceLinkInFrame && components.length > 0;
 
@@ -383,13 +384,17 @@ function NativeFrame({
           <GenericCellWrapper>
             {showStacktraceLinkInFrame && (
               <ErrorBoundary>
-                <StacktraceLink frame={frame} line={contextLine[1]} event={event} />
+                <StacktraceLink
+                  frame={frame}
+                  line={contextLine ? contextLine[1] : ''}
+                  event={event}
+                />
               </ErrorBoundary>
             )}
             {showSentryAppStacktraceLinkInFrame && (
               <ErrorBoundary mini>
                 <OpenInContextLine
-                  lineNo={contextLine[0]}
+                  lineNo={frame.lineNo}
                   filename={frame.filename || ''}
                   components={components}
                 />

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -26,15 +26,9 @@ import {IconWarning} from 'sentry/icons/iconWarning';
 import {t, tn} from 'sentry/locale';
 import DebugMetaStore from 'sentry/stores/debugMetaStore';
 import {space} from 'sentry/styles/space';
-import {
-  Frame,
-  PlatformKey,
-  SentryAppComponent,
-  SentryAppSchemaStacktraceLink,
-} from 'sentry/types';
+import {Frame, PlatformKey} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
-import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
 
 import DebugImage from './debugMeta/debugImage';
 import {combineStatus} from './debugMeta/utils';
@@ -42,7 +36,6 @@ import Context from './frame/context';
 import {SymbolicatorStatus} from './types';
 
 type Props = {
-  components: SentryAppComponent<SentryAppSchemaStacktraceLink>[];
   event: Event;
   frame: Frame;
   isUsedForGrouping: boolean;
@@ -80,7 +73,6 @@ function NativeFrame({
   registers,
   isOnlyFrame,
   event,
-  components,
   hiddenFrameCount,
   isShowFramesToggleExpanded,
   isSubFrame,
@@ -379,7 +371,6 @@ function NativeFrame({
           frame={frame}
           event={event}
           registers={registers}
-          components={components}
           hasContextSource={hasContextSource(frame)}
           hasContextVars={hasContextVars(frame)}
           hasContextRegisters={hasContextRegisters(registers)}
@@ -394,7 +385,7 @@ function NativeFrame({
   );
 }
 
-export default withSentryAppComponents(NativeFrame, {componentType: 'stacktrace-link'});
+export default NativeFrame;
 
 const AddressCellWrapper = styled('div')`
   display: flex;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -147,7 +147,7 @@ function NativeFrame({
   const [expanded, setExpanded] = useState(expandable ? isExpanded ?? false : false);
   const [isHovering, setHovering] = useState(false);
 
-  const contextLine = frame.context.find(l => l[0] === frame.lineNo);
+  const contextLine = (frame?.context || []).find(l => l[0] === frame.lineNo);
   const hasStacktraceLink =
     frame.inApp && !!frame.filename && frame.lineNo && (isHovering || expanded);
   const hasStacktraceLinkInFrameFeatureFlag =

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -26,9 +26,15 @@ import {IconWarning} from 'sentry/icons/iconWarning';
 import {t, tn} from 'sentry/locale';
 import DebugMetaStore from 'sentry/stores/debugMetaStore';
 import {space} from 'sentry/styles/space';
-import {Frame, PlatformKey} from 'sentry/types';
+import {
+  Frame,
+  PlatformKey,
+  SentryAppComponent,
+  SentryAppSchemaStacktraceLink,
+} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
+import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
 
 import DebugImage from './debugMeta/debugImage';
 import {combineStatus} from './debugMeta/utils';
@@ -36,6 +42,7 @@ import Context from './frame/context';
 import {SymbolicatorStatus} from './types';
 
 type Props = {
+  components: SentryAppComponent<SentryAppSchemaStacktraceLink>[];
   event: Event;
   frame: Frame;
   isUsedForGrouping: boolean;
@@ -73,6 +80,7 @@ function NativeFrame({
   registers,
   isOnlyFrame,
   event,
+  components,
   hiddenFrameCount,
   isShowFramesToggleExpanded,
   isSubFrame,
@@ -371,6 +379,7 @@ function NativeFrame({
           frame={frame}
           event={event}
           registers={registers}
+          components={components}
           hasContextSource={hasContextSource(frame)}
           hasContextVars={hasContextVars(frame)}
           hasContextRegisters={hasContextRegisters(registers)}
@@ -385,7 +394,7 @@ function NativeFrame({
   );
 }
 
-export default NativeFrame;
+export default withSentryAppComponents(NativeFrame, {componentType: 'stacktrace-link'});
 
 const AddressCellWrapper = styled('div')`
   display: flex;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -3,6 +3,9 @@ import styled from '@emotion/styled';
 import scrollToElement from 'scroll-to-element';
 
 import {Button} from 'sentry/components/button';
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import {OpenInContextLine} from 'sentry/components/events/interfaces/frame/openInContextLine';
+import {StacktraceLink} from 'sentry/components/events/interfaces/frame/stacktraceLink';
 import {
   getLeadHint,
   hasAssembly,
@@ -34,6 +37,7 @@ import {
 } from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
+import useOrganization from 'sentry/utils/useOrganization';
 import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
 
 import DebugImage from './debugMeta/debugImage';
@@ -95,6 +99,8 @@ function NativeFrame({
    */
   isHoverPreviewed = false,
 }: Props) {
+  const organization = useOrganization();
+
   const traceEventDataSectionContext = useContext(TraceEventDataSectionContext);
 
   const absolute = traceEventDataSectionContext?.display.includes('absolute-addresses');
@@ -139,6 +145,20 @@ function NativeFrame({
     frame.function !== frame.rawFunction;
 
   const [expanded, setExpanded] = useState(expandable ? isExpanded ?? false : false);
+  const [isHovering, setHovering] = useState(false);
+
+  const contextLine = frame.context.find(l => l[0] === frame.lineNo);
+  const hasStacktraceLink = frame.inApp && !!frame.filename && (isHovering || expanded);
+  const hasStacktraceLinkInFrameFeatureFlag =
+    organization?.features?.includes('issue-details-stacktrace-link-in-frame') ?? false;
+  const showStacktraceLinkInFrame =
+    hasStacktraceLink && contextLine && hasStacktraceLinkInFrameFeatureFlag;
+  const showSentryAppStacktraceLinkInFrame =
+    showStacktraceLinkInFrame && components.length > 0;
+
+  const handleMouseEnter = () => setHovering(true);
+
+  const handleMouseLeave = () => setHovering(false);
 
   function getRelativeAddress() {
     if (!startingAddress) {
@@ -252,6 +272,8 @@ function NativeFrame({
           expanded={expanded}
           isInAppFrame={frame.inApp}
           isSubFrame={!!isSubFrame}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
         >
           <SymbolicatorIcon>
             {status === 'error' ? (
@@ -299,7 +321,7 @@ function NativeFrame({
               </Package>
             </Tooltip>
           </div>
-          <AddressCellWrapper>
+          <GenericCellWrapper>
             <AddressCell onClick={packageClickable ? handleGoToImagesLoaded : undefined}>
               <Tooltip
                 title={addressTooltip}
@@ -309,7 +331,7 @@ function NativeFrame({
                 {!relativeAddress || absolute ? frame.instructionAddr : relativeAddress}
               </Tooltip>
             </AddressCell>
-          </AddressCellWrapper>
+          </GenericCellWrapper>
           <FunctionNameCell>
             {functionName ? (
               <AnnotatedText value={functionName.value} meta={functionName.meta} />
@@ -358,7 +380,25 @@ function NativeFrame({
                 : tn('Show %s more frame', 'Show %s more frames', hiddenFrameCount)}
             </ShowHideButton>
           ) : null}
-          <TypeCell>{frame.inApp ? <Tag type="info">{t('In App')}</Tag> : null}</TypeCell>
+          <GenericCellWrapper>
+            {showStacktraceLinkInFrame && (
+              <ErrorBoundary>
+                <StacktraceLink frame={frame} line={contextLine[1]} event={event} />
+              </ErrorBoundary>
+            )}
+            {showSentryAppStacktraceLinkInFrame && (
+              <ErrorBoundary mini>
+                <OpenInContextLine
+                  lineNo={contextLine[0]}
+                  filename={frame.filename || ''}
+                  components={components}
+                />
+              </ErrorBoundary>
+            )}
+            <TypeCell>
+              {frame.inApp ? <Tag type="info">{t('In App')}</Tag> : null}
+            </TypeCell>
+          </GenericCellWrapper>
           <ExpandCell>
             {expandable && (
               <ToggleButton
@@ -396,7 +436,7 @@ function NativeFrame({
 
 export default withSentryAppComponents(NativeFrame, {componentType: 'stacktrace-link'});
 
-const AddressCellWrapper = styled('div')`
+const GenericCellWrapper = styled('div')`
   display: flex;
 `;
 

--- a/static/app/components/events/interfaces/threads.spec.tsx
+++ b/static/app/components/events/interfaces/threads.spec.tsx
@@ -1,15 +1,26 @@
 import merge from 'lodash/merge';
+import {Organization} from 'sentry-fixture/organization';
+import {Project as ProjectFixture} from 'sentry-fixture/project';
+import {Repository} from 'sentry-fixture/repository';
+import {RepositoryProjectPathConfig} from 'sentry-fixture/repositoryProjectPathConfig';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {Threads} from 'sentry/components/events/interfaces/threads';
 import {displayOptions} from 'sentry/components/events/traceEventDataSection';
+import ProjectsStore from 'sentry/stores/projectsStore';
 import {EventOrGroupType} from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
 
 describe('Threads', function () {
+  const organization = Organization();
+  const project = ProjectFixture({});
+  const integration = TestStubs.GitHubIntegration();
+  const repo = Repository({integrationId: integration.id});
+  const config = RepositoryProjectPathConfig({project, repo, integration});
+
   beforeEach(() => {
+    MockApiClient.clearMockResponses();
     const promptResponse = {
       dismissed_ts: undefined,
       snoozed_ts: undefined,
@@ -18,8 +29,12 @@ describe('Threads', function () {
       url: '/prompts-activity/',
       body: promptResponse,
     });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/stacktrace-link/`,
+      body: {config, sourceUrl: 'https://something.io', integrations: [integration]},
+    });
+    ProjectsStore.loadInitialData([project]);
   });
-  const {project, organization} = initializeOrg();
 
   describe('non native platform', function () {
     describe('other platform', function () {
@@ -27,7 +42,7 @@ describe('Threads', function () {
         id: '020eb33f6ce64ed6adc60f8993535816',
         groupID: '68',
         eventID: '020eb33f6ce64ed6adc60f8993535816',
-        projectID: '2',
+        projectID: project.id,
         size: 3481,
         entries: [
           {
@@ -321,7 +336,7 @@ describe('Threads', function () {
         id: 'bfe4379d82934b2b91d70b1167bcae8d',
         groupID: '24',
         eventID: 'bfe4379d82934b2b91d70b1167bcae8d',
-        projectID: '2',
+        projectID: project.id,
         size: 89101,
         entries: [
           {

--- a/static/app/components/placeholder.tsx
+++ b/static/app/components/placeholder.tsx
@@ -37,7 +37,7 @@ const Placeholder = styled(
   justify-content: center;
   align-items: center;
 
-  background-color: ${p => (p.error ? p.theme.red100 : p.theme.backgroundSecondary)};
+  background-color: ${p => (p.error ? p.theme.red100 : p.theme.backgroundTertiary)};
   ${p => p.error && `color: ${p.theme.red200};`}
   width: ${p => p.width};
   height: ${p => p.height};

--- a/static/app/views/sharedGroupDetails/index.spec.tsx
+++ b/static/app/views/sharedGroupDetails/index.spec.tsx
@@ -5,7 +5,7 @@ import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 
-import {render} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {RouteContext} from 'sentry/views/routeContext';
 import SharedGroupDetails from 'sentry/views/sharedGroupDetails';
@@ -43,7 +43,7 @@ describe('SharedGroupDetails', function () {
     MockApiClient.clearMockResponses();
   });
 
-  it('renders', function () {
+  it('renders', async function () {
     render(
       <RouteContext.Provider value={{router, ...router}}>
         <SharedGroupDetails
@@ -57,9 +57,10 @@ describe('SharedGroupDetails', function () {
         />
       </RouteContext.Provider>
     );
+    await waitFor(() => expect(screen.getByText('Details')).toBeInTheDocument());
   });
 
-  it('renders with org slug in path', function () {
+  it('renders with org slug in path', async function () {
     const params_with_slug = {shareId: 'a', orgId: 'test-org'};
     const router_with_slug = TestStubs.router({params_with_slug});
     render(
@@ -75,5 +76,6 @@ describe('SharedGroupDetails', function () {
         />
       </RouteContext.Provider>
     );
+    await waitFor(() => expect(screen.getByText('Details')).toBeInTheDocument());
   });
 });


### PR DESCRIPTION
## Objective:

- [x] Remove the inline stack trace link from the stack
- [x] Add stack trace links to the trailing edge of the stack frame, to the left of the "In App" label
- [x] Hide the links by default, and show when:
   - [x] Hovering over any part of the frame header, or
   - [x] When the frame is expanded (regardless of hover state)
 - [x] Handle sentry app components the same way
 - [x] Make requests one-by-one as needed on hover or expansion. Debounce with a 100ms delay so moving your cursor over the whole stack doesn't make many unnecessary requests.
- [x] Wrap in feature flag
- [x] Support native frames
- [x] Add tests


## UI

https://github.com/getsentry/sentry/assets/10491193/64e34103-1fdd-4bfa-8662-13e334510115

Native Frames

https://github.com/getsentry/sentry/assets/10491193/7d504eb1-f6f8-4976-9beb-7e11906b9bd4

