### PR TITLE
fix(grouping): Mark swizzle non inApp for Cocoa

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/newstyle@2023-01-11.txt
@@ -62,6 +62,7 @@ family:native function:kscrash_*                                  -app -group
 family:native function:*sentrycrash_*                             -app -group
 family:native function:"?[[]KSCrash*"                             -app -group
 family:native function:"?[[]RNSentry*"                            -app -group
+family:native function:"__*[[]Sentry*"                            -app -group
 
 # Projects shipping their own class called "SentryFoo" can then easily override this in their
 # own grouping enhancers.

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-12-12T13:53:13.957393Z'
+created: '2023-12-18T12:12:51.554639Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -74,7 +74,7 @@ app:
           frame (non app frame)
             function*
               "-[UIControl sendAction:to:forEvent:]"
-          frame (non app frame)
+          frame (marked out of app by stack trace rule (family:native function:__*[[]Sentry* -app -group))
             function*
               "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
           frame (non app frame)
@@ -150,7 +150,7 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "-[UIControl sendAction:to:forEvent:]"
-          frame (ignored by stack trace rule (category:internals -group))
+          frame (ignored by stack trace rule (family:native function:__*[[]Sentry* -app -group))
             function*
               "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
           frame (ignored by stack trace rule (category:internals -group))

--- a/tests/sentry/stacktraces/test_in_app_normalization.py
+++ b/tests/sentry/stacktraces/test_in_app_normalization.py
@@ -290,6 +290,20 @@ class iOSInAppDetectionTest(TestCase):
             function="-[SentryHttpTransport sendEvent:attachments:]", is_in_app=False
         )
 
+    def test_swizzling_in_app_detection(self):
+        self.assert_correct_in_app_value(
+            function="__42-[SentryCoreDataSwizzling swizzleCoreData]_block_invoke_2.24",
+            is_in_app=False,
+        )
+        self.assert_correct_in_app_value(
+            function="__49-[SentrySwizzleWrapper swizzleSendAction:forKey:]_block_invoke_2",
+            is_in_app=False,
+        )
+        self.assert_correct_in_app_value(
+            function="__49+[SentrySwizzleWrapper swizzleSendAction:forKey:]_block_invoke_2",
+            is_in_app=False,
+        )
+
     def test_ios_package_in_app_detection(self):
         data: dict[str, Any] = {
             "platform": "native",


### PR DESCRIPTION
Mark swizzling functions as non-inApp for Cocoa SDK frames.

Fixes GH-60515