### PR TITLE
ref(slack): Convert resolve modal to block kit

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -55,6 +55,9 @@ class SlackNotifyServiceAction(IntegrationEventAction):
 
         def send_notification(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             rules = [f.rule for f in futures]
+            additional_attachment = get_additional_attachment(
+                integration, self.project.organization
+            )
             if features.has("organizations:slack-block-kit", event.group.project.organization):
                 blocks = build_group_attachment(
                     event.group,
@@ -62,9 +65,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     tags=tags,
                     rules=rules,
                     notification_uuid=notification_uuid,
-                )
-                additional_attachment = get_additional_attachment(
-                    integration, self.project.organization
                 )
                 if additional_attachment:
                     for block in additional_attachment:
@@ -89,9 +89,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     )
                 ]
                 # getsentry might add a billing related attachment
-                additional_attachment = get_additional_attachment(
-                    integration, self.project.organization
-                )
                 if additional_attachment:
                     attachments.append(additional_attachment)
 

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -141,10 +141,11 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         color: Optional[str] = None,
         block_id: Optional[dict[str, int]] = None,
         callback_id: Optional[str] = None,
+        skip_fallback: bool = False,
     ) -> SlackBlock:
         blocks: dict[str, Any] = {"blocks": list(args)}
 
-        if fallback_text:
+        if fallback_text and not skip_fallback:
             blocks["text"] = fallback_text
 
         if color:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -301,6 +301,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         notification: ProjectNotification | None = None,
         recipient: RpcActor | None = None,
         is_unfurl: bool = False,
+        skip_fallback: bool = False,
     ) -> None:
         super().__init__()
         self.group = group
@@ -314,6 +315,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self.notification = notification
         self.recipient = recipient
         self.is_unfurl = is_unfurl
+        self.skip_fallback = skip_fallback
 
     @property
     def escape_text(self) -> bool:
@@ -438,6 +440,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             *blocks,
             fallback_text=self.build_fallback_text(obj, project.slug),
             block_id=json.dumps({"issue": self.group.id}),
+            skip_fallback=self.skip_fallback,
         )
 
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -234,7 +234,16 @@ def build_actions(
             value="ignored:until_escalating" if has_escalating else "ignored:forever",
         )
 
