### PR TITLE
ref(crons): Increase pagination limit for monitor details issues

### DIFF
--- a/static/app/views/monitors/components/monitorIssues.tsx
+++ b/static/app/views/monitors/components/monitorIssues.tsx
@@ -91,7 +91,7 @@ function MonitorIssues({orgSlug, monitor, monitorEnvs}: Props) {
             .map(e => e.name)
             .join(',')}]`,
           project: monitor.project.id,
-          limit: 5,
+          limit: 20,
           ...timeProps,
         }}
         query=""


### PR DESCRIPTION
With thresholds rolling out, we should increase the number of issues shown in this component to accomodate new issue creation.