### PR TITLE
feat(replays): add banner about masking config docs to breadcrumbs tab

### DIFF
--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -15,6 +15,7 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import useJumpButtons from 'sentry/components/replays/useJumpButtons';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import useExtractedDomNodes from 'sentry/utils/replays/hooks/useExtractedDomNodes';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
@@ -135,7 +136,7 @@ function Breadcrumbs() {
         <BreadcrumbFilters frames={frames} {...filterProps} />
       </FilterLoadingIndicator>
       {isDismissed ? null : (
-        <Alert
+        <StyledAlert
           type="info"
           showIcon
           trailingItems={<StyledCloseButton onClick={dismiss} />}
@@ -145,7 +146,7 @@ function Breadcrumbs() {
               <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/privacy/" />
             ),
           })}
-        </Alert>
+        </StyledAlert>
       )}
       <TabItemContainer data-test-id="replay-details-breadcrumbs-tab">
         {frames ? (
@@ -195,6 +196,10 @@ function Breadcrumbs() {
 
 const StyledCloseButton = styled(IconClose)`
   cursor: pointer;
+`;
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: ${space(1)};
 `;
 
 export default Breadcrumbs;

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -8,6 +8,7 @@ import {
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
+import {Button} from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Placeholder from 'sentry/components/placeholder';
 import JumpButtons from 'sentry/components/replays/jumpButtons';
@@ -139,7 +140,15 @@ function Breadcrumbs() {
         <StyledAlert
           type="info"
           showIcon
-          trailingItems={<StyledCloseButton onClick={dismiss} />}
+          trailingItems={
+            <Button
+              aria-label={t('Dismiss banner')}
+              icon={<IconClose />}
+              onClick={dismiss}
+              size="zero"
+              borderless
+            />
+          }
         >
           {tct('Learn how to unmask text (****) and unblock media [link:here].', {
             link: (
@@ -193,10 +202,6 @@ function Breadcrumbs() {
     </FluidHeight>
   );
 }
-
-const StyledCloseButton = styled(IconClose)`
-  cursor: pointer;
-`;
 
 const StyledAlert = styled(Alert)`
   margin-bottom: ${space(1)};

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -5,14 +5,19 @@ import {
   List as ReactVirtualizedList,
   ListRowProps,
 } from 'react-virtualized';
+import styled from '@emotion/styled';
 
+import Alert from 'sentry/components/alert';
+import ExternalLink from 'sentry/components/links/externalLink';
 import Placeholder from 'sentry/components/placeholder';
 import JumpButtons from 'sentry/components/replays/jumpButtons';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import useJumpButtons from 'sentry/components/replays/useJumpButtons';
-import {t} from 'sentry/locale';
+import {IconClose} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import useExtractedDomNodes from 'sentry/utils/replays/hooks/useExtractedDomNodes';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useOrganization from 'sentry/utils/useOrganization';
 import useVirtualizedInspector from 'sentry/views/replays/detail//useVirtualizedInspector';
 import BreadcrumbFilters from 'sentry/views/replays/detail/breadcrumbs/breadcrumbFilters';
@@ -27,6 +32,8 @@ import TabItemContainer from 'sentry/views/replays/detail/tabItemContainer';
 import useVirtualizedList from 'sentry/views/replays/detail/useVirtualizedList';
 import useVirtualListDimentionChange from 'sentry/views/replays/detail/useVirtualListDimentionChange';
 
+const LOCAL_STORAGE_KEY = 'replay-details-mask-config-instructions-dismissed';
+
 // Ensure this object is created once as it is an input to
 // `useVirtualizedList`'s memoization
 const cellMeasurer = {
@@ -35,6 +42,7 @@ const cellMeasurer = {
 };
 
 function Breadcrumbs() {
+  const {dismiss, isDismissed} = useDismissAlert({key: LOCAL_STORAGE_KEY});
   const {currentTime, replay} = useReplayContext();
   const organization = useOrganization();
   const hasPerfTab = organization.features.includes('session-replay-trace-table');
@@ -126,6 +134,19 @@ function Breadcrumbs() {
       <FilterLoadingIndicator isLoading={isFetchingExtractions || isFetchingTraces}>
         <BreadcrumbFilters frames={frames} {...filterProps} />
       </FilterLoadingIndicator>
+      {isDismissed ? null : (
+        <Alert
+          type="info"
+          showIcon
+          trailingItems={<StyledCloseButton onClick={dismiss} />}
+        >
+          {tct('Learn how to unmask text (****) and unblock media [link:here].', {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/privacy/" />
+            ),
+          })}
+        </Alert>
+      )}
       <TabItemContainer data-test-id="replay-details-breadcrumbs-tab">
         {frames ? (
           <AutoSizer onResize={updateList}>
@@ -171,5 +192,9 @@ function Breadcrumbs() {
     </FluidHeight>
   );
 }
+
+const StyledCloseButton = styled(IconClose)`
+  cursor: pointer;
+`;
 
 export default Breadcrumbs;


### PR DESCRIPTION
- Shows for every user on the replay details breadcrumb tab
- Is dismissible, only comes back if local storage is cleared
- Links to https://docs.sentry.io/platforms/javascript/session-replay/privacy/

<img width="618" alt="SCR-20231219-oqpr" src="https://github.com/getsentry/sentry/assets/56095982/5cce0ea0-a32f-4c0e-b9d5-a55f182010ac">


Closes https://github.com/getsentry/team-replay/issues/322