### PR TITLE
ref(ingest): Move `HashDiscarded` to `exceptions` module

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -60,6 +60,7 @@ from sentry.dynamic_sampling import LatestReleaseBias, LatestReleaseParams
 from sentry.eventstore.processing import event_processing_store
 from sentry.eventtypes import EventType
 from sentry.eventtypes.transaction import TransactionEvent
+from sentry.exceptions import HashDiscarded
 from sentry.grouping.api import (
     BackgroundGroupingConfigLoader,
     GroupingConfig,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -280,15 +280,6 @@ def get_stored_crashreports(cache_key: Optional[str], event: Event, max_crashrep
     return query[:max_crashreports].count()
 
 
-class HashDiscarded(Exception):
-    def __init__(
-        self, message: str = "", reason: Optional[str] = None, tombstone_id: Optional[int] = None
-    ):
-        super().__init__(message)
-        self.reason = reason
-        self.tombstone_id = tombstone_id
-
-
 class ScoreClause(Func):
     def __init__(self, group=None, last_seen=None, times_seen=None, *args, **kwargs):
         self.group = group

--- a/src/sentry/exceptions.py
+++ b/src/sentry/exceptions.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.core.exceptions import SuspiciousOperation
 
 
@@ -82,3 +84,12 @@ class UnsupportedQuerySubscription(Exception):
 
 class InvalidQuerySubscription(Exception):
     pass
+
+
+class HashDiscarded(Exception):
+    def __init__(
+        self, message: str = "", reason: Optional[str] = None, tombstone_id: Optional[int] = None
+    ):
+        super().__init__(message)
+        self.reason = reason
+        self.tombstone_id = tombstone_id

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -342,7 +342,8 @@ class GroupManager(BaseManager["Group"]):
         return groups
 
     def from_kwargs(self, project, **kwargs):
-        from sentry.event_manager import EventManager, HashDiscarded
+        from sentry.event_manager import EventManager
+        from sentry.exceptions import HashDiscarded
 
         manager = EventManager(kwargs)
         manager.normalize()

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -676,7 +676,8 @@ def _do_save_event(
 
     set_current_event_project(project_id)
 
-    from sentry.event_manager import EventManager, HashDiscarded
+    from sentry.event_manager import EventManager
+    from sentry.exceptions import HashDiscarded
 
     event_type = "none"
 

--- a/src/sentry/utils/mockdata/core.py
+++ b/src/sentry/utils/mockdata/core.py
@@ -17,7 +17,7 @@ from django.utils import timezone as django_timezone
 
 from sentry import buffer, roles, tsdb
 from sentry.constants import ObjectStatus
-from sentry.event_manager import HashDiscarded
+from sentry.exceptions import HashDiscarded
 from sentry.incidents.logic import create_alert_rule, create_alert_rule_trigger, create_incident
 from sentry.incidents.models import AlertRuleThresholdType, IncidentType
 from sentry.models.activity import Activity

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -38,7 +38,6 @@ from sentry.dynamic_sampling import (
 )
 from sentry.event_manager import (
     EventManager,
-    HashDiscarded,
     _get_event_instance,
     _save_grouphash_and_group,
     get_event_type,
@@ -46,6 +45,7 @@ from sentry.event_manager import (
     materialize_metadata,
 )
 from sentry.eventstore.models import Event
+from sentry.exceptions import HashDiscarded
 from sentry.grouping.utils import hash_from_values
 from sentry.ingest.inbound_filters import FilterStatKeys
 from sentry.issues.grouptype import (

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -5,7 +5,8 @@ import pytest
 from django.test.utils import override_settings
 
 from sentry import quotas
-from sentry.event_manager import EventManager, HashDiscarded
+from sentry.event_manager import EventManager
+from sentry.exceptions import HashDiscarded
 from sentry.plugins.base.v2 import Plugin2
 from sentry.tasks.store import (
     preprocess_event,


### PR DESCRIPTION
This PR moves `HashDiscarded` (which is raised when we don't save an incoming event, intentionally or not) to the `exceptions` module. This is part of a larger refactoring of the `event_manager` code controlling grouping, and is necessary to prevent a future circular import.