### PR TITLE
Fix Craft publish

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -6,7 +6,7 @@ statusProvider:
   name: github
   config:
     contexts:
-      - 'self-hosted-builder (sentryio)'
+      - 'self-hosted'
 targets:
   - id: release
     name: docker


### PR DESCRIPTION
This should get the https://github.com/getsentry/publish/issues/3160 release back on track.