### PR TITLE
ref(open-pr-comments): single API call for workflow

### DIFF
--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -236,10 +236,8 @@ class TestGetFilenames(GithubCommentTestCase):
     @responses.activate
     def test_get_pr_filenames(self):
         data: JSONData = [
-            {"filename": "foo.py", "status": "added"},
             {"filename": "bar.py", "status": "modified"},
             {"filename": "baz.py", "status": "deleted"},
-            {"filename": "bee.js", "status": "modified"},
         ]
 
         assert set(get_pr_filenames(data)) == {"bar.py", "baz.py"}

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -100,7 +100,10 @@ class TestSafeForComment(GithubCommentTestCase):
 
         is_safe, pr_files = safe_for_comment(self.gh_client, self.gh_repo, self.pr)
         assert is_safe
-        assert pr_files == data
+        assert pr_files == [
+            {"filename": "foo.py", "changes": 100, "status": "modified"},
+            {"filename": "bee.py", "changes": 100, "status": "deleted"},
+        ]
 
     @responses.activate
     def test_too_many_files(self):
@@ -171,9 +174,6 @@ class TestSafeForComment(GithubCommentTestCase):
         assert pr_files == []
         self.mock_metrics.incr.assert_any_call(
             "github_open_pr_comment.rejected_comment", tags={"reason": "too_many_lines"}
-        )
-        self.mock_metrics.incr.assert_any_call(
-            "github_open_pr_comment.rejected_comment", tags={"reason": "too_many_files"}
         )
 
     @responses.activate


### PR DESCRIPTION
This PR refactors the open PR comment workflow to only use a single Github API call ([List pull request files](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files)) to:
1. Determine if a PR can be commented on.
2. Fetch the filenames in a PR
3. (in a followup) Fetch the diff patches for each file in a PR

In the original implementation, we hit the [Get a pull request](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request) API to determine whether a pull request was safe for comment (get the count of lines and files changed and whether the PR is open), and then hit the [List pull request files](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files) API to fetch the files in the PR. This can be consolidated into one API call.

We can remove the check for whether the PR is open because we only queue the open PR comment workflow in the Github `PullRequestEventWebhook` if the PR has been opened. We can also see the total lines modified in a PR directly in [List pull request files](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files) by iterating through the files and adding them up.

Additionally, we want to fetch the files first because we will only be finding function names for Python files, and we should use the count of Python files to determine whether a PR is safe to comment on.