-    def _resolve_button() -> MessageAction:
+    def _resolve_button(use_block_kit) -> MessageAction:
+        if use_block_kit:
+            # TODO(CEO): handle if the issue is resolved - render a button that unresolves
+            # TODO(CEO): handle if not project.flags.has_releases in block kit - render a resolve button instead of a modal
+            return MessageAction(
+                name="status",
+                label="Resolve",
+                value="resolve_dialog",
+            )
+
         if status == GroupStatus.RESOLVED:
             return MessageAction(
                 name="status",
@@ -269,7 +278,7 @@ def build_actions(
 
     action_list = [
         a
-        for a in [_resolve_button(), _ignore_button(), _assign_button(use_block_kit)]
+        for a in [_resolve_button(use_block_kit), _ignore_button(), _assign_button(use_block_kit)]
         if a is not None
     ]
 
@@ -408,7 +417,15 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         # build actions
         actions = []
         for action in payload_actions:
-            if action.label in ("Archive", "Ignore", "Mark as Ongoing", "Stop Ignoring"):
+            if action.label in (
+                "Archive",
+                "Ignore",
+                "Mark as Ongoing",
+                "Stop Ignoring",
+                "Resolve",
+                "Unresolve",
+                "Resolve...",
+            ):
                 actions.append(self.get_button_action(action))
             elif action.name == "assign":
                 actions.append(self.get_static_action(action))

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -424,7 +424,11 @@ class SlackActionEndpoint(Endpoint):
                 return self.api_error(slack_request, group, identity_user, error, "status_dialog")
 
             attachment = SlackIssuesMessageBuilder(
-                group, identity=identity, actions=[action], tags=original_tags_from_request
+                group,
+                identity=identity,
+                actions=[action],
+                tags=original_tags_from_request,
+                skip_fallback=True,
             ).build()
             body = self.construct_reply(
                 attachment, is_message=slack_request.callback_data["is_message"]

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -77,6 +77,12 @@ RESOLVE_SELECTOR = {
     ],
 }
 
+RESOLVE_OPTIONS = {
+    "Immediately": "resolved",
+    "In the next release": "resolved:inNextRelease",
+    "In the current release": "resolved:inCurrentRelease",
+}
+
 
 def update_group(
     group: Group,
@@ -161,14 +167,26 @@ class SlackActionEndpoint(Endpoint):
                 "action_type": action_type,
             },
         )
+        channel_id = None
+        response_url = None
+        view = None
+        if features.has("organizations:slack-block-kit", group.project.organization):
+            # the channel ID and response URL are in a different place if it's coming from a modal
+            view = slack_request.data.get("view")
+            if view:
+                private_metadata = view.get("private_metadata")
+                if private_metadata:
+                    data = json.loads(private_metadata)
+                    channel_id = data.get("channel_id")
+                    response_url = data.get("orig_response_url")
 
         if error.status_code == 403:
             text = UNLINK_IDENTITY_MESSAGE.format(
                 associate_url=build_unlinking_url(
                     slack_request.integration.id,
                     slack_request.user_id,
-                    slack_request.channel_id,
-                    slack_request.response_url,
+                    channel_id or slack_request.channel_id,
+                    response_url or slack_request.response_url,
                 ),
                 user_email=user.email,
                 org_name=group.organization.name,
@@ -260,13 +278,16 @@ class SlackActionEndpoint(Endpoint):
         # but seems like there's no other solutions [1]:
         #
         # [1]: https://stackoverflow.com/questions/46629852/update-a-bot-message-after-responding-to-a-slack-dialog#comment80795670_46629852
-        callback_id = json.dumps(
-            {
-                "issue": group.id,
-                "orig_response_url": slack_request.data["response_url"],
-                "is_message": _is_message(slack_request.data),
-            }
-        )
+        use_block_kit = features.has("organizations:slack-block-kit", group.project.organization)
+        callback_id = {
+            "issue": group.id,
+            "orig_response_url": slack_request.data["response_url"],
+            "is_message": _is_message(slack_request.data),
+        }
+        if use_block_kit and slack_request.data.get("channel"):
+            callback_id["channel_id"] = slack_request.data["channel"]["id"]
+
+        callback_id = json.dumps(callback_id)
 
         dialog = {
             "callback_id": callback_id,
@@ -280,10 +301,64 @@ class SlackActionEndpoint(Endpoint):
             "trigger_id": slack_request.data["trigger_id"],
         }
         slack_client = SlackClient(integration_id=slack_request.integration.id)
-        try:
-            slack_client.post("/dialog.open", data=payload)
-        except ApiError as e:
-            logger.error("slack.action.response-error", extra={"error": str(e)})
+
+        if use_block_kit:
+            # XXX(CEO): the second you make a selection (without hitting Submit) it sends a slightly different request
+            formatted_resolve_options = []
+            for text, value in RESOLVE_OPTIONS.items():
+                formatted_resolve_options.append(
+                    {
+                        "text": {
+                            "type": "plain_text",
+                            "text": text,
+                            "emoji": True,
+                        },
+                        "value": value,
+                    }
+                )
+
+            modal_payload = {
+                "type": "modal",
+                "title": {"type": "plain_text", "text": "Resolve Issue"},
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": "Resolve in"},
+                        "accessory": {
+                            "type": "static_select",
+                            "initial_option": {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "Immediately",
+                                    "emoji": True,
+                                },
+                                "value": "resolved",
+                            },
+                            "options": formatted_resolve_options,
+                            "action_id": "static_select-action",
+                        },
+                    }
+                ],
+                "close": {"type": "plain_text", "text": "Cancel"},
+                "submit": {"type": "plain_text", "text": "Resolve"},
+                "private_metadata": callback_id,
+                "callback_id": callback_id,
+            }
+            try:
+                payload = {
+                    "view": json.dumps(modal_payload),
+                    "trigger_id": slack_request.data["trigger_id"],
+                }
+                headers = {"content-type": "application/json; charset=utf-8"}
+                slack_client.post("/views.open", data=json.dumps(payload), headers=headers)
+            except ApiError as e:
+                logger.error("slack.action.response-error", extra={"error": str(e)})
+
+        else:
+            try:
+                slack_client.post("/dialog.open", data=payload)
+            except ApiError as e:
+                logger.error("slack.action.response-error", extra={"error": str(e)})
 
     def construct_reply(self, attachment: SlackBody, is_message: bool = False) -> SlackBody:
         # XXX(epurkhiser): Slack is inconsistent about it's expected responses
@@ -325,6 +400,43 @@ class SlackActionEndpoint(Endpoint):
             return self.respond_ephemeral(LINK_IDENTITY_MESSAGE.format(associate_url=associate_url))
 
         original_tags_from_request = slack_request.get_tags()
