### PR TITLE
fix(ddm): display all code locations

### DIFF
--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -125,9 +125,10 @@ export type MetricCodeLocationFrame = {
 };
 
 export type MetricMetaCodeLocation = {
-  frames: MetricCodeLocationFrame[];
   mri: string;
   timestamp: number;
+  codeLocations?: MetricCodeLocationFrame[];
+  frames?: MetricCodeLocationFrame[];
 };
 export function getDdmUrl(
   orgSlug: string,

--- a/static/app/utils/metrics/useMetricsCodeLocations.tsx
+++ b/static/app/utils/metrics/useMetricsCodeLocations.tsx
@@ -40,10 +40,11 @@ export function useMetricsCodeLocations(mri: string | undefined) {
 }
 
 const mapToNewResponseShape = (data: ApiResponse) => {
+  // If the response is already in the new shape, do nothing
   if (data.metrics) {
     return;
   }
-  // @ts-expect-error
+  // @ts-expect-error codeLocations is defined in the old response shape
   data.metrics = (data.codeLocations ?? [])?.map(codeLocation => {
     return {
       mri: codeLocation.mri,

--- a/static/app/views/ddm/codeLocations.tsx
+++ b/static/app/views/ddm/codeLocations.tsx
@@ -14,7 +14,7 @@ import {space} from 'sentry/styles/space';
 import {Frame} from 'sentry/types';
 import {useMetricsCodeLocations} from 'sentry/utils/metrics/useMetricsCodeLocations';
 
-import {MetricCodeLocationFrame, MetricMetaCodeLocation} from '../../utils/metrics/index';
+import {MetricCodeLocationFrame} from '../../utils/metrics/index';
 
 export function CodeLocations({mri}: {mri: string}) {
   const {data, isLoading, isError, refetch} = useMetricsCodeLocations(mri);
@@ -27,7 +27,7 @@ export function CodeLocations({mri}: {mri: string}) {
     return <LoadingError onRetry={refetch} />;
   }
 
-  if (!Array.isArray(data?.codeLocations) || data?.codeLocations.length === 0) {
+  if (!Array.isArray(data?.metrics) || data?.metrics.length === 0) {
     return (
       <CenterContent>
         <EmptyMessage
@@ -40,18 +40,18 @@ export function CodeLocations({mri}: {mri: string}) {
     );
   }
 
-  const codeLocations = data?.codeLocations ?? [];
+  const codeLocations = data.metrics[0].codeLocations ?? [];
 
   // We only want to show the first 5 code locations
-  const reversedCodeLocations = codeLocations.slice(0, 5);
+  const codeLocationsToShow = codeLocations.slice(0, 5);
   return (
     <CodeLocationsWrapper>
-      {reversedCodeLocations.map((location, index) => (
+      {codeLocationsToShow.slice(0, 5).map((location, index) => (
         <CodeLocation
           key={`location-${index}`}
           codeLocation={location}
           isFirst={index === 0}
-          isLast={index === reversedCodeLocations.length - 1}
+          isLast={index === codeLocationsToShow.length - 1}
         />
       ))}
     </CodeLocationsWrapper>
@@ -59,7 +59,7 @@ export function CodeLocations({mri}: {mri: string}) {
 }
 
 type CodeLocationProps = {
-  codeLocation: MetricMetaCodeLocation;
+  codeLocation: MetricCodeLocationFrame;
   isFirst?: boolean;
   isLast?: boolean;
 };
@@ -71,12 +71,7 @@ function CodeLocation({codeLocation, isFirst, isLast}: CodeLocationProps) {
     setShowContext(prevState => !prevState);
   }, []);
 
-  const frameToShow = codeLocation.frames[0];
-  if (!frameToShow) {
-    return null;
-  }
-
-  const hasContext = !!frameToShow.contextLine;
+  const hasContext = !!codeLocation.contextLine;
 
   return (
     <CodeLocationWrapper>
@@ -95,18 +90,17 @@ function CodeLocation({codeLocation, isFirst, isLast}: CodeLocationProps) {
           <DefaultLineTitleWrapper>
             <LeftLineTitle>
               <DefaultTitle
-                frame={frameToShow as Frame}
+                frame={codeLocation as Frame}
                 isHoverPreviewed={false}
                 platform="other"
               />
             </LeftLineTitle>
             <DefaultLineActionButtons>
               <CopyToClipboardButton
-                text={`${frameToShow.filename}:${frameToShow.lineNo}`}
+                text={`${codeLocation.filename}:${codeLocation.lineNo}`}
                 size="zero"
                 iconSize="xs"
                 borderless
-                onClick={(event: React.MouseEvent) => event.stopPropagation()}
               />
               <ToggleCodeLocationContextButton
                 disabled={!hasContext}
@@ -117,7 +111,7 @@ function CodeLocation({codeLocation, isFirst, isLast}: CodeLocationProps) {
           </DefaultLineTitleWrapper>
         </DefaultLine>
         {showContext && hasContext && (
-          <CodeLocationContext frame={frameToShow} isLast={isLast} />
+          <CodeLocationContext codeLocation={codeLocation} isLast={isLast} />
         )}
       </DefaultLineWrapper>
     </CodeLocationWrapper>
@@ -152,21 +146,21 @@ function ToggleCodeLocationContextButton({
 }
 
 type CodeLocationContextProps = {
-  frame: MetricCodeLocationFrame;
+  codeLocation: MetricCodeLocationFrame;
   isLast?: boolean;
 };
 
-function CodeLocationContext({frame, isLast}: CodeLocationContextProps) {
-  const lineNo = frame.lineNo ?? 0;
+function CodeLocationContext({codeLocation, isLast}: CodeLocationContextProps) {
+  const lineNo = codeLocation.lineNo ?? 0;
 
   const preContextLines: [number, string][] = useMemo(
-    () => frame.preContext?.map((line, index) => [lineNo - 5 + index, line]) ?? [],
-    [frame.preContext, lineNo]
+    () => codeLocation.preContext?.map((line, index) => [lineNo - 5 + index, line]) ?? [],
+    [codeLocation.preContext, lineNo]
   );
 
   const postContextLines: [number, string][] = useMemo(
-    () => frame.postContext?.map((line, index) => [lineNo + index, line]) ?? [],
-    [frame.postContext, lineNo]
+    () => codeLocation.postContext?.map((line, index) => [lineNo + index, line]) ?? [],
+    [codeLocation.postContext, lineNo]
   );
 
   return (
@@ -174,7 +168,7 @@ function CodeLocationContext({frame, isLast}: CodeLocationContextProps) {
       {preContextLines.map(line => (
         <ContextLine key={`pre-${line[1]}`} line={line} isActive={false} />
       ))}
-      <ContextLine line={[lineNo, frame.contextLine ?? '']} isActive />
+      <ContextLine line={[lineNo, codeLocation.contextLine ?? '']} isActive />
       {postContextLines.map(line => (
         <ContextLine key={`post-${line[1]}`} line={line} isActive={false} />
       ))}


### PR DESCRIPTION
Displays all "frames" of the last code location.
Adds *temporary* mapping to the intended api response shape (#61995)

closes #62000