### PR TITLE
ref(grouping): Move primary/secondary hashing into/out of functions

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -565,7 +565,7 @@ class EventManager:
             op="event_manager",
             description="event_manager.save.calculate_event_grouping",
         ), metrics.timer("event_manager.calculate_event_grouping", tags=metric_tags):
-            hashes = _calculate_event_grouping(project, job["event"], grouping_config)
+            hashes = _calculate_primary_hash(project, job, grouping_config)
 
         # Track the total number of grouping calculations done overall, so we can divide by the
         # count to get an average number of calculations per event
@@ -753,6 +753,17 @@ def _should_run_secondary_grouping(project: Project) -> bool:
     if secondary_grouping_config and (secondary_grouping_expiry or 0) >= time.time():
         result = True
     return result
+
+
+def _calculate_primary_hash(
+    project: Project, job: Job, grouping_config: GroupingConfig
+) -> CalculatedHashes:
+    """
+    Get the primary hash for the event.
+
+    This is pulled out into a separate function mostly in order to make testing easier.
+    """
+    return _calculate_event_grouping(project, job["event"], grouping_config)
 
 
 def _calculate_secondary_hash(

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -769,6 +769,8 @@ def _calculate_secondary_hash(
             op="event_manager",
             description="event_manager.save.secondary_calculate_event_grouping",
         ):
+            # create a copy since `_calculate_event_grouping` modifies the event to add all sorts
+            # of grouping info and we don't want the backup grouping data in there
             event_copy = copy.deepcopy(job["event"])
             secondary_hashes = _calculate_event_grouping(
                 project, event_copy, secondary_grouping_config

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -769,9 +769,9 @@ def _calculate_secondary_hash(
             op="event_manager",
             description="event_manager.save.secondary_calculate_event_grouping",
         ):
-            secondary_event = copy.deepcopy(job["event"])
+            event_copy = copy.deepcopy(job["event"])
             secondary_hashes = _calculate_event_grouping(
-                project, secondary_event, secondary_grouping_config
+                project, event_copy, secondary_grouping_config
             )
     except Exception:
         sentry_sdk.capture_exception()

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -540,7 +540,10 @@ class EventManager:
 
         if _should_run_secondary_grouping(project):
             with metrics.timer("event_manager.secondary_grouping", tags=metric_tags):
-                secondary_hashes = _calculate_secondary_hash(project, job)
+                secondary_grouping_config = SecondaryGroupingConfigLoader().get_config_dict(project)
+                secondary_hashes = _calculate_secondary_hash(
+                    project, job, secondary_grouping_config
+                )
 
         with metrics.timer("event_manager.load_grouping_config"):
             # At this point we want to normalize the in_app values in case the
@@ -752,7 +755,9 @@ def _should_run_secondary_grouping(project: Project) -> bool:
     return result
 
 
-def _calculate_secondary_hash(project: Project, job: Job) -> None | CalculatedHashes:
+def _calculate_secondary_hash(
+    project: Project, job: Job, secondary_grouping_config: GroupingConfig
+) -> None | CalculatedHashes:
     """Calculate secondary hash for event using a fallback grouping config for a period of time.
     This happens when we upgrade all projects that have not opted-out to automatic upgrades plus
     when the customer changes the grouping config.
@@ -765,8 +770,6 @@ def _calculate_secondary_hash(project: Project, job: Job) -> None | CalculatedHa
             description="event_manager.save.secondary_calculate_event_grouping",
         ):
             secondary_event = copy.deepcopy(job["event"])
-            loader = SecondaryGroupingConfigLoader()
-            secondary_grouping_config = loader.get_config_dict(project)
             secondary_hashes = _calculate_event_grouping(
                 project, secondary_event, secondary_grouping_config
             )


### PR DESCRIPTION
This is a small refactoring PR which makes the structure of our primary and secondary grouping code match slightly better, both for the purposes of an upcoming metric and in order to make testing easier. Specifically:

- Getting the secondary grouping config now happens in the main flow, just as it does with the primary grouping config.
- Actually calculating the primary hashes now happens in a helper function, just as it does with the calculation of the secondary hash.