### PR TITLE
fix(user token): Stop leaking API token

### DIFF
--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -46,7 +46,7 @@ class ApiTokensEndpoint(Endpoint):
                 "application"
             )
         )
-
+        # TODO: when the delete endpoint no longer requires the full token value, update this to stop including token
         return Response(serialize(token_list, request.user))
 
     @method_decorator(never_cache)
@@ -82,6 +82,7 @@ class ApiTokensEndpoint(Endpoint):
         user_id = request.user.id
         if is_active_superuser(request):
             user_id = request.data.get("userId", user_id)
+        # TODO: we should not be requiring full token value in the delete endpoint, and should instead be using the id
         token = request.data.get("token")
         if not token:
             return Response({"token": ""}, status=400)

--- a/src/sentry/api/serializers/models/apitoken.py
+++ b/src/sentry/api/serializers/models/apitoken.py
@@ -4,7 +4,7 @@ from sentry.models.apitoken import ApiToken
 
 @register(ApiToken)
 class ApiTokenSerializer(Serializer):
-    def get_attrs(self, item_list, user):
+    def get_attrs(self, item_list, user, **kwargs):
         apps = {
             d["id"]: d
             for d in serialize({i.application for i in item_list if i.application_id}, user)
@@ -17,7 +17,7 @@ class ApiTokenSerializer(Serializer):
             }
         return attrs
 
-    def serialize(self, obj, attrs, user):
+    def serialize(self, obj, attrs, user, **kwargs):
         data = {
             "id": str(obj.id),
             "scopes": obj.get_scopes(),
@@ -27,6 +27,13 @@ class ApiTokenSerializer(Serializer):
             "state": attrs.get("state"),
         }
         if not attrs["application"]:
-            data["token"] = obj.token
+            include_token = kwargs.get("include_token", True)
+            if include_token:
+                data["token"] = obj.token
+
             data["refreshToken"] = obj.refresh_token
+
+        data["tokenLastCharacters"] = (
+            obj.token_last_characters if obj.token_last_characters else obj.token[-4:]
+        )
         return data

--- a/tests/sentry/api/serializers/test_apitoken.py
+++ b/tests/sentry/api/serializers/test_apitoken.py
@@ -1,0 +1,49 @@
+from sentry.api.serializers import ApiTokenSerializer
+from sentry.testutils.cases import TestCase
+
+
+class TestApiTokenSerializer(TestCase):
+    def setUp(self) -> None:
+        self._user = self.create_user()
+        self._scopes = ["test_scope"]
+        self._token = self.create_user_auth_token(user=self._user, scope_list=self._scopes)
+        self._serializer = ApiTokenSerializer()
+
+
+class TestIncludeTokenFlag(TestApiTokenSerializer):
+    def setUp(self) -> None:
+        super().setUp()
+        attrs = self._serializer.get_attrs(item_list=[self._token], user=self._user)
+        attrs["application"] = None
+        self._attrs = attrs
+
+    def test_when_no_flag_is_passed(self) -> None:
+        serialized_object = self._serializer.serialize(
+            obj=self._token, user=self._user, attrs=self._attrs
+        )
+        assert "token" in serialized_object
+        assert serialized_object["token"] == self._token.token
+
+    def test_when_no_flag_is_true(self) -> None:
+        serialized_object = self._serializer.serialize(
+            obj=self._token, user=self._user, attrs=self._attrs
+        )
+        assert "token" in serialized_object
+        assert serialized_object["token"] == self._token.token
+
+    def test_when_flag_is_false(self) -> None:
+        serialized_object = self._serializer.serialize(
+            obj=self._token, user=self._user, attrs=self._attrs, include_token=False
+        )
+        assert "token" not in serialized_object
+
+
+class TestLastTokenCharacters(TestApiTokenSerializer):
+    def test_field_is_returned(self) -> None:
+        attrs = self._serializer.get_attrs(item_list=[self._token], user=self._user)
+        attrs["application"] = None
+        serialized_object = self._serializer.serialize(
+            obj=self._token, user=self._user, attrs=attrs
+        )
+        assert "tokenLastCharacters" in serialized_object
+        assert serialized_object["tokenLastCharacters"] == self._token.token[-4:]


### PR DESCRIPTION
Update API contract to stop sending API token and send new field of lastTokenCharacters instead. Currently the API token in user settings can always be seen, even after creation. This experience also deviates from the org auth tokens. To keep both experiences consistent, and increase security around tokens from leaking, we are updating the API token contract and UI. The current PR focuses on BE, and updating the contract to send a field `lastTokenCharacters`

- Serializer has an option to include full token value. This is to setup for the future to stop leaking the value in the API. Currently we need this for the delete endpoint to work. Future work captured in https://github.com/getsentry/team-enterprise/issues/21#issue-2047202292
- The API contract for /api-tokens will include a new field of tokenLastCharacters

This PR should go **_after_** https://github.com/getsentry/sentry/pull/61939

Resolves https://github.com/getsentry/team-enterprise/issues/1#issue-2003077670