### PR TITLE
ref(crons): Change thresholds -> margins

### DIFF
--- a/static/app/views/monitors/components/detailsSidebar.tsx
+++ b/static/app/views/monitors/components/detailsSidebar.tsx
@@ -75,7 +75,7 @@ export default function DetailsSidebar({monitorEnv, monitor}: Props) {
           <CrontabText>({schedule})</CrontabText>
         )}
       </Schedule>
-      <SectionHeading>{t('Thresholds')}</SectionHeading>
+      <SectionHeading>{t('Margins')}</SectionHeading>
       <Thresholds>
         <MonitorIcon status={MonitorStatus.MISSED_CHECKIN} size={12} />
         <Text>

--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -379,7 +379,7 @@ function MonitorForm({
             }}
           </Observer>
         </InputGroup>
-        <StyledListItem>{t('Set thresholds')}</StyledListItem>
+        <StyledListItem>{t('Set margins')}</StyledListItem>
         <ListItemSubText>
           {t('Configure when we mark your monitor as failed or missed.')}
         </ListItemSubText>
@@ -415,7 +415,7 @@ function MonitorForm({
         </InputGroup>
         {hasIssuePlatform && (
           <Fragment>
-            <StyledListItem>{t('Set tolerance')}</StyledListItem>
+            <StyledListItem>{t('Set thresholds')}</StyledListItem>
             <ListItemSubText>
               {t('Configure when an issue is created or resolved.')}
             </ListItemSubText>


### PR DESCRIPTION
Change thresholds to margins here and in the form, because thresholds should only be describing issue creation limits, not conditions relating to when a checkin is marked as time out or error.