### PR TITLE
feat(crons): Handle disabled monitors in the overview UI

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -1,7 +1,7 @@
 import {useRef} from 'react';
 import styled from '@emotion/styled';
 
-import {deleteMonitorEnvironment} from 'sentry/actionCreators/monitors';
+import {deleteMonitorEnvironment, updateMonitor} from 'sentry/actionCreators/monitors';
 import Panel from 'sentry/components/panels/panel';
 import {Sticky} from 'sentry/components/sticky';
 import {space} from 'sentry/styles/space';
@@ -95,6 +95,22 @@ export function OverviewTimeline({monitorList}: Props) {
     });
   };
 
+  const handleToggleStatus = async (monitor: Monitor) => {
+    const data: Partial<Monitor> = {
+      status: monitor.status === 'active' ? 'disabled' : 'active',
+    };
+
+    const resp = await updateMonitor(api, organization.slug, monitor.slug, data);
+
+    const queryKey = makeMonitorListQueryKey(organization, router.location);
+    setApiQueryData(queryClient, queryKey, (oldMonitorList: Monitor[]) => {
+      const monitorIdx = oldMonitorList.findIndex(m => m.slug === monitor.slug);
+      oldMonitorList[monitorIdx] = resp;
+
+      return oldMonitorList;
+    });
+  };
+
   return (
     <MonitorListPanel>
       <TimelineWidthTracker ref={elementRef} />
@@ -128,6 +144,7 @@ export function OverviewTimeline({monitorList}: Props) {
           end={nowRef.current}
           width={timelineWidth}
           onDeleteEnvironment={env => handleDeleteEnvironment(monitor, env)}
+          onToggleStatus={handleToggleStatus}
         />
       ))}
     </MonitorListPanel>


### PR DESCRIPTION
- Adds a Play / Pause (Activate / Deactivate) button to each row.
 - Indicates disabled monitors via a tag + opacity adjustment

Looks like this

<img alt="clipboard.png" width="985" src="https://i.imgur.com/Ch1jjb8.png" />