### PR TITLE
feat(issue-alerts): Add latest adopted release filter to project rules config endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -34,7 +34,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         )
         has_issue_severity_alerts = features.has("projects:first-event-severity-alerting", project)
         has_latest_adopted_release = features.has(
-            "organizations:latest-adopted-release-filter", project
+            "organizations:latest-adopted-release-filter", project.organization
         )
 
         # TODO: conditions need to be based on actions

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -33,6 +33,9 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
             "organizations:integrations-ticket-rules", project.organization
         )
         has_issue_severity_alerts = features.has("projects:first-event-severity-alerting", project)
+        has_latest_adopted_release = features.has(
+            "organizations:latest-adopted-release-filter", project
+        )
 
         # TODO: conditions need to be based on actions
         for rule_type, rule_cls in rules:
@@ -84,6 +87,12 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
                 if (
                     context["id"] == "sentry.rules.filters.issue_severity.IssueSeverityFilter"
                     and not has_issue_severity_alerts
+                ):
+                    continue
+                if (
+                    context["id"]
+                    == "sentry.rules.filters.latest_adopted_release_filter.LatestAdoptedReleaseFilter"
+                    and not has_latest_adopted_release
                 ):
                     continue
                 filter_list.append(context)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1629,6 +1629,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:issue-stream-performance": False,
     # Enable issue stream performance improvements (cache)
     "organizations:issue-stream-performance-cache": False,
