### PR TITLE
feat(browser-starfish): fetch number values for image resource size

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -15,7 +15,7 @@ const imageWidth = '200px';
 function SampleImages({groupId}: Props) {
   const imageResources = useIndexedResourcesQuery({
     queryConditions: [`${SPAN_GROUP}:${groupId}`],
-    sorts: [{field: HTTP_RESPONSE_CONTENT_LENGTH, kind: 'desc'}],
+    sorts: [{field: `measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`, kind: 'desc'}],
     limit: 100,
   });
 
@@ -40,7 +40,7 @@ function SampleImages({groupId}: Props) {
             <ImageContainer
               src={resource[SPAN_DESCRIPTION]}
               fileName={getFileNameFromDescription(resource[SPAN_DESCRIPTION])}
-              size={resource[HTTP_RESPONSE_CONTENT_LENGTH]}
+              size={resource[`measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`]}
               key={resource[SPAN_DESCRIPTION]}
             />
           );

--- a/static/app/views/performance/browser/resources/utils/useIndexedResourceQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useIndexedResourceQuery.ts
@@ -34,12 +34,11 @@ export const useIndexedResourcesQuery = ({
         'project',
         'span.group',
         SPAN_DESCRIPTION,
-        HTTP_RESPONSE_CONTENT_LENGTH,
+        `measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`,
       ],
       name: 'Indexed Resource Query',
       query: queryConditions.join(' '),
       version: 2,
-      orderby: '-count()',
       dataset: DiscoverDatasets.SPANS_INDEXED,
     },
     pageFilters.selection
@@ -66,9 +65,9 @@ export const useIndexedResourcesQuery = ({
       'transaction.id': row['transaction.id'] as string,
       [SPAN_DESCRIPTION]: row[SPAN_DESCRIPTION]?.toString(),
       // TODO - parseFloat here is temporary, we should be parsing from the backend
-      [HTTP_RESPONSE_CONTENT_LENGTH]: parseFloat(
-        (row[HTTP_RESPONSE_CONTENT_LENGTH] as string) || '0'
-      ),
+      'measurements.http.response_content_length': row[
+        `measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`
+      ] as number,
     })) ?? [];
 
   return {...result, data};

--- a/static/app/views/performance/browser/resources/utils/useIndexedResourceQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useIndexedResourceQuery.ts
@@ -64,7 +64,6 @@ export const useIndexedResourcesQuery = ({
       project: row.project as string,
       'transaction.id': row['transaction.id'] as string,
       [SPAN_DESCRIPTION]: row[SPAN_DESCRIPTION]?.toString(),
-      // TODO - parseFloat here is temporary, we should be parsing from the backend
       'measurements.http.response_content_length': row[
         `measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`
       ] as number,


### PR DESCRIPTION
Instead of using string values for resources sizes, we're now fetching and sorting by the number value.