### PR TITLE
fix(replay): Disable line wrapping in hydration html formatter

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -105,14 +105,14 @@ function ReplaySide({expectedTime, selector, onLoad}) {
 
   useEffect(() => {
     if (currentTime === expectedTime) {
+      // Wait for the replay iframe to load before selecting the body
       setTimeout(() => {
-        const iframe = document.querySelector(selector) as HTMLIFrameElement;
+        const iframe = document.querySelector<HTMLIFrameElement>(selector)!;
         const body = iframe.contentWindow?.document.body;
         if (body) {
           onLoad(
             beautify.html(body.innerHTML, {
               indent_size: 2,
-              wrap_line_length: 80,
             })
           );
         }


### PR DESCRIPTION
The line wrapping increases the number of lines with diffs once there is an additional attribute or longer style (width, etc)
