### PR TITLE
ref(crons): Consistent button sizing on alert

### DIFF
--- a/static/app/views/monitors/components/monitorIssues.tsx
+++ b/static/app/views/monitors/components/monitorIssues.tsx
@@ -59,7 +59,7 @@ function MonitorIssues({orgSlug, monitor, monitorEnvs}: Props) {
           trailingItems={
             <ButtonBar gap={1}>
               <LinkButton
-                size="sm"
+                size="xs"
                 to={{
                   pathname: `/organizations/${orgSlug}/crons/${monitor.slug}/edit/`,
                   query: {


### PR DESCRIPTION
<img width="904" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/593a657c-c25c-458d-95ab-f358d0380838">
