### PR TITLE
fix(crons): Just update status when toggling status

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -96,16 +96,17 @@ export function OverviewTimeline({monitorList}: Props) {
   };
 
   const handleToggleStatus = async (monitor: Monitor) => {
-    const data: Partial<Monitor> = {
-      status: monitor.status === 'active' ? 'disabled' : 'active',
-    };
+    const status = monitor.status === 'active' ? 'disabled' : 'active';
+    const resp = await updateMonitor(api, organization.slug, monitor.slug, {status});
 
-    const resp = await updateMonitor(api, organization.slug, monitor.slug, data);
+    if (resp === null) {
+      return;
+    }
 
     const queryKey = makeMonitorListQueryKey(organization, router.location);
     setApiQueryData(queryClient, queryKey, (oldMonitorList: Monitor[]) => {
       const monitorIdx = oldMonitorList.findIndex(m => m.slug === monitor.slug);
-      oldMonitorList[monitorIdx] = resp;
+      oldMonitorList[monitorIdx] = {...oldMonitorList[monitorIdx], status: resp.status};
 
       return oldMonitorList;
     });


### PR DESCRIPTION
This fixes a bug where updating the status in the monitors overview would load the updated monitor with all environments even if the original list request had filtered environments. Leading to the updated monitor having all environments displayed after toggling the status

Instead we just set the status to its new value