### PR TITLE
feat(devserver) Bake in options to streamline devserver + ngrok

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3981,6 +3981,16 @@ REGION_PINNED_URL_NAMES = {
 EVENT_PROCESSING_STORE = "rc_processing_redis"
 COGS_EVENT_STORE_LABEL = "bigtable_nodestore"
 
+# Devserver configuration overrides.
+ngrok_host = os.environ.get("SENTRY_DEVSERVER_NGROK")
+if ngrok_host and SILO_MODE != "REGION":
+    SENTRY_OPTIONS["system.url-prefix"] = f"https://{ngrok_host}"
+    CSRF_TRUSTED_ORIGINS = [f".{ngrok_host}"]
+    ALLOWED_HOSTS = [f".{ngrok_host}", "localhost", "127.0.0.1", "docker.internal"]
+
+    SESSION_COOKIE_DOMAIN = f".{ngrok_host}"
+    CSRF_COOKIE_DOMAIN = SESSION_COOKIE_DOMAIN
+    SUDO_COOKIE_DOMAIN = SESSION_COOKIE_DOMAIN
 
 if SILO_DEVSERVER:
     # Add connections for the region & control silo databases.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3986,7 +3986,7 @@ ngrok_host = os.environ.get("SENTRY_DEVSERVER_NGROK")
 if ngrok_host and SILO_MODE != "REGION":
     SENTRY_OPTIONS["system.url-prefix"] = f"https://{ngrok_host}"
     CSRF_TRUSTED_ORIGINS = [f".{ngrok_host}"]
-    ALLOWED_HOSTS = [f".{ngrok_host}", "localhost", "127.0.0.1", "docker.internal"]
+    ALLOWED_HOSTS = [f".{ngrok_host}", "localhost", "127.0.0.1", ".docker.internal"]
 
     SESSION_COOKIE_DOMAIN = f".{ngrok_host}"
     CSRF_COOKIE_DOMAIN = SESSION_COOKIE_DOMAIN

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3988,7 +3988,7 @@ if ngrok_host and SILO_MODE != "REGION":
     CSRF_TRUSTED_ORIGINS = [f".{ngrok_host}"]
     ALLOWED_HOSTS = [f".{ngrok_host}", "localhost", "127.0.0.1", ".docker.internal"]
 
-    SESSION_COOKIE_DOMAIN = f".{ngrok_host}"
+    SESSION_COOKIE_DOMAIN: str = f".{ngrok_host}"
     CSRF_COOKIE_DOMAIN = SESSION_COOKIE_DOMAIN
     SUDO_COOKIE_DOMAIN = SESSION_COOKIE_DOMAIN
 

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -122,6 +122,17 @@ def _get_daemon(name: str) -> tuple[str, list[str]]:
     help="The hostname that clients will use. Useful for ngrok workflows eg `--client-hostname=alice.ngrok.io`",
 )
 @click.option(
+    "--ngrok",
+    default=None,
+    required=False,
+    help=(
+        "The hostname that you have ngrok forwarding to your devserver. "
+        "This option will modify application settings to be compatible with ngrok forwarding. "
+        "Expects a host name without protocol e.g `--ngrok=yourname.ngrok.app`. "
+        "You will also need to run ngrok."
+    ),
+)
+@click.option(
     "--silo",
     default=None,
     type=click.Choice(["control", "region"]),
@@ -151,6 +162,7 @@ def devserver(
     dev_consumer: bool,
     bind: str | None,
     client_hostname: str,
+    ngrok: str | None,
     silo: str | None,
 ) -> NoReturn:
     "Starts a lightweight web server for development."
@@ -189,6 +201,8 @@ def devserver(
     os.environ["SENTRY_SYSTEM_BASE_HOSTNAME"] = client_host
     os.environ["SENTRY_ORGANIZATION_BASE_HOSTNAME"] = f"{{slug}}.{client_host}"
     os.environ["SENTRY_ORGANIZATION_URL_TEMPLATE"] = "http://{hostname}"
+    if ngrok:
+        os.environ["SENTRY_DEVSERVER_NGROK"] = ngrok
 
     from django.conf import settings
 


### PR DESCRIPTION
Bake in configuration for getting sentry devserver + ngrok working. Collectively we've spent too much time getting this knowledge out to folks that need it. Instead of notion pages or docs we can have devserver presets.
