### PR TITLE
fix(ddm): Enable `p90` in alerts

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -1532,6 +1532,14 @@ FUNCTIONS = {
             redundant_grouping=True,
         ),
         DiscoverFunction(
+            "p90",
+            optional_args=[with_default("transaction.duration", NumericColumn("column"))],
+            aggregate=["quantile(0.90)", ArgValue("column"), None],
+            result_type_fn=reflective_result_type(),
+            default_result_type="duration",
+            redundant_grouping=True,
+        ),
+        DiscoverFunction(
             "p95",
             optional_args=[with_default("transaction.duration", NumericColumn("column"))],
             aggregate=["quantile(0.95)", ArgValue("column"), None],

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -778,7 +778,13 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
                 "organizations:use-metrics-layer-in-alerts",
             ]
         ):
-            for mri in ("apdex()", "failure_rate()"):
+            for mri in (
+                "count()",
+                "avg(transaction.duration)",
+                "apdex()",
+                "failure_rate()",
+                "p90(transaction.duration)",
+            ):
                 test_params = {
                     **self.alert_rule_dict,
                     "aggregate": mri,


### PR DESCRIPTION
This PR adds `p90` as a supported discover function.