### PR TITLE
feat(starfish): Allow querying measurements array in indexed spans

### DIFF
--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -11,6 +11,7 @@ class Column:
     discover_name: Optional[str]
     alias: str
     issue_platform_name: Optional[str] = None
+    spans_name: Optional[str] = None
 
 
 class Columns(Enum):
@@ -635,6 +636,7 @@ class Columns(Enum):
         event_name=None,
         transaction_name="measurements.key",
         discover_name="measurements.key",
+        spans_name="measurements.key",
         alias="measurements_key",
     )
     MEASUREMENTS_VALUES = Column(
@@ -642,6 +644,7 @@ class Columns(Enum):
         event_name=None,
         transaction_name="measurements.value",
         discover_name="measurements.value",
+        spans_name="measurements.value",
         alias="measurements_value",
     )
     SPAN_OP_BREAKDOWNS_KEYS = Column(

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -127,6 +127,10 @@ SPAN_COLUMN_MAP = {
     "profile_id": "profile_id",
 }
 
+SPAN_COLUMN_MAP.update(
+    {col.value.alias: col.value.spans_name for col in Columns if col.value.spans_name is not None}
+)
+
 SESSIONS_FIELD_LIST = [
     "release",
     "sessions",


### PR DESCRIPTION
A request like this:
http://127.0.0.1:8000/api/0/organizations/sentry/events/?dataset=spansIndexed&field=title&field=measurements.http.decoded_response_content_length&per_page=50&query=has%3Ameasurements.http.decoded_response_content_length&referrer=api.discover.query-table&sort=-measurements.http.decoded_response_content_length&statsPeriod=14d

produces a query like this
```
  SELECT (arrayElement(measurements.value, indexOf(measurements.key, 'http.decoded_response_content_length')) AS `_snuba_measurements[http.decoded_response_content_length]`), (arrayElement(tags.value, indexOf(tags.key, 'title')) AS `_snuba_tags[title]`), (lower(hex(span_id)) AS _snuba_span_id), (project_id AS _snuba_project_id)
   FROM spans_local
  WHERE notEquals(isNull(`_snuba_measurements[http.decoded_response_content_length]`), 1)
    AND greaterOrEquals((end_timestamp AS _snuba_timestamp), toDateTime('2023-12-04T20:58:01', 'Universal'))
    AND less(_snuba_timestamp, toDateTime('2023-12-18T20:58:01', 'Universal'))
    AND in(_snuba_project_id, [1])
  ORDER BY `_snuba_measurements[http.decoded_response_content_length]` DESC
  LIMIT 51
 OFFSET 0
```

allowing us to get sorted values for measurements like `http.decoded_response_content_length` on the indexed spans dataset