### PR TITLE
ref(slack): Prioritize title if available

### DIFF
--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -65,7 +65,10 @@ def build_attachment_title(obj: Group | GroupEvent) -> str:
     title = obj.title
 
     if ev_type == "error" and "type" in ev_metadata:
-        title = ev_metadata["type"]
+        if "title" in ev_metadata:
+            title = ev_metadata["title"]
+        else:
+            title = ev_metadata["type"]
 
     elif ev_type == "csp":
         title = f'{ev_metadata["directive"]} - {ev_metadata["uri"]}'


### PR DESCRIPTION
If using fingerprinting rules to change the title of an event, we want to use that new title in a Slack issue alert notification. 

Here is the Slack notification:
<img width="377" alt="Screenshot 2023-12-18 at 4 36 00 PM" src="https://github.com/getsentry/sentry/assets/29959063/6294c987-34ec-4fa0-a118-38a94ddefe88">

Normally it would use the event type `NameError`:
<img width="912" alt="Screenshot 2023-12-18 at 4 36 25 PM" src="https://github.com/getsentry/sentry/assets/29959063/cfd14e65-a13d-4fb7-afe8-ee5279ad9b01">
