### PR TITLE
feat(alerts): p90 support

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -408,6 +408,19 @@ export const AGGREGATIONS = {
     isSortable: true,
     multiPlotType: 'line',
   },
+  [AggregationKey.P90]: {
+    ...getDocsAndOutputType(AggregationKey.P90),
+    parameters: [
+      {
+        kind: 'column',
+        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
+        defaultValue: 'transaction.duration',
+        required: false,
+      },
+    ],
+    isSortable: true,
+    multiPlotType: 'line',
+  },
   [AggregationKey.P95]: {
     ...getDocsAndOutputType(AggregationKey.P95),
     parameters: [

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -209,6 +209,7 @@ export enum AggregationKey {
   ANY = 'any',
   P50 = 'p50',
   P75 = 'p75',
+  P90 = 'p90',
   P95 = 'p95',
   P99 = 'p99',
   P100 = 'p100',
@@ -314,6 +315,11 @@ export const AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
   },
   [AggregationKey.P75]: {
     desc: t('Returns the 75th percentile of the selected field'),
+    kind: FieldKind.FUNCTION,
+    valueType: null,
+  },
+  [AggregationKey.P90]: {
+    desc: t('Returns the 90th percentile of the selected field'),
     kind: FieldKind.FUNCTION,
     valueType: null,
   },

--- a/static/app/views/alerts/rules/metric/constants.tsx
+++ b/static/app/views/alerts/rules/metric/constants.tsx
@@ -67,6 +67,7 @@ const commonAggregations = [
   AggregationKey.P50,
   AggregationKey.P75,
   AggregationKey.P95,
+  AggregationKey.P90,
   AggregationKey.P99,
   AggregationKey.P100,
 ];

--- a/static/app/views/alerts/rules/metric/constants.tsx
+++ b/static/app/views/alerts/rules/metric/constants.tsx
@@ -66,8 +66,8 @@ const commonAggregations = [
   AggregationKey.PERCENTILE,
   AggregationKey.P50,
   AggregationKey.P75,
-  AggregationKey.P95,
   AggregationKey.P90,
+  AggregationKey.P95,
   AggregationKey.P99,
   AggregationKey.P100,
 ];


### PR DESCRIPTION
Adds support for p90 common aggregate for metric alerts

<img width="1066" alt="image" src="https://github.com/getsentry/sentry/assets/86684834/696d885d-2bb0-4c3e-9881-b30b5af4759d">
