### PR TITLE
feat(inbound-filters): Relax pattern for matching ChunkLoadError(s)

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -158,7 +158,10 @@ def get_filter_settings(project: Project) -> Mapping[str, Any]:
     if project.get_option("filters:chunk-load-error") == "1":
         # ChunkLoadError: Loading chunk 3662 failed.\n(error:
         # https://xxx.com/_next/static/chunks/29107295-0151559bd23117ba.js)
-        error_messages += ["ChunkLoadError: Loading chunk *"]
+        error_messages += [
+            "ChunkLoadError: Loading chunk *",
+            "Uncaught *: ChunkLoadError: Loading chunk *",
+        ]
 
     if error_messages:
         filter_settings["errorMessages"] = {"patterns": error_messages}

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2023-10-31T14:18:43.516229Z'
+created: '2023-12-19T08:38:08.254426Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -84,6 +84,7 @@ config:
       patterns:
       - '*https://reactjs.org/docs/error-decoder.html?invariant={418,419,422,423,425}*'
       - 'ChunkLoadError: Loading chunk *'
+      - 'Uncaught *: ChunkLoadError: Loading chunk *'
     ignoreTransactions:
       isEnabled: true
       patterns:


### PR DESCRIPTION
This PR adds a new pattern to match `ChunkLoadError`(s) that considers the `Uncaught *` prefix.

Closes https://github.com/getsentry/sentry/issues/61986 https://github.com/getsentry/sentry/issues/61944