### PR TITLE
ref(stats-detectors): Move classes for better imports

### DIFF
--- a/src/sentry/statistical_detectors/algorithm.py
+++ b/src/sentry/statistical_detectors/algorithm.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import logging
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, MutableMapping, Optional, Tuple
 
-from sentry.statistical_detectors.detector import (
-    DetectorAlgorithm,
+from sentry.statistical_detectors.base import (
     DetectorConfig,
     DetectorPayload,
     DetectorState,
@@ -16,6 +16,27 @@ from sentry.utils import metrics
 from sentry.utils.math import MovingAverage
 
 logger = logging.getLogger("sentry.tasks.statistical_detectors.algorithm")
+
+
+class DetectorAlgorithm(ABC):
+    @abstractmethod
+    def __init__(
+        self,
+        source: str,
+        kind: str,
+        state: DetectorState,
+        config: DetectorConfig,
+    ):
+        ...
+
+    @abstractmethod
+    def update(self, payload: DetectorPayload) -> Tuple[Optional[TrendType], float]:
+        ...
+
+    @property
+    @abstractmethod
+    def state(self) -> DetectorState:
+        ...
 
 
 @dataclass(frozen=True)

--- a/src/sentry/statistical_detectors/base.py
+++ b/src/sentry/statistical_detectors/base.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, Mapping
+
+
+class TrendType(Enum):
+    Regressed = "regressed"
+    Improved = "improved"
+    Unchanged = "unchanged"
+
+
+@dataclass(frozen=True)
+class DetectorPayload:
+    project_id: int
+    group: str | int
+    fingerprint: str
+    count: float
+    value: float
+    timestamp: datetime
+
+
+@dataclass(frozen=True)
+class DetectorState(ABC):
+    @classmethod
+    @abstractmethod
+    def from_redis_dict(cls, data: Any) -> DetectorState:
+        ...
+
+    @abstractmethod
+    def to_redis_dict(self) -> Mapping[str | bytes, bytes | float | int | str]:
+        ...
+
+    @abstractmethod
+    def should_auto_resolve(self, target: float, rel_threshold: float) -> bool:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def empty(cls) -> DetectorState:
+        ...
+
+
+@dataclass(frozen=True)
+class DetectorConfig(ABC):
+    ...

--- a/src/sentry/statistical_detectors/store.py
+++ b/src/sentry/statistical_detectors/store.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+from typing import Generic, List, TypeVar
+
+from sentry.statistical_detectors.base import DetectorPayload
+
+T = TypeVar("T")
+
+
+class DetectorStore(ABC, Generic[T]):
+    @abstractmethod
+    def bulk_read_states(self, payloads: List[DetectorPayload]) -> List[T]:
+        ...
+
+    @abstractmethod
+    def bulk_write_states(self, payloads: List[DetectorPayload], states: List[T]):
+        ...

--- a/tests/sentry/statistical_detectors/test_algorithm.py
+++ b/tests/sentry/statistical_detectors/test_algorithm.py
@@ -7,7 +7,7 @@ from sentry.statistical_detectors.algorithm import (
     MovingAverageRelativeChangeDetector,
     MovingAverageRelativeChangeDetectorConfig,
 )
-from sentry.statistical_detectors.detector import DetectorPayload, TrendType
+from sentry.statistical_detectors.base import DetectorPayload, TrendType
 from sentry.utils.math import ExponentialMovingAverage
 
 

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -20,7 +20,8 @@ from sentry.seer.utils import BreakpointData
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.discover import zerofill
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
-from sentry.statistical_detectors.detector import DetectorPayload, TrendType, generate_fingerprint
+from sentry.statistical_detectors.base import DetectorPayload, TrendType
+from sentry.statistical_detectors.detector import generate_fingerprint
 from sentry.tasks.statistical_detectors import (
     EndpointRegressionDetector,
     FunctionRegressionDetector,


### PR DESCRIPTION
Having everything in the `detector.py` makes for some cyclic dependencies for some planned changes. Refactoring it here.