### PR TITLE
prefetch the thresholds in release index so we don't have rows jumping

### DIFF
--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -203,7 +203,8 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
     }
 
     fetchThresholdStatuses(organization, api, query).then(thresholdStatuses => {
-      this.setState({thresholdStatuses});
+      window.setTimeout(() => this.setState({thresholdStatuses}), 5000);
+      // this.setState({thresholdStatuses});
     });
   }
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -601,7 +601,7 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
                   isTopRelease={index === 0}
                   getHealthData={getHealthData}
                   showReleaseAdoptionStages={showReleaseAdoptionStages}
-                  thresholds={this.getThresholdsForRelease(release)} // TODO: filter by project, and environment
+                  thresholds={this.getThresholdsForRelease(release)}
                   thresholdStatuses={thresholdStatuses || {}}
                 />
               ))}

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -278,6 +278,9 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
   }
 
   getThresholdsForRelease(release: Release): Threshold[] {
+    if (!this.hasV2ReleaseUIEnabled) {
+      return [];
+    }
     const {thresholds} = this.state;
     const lastDeploy = release.lastDeploy;
     const projectSlugs = release.projects.map(p => p.slug);

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -54,7 +54,12 @@ import ReleaseFeedbackBanner from '../components/releaseFeedbackBanner';
 import ReleaseArchivedNotice from '../detail/overview/releaseArchivedNotice';
 import {isMobileRelease} from '../utils';
 import {fetchThresholdStatuses} from '../utils/fetchThresholdStatus';
-import {ThresholdStatus, ThresholdStatusesQuery} from '../utils/types';
+import {
+  Threshold,
+  ThresholdQuery,
+  ThresholdStatus,
+  ThresholdStatusesQuery,
+} from '../utils/types';
 
 import ReleaseCard from './releaseCard';
 import ReleasesAdoptionChart from './releasesAdoptionChart';
@@ -77,6 +82,7 @@ type Props = RouteComponentProps<RouteParams, {}> & {
 
 type State = {
   releases: Release[];
+  thresholds: Threshold[];
   thresholdStatuses?: {[key: string]: ThresholdStatus[]};
 } & DeprecatedAsyncView['state'];
 
@@ -92,7 +98,7 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
   }
 
   getEndpoints(): ReturnType<DeprecatedAsyncView['getEndpoints']> {
-    const {organization, location} = this.props;
+    const {organization, location, selection} = this.props;
     const {statsPeriod} = location.query;
     const activeSort = this.getSort();
     const activeStatus = this.getStatus();
@@ -117,6 +123,24 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
         {disableEntireQuery: true}, // options
       ],
     ];
+
+    if (this.hasV2ReleaseUIEnabled) {
+      const thresholdQuery: ThresholdQuery = {};
+      if (selection.projects.length) {
+        thresholdQuery.project = selection.projects;
+      } else {
+        thresholdQuery.project = [-1];
+      }
+      if (selection.environments.length) {
+        thresholdQuery.environment = selection.environments;
+      }
+
+      endpoints.push([
+        'thresholds',
+        `/organizations/${organization.slug}/release-thresholds/`,
+        {query: thresholdQuery},
+      ]);
+    }
 
     return endpoints;
   }
@@ -250,6 +274,19 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
 
   get projectHasSessions() {
     return this.getSelectedProject()?.hasSessions ?? null;
+  }
+
+  getThresholdsForRelease(release: Release): Threshold[] {
+    const {thresholds} = this.state;
+    const lastDeploy = release.lastDeploy;
+    const projectSlugs = release.projects.map(p => p.slug);
+
+    return thresholds.filter(
+      threshold =>
+        projectSlugs.includes(threshold.project.slug) &&
+        (lastDeploy && lastDeploy.environment) ===
+          (threshold.environment && threshold.environment.name)
+    );
   }
 
   handleSearch = (query: string) => {
@@ -561,6 +598,7 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
                   isTopRelease={index === 0}
                   getHealthData={getHealthData}
                   showReleaseAdoptionStages={showReleaseAdoptionStages}
+                  thresholds={this.getThresholdsForRelease(release)} // TODO: filter by project, and environment
                   thresholdStatuses={thresholdStatuses || {}}
                 />
               ))}

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -203,8 +203,7 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
     }
 
     fetchThresholdStatuses(organization, api, query).then(thresholdStatuses => {
-      window.setTimeout(() => this.setState({thresholdStatuses}), 5000);
-      // this.setState({thresholdStatuses});
+      this.setState({thresholdStatuses});
     });
   }
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -129,7 +129,7 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
       if (selection.projects.length) {
         thresholdQuery.project = selection.projects;
       } else {
-        thresholdQuery.project = [-1];
+        thresholdQuery.project = [ALL_ACCESS_PROJECTS];
       }
       if (selection.environments.length) {
         thresholdQuery.environment = selection.environments;
@@ -287,8 +287,7 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
     return thresholds.filter(
       threshold =>
         projectSlugs.includes(threshold.project.slug) &&
-        (lastDeploy && lastDeploy.environment) ===
-          (threshold.environment && threshold.environment.name)
+        lastDeploy?.environment === threshold.environment?.name
     );
   }
 

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -18,7 +18,7 @@ import {t, tct, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization, PageFilters, Release} from 'sentry/types';
 
-import {ThresholdStatus} from '../../utils/types';
+import {Threshold, ThresholdStatus} from '../../utils/types';
 import {ReleasesDisplayOption} from '../releasesDisplayOptions';
 import {ReleasesRequestRenderProps} from '../releasesRequest';
 
