### PR TITLE
ref(ddm): rename code location response

### DIFF
--- a/src/sentry/api/endpoints/organization_ddm.py
+++ b/src/sentry/api/endpoints/organization_ddm.py
@@ -33,6 +33,6 @@ class OrganizationDDMMetaEndpoint(OrganizationEndpoint):
         )
 
         return Response(
-            {"codeLocations": serialize(code_locations, request.user, CodeLocationsSerializer())},
+            {"metrics": serialize(code_locations, request.user, CodeLocationsSerializer())},
             status=200,
         )

--- a/src/sentry/api/serializers/models/code_locations.py
+++ b/src/sentry/api/serializers/models/code_locations.py
@@ -9,7 +9,7 @@ class CodeLocationsSerializer(Serializer):
         return {
             "mri": item.query.metric_mri,
             "timestamp": item.query.timestamp,
-            "frames": [location.__dict__ for location in item.frames],
+            "codeLocations": [location.__dict__ for location in item.code_locations],
         }
 
     def get_attrs(self, item_list, user):
@@ -31,7 +31,8 @@ class CodeLocationsSerializer(Serializer):
         return {
             "mri": attrs["mri"],
             "timestamp": attrs["timestamp"],
-            "frames": [
-                self._serialize_code_location_payload(location) for location in attrs["frames"]
+            "codeLocations": [
+                self._serialize_code_location_payload(location)
+                for location in attrs["codeLocations"]
             ],
         }

--- a/src/sentry/sentry_metrics/querying/metadata.py
+++ b/src/sentry/sentry_metrics/querying/metadata.py
@@ -34,7 +34,7 @@ class CodeLocationPayload:
 @dataclass(frozen=True)
 class MetricCodeLocations:
     query: CodeLocationQuery
-    frames: Sequence[CodeLocationPayload]
+    code_locations: Sequence[CodeLocationPayload]
 
     def __hash__(self):
         # For the serializer we need to implement a hashing function that uniquely identifies a metric code location.
@@ -143,7 +143,7 @@ class CodeLocationsFetcher:
             )
             pipeline.smembers(cache_key)
 
-        frames = []
+        code_locations = []
         for query, locations in zip(queries, pipeline.execute()):
             if not locations:
                 continue
@@ -153,9 +153,9 @@ class CodeLocationsFetcher:
             ]
             # To maintain consistent ordering, we sort by filename.
             sorted_locations = sorted(parsed_locations, key=lambda value: value.filename or "")
-            frames.append(MetricCodeLocations(query=query, frames=sorted_locations))
+            code_locations.append(MetricCodeLocations(query=query, code_locations=sorted_locations))
 
-        return frames
+        return code_locations
 
     def fetch(self) -> Sequence[MetricCodeLocations]:
         code_locations: List[MetricCodeLocations] = []


### PR DESCRIPTION
Rename the code location `frames` to `codeLocations` to avoid confusion with stackframes. Rename top level `codeLocations` to `metrics` since we might add more meta info to every metric.

Frontend support done in #61994 