### PR TITLE
feat(replay): Switch hydration diff back to splitdiff

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -1,6 +1,5 @@
 import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
-import {DiffEditor} from '@monaco-editor/react';
 import beautify from 'js-beautify';
 
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -10,10 +9,9 @@ import {
   useReplayContext,
 } from 'sentry/components/replays/replayContext';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
+import SplitDiff from 'sentry/components/splitDiff';
 import {TabList} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
-import ConfigStore from 'sentry/stores/configStore';
-import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import ReplayReader from 'sentry/utils/replays/replayReader';
@@ -35,9 +33,6 @@ export default function ReplayComparisonModal({
   rightTimestamp,
 }: Props) {
   const fetching = false;
-
-  const config = useLegacyStore(ConfigStore);
-  const isDark = config.theme === 'dark';
 
   const [activeTab, setActiveTab] = useState<'visual' | 'html'>('html');
 
@@ -95,20 +90,9 @@ export default function ReplayComparisonModal({
             </ReplayContextProvider>
           </Flex>
           {activeTab === 'html' && leftBody && rightBody ? (
-            <div>
-              <DiffEditor
-                height="60vh"
-                theme={isDark ? 'vs-dark' : 'light'}
-                language="html"
-                original={leftBody}
-                modified={rightBody}
-                options={{
-                  // Options - https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IDiffEditorConstructionOptions.html
-                  scrollBeyondLastLine: false,
-                  readOnly: true,
-                }}
-              />
-            </div>
+            <SplitDiffScrollWrapper>
+              <SplitDiff base={leftBody} target={rightBody} type="words" />
+            </SplitDiffScrollWrapper>
           ) : null}
         </Flex>
       </Body>
@@ -126,7 +110,7 @@ function ReplaySide({expectedTime, selector, onLoad}) {
         const body = iframe.contentWindow?.document.body;
         if (body) {
           onLoad(
-            beautify.html(body.innerHTML, {
+            beautify.html(body.innerHTML.repeat(100), {
               indent_size: 2,
               wrap_line_length: 80,
             })
@@ -142,4 +126,9 @@ const ComparisonSideWrapper = styled('div')`
   display: contents;
   flex-grow: 1;
   max-width: 50%;
+`;
+
+const SplitDiffScrollWrapper = styled('div')`
+  height: 70vh;
+  overflow: auto;
 `;

--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -110,7 +110,7 @@ function ReplaySide({expectedTime, selector, onLoad}) {
         const body = iframe.contentWindow?.document.body;
         if (body) {
           onLoad(
-            beautify.html(body.innerHTML.repeat(100), {
+            beautify.html(body.innerHTML, {
               indent_size: 2,
               wrap_line_length: 80,
             })


### PR DESCRIPTION
the monaco editor loads its assets from a js cdn instead of the webpack bundle. In order to load it from webpack it requires a webpack extension and all this other configuration. Not currently worth it for this modal.

fixes #61725

![image](https://github.com/getsentry/sentry/assets/1400464/4569d154-5735-4056-b51d-33de436344b2)


todo: remove monaco editor from dependencies. nobody should use it in its current state and it's only used in a hackweek related part of the app.