### PR TITLE
ref(ts): Remove usage of `TestStubs.location`

### DIFF
--- a/static/app/components/events/eventEntries.spec.tsx
+++ b/static/app/components/events/eventEntries.spec.tsx
@@ -1,4 +1,5 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -10,7 +11,7 @@ describe('EventEntries', function () {
     organization: Organization(),
     project: TestStubs.Project(),
     event: EventFixture(),
-    location: TestStubs.location(),
+    location: LocationFixture(),
   };
 
   beforeEach(function () {

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -1,4 +1,5 @@
 import selectEvent from 'react-select-event';
+import LocationFixture from 'sentry-fixture/locationFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -116,7 +117,7 @@ describe('add to dashboard modal', () => {
         selection={defaultSelection}
         router={initialData.router}
         widgetAsQueryParams={mockWidgetAsQueryParams}
-        location={TestStubs.location()}
+        location={LocationFixture()}
       />
     );
 
@@ -148,7 +149,7 @@ describe('add to dashboard modal', () => {
         selection={defaultSelection}
         router={initialData.router}
         widgetAsQueryParams={mockWidgetAsQueryParams}
-        location={TestStubs.location()}
+        location={LocationFixture()}
       />
     );
 
@@ -178,7 +179,7 @@ describe('add to dashboard modal', () => {
         selection={defaultSelection}
         router={initialData.router}
         widgetAsQueryParams={mockWidgetAsQueryParams}
-        location={TestStubs.location()}
+        location={LocationFixture()}
       />
     );
 
@@ -204,7 +205,7 @@ describe('add to dashboard modal', () => {
         selection={defaultSelection}
         router={initialData.router}
         widgetAsQueryParams={mockWidgetAsQueryParams}
-        location={TestStubs.location()}
+        location={LocationFixture()}
       />
     );
 
@@ -258,7 +259,7 @@ describe('add to dashboard modal', () => {
         selection={defaultSelection}
         router={initialData.router}
         widgetAsQueryParams={mockWidgetAsQueryParams}
-        location={TestStubs.location()}
+        location={LocationFixture()}
       />
     );
 
@@ -294,7 +295,7 @@ describe('add to dashboard modal', () => {
         selection={defaultSelection}
         router={initialData.router}
         widgetAsQueryParams={mockWidgetAsQueryParams}
-        location={TestStubs.location()}
+        location={LocationFixture()}
       />
     );
 
@@ -323,7 +324,7 @@ describe('add to dashboard modal', () => {
         selection={defaultSelection}
         router={initialData.router}
         widgetAsQueryParams={mockWidgetAsQueryParams}
-        location={TestStubs.location()}
+        location={LocationFixture()}
       />
     );
 
@@ -369,7 +370,7 @@ describe('add to dashboard modal', () => {
         selection={defaultSelection}
         router={initialData.router}
         widgetAsQueryParams={mockWidgetAsQueryParams}
-        location={TestStubs.location()}
+        location={LocationFixture()}
       />
     );
 
@@ -427,7 +428,7 @@ describe('add to dashboard modal', () => {
         selection={defaultSelection}
         router={initialData.router}
         widgetAsQueryParams={mockWidgetAsQueryParams}
-        location={TestStubs.location()}
+        location={LocationFixture()}
       />
     );
 
@@ -508,7 +509,7 @@ describe('add to dashboard modal', () => {
         selection={defaultSelection}
         router={initialData.router}
         widgetAsQueryParams={mockWidgetAsQueryParams}
-        location={TestStubs.location()}
+        location={LocationFixture()}
       />
     );
 
@@ -566,7 +567,7 @@ describe('add to dashboard modal', () => {
         selection={defaultSelection}
         router={initialData.router}
         widgetAsQueryParams={mockWidgetAsQueryParams}
-        location={TestStubs.location()}
+        location={LocationFixture()}
       />
     );
 

--- a/static/app/utils/discover/eventView.spec.tsx
+++ b/static/app/utils/discover/eventView.spec.tsx
@@ -1,4 +1,5 @@
 import shuffle from 'lodash/shuffle';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {PageFilters} from 'sentry-fixture/pageFilters';
 
@@ -71,7 +72,7 @@ describe('EventView constructor', function () {
 
 describe('EventView.fromLocation()', function () {
   it('maps query strings', function () {
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         id: '42',
         name: 'best query',
@@ -115,7 +116,7 @@ describe('EventView.fromLocation()', function () {
   });
 
   it('includes first valid statsPeriod', function () {
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         id: '42',
         name: 'best query',
@@ -151,7 +152,7 @@ describe('EventView.fromLocation()', function () {
   });
 
   it('includes start and end', function () {
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         id: '42',
         name: 'best query',
@@ -185,7 +186,7 @@ describe('EventView.fromLocation()', function () {
   });
 
   it('generates event view when there are no query strings', function () {
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {},
     });
 
@@ -575,7 +576,7 @@ describe('EventView.fromNewQueryWithLocation()', function () {
   };
 
   it('maps basic properties of a prebuilt query', function () {
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         statsPeriod: '99d',
       },
@@ -606,7 +607,7 @@ describe('EventView.fromNewQueryWithLocation()', function () {
   });
 
   it('merges global selection values', function () {
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         statsPeriod: '99d',
         project: ['456'],
@@ -638,7 +639,7 @@ describe('EventView.fromNewQueryWithLocation()', function () {
   });
 
   it('new query takes precedence over global selection values', function () {
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         statsPeriod: '99d',
         project: ['456'],
@@ -677,7 +678,7 @@ describe('EventView.fromNewQueryWithLocation()', function () {
 
     // also test start and end
 
-    const location2 = TestStubs.location({
+    const location2 = LocationFixture({
       query: {
         start: '2019-10-01T00:00:00',
         end: '2019-10-02T00:00:00',
@@ -738,7 +739,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
       version: 2,
     };
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         statsPeriod: '14d',
         project: ['123'],
@@ -770,7 +771,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
     });
 
     const savedQuery2: SavedQuery = {...saved, range: undefined};
-    const location2 = TestStubs.location({
+    const location2 = LocationFixture({
       query: {
         project: ['123'],
         environment: ['staging'],
@@ -817,7 +818,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
       version: 2,
     };
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         id: '42',
         statsPeriod: '7d',
@@ -863,7 +864,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
       yAxis: ['count()'],
     };
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         id: '5',
         project: ['1'],
@@ -906,7 +907,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
       version: 2,
     };
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         id: '42',
         statsPeriod: '7d',
@@ -932,7 +933,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
       display: 'previous',
     });
 
-    const location2 = TestStubs.location({
+    const location2 = LocationFixture({
       query: {
         id: '42',
         statsPeriod: '7d',
@@ -975,7 +976,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
       id: '3',
     };
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         id: '3',
         start: '2019-10-20T21:02:51+0000',
@@ -985,7 +986,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
 
     const eventView = EventView.fromSavedQueryOrLocation(saved, location);
 
-    const location2 = TestStubs.location({
+    const location2 = LocationFixture({
       query: {
         id: '3',
         start: '2019-10-20T21:02:51Z',
@@ -996,7 +997,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
 
     expect(eventView.isEqualTo(eventView2)).toBe(true);
 
-    const location3 = TestStubs.location({
+    const location3 = LocationFixture({
       query: {
         id: '3',
         start: '2019-10-20T21:02:51Z',
@@ -1007,7 +1008,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
 
     expect(eventView.isEqualTo(eventView3)).toBe(true);
 
-    const location4 = TestStubs.location({
+    const location4 = LocationFixture({
       query: {
         id: '3',
         start: '2019-10-20T21:02:51+0000',
@@ -1034,7 +1035,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
       projects: [1],
     };
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         id: '3',
         end: '2019-10-23T19:27:04+0000',
@@ -1044,7 +1045,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
 
     const eventView = EventView.fromSavedQueryOrLocation(saved, location);
 
-    const location2 = TestStubs.location({
+    const location2 = LocationFixture({
       query: {
         id: '3',
         end: '2019-10-23T19:27:04+0000',
@@ -1055,7 +1056,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
 
     expect(eventView.isEqualTo(eventView2)).toBe(false);
 
-    const location3 = TestStubs.location({
+    const location3 = LocationFixture({
       query: {
         id: '3',
         end: '',
@@ -1089,7 +1090,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
       version: 2,
     };
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         statsPeriod: '14d',
         project: ['123'],
@@ -1122,7 +1123,7 @@ describe('EventView.fromSavedQueryOrLocation()', function () {
   it('filters out invalid teams', function () {
     const eventView = EventView.fromSavedQueryOrLocation(
       undefined,
-      TestStubs.location({
+      LocationFixture({
         query: {
           statsPeriod: '14d',
           project: ['123'],
@@ -1254,7 +1255,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       display: 'releases',
     });
 
-    expect(eventView.getEventsAPIPayload(TestStubs.location())).toEqual({
+    expect(eventView.getEventsAPIPayload(LocationFixture())).toEqual({
       field: ['id'],
       per_page: 50,
       sort: '-id',
@@ -1273,7 +1274,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       query: 'event.type:csp',
     });
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         query: 'TypeError',
       },
@@ -1289,7 +1290,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       query: 'event.type:csp',
     });
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {},
     });
 
@@ -1304,7 +1305,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       query: 'event.type:csp',
     });
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {},
     });
 
@@ -1319,7 +1320,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       query: 'event.type:csp',
     });
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         start: '2020-08-12 12:13:14',
         end: '2020-08-26 12:13:14',
@@ -1359,7 +1360,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       environment: ['staging'],
     });
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         start: '',
         end: '',
@@ -1383,7 +1384,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       cursor: 'some cursor',
     });
 
-    const location2 = TestStubs.location({
+    const location2 = LocationFixture({
       query: {
         start: '',
         end: '',
@@ -1417,7 +1418,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       environment: ['staging'],
     });
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         start: '',
         utc: 'true',
@@ -1439,7 +1440,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       cursor: 'some cursor',
     });
 
-    const location2 = TestStubs.location({
+    const location2 = LocationFixture({
       query: {
         end: '',
         utc: 'true',
@@ -1474,7 +1475,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       project: [],
     });
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         // these should not be part of the API payload
         statsPeriod: '55d',
@@ -1522,7 +1523,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       end: '2019-10-02T00:00:00',
     });
 
-    let location = TestStubs.location({
+    let location = LocationFixture({
       query: {
         // these should not be part of the API payload
         statsPeriod: '55d',
@@ -1546,7 +1547,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       end: '2019-10-02T00:00:00',
     });
 
-    location = TestStubs.location({
+    location = LocationFixture({
       query: {
         // these should not be part of the API payload
         statsPeriod: '55d',
@@ -1569,7 +1570,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       ...initialState,
     });
 
-    location = TestStubs.location({
+    location = LocationFixture({
       query: {
         statsPeriod: '55d',
         period: '30d',
@@ -1583,7 +1584,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       statsPeriod: '55d',
     });
 
-    location = TestStubs.location({
+    location = LocationFixture({
       query: {
         period: '30d',
         start: '2020-10-01T00:00:00',
@@ -1596,7 +1597,7 @@ describe('EventView.getEventsAPIPayload()', function () {
       statsPeriod: '30d',
     });
 
-    location = TestStubs.location({
+    location = LocationFixture({
       query: {
         start: '2020-10-01T00:00:00',
         end: '2020-10-02T00:00:00',
@@ -1620,7 +1621,7 @@ describe('EventView.getFacetsAPIPayload()', function () {
       query: 'event.type:csp',
     });
 
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         start: '',
         end: '',
@@ -3573,7 +3574,7 @@ describe('isAPIPayloadSimilar', function () {
   describe('getEventsAPIPayload', function () {
     it('is not similar when relevant query string keys are present in the Location object', function () {
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({
+      const location = LocationFixture({
         query: {
           project: 'project',
           environment: 'environment',
@@ -3586,7 +3587,7 @@ describe('isAPIPayloadSimilar', function () {
       });
       const thisAPIPayload = thisEventView.getEventsAPIPayload(location);
 
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = thisEventView.getEventsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3596,14 +3597,14 @@ describe('isAPIPayloadSimilar', function () {
 
     it('is similar when irrelevant query string keys are present in the Location object', function () {
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({
+      const location = LocationFixture({
         query: {
           bestCountry: 'canada',
         },
       });
       const thisAPIPayload = thisEventView.getEventsAPIPayload(location);
 
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = thisEventView.getEventsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3613,11 +3614,11 @@ describe('isAPIPayloadSimilar', function () {
 
     it('is not similar on sort key sorted in opposite directions', function () {
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({});
+      const location = LocationFixture({});
       const thisAPIPayload = thisEventView.getEventsAPIPayload(location);
 
       const otherEventView = thisEventView.sortOnField({field: 'count()'}, meta);
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = otherEventView.getEventsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3627,14 +3628,14 @@ describe('isAPIPayloadSimilar', function () {
 
     it('is not similar when a new column is added', function () {
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({});
+      const location = LocationFixture({});
       const thisAPIPayload = thisEventView.getEventsAPIPayload(location);
 
       const otherEventView = new EventView({
         ...state,
         fields: [...state.fields, {field: 'title', width: COL_WIDTH_UNDEFINED}],
       });
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = otherEventView.getEventsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3644,7 +3645,7 @@ describe('isAPIPayloadSimilar', function () {
 
     it('is similar when a column is updated with no changes', function () {
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({});
+      const location = LocationFixture({});
       const thisAPIPayload = thisEventView.getEventsAPIPayload(location);
 
       const newColumn: Column = {
@@ -3653,7 +3654,7 @@ describe('isAPIPayloadSimilar', function () {
       };
 
       const otherEventView = thisEventView.withUpdatedColumn(0, newColumn, meta);
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = otherEventView.getEventsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3663,7 +3664,7 @@ describe('isAPIPayloadSimilar', function () {
 
     it('is not similar when a column is updated with a replaced field', function () {
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({});
+      const location = LocationFixture({});
       const thisAPIPayload = thisEventView.getEventsAPIPayload(location);
 
       const newColumn: Column = {
@@ -3672,7 +3673,7 @@ describe('isAPIPayloadSimilar', function () {
       };
 
       const otherEventView = thisEventView.withUpdatedColumn(0, newColumn, meta);
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = otherEventView.getEventsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3682,7 +3683,7 @@ describe('isAPIPayloadSimilar', function () {
 
     it('is not similar when a column is updated with a replaced aggregation', function () {
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({});
+      const location = LocationFixture({});
       const thisAPIPayload = thisEventView.getEventsAPIPayload(location);
 
       const newColumn: Column = {
@@ -3691,7 +3692,7 @@ describe('isAPIPayloadSimilar', function () {
       };
 
       const otherEventView = thisEventView.withUpdatedColumn(0, newColumn, meta);
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = otherEventView.getEventsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3701,7 +3702,7 @@ describe('isAPIPayloadSimilar', function () {
 
     it('is similar when a column is renamed', function () {
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({});
+      const location = LocationFixture({});
       const thisAPIPayload = thisEventView.getEventsAPIPayload(location);
 
       const newColumn: Column = {
@@ -3710,7 +3711,7 @@ describe('isAPIPayloadSimilar', function () {
       };
 
       const otherEventView = thisEventView.withUpdatedColumn(0, newColumn, meta);
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = otherEventView.getEventsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3720,11 +3721,11 @@ describe('isAPIPayloadSimilar', function () {
 
     it('is not similar when a column is deleted', function () {
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({});
+      const location = LocationFixture({});
       const thisAPIPayload = thisEventView.getEventsAPIPayload(location);
 
       const otherEventView = thisEventView.withDeletedColumn(0, meta);
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = otherEventView.getEventsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3734,11 +3735,11 @@ describe('isAPIPayloadSimilar', function () {
 
     it('is similar if column order changes', function () {
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({});
+      const location = LocationFixture({});
       const thisAPIPayload = thisEventView.getEventsAPIPayload(location);
 
       const otherEventView = new EventView({...state, fields: shuffle(state.fields)});
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = otherEventView.getEventsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3756,7 +3757,7 @@ describe('isAPIPayloadSimilar', function () {
         otherEquationField,
       ];
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({});
+      const location = LocationFixture({});
       const thisAPIPayload = thisEventView.getEventsAPIPayload(location);
 
       state.fields = [
@@ -3766,7 +3767,7 @@ describe('isAPIPayloadSimilar', function () {
         otherEquationField,
       ];
       const otherEventView = new EventView(state);
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = otherEventView.getEventsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3784,7 +3785,7 @@ describe('isAPIPayloadSimilar', function () {
         otherEquationField,
       ];
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({});
+      const location = LocationFixture({});
       const thisAPIPayload = thisEventView.getEventsAPIPayload(location);
 
       state.fields = [
@@ -3794,7 +3795,7 @@ describe('isAPIPayloadSimilar', function () {
         equationField,
       ];
       const otherEventView = new EventView(state);
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = otherEventView.getEventsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3806,7 +3807,7 @@ describe('isAPIPayloadSimilar', function () {
   describe('getFacetsAPIPayload', function () {
     it('only includes relevant parameters', function () {
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({});
+      const location = LocationFixture({});
       const results = thisEventView.getFacetsAPIPayload(location);
       const expected = {
         query: state.query,
@@ -3820,7 +3821,7 @@ describe('isAPIPayloadSimilar', function () {
 
     it('is similar on sort key sorted in opposite directions', function () {
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({});
+      const location = LocationFixture({});
       const thisAPIPayload = thisEventView.getFacetsAPIPayload(location);
 
       const newColumn: Column = {
@@ -3829,7 +3830,7 @@ describe('isAPIPayloadSimilar', function () {
       };
 
       const otherEventView = thisEventView.withUpdatedColumn(0, newColumn, meta);
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = otherEventView.getFacetsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3838,14 +3839,14 @@ describe('isAPIPayloadSimilar', function () {
 
     it('is similar when a columns are different', function () {
       const thisEventView = new EventView(state);
-      const location = TestStubs.location({});
+      const location = LocationFixture({});
       const thisAPIPayload = thisEventView.getFacetsAPIPayload(location);
 
       const otherEventView = new EventView({
         ...state,
         fields: [...state.fields, {field: 'title', width: COL_WIDTH_UNDEFINED}],
       });
-      const otherLocation = TestStubs.location({});
+      const otherLocation = LocationFixture({});
       const otherAPIPayload = otherEventView.getFacetsAPIPayload(otherLocation);
 
       const results = isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
@@ -3856,7 +3857,7 @@ describe('isAPIPayloadSimilar', function () {
 
 describe('pickRelevantLocationQueryStrings', function () {
   it('picks relevant query strings', function () {
-    const location = TestStubs.location({
+    const location = LocationFixture({
       query: {
         project: 'project',
         environment: 'environment',

--- a/static/app/utils/recreateRoute.spec.tsx
+++ b/static/app/utils/recreateRoute.spec.tsx
@@ -1,3 +1,5 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
+
 import recreateRoute from 'sentry/utils/recreateRoute';
 
 jest.unmock('sentry/utils/recreateRoute');
@@ -26,7 +28,7 @@ const params = {
 };
 
 const location = {
-  ...TestStubs.location(),
+  ...LocationFixture(),
   search: '',
 };
 
@@ -82,7 +84,7 @@ describe('recreateRoute', function () {
 
   it('maintains the query string', function () {
     const withSearch = {
-      ...TestStubs.location(),
+      ...LocationFixture(),
       search: '?key1=foo&key2=bar',
     };
 

--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.spec.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.spec.tsx
@@ -1,5 +1,6 @@
 import {browserHistory} from 'react-router';
 import type {Location} from 'history';
+import LocationFixture from 'sentry-fixture/locationFixture';
 
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
@@ -45,7 +46,7 @@ describe('useCleanQueryParamsOnRouteLeave', () => {
   it('should not update the history if shouldLeave returns false', () => {
     MockBrowserHistoryListen.mockImplementation(onRouteLeave => {
       onRouteLeave(
-        TestStubs.location({
+        LocationFixture({
           pathname: '/next',
           query: {
             cursor: '0:1:0',

--- a/static/app/utils/withDomainRequired.spec.tsx
+++ b/static/app/utils/withDomainRequired.spec.tsx
@@ -1,5 +1,6 @@
 import {RouteComponentProps} from 'react-router';
 import {Location, LocationDescriptor, LocationDescriptorObject} from 'history';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -21,7 +22,7 @@ describe('normalizeUrl', function () {
   });
 
   it('replaces paths in strings', function () {
-    const location = TestStubs.location();
+    const location = LocationFixture();
     const cases = [
       // input, expected
       ['/settings/', '/settings/'],
@@ -129,7 +130,7 @@ describe('normalizeUrl', function () {
   });
 
   it('replaces pathname in objects', function () {
-    const location = TestStubs.location();
+    const location = LocationFixture();
     result = normalizeUrl({pathname: '/settings/acme/'}, location);
     expect(result.pathname).toEqual('/settings/organization/');
 
@@ -183,7 +184,7 @@ describe('normalizeUrl', function () {
   });
 
   it('replaces pathname in function callback', function () {
-    const location = TestStubs.location();
+    const location = LocationFixture();
     function objectCallback(_loc: Location): LocationDescriptorObject {
       return {pathname: '/settings/'};
     }

--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -1,5 +1,6 @@
 import selectEvent from 'react-select-event';
 import {Groups} from 'sentry-fixture/groups';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {ProjectAlertRule} from 'sentry-fixture/projectAlertRule';
 import {ProjectAlertRuleConfiguration} from 'sentry-fixture/projectAlertRuleConfiguration';
@@ -96,7 +97,7 @@ describe('ProjectAlertsCreate', function () {
             params={params}
             organization={organization}
             project={project}
-            location={TestStubs.location({
+            location={LocationFixture({
               pathname: `/organizations/org-slug/alerts/rules/${project.slug}/new/`,
               query: {createFromWizard: 'true'},
               ...location,

--- a/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
@@ -1,4 +1,5 @@
 import {Incident} from 'sentry-fixture/incident';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {MetricRule} from 'sentry-fixture/metricRule';
 import {Organization} from 'sentry-fixture/organization';
 import {ProjectAlertRule} from 'sentry-fixture/projectAlertRule';
@@ -240,7 +241,7 @@ describe('AlertRulesList', () => {
     const {routerContext, organization} = initializeOrg({
       organization: defaultOrg,
       router: {
-        location: TestStubs.location({
+        location: LocationFixture({
           query: {asc: '1', sort: 'name'},
           // Sort by the name column
           search: '?asc=1&sort=name`',
@@ -296,7 +297,7 @@ describe('AlertRulesList', () => {
   it('uses empty team query parameter when removing all teams', async () => {
     const {routerContext, organization, router} = initializeOrg({
       router: {
-        location: TestStubs.location({
+        location: LocationFixture({
           query: {team: 'myteams'},
           search: '?team=myteams`',
         }),

--- a/static/app/views/alerts/rules/metric/create.spec.tsx
+++ b/static/app/views/alerts/rules/metric/create.spec.tsx
@@ -1,4 +1,5 @@
 import {EventsStats} from 'sentry-fixture/events';
+import LocationFixture from 'sentry-fixture/locationFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render} from 'sentry-test/reactTestingLibrary';
@@ -50,7 +51,7 @@ describe('Incident Rules Create', function () {
     render(
       <MetricRulesCreate
         {...TestStubs.routeComponentProps()}
-        eventView={EventView.fromLocation(TestStubs.location())}
+        eventView={EventView.fromLocation(LocationFixture())}
         params={{projectId: project.slug}}
         organization={organization}
         project={project}

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -213,7 +214,7 @@ describe('Dashboards > Detail', function () {
       initialData = initializeOrg({
         organization,
         router: {
-          location: TestStubs.location(),
+          location: LocationFixture(),
         },
       });
       widgets = [
@@ -1017,7 +1018,7 @@ describe('Dashboards > Detail', function () {
         }),
         router: {
           location: {
-            ...TestStubs.location(),
+            ...LocationFixture(),
             query: {
               statsPeriod: '7d',
               release: ['sentry-android-shop@1.2.0'],
@@ -1081,7 +1082,7 @@ describe('Dashboards > Detail', function () {
         }),
         router: {
           location: {
-            ...TestStubs.location(),
+            ...LocationFixture(),
             query: {
               statsPeriod: '7d',
             },
@@ -1128,7 +1129,7 @@ describe('Dashboards > Detail', function () {
         }),
         router: {
           location: {
-            ...TestStubs.location(),
+            ...LocationFixture(),
             query: {
               start: '2022-07-14T07:00:00',
               end: '2022-07-19T23:59:59',
@@ -1185,7 +1186,7 @@ describe('Dashboards > Detail', function () {
         }),
         router: {
           location: {
-            ...TestStubs.location(),
+            ...LocationFixture(),
             query: {
               statsPeriod: '7d',
               environment: ['alpha', 'beta'],
@@ -1247,7 +1248,7 @@ describe('Dashboards > Detail', function () {
         }),
         router: {
           location: {
-            ...TestStubs.location(),
+            ...LocationFixture(),
             query: {
               statsPeriod: '7d',
               environment: ['alpha', 'beta'],
@@ -1305,7 +1306,7 @@ describe('Dashboards > Detail', function () {
         }),
         router: {
           location: {
-            ...TestStubs.location(),
+            ...LocationFixture(),
             query: {
               environment: ['beta', 'alpha'], // Reversed order from saved dashboard
             },
@@ -1353,7 +1354,7 @@ describe('Dashboards > Detail', function () {
         }),
         router: {
           location: {
-            ...TestStubs.location(),
+            ...LocationFixture(),
             query: {
               release: ['not-selected-1'],
             },
@@ -1400,7 +1401,7 @@ describe('Dashboards > Detail', function () {
         }),
         router: {
           location: {
-            ...TestStubs.location(),
+            ...LocationFixture(),
             query: {
               release: ['not-selected-1'],
             },
@@ -1458,7 +1459,7 @@ describe('Dashboards > Detail', function () {
           ],
         }),
         router: {
-          location: TestStubs.location(),
+          location: LocationFixture(),
         },
       });
       render(
@@ -1521,7 +1522,7 @@ describe('Dashboards > Detail', function () {
           ],
         }),
         router: {
-          location: TestStubs.location(),
+          location: LocationFixture(),
         },
       });
       render(

--- a/static/app/views/dashboards/manage/dashboardList.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardList.spec.tsx
@@ -1,3 +1,4 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -185,7 +186,7 @@ describe('Dashboards - DashboardList', function () {
         organization={organization}
         dashboards={dashboards}
         pageLinks=""
-        location={{...TestStubs.location(), query: {statsPeriod: '7d'}}}
+        location={{...LocationFixture(), query: {statsPeriod: '7d'}}}
       />,
       {context: routerContext}
     );
@@ -202,7 +203,7 @@ describe('Dashboards - DashboardList', function () {
         organization={organization}
         dashboards={dashboards}
         pageLinks=""
-        location={{...TestStubs.location(), query: {}}}
+        location={{...LocationFixture(), query: {}}}
         onDashboardsChange={dashboardUpdateMock}
       />,
       {context: routerContext}
@@ -239,7 +240,7 @@ describe('Dashboards - DashboardList', function () {
         organization={organization}
         dashboards={singleDashboard}
         pageLinks=""
-        location={TestStubs.location()}
+        location={LocationFixture()}
         onDashboardsChange={dashboardUpdateMock}
       />
     );
@@ -257,7 +258,7 @@ describe('Dashboards - DashboardList', function () {
         organization={organization}
         dashboards={dashboards}
         pageLinks=""
-        location={{...TestStubs.location(), query: {}}}
+        location={{...LocationFixture(), query: {}}}
         onDashboardsChange={dashboardUpdateMock}
       />
     );
@@ -283,7 +284,7 @@ describe('Dashboards - DashboardList', function () {
         organization={organization}
         dashboards={dashboards}
         pageLinks=""
-        location={{...TestStubs.location(), query: {}}}
+        location={{...LocationFixture(), query: {}}}
         onDashboardsChange={dashboardUpdateMock}
       />
     );

--- a/static/app/views/dashboards/orgDashboards.spec.tsx
+++ b/static/app/views/dashboards/orgDashboards.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -20,7 +21,7 @@ describe('OrgDashboards', () => {
       organization,
       projects: [],
       router: {
-        location: TestStubs.location(),
+        location: LocationFixture(),
         params: {orgId: 'org-slug'},
       },
     });
@@ -72,7 +73,7 @@ describe('OrgDashboards', () => {
     render(
       <OrgDashboards
         api={api}
-        location={TestStubs.location()}
+        location={LocationFixture()}
         organization={initialData.organization}
         params={{orgId: 'org-slug', dashboardId: '1'}}
       >
@@ -132,7 +133,7 @@ describe('OrgDashboards', () => {
       <OrgDashboards
         api={api}
         location={{
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: {
             // This query param is not a page filter, so it should not interfere
             // with the redirect logic
@@ -180,7 +181,7 @@ describe('OrgDashboards', () => {
       projects: [],
       router: {
         location: {
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: {
             // project is supplied in the URL, so we should avoid redirecting
             project: ['1'],
@@ -241,7 +242,7 @@ describe('OrgDashboards', () => {
     render(
       <OrgDashboards
         api={api}
-        location={TestStubs.location()}
+        location={LocationFixture()}
         organization={initialData.organization}
         params={{orgId: 'org-slug', dashboardId: '1'}}
       >
@@ -288,7 +289,7 @@ describe('OrgDashboards', () => {
     const {rerender} = render(
       <OrgDashboards
         api={api}
-        location={TestStubs.location()}
+        location={LocationFixture()}
         organization={initialData.organization}
         params={{orgId: 'org-slug', dashboardId: '1'}}
       >

--- a/static/app/views/dashboards/utils.spec.tsx
+++ b/static/app/views/dashboards/utils.spec.tsx
@@ -1,3 +1,4 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {
@@ -326,7 +327,7 @@ describe('Dashboards util', () => {
         projects: [1, 2],
       } as DashboardDetails;
       const location = {
-        ...TestStubs.location(),
+        ...LocationFixture(),
         query: {
           project: ['2', '1'],
         },
@@ -340,7 +341,7 @@ describe('Dashboards util', () => {
         environment: ['alpha', 'beta'],
       } as DashboardDetails;
       const location = {
-        ...TestStubs.location(),
+        ...LocationFixture(),
         query: {
           environment: ['beta', 'alpha'],
         },
@@ -358,7 +359,7 @@ describe('Dashboards util', () => {
 
       expect(
         hasUnsavedFilterChanges(initialDashboard, {
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: {
             release: ['v2', 'v1'],
           },

--- a/static/app/views/dashboards/view.spec.tsx
+++ b/static/app/views/dashboards/view.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import LocationFixture from 'sentry-fixture/locationFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render} from 'sentry-test/reactTestingLibrary';
@@ -37,7 +38,7 @@ describe('Dashboards > ViewEditDashboard', function () {
 
     render(
       <ViewEditDashboard
-        location={TestStubs.location(location)}
+        location={LocationFixture(location)}
         organization={initialData.organization}
         router={initialData.router}
         params={{

--- a/static/app/views/discover/eventDetails/index.spec.tsx
+++ b/static/app/views/discover/eventDetails/index.spec.tsx
@@ -1,3 +1,4 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -110,7 +111,7 @@ describe('Discover > EventDetails', function () {
         organization={Organization()}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: allEventsView.generateQueryStringObject(),
         }}
       />
@@ -125,7 +126,7 @@ describe('Discover > EventDetails', function () {
         organization={Organization()}
         params={{eventSlug: 'project-slug:abad1'}}
         location={{
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: allEventsView.generateQueryStringObject(),
         }}
       />
@@ -141,7 +142,7 @@ describe('Discover > EventDetails', function () {
         organization={Organization()}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: errorsView.generateQueryStringObject(),
         }}
       />
@@ -162,7 +163,7 @@ describe('Discover > EventDetails', function () {
         organization={Organization()}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: allEventsView.generateQueryStringObject(),
         }}
       />
@@ -190,7 +191,7 @@ describe('Discover > EventDetails', function () {
         organization={organization}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: allEventsView.generateQueryStringObject(),
         }}
       />,
@@ -273,7 +274,7 @@ describe('Discover > EventDetails', function () {
         organization={organization}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: {...allEventsView.generateQueryStringObject(), query: 'Dumpster'},
         }}
       />,

--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -28,7 +29,7 @@ describe('Discover > Homepage', () => {
     initialData = initializeOrg({
       organization,
       router: {
-        location: TestStubs.location(),
+        location: LocationFixture(),
       },
     });
 
@@ -130,7 +131,7 @@ describe('Discover > Homepage', () => {
       organization,
       router: {
         location: {
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: {
             ...EventView.fromSavedQuery(DEFAULT_EVENT_VIEW).generateQueryStringObject(),
             field: ['project'],
@@ -254,7 +255,7 @@ describe('Discover > Homepage', () => {
       organization,
       router: {
         location: {
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: {
             ...EventView.fromSavedQuery(DEFAULT_EVENT_VIEW).generateQueryStringObject(),
           },
@@ -290,7 +291,7 @@ describe('Discover > Homepage', () => {
       organization,
       router: {
         location: {
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: {
             ...EventView.fromSavedQuery(DEFAULT_EVENT_VIEW).generateQueryStringObject(),
           },
@@ -326,7 +327,7 @@ describe('Discover > Homepage', () => {
       organization,
       router: {
         location: {
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: {
             ...EventView.fromSavedQuery(DEFAULT_EVENT_VIEW).generateQueryStringObject(),
             field: ['title'],
@@ -358,7 +359,7 @@ describe('Discover > Homepage', () => {
       organization,
       router: {
         location: {
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: {
             ...EventView.fromSavedQuery(DEFAULT_EVENT_VIEW).generateQueryStringObject(),
             field: ['event.type'],
@@ -388,7 +389,7 @@ describe('Discover > Homepage', () => {
       organization,
       router: {
         location: {
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: {
             ...EventView.fromSavedQuery(DEFAULT_EVENT_VIEW).generateQueryStringObject(),
             field: ['title'],
@@ -414,7 +415,7 @@ describe('Discover > Homepage', () => {
       organization,
       router: {
         location: {
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: {
             ...EventView.fromSavedQuery(DEFAULT_EVENT_VIEW).generateQueryStringObject(),
             field: ['event.type'],
@@ -478,7 +479,7 @@ describe('Discover > Homepage', () => {
       organization,
       router: {
         location: {
-          ...TestStubs.location(),
+          ...LocationFixture(),
           query: {
             ...EventView.fromSavedQuery(DEFAULT_EVENT_VIEW).generateQueryStringObject(),
           },

--- a/static/app/views/discover/miniGraph.spec.tsx
+++ b/static/app/views/discover/miniGraph.spec.tsx
@@ -1,3 +1,4 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -11,7 +12,7 @@ jest.mock('sentry/components/charts/eventsRequest');
 
 describe('Discover > MiniGraph', function () {
   const features = ['discover-basic'];
-  const location = TestStubs.location({
+  const location = LocationFixture({
     query: {query: 'tag:value'},
     pathname: '/',
   });

--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -1,5 +1,6 @@
 import {browserHistory} from 'react-router';
 import selectEvent from 'react-select-event';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -1298,11 +1299,11 @@ describe('Results', function () {
         organization,
         router: {
           location: {
-            ...TestStubs.location(),
+            ...LocationFixture(),
             query: {
               ...EventView.fromNewQueryWithLocation(
                 TRANSACTION_VIEWS[0],
-                TestStubs.location()
+                LocationFixture()
               ).generateQueryStringObject(),
             },
           },
@@ -1428,11 +1429,11 @@ describe('Results', function () {
         organization,
         router: {
           location: {
-            ...TestStubs.location(),
+            ...LocationFixture(),
             query: {
               ...EventView.fromNewQueryWithLocation(
                 DEFAULT_EVENT_VIEW,
-                TestStubs.location()
+                LocationFixture()
               ).generateQueryStringObject(),
             },
           },
@@ -1468,11 +1469,11 @@ describe('Results', function () {
         organization,
         router: {
           location: {
-            ...TestStubs.location(),
+            ...LocationFixture(),
             query: {
               ...EventView.fromNewQueryWithLocation(
                 {...DEFAULT_EVENT_VIEW, query: 'event.type:error'},
-                TestStubs.location()
+                LocationFixture()
               ).generateQueryStringObject(),
             },
           },

--- a/static/app/views/discover/resultsChart.spec.tsx
+++ b/static/app/views/discover/resultsChart.spec.tsx
@@ -1,3 +1,4 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -9,7 +10,7 @@ import ResultsChart from 'sentry/views/discover/resultsChart';
 
 describe('Discover > ResultsChart', function () {
   const features = ['discover-basic'];
-  const location = TestStubs.location({
+  const location = LocationFixture({
     query: {query: 'tag:value'},
     pathname: '/',
   });

--- a/static/app/views/discover/table/cellAction.spec.tsx
+++ b/static/app/views/discover/table/cellAction.spec.tsx
@@ -1,4 +1,5 @@
 import {Location} from 'history';
+import LocationFixture from 'sentry-fixture/locationFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -55,7 +56,7 @@ function renderComponent({
 }
 
 describe('Discover -> CellAction', function () {
-  const location: Location = TestStubs.location({
+  const location: Location = LocationFixture({
     query: {
       id: '42',
       name: 'best query',
@@ -132,7 +133,7 @@ describe('Discover -> CellAction', function () {
 
     it('exclude button appends exclusions', async function () {
       const excludeView = EventView.fromLocation(
-        TestStubs.location({
+        LocationFixture({
           query: {...location.query, query: '!transaction:nope'},
         })
       );

--- a/static/app/views/discover/table/quickContext/actionDropdown.spec.tsx
+++ b/static/app/views/discover/table/quickContext/actionDropdown.spec.tsx
@@ -1,5 +1,6 @@
 import {browserHistory} from 'react-router';
 import type {Location} from 'history';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -25,7 +26,7 @@ const mockEventView = EventView.fromSavedQuery({
   projects: [1],
 });
 
-const mockedLocation = TestStubs.location({
+const mockedLocation = LocationFixture({
   query: {
     field: 'title',
   },

--- a/static/app/views/discover/table/quickContext/eventContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/eventContext.spec.tsx
@@ -1,5 +1,6 @@
 import type {Location} from 'history';
 import {Event as EventFixture} from 'sentry-fixture/event';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {makeTestQueryClient} from 'sentry-test/queryClient';
@@ -20,7 +21,7 @@ import {QueryClientProvider} from 'sentry/utils/queryClient';
 
 import EventContext from './eventContext';
 
-const mockedLocation = TestStubs.location({
+const mockedLocation = LocationFixture({
   query: {
     field: ['issue', 'transaction.duration'],
   },

--- a/static/app/views/discover/table/tableView.spec.tsx
+++ b/static/app/views/discover/table/tableView.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -12,7 +13,7 @@ import TableView from 'sentry/views/discover/table/tableView';
 describe('TableView > CellActions', function () {
   let initialData, rows, onChangeShowTags;
 
-  const location = TestStubs.location({
+  const location = LocationFixture({
     pathname: '/organizations/org-slug/discover/results/',
     query: {
       id: '42',

--- a/static/app/views/discover/tags.spec.tsx
+++ b/static/app/views/discover/tags.spec.tsx
@@ -1,3 +1,4 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
 import {User} from 'sentry-fixture/user';
@@ -85,7 +86,7 @@ describe('Tags', function () {
         api={new MockApiClient()}
         totalValues={30}
         organization={org}
-        location={{...TestStubs.location(), query: {}}}
+        location={{...LocationFixture(), query: {}}}
         generateUrl={generateUrl}
         confirmedQuery={false}
       />
@@ -157,7 +158,7 @@ describe('Tags', function () {
         api={new MockApiClient()}
         totalValues={30}
         organization={org}
-        location={{...TestStubs.location(), query: {}}}
+        location={{...LocationFixture(), query: {}}}
         generateUrl={generateUrl}
         confirmedQuery={false}
       />
@@ -257,7 +258,7 @@ describe('Tags', function () {
         api={new MockApiClient()}
         totalValues={30}
         organization={org}
-        location={{...TestStubs.location(), query: {}}}
+        location={{...LocationFixture(), query: {}}}
         generateUrl={generateUrl}
         confirmedQuery={false}
       />

--- a/static/app/views/discover/utils.spec.tsx
+++ b/static/app/views/discover/utils.spec.tsx
@@ -1,5 +1,6 @@
 import {browserHistory} from 'react-router';
 import {Event as EventFixture} from 'sentry-fixture/event';
+import LocationFixture from 'sentry-fixture/locationFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
@@ -244,7 +245,7 @@ describe('pushEventViewToLocation', function () {
     environment: ['staging'],
   };
 
-  const location = TestStubs.location({
+  const location = LocationFixture({
     query: {
       bestCountry: 'canada',
     },
@@ -512,7 +513,7 @@ describe('getExpandedResults()', function () {
   });
 
   it('generate eventview from an empty eventview', () => {
-    const view = EventView.fromLocation(TestStubs.location());
+    const view = EventView.fromLocation(LocationFixture());
     const result = getExpandedResults(view, {some_tag: 'value'}, EventFixture());
     expect(result.fields).toEqual([]);
     expect(result.query).toEqual('some_tag:value');

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -1,4 +1,5 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Team} from 'sentry-fixture/team';
 import {User} from 'sentry-fixture/user';
 
@@ -219,7 +220,7 @@ describe('groupDetails', () => {
     const init = initializeOrg({
       router: {
         ...initRouter,
-        location: TestStubs.location({
+        location: LocationFixture({
           ...initRouter.location,
           query: {environment: 'staging'},
         }),

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -3,6 +3,7 @@ import {Location} from 'history';
 import {Commit} from 'sentry-fixture/commit';
 import {CommitAuthor} from 'sentry-fixture/commitAuthor';
 import {Event as EventFixture} from 'sentry-fixture/event';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {SentryApp} from 'sentry-fixture/sentryApp';
 import {SentryAppComponent} from 'sentry-fixture/sentryAppComponent';
@@ -38,7 +39,7 @@ const makeDefaultMockData = (
     project: project ?? initializeOrg().project,
     group: TestStubs.Group(),
     router: TestStubs.router({
-      location: TestStubs.location({
+      location: LocationFixture({
         query: {
           environment: environments,
         },

--- a/static/app/views/issueDetails/quickTrace/index.spec.tsx
+++ b/static/app/views/issueDetails/quickTrace/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render} from 'sentry-test/reactTestingLibrary';
@@ -10,7 +11,7 @@ describe('IssueQuickTrace', () => {
     organization: Organization({features: ['performance-view']}),
     event: EventFixture({contexts: {trace: {trace_id: 100}}}),
     group: TestStubs.Group(),
-    location: TestStubs.location(),
+    location: LocationFixture(),
   };
 
   it('renders nothing without performance-view flag', () => {

--- a/static/app/views/issueList/overview.polling.spec.tsx
+++ b/static/app/views/issueList/overview.polling.spec.tsx
@@ -1,4 +1,5 @@
 import {GroupStats} from 'sentry-fixture/groupStats';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Search} from 'sentry-fixture/search';
 import {Tags} from 'sentry-fixture/tags';
 
@@ -52,7 +53,7 @@ describe('IssueList -> Polling', function () {
   const group2 = TestStubs.Group({project, id: 2});
 
   const defaultProps = {
-    location: TestStubs.location({
+    location: LocationFixture({
       query: {query: 'is:unresolved'},
       search: 'query=is:unresolved',
     }),

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -1,6 +1,7 @@
 import {browserHistory} from 'react-router';
 import merge from 'lodash/merge';
 import {GroupStats} from 'sentry-fixture/groupStats';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Search} from 'sentry-fixture/search';
 import {Tags} from 'sentry-fixture/tags';
@@ -241,7 +242,7 @@ describe('IssueList', function () {
         ],
       });
 
-      const location = TestStubs.location({query: {query: 'level:foo'}});
+      const location = LocationFixture({query: {query: 'level:foo'}});
 
       render(<IssueListWithStores {...merge({}, routerProps, {location})} />, {
         context: routerContext,

--- a/static/app/views/organizationContextContainer.spec.tsx
+++ b/static/app/views/organizationContextContainer.spec.tsx
@@ -1,3 +1,4 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
 
@@ -40,7 +41,7 @@ describe('OrganizationContextContainer', function () {
         {...routerProps}
         api={api}
         params={{orgId: 'org-slug'}}
-        location={TestStubs.location({query: {}})}
+        location={LocationFixture({query: {}})}
         useLastOrganization={false}
         organizationsLoading={false}
         organizations={[]}

--- a/static/app/views/performance/data.spec.tsx
+++ b/static/app/views/performance/data.spec.tsx
@@ -1,3 +1,4 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {
@@ -14,7 +15,7 @@ describe('generatePerformanceEventView()', function () {
 
   it('generates default values', function () {
     const result = generatePerformanceEventView(
-      TestStubs.location({query: {}}),
+      LocationFixture({query: {}}),
       [],
       {},
       organization
@@ -31,7 +32,7 @@ describe('generatePerformanceEventView()', function () {
 
   it('applies sort from location', function () {
     const result = generatePerformanceEventView(
-      TestStubs.location({query: {sort: ['-p50', '-count']}}),
+      LocationFixture({query: {sort: ['-p50', '-count']}}),
       [],
       {},
       organization
@@ -43,7 +44,7 @@ describe('generatePerformanceEventView()', function () {
 
   it('does not override statsPeriod from location', function () {
     const result = generatePerformanceEventView(
-      TestStubs.location({query: {statsPeriod: ['90d', '45d']}}),
+      LocationFixture({query: {statsPeriod: ['90d', '45d']}}),
       [],
       {},
       organization
@@ -55,7 +56,7 @@ describe('generatePerformanceEventView()', function () {
 
   it('does not apply range when start and end are present', function () {
     const result = generatePerformanceEventView(
-      TestStubs.location({
+      LocationFixture({
         query: {start: '2020-04-25T12:00:00', end: '2020-05-25T12:00:00'},
       }),
       [],
@@ -69,7 +70,7 @@ describe('generatePerformanceEventView()', function () {
 
   it('converts bare query into transaction name wildcard', function () {
     const result = generatePerformanceEventView(
-      TestStubs.location({query: {query: 'things.update'}}),
+      LocationFixture({query: {query: 'things.update'}}),
       [],
       {},
       organization
@@ -82,7 +83,7 @@ describe('generatePerformanceEventView()', function () {
 
   it('bare query overwrites transaction condition', function () {
     const result = generatePerformanceEventView(
-      TestStubs.location({query: {query: 'things.update transaction:thing.gone'}}),
+      LocationFixture({query: {query: 'things.update transaction:thing.gone'}}),
       [],
       {},
       organization
@@ -96,7 +97,7 @@ describe('generatePerformanceEventView()', function () {
 
   it('retains tag filter conditions', function () {
     const result = generatePerformanceEventView(
-      TestStubs.location({query: {query: 'key:value tag:value'}}),
+      LocationFixture({query: {query: 'key:value tag:value'}}),
       [],
       {},
       organization
@@ -110,7 +111,7 @@ describe('generatePerformanceEventView()', function () {
 
   it('gets the right column', function () {
     const result = generatePerformanceEventView(
-      TestStubs.location({query: {query: 'key:value tag:value'}}),
+      LocationFixture({query: {query: 'key:value tag:value'}}),
       [],
       {},
       organization
@@ -128,7 +129,7 @@ describe('generatePerformanceEventView()', function () {
 
   it('removes unsupported tokens for limited search', function () {
     const result = generatePerformanceEventView(
-      TestStubs.location({
+      LocationFixture({
         query: {
           query: 'tag:value transaction:*auth*',
           [METRIC_SEARCH_SETTING_PARAM]: MEPState.METRICS_ONLY,

--- a/static/app/views/performance/trends/utils.spec.tsx
+++ b/static/app/views/performance/trends/utils.spec.tsx
@@ -1,3 +1,5 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
+
 import {
   TrendParameterColumn,
   TrendParameterLabel,
@@ -50,7 +52,7 @@ describe('Trend parameter utils', function () {
 
   describe('getCurrentTrendParameter', function () {
     it('returns trend parameter from location', () => {
-      const location = TestStubs.location({query: {trendParameter: 'FCP'}});
+      const location = LocationFixture({query: {trendParameter: 'FCP'}});
       const expectedTrendParameter = {
         label: TrendParameterLabel.FCP,
         column: TrendParameterColumn.FCP,
@@ -63,7 +65,7 @@ describe('Trend parameter utils', function () {
     });
 
     it('returns default trend parameter based on project type if no trend parameter set in location', function () {
-      const location = TestStubs.location();
+      const location = LocationFixture();
       const expectedTrendParameter = {
         label: TrendParameterLabel.DURATION,
         column: TrendParameterColumn.DURATION,

--- a/static/app/views/projectDetail/projectLatestAlerts.spec.tsx
+++ b/static/app/views/projectDetail/projectLatestAlerts.spec.tsx
@@ -1,3 +1,4 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {MetricRule} from 'sentry-fixture/metricRule';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -134,7 +135,7 @@ describe('ProjectDetail > ProjectLatestAlerts', function () {
       <ProjectLatestAlerts
         organization={organization}
         projectSlug={project.slug}
-        location={TestStubs.location({
+        location={LocationFixture({
           query: {statsPeriod: '7d', environment: 'staging', somethingBad: 'nope'},
         })}
         isProjectStabilized

--- a/static/app/views/projectDetail/projectLatestReleases.spec.tsx
+++ b/static/app/views/projectDetail/projectLatestReleases.spec.tsx
@@ -1,3 +1,5 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
@@ -113,7 +115,7 @@ describe('ProjectDetail > ProjectLatestReleases', function () {
       <ProjectLatestReleases
         organization={organization}
         projectSlug={project.slug}
-        location={TestStubs.location({
+        location={LocationFixture({
           query: {statsPeriod: '7d', environment: 'staging', somethingBad: 'nope'},
         })}
         projectId={project.slug}
@@ -135,7 +137,7 @@ describe('ProjectDetail > ProjectLatestReleases', function () {
       <ProjectLatestReleases
         organization={organization}
         projectSlug={project.slug}
-        location={TestStubs.location({
+        location={LocationFixture({
           query: {statsPeriod: '7d', environment: 'staging', somethingBad: 'nope'},
         })}
         projectId={project.slug}

--- a/static/app/views/releases/detail/header/releaseActions.spec.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.spec.tsx
@@ -1,5 +1,6 @@
 import {browserHistory} from 'react-router';
 import {Location} from 'history';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
@@ -17,7 +18,7 @@ describe('ReleaseActions', function () {
   const organization = Organization();
   const release = TestStubs.Release({projects: [{slug: 'project1'}, {slug: 'project2'}]});
   const location: Location = {
-    ...TestStubs.location(),
+    ...LocationFixture(),
     pathname: `/organizations/sentry/releases/${release.version}/`,
     query: {
       project: '1',

--- a/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
@@ -1,3 +1,4 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -17,7 +18,7 @@ describe('ReleaseIssues', function () {
     orgId: 'org',
     organization: Organization(),
     version: '1.0.0',
-    location: TestStubs.location({query: {}}),
+    location: LocationFixture({query: {}}),
     releaseBounds: getReleaseBounds(TestStubs.Release({version: '1.0.0'})),
   };
 
@@ -75,7 +76,7 @@ describe('ReleaseIssues', function () {
     rerender(
       <ReleaseIssues
         {...props}
-        location={TestStubs.location({query: {issuesType: 'resolved'}})}
+        location={LocationFixture({query: {issuesType: 'resolved'}})}
       />
     );
     expect(
@@ -86,7 +87,7 @@ describe('ReleaseIssues', function () {
   it('shows an empty sttate with stats period', async function () {
     const query = {pageStatsPeriod: '24h'};
     const {rerender} = render(
-      <ReleaseIssues {...props} location={TestStubs.location({query})} />
+      <ReleaseIssues {...props} location={LocationFixture({query})} />
     );
 
     expect(
@@ -100,7 +101,7 @@ describe('ReleaseIssues', function () {
     rerender(
       <ReleaseIssues
         {...props}
-        location={TestStubs.location({query: {...query, issuesType: 'unhandled'}})}
+        location={LocationFixture({query: {...query, issuesType: 'unhandled'}})}
       />
     );
     expect(
@@ -129,7 +130,7 @@ describe('ReleaseIssues', function () {
     rerender(
       <ReleaseIssues
         {...props}
-        location={TestStubs.location({query: {issuesType: 'resolved'}})}
+        location={LocationFixture({query: {issuesType: 'resolved'}})}
       />
     );
     expect(screen.getByRole('button', {name: 'Open in Issues'})).toHaveAttribute(
@@ -143,7 +144,7 @@ describe('ReleaseIssues', function () {
     rerender(
       <ReleaseIssues
         {...props}
-        location={TestStubs.location({query: {issuesType: 'unhandled'}})}
+        location={LocationFixture({query: {issuesType: 'unhandled'}})}
       />
     );
     expect(screen.getByRole('button', {name: 'Open in Issues'})).toHaveAttribute(
@@ -157,7 +158,7 @@ describe('ReleaseIssues', function () {
     rerender(
       <ReleaseIssues
         {...props}
-        location={TestStubs.location({query: {issuesType: 'all'}})}
+        location={LocationFixture({query: {issuesType: 'all'}})}
       />
     );
     expect(screen.getByRole('button', {name: 'Open in Issues'})).toHaveAttribute(

--- a/static/app/views/settings/account/accountAuthorizations.spec.tsx
+++ b/static/app/views/settings/account/accountAuthorizations.spec.tsx
@@ -1,3 +1,4 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render} from 'sentry-test/reactTestingLibrary';
@@ -19,7 +20,7 @@ describe('AccountAuthorizations', function () {
     const router = TestStubs.router({});
     render(
       <AccountAuthorizations
-        location={TestStubs.location()}
+        location={LocationFixture()}
         routeParams={router.params}
         params={router.params}
         routes={router.routes}

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -1,4 +1,5 @@
 import {GitHubIntegrationProvider} from 'sentry-fixture/githubIntegrationProvider';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -81,7 +82,7 @@ describe('IntegrationDetailedView', function () {
       <IntegrationDetailedView
         {...TestStubs.routeComponentProps()}
         params={{integrationSlug: 'bitbucket'}}
-        location={TestStubs.location({query: {}})}
+        location={LocationFixture({query: {}})}
       />
     );
     expect(screen.getByText('Bitbucket')).toBeInTheDocument();
@@ -94,7 +95,7 @@ describe('IntegrationDetailedView', function () {
       <IntegrationDetailedView
         {...TestStubs.routeComponentProps()}
         params={{integrationSlug: 'bitbucket'}}
-        location={TestStubs.location({query: {tab: 'configurations'}})}
+        location={LocationFixture({query: {tab: 'configurations'}})}
       />
     );
 
@@ -109,7 +110,7 @@ describe('IntegrationDetailedView', function () {
       <IntegrationDetailedView
         {...TestStubs.routeComponentProps()}
         params={{integrationSlug: 'bitbucket'}}
-        location={TestStubs.location({query: {tab: 'configurations'}})}
+        location={LocationFixture({query: {tab: 'configurations'}})}
       />,
       {organization: Organization({access: ['org:read']})}
     );
@@ -153,7 +154,7 @@ describe('IntegrationDetailedView', function () {
       <IntegrationDetailedView
         {...TestStubs.routeComponentProps()}
         params={{integrationSlug: 'github'}}
-        location={TestStubs.location({query: {tab: 'configurations'}})}
+        location={LocationFixture({query: {tab: 'configurations'}})}
       />,
       {organization: Organization({access: ['org:read']})}
     );
@@ -198,7 +199,7 @@ describe('IntegrationDetailedView', function () {
         {...TestStubs.routeComponentProps()}
         params={{integrationSlug: 'github'}}
         organization={org}
-        location={TestStubs.location({query: {}})}
+        location={LocationFixture({query: {}})}
       />
     );
     expect(screen.getByText('features')).toBeInTheDocument();
@@ -222,7 +223,7 @@ describe('IntegrationDetailedView', function () {
         {...TestStubs.routeComponentProps()}
         params={{integrationSlug: 'github'}}
         organization={org}
-        location={TestStubs.location({query: {}})}
+        location={LocationFixture({query: {}})}
       />
     );
 
@@ -257,7 +258,7 @@ describe('IntegrationDetailedView', function () {
         {...TestStubs.routeComponentProps()}
         params={{integrationSlug: 'github'}}
         organization={org}
-        location={TestStubs.location({query: {}})}
+        location={LocationFixture({query: {}})}
       />
     );
     await userEvent.click(screen.getByText('features'));

--- a/static/app/views/settings/project/projectEnvironments.spec.tsx
+++ b/static/app/views/settings/project/projectEnvironments.spec.tsx
@@ -1,4 +1,5 @@
 import {HiddenEnvironments} from 'sentry-fixture/environments';
+import LocationFixture from 'sentry-fixture/locationFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -19,7 +20,7 @@ function renderComponent(isHidden: boolean) {
     <ProjectEnvironments
       {...routerProps}
       params={{projectId: project.slug}}
-      location={TestStubs.location({pathname})}
+      location={LocationFixture({pathname})}
       organization={organization}
       project={project}
     />

--- a/static/app/views/settings/projectGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.spec.tsx
@@ -1,6 +1,7 @@
 import {browserHistory} from 'react-router';
 import selectEvent from 'react-select-event';
 import {GroupingConfigs} from 'sentry-fixture/groupingConfigs';
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
@@ -44,7 +45,7 @@ describe('projectGeneralSettings', function () {
 
   const router = TestStubs.router();
   const routerProps = {
-    location: TestStubs.location(),
+    location: LocationFixture(),
     routes: router.routes,
     route: router.routes[0],
     router,

--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
@@ -1,3 +1,4 @@
+import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
 import {
@@ -27,7 +28,7 @@ describe('projectPerformance', function () {
   const router = TestStubs.router();
   const routerProps = {
     router,
-    location: TestStubs.location(),
+    location: LocationFixture(),
     routes: router.routes,
     route: router.routes[0],
     routeParams: router.params,


### PR DESCRIPTION
Miraculously this didn't require any changes at all! Adds to 
https://github.com/getsentry/frontend-tsc/issues/49
