### PR TITLE
ref(stats-detectors): Rename redirect escalation

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -243,7 +243,6 @@ def detect_transaction_trends(
 
     trends = EndpointRegressionDetector.detect_trends(projects, start)
     trends = EndpointRegressionDetector.redirect_resolutions(trends, start)
-    trends = EndpointRegressionDetector.redirect_resolutions(trends, start)
     regressions = EndpointRegressionDetector.limit_regressions_by_project(trends)
 
     delay = 12  # hours

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -243,6 +243,7 @@ def detect_transaction_trends(
 
     trends = EndpointRegressionDetector.detect_trends(projects, start)
     trends = EndpointRegressionDetector.redirect_resolutions(trends, start)
+    trends = EndpointRegressionDetector.redirect_resolutions(trends, start)
     regressions = EndpointRegressionDetector.limit_regressions_by_project(trends)
 
     delay = 12  # hours
@@ -287,8 +288,7 @@ def detect_transaction_change_points(
     regressions = EndpointRegressionDetector.detect_regressions(
         transaction_pairs, start, "p95(transaction.duration)", TIMESERIES_PER_BATCH
     )
-    versioned_regressions = EndpointRegressionDetector.redirect_escalations(regressions)
-    regressions = EndpointRegressionDetector.save_versioned_regressions(versioned_regressions)
+    regressions = EndpointRegressionDetector.save_regressions_with_versions(regressions)
 
     breakpoint_count = 0
 
@@ -364,10 +364,7 @@ def detect_function_change_points(
     regressions = FunctionRegressionDetector.detect_regressions(
         function_pairs, start, "p95()", TIMESERIES_PER_BATCH
     )
-
-    versioned_regressions = FunctionRegressionDetector.redirect_escalations(regressions)
-
-    regressions = FunctionRegressionDetector.save_versioned_regressions(versioned_regressions)
+    regressions = FunctionRegressionDetector.save_regressions_with_versions(regressions)
 
     breakpoint_count = 0
     emitted_count = 0

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -558,7 +558,7 @@ def test_limit_regressions_by_project(detector_cls, ratelimit, timestamp, expect
     ],
 )
 @django_db_all
-def test_redirect_escalations(
+def test_get_regression_versions(
     detector_cls,
     existing,
     expected_versions,
@@ -601,7 +601,7 @@ def test_redirect_escalations(
     def mock_regressions():
         yield from breakpoints
 
-    regressions = list(detector_cls.redirect_escalations(mock_regressions()))
+    regressions = list(detector_cls.get_regression_versions(mock_regressions()))
 
     assert regressions == [
         (expected_version, breakpoints[i])
@@ -892,8 +892,7 @@ def test_new_regression_group(
         }
 
     regressions = get_regressions()
-    versioned_regressions = detector_cls.redirect_escalations(regressions)
-    regressions = detector_cls.save_versioned_regressions(versioned_regressions)
+    regressions = detector_cls.save_regressions_with_versions(regressions)
     assert len(list(regressions)) == 1  # indicates we should've saved 1 regression group
 
     regression_groups = get_regression_groups(


### PR DESCRIPTION
We're changing the approach for detecting escalations to something similar to how resolution works. The condition will be if the moving average is X% above the regressed value. In preparation for that, rename the existing function.