### PR TITLE
fix(replay): Fix alignment of FeatureBadge in Replay Details tabs

### DIFF
--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -1,4 +1,5 @@
 import {Fragment, ReactNode} from 'react';
+import styled from '@emotion/styled';
 import queryString from 'query-string';
 
 import FeatureBadge from 'sentry/components/featureBadge';
@@ -44,10 +45,9 @@ function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
         >
           {t('Accessibility')}
         </Tooltip>
-        <FeatureBadge
+        <FlexFeatureBadge
           type="alpha"
           title={t('This feature is available for early adopters and may change')}
-          tooltipProps={{overlayStyle: {display: 'flex'}}}
         />
       </Fragment>
     ) : null,
@@ -92,5 +92,11 @@ function FocusTabs({className}: Props) {
     </ScrollableTabs>
   );
 }
+
+const FlexFeatureBadge = styled(FeatureBadge)`
+  & > span {
+    display: flex;
+  }
+`;
 
 export default FocusTabs;


### PR DESCRIPTION
the feature badge was lower than the "Accessibility" text next to it. Now it's up near the baseline better

| Before | After |
| --- | --- |
| <img width="291" alt="before" src="https://github.com/getsentry/sentry/assets/187460/3f7d2239-8504-404e-9d1c-651c3cc27b83"> | <img width="286" alt="after" src="https://github.com/getsentry/sentry/assets/187460/676977e7-626a-4719-8cd5-a8460e8af8be"> |

It might be hard to see in this table, but you can tell the difference by opening each pic in two tabs and flipping back and forth rapidly.