### PR TITLE
fix(hybridcloud) Fix serialization failures on missing tokens

### DIFF
--- a/src/sentry/services/hybrid_cloud/app/serial.py
+++ b/src/sentry/services/hybrid_cloud/app/serial.py
@@ -57,7 +57,8 @@ def serialize_sentry_app_installation(
     api_token = None
     if installation.api_token_id:
         try:
-            api_token = installation.api_token.token
+            if token := installation.api_token:
+                api_token = token.token
         except ApiToken.DoesNotExist:
             pass
 

--- a/src/sentry/services/hybrid_cloud/app/serial.py
+++ b/src/sentry/services/hybrid_cloud/app/serial.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from sentry.constants import SentryAppStatus
 from sentry.models.apiapplication import ApiApplication
+from sentry.models.apitoken import ApiToken
 from sentry.models.integrations import SentryAppComponent
 from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
@@ -52,9 +53,13 @@ def serialize_sentry_app_installation(
     if app is None:
         app = installation.sentry_app
         assert app is not None
+
     api_token = None
-    if installation.api_token_id and installation.api_token:
-        api_token = installation.api_token.token
+    if installation.api_token_id:
+        try:
+            api_token = installation.api_token.token
+        except ApiToken.DoesNotExist:
+            pass
 
     return RpcSentryAppInstallation(
         id=installation.id,


### PR DESCRIPTION
When a sentryapp installation is missing the related ApiToken we shouldn't fail to serialize all the data because an optional relation is missing. SentryApp installations are often serialized to deliver webhooks, which don't require ApiTokens.

Fixes SENTRY-2B6N
Fixes SENTRY-19ED
