### PR TITLE
fix(replay): Fix vertically misaligned accessibility and alpha badge

### DIFF
--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -47,7 +47,7 @@ function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
         <FeatureBadge
           type="alpha"
           title={t('This feature is available for early adopters and may change')}
-          tooltipProps={{style: {display: 'flex'}}}
+          tooltipProps={{overlayStyle: {display: 'flex'}}}
         />
       </Fragment>
     ) : null,

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -47,6 +47,7 @@ function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
         <FeatureBadge
           type="alpha"
           title={t('This feature is available for early adopters and may change')}
+          tooltipProps={{style: {display: 'flex'}}}
         />
       </Fragment>
     ) : null,


### PR DESCRIPTION
<!-- Describe your PR here. -->

On [twitter](https://twitter.com/brungarc/status/1736700064695750766/photo/1) I saw a screenshot about replays now having canvas functionality for dotNet. 
In the screenshot seemed like ( please ignore / close this pr if wrong ) the alpha badge seems misaligned with it's label. 

Seems like the `Tooltip` func wasnt aligning it properly, i tried something in dev tools and seemed to work, but had no way to reproduce this ( I am on my work machine ) , but wrote a small fix ( maybe a shot in the dark)

Hope this helps and solves a sort of nitpick but a sort of an annoying thing I noticed on frontend. 

Before:
<img width="236" alt="Screenshot 2023-12-18 at 6 22 26 PM" src="https://github.com/getsentry/sentry/assets/136301926/e2fbd9e8-595a-41cf-9ea0-197b532421ea">

After: ( the spacing above the alpha badge )
<img width="209" alt="Screenshot 2023-12-18 at 6 22 50 PM" src="https://github.com/getsentry/sentry/assets/136301926/95adbba8-1d09-4748-8e35-323aad0f7ac4">


Thanks team for a great feature!


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
