### PR TITLE
fix(user token): Hide API token after creation

### DIFF
--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -91,6 +91,7 @@ export interface InternalAppApiToken extends BaseApiToken {
   application: null;
   refreshToken: string;
   token: string;
+  tokenLastCharacters?: string;
 }
 
 export type ApiApplication = {

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -8,14 +8,17 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
-import {Permissions} from 'sentry/types';
+import {InternalAppApiToken, Permissions} from 'sentry/types';
+import getDynamicText from 'sentry/utils/getDynamicText';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import NewTokenHandler from 'sentry/views/settings/components/newTokenHandler';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import PermissionSelection from 'sentry/views/settings/organizationDeveloperSettings/permissionSelection';
 
 const API_INDEX_ROUTE = '/settings/account/api/auth-tokens/';
 type State = {
+  newToken: InternalAppApiToken | null;
   permissions: Permissions;
 };
 
@@ -31,6 +34,7 @@ export default class ApiNewToken extends Component<{}, State> {
         Release: 'no-access',
         Organization: 'no-access',
       },
+      newToken: null,
     };
   }
 
@@ -38,12 +42,13 @@ export default class ApiNewToken extends Component<{}, State> {
     browserHistory.push(normalizeUrl(API_INDEX_ROUTE));
   };
 
-  onSubmitSuccess = () => {
+  handleGoBack = () => {
     browserHistory.push(normalizeUrl(API_INDEX_ROUTE));
   };
 
   render() {
-    const {permissions} = this.state;
+    const {permissions, newToken} = this.state;
+
     return (
       <SentryDocumentTitle title={t('Create User Auth Token')}>
         <div>
@@ -61,34 +66,46 @@ export default class ApiNewToken extends Component<{}, State> {
               }
             )}
           </TextBlock>
-          <Panel>
-            <PanelHeader>{t('Permissions')}</PanelHeader>
-            <ApiForm
-              apiMethod="POST"
-              apiEndpoint="/api-tokens/"
-              initialData={{scopes: []}}
-              onSubmitSuccess={this.onSubmitSuccess}
-              onCancel={this.onCancel}
-              footerStyle={{
-                marginTop: 0,
-                paddingRight: 20,
-              }}
-              submitDisabled={Object.values(permissions).every(
-                value => value === 'no-access'
-              )}
-              submitLabel={t('Create Token')}
-            >
-              <PanelBody>
-                <PermissionSelection
-                  appPublished={false}
-                  permissions={permissions}
-                  onChange={value => {
-                    this.setState({permissions: value});
-                  }}
-                />
-              </PanelBody>
-            </ApiForm>
-          </Panel>
+          {newToken !== null ? (
+            <NewTokenHandler
+              token={
+                getDynamicText({value: newToken.token, fixed: 'CI_AUTH_TOKEN'}) ||
+                'CI_AUTH_TOKEN'
+              }
+              handleGoBack={this.handleGoBack}
+            />
+          ) : (
+            <Panel>
+              <PanelHeader>{t('Permissions')}</PanelHeader>
+              <ApiForm
+                apiMethod="POST"
+                apiEndpoint="/api-tokens/"
+                initialData={{scopes: []}}
+                onSubmitSuccess={response => {
+                  this.setState({newToken: response});
+                }}
+                onCancel={this.onCancel}
+                footerStyle={{
+                  marginTop: 0,
+                  paddingRight: 20,
+                }}
+                submitDisabled={Object.values(permissions).every(
+                  value => value === 'no-access'
+                )}
+                submitLabel={t('Create Token')}
+              >
+                <PanelBody>
+                  <PermissionSelection
+                    appPublished={false}
+                    permissions={permissions}
+                    onChange={value => {
+                      this.setState({permissions: value});
+                    }}
+                  />
+                </PanelBody>
+              </ApiForm>
+            </Panel>
+          )}
         </div>
       </SentryDocumentTitle>
     );

--- a/static/app/views/settings/account/apiTokenRow.spec.tsx
+++ b/static/app/views/settings/account/apiTokenRow.spec.tsx
@@ -14,4 +14,21 @@ describe('ApiTokenRow', () => {
     await userEvent.click(screen.getByLabelText('Remove'));
     expect(cb).toHaveBeenCalled();
   });
