### PR TITLE
fix(dev): be sure to check sentry's requirements-dev 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -193,7 +193,7 @@ venv_name=".venv"
 
 # Use requirements-dev.txt to decide when to cut over to `devenv` tooling.
 # This also provides us with a clean-cut rollback procedure.
-if [ -n "$SENTRY_DEVENV_BETA" ] || grep -Eq "^devenv($|>)" requirements-dev.txt; then
+if [ -n "$SENTRY_DEVENV_BETA" ] || grep -Eq "^devenv($|>)" "${SENTRY_ROOT}/requirements-dev.txt"; then
     # The new hotness. (but not ready yet)
     echo "Using devenv."
     export SENTRY_DEVENV_HOME="${SENTRY_DEVENV_HOME:-$XDG_DATA_HOME/sentry-devenv}"


### PR DESCRIPTION
when running direnv in getsentry it'll always fail this: `grep: requirements-dev.txt: No such file or directory`

