### PR TITLE
ref(stats-detectors): Split regression group fetch from redirect reso…

### DIFF
--- a/src/sentry/statistical_detectors/algorithm.py
+++ b/src/sentry/statistical_detectors/algorithm.py
@@ -30,7 +30,7 @@ class DetectorAlgorithm(ABC):
         ...
 
     @abstractmethod
-    def update(self, payload: DetectorPayload) -> Tuple[Optional[TrendType], float]:
+    def update(self, payload: DetectorPayload) -> Tuple[TrendType, float]:
         ...
 
     @property
@@ -142,7 +142,7 @@ class MovingAverageRelativeChangeDetectorConfig(MovingAverageDetectorConfig):
 class MovingAverageRelativeChangeDetector(MovingAverageDetector):
     config: MovingAverageRelativeChangeDetectorConfig
 
-    def update(self, payload: DetectorPayload) -> Tuple[Optional[TrendType], float]:
+    def update(self, payload: DetectorPayload) -> Tuple[TrendType, float]:
         if self.timestamp is not None and self.timestamp > payload.timestamp:
             # In the event that the timestamp is before the payload's timestamps,
             # we do not want to process this payload.
@@ -153,7 +153,7 @@ class MovingAverageRelativeChangeDetector(MovingAverageDetector):
                 payload.timestamp.isoformat(),
                 self.timestamp.isoformat(),
             )
-            return None, 0
+            return TrendType.Skipped, 0
 
         old_moving_avg_short = self.moving_avg_short.value
         old_moving_avg_long = self.moving_avg_long.value

--- a/src/sentry/statistical_detectors/base.py
+++ b/src/sentry/statistical_detectors/base.py
@@ -11,6 +11,7 @@ class TrendType(Enum):
     Regressed = "regressed"
     Improved = "improved"
     Unchanged = "unchanged"
+    Skipped = "skipped"
 
 
 @dataclass(frozen=True)

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -250,16 +250,17 @@ def detect_transaction_trends(
     )
 
     trends = EndpointRegressionDetector.detect_trends(projects, start)
+    trends = EndpointRegressionDetector.get_regression_groups(trends)
     trends = EndpointRegressionDetector.redirect_resolutions(trends, start)
-    regressions = EndpointRegressionDetector.limit_regressions_by_project(trends)
+    trends = EndpointRegressionDetector.limit_regressions_by_project(trends)
 
     delay = 12  # hours
     delayed_start = start + timedelta(hours=delay)
 
-    for regression_chunk in chunked(regressions, TRANSACTIONS_PER_BATCH):
+    for regression_chunk in chunked(trends, TRANSACTIONS_PER_BATCH):
         detect_transaction_change_points.apply_async(
             args=[
-                [(payload.project_id, payload.group) for payload in regression_chunk],
+                [(bundle.payload.project_id, bundle.payload.group) for bundle in regression_chunk],
                 delayed_start,
             ],
             # delay the check by delay hours because we want to make sure there
@@ -326,16 +327,17 @@ def detect_function_trends(project_ids: List[int], start: datetime, *args, **kwa
     )
 
     trends = FunctionRegressionDetector.detect_trends(projects, start)
+    trends = FunctionRegressionDetector.get_regression_groups(trends)
     trends = FunctionRegressionDetector.redirect_resolutions(trends, start)
-    regressions = FunctionRegressionDetector.limit_regressions_by_project(trends)
+    trends = FunctionRegressionDetector.limit_regressions_by_project(trends)
 
     delay = 12  # hours
     delayed_start = start + timedelta(hours=delay)
 
-    for regression_chunk in chunked(regressions, FUNCTIONS_PER_BATCH):
+    for regression_chunk in chunked(trends, FUNCTIONS_PER_BATCH):
         detect_function_change_points.apply_async(
             args=[
-                [(payload.project_id, payload.group) for payload in regression_chunk],
+                [(bundle.payload.project_id, bundle.payload.group) for bundle in regression_chunk],
                 delayed_start,
             ],
             # delay the check by delay hours because we want to make sure there

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -21,7 +21,7 @@ from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.discover import zerofill
 from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.statistical_detectors.base import DetectorPayload, TrendType
-from sentry.statistical_detectors.detector import generate_fingerprint
+from sentry.statistical_detectors.detector import TrendBundle, generate_fingerprint
 from sentry.tasks.statistical_detectors import (
     EndpointRegressionDetector,
     FunctionRegressionDetector,
@@ -491,19 +491,18 @@ def test_limit_regressions_by_project(detector_cls, ratelimit, timestamp, expect
     }
 
     def trends():
-        # we do not need the detector state here so mock it with None
-        yield (None, 0, payloads[(1, 1)], None)
-        yield (TrendType.Improved, 0, payloads[(2, 1)], None)
-        yield (TrendType.Regressed, 0, payloads[(2, 2)], None)
-        yield (TrendType.Regressed, 0, payloads[(3, 1)], None)
-        yield (TrendType.Regressed, 1, payloads[(3, 2)], None)
-        yield (TrendType.Regressed, 2, payloads[(3, 3)], None)
+        yield TrendBundle(TrendType.Skipped, 0, payloads[(1, 1)])
+        yield TrendBundle(TrendType.Improved, 0, payloads[(2, 1)])
+        yield TrendBundle(TrendType.Regressed, 0, payloads[(2, 2)])
+        yield TrendBundle(TrendType.Regressed, 0, payloads[(3, 1)])
+        yield TrendBundle(TrendType.Regressed, 1, payloads[(3, 2)])
+        yield TrendBundle(TrendType.Regressed, 2, payloads[(3, 3)])
 
     expected_regressions = [
-        payloads[(2, 2)],
-        payloads[(3, 3)],
-        payloads[(3, 2)],
-        payloads[(3, 1)],
+        TrendBundle(TrendType.Regressed, 0, payloads[(2, 2)]),
+        TrendBundle(TrendType.Regressed, 2, payloads[(3, 3)]),
+        TrendBundle(TrendType.Regressed, 1, payloads[(3, 2)]),
+        TrendBundle(TrendType.Regressed, 0, payloads[(3, 1)]),
     ][:expected_idx]
     regressions = detector_cls.limit_regressions_by_project(trends(), ratelimit)
     assert set(regressions) == set(expected_regressions)
@@ -918,9 +917,15 @@ def test_new_regression_group(
             moving_avg_short=100,
             moving_avg_long=100,
         )
-        yield TrendType.Unchanged, 1, payload, state
+        yield TrendBundle(
+            type=TrendType.Unchanged,
+            score=1,
+            payload=payload,
+            state=state,
+        )
 
     trends = get_trends()
+    trends = detector_cls.get_regression_groups(trends)
     trends = detector_cls.redirect_resolutions(trends, timestamp)
     assert len(list(trends)) == 0  # should resolve, so it is redirected, thus 0
     assert produce_occurrence_to_kafka.called


### PR DESCRIPTION
…lution

The regression group will be used when redirecting escalations as well so let's clean this up and allow it to be cleanly reused by changing the signature to process bundles and returning bundles.