+
+  it('uses NewTokenHandler when lastTokenCharacters field is found', () => {
+    const token = TestStubs.ApiToken();
+    token.tokenLastCharacters = 'a1b2c3d4';
+
+    const cb = jest.fn();
+    render(<ApiTokenRow onRemove={cb} token={token} />);
+    expect(screen.queryByLabelText('Token preview')).toBeInTheDocument();
+  });
+
+  it('uses old logic when lastTokenCharacters field is not found', () => {
+    const token = TestStubs.ApiToken();
+
+    const cb = jest.fn();
+    render(<ApiTokenRow onRemove={cb} token={token} />);
+    expect(screen.queryByLabelText('Token preview')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/settings/account/apiTokenRow.tsx
+++ b/static/app/views/settings/account/apiTokenRow.tsx
@@ -9,27 +9,43 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {InternalAppApiToken} from 'sentry/types';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import {tokenPreview} from 'sentry/views/settings/organizationAuthTokens';
 
 type Props = {
   onRemove: (token: InternalAppApiToken) => void;
   token: InternalAppApiToken;
 };
 
+// TODO: After the BE portion of code changes have been released, remove the conditional rendering of the token.
+// We are currently doing the conditional logic to do safe blue/green deploys and handle contract changes.
 function ApiTokenRow({token, onRemove}: Props) {
   return (
     <StyledPanelItem>
       <Controls>
-        <InputWrapper>
-          <TextCopyInput>
-            {getDynamicText({value: token.token, fixed: 'CI_AUTH_TOKEN'})}
-          </TextCopyInput>
-        </InputWrapper>
-        <Button
-          onClick={() => onRemove(token)}
-          icon={<IconSubtract isCircled size="xs" />}
-        >
-          {t('Remove')}
-        </Button>
+        {token.tokenLastCharacters ? (
+          <TokenPreview aria-label={t('Token preview')}>
+            {tokenPreview(
+              getDynamicText({
+                value: token.tokenLastCharacters,
+                fixed: 'ABCD',
+              })
+            )}
+          </TokenPreview>
+        ) : (
+          <InputWrapper>
+            <TextCopyInput>
+              {getDynamicText({value: token.token, fixed: 'CI_AUTH_TOKEN'})}
+            </TextCopyInput>
+          </InputWrapper>
+        )}
+        <ButtonWrapper>
+          <Button
+            onClick={() => onRemove(token)}
+            icon={<IconSubtract isCircled size="xs" />}
+          >
+            {t('Remove')}
+          </Button>
+        </ButtonWrapper>
       </Controls>
 
       <Details>
@@ -94,6 +110,20 @@ const Heading = styled('div')`
   text-transform: uppercase;
   color: ${p => p.theme.subText};
   margin-bottom: ${space(1)};
+`;
+
+const TokenPreview = styled('div')`
+  color: ${p => p.theme.gray300};
+`;
+
+const ButtonWrapper = styled('div')`
+  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: flex-end;
+  font-size: ${p => p.theme.fontSizeSmall};
+  gap: ${space(1)};
 `;
 
 export default ApiTokenRow;

--- a/static/app/views/settings/components/newTokenHandler.spec.tsx
+++ b/static/app/views/settings/components/newTokenHandler.spec.tsx
@@ -1,0 +1,10 @@
+import {render} from 'sentry-test/reactTestingLibrary';
+
+import NewTokenHandler from 'sentry/views/settings/components/newTokenHandler';
+
+describe('NewTokenHandler', () => {
+  it('renders', () => {
+    const callback = ({}) => {};
+    render(<NewTokenHandler token={TestStubs.ApiToken()} handleGoBack={callback} />);
+  });
+});

--- a/static/app/views/settings/components/newTokenHandler.tsx
+++ b/static/app/views/settings/components/newTokenHandler.tsx
@@ -1,0 +1,66 @@
+import {MouseEventHandler} from 'react';
+import styled from '@emotion/styled';
+
+import Alert from 'sentry/components/alert';
+import {Button} from 'sentry/components/button';
+import FieldGroup from 'sentry/components/forms/fieldGroup';
+import PanelItem from 'sentry/components/panels/panelItem';
+import TextCopyInput from 'sentry/components/textCopyInput';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+function NewTokenHandler({
+  token,
+  handleGoBack,
+}: {
+  handleGoBack: MouseEventHandler;
+  token: string;
+}) {
+  return (
+    <div>
+      <Alert type="warning" showIcon system>
+        {t("Please copy this token to a safe place — it won't be shown again!")}
+      </Alert>
+
+      <PanelItem>
+        <InputWrapper>
+          <FieldGroupNoPadding
+            label={t('Token')}
+            help={t('You can only view this token when it was created.')}
+            inline
+            flexibleControlStateSize
+          >
+            <TextCopyInput aria-label={t('Generated token')}>{token}</TextCopyInput>
+          </FieldGroupNoPadding>
+        </InputWrapper>
+      </PanelItem>
+
+      <PanelItem>
+        <ButtonWrapper>
+          <Button onClick={handleGoBack} priority="primary">
+            {t('Done')}
+          </Button>
+        </ButtonWrapper>
+      </PanelItem>
+    </div>
+  );
+}
+
+const InputWrapper = styled('div')`
+  flex: 1;
+`;
+
+const FieldGroupNoPadding = styled(FieldGroup)`
+  padding: 0;
+`;
+
+const ButtonWrapper = styled('div')`
+  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-size: ${p => p.theme.fontSizeSmall};
+  gap: ${space(1)};
+`;
+
+export default NewTokenHandler;

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
@@ -7,8 +7,6 @@ import {
   addLoadingMessage,
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
-import Alert from 'sentry/components/alert';
-import {Button} from 'sentry/components/button';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import TextField from 'sentry/components/forms/fields/textField';
 import Form from 'sentry/components/forms/form';
@@ -16,11 +14,8 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
-import PanelItem from 'sentry/components/panels/panelItem';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {Organization, OrgAuthToken} from 'sentry/types';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
@@ -29,6 +24,7 @@ import RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import withOrganization from 'sentry/utils/withOrganization';
+import NewTokenHandler from 'sentry/views/settings/components/newTokenHandler';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import {makeFetchOrgAuthTokensForOrgQueryKey} from 'sentry/views/settings/organizationAuthTokens';
@@ -132,55 +128,16 @@ function AuthTokenCreateForm({
   );
 }
 
-function ShowNewToken({
-  token,
-  organization,
-}: {
-  organization: Organization;
-  token: OrgAuthTokenWithToken;
-}) {
-  const handleGoBack = useCallback(() => {
-    browserHistory.push(normalizeUrl(`/settings/${organization.slug}/auth-tokens/`));
-  }, [organization.slug]);
-
-  return (
-    <div>
-      <Alert type="warning" showIcon system>
-        {t("Please copy this token to a safe place — it won't be shown again!")}
-      </Alert>
-
-      <PanelItem>
-        <InputWrapper>
-          <FieldGroupNoPadding
-            label={t('Token')}
-            help={t('You can only view this token when it was created.')}
-            inline
-            flexibleControlStateSize
-          >
-            <TextCopyInput aria-label={t('Generated token')}>
-              {getDynamicText({value: token.token, fixed: 'ORG_AUTH_TOKEN'})}
-            </TextCopyInput>
-          </FieldGroupNoPadding>
-        </InputWrapper>
-      </PanelItem>
-
-      <PanelItem>
-        <ButtonWrapper>
-          <Button onClick={handleGoBack} priority="primary">
-            {t('Done')}
-          </Button>
-        </ButtonWrapper>
-      </PanelItem>
-    </div>
-  );
-}
-
 export function OrganizationAuthTokensNewAuthToken({
   organization,
 }: {
   organization: Organization;
 }) {
   const [newToken, setNewToken] = useState<OrgAuthTokenWithToken | null>(null);
+
+  const handleGoBack = useCallback(() => {
+    browserHistory.push(normalizeUrl(`/settings/${organization.slug}/auth-tokens/`));
+  }, [organization.slug]);
 
   return (
     <div>
@@ -205,7 +162,10 @@ export function OrganizationAuthTokensNewAuthToken({
 
         <PanelBody>
           {newToken ? (
-            <ShowNewToken token={newToken} organization={organization} />
+            <NewTokenHandler
+              token={getDynamicText({value: newToken.token, fixed: 'ORG_AUTH_TOKEN'})}
+              handleGoBack={handleGoBack}
+            />
           ) : (
             <AuthTokenCreateForm
               organization={organization}
@@ -219,23 +179,6 @@ export function OrganizationAuthTokensNewAuthToken({
 }
 
 export default withOrganization(OrganizationAuthTokensNewAuthToken);
-
-const InputWrapper = styled('div')`
-  flex: 1;
-`;
-
-const ButtonWrapper = styled('div')`
-  margin-left: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  font-size: ${p => p.theme.fontSizeSmall};
-  gap: ${space(1)};
-`;
-
-const FieldGroupNoPadding = styled(FieldGroup)`
-  padding: 0;
-`;
 
 const ScopeHelpText = styled('div')`
   color: ${p => p.theme.gray300};


### PR DESCRIPTION
Hide the user API token after it's been created. Currently the API token in user settings can always be seen, even after creation. This experience also deviates from the org auth tokens. To keep both experiences consistent, and increase security around tokens from leaking, we are updating the API token contract and UI. The current PR focuses on UI/FE, and addressing a safe blue/green change, while the BE will change independently in another PR.

- The API contract for /api-tokens will include a new field of tokenLastCharacters
- A general component for showing new tokens has been created and utilized to keep token experiences consistent

Video showing experience when **no** BE changes have been made:

https://github.com/getsentry/sentry/assets/5581484/0563d32d-1f6b-4971-a4f0-6ad5c14eadc5


Video showing overall experience when the BE changes _have_ been made:

https://github.com/getsentry/sentry/assets/5581484/e44bd860-f9e1-4ed7-aaea-f753bf01a631

Resolves https://github.com/getsentry/team-enterprise/issues/1#issue-2003077670