+    # Enabled latest adopted release filter for issue alerts
+    "organizations:latest-adopted-release-filter": False,
     # Enable metric alert charts in email/slack
     "organizations:metric-alert-chartcuterie": False,
     # Enable ignoring archived issues in metric alerts

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -273,6 +273,7 @@ _SENTRY_RULES = (
     "sentry.rules.filters.age_comparison.AgeComparisonFilter",
     "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
     "sentry.rules.filters.assigned_to.AssignedToFilter",
+    "sentry.rules.filters.latest_adopted_release_filter.LatestAdoptedReleaseFilter",
     "sentry.rules.filters.latest_release.LatestReleaseFilter",
     "sentry.rules.filters.issue_category.IssueCategoryFilter",
     "sentry.rules.filters.issue_severity.IssueSeverityFilter",

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -133,6 +133,7 @@ default_manager.add("organizations:issue-search-use-cdc-secondary", Organization
 default_manager.add("organizations:issue-stream-performance-cache", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-stream-performance", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:large-debug-files", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:latest-adopted-release-filter", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:mep-rollout-flag", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:metric-alert-chartcuterie", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:metric-alert-ignore-archived", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/rules/filters/latest_adopted_release_filter.py
+++ b/src/sentry/rules/filters/latest_adopted_release_filter.py
@@ -31,7 +31,7 @@ from sentry.utils.cache import cache
 class LatestAdoptedReleaseForm(forms.Form):
     oldest_or_newest = forms.ChoiceField(choices=list(model_age_choices))
     older_or_newer = forms.ChoiceField(choices=list(age_comparison_choices))
-    environment = forms.CharField(required=False)
+    environment = forms.CharField()
 
     def __init__(self, project, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/sentry/rules/filters/latest_adopted_release_filter.py
+++ b/src/sentry/rules/filters/latest_adopted_release_filter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from itertools import product
 from typing import Any
 
@@ -28,57 +29,58 @@ from sentry.utils.cache import cache
 
 
 class LatestAdoptedReleaseForm(forms.Form):
-    release_age_type = forms.ChoiceField(choices=list(model_age_choices))
-    age_comparison = forms.ChoiceField(choices=list(age_comparison_choices))
-    environment_id = forms.CharField(required=False)
+    oldest_or_newest = forms.ChoiceField(choices=list(model_age_choices))
+    older_or_newer = forms.ChoiceField(choices=list(age_comparison_choices))
+    environment = forms.CharField(required=False)
 
     def __init__(self, project, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.project = project
 
-    def clean_environment_id(self):
-        environment_id = self.cleaned_data.get("environment_id")
-        if environment_id == "None":
-            environment_id = None
-        if environment_id:
-            try:
-                environment_id = int(environment_id)
-            except ValueError:
-                raise forms.ValidationError("environmentId must be an integer")
+    def clean_environment(self):
+        environment = self.cleaned_data.get("environment")
+        if environment:
             if not Environment.objects.filter(
-                environment_id=environment_id, organization_id=self.project.organization_id
+                name=environment, organization_id=self.project.organization_id
             ).exists():
                 raise forms.ValidationError(
-                    "environmentId does not exist or is not associated with this organization"
+                    "environment does not exist or is not associated with this organization"
                 )
-        return environment_id
+        return environment
 
 
 class LatestAdoptedReleaseFilter(EventFilter):
     id = "sentry.rules.filters.latest_adopted_release_filter.LatestAdoptedReleaseFilter"
     form_cls = LatestAdoptedReleaseForm
-    label = "The {release_age_type} release associated with the event's issue is {age_comparison} than the latest release in the {environmentId} environment"
+    label = "The {oldest_or_newest} release associated with the event's issue is {older_or_newer} than the latest release in {environment}"
 
     form_fields = {
-        "release_age_type": {"type": "choice", "choices": list(model_age_choices)},
-        "age_comparison": {"type": "choice", "choices": list(age_comparison_choices)},
-        "environment_id": {"type": "string", "placeholder": "value"},
+        "oldest_or_newest": {"type": "choice", "choices": list(model_age_choices)},
+        "older_or_newer": {"type": "choice", "choices": list(age_comparison_choices)},
+        "environment": {"type": "string", "placeholder": "value"},
     }
 
-    def get_latest_release_for_env(self, event: GroupEvent, environment_id: int) -> Release | None:
-        cache_key = get_project_release_cache_key(event.project_id, environment_id)
+    def get_latest_release_for_env(self, event: GroupEvent, environment: str) -> Release | None:
+        cache_key = get_project_release_cache_key(event.project_id, environment)
         latest_release = cache.get(cache_key)
         if latest_release is None:
             organization_id = event.organization.id
-            environments = [Environment.objects.get(id=environment_id)]
             try:
+                try:
+                    environment_instance = Environment.objects.get(
+                        name=environment, organization_id=self.project.organization_id
+                    )
+                except Environment.DoesNotExist:
+                    logging.info("Environment not found")
+                    return None
                 latest_release_versions = get_latest_release(
                     [event.project],
-                    environments,
+                    [environment_instance],
                     organization_id,
                     adopted=True,
                 )
             except Release.DoesNotExist:
+                logging.info("Latest release not found")
                 return None
             latest_release = Release.objects.get(
                 version=latest_release_versions[0], organization_id=organization_id
@@ -118,16 +120,16 @@ class LatestAdoptedReleaseFilter(EventFilter):
         return release
 
     def passes(self, event: GroupEvent, state: EventState) -> bool:
-        release_age_type = self.get_option("release_age_type")
-        age_comparison = self.get_option("age_comparison")
-        environment_id = self.get_option("environment_id")
+        release_age_type = self.get_option("oldest_or_newest")
+        age_comparison = self.get_option("older_or_newer")
+        environment = self.get_option("environment")
 
         if follows_semver_versioning_scheme(event.organization.id, event.project_id):
             order_type = LatestReleaseOrders.SEMVER
         else:
             order_type = LatestReleaseOrders.DATE
 
-        latest_project_release = self.get_latest_release_for_env(event, int(environment_id))
+        latest_project_release = self.get_latest_release_for_env(event, environment)
         if not latest_project_release:
             return False
 
@@ -185,8 +187,8 @@ def clear_get_first_last_release_for_group_cache(instance: GroupRelease, **kwarg
     )
 
 
-def get_project_release_cache_key(project_id: int, environment_id: int) -> str:
-    return f"project:{project_id}:env:{environment_id}:latest_release_adopted"
+def get_project_release_cache_key(project_id: int, environment: str) -> str:
+    return f"project:{project_id}:env:{environment}:latest_release_adopted"
 
 
 def clear_release_environment_project_cache(instance: ReleaseEnvironment, **kwargs: Any) -> None:
@@ -198,7 +200,7 @@ def clear_release_environment_project_cache(instance: ReleaseEnvironment, **kwar
 
     cache.delete_many(
         [
-            get_project_release_cache_key(proj_id, instance.environment_id)
+            get_project_release_cache_key(proj_id, instance.environment.name)
             for proj_id in release_project_ids
         ]
     )

--- a/tests/sentry/rules/filters/test_latest_adopted_release.py
+++ b/tests/sentry/rules/filters/test_latest_adopted_release.py
@@ -36,7 +36,7 @@ class LatestAdoptedReleaseFilterTest(RuleTestCase):
             adopted=now,
         )
         # Test no release
-        data = {"release_age_type": "oldest", "age_comparison": "newer", "environment_id": prod.id}
+        data = {"oldest_or_newest": "oldest", "older_or_newer": "newer", "environment": prod.name}
         rule = self.get_rule(data=data)
         self.assertDoesNotPass(rule, event)
 
@@ -107,7 +107,7 @@ class LatestAdoptedReleaseFilterTest(RuleTestCase):
         )
         self.create_group_release(group=self.event.group, release=newest_release)
 
-        data = {"release_age_type": "oldest", "age_comparison": "newer", "environment_id": prod.id}
+        data = {"oldest_or_newest": "oldest", "older_or_newer": "newer", "environment": prod.name}
         rule = self.get_rule(data=data)
         self.assertPasses(rule, event)
 


### PR DESCRIPTION
This adds the latest adopted release filter ot the project rules config endpoint, and adds tests for the form validation.

Also renamed some of the parameters of the filter so that they'd read in a more intuitive way to the user.