+
+        use_block_kit = features.has("organizations:slack-block-kit", group.project.organization)
+        if use_block_kit and slack_request.type == "view_submission":
+            # TODO: if we use modals for something other than resolve, this will need to be more specific
+
+            # Masquerade a status action
+            selection = None
+            values = slack_request.data["view"]["state"]["values"]
+            for value in values:
+                for val in values[value]:
+                    selection = values[value][val]["selected_option"]["value"]
+                    if selection:
+                        break
+                if selection:
+                    break
+
+            action = MessageAction(name="status", value=selection)
+
+            try:
+                self.on_status(request, identity_user, group, action)
+            except client.ApiError as error:
+                return self.api_error(slack_request, group, identity_user, error, "status_dialog")
+
+            attachment = SlackIssuesMessageBuilder(
+                group, identity=identity, actions=[action], tags=original_tags_from_request
+            ).build()
+            body = self.construct_reply(
+                attachment, is_message=slack_request.callback_data["is_message"]
+            )
+            # use the original response_url to update the link attachment
+            slack_client = SlackClient(integration_id=slack_request.integration.id)
+            try:
+                private_metadata = json.loads(slack_request.data["view"]["private_metadata"])
+                slack_client.post(private_metadata["orig_response_url"], data=body, json=True)
+            except ApiError as e:
+                logger.error("slack.action.response-error", extra={"error": str(e)})
+            return self.respond()
 
         # Handle status dialog submission
         if (

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -81,6 +81,12 @@ def build_test_message_blocks(
                 "elements": [
                     {
                         "type": "button",
+                        "action_id": "resolve_dialog",
+                        "text": {"type": "plain_text", "text": "Resolve"},
+                        "value": "resolve_dialog",
+                    },
+                    {
+                        "type": "button",
                         "action_id": "ignored:forever",
                         "text": {"type": "plain_text", "text": "Ignore"},
                         "value": "ignored:forever",

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -108,7 +108,91 @@ class BaseEventTest(APITestCase):
             "is_enterprise_install": False,
         }
 
-        if type == "block_actions":
+        if type == "view_submission":
+            view = {
+                "id": "V069MCJ1Y4X",
+                "team_id": team_id,
+                "type": "modal",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "block_id": "a6HD+",
+                        "text": {"type": "mrkdwn", "text": "Resolve in", "verbatim": False},
+                        "accessory": {
+                            "type": "static_select",
+                            "action_id": "static_select-action",
+                            "initial_option": {
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": "Immediately",
+                                    "emoji": True,
+                                },
+                                "value": "resolved",
+                            },
+                            "options": [
+                                {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Immediately",
+                                        "emoji": True,
+                                    },
+                                    "value": "resolved",
+                                },
+                                {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "In the next release",
+                                        "emoji": True,
+                                    },
+                                    "value": "resolved:inNextRelease",
+                                },
+                                {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "In the current release",
+                                        "emoji": True,
+                                    },
+                                    "value": "resolved:inCurrentRelease",
+                                },
+                            ],
+                        },
+                    }
+                ],
+                "private_metadata": private_metadata,
+                "state": {
+                    "values": {
+                        "a6HD+": {
+                            "static_select-action": {
+                                "type": "static_select",
+                                "selected_option": {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Immediately",
+                                        "emoji": True,
+                                    },
+                                    "value": selected_option,
+                                },
+                            }
+                        }
+                    }
+                },
+                "hash": "1702502121.CZNlXHKw",
+                "title": {"type": "plain_text", "text": "Resolve Issue", "emoji": True},
+                "clear_on_close": False,
+                "notify_on_close": False,
+                "close": {"type": "plain_text", "text": "Cancel", "emoji": True},
+                "submit": {"type": "plain_text", "text": "Resolve", "emoji": True},
+                "previous_view_id": None,
+                "root_view_id": "V069MCJ1Y4X",
+                "app_id": "A058NGW5NDP",
+                "external_id": "",
+                "app_installed_team_id": "TA17GH2QL",
+                "bot_id": "B058CDV2LKW",
+            }
+            payload["response_urls"] = []
+            payload["view"] = view
+
+        elif type == "block_actions":
             payload["container"] = {
                 "type": "message",
                 "message_ts": "1702424381.221719",


### PR DESCRIPTION
The final chunk of https://github.com/getsentry/sentry/pull/61215 and a follow up to https://github.com/getsentry/sentry/pull/61806 to add a Resolve button that opens a modal to issue alerts.