### PR TITLE
fix(craft): Set craft artifact provider to none

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -7,6 +7,8 @@ statusProvider:
   config:
     contexts:
       - 'self-hosted'
+artifactProvider:
+  name: none
 targets:
   - id: release
     name: docker


### PR DESCRIPTION
Release not going through, let's set artifact provider to none since it's no longer needed