### PR TITLE
feat(backup): Add creator/owner email/username to GET /relocations/

### DIFF
--- a/src/sentry/api/endpoints/relocations/unpause.py
+++ b/src/sentry/api/endpoints/relocations/unpause.py
@@ -115,4 +115,5 @@ class RelocationUnpauseEndpoint(Endpoint):
                 )
 
             task.delay(str(relocation.uuid))
-            return self.respond(serialize(relocation))
+
+        return self.respond(serialize(relocation))

--- a/src/sentry/api/serializers/models/relocation.py
+++ b/src/sentry/api/serializers/models/relocation.py
@@ -1,17 +1,18 @@
-from typing import Any, Mapping
+from typing import Any, Mapping, MutableMapping, Sequence
 
 from sentry.api.serializers import Serializer, register
 from sentry.models.relocation import Relocation
+from sentry.models.user import User
+from sentry.services.hybrid_cloud.user.model import RpcUser
+from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.utils.json import JSONData
 
 
 @register(Relocation)
 class RelocationSerializer(Serializer):
     def serialize(
-        self, obj: Any, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
+        self, obj: Relocation, attrs: Mapping[int, RpcUser], user: User, **kwargs: Any
     ) -> Mapping[str, JSONData]:
-        assert isinstance(obj, Relocation)
-
         scheduled_at_pause_step = (
             Relocation.Step(obj.scheduled_pause_at_step).name
             if obj.scheduled_pause_at_step is not None
@@ -27,12 +28,17 @@ class RelocationSerializer(Serializer):
             if obj.latest_notified is not None
             else None
         )
+
         return {
             "dateAdded": obj.date_added,
             "dateUpdated": obj.date_updated,
             "uuid": str(obj.uuid),
+            "creatorEmail": attrs[obj.creator_id].email,
             "creatorId": str(obj.creator_id),
+            "creatorUsername": attrs[obj.creator_id].username,
+            "ownerEmail": attrs[obj.owner_id].email,
             "ownerId": str(obj.owner_id),
+            "ownerUsername": attrs[obj.owner_id].username,
             "status": Relocation.Status(obj.status).name,
             "step": Relocation.Step(obj.step).name,
             "failureReason": obj.failure_reason,
@@ -43,3 +49,15 @@ class RelocationSerializer(Serializer):
             "latestNotified": latest_notified,
             "latestUnclaimedEmailsSentAt": obj.latest_unclaimed_emails_sent_at,
         }
+
+    def get_attrs(
+        self, item_list: Sequence[Relocation], user: User, **kwargs: Any
+    ) -> MutableMapping[Relocation, Mapping[int, RpcUser]]:
+        user_ids = set()
+        for relocation in item_list:
+            user_ids.add(relocation.creator_id)
+            user_ids.add(relocation.owner_id)
+
+        users = user_service.get_many(filter=dict(user_ids=list(user_ids)))
+        user_map = {u.id: u for u in users}
+        return {r: user_map for r in item_list}

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -117,6 +117,12 @@ class GetRelocationsTest(APITestCase):
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
         assert response.data[0]["status"] == Relocation.Status.IN_PROGRESS.name
+        assert response.data[0]["creatorId"] == str(self.superuser.id)
+        assert response.data[0]["creatorEmail"] == str(self.superuser.email)
+        assert response.data[0]["creatorUsername"] == str(self.superuser.username)
+        assert response.data[0]["ownerId"] == str(self.owner.id)
+        assert response.data[0]["ownerEmail"] == str(self.owner.email)
+        assert response.data[0]["ownerUsername"] == str(self.owner.username)
 
     def test_good_status_pause(self):
         self.login_as(user=self.superuser, superuser=True)

--- a/tests/sentry/api/serializers/test_relocation.py
+++ b/tests/sentry/api/serializers/test_relocation.py
@@ -42,7 +42,11 @@ class RelocationSerializerTest(TestCase):
         assert result["dateUpdated"] == TEST_DATE_UPDATED
         assert result["uuid"] == str(relocation.uuid)
         assert result["creatorId"] == str(self.superuser.id)
+        assert result["creatorEmail"] == self.superuser.email
+        assert result["creatorUsername"] == self.superuser.username
         assert result["ownerId"] == str(self.owner.id)
+        assert result["ownerEmail"] == self.owner.email
+        assert result["ownerUsername"] == self.owner.username
         assert result["status"] == Relocation.Status.IN_PROGRESS.name
         assert result["step"] == Relocation.Step.UPLOADING.name
         assert not result["failureReason"]
@@ -74,7 +78,11 @@ class RelocationSerializerTest(TestCase):
         assert result["dateUpdated"] == TEST_DATE_UPDATED
         assert result["uuid"] == str(relocation.uuid)
         assert result["creatorId"] == str(self.superuser.id)
+        assert result["creatorEmail"] == self.superuser.email
+        assert result["creatorUsername"] == self.superuser.username
         assert result["ownerId"] == str(self.owner.id)
+        assert result["ownerEmail"] == self.owner.email
+        assert result["ownerUsername"] == self.owner.username
         assert result["status"] == Relocation.Status.PAUSE.name
         assert result["step"] == Relocation.Step.IMPORTING.name
         assert not result["failureReason"]
@@ -107,7 +115,11 @@ class RelocationSerializerTest(TestCase):
         assert result["dateUpdated"] == TEST_DATE_UPDATED
         assert result["uuid"] == str(relocation.uuid)
         assert result["creatorId"] == str(self.superuser.id)
+        assert result["creatorEmail"] == self.superuser.email
+        assert result["creatorUsername"] == self.superuser.username
         assert result["ownerId"] == str(self.owner.id)
+        assert result["ownerEmail"] == self.owner.email
+        assert result["ownerUsername"] == self.owner.username
         assert result["status"] == Relocation.Status.SUCCESS.name
         assert result["step"] == Relocation.Step.COMPLETED.name
         assert not result["failureReason"]
@@ -141,7 +153,11 @@ class RelocationSerializerTest(TestCase):
         assert result["dateUpdated"] == TEST_DATE_UPDATED
         assert result["uuid"] == str(relocation.uuid)
         assert result["creatorId"] == str(self.superuser.id)
+        assert result["creatorEmail"] == self.superuser.email
+        assert result["creatorUsername"] == self.superuser.username
         assert result["ownerId"] == str(self.owner.id)
+        assert result["ownerEmail"] == self.owner.email
+        assert result["ownerUsername"] == self.owner.username
         assert result["status"] == Relocation.Status.FAILURE.name
         assert result["step"] == Relocation.Step.VALIDATING.name
         assert result["failureReason"] == "Some failure reason"


### PR DESCRIPTION
This makes the list a bit easier to render in the admin panel, and minimizes the number of round trips to the server.

Issue: getsentry/team-ospo#214