### PR TITLE
instr(cache): Log more data on invalid cache

### DIFF
--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -281,7 +281,10 @@ class BaseManager(DjangoBaseManager.from_queryset(BaseQuerySet), Generic[M]):  #
 
             if settings.DEBUG:
                 raise ValueError("Unexpected value type returned from cache")
-            logger.error("Cache response returned invalid value", extra={"instance": inst})
+            logger.error(
+                "Cache response returned invalid value",
+                extra={"instance": inst, "key": key, "model": str(self.model)},
+            )
             if local_cache is not None and cache_key in local_cache:
                 del local_cache[cache_key]
             cache.delete(cache_key, version=self.cache_version)


### PR DESCRIPTION
Log more variables to get insights on [SENTRY-1632](https://sentry.sentry.io/issues/4498514326/).