### PR TITLE
feat(settings): add audit tracking for team remove

### DIFF
--- a/src/sentry/api/endpoints/project_team_details.py
+++ b/src/sentry/api/endpoints/project_team_details.py
@@ -2,6 +2,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import audit_log
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -93,5 +94,12 @@ class ProjectTeamDetailsEndpoint(ProjectEndpoint):
                 {"detail": ["You do not have permission to perform this action."]}, status=403
             )
         project.remove_team(team)
+        self.create_audit_entry(
+            request=self.request,
+            organization_id=project.organization_id,
+            target_object=project.id,
+            event=audit_log.get_event_id("PROJECT_TEAM_REMOVE"),
+            data={"team_slug": team_slug, "project_slug": project.slug},
+        )
 
         return Response(serialize(project, request.user, ProjectWithTeamSerializer()), status=200)

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -393,12 +393,12 @@ default_manager.add(
         template="added org auth token {name}",
     )
 )
+default_manager.add(events.ProjectOwnershipRuleEditAuditLogEvent())
 default_manager.add(
     AuditLogEvent(
-        event_id=177,
-        name="ORGAUTHTOKEN_REMOVE",
-        api_name="org-auth-token.remove",
-        template="removed org auth token {name}",
+        event_id=180,
+        name="PROJECT_TEAM_REMOVE",
+        api_name="project-team.remove",
+        template="removed team {team_slug} from project {project_slug}",
     )
 )
-default_manager.add(events.ProjectOwnershipRuleEditAuditLogEvent())

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -393,6 +393,14 @@ default_manager.add(
         template="added org auth token {name}",
     )
 )
+default_manager.add(
+    AuditLogEvent(
+        event_id=177,
+        name="ORGAUTHTOKEN_REMOVE",
+        api_name="org-auth-token.remove",
+        template="removed org auth token {name}",
+    )
+)
 default_manager.add(events.ProjectOwnershipRuleEditAuditLogEvent())
 default_manager.add(
     AuditLogEvent(

--- a/tests/sentry/audit_log/test_register.py
+++ b/tests/sentry/audit_log/test_register.py
@@ -82,6 +82,7 @@ class AuditLogEventRegisterTest(TestCase):
             "notification_action.remove",
             "team-and-project.created",
             "org-auth-token.create",
+            "org-auth-token.remove",
             "project-team.remove",
         ]
 

--- a/tests/sentry/audit_log/test_register.py
+++ b/tests/sentry/audit_log/test_register.py
@@ -82,7 +82,7 @@ class AuditLogEventRegisterTest(TestCase):
             "notification_action.remove",
             "team-and-project.created",
             "org-auth-token.create",
-            "org-auth-token.remove",
+            "project-team.remove",
         ]
 
         assert set(audit_log.get_api_names()) == set(audit_log_api_name_list)


### PR DESCRIPTION
Adds auditing to the team removal in a project. When clients have multiple teams in a project, and accidentally remove one team, it's hard to figure out which team was removed from which project. Adding an audit log helps quickly resolve and find that information.

https://github.com/getsentry/sentry/assets/5581484/97339ad9-8ea2-4aac-992e-88faa814ba56

