### PR TITLE
fix(hybridcloud) Handle installation hooks in control

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -38,9 +38,9 @@ from sentry.services.hybrid_cloud.integration.model import (
 )
 from sentry.services.hybrid_cloud.integration.service import integration_service
 from sentry.services.hybrid_cloud.organization.serial import serialize_rpc_organization
+from sentry.services.hybrid_cloud.repository.service import repository_service
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo import SiloMode
 from sentry.tasks.integrations.github.open_pr_comment import open_pr_comment_workflow
 from sentry.utils import json, metrics
 from sentry.utils.json import JSONData
@@ -69,6 +69,10 @@ def get_file_language(filename: str) -> str | None:
 
 
 class Webhook:
+    """
+    Base class for GitHub webhooks handled in region silos.
+    """
+
     provider = "github"
 
     def _handle(
@@ -110,8 +114,6 @@ class Webhook:
                     id__in=[install.organization_id for install in installs]
                 )
             }
-
-            # TODO: Replace with repository_service; deal with potential multiple regions
             repos = Repository.objects.filter(
                 organization_id__in=orgs.keys(),
                 provider=f"integrations:{self.provider}",
@@ -179,8 +181,15 @@ class Webhook:
             )
 
 
-class InstallationEventWebhook(Webhook):
-    # https://developer.github.com/v3/activity/events/types/#installationevent
+class InstallationEventWebhook:
+    """
+    Unlike other GitHub webhooks, installation webhooks are handled in control silo.
+
+    https://developer.github.com/v3/activity/events/types/#installationevent
+    """
+
+    provider = "github"
+
     def __call__(self, event: Mapping[str, Any], host: str | None = None) -> None:
         installation = event["installation"]
 
@@ -242,13 +251,12 @@ class InstallationEventWebhook(Webhook):
         integration_service.update_integration(
             integration_id=integration.id, status=ObjectStatus.DISABLED
         )
-
-        if len(org_ids) > 0 and SiloMode.get_current_mode() != SiloMode.CONTROL:
-            Repository.objects.filter(
-                organization_id__in=org_ids,
+        for organization_id in org_ids:
+            repository_service.disable_repositories_for_integration(
+                organization_id=organization_id,
                 provider=f"integrations:{self.provider}",
                 integration_id=integration.id,
-            ).update(status=ObjectStatus.DISABLED)
+            )
 
 
 class PushEventWebhook(Webhook):

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -51,7 +51,7 @@ class GithubRequestParser(BaseRequestParser):
         except json.JSONDecodeError:
             return HttpResponse(status=400)
 
-        if event.get("installation") and event.get("action") == "created":
+        if event.get("installation") and event.get("action") in {"created", "deleted"}:
             return self.get_response_from_control_silo()
 
         regions = self.get_regions_from_organizations()

--- a/src/sentry/services/hybrid_cloud/repository/impl.py
+++ b/src/sentry/services/hybrid_cloud/repository/impl.py
@@ -99,6 +99,16 @@ class DatabaseBackedRepositoryService(RepositoryService):
                 provider=provider,
             ).update(status=ObjectStatus.ACTIVE)
 
+    def disable_repositories_for_integration(
+        self, *, organization_id: int, integration_id: int, provider: str
+    ) -> None:
+        with transaction.atomic(router.db_for_write(Repository)):
+            Repository.objects.filter(
+                organization_id=organization_id,
+                integration_id=integration_id,
+                provider=provider,
+            ).update(status=ObjectStatus.DISABLED)
+
     def disassociate_organization_integration(
         self,
         *,

--- a/src/sentry/services/hybrid_cloud/repository/service.py
+++ b/src/sentry/services/hybrid_cloud/repository/service.py
@@ -83,6 +83,17 @@ class RepositoryService(RpcService):
 
     @regional_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
+    def disable_repositories_for_integration(
+        self, *, organization_id: int, integration_id: int, provider: str
+    ) -> None:
+        """
+        Disables all repositories associated with the given integration by marking them as disabled.
+        Code owners and code mappings will not be changed.
+        """
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
     def disassociate_organization_integration(
         self,
         *,
@@ -91,7 +102,8 @@ class RepositoryService(RpcService):
         integration_id: int,
     ) -> None:
         """
-        Disassociates all repositories, code owners, and code mapping associated with the given organization integration.
+        Disassociates all repositories for an organization integration.
+        This will also delete code owners, and code mapping associated with matching repositories.
         """
         pass
 

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -122,3 +122,19 @@ class GithubRequestParserTest(TestCase):
             parser.get_response()
             assert get_response_from_control_silo.called
             assert not get_response_from_outbox_creation.called
+
+    def test_installation_deleted_routing(self):
+        request = self.factory.post(
+            reverse("sentry-integration-github-webhook"),
+            data={"installation": {"id": "github:1"}, "action": "deleted"},
+            content_type="application/json",
+        )
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        with mock.patch.object(
+            parser, "get_response_from_outbox_creation"
+        ) as get_response_from_outbox_creation, mock.patch.object(
+            parser, "get_response_from_control_silo"
+        ) as get_response_from_control_silo:
+            parser.get_response()
+            assert get_response_from_control_silo.called
+            assert not get_response_from_outbox_creation.called


### PR DESCRIPTION
Partially handling installation hooks in control and partially in region has resulted in some cross-silo query gaps. By moving install/delete actions to both be in control we avoid hard to spot silo bugs, and restore the behavior to disable repositories when a github app is deleted.

Fixes HC-988