### PR TITLE
feat(stats-detectors): Add stub to redirect escalations

### DIFF
--- a/src/sentry/statistical_detectors/algorithm.py
+++ b/src/sentry/statistical_detectors/algorithm.py
@@ -86,6 +86,21 @@ class MovingAverageDetectorState(DetectorState):
 
         return False
 
+    def should_escalate(
+        self, baseline: float, regressed: float, min_change: float, rel_threshold: float
+    ) -> bool:
+        value = self.moving_avg_long
+
+        change = value - regressed
+        if change < min_change:
+            return False
+
+        rel_change = change / baseline
+        if rel_change > rel_threshold:
+            return True
+
+        return False
+
     @classmethod
     def empty(cls) -> MovingAverageDetectorState:
         return cls(

--- a/src/sentry/statistical_detectors/base.py
+++ b/src/sentry/statistical_detectors/base.py
@@ -39,6 +39,12 @@ class DetectorState(ABC):
     def should_auto_resolve(self, target: float, rel_threshold: float) -> bool:
         ...
 
+    @abstractmethod
+    def should_escalate(
+        self, baseline: float, regressed: float, min_change: float, rel_threshold: float
+    ) -> bool:
+        ...
+
     @classmethod
     @abstractmethod
     def empty(cls) -> DetectorState:

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -172,6 +172,7 @@ class EndpointRegressionDetector(RegressionDetector):
     detector_cls = MovingAverageRelativeChangeDetector
     min_change = 200  # 200ms in ms
     resolution_rel_threshold = 0.1
+    escalation_rel_threshold = 0.3
 
     @classmethod
     def make_detector_store(cls) -> DetectorStore:
@@ -209,6 +210,7 @@ class FunctionRegressionDetector(RegressionDetector):
     detector_cls = MovingAverageRelativeChangeDetector
     min_change = 100_000_000  # 100ms in ns
     resolution_rel_threshold = 0.1
+    escalation_rel_threshold = 0.3
 
     @classmethod
     def make_detector_store(cls) -> DetectorStore:
@@ -252,6 +254,7 @@ def detect_transaction_trends(
     trends = EndpointRegressionDetector.detect_trends(projects, start)
     trends = EndpointRegressionDetector.get_regression_groups(trends)
     trends = EndpointRegressionDetector.redirect_resolutions(trends, start)
+    trends = EndpointRegressionDetector.redirect_escalations(trends, start)
     trends = EndpointRegressionDetector.limit_regressions_by_project(trends)
 
     delay = 12  # hours
@@ -329,6 +332,7 @@ def detect_function_trends(project_ids: List[int], start: datetime, *args, **kwa
     trends = FunctionRegressionDetector.detect_trends(projects, start)
     trends = FunctionRegressionDetector.get_regression_groups(trends)
     trends = FunctionRegressionDetector.redirect_resolutions(trends, start)
+    trends = FunctionRegressionDetector.redirect_escalations(trends, start)
     trends = FunctionRegressionDetector.limit_regressions_by_project(trends)
 
     delay = 12  # hours

--- a/tests/sentry/statistical_detectors/test_algorithm.py
+++ b/tests/sentry/statistical_detectors/test_algorithm.py
@@ -187,23 +187,50 @@ def test_moving_average_detector_state_from_redis_dict_error(data, error):
 
 
 @pytest.mark.parametrize(
-    ["baseline", "rel_threshold", "auto_resolve"],
+    ["baseline", "avg", "rel_threshold", "auto_resolve"],
     [
-        pytest.param(100, 0.1, True, id="equal"),
-        pytest.param(105, 0.1, True, id="within threshold above"),
-        pytest.param(95, 0.1, True, id="within threshold below"),
-        pytest.param(115, 0.1, False, id="exceed threshold above"),
-        pytest.param(85, 0.1, True, id="exceed threshold below"),
+        pytest.param(100, 100, 0.1, True, id="equal"),
+        pytest.param(100, 105, 0.1, True, id="within threshold above"),
+        pytest.param(100, 95, 0.1, True, id="within threshold below"),
+        pytest.param(100, 115, 0.1, False, id="exceed threshold above"),
+        pytest.param(100, 85, 0.1, True, id="exceed threshold below"),
     ],
 )
-def test_moving_average_detector_state_should_auto_resolve(baseline, rel_threshold, auto_resolve):
+def test_moving_average_detector_state_should_auto_resolve(
+    baseline, avg, rel_threshold, auto_resolve
+):
     state = MovingAverageDetectorState(
         timestamp=datetime(2023, 8, 31, 11, 28, 52),
         count=10,
-        moving_avg_short=baseline,
-        moving_avg_long=baseline,
+        moving_avg_short=avg,
+        moving_avg_long=avg,
     )
-    assert state.should_auto_resolve(100, rel_threshold) == auto_resolve
+    assert state.should_auto_resolve(baseline, rel_threshold) == auto_resolve
+
+
+@pytest.mark.parametrize(
+    ["baseline", "regressed", "avg", "min_change", "rel_threshold", "escalate"],
+    [
+        pytest.param(50, 100, 100, 10, 0.1, False, id="equal"),
+        pytest.param(50, 100, 105, 10, 0.1, False, id="within threshold above"),
+        pytest.param(50, 100, 95, 10, 0.1, False, id="within threshold below"),
+        pytest.param(50, 100, 115, 10, 0.1, True, id="exceed threshold above"),
+        pytest.param(50, 100, 85, 10, 0.1, False, id="exceed threshold below"),
+        pytest.param(
+            50, 100, 115, 20, 0.1, False, id="exceed threshold above but below min_change"
+        ),
+    ],
+)
+def test_moving_average_detector_state_should_escalate(
+    baseline, regressed, avg, min_change, rel_threshold, escalate
+):
+    state = MovingAverageDetectorState(
+        timestamp=datetime(2023, 8, 31, 11, 28, 52),
+        count=10,
+        moving_avg_short=avg,
+        moving_avg_long=avg,
+    )
+    assert state.should_escalate(baseline, regressed, min_change, rel_threshold) == escalate
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
To support auto escalations, this adds in the stub to identify potential escalations and emits a metric for it.