### PR TITLE
feat(alerts): Render environment dropdown inside the adopted release filter

### DIFF
--- a/fixtures/js-stubs/projectAlertRuleConfiguration.ts
+++ b/fixtures/js-stubs/projectAlertRuleConfiguration.ts
@@ -182,6 +182,32 @@ export function ProjectAlertRuleConfiguration(
         },
       },
       {
+        id: 'sentry.rules.filters.latest_adopted_release_filter.LatestAdoptedReleaseFilter',
+        label:
+          "The {oldest_or_newest} release associated with the event's issue is {older_or_newer} than the latest release in {environment}",
+        enabled: true,
+        formFields: {
+          oldest_or_newest: {
+            type: 'choice',
+            choices: [
+              ['oldest', 'oldest'],
+              ['newest', 'newest'],
+            ],
+          },
+          older_or_newer: {
+            type: 'choice',
+            choices: [
+              ['older', 'older'],
+              ['newer', 'newer'],
+            ],
+          },
+          environment: {
+            type: 'string',
+            placeholder: 'value',
+          },
+        },
+      },
+      {
         id: 'sentry.rules.filters.event_attribute.EventAttributeFilter',
         label: "The event's {attribute} value {match} {value}",
         enabled: true,

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -46,6 +46,7 @@ export const enum IssueAlertFilterType {
   AGE_COMPARISON = 'sentry.rules.filters.age_comparison.AgeComparisonFilter',
   ISSUE_OCCURRENCES = 'sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter',
   ASSIGNED_TO = 'sentry.rules.filters.assigned_to.AssignedToFilter',
+  LATEST_ADOPTED_RELEASE = 'sentry.rules.filters.latest_adopted_release_filter.LatestAdoptedReleaseFilter',
   LATEST_RELEASE = 'sentry.rules.filters.latest_release.LatestReleaseFilter',
   ISSUE_CATEGORY = 'sentry.rules.filters.issue_category.IssueCategoryFilter',
   EVENT_ATTRIBUTE = 'sentry.rules.filters.event_attribute.EventAttributeFilter',

--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -12,6 +12,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import {
@@ -118,6 +119,7 @@ const createWrapper = (props = {}) => {
 
 describe('IssueRuleEditor', function () {
   beforeEach(function () {
+    MockApiClient.clearMockResponses();
     browserHistory.replace = jest.fn();
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/rules/configuration/',
@@ -152,7 +154,6 @@ describe('IssueRuleEditor', function () {
   });
 
   afterEach(function () {
-    MockApiClient.clearMockResponses();
     jest.clearAllMocks();
     ProjectsStore.reset();
   });
@@ -362,6 +363,25 @@ describe('IssueRuleEditor', function () {
         )
       );
     });
+
+    it('renders environment selector in adopted release filter', async function () {
+      createWrapper({project: ProjectFixture({environments: ['production', 'staging']})});
+
+      // Add the adopted release filter
+      await selectEvent.select(
+        screen.getByText('Add optional filter...'),
+        /The {oldest_or_newest} release associated/
+      );
+
+      const filtersContainer = screen.getByTestId('rule-filters');
+
+      // Production environment is preselected because it's the first option.
+      // staging should also be selectable.
+      selectEvent.select(
+        within(filtersContainer).getAllByText('production')[0],
+        'staging'
+      );
+    });
   });
 
   describe('Edit Rule: Slack Channel Look Up', function () {
@@ -373,7 +393,6 @@ describe('IssueRuleEditor', function () {
 
     afterEach(function () {
       jest.clearAllTimers();
-      MockApiClient.clearMockResponses();
     });
 
     it('success status updates the rule', async function () {

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1297,7 +1297,7 @@ class IssueRuleEditor extends DeprecatedAsyncView<Props, State> {
                         />
                       </ChevronContainer>
 
-                      <StepContent>
+                      <StepContent data-test-id="rule-filters">
                         <StepLead>
                           {tct('[if:If][selector] of these filters match', {
                             if: <Badge />,

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useCallback, useEffect} from 'react';
 import styled from '@emotion/styled';
+import merge from 'lodash/merge';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {Alert} from 'sentry/components/alert';
@@ -278,6 +279,16 @@ function RuleNode({
       onPropertyChange,
       onReset,
     };
+
+    if (name === 'environment') {
+      return (
+        <ChoiceField
+          {...merge(fieldProps, {
+            fieldConfig: {choices: project.environments.map(env => [env, env])},
+          })}
+        />
+      );
+    }
 
     switch (fieldConfig.type) {
       case 'choice':


### PR DESCRIPTION
The new adopted release filter (`The {oldest_or_newest} release associated with...`) has been added, but the environment should allow the user to select from the list of project environments. It was decided that this was better done on the front end because the environment list can be extremely long in some cases. 

We already have the environments in `project.environments` so I just used that. In the future we will probably need to make this a searchable dropdown with a paginated API, but we that endpoint does not exist yet.

Before:

![CleanShot 2023-12-19 at 16 52 18](https://github.com/getsentry/sentry/assets/10888943/7f6fac3f-7a77-4ffd-9f29-6be025b8d2be)

After:

![CleanShot 2023-12-19 at 16 51 11](https://github.com/getsentry/sentry/assets/10888943/d62c0b78-b371-4035-830c-f63714038938)
