### PR TITLE
fix(hybrid-cloud): Fix Bitbucket webhook handler

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -637,7 +637,6 @@ class ControlOrganizationCheckService(OrganizationCheckService):
         # See RegionOrganizationCheckService below
         org_mapping = OrganizationMapping.objects.filter(organization_id=id).first()
         if org_mapping is None:
-            logger.info(f"Organization by id not found: {id}")
             return False
         if only_visible and org_mapping.status != OrganizationStatus.ACTIVE:
             return False
@@ -665,7 +664,7 @@ class RegionOrganizationCheckService(OrganizationCheckService):
                 raise Organization.DoesNotExist
             return True
         except Organization.DoesNotExist:
-            logger.info(f"Organization by id not found: {id}")
+            pass
 
         return False
 

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -182,6 +182,14 @@ class OrganizationService(RpcService):
             slug=slug, only_visible=only_visible
         )
 
+    def check_organization_by_id(self, *, id: int, only_visible: bool) -> bool:
+        """
+        Checks if an organization exists by the id.
+        """
+        return _organization_check_service.check_organization_by_id(
+            id=id, only_visible=only_visible
+        )
+
     def get_organization_by_slug(
         self, *, slug: str, only_visible: bool, user_id: Optional[int] = None
     ) -> Optional[RpcUserOrganizationContext]:
@@ -368,6 +376,13 @@ class OrganizationCheckService(abc.ABC):
     def check_organization_by_slug(self, *, slug: str, only_visible: bool) -> Optional[int]:
         """
         If exists and matches the only_visible requirement, returns an organization's id by the slug.
+        """
+        pass
+
+    @abstractmethod
+    def check_organization_by_id(self, *, id: int, only_visible: bool) -> bool:
+        """
+        Checks if an organization exists by the id.
         """
         pass
 

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -14,9 +14,10 @@ from rest_framework.request import Request
 from sentry.integrations.bitbucket.constants import BITBUCKET_IP_RANGES, BITBUCKET_IPS
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
-from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.plugins.providers import RepositoryProvider
+from sentry.services.hybrid_cloud.organization.model import RpcOrganization
+from sentry.services.hybrid_cloud.organization.service import organization_service
 from sentry.utils import json
 from sentry.utils.email import parse_email
 

--- a/tests/sentry/services/hybrid_cloud/organization/test_service.py
+++ b/tests/sentry/services/hybrid_cloud/organization/test_service.py
@@ -37,3 +37,36 @@ class CheckOrganizationTest(TestCase):
             organization_service.check_organization_by_slug(slug="test", only_visible=False)
             == self.organization.id
         )
+
+    def test_check_active_organization_by_id(self):
+        organization = self.create_organization(slug="test")
+        assert (
+            organization_service.check_organization_by_id(id=organization.id, only_visible=True)
+            is True
+        )
+        assert (
+            organization_service.check_organization_by_id(id=organization.id, only_visible=False)
+            is True
+        )
+
+    def test_check_missing_organization_by_id(self):
+        assert organization_service.check_organization_by_id(id=1234, only_visible=True) is False
+        assert organization_service.check_organization_by_id(id=1234, only_visible=False) is False
+
+    def test_check_pending_deletion_organization_by_id(self):
+        self.organization = self.create_organization(slug="test")
+        self.organization.status = OrganizationStatus.PENDING_DELETION
+        with assume_test_silo_mode_of(Organization):
+            self.organization.save()
+        assert (
+            organization_service.check_organization_by_id(
+                id=self.organization.id, only_visible=True
+            )
+            is False
+        )
+        assert (
+            organization_service.check_organization_by_id(
+                id=self.organization.id, only_visible=False
+            )
+            is True
+        )


### PR DESCRIPTION
The Bitbucket plugin webhook handler may run in the control silo if the organization's region cannot be found.

This pull request fixes that.