### PR TITLE
fix(ddm): Fix metrics meta when no projects are supplied

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -191,7 +191,7 @@ def get_available_derived_metrics(
 
 def get_metrics_meta(projects: Sequence[Project], use_case_id: UseCaseID) -> Sequence[MetricMeta]:
     metas = []
-    stored_mris = get_stored_mris(projects, use_case_id) if projects else []
+    stored_mris = get_stored_mris(projects, use_case_id) if projects else {}
 
     for metric_mri, project_ids in stored_mris.items():
         parsed_mri = parse_mri(metric_mri)

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -119,6 +119,13 @@ class OrganizationMetricsMetaTest(OrganizationMetricMetaIntegrationTestCase):
 
         assert response.status_code == 400
 
+    def test_metrics_meta_no_projects(self):
+        response = self.get_success_response(
+            self.organization.slug, project=[], useCase=["transactions"]
+        )
+
+        assert isinstance(response.data, list)
+
     def test_metrics_meta_for_custom_metrics(self):
         project_1 = self.create_project()
         project_2 = self.create_project()

--- a/tests/sentry/snuba/metrics/test_datasource.py
+++ b/tests/sentry/snuba/metrics/test_datasource.py
@@ -68,6 +68,10 @@ class DatasourceTestCase(BaseMetricsLayerTestCase, TestCase):
             custom_mri: [self.project.id],
         }
 
+        # We want to also test without projects.
+        mris = get_stored_mris([], UseCaseID.CUSTOM)
+        assert len(mris) == 0
+
     def test_get_tag_values_with_mri(self):
         releases = ["1.0", "2.0"]
         for release in ("1.0", "2.0"):

--- a/tests/sentry/snuba/metrics/test_datasource.py
+++ b/tests/sentry/snuba/metrics/test_datasource.py
@@ -68,10 +68,6 @@ class DatasourceTestCase(BaseMetricsLayerTestCase, TestCase):
             custom_mri: [self.project.id],
         }
 
-        # We want to also test without projects.
-        mris = get_stored_mris([], UseCaseID.CUSTOM)
-        assert len(mris) == 0
-
     def test_get_tag_values_with_mri(self):
         releases = ["1.0", "2.0"]
         for release in ("1.0", "2.0"):


### PR DESCRIPTION
This PR fixes a problem when no `projects` are supplied to the meta endpoint. In that case we were previously defaulting to `[]` which has no attribute `items()`.