### PR TITLE
ref(ts): Remove usage of `TestStubs.User`

### DIFF
--- a/fixtures/js-stubs/actor.tsx
+++ b/fixtures/js-stubs/actor.tsx
@@ -1,0 +1,11 @@
+import type {Actor as ActorType} from 'sentry/types';
+
+export function Actor(params: Partial<ActorType> = {}): ActorType {
+  return {
+    id: '1',
+    email: 'foo@example.com',
+    name: 'Foo Bar',
+    type: 'user',
+    ...params,
+  };
+}

--- a/fixtures/js-stubs/authenticators.tsx
+++ b/fixtures/js-stubs/authenticators.tsx
@@ -3,6 +3,7 @@ import type {
   SmsAuthenticator as SmsAuthenticatorType,
   TotpAuthenticator as TotpAuthenticatorType,
   U2fAuthenticator as U2fAuthenticatorType,
+  UserEnrolledAuthenticator as UserEnrolledAuthenticatorType,
 } from 'sentry/types';
 
 export function Authenticators(): {
@@ -129,4 +130,17 @@ export function Authenticators(): {
 
 export function AllAuthenticators() {
   return Object.values(Authenticators()).map(x => x());
+}
+
+export function UserEnrolledAuthenticator(
+  params: Partial<UserEnrolledAuthenticatorType>
+): UserEnrolledAuthenticatorType {
+  return {
+    id: '1',
+    type: 'totp',
+    name: 'auth',
+    dateCreated: '2020-01-01T00:00:00.000Z',
+    dateUsed: '2020-01-01T00:00:00.000Z',
+    ...params,
+  };
 }

--- a/static/app/components/acl/access.spec.tsx
+++ b/static/app/components/acl/access.spec.tsx
@@ -1,6 +1,7 @@
 import {Organization} from 'sentry-fixture/organization';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -146,7 +147,7 @@ describe('Access', function () {
 
     it('is superuser', function () {
       ConfigStore.config = TestStubs.Config({
-        user: TestStubs.User({isSuperuser: true}),
+        user: User({isSuperuser: true}),
       });
 
       render(<Access isSuperuser>{childrenMock}</Access>, {
@@ -162,7 +163,7 @@ describe('Access', function () {
 
     it('is not superuser', function () {
       ConfigStore.config = TestStubs.Config({
-        user: TestStubs.User({isSuperuser: false}),
+        user: User({isSuperuser: false}),
       });
 
       render(<Access isSuperuser>{childrenMock}</Access>, {
@@ -202,7 +203,7 @@ describe('Access', function () {
 
     it('has superuser', function () {
       ConfigStore.config = TestStubs.Config({
-        user: TestStubs.User({isSuperuser: true}),
+        user: User({isSuperuser: true}),
       });
 
       render(
@@ -217,7 +218,7 @@ describe('Access', function () {
 
     it('has no superuser', function () {
       ConfigStore.config = TestStubs.Config({
-        user: TestStubs.User({isSuperuser: false}),
+        user: User({isSuperuser: false}),
       });
 
       render(

--- a/static/app/components/assigneeSelector.spec.tsx
+++ b/static/app/components/assigneeSelector.spec.tsx
@@ -1,5 +1,6 @@
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -27,17 +28,17 @@ describe('AssigneeSelector', () => {
   let GROUP_2;
 
   beforeEach(() => {
-    USER_1 = TestStubs.User({
+    USER_1 = User({
       id: '1',
       name: 'Jane Bloggs',
       email: 'janebloggs@example.com',
     });
-    USER_2 = TestStubs.User({
+    USER_2 = User({
       id: '2',
       name: 'John Smith',
       email: 'johnsmith@example.com',
     });
-    USER_3 = TestStubs.User({
+    USER_3 = User({
       id: '3',
       name: 'J J',
       email: 'jj@example.com',
@@ -152,7 +153,7 @@ describe('AssigneeSelector', () => {
     it("should return the same member list if the session user isn't present", () => {
       render(<AssigneeSelectorComponent id={GROUP_1.id} />);
       jest.spyOn(ConfigStore, 'get').mockImplementation(() =>
-        TestStubs.User({
+        User({
           id: '555',
           name: 'Here Comes a New Challenger',
           email: 'guile@mail.us.af.mil',

--- a/static/app/components/assistant/guideAnchor.spec.tsx
+++ b/static/app/components/assistant/guideAnchor.spec.tsx
@@ -18,7 +18,7 @@ describe('GuideAnchor', function () {
     ConfigStore.config = TestStubs.Config({
       user: User({
         isSuperuser: false,
-        dateJoined: new Date(2020, 0, 1),
+        dateJoined: '2020-01-01T00:00:00',
       }),
     });
   });

--- a/static/app/components/assistant/guideAnchor.spec.tsx
+++ b/static/app/components/assistant/guideAnchor.spec.tsx
@@ -1,3 +1,5 @@
+import {User} from 'sentry-fixture/user';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
@@ -14,7 +16,7 @@ describe('GuideAnchor', function () {
 
   beforeEach(function () {
     ConfigStore.config = TestStubs.Config({
-      user: TestStubs.User({
+      user: User({
         isSuperuser: false,
         dateJoined: new Date(2020, 0, 1),
       }),

--- a/static/app/components/avatar/avatarList.spec.tsx
+++ b/static/app/components/avatar/avatarList.spec.tsx
@@ -1,4 +1,5 @@
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -15,7 +16,7 @@ function renderComponent({
 }
 
 describe('AvatarList', () => {
-  const user = TestStubs.User();
+  const user = User();
   const team = Team();
 
   it('renders with user letter avatars', () => {

--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -264,7 +264,7 @@ describe('ContextPickerModal', function () {
   it('is superUser and no integration configurations and calls `onFinish` with URL to integration overview page', async function () {
     OrganizationsStore.load([org]);
     OrganizationStore.onUpdate(org);
-    ConfigStore.config = User({isSuperuser: false});
+    ConfigStore.config.user = User({isSuperuser: false});
 
     const provider = {slug: 'github'};
     const configUrl = `/api/0/organizations/${org.slug}/integrations/?provider_key=${provider.slug}&includeConfig=0`;

--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -1,5 +1,6 @@
 import selectEvent from 'react-select-event';
 import {Organization} from 'sentry-fixture/organization';
+import {User} from 'sentry-fixture/user';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -191,7 +192,7 @@ describe('ContextPickerModal', function () {
   it('isSuperUser and selects an integrationConfig and calls `onFinish` with URL to that configuration', async function () {
     OrganizationsStore.load([org]);
     OrganizationStore.onUpdate(org);
-    ConfigStore.config.user = TestStubs.User({isSuperuser: true});
+    ConfigStore.config.user = User({isSuperuser: true});
 
     const provider = {slug: 'github'};
     const configUrl = `/api/0/organizations/${org.slug}/integrations/?provider_key=${provider.slug}&includeConfig=0`;
@@ -231,7 +232,7 @@ describe('ContextPickerModal', function () {
   it('not superUser and cannot select an integrationConfig and calls `onFinish` with URL to integration overview page', async function () {
     OrganizationsStore.load([org]);
     OrganizationStore.onUpdate(org);
-    ConfigStore.config.user = TestStubs.User({isSuperuser: false});
+    ConfigStore.config.user = User({isSuperuser: false});
 
     const provider = {slug: 'github'};
     const configUrl = `/api/0/organizations/${org.slug}/integrations/?provider_key=${provider.slug}&includeConfig=0`;
@@ -263,7 +264,7 @@ describe('ContextPickerModal', function () {
   it('is superUser and no integration configurations and calls `onFinish` with URL to integration overview page', async function () {
     OrganizationsStore.load([org]);
     OrganizationStore.onUpdate(org);
-    ConfigStore.config = TestStubs.User({isSuperuser: false});
+    ConfigStore.config = User({isSuperuser: false});
 
     const provider = {slug: 'github'};
     const configUrl = `/api/0/organizations/${org.slug}/integrations/?provider_key=${provider.slug}&includeConfig=0`;

--- a/static/app/components/customResolutionModal.spec.tsx
+++ b/static/app/components/customResolutionModal.spec.tsx
@@ -1,6 +1,7 @@
 import selectEvent from 'react-select-event';
 import styled from '@emotion/styled';
 import {Organization} from 'sentry-fixture/organization';
+import {User} from 'sentry-fixture/user';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -15,7 +16,7 @@ describe('CustomResolutionModal', () => {
     ConfigStore.init();
     releasesMock = MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/releases/',
-      body: [TestStubs.Release({authors: [TestStubs.User()]})],
+      body: [TestStubs.Release({authors: [User()]})],
     });
   });
 
@@ -52,7 +53,7 @@ describe('CustomResolutionModal', () => {
   });
 
   it('indicates which releases had commits from the user', async () => {
-    const user = TestStubs.User();
+    const user = User();
     ConfigStore.set('user', user);
     render(
       <CustomResolutionModal

--- a/static/app/components/dateTime.spec.tsx
+++ b/static/app/components/dateTime.spec.tsx
@@ -1,10 +1,12 @@
+import {User} from 'sentry-fixture/user';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import DateTime from 'sentry/components/dateTime';
 import ConfigStore from 'sentry/stores/configStore';
 
 describe('DateTime', () => {
-  const user = TestStubs.User({
+  const user = User({
     options: {
       clock24Hours: false,
       timezone: 'America/Los_Angeles',

--- a/static/app/components/dateTime.spec.tsx
+++ b/static/app/components/dateTime.spec.tsx
@@ -8,6 +8,7 @@ import ConfigStore from 'sentry/stores/configStore';
 describe('DateTime', () => {
   const user = User({
     options: {
+      ...User().options,
       clock24Hours: false,
       timezone: 'America/Los_Angeles',
     },

--- a/static/app/components/eventOrGroupHeader.spec.tsx
+++ b/static/app/components/eventOrGroupHeader.spec.tsx
@@ -1,4 +1,5 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -245,7 +246,7 @@ describe('EventOrGroupHeader', function () {
             function: 'useOverflowTabs',
             display_title_with_tree_label: false,
           },
-          actor: TestStubs.User(),
+          actor: User(),
           isTombstone: true,
         }}
         {...router}

--- a/static/app/components/eventOrGroupTitle.spec.tsx
+++ b/static/app/components/eventOrGroupTitle.spec.tsx
@@ -1,5 +1,6 @@
 import {Organization} from 'sentry-fixture/organization';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import {User} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -118,7 +119,7 @@ describe('EventOrGroupTitle', function () {
             function: 'useOverflowTabs',
             display_title_with_tree_label: false,
           },
-          actor: TestStubs.User(),
+          actor: User(),
           isTombstone: true,
         }}
         withStackTracePreview

--- a/static/app/components/forms/jsonForm.spec.tsx
+++ b/static/app/components/forms/jsonForm.spec.tsx
@@ -1,3 +1,5 @@
+import {User} from 'sentry-fixture/user';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import JsonForm from 'sentry/components/forms/jsonForm';
@@ -6,7 +8,7 @@ import {fields} from 'sentry/data/forms/projectGeneralSettings';
 
 import {JsonFormObject} from './types';
 
-const user = TestStubs.User();
+const user = User();
 
 describe('JsonForm', function () {
   describe('form prop', function () {

--- a/static/app/components/group/assignedTo.spec.tsx
+++ b/static/app/components/group/assignedTo.spec.tsx
@@ -3,6 +3,7 @@ import {CommitAuthor} from 'sentry-fixture/commitAuthor';
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -17,12 +18,12 @@ import type {
   Organization as TOrganization,
   Project,
   Team as TeamType,
-  User,
+  User as UserType,
 } from 'sentry/types';
 
 describe('Group > AssignedTo', () => {
-  let USER_1!: User;
-  let USER_2!: User;
+  let USER_1!: UserType;
+  let USER_2!: UserType;
   let TEAM_1!: TeamType;
   let PROJECT_1!: Project;
   let GROUP_1!: Group;
@@ -32,12 +33,12 @@ describe('Group > AssignedTo', () => {
 
   beforeEach(() => {
     organization = Organization();
-    USER_1 = TestStubs.User({
+    USER_1 = User({
       id: '1',
       name: 'Jane Bloggs',
       email: 'janebloggs@example.com',
     });
-    USER_2 = TestStubs.User({
+    USER_2 = User({
       id: '2',
       name: 'John Smith',
       email: 'johnsmith@example.com',

--- a/static/app/components/idBadge/index.spec.tsx
+++ b/static/app/components/idBadge/index.spec.tsx
@@ -1,5 +1,6 @@
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -7,7 +8,7 @@ import IdBadge from 'sentry/components/idBadge';
 
 describe('IdBadge', function () {
   it('renders the correct component when `user` property is passed', function () {
-    const user = TestStubs.User();
+    const user = User();
     render(<IdBadge user={user} />);
     expect(screen.getByTestId('letter_avatar-avatar')).toHaveTextContent('FB');
     expect(screen.getByText(user.email)).toBeInTheDocument();

--- a/static/app/components/idBadge/memberBadge.spec.tsx
+++ b/static/app/components/idBadge/memberBadge.spec.tsx
@@ -1,4 +1,5 @@
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import {User} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -48,7 +49,7 @@ describe('MemberBadge', function () {
   });
 
   it('can coalesce using username', function () {
-    member.user = TestStubs.User({
+    member.user = User({
       name: null,
       email: null,
       username: 'the-batman',
@@ -60,7 +61,7 @@ describe('MemberBadge', function () {
   });
 
   it('can coalesce using ipaddress', function () {
-    member.user = TestStubs.User({
+    member.user = User({
       name: null,
       email: null,
       username: null,

--- a/static/app/components/idBadge/memberBadge.spec.tsx
+++ b/static/app/components/idBadge/memberBadge.spec.tsx
@@ -50,8 +50,8 @@ describe('MemberBadge', function () {
 
   it('can coalesce using username', function () {
     member.user = User({
-      name: null,
-      email: null,
+      name: undefined,
+      email: undefined,
       username: 'the-batman',
     });
 
@@ -62,9 +62,9 @@ describe('MemberBadge', function () {
 
   it('can coalesce using ipaddress', function () {
     member.user = User({
-      name: null,
-      email: null,
-      username: null,
+      name: undefined,
+      email: undefined,
+      username: undefined,
       ipAddress: '127.0.0.1',
     });
     render(<MemberBadge member={member} />);

--- a/static/app/components/idBadge/userBadge.spec.tsx
+++ b/static/app/components/idBadge/userBadge.spec.tsx
@@ -1,10 +1,12 @@
+import {User} from 'sentry-fixture/user';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import UserBadge from 'sentry/components/idBadge/userBadge';
 import {AvatarUser} from 'sentry/types';
 
 describe('UserBadge', function () {
-  const user: AvatarUser = TestStubs.User();
+  const user: AvatarUser = User();
 
   it('renders with no link when user is supplied', function () {
     render(<UserBadge user={user} />);
@@ -27,7 +29,7 @@ describe('UserBadge', function () {
   });
 
   it('can coalesce using username', function () {
-    const username = TestStubs.User({
+    const username = User({
       name: null,
       email: null,
       username: 'the-batman',
@@ -38,7 +40,7 @@ describe('UserBadge', function () {
   });
 
   it('can coalesce using ipaddress', function () {
-    const ipUser = TestStubs.User({
+    const ipUser = User({
       name: null,
       email: null,
       username: null,
@@ -51,7 +53,7 @@ describe('UserBadge', function () {
   });
 
   it('can coalesce using id', function () {
-    const idUser = TestStubs.User({
+    const idUser = User({
       id: '99',
       name: null,
       email: null,
@@ -70,7 +72,7 @@ describe('UserBadge', function () {
   });
 
   it('can coalesce using ip', function () {
-    const ipUser = TestStubs.User({
+    const ipUser = User({
       name: null,
       email: null,
       username: null,

--- a/static/app/components/idBadge/userBadge.spec.tsx
+++ b/static/app/components/idBadge/userBadge.spec.tsx
@@ -30,8 +30,8 @@ describe('UserBadge', function () {
 
   it('can coalesce using username', function () {
     const username = User({
-      name: null,
-      email: null,
+      name: undefined,
+      email: undefined,
       username: 'the-batman',
     });
     render(<UserBadge user={username} />);
@@ -41,10 +41,10 @@ describe('UserBadge', function () {
 
   it('can coalesce using ipaddress', function () {
     const ipUser = User({
-      name: null,
-      email: null,
-      username: null,
-      ip_address: null,
+      name: undefined,
+      email: undefined,
+      username: undefined,
+      ip_address: undefined,
       ipAddress: '127.0.0.1',
     });
     render(<UserBadge user={ipUser} />);
@@ -55,11 +55,11 @@ describe('UserBadge', function () {
   it('can coalesce using id', function () {
     const idUser = User({
       id: '99',
-      name: null,
-      email: null,
-      username: null,
-      ip_address: null,
-      ipAddress: null,
+      name: undefined,
+      email: undefined,
+      username: undefined,
+      ip_address: undefined,
+      ipAddress: undefined,
     });
     render(<UserBadge user={idUser} />);
 
@@ -73,9 +73,9 @@ describe('UserBadge', function () {
 
   it('can coalesce using ip', function () {
     const ipUser = User({
-      name: null,
-      email: null,
-      username: null,
+      name: undefined,
+      email: undefined,
+      username: undefined,
       ip: '127.0.0.1',
     });
     render(<UserBadge user={ipUser} />);

--- a/static/app/components/idBadge/userBadge.spec.tsx
+++ b/static/app/components/idBadge/userBadge.spec.tsx
@@ -49,7 +49,7 @@ describe('UserBadge', function () {
     });
     render(<UserBadge user={ipUser} />);
 
-    expect(screen.getByText(ipUser.ipAddress)).toBeInTheDocument();
+    expect(screen.getByText('127.0.0.1')).toBeInTheDocument();
   });
 
   it('can coalesce using id', function () {
@@ -80,6 +80,6 @@ describe('UserBadge', function () {
     });
     render(<UserBadge user={ipUser} />);
 
-    expect(screen.getByText(ipUser.ip)).toBeInTheDocument();
+    expect(screen.getByText('127.0.0.1')).toBeInTheDocument();
   });
 });

--- a/static/app/components/organizations/pageFilters/container.spec.tsx
+++ b/static/app/components/organizations/pageFilters/container.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -563,7 +564,7 @@ describe('PageFiltersContainer', function () {
       ConfigStore.init();
       ConfigStore.loadInitialData(
         TestStubs.Config({
-          user: TestStubs.User({isSuperuser: true}),
+          user: User({isSuperuser: true}),
         })
       );
       const project = TestStubs.Project({id: '3', isMember: false});

--- a/static/app/components/resolutionBox.spec.tsx
+++ b/static/app/components/resolutionBox.spec.tsx
@@ -1,4 +1,5 @@
 import {Commit} from 'sentry-fixture/commit';
+import {User} from 'sentry-fixture/user';
 
 import {render} from 'sentry-test/reactTestingLibrary';
 
@@ -44,7 +45,7 @@ describe('ResolutionBox', function () {
       <ResolutionBox
         statusDetails={{
           inNextRelease: true,
-          actor: TestStubs.User(),
+          actor: User(),
         }}
         projectId="1"
         activities={[

--- a/static/app/components/seenByList.spec.tsx
+++ b/static/app/components/seenByList.spec.tsx
@@ -1,3 +1,5 @@
+import {User} from 'sentry-fixture/user';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import SeenByList from 'sentry/components/seenByList';
@@ -14,14 +16,11 @@ describe('SeenByList', function () {
   });
 
   it('should return a list of each user that saw', function () {
-    ConfigStore.set('user', TestStubs.User());
+    ConfigStore.set('user', User());
 
     render(
       <SeenByList
-        seenBy={[
-          TestStubs.User({id: '2', name: 'jane'}),
-          TestStubs.User({id: '3', name: 'john'}),
-        ]}
+        seenBy={[User({id: '2', name: 'jane'}), User({id: '3', name: 'john'})]}
       />
     );
 
@@ -30,14 +29,11 @@ describe('SeenByList', function () {
   });
 
   it('filters out the current user from list of users', function () {
-    ConfigStore.set('user', TestStubs.User({id: '2', name: 'jane'}));
+    ConfigStore.set('user', User({id: '2', name: 'jane'}));
 
     render(
       <SeenByList
-        seenBy={[
-          TestStubs.User({id: '2', name: 'jane'}),
-          TestStubs.User({id: '3', name: 'john'}),
-        ]}
+        seenBy={[User({id: '2', name: 'jane'}), User({id: '3', name: 'john'})]}
       />
     );
 

--- a/static/app/components/sidebar/sidebarDropdown/index.spec.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.spec.tsx
@@ -1,5 +1,6 @@
 import {Organization} from 'sentry-fixture/organization';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import {User} from 'sentry-fixture/user';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -7,7 +8,7 @@ import SidebarDropdown from 'sentry/components/sidebar/sidebarDropdown';
 import ConfigStore from 'sentry/stores/configStore';
 
 function renderDropdown(props: any = {}) {
-  const user = TestStubs.User();
+  const user = User();
   const config = TestStubs.Config();
   const organization = Organization({orgRole: 'member'});
   const routerContext = RouterContextFixture([

--- a/static/app/stores/groupStore.spec.tsx
+++ b/static/app/stores/groupStore.spec.tsx
@@ -1,5 +1,5 @@
+import {Actor} from 'sentry-fixture/actor';
 import {Project} from 'sentry-fixture/project';
-import {User} from 'sentry-fixture/user';
 
 import GroupStore from 'sentry/stores/groupStore';
 import {Group, GroupActivityType, GroupStats, TimeseriesValue} from 'sentry/types';
@@ -222,7 +222,7 @@ describe('GroupStore', function () {
     describe('onAssignToSuccess()', function () {
       it("should treat undefined itemIds argument as 'all'", function () {
         GroupStore.items = [g('1')];
-        const assignedGroup = g('1', {assignedTo: User({type: 'user'})});
+        const assignedGroup = g('1', {assignedTo: Actor()});
         GroupStore.onAssignToSuccess('1337', '1', assignedGroup);
 
         expect(GroupStore.trigger).toHaveBeenCalledTimes(1);

--- a/static/app/stores/groupStore.spec.tsx
+++ b/static/app/stores/groupStore.spec.tsx
@@ -1,4 +1,5 @@
 import {Project} from 'sentry-fixture/project';
+import {User} from 'sentry-fixture/user';
 
 import GroupStore from 'sentry/stores/groupStore';
 import {Group, GroupActivityType, GroupStats, TimeseriesValue} from 'sentry/types';
@@ -221,7 +222,7 @@ describe('GroupStore', function () {
     describe('onAssignToSuccess()', function () {
       it("should treat undefined itemIds argument as 'all'", function () {
         GroupStore.items = [g('1')];
-        const assignedGroup = g('1', {assignedTo: TestStubs.User({type: 'user'})});
+        const assignedGroup = g('1', {assignedTo: User({type: 'user'})});
         GroupStore.onAssignToSuccess('1337', '1', assignedGroup);
 
         expect(GroupStore.trigger).toHaveBeenCalledTimes(1);

--- a/static/app/stores/guideStore.spec.tsx
+++ b/static/app/stores/guideStore.spec.tsx
@@ -16,7 +16,7 @@ describe('GuideStore', function () {
       user: User({
         id: '5',
         isSuperuser: false,
-        dateJoined: new Date(2020, 0, 1),
+        dateJoined: '2020-01-01T00:00:00',
       }),
     });
     GuideStore.init();

--- a/static/app/stores/guideStore.spec.tsx
+++ b/static/app/stores/guideStore.spec.tsx
@@ -1,3 +1,5 @@
+import {User} from 'sentry-fixture/user';
+
 import ConfigStore from 'sentry/stores/configStore';
 import GuideStore from 'sentry/stores/guideStore';
 import ModalStore from 'sentry/stores/modalStore';
@@ -11,7 +13,7 @@ describe('GuideStore', function () {
   beforeEach(function () {
     jest.clearAllMocks();
     ConfigStore.config = TestStubs.Config({
-      user: TestStubs.User({
+      user: User({
         id: '5',
         isSuperuser: false,
         dateJoined: new Date(2020, 0, 1),

--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -1,4 +1,4 @@
-import type {Authenticator, EnrolledAuthenticator} from './auth';
+import type {UserEnrolledAuthenticator} from './auth';
 import type {Avatar, Scope} from './core';
 import type {UserExperiments} from './experiments';
 
@@ -20,17 +20,6 @@ export type AvatarUser = {
   options?: {
     avatarType: Avatar['avatarType'];
   };
-};
-
-/**
- * This is an authenticator that a user is enrolled in
- */
-export type UserEnrolledAuthenticator = {
-  dateCreated: EnrolledAuthenticator['createdAt'];
-  dateUsed: EnrolledAuthenticator['lastUsedAt'];
-  id: EnrolledAuthenticator['authId'];
-  name: EnrolledAuthenticator['name'];
-  type: Authenticator['id'];
 };
 
 export interface User extends Omit<AvatarUser, 'options'> {

--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -25,7 +25,7 @@ export type AvatarUser = {
 /**
  * This is an authenticator that a user is enrolled in
  */
-type UserEnrolledAuthenticator = {
+export type UserEnrolledAuthenticator = {
   dateCreated: EnrolledAuthenticator['createdAt'];
   dateUsed: EnrolledAuthenticator['lastUsedAt'];
   id: EnrolledAuthenticator['authId'];

--- a/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
@@ -1,3 +1,5 @@
+import {User} from 'sentry-fixture/user';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -71,7 +73,7 @@ describe('getIssueFieldRenderer', function () {
   describe('Issue fields', () => {
     it('can render assignee', async function () {
       MemberListStore.loadInitialData([
-        TestStubs.User({
+        User({
           name: 'Test User',
           email: 'test@sentry.io',
           avatar: {

--- a/static/app/utils/dates.spec.tsx
+++ b/static/app/utils/dates.spec.tsx
@@ -1,3 +1,5 @@
+import {User} from 'sentry-fixture/user';
+
 import ConfigStore from 'sentry/stores/configStore';
 import {
   getTimeFormat,
@@ -66,19 +68,19 @@ describe('utils.dates', function () {
 
   describe('user clock preferences', function () {
     afterEach(function () {
-      ConfigStore.set('user', TestStubs.User({}));
+      ConfigStore.set('user', User({}));
     });
 
     describe('shouldUse24Hours()', function () {
       it('returns false if user preference is 12 hour clock', function () {
-        const user = TestStubs.User();
+        const user = User();
         user.options.clock24Hours = false;
         ConfigStore.set('user', user);
         expect(shouldUse24Hours()).toBe(false);
       });
 
       it('returns true if user preference is 24 hour clock', function () {
-        const user = TestStubs.User();
+        const user = User();
         user.options.clock24Hours = true;
         ConfigStore.set('user', user);
         expect(shouldUse24Hours()).toBe(true);
@@ -87,13 +89,13 @@ describe('utils.dates', function () {
 
     describe('getTimeFormat()', function () {
       it('does not use AM/PM if shouldUse24Hours is true', function () {
-        const user = TestStubs.User();
+        const user = User();
         user.options.clock24Hours = true;
         ConfigStore.set('user', user);
         expect(getTimeFormat()).toBe('HH:mm');
       });
       it('uses AM/PM if shouldUse24Hours is false', function () {
-        const user = TestStubs.User();
+        const user = User();
         user.options.clock24Hours = false;
         ConfigStore.set('user', user);
         expect(getTimeFormat()).toBe('LT');

--- a/static/app/utils/discover/fieldRenderers.spec.tsx
+++ b/static/app/utils/discover/fieldRenderers.spec.tsx
@@ -1,3 +1,5 @@
+import {User} from 'sentry-fixture/user';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -105,9 +107,9 @@ describe('getFieldRenderer', function () {
     beforeEach(function () {
       ConfigStore.loadInitialData(
         TestStubs.Config({
-          user: TestStubs.User({
+          user: User({
             options: {
-              ...TestStubs.User().options,
+              ...User().options,
               timezone: 'America/Los_Angeles',
             },
           }),
@@ -146,9 +148,9 @@ describe('getFieldRenderer', function () {
     // Set timezone
     ConfigStore.loadInitialData(
       TestStubs.Config({
-        user: TestStubs.User({
+        user: User({
           options: {
-            ...TestStubs.User().options,
+            ...User().options,
             timezone: 'America/Los_Angeles',
           },
         }),
@@ -335,7 +337,7 @@ describe('getFieldRenderer', function () {
           organization,
           eventView: new EventView({
             sorts: [{field: 'spans.db', kind: 'desc'}],
-            createdBy: TestStubs.User(),
+            createdBy: User(),
             display: undefined,
             end: undefined,
             start: undefined,

--- a/static/app/utils/useMembers.spec.tsx
+++ b/static/app/utils/useMembers.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {User} from 'sentry-fixture/user';
 
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
@@ -9,7 +10,7 @@ import {useMembers} from 'sentry/utils/useMembers';
 describe('useMembers', function () {
   const org = Organization();
 
-  const mockUsers = [TestStubs.User()];
+  const mockUsers = [User()];
 
   beforeEach(function () {
     MemberListStore.reset();
@@ -27,8 +28,8 @@ describe('useMembers', function () {
 
   it('loads more members when using onSearch', async function () {
     MemberListStore.loadInitialData(mockUsers);
-    const newUser2 = TestStubs.User({id: '2', email: 'test-user2@example.com'});
-    const newUser3 = TestStubs.User({id: '3', email: 'test-user3@example.com'});
+    const newUser2 = User({id: '2', email: 'test-user2@example.com'});
+    const newUser3 = User({id: '3', email: 'test-user3@example.com'});
 
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/members/`,
@@ -63,7 +64,7 @@ describe('useMembers', function () {
 
   it('provides only the specified emails', async function () {
     MemberListStore.loadInitialData(mockUsers);
-    const userFoo = TestStubs.User({email: 'foo@test.com'});
+    const userFoo = User({email: 'foo@test.com'});
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/members/`,
       method: 'GET',
@@ -85,7 +86,7 @@ describe('useMembers', function () {
 
   it('provides only the specified ids', async function () {
     MemberListStore.loadInitialData(mockUsers);
-    const userFoo = TestStubs.User({id: '10'});
+    const userFoo = User({id: '10'});
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/members/`,
       method: 'GET',

--- a/static/app/utils/withIssueTags.spec.tsx
+++ b/static/app/utils/withIssueTags.spec.tsx
@@ -1,5 +1,6 @@
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -79,10 +80,7 @@ describe('withIssueTags HoC', function () {
       TeamStore.loadInitialData([
         Team({slug: 'best-team-na', name: 'Best Team NA', isMember: true}),
       ]);
-      MemberListStore.loadInitialData([
-        TestStubs.User(),
-        TestStubs.User({username: 'joe@example.com'}),
-      ]);
+      MemberListStore.loadInitialData([User(), User({username: 'joe@example.com'})]);
     });
 
     expect(
@@ -102,10 +100,7 @@ describe('withIssueTags HoC', function () {
       Team({id: '1', slug: 'best-team', name: 'Best Team', isMember: true}),
       Team({id: '2', slug: 'worst-team', name: 'Worst Team', isMember: false}),
     ]);
-    MemberListStore.loadInitialData([
-      TestStubs.User(),
-      TestStubs.User({username: 'joe@example.com'}),
-    ]);
+    MemberListStore.loadInitialData([User(), User({username: 'joe@example.com'})]);
     const {container} = render(
       <Container organization={Organization()} forwardedValue="value" />
     );

--- a/static/app/views/alerts/rules/metric/constants.spec.tsx
+++ b/static/app/views/alerts/rules/metric/constants.spec.tsx
@@ -1,10 +1,12 @@
+import {User} from 'sentry-fixture/user';
+
 import EventView, {EventViewOptions} from 'sentry/utils/discover/eventView';
 import {createRuleFromEventView} from 'sentry/views/alerts/rules/metric/constants';
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 
 describe('createRuleFromEventView()', () => {
   const commonEventViewProps: EventViewOptions = {
-    createdBy: TestStubs.User(),
+    createdBy: User(),
     id: '',
     name: '',
     start: '',

--- a/static/app/views/dashboards/datasetConfig/errorsAndTransactions.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/errorsAndTransactions.spec.tsx
@@ -1,3 +1,5 @@
+import {User} from 'sentry-fixture/user';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -10,7 +12,7 @@ describe('getCustomFieldRenderer', function () {
   const baseEventViewOptions: EventViewOptions = {
     start: undefined,
     end: undefined,
-    createdBy: TestStubs.User(),
+    createdBy: User(),
     display: undefined,
     fields: [],
     sorts: [],

--- a/static/app/views/discover/tags.spec.tsx
+++ b/static/app/views/discover/tags.spec.tsx
@@ -1,5 +1,6 @@
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -26,7 +27,7 @@ const commonQueryConditions = {
   environment: [],
   topEvents: '',
   yAxis: '',
-  createdBy: TestStubs.User(),
+  createdBy: User(),
   team: [parseInt(Team().id, 10)],
   statsPeriod: '14d',
 };

--- a/static/app/views/issueDetails/groupActivity.spec.tsx
+++ b/static/app/views/issueDetails/groupActivity.spec.tsx
@@ -1,6 +1,7 @@
 import {Organization} from 'sentry-fixture/organization';
 import {Repository} from 'sentry-fixture/repository';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -28,7 +29,7 @@ describe('GroupActivity', function () {
     project = TestStubs.Project();
     ProjectsStore.loadInitialData([project]);
     ConfigStore.init();
-    ConfigStore.set('user', TestStubs.User({id: '123'}));
+    ConfigStore.set('user', User({id: '123'}));
     GroupStore.init();
   });
 
@@ -47,7 +48,7 @@ describe('GroupActivity', function () {
     const group = TestStubs.Group({
       id: '1337',
       activity: activity ?? [
-        {type: 'note', id: 'note-1', data: {text: 'Test Note'}, user: TestStubs.User()},
+        {type: 'note', id: 'note-1', data: {text: 'Test Note'}, user: User()},
       ],
       project,
     });
@@ -75,7 +76,7 @@ describe('GroupActivity', function () {
   });
 
   it('renders a marked reviewed activity', function () {
-    const user = TestStubs.User({name: 'Samwise'});
+    const user = User({name: 'Samwise'});
     createWrapper({
       activity: [
         {
@@ -93,7 +94,7 @@ describe('GroupActivity', function () {
   });
 
   it('renders a pr activity', function () {
-    const user = TestStubs.User({name: 'Test User'});
+    const user = User({name: 'Test User'});
     const repository = Repository();
     createWrapper({
       activity: [
@@ -120,7 +121,7 @@ describe('GroupActivity', function () {
   });
 
   it('renders a assigned to self activity', function () {
-    const user = TestStubs.User({id: '123', name: 'Mark'});
+    const user = User({id: '123', name: 'Mark'});
     createWrapper({
       activity: [
         {
@@ -153,7 +154,7 @@ describe('GroupActivity', function () {
             assigneeType: 'user',
             integration: 'codeowners',
             rule: 'path:something/*.py #workflow',
-            user: TestStubs.User(),
+            user: User(),
           },
           project: TestStubs.Project(),
           dateCreated: '2021-10-01T15:31:38.950115Z',
@@ -169,7 +170,7 @@ describe('GroupActivity', function () {
   });
 
   it('renders an assigned via slack activity', function () {
-    const user = TestStubs.User({id: '301', name: 'Mark'});
+    const user = User({id: '301', name: 'Mark'});
     createWrapper({
       activity: [
         {
@@ -178,7 +179,7 @@ describe('GroupActivity', function () {
             assigneeEmail: 'anotheruser@sentry.io',
             assigneeType: 'user',
             integration: 'slack',
-            user: TestStubs.User(),
+            user: User(),
           },
           project: TestStubs.Project(),
           dateCreated: '2021-10-01T15:31:38.950115Z',
@@ -210,7 +211,7 @@ describe('GroupActivity', function () {
               releases: [],
             },
           },
-          user: TestStubs.User(),
+          user: User(),
         },
       ],
     });
@@ -242,7 +243,7 @@ describe('GroupActivity', function () {
               ],
             },
           },
-          user: TestStubs.User(),
+          user: User(),
         },
       ],
     });
@@ -289,7 +290,7 @@ describe('GroupActivity', function () {
               ],
             },
           },
-          user: TestStubs.User(),
+          user: User(),
         },
       ],
     });
@@ -314,7 +315,7 @@ describe('GroupActivity', function () {
           data: {
             assignee: team.id,
             assigneeType: 'team',
-            user: TestStubs.User(),
+            user: User(),
           },
           dateCreated: '2021-10-28T13:40:10.634821Z',
         },
@@ -338,7 +339,7 @@ describe('GroupActivity', function () {
         url: '/organizations/org-slug/issues/1337/comments/note-1/',
         method: 'DELETE',
       });
-      ConfigStore.set('user', TestStubs.User({id: '123', isSuperuser: true}));
+      ConfigStore.set('user', User({id: '123', isSuperuser: true}));
     });
 
     it('should do nothing if not present in GroupStore', async function () {
@@ -384,7 +385,7 @@ describe('GroupActivity', function () {
           data: {
             ignoreUntilEscalating: true,
           },
-          user: TestStubs.User(),
+          user: User(),
           dateCreated,
         },
       ],
@@ -404,7 +405,7 @@ describe('GroupActivity', function () {
           data: {
             ignoreUntilEscalating: true,
           },
-          user: TestStubs.User(),
+          user: User(),
           dateCreated,
         },
       ],
@@ -481,7 +482,7 @@ describe('GroupActivity', function () {
             ignoreCount: 400,
             ignoreWindow: 1,
           },
-          user: TestStubs.User(),
+          user: User(),
           dateCreated,
         },
       ],
@@ -575,7 +576,7 @@ describe('GroupActivity', function () {
           type: GroupActivityType.SET_IGNORED,
           project: TestStubs.Project(),
           data: {},
-          user: TestStubs.User(),
+          user: User(),
           dateCreated,
         },
       ],
@@ -596,7 +597,7 @@ describe('GroupActivity', function () {
           data: {
             version: 'frontend@1.0.0',
           },
-          user: TestStubs.User(),
+          user: User(),
           dateCreated,
         },
       ],
@@ -616,7 +617,7 @@ describe('GroupActivity', function () {
           data: {
             current_release_version: 'frontend@1.0.0',
           },
-          user: TestStubs.User(),
+          user: User(),
           dateCreated,
         },
       ],

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -1,5 +1,6 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -50,17 +51,17 @@ describe('groupDetails', () => {
     router: initRouter,
   });
 
-  const recommendedUser = TestStubs.User({
+  const recommendedUser = User({
     options: {
       defaultIssueEvent: 'recommended',
     },
   });
-  const latestUser = TestStubs.User({
+  const latestUser = User({
     options: {
       defaultIssueEvent: 'latest',
     },
   });
-  const oldestUser = TestStubs.User({
+  const oldestUser = User({
     options: {
       defaultIssueEvent: 'oldest',
     },

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -53,16 +53,19 @@ describe('groupDetails', () => {
 
   const recommendedUser = User({
     options: {
+      ...User().options,
       defaultIssueEvent: 'recommended',
     },
   });
   const latestUser = User({
     options: {
+      ...User().options,
       defaultIssueEvent: 'latest',
     },
   });
   const oldestUser = User({
     options: {
+      ...User().options,
       defaultIssueEvent: 'oldest',
     },
   });

--- a/static/app/views/issueDetails/groupEventCarousel.spec.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.spec.tsx
@@ -44,16 +44,19 @@ describe('GroupEventCarousel', () => {
   describe('recommended event ui', () => {
     const recommendedUser = User({
       options: {
+        ...User().options,
         defaultIssueEvent: 'recommended',
       },
     });
     const latestUser = User({
       options: {
+        ...User().options,
         defaultIssueEvent: 'latest',
       },
     });
     const oldestUser = User({
       options: {
+        ...User().options,
         defaultIssueEvent: 'oldest',
       },
     });

--- a/static/app/views/issueDetails/groupEventCarousel.spec.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.spec.tsx
@@ -1,6 +1,7 @@
 import {browserHistory} from 'react-router';
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
+import {User} from 'sentry-fixture/user';
 
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
@@ -41,17 +42,17 @@ describe('GroupEventCarousel', () => {
   });
 
   describe('recommended event ui', () => {
-    const recommendedUser = TestStubs.User({
+    const recommendedUser = User({
       options: {
         defaultIssueEvent: 'recommended',
       },
     });
-    const latestUser = TestStubs.User({
+    const latestUser = User({
       options: {
         defaultIssueEvent: 'latest',
       },
     });
-    const oldestUser = TestStubs.User({
+    const oldestUser = User({
       options: {
         defaultIssueEvent: 'oldest',
       },

--- a/static/app/views/issueDetails/groupSidebar.spec.tsx
+++ b/static/app/views/issueDetails/groupSidebar.spec.tsx
@@ -1,7 +1,7 @@
+import {Actor} from 'sentry-fixture/actor';
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {Tags} from 'sentry-fixture/tags';
 import {Team} from 'sentry-fixture/team';
-import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -196,13 +196,13 @@ describe('GroupSidebar', function () {
     };
     const teams = [{...Team(), type: 'team'}];
     const users = [
-      User({
+      Actor({
         id: '2',
         name: 'John Smith',
         email: 'johnsmith@example.com',
         type: 'user',
       }),
-      User({
+      Actor({
         id: '3',
         name: 'Sohn Jmith',
         email: 'sohnjmith@example.com',

--- a/static/app/views/issueDetails/groupSidebar.spec.tsx
+++ b/static/app/views/issueDetails/groupSidebar.spec.tsx
@@ -1,6 +1,7 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {Tags} from 'sentry-fixture/tags';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -195,13 +196,13 @@ describe('GroupSidebar', function () {
     };
     const teams = [{...Team(), type: 'team'}];
     const users = [
-      TestStubs.User({
+      User({
         id: '2',
         name: 'John Smith',
         email: 'johnsmith@example.com',
         type: 'user',
       }),
-      TestStubs.User({
+      User({
         id: '3',
         name: 'Sohn Jmith',
         email: 'sohnjmith@example.com',

--- a/static/app/views/performance/transactionSummary/teamKeyTransactionButton.spec.tsx
+++ b/static/app/views/performance/transactionSummary/teamKeyTransactionButton.spec.tsx
@@ -1,5 +1,6 @@
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -34,7 +35,7 @@ describe('TeamKeyTransactionButton', function () {
     end: '2019-10-02T00:00:00',
     statsPeriod: '14d',
     environment: [],
-    createdBy: TestStubs.User(),
+    createdBy: User(),
     display: 'line',
     team: ['myteams'],
     topEvents: '5',

--- a/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
@@ -1,5 +1,6 @@
 import {AuditLogs} from 'sentry-fixture/auditLogs';
 import {AuditLogsApiEventNames} from 'sentry-fixture/auditLogsApiEventNames';
+import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -97,7 +98,7 @@ describe('OrganizationAuditLog', function () {
       body: {
         rows: [
           {
-            actor: TestStubs.User(),
+            actor: User(),
             event: 'rule.edit',
             ipAddress: '127.0.0.1',
             id: '214',
@@ -107,7 +108,7 @@ describe('OrganizationAuditLog', function () {
             data: {},
           },
           {
-            actor: TestStubs.User(),
+            actor: User(),
             event: 'alertrule.edit',
             ipAddress: '127.0.0.1',
             id: '215',

--- a/static/app/views/settings/organizationAuditLog/index.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.spec.tsx
@@ -14,6 +14,7 @@ describe('OrganizationAuditLog', function () {
   const user: UserType = {
     ...User(),
     options: {
+      ...User().options,
       clock24Hours: true,
       timezone: 'America/Los_Angeles',
     },

--- a/static/app/views/settings/organizationAuditLog/index.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.spec.tsx
@@ -1,4 +1,5 @@
 import {AuditLogsApiEventNames} from 'sentry-fixture/auditLogsApiEventNames';
+import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -6,12 +7,12 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import ConfigStore from 'sentry/stores/configStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {Config, User} from 'sentry/types';
+import {Config, User as UserType} from 'sentry/types';
 import OrganizationAuditLog from 'sentry/views/settings/organizationAuditLog';
 
 describe('OrganizationAuditLog', function () {
-  const user: User = {
-    ...TestStubs.User(),
+  const user: UserType = {
+    ...User(),
     options: {
       clock24Hours: true,
       timezone: 'America/Los_Angeles',
@@ -32,7 +33,7 @@ describe('OrganizationAuditLog', function () {
         rows: [
           {
             id: '4500000',
-            actor: TestStubs.User(),
+            actor: User(),
             event: 'project.remove',
             ipAddress: '127.0.0.1',
             note: 'removed project test',
@@ -43,7 +44,7 @@ describe('OrganizationAuditLog', function () {
           },
           {
             id: '430000',
-            actor: TestStubs.User(),
+            actor: User(),
             event: 'org.create',
             ipAddress: '127.0.0.1',
             note: 'created the organization',
@@ -89,7 +90,7 @@ describe('OrganizationAuditLog', function () {
       body: {
         rows: [
           {
-            actor: TestStubs.User(),
+            actor: User(),
             event: 'sampling_priority.enabled',
             ipAddress: '127.0.0.1',
             id: '14',
@@ -105,7 +106,7 @@ describe('OrganizationAuditLog', function () {
             },
           },
           {
-            actor: TestStubs.User(),
+            actor: User(),
             event: 'sampling_priority.disabled',
             ipAddress: '127.0.0.1',
             id: '15',

--- a/static/app/views/settings/organizationMembers/inviteRequestRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteRequestRow.spec.tsx
@@ -1,6 +1,7 @@
 import selectEvent from 'react-select-event';
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {
   render,
@@ -48,8 +49,8 @@ describe('InviteRequestRow', function () {
 
   const inviteRequest = TestStubs.Member({
     user: null,
-    inviterName: TestStubs.User().name,
-    inviterId: TestStubs.User().id,
+    inviterName: User().name,
+    inviterId: User().id,
     inviteStatus: 'requested_to_be_invited',
     role: 'member',
     teams: ['myteam'],
@@ -166,8 +167,8 @@ describe('InviteRequestRow', function () {
   it('admin can change role and teams', async function () {
     const adminInviteRequest = TestStubs.Member({
       user: null,
-      inviterName: TestStubs.User().name,
-      inviterId: TestStubs.User().id,
+      inviterName: User().name,
+      inviterId: User().id,
       inviteStatus: 'requested_to_be_invited',
       role: 'admin',
       teams: ['myteam'],
@@ -205,8 +206,8 @@ describe('InviteRequestRow', function () {
   it('cannot be approved when invitee role is not allowed', function () {
     const ownerInviteRequest = TestStubs.Member({
       user: null,
-      inviterName: TestStubs.User().name,
-      inviterId: TestStubs.User().id,
+      inviterName: User().name,
+      inviterId: User().id,
       inviteStatus: 'requested_to_be_invited',
       role: 'owner',
       teams: ['myteam'],

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
@@ -3,6 +3,7 @@ import {Authenticators} from 'sentry-fixture/authenticators';
 import {Organization} from 'sentry-fixture/organization';
 import {OrgRoleList} from 'sentry-fixture/roleList';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -520,19 +521,19 @@ describe('OrganizationMemberDetail', function () {
     const noAccess = TestStubs.Member({
       ...fields,
       id: '4',
-      user: TestStubs.User({has2fa: false, authenticators: undefined}),
+      user: User({has2fa: false, authenticators: undefined}),
     });
 
     const no2fa = TestStubs.Member({
       ...fields,
       id: '5',
-      user: TestStubs.User({has2fa: false, authenticators: [], canReset2fa: true}),
+      user: User({has2fa: false, authenticators: [], canReset2fa: true}),
     });
 
     const has2fa = TestStubs.Member({
       ...fields,
       id: '6',
-      user: TestStubs.User({
+      user: User({
         has2fa: true,
         authenticators: [
           Authenticators().Totp(),
@@ -546,7 +547,7 @@ describe('OrganizationMemberDetail', function () {
     const multipleOrgs = TestStubs.Member({
       ...fields,
       id: '7',
-      user: TestStubs.User({
+      user: User({
         has2fa: true,
         authenticators: [Authenticators().Totp()],
         canReset2fa: false,

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.tsx
@@ -1,5 +1,5 @@
 import selectEvent from 'react-select-event';
-import {Authenticators} from 'sentry-fixture/authenticators';
+import {UserEnrolledAuthenticator} from 'sentry-fixture/authenticators';
 import {Organization} from 'sentry-fixture/organization';
 import {OrgRoleList} from 'sentry-fixture/roleList';
 import {Team} from 'sentry-fixture/team';
@@ -536,9 +536,9 @@ describe('OrganizationMemberDetail', function () {
       user: User({
         has2fa: true,
         authenticators: [
-          Authenticators().Totp(),
-          Authenticators().Sms(),
-          Authenticators().U2f(),
+          UserEnrolledAuthenticator({type: 'totp', id: 'totp'}),
+          UserEnrolledAuthenticator({type: 'sms', id: 'sms'}),
+          UserEnrolledAuthenticator({type: 'u2f', id: 'u2f'}),
         ],
         canReset2fa: true,
       }),
@@ -549,7 +549,7 @@ describe('OrganizationMemberDetail', function () {
       id: '7',
       user: User({
         has2fa: true,
-        authenticators: [Authenticators().Totp()],
+        authenticators: [UserEnrolledAuthenticator({type: 'totp', id: 'totp'})],
         canReset2fa: false,
       }),
     });

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
@@ -1,5 +1,6 @@
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -40,7 +41,7 @@ describe('OrganizationMemberRow', function () {
     ],
   });
 
-  const currentUser = TestStubs.User({
+  const currentUser = User({
     id: '2',
     email: 'currentUser@email.com',
   });
@@ -82,7 +83,7 @@ describe('OrganizationMemberRow', function () {
           {...defaultProps}
           member={TestStubs.Member({
             ...member,
-            user: TestStubs.User({...member.user, has2fa: true}),
+            user: User({...member.user, has2fa: true}),
           })}
         />
       );

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -5,6 +5,7 @@ import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {
   render,
@@ -450,7 +451,7 @@ describe('OrganizationMembersList', function () {
       id: '123',
       user: null,
       inviteStatus: 'requested_to_be_invited',
-      inviter: TestStubs.User(),
+      inviter: User(),
       role: 'member',
       teams: [],
     });

--- a/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
@@ -1,6 +1,7 @@
 import {AccessRequest} from 'sentry-fixture/accessRequest';
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -202,7 +203,7 @@ describe('OrganizationTeams', function () {
     const accessRequest = AccessRequest({
       requester: {},
     });
-    const requester = TestStubs.User({
+    const requester = User({
       id: '9',
       username: 'requester@example.com',
       email: 'requester@example.com',

--- a/static/app/views/settings/project/projectOwnership/editRulesModal.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/editRulesModal.spec.tsx
@@ -1,5 +1,6 @@
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
+import {User} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -11,7 +12,7 @@ import {EditOwnershipRules} from './editRulesModal';
 describe('Project Ownership Input', () => {
   const org = Organization();
   const project = TestStubs.Project();
-  const user = TestStubs.User();
+  const user = User();
 
   beforeEach(() => {
     ConfigStore.set('user', user);

--- a/static/app/views/settings/project/projectOwnership/modal.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/modal.spec.tsx
@@ -2,6 +2,7 @@ import {Event as EventFixture} from 'sentry-fixture/event';
 import {EventEntryStacktrace} from 'sentry-fixture/eventEntryStacktrace';
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
+import {User} from 'sentry-fixture/user';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -17,7 +18,7 @@ describe('Project Ownership', () => {
   const event = EventFixture({
     entries: [stacktrace],
   });
-  const user = TestStubs.User();
+  const user = User();
 
   beforeEach(() => {
     ConfigStore.set('user', user);

--- a/static/app/views/settings/project/projectOwnership/ownerInput.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownerInput.spec.tsx
@@ -1,5 +1,6 @@
 import selectEvent from 'react-select-event';
 import {Members} from 'sentry-fixture/members';
+import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -23,9 +24,7 @@ describe('Project Ownership Input', function () {
       body: {raw: 'url:src @dummy@example.com'},
     });
     MemberListStore.init();
-    MemberListStore.loadInitialData([
-      TestStubs.User({id: '1', email: 'bob@example.com'}),
-    ]);
+    MemberListStore.loadInitialData([User({id: '1', email: 'bob@example.com'})]);
   });
 
   it('renders', async function () {

--- a/static/app/views/settings/project/projectOwnership/ownershipRulesTable.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownershipRulesTable.spec.tsx
@@ -1,3 +1,5 @@
+import {User} from 'sentry-fixture/user';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
@@ -7,8 +9,8 @@ import type {Actor, ParsedOwnershipRule} from 'sentry/types';
 import {OwnershipRulesTable} from './ownershipRulesTable';
 
 describe('OwnershipRulesTable', () => {
-  const user1 = TestStubs.User();
-  const user2 = TestStubs.User({id: '2', name: 'Jane Doe'});
+  const user1 = User();
+  const user2 = User({id: '2', name: 'Jane Doe'});
 
   beforeEach(() => {
     ConfigStore.init();

--- a/static/app/views/settings/project/projectOwnership/ruleBuilder.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/ruleBuilder.spec.tsx
@@ -26,21 +26,11 @@ describe('RuleBuilder', function () {
     id: '1',
     name: 'Jane Bloggs',
     email: 'janebloggs@example.com',
-    user: {
-      id: '1',
-      name: 'Jane Bloggs',
-      email: 'janebloggs@example.com',
-    },
   });
   const USER_2 = User({
     id: '2',
     name: 'John Smith',
     email: 'johnsmith@example.com',
-    user: {
-      id: '2',
-      name: 'John Smith',
-      email: 'johnsmith@example.com',
-    },
   });
 
   const TEAM_1 = Team({
@@ -71,7 +61,10 @@ describe('RuleBuilder', function () {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/',
-      body: [USER_1, USER_2],
+      body: [
+        {...USER_1, user: USER_1},
+        {...USER_2, user: USER_2},
+      ],
     });
   });
 

--- a/static/app/views/settings/project/projectOwnership/ruleBuilder.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/ruleBuilder.spec.tsx
@@ -1,5 +1,6 @@
 import selectEvent from 'react-select-event';
 import {Team} from 'sentry-fixture/team';
+import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -21,7 +22,7 @@ describe('RuleBuilder', function () {
   let project: Project;
   let handleAdd: jest.Mock;
 
-  const USER_1 = TestStubs.User({
+  const USER_1 = User({
     id: '1',
     name: 'Jane Bloggs',
     email: 'janebloggs@example.com',
@@ -31,7 +32,7 @@ describe('RuleBuilder', function () {
       email: 'janebloggs@example.com',
     },
   });
-  const USER_2 = TestStubs.User({
+  const USER_2 = User({
     id: '2',
     name: 'John Smith',
     email: 'johnsmith@example.com',


### PR DESCRIPTION
Working on https://github.com/getsentry/frontend-tsc/issues/49. See commit history for details of why the non-obvious changes were made.

## Changes

- Replace `TestStubs.User` with correct import
- Use `undefined`
- Splat user options
- Eval test against a string
- Add specific `Actor` fixture
- Add `UserEnrolledAuthenticator`
- Correct a weird `User` mock
- Fix typo
- Remove duplicate type
- Correct a date mock
