### PR TITLE
fix(integrations) Fix jira sync always failing

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -289,6 +289,8 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
     def sync_metadata(self):
         client = self.get_client()
 
+        server_info = {}
+        projects = []
         try:
             server_info = client.get_server_info()
             projects = client.get_projects_list()
@@ -301,7 +303,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         # possible to query that with the API). So instead we just use the first
         # project Icon.
         if len(projects) > 0:
-            avatar = (projects[0]["avatarUrls"]["48x48"],)
+            avatar = projects[0]["avatarUrls"]["48x48"]
             self.model.metadata.update({"icon": avatar})
 
         self.model.save()

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -458,7 +458,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
         # possible to query that with the API). So instead we just use the first
         # project Icon.
         if len(projects) > 0:
-            avatar = (projects[0]["avatarUrls"]["48x48"],)
+            avatar = projects[0]["avatarUrls"]["48x48"]
             self.model.metadata.update({"icon": avatar})
 
         self.model.save()

--- a/src/sentry/tasks/integrations/sync_metadata.py
+++ b/src/sentry/tasks/integrations/sync_metadata.py
@@ -14,5 +14,8 @@ from sentry.tasks.base import instrumented_task, retry
 @retry(on=(IntegrationError,), exclude=(Integration.DoesNotExist,))
 def sync_metadata(integration_id: int) -> None:
     integration = Integration.objects.get(id=integration_id)
-    installation = integration.get_installation(None)
+    org_install = integration.organizationintegration_set.first()
+    if not org_install:
+        return
+    installation = integration.get_installation(org_install.organization_id)
     installation.sync_metadata()

--- a/tests/sentry/tasks/integrations/test_sync_metadata.py
+++ b/tests/sentry/tasks/integrations/test_sync_metadata.py
@@ -1,0 +1,54 @@
+import responses
+
+from sentry.tasks.integrations.sync_metadata import sync_metadata
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test
+class SyncMetadataTest(TestCase):
+    @responses.activate
+    def test_no_sync_with_no_org(self):
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="jira",
+            external_id="abc123",
+            metadata={
+                "base_url": "https://acme.atlassian.net",
+                "shared_secret": "super-sekret",
+            },
+        )
+        integration.organizationintegration_set.first().delete()
+        sync_metadata(integration.id)
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_success(self):
+        responses.add(
+            responses.GET,
+            "https://acme.atlassian.net/rest/api/2/serverInfo",
+            json={
+                "serverTitle": "Acme Jira",
+            },
+        )
+        responses.add(
+            responses.GET,
+            "https://acme.atlassian.net/rest/api/2/project",
+            json=[
+                {"avatarUrls": {"48x48": "https://example.com/avatar.jpg"}},
+            ],
+        )
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="jira",
+            external_id="abc123",
+            metadata={
+                "base_url": "https://acme.atlassian.net",
+                "shared_secret": "super-sekret",
+            },
+        )
+        sync_metadata(integration.id)
+
+        integration.refresh_from_db()
+        assert integration.name == "Acme Jira"
+        assert integration.metadata["icon"] == "https://example.com/avatar.jpg"

--- a/tests/sentry/tasks/integrations/test_sync_metadata.py
+++ b/tests/sentry/tasks/integrations/test_sync_metadata.py
@@ -18,7 +18,9 @@ class SyncMetadataTest(TestCase):
                 "shared_secret": "super-sekret",
             },
         )
-        integration.organizationintegration_set.first().delete()
+        org_integration = integration.organizationintegration_set.first()
+        if org_integration:
+            org_integration.delete()
         sync_metadata(integration.id)
         assert len(responses.calls) == 0
 


### PR DESCRIPTION
Getting an installation requires an organization_id. Provide one if we have an organization linked to the integration.

I've also fixed the integration icon being saved as a tuple. The JS types and API serializer imply that this value should be a string.

Fixes SENTRY-1680