### PR TITLE
fix(ui): Invert pattern-bg for dark mode

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -100,6 +100,11 @@ const styles = (theme: Theme, isDark: boolean) => css`
           border-left-color: ${theme.purple300};
         }
 
+        .pattern-bg {
+          opacity: 1;
+          filter: invert(1) brightness(0.6);
+        }
+
         .nav-tabs {
           & > li {
             &.active {


### PR DESCRIPTION
Before

<img width="1840" alt="image" src="https://github.com/getsentry/sentry/assets/1421724/bc2a0146-1314-4e5b-a0c2-0e2d766e57ef">


After

<img width="1840" alt="image" src="https://github.com/getsentry/sentry/assets/1421724/4f755526-07bb-43e1-bb5d-904fa0a79729">
