### PR TITLE
fix(metrics-extraction): Don't emit messages for spec-less widgets

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -340,7 +340,7 @@ def convert_widget_query_to_metric(
 def _can_widget_use_stateful_extraction(
     widget_query: DashboardWidgetQuery, metrics_specs: Sequence[HashedMetricSpec]
 ):
-    if not metric_specs:
+    if not metrics_specs:
         return False
     spec_hashes = [hashed_spec[0] for hashed_spec in metrics_specs]
     on_demand_entries = widget_query.dashboardwidgetqueryondemand_set.all()
@@ -408,7 +408,6 @@ def _is_widget_query_low_cardinality(widget_query: DashboardWidgetQuery, project
 
     # No columns or only errors means no high-cardinality tags.
     if not widget_query.columns or "event.type:error" in widget_query.conditions:
-
         metrics.incr("on_demand_metrics.cardinality_check.not_applicable")
         return True
 

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -340,6 +340,8 @@ def convert_widget_query_to_metric(
 def _can_widget_use_stateful_extraction(
     widget_query: DashboardWidgetQuery, metrics_specs: Sequence[HashedMetricSpec]
 ):
+    if not metric_specs:
+        return False
     spec_hashes = [hashed_spec[0] for hashed_spec in metrics_specs]
     on_demand_entries = widget_query.dashboardwidgetqueryondemand_set.all()
 


### PR DESCRIPTION
If a widget doesn't have any specs, it's assumed it won't have any on_demand_entries as well. This should close [SENTRY-2B48](https://sentry.sentry.io/issues/4729081560/)