@@ -56,6 +56,7 @@ type Props = {
   showHealthPlaceholders: boolean;
   showReleaseAdoptionStages: boolean;
   thresholdStatuses: {[key: string]: ThresholdStatus[]};
+  thresholds: Threshold[];
 };
 
 function ReleaseCard({
@@ -70,6 +71,7 @@ function ReleaseCard({
   getHealthData,
   showReleaseAdoptionStages,
   thresholdStatuses,
+  thresholds,
 }: Props) {
   const {
     version,
@@ -94,16 +96,18 @@ function ReleaseCard({
     );
   }, [projects, selection.projects]);
 
-  const hasThresholds = useMemo(() => {
-    const project_slugs = projects.map(proj => proj.slug);
-    let has = false;
-    project_slugs.forEach(slug => {
-      if (`${slug}-${version}` in thresholdStatuses) {
-        has = thresholdStatuses[`${slug}-${version}`].length > 0;
-      }
-    });
-    return has;
-  }, [thresholdStatuses, version, projects]);
+  // const hasThresholds = useMemo(() => {
+  //   const project_slugs = projects.map(proj => proj.slug);
+  //   let has = false;
+  //   project_slugs.forEach(slug => {
+  //     if (`${slug}-${version}` in thresholdStatuses) {
+  //       has = thresholdStatuses[`${slug}-${version}`].length > 0;
+  //     }
+  //   });
+  //   return has;
+  // }, [thresholdStatuses, version, projects]);
+
+  const hasThresholds = thresholds.length > 0;
 
   const getHiddenProjectsTooltip = () => {
     const limitedProjects = projectsToHide.map(p => p.slug).slice(0, 5);
@@ -201,6 +205,7 @@ function ReleaseCard({
                   adoptionStages={adoptionStages}
                   getHealthData={getHealthData}
                   hasThresholds={hasThresholds}
+                  expectedThresholds={thresholds.length}
                   index={index}
                   isTopRelease={isTopRelease}
                   location={location}

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -96,17 +96,6 @@ function ReleaseCard({
     );
   }, [projects, selection.projects]);
 
-  // const hasThresholds = useMemo(() => {
-  //   const project_slugs = projects.map(proj => proj.slug);
-  //   let has = false;
-  //   project_slugs.forEach(slug => {
-  //     if (`${slug}-${version}` in thresholdStatuses) {
-  //       has = thresholdStatuses[`${slug}-${version}`].length > 0;
-  //     }
-  //   });
-  //   return has;
-  // }, [thresholdStatuses, version, projects]);
-
   const hasThresholds = thresholds.length > 0;
 
   const getHiddenProjectsTooltip = () => {
@@ -198,6 +187,9 @@ function ReleaseCard({
           >
             {projectsToShow.map((project, index) => {
               const key = `${project.slug}-${version}`;
+              const projectThresholds = thresholds.filter(
+                threshold => threshold.project.slug === project.slug
+              );
               return (
                 <ReleaseCardProjectRow
                   key={`${key}-row`}
@@ -205,7 +197,7 @@ function ReleaseCard({
                   adoptionStages={adoptionStages}
                   getHealthData={getHealthData}
                   hasThresholds={hasThresholds}
-                  expectedThresholds={thresholds.length}
+                  expectedThresholds={projectThresholds.length}
                   index={index}
                   isTopRelease={isTopRelease}
                   location={location}

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -62,6 +62,7 @@ function getCrashFreeIcon(crashFreePercent: number, iconSize: IconSize = 'sm') {
 
 type Props = {
   activeDisplay: ReleasesDisplayOption;
+  expectedThresholds: number;
   getHealthData: ReleasesRequestRenderProps['getHealthData'];
   hasThresholds: boolean;
   index: number;
@@ -80,6 +81,7 @@ type Props = {
 function ReleaseCardProjectRow({
   activeDisplay,
   adoptionStages,
+  expectedThresholds,
   getHealthData,
   hasThresholds,
   index,
@@ -239,7 +241,7 @@ function ReleaseCardProjectRow({
         {hasThresholds && (
           <DisplaySmallCol>
             {/* TODO: link to release details page */}
-            {thresholds && thresholds.length > 0 && (
+            {expectedThresholds && (
               <Tooltip
                 title={
                   <div>
@@ -255,15 +257,24 @@ function ReleaseCardProjectRow({
                           t('still pending')}
                       </div>
                     )}
+                    {thresholds.length !== expectedThresholds && (
+                      <div>{`... / ${expectedThresholds}`}</div>
+                    )}
                     {t('Open in Release Details')}
                   </div>
                 }
               >
                 <ThresholdHealth
-                  allHealthy={healthyThresholds.length === thresholds.length}
-                  allThresholdsFinished={pendingThresholds.length === 0}
+                  allHealthy={healthyThresholds.length === expectedThresholds}
+                  allThresholdsFinished={
+                    pendingThresholds.length === 0 &&
+                    thresholds.length === expectedThresholds
+                  }
                 >
-                  {healthyThresholds.length} / {thresholds && thresholds.length}
+                  {thresholds.length === expectedThresholds
+                    ? healthyThresholds.length
+                    : '...'}{' '}
+                  / {expectedThresholds}
                 </ThresholdHealth>
               </Tooltip>
             )}


### PR DESCRIPTION
Fetches the thresholds from the releases page and pre-populates the columns on the table so a slow request to threshold-statuses won't make the columns jump around

https://github.com/getsentry/sentry/assets/6186377/8502f5aa-9dc3-47ca-b2b3-3ad68b830ab4


