### PR TITLE
ref(onboarding-docs): Migrate python docs to new structure

### DIFF
--- a/static/app/gettingStartedDocs/python/awslambda.spec.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.spec.tsx
@@ -1,18 +1,37 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './awslambda';
 
-import {GettingStartedWithAwsLambda, steps} from './awslambda';
-
-describe('GettingStartedWithAwsLambda', function () {
+describe('awslambda onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithAwsLambda dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({sentryInitContent: 'test-init-content', dsn: 'test-dsn'})) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Timeout Warning'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
+    ).toBeInTheDocument();
+  });
+
+  it('renders without performance monitoring', function () {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [],
+    });
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profiles_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/awslambda.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.tsx
@@ -1,174 +1,143 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
+import {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
-// Configuration Start
-const performanceConfiguration = `    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,`;
+type Params = DocsParams;
 
-const profilingConfiguration = `    # Set profiles_sample_rate to 1.0 to profile 100%
+const getSdkSetupSnippet = (params: Params) => `
+import sentry_sdk
+from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
+
+sentry_sdk.init(
+    dsn="${params.dsn}",
+    integrations=[AwsLambdaIntegration()],${
+      params.isPerformanceSelected
+        ? `
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,`
+        : ''
+    }${
+      params.isProfilingSelected
+        ? `
+    # Set profiles_sample_rate to 1.0 to profile 100%
     # of sampled transactions.
     # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,`;
+    profiles_sample_rate=1.0,`
+        : ''
+    }
+)
 
-const introduction = (
-  <p>
-    {tct(
+def my_function(event, context):
+    ....`;
+
+const getTimeoutWarningSnippet = (params: Params) => `
+sentry_sdk.init(
+  dsn="${params.dsn}",
+  integrations=[
+      AwsLambdaIntegration(timeout_warning=True),
+  ],
+)`;
+
+const onboarding: OnboardingConfig = {
+  introduction: () =>
+    tct(
       'Create a deployment package on your local machine and install the required dependencies in the deployment package. For more information, see [link:AWS Lambda deployment package in Python].',
       {
         link: (
           <ExternalLink href="https://docs.aws.amazon.com/lambda/latest/dg/python-package.html" />
         ),
       }
-    )}
-  </p>
-);
-
-export const steps = ({
-  dsn,
-  sentryInitContent,
-}: {
-  dsn: string;
-  sentryInitContent: string;
-}): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: (
-      <p>{tct('Install our Python SDK using [code:pip]:', {code: <code />})}</p>
     ),
-    configurations: [
-      {
-        language: 'bash',
-        code: 'pip install --upgrade sentry-sdk',
-      },
-    ],
-  },
-  {
-    type: StepType.CONFIGURE,
-    description: t(
-      'You can use the AWS Lambda integration for the Python SDK like this:'
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `
-import sentry_sdk
-from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
-
-sentry_sdk.init(
-${sentryInitContent}
-)
-
-def my_function(event, context):
-    ....
-        `,
-      },
-    ],
-    additionalInfo: (
-      <p>
-        {tct("Check out Sentry's [link:AWS sample apps] for detailed examples.", {
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct('Install our Python SDK using [code:pip]:', {code: <code />}),
+      configurations: [
+        {
+          language: 'bash',
+          code: 'pip install --upgrade sentry-sdk',
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      description: t(
+        'You can use the AWS Lambda integration for the Python SDK like this:'
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: getSdkSetupSnippet(params),
+        },
+      ],
+      additionalInfo: tct(
+        "Check out Sentry's [link:AWS sample apps] for detailed examples.",
+        {
           link: (
             <ExternalLink href="https://github.com/getsentry/examples/tree/master/aws-lambda/python" />
           ),
-        })}
-      </p>
-    ),
-  },
-  {
-    title: t('Timeout Warning'),
-    description: (
-      <p>
-        {tct(
-          'The timeout warning reports an issue when the function execution time is near the [link:configured timeout].',
-          {
-            link: (
-              <ExternalLink href="https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html" />
-            ),
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        description: (
-          <p>
-            {tct(
-              'To enable the warning, update the SDK initialization to set [codeTimeout:timeout_warning] to [codeStatus:true]:',
-              {codeTimeout: <code />, codeStatus: <code />}
-            )}
-          </p>
-        ),
-        language: 'python',
-        code: `
-sentry_sdk.init(
-  dsn="${dsn}",
-  integrations=[
-      AwsLambdaIntegration(timeout_warning=True),
+        }
+      ),
+    },
+    {
+      title: t('Timeout Warning'),
+      description: tct(
+        'The timeout warning reports an issue when the function execution time is near the [link:configured timeout].',
+        {
+          link: (
+            <ExternalLink href="https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html" />
+          ),
+        }
+      ),
+      configurations: [
+        {
+          description: tct(
+            'To enable the warning, update the SDK initialization to set [codeTimeout:timeout_warning] to [codeStatus:true]:',
+            {codeTimeout: <code />, codeStatus: <code />}
+          ),
+          language: 'python',
+          code: getTimeoutWarningSnippet(params),
+        },
+        {
+          description: t(
+            'The timeout warning is sent only if the timeout in the Lambda Function configuration is set to a value greater than one second.'
+          ),
+        },
+      ],
+      additionalInfo: (
+        <AlertWithMarginBottom type="info">
+          {tct(
+            'If you are using another web framework inside of AWS Lambda, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [link:Integrations] for more information.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/#integrations" />
+              ),
+            }
+          )}
+        </AlertWithMarginBottom>
+      ),
+    },
   ],
-)
-        `,
-      },
-    ],
-    additionalInfo: t(
-      'The timeout warning is sent only if the timeout in the Lambda Function configuration is set to a value greater than one second.'
-    ),
-  },
-];
-// Configuration End
+  verify: () => [],
+};
 
-export function GettingStartedWithAwsLambda({
-  dsn,
-  activeProductSelection = [],
-  ...props
-}: ModuleProps) {
-  const otherConfigs: string[] = [];
+const docs: Docs = {
+  onboarding,
+};
 
-  let sentryInitContent: string[] = [
-    `    dsn="${dsn}",`,
-    `    integrations=[AwsLambdaIntegration()],`,
-  ];
-
-  if (activeProductSelection.includes(ProductSolution.PERFORMANCE_MONITORING)) {
-    otherConfigs.push(performanceConfiguration);
-  }
-
-  if (activeProductSelection.includes(ProductSolution.PROFILING)) {
-    otherConfigs.push(profilingConfiguration);
-  }
-
-  sentryInitContent = sentryInitContent.concat(otherConfigs);
-
-  return (
-    <Fragment>
-      <Layout
-        introduction={introduction}
-        steps={steps({dsn, sentryInitContent: sentryInitContent.join('\n')})}
-        {...props}
-      />
-      <AlertWithMarginBottom type="info">
-        {tct(
-          'If you are using another web framework inside of AWS Lambda, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [link:Integrations] for more information.',
-          {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/platforms/python/#integrations" />
-            ),
-          }
-        )}
-      </AlertWithMarginBottom>
-    </Fragment>
-  );
-}
-
-export default GettingStartedWithAwsLambda;
+export default docs;
 
 const AlertWithMarginBottom = styled(Alert)`
   margin-top: ${space(2)};

--- a/static/app/gettingStartedDocs/python/celery.spec.tsx
+++ b/static/app/gettingStartedDocs/python/celery.spec.tsx
@@ -1,18 +1,39 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './celery';
 
-import {GettingStartedWithCelery, steps} from './celery';
-
-describe('GettingStartedWithCelery', function () {
+describe('celery onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithCelery dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({sentryInitContent: 'test-init-content'})) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Standalone Setup'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Setup With Django'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
+    ).toBeInTheDocument();
+  });
+
+  it('renders without performance monitoring', function () {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [],
+    });
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profiles_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -4,204 +4,184 @@ import styled from '@emotion/styled';
 import Alert from 'sentry/components/alert';
 import {CodeSnippet} from 'sentry/components/codeSnippet';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
+import type {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
-// Configuration Start
-const performanceConfiguration = `    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,`;
+type Params = DocsParams;
 
-const profilingConfiguration = `    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,`;
-
-const introduction = (
-  <p>
-    {tct('The celery integration adds support for the [link:Celery Task Queue System].', {
-      link: <ExternalLink href="https://docs.celeryq.dev/en/stable/" />,
-    })}
-  </p>
-);
-
-export const steps = ({
-  sentryInitContent,
-}: {
-  sentryInitContent: string;
-}): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: (
-      <p>
-        {tct('Install [code:sentry-sdk] from PyPI with the [code:celery] extra:', {
-          code: <code />,
-        })}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'bash',
-        code: 'pip install --upgrade sentry-sdk[celery]',
-      },
-    ],
-  },
-  {
-    type: StepType.CONFIGURE,
-    description: (
-      <div>
-        <p>
-          {tct(
-            'If you have the [code:celery] package in your dependencies, the Celery integration will be enabled automatically when you initialize the Sentry SDK.',
-            {
-              code: <code />,
-            }
-          )}
-        </p>
-        <p>
-          {tct(
-            'Make sure that the call to [code:init] is loaded on worker startup, and not only in the module where your tasks are defined. Otherwise, the initialization happens too late and events might end up not being reported.',
-            {
-              code: <code />,
-            }
-          )}
-        </p>
-      </div>
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `
+const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 
 sentry_sdk.init(
-${sentryInitContent}
-)
-      `,
-      },
-    ],
-    additionalInfo: (
-      <Fragment>
-        <h5>{t('Standalone Setup')}</h5>
-        {t("If you're using Celery standalone, there are two ways to set this up:")}
-        <ul>
-          <li>
+    dsn="${params.dsn}",${
+      params.isPerformanceSelected
+        ? `
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,`
+        : ''
+    }${
+      params.isProfilingSelected
+        ? `
+    # Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production.
+    profiles_sample_rate=1.0,`
+        : ''
+    }
+)`;
+
+const onboarding: OnboardingConfig = {
+  introduction: () =>
+    tct('The celery integration adds support for the [link:Celery Task Queue System].', {
+      link: <ExternalLink href="https://docs.celeryq.dev/en/stable/" />,
+    }),
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'Install [code:sentry-sdk] from PyPI with the [code:celery] extra:',
+        {
+          code: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: 'pip install --upgrade sentry-sdk[celery]',
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      description: (
+        <div>
+          <p>
             {tct(
-              "Initializing the SDK in the configuration file loaded with Celery's [code:--config] parameter",
+              'If you have the [code:celery] package in your dependencies, the Celery integration will be enabled automatically when you initialize the Sentry SDK.',
               {
                 code: <code />,
               }
             )}
-          </li>
-          <li>
+          </p>
+          <p>
             {tct(
-              'Initializing the SDK by hooking it to either the [celerydInit: celeryd_init] or [workerInit: worker_init] signals:',
+              'Make sure that the call to [code:init] is loaded on worker startup, and not only in the module where your tasks are defined. Otherwise, the initialization happens too late and events might end up not being reported.',
               {
-                celerydInit: (
-                  <ExternalLink href="https://docs.celeryq.dev/en/stable/userguide/signals.html?#celeryd-init" />
+                code: <code />,
+              }
+            )}
+          </p>
+        </div>
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: getSdkSetupSnippet(params),
+        },
+      ],
+      additionalInfo: (
+        <Fragment>
+          <h5>{t('Standalone Setup')}</h5>
+          {t("If you're using Celery standalone, there are two ways to set this up:")}
+          <ul>
+            <li>
+              {tct(
+                "Initializing the SDK in the configuration file loaded with Celery's [code:--config] parameter",
+                {
+                  code: <code />,
+                }
+              )}
+            </li>
+            <li>
+              {tct(
+                'Initializing the SDK by hooking it to either the [celerydInit: celeryd_init] or [workerInit: worker_init] signals:',
+                {
+                  celerydInit: (
+                    <ExternalLink href="https://docs.celeryq.dev/en/stable/userguide/signals.html?#celeryd-init" />
+                  ),
+                  workerInit: (
+                    <ExternalLink href="https://docs.celeryq.dev/en/stable/userguide/signals.html?#worker-init" />
+                  ),
+                }
+              )}
+              <CodeSnippet dark language="python">
+                {`import sentry_sdk
+  from celery import Celery, signals
+
+  app = Celery("myapp")
+
+  #@signals.worker_init.connect
+  @signals.celeryd_init.connect
+  def init_sentry(**_kwargs):
+      sentry_sdk.init(...)  # same as above
+                `}
+              </CodeSnippet>
+            </li>
+          </ul>
+          <h5>{t('Setup With Django')}</h5>
+          <p>
+            {tct(
+              "If you're using Celery with Django in a conventional setup, have already initialized the SDK in [settingsLink:your settings.py], and have Celery using the same settings with [celeryDocsLinks:config_from_object], you don't need to initialize the SDK separately for Celery.",
+              {
+                settingsLink: (
+                  <ExternalLink href="https://docs.sentry.io/platforms/python/guides/django/#configure" />
                 ),
-                workerInit: (
-                  <ExternalLink href="https://docs.celeryq.dev/en/stable/userguide/signals.html?#worker-init" />
+                celeryDocsLinks: (
+                  <ExternalLink href="https://docs.celeryq.dev/en/stable/django/first-steps-with-django.html" />
                 ),
               }
             )}
-            <CodeSnippet dark language="python">
-              {`import sentry_sdk
-from celery import Celery, signals
+          </p>
+        </Fragment>
+      ),
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: (
+        <Fragment>
+          <p>
+            {t(
+              "To verify if your SDK is initialized on worker start, you can pass `debug=True` to `sentry_sdk.init()` to see extra output when the SDK is initialized. If the output appears during worker startup and not only after a task has started, then it's working properly."
+            )}
+          </p>
+          <AlertWithMarginBottom type="info">
+            {tct(
+              `Sentry uses custom message headers for distributed tracing. For Celery versions 4.x, with [celeryDocLink: message protocol of version 1], this functionality is broken, and Celery fails to propagate custom headers to the worker. Protocol version 2, which is the default since Celery version 4.0, is not affected.
 
-app = Celery("myapp")
+              The fix for the custom headers propagation issue was introduced to Celery project ([celeryPRLink: PR]) starting with version 5.0.1. However, the fix was not backported to versions 4.x.
+              `,
+              {
+                celeryDocLink: (
+                  <ExternalLink href="https://docs.celeryq.dev/en/stable/internals/protocol.html#version-1" />
+                ),
+                celeryPRLink: (
+                  <ExternalLink href="https://github.com/celery/celery/pull/6374" />
+                ),
+              }
+            )}
+          </AlertWithMarginBottom>
+        </Fragment>
+      ),
+    },
+  ],
+};
 
-#@signals.worker_init.connect
-@signals.celeryd_init.connect
-def init_sentry(**_kwargs):
-    sentry_sdk.init(...)  # same as above
-              `}
-            </CodeSnippet>
-          </li>
-        </ul>
-        <h5>{t('Setup With Django')}</h5>
-        <p>
-          {tct(
-            "If you're using Celery with Django in a conventional setup, have already initialized the SDK in [settingsLink:your settings.py], and have Celery using the same settings with [celeryDocsLinks:config_from_object], you don't need to initialize the SDK separately for Celery.",
-            {
-              settingsLink: (
-                <ExternalLink href="https://docs.sentry.io/platforms/python/guides/django/#configure" />
-              ),
-              celeryDocsLinks: (
-                <ExternalLink href="https://docs.celeryq.dev/en/stable/django/first-steps-with-django.html" />
-              ),
-            }
-          )}
-        </p>
-      </Fragment>
-    ),
-  },
-  {
-    type: StepType.VERIFY,
-    description: (
-      <div>
-        <p>
-          {t(
-            "To verify if your SDK is initialized on worker start, you can pass `debug=True` to `sentry_sdk.init()` to see extra output when the SDK is initialized. If the output appears during worker startup and not only after a task has started, then it's working properly."
-          )}
-        </p>
-        <AlertWithMarginBottom type="info">
-          {tct(
-            `Sentry uses custom message headers for distributed tracing. For Celery versions 4.x, with [celeryDocLink: message protocol of version 1], this functionality is broken, and Celery fails to propagate custom headers to the worker. Protocol version 2, which is the default since Celery version 4.0, is not affected.
+const docs: Docs = {
+  onboarding,
+};
 
-            The fix for the custom headers propagation issue was introduced to Celery project ([celeryPRLink: PR]) starting with version 5.0.1. However, the fix was not backported to versions 4.x.
-            `,
-            {
-              celeryDocLink: (
-                <ExternalLink href="https://docs.celeryq.dev/en/stable/internals/protocol.html#version-1" />
-              ),
-              celeryPRLink: (
-                <ExternalLink href="https://github.com/celery/celery/pull/6374" />
-              ),
-            }
-          )}
-        </AlertWithMarginBottom>
-      </div>
-    ),
-  },
-];
-// Configuration End
-
-export function GettingStartedWithCelery({
-  dsn,
-  activeProductSelection = [],
-  ...props
-}: ModuleProps) {
-  const otherConfigs: string[] = [];
-
-  let sentryInitContent: string[] = [`    dsn="${dsn}",`];
-
-  if (activeProductSelection.includes(ProductSolution.PERFORMANCE_MONITORING)) {
-    otherConfigs.push(performanceConfiguration);
-  }
-
-  if (activeProductSelection.includes(ProductSolution.PROFILING)) {
-    otherConfigs.push(profilingConfiguration);
-  }
-
-  sentryInitContent = sentryInitContent.concat(otherConfigs);
-
-  return (
-    <Layout
-      introduction={introduction}
-      steps={steps({
-        sentryInitContent: sentryInitContent.join('\n'),
-      })}
-      {...props}
-    />
-  );
-}
-
-export default GettingStartedWithCelery;
+export default docs;
 
 const AlertWithMarginBottom = styled(Alert)`
   margin-top: ${space(2)};

--- a/static/app/gettingStartedDocs/python/chalice.spec.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.spec.tsx
@@ -1,18 +1,39 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './chalice';
 
-import {GettingStartedWithChalice, steps} from './chalice';
-
-describe('GettingStartedWithChalice', function () {
+describe('chalice onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithChalice dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({sentryInitContent: 'test-init-content'})) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(/pip install --upgrade sentry-sdk\[chalice\]/)
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders without performance monitoring', function () {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [],
+    });
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profiles_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -1,74 +1,42 @@
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import type {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 
-// Configuration Start
-export const steps = ({
-  sentryInitContent,
-}: {
-  sentryInitContent: string;
-}): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: (
-      <p>
-        {tct(
-          'Install [sentrySdkCode:sentry-sdk] from PyPI with the [sentryBotteCode:chalice] extra:',
-          {
-            sentrySdkCode: <code />,
-            sentryBotteCode: <code />,
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'bash',
-        code: 'pip install --upgrade sentry-sdk[chalice]',
-      },
-    ],
-  },
-  {
-    type: StepType.CONFIGURE,
-    description: t(
-      'To configure the SDK, initialize it with the integration before or after your app has been initialized:'
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `
+type Params = DocsParams;
+
+const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 from chalice import Chalice
 
 from sentry_sdk.integrations.chalice import ChaliceIntegration
 
-
 sentry_sdk.init(
-${sentryInitContent}
+    dsn="${params.dsn}",
+    integrations=[ChaliceIntegration()],${
+      params.isPerformanceSelected
+        ? `
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,`
+        : ''
+    }${
+      params.isProfilingSelected
+        ? `
+    # Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production.
+    profiles_sample_rate=1.0,`
+        : ''
+    }
 )
 
-app = Chalice(app_name="appname")
-      `,
-      },
-    ],
-  },
-  {
-    type: StepType.VERIFY,
-    description: (
-      <p>{t('To verify that everything is working trigger an error on purpose:')}</p>
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `from chalice import Chalice
+app = Chalice(app_name="appname")`;
 
-sentry_sdk.init(
-${sentryInitContent}
-)
-
-app = Chalice(app_name="helloworld")
-
+const getVerifySnippet = () => `
 @app.schedule(Rate(1, unit=Rate.MINUTES))
 def every_minute(event):
     1/0  # raises an error
@@ -76,40 +44,63 @@ def every_minute(event):
 @app.route("/")
 def index():
     1/0  # raises an error
-    return {"hello": "world"}`,
-      },
-    ],
-    additionalInfo: (
-      <p>
-        {tct(
-          'When you enter the [code:"/"] route or the scheduled task is run, an error event will be sent to Sentry.',
-          {
-            code: <code />,
-          }
-        )}
-      </p>
-    ),
-  },
-];
-// Configuration End
+    return {"hello": "world"}`;
 
-export function GettingStartedWithChalice({dsn, ...props}: ModuleProps) {
-  const otherConfigs: string[] = [];
+const onboarding: OnboardingConfig = {
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'Install [sentrySdkCode:sentry-sdk] from PyPI with the [sentryBotteCode:chalice] extra:',
+        {
+          sentrySdkCode: <code />,
+          sentryBotteCode: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: 'pip install --upgrade sentry-sdk[chalice]',
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      description: t(
+        'To configure the SDK, initialize it with the integration before or after your app has been initialized:'
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: getSdkSetupSnippet(params),
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: t('To verify that everything is working trigger an error on purpose:'),
+      configurations: [
+        {
+          language: 'python',
+          code: getVerifySnippet(),
+        },
+      ],
+      additionalInfo: tct(
+        'When you enter the [code:"/"] route or the scheduled task is run, an error event will be sent to Sentry.',
+        {
+          code: <code />,
+        }
+      ),
+    },
+  ],
+};
 
-  let sentryInitContent: string[] = [
-    `    dsn="${dsn}",`,
-    `    integrations=[ChaliceIntegration()],`,
-  ];
+const docs: Docs = {
+  onboarding,
+};
 
-  sentryInitContent = sentryInitContent.concat(otherConfigs);
-
-  return (
-    <Layout
-      steps={steps({
-        sentryInitContent: sentryInitContent.join('\n'),
-      })}
-      {...props}
-    />
-  );
-}
-export default GettingStartedWithChalice;
+export default docs;

--- a/static/app/gettingStartedDocs/python/gcpfunctions.spec.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.spec.tsx
@@ -1,18 +1,37 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './gcpfunctions';
 
-import {GettingStartedWithGCPFunctions, steps} from './gcpfunctions';
-
-describe('GettingStartedWithGCPFunctions', function () {
+describe('gcpfunctions onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithGCPFunctions dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({sentryInitContent: 'test-init-content', dsn: 'test-dsn'})) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Timeout Warning'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
+    ).toBeInTheDocument();
+  });
+
+  it('renders without performance monitoring', function () {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [],
+    });
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profiles_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -1,160 +1,136 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
 import ExternalLink from 'sentry/components/links/externalLink';
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
+import type {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
-// Configuration Start
-const performanceConfiguration = `    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,`;
+type Params = DocsParams;
 
-const profilingConfiguration = `    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,`;
-
-export const steps = ({
-  dsn,
-  sentryInitContent,
-}: {
-  dsn: string;
-  sentryInitContent: string;
-}): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: (
-      <p>{tct('Install our Python SDK using [code:pip]:', {code: <code />})}</p>
-    ),
-    configurations: [
-      {
-        language: 'bash',
-        code: 'pip install --upgrade sentry-sdk',
-      },
-    ],
-  },
-  {
-    type: StepType.CONFIGURE,
-    description: t(
-      'You can use the Google Cloud Functions integration for the Python SDK like this:'
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `
+const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 from sentry_sdk.integrations.gcp import GcpIntegration
 
 sentry_sdk.init(
-${sentryInitContent}
+    dsn="${params.dsn}",
+    integrations=[GcpIntegration()],${
+      params.isPerformanceSelected
+        ? `
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,`
+        : ''
+    }${
+      params.isProfilingSelected
+        ? `
+    # Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production.
+    profiles_sample_rate=1.0,`
+        : ''
+    }
 )
 
 def http_function_entrypoint(request):
-    ...
-        `,
-      },
-    ],
-    additionalInfo: (
-      <p>
-        {tct("Check out Sentry's [link:GCP sample apps] for detailed examples.", {
-          link: (
-            <ExternalLink href="https://github.com/getsentry/examples/tree/master/gcp-cloud-functions" />
-          ),
-        })}
-      </p>
-    ),
-  },
-  {
-    title: t('Timeout Warning'),
-    description: (
-      <p>
-        {tct(
-          'The timeout warning reports an issue when the function execution time is near the [link:configured timeout].',
-          {
-            link: (
-              <ExternalLink href="https://cloud.google.com/functions/docs/concepts/execution-environment#timeout" />
-            ),
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        description: (
-          <p>
-            {tct(
-              'To enable the warning, update the SDK initialization to set [codeTimeout:timeout_warning] to [codeStatus:true]:',
-              {codeTimeout: <code />, codeStatus: <code />}
-            )}
-          </p>
-        ),
-        language: 'python',
-        code: `
+    ...`;
+
+const getTimeoutWarningSnippet = (params: Params) => `
 sentry_sdk.init(
-    dsn="${dsn}",
+    dsn="${params.dsn}",
     integrations=[
         GcpIntegration(timeout_warning=True),
     ],
-)
-        `,
-      },
-    ],
-    additionalInfo: t(
-      'The timeout warning is sent only if the timeout in the Cloud Function configuration is set to a value greater than one second.'
-    ),
-  },
-];
-// Configuration End
+)`;
 
-export function GettingStartedWithGCPFunctions({
-  dsn,
-  activeProductSelection = [],
-  ...props
-}: ModuleProps) {
-  const otherConfigs: string[] = [];
+const onboarding: OnboardingConfig = {
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: (
+        <p>{tct('Install our Python SDK using [code:pip]:', {code: <code />})}</p>
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: 'pip install --upgrade sentry-sdk',
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      description: t(
+        'You can use the Google Cloud Functions integration for the Python SDK like this:'
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: getSdkSetupSnippet(params),
+        },
+      ],
+      additionalInfo: tct(
+        "Check out Sentry's [link:GCP sample apps] for detailed examples.",
+        {
+          link: (
+            <ExternalLink href="https://github.com/getsentry/examples/tree/master/gcp-cloud-functions" />
+          ),
+        }
+      ),
+    },
+    {
+      title: t('Timeout Warning'),
+      description: tct(
+        'The timeout warning reports an issue when the function execution time is near the [link:configured timeout].',
+        {
+          link: (
+            <ExternalLink href="https://cloud.google.com/functions/docs/concepts/execution-environment#timeout" />
+          ),
+        }
+      ),
+      configurations: [
+        {
+          description: tct(
+            'To enable the warning, update the SDK initialization to set [codeTimeout:timeout_warning] to [codeStatus:true]:',
+            {codeTimeout: <code />, codeStatus: <code />}
+          ),
+          language: 'python',
+          code: getTimeoutWarningSnippet(params),
+        },
+        {
+          description: t(
+            'The timeout warning is sent only if the timeout in the Cloud Function configuration is set to a value greater than one second.'
+          ),
+        },
+      ],
+      additionalInfo: (
+        <AlertWithMarginBottom type="info">
+          {tct(
+            'If you are using a web framework in your Cloud Function, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [link:Integrations] for more information.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/#integrations" />
+              ),
+            }
+          )}
+        </AlertWithMarginBottom>
+      ),
+    },
+  ],
+  verify: () => [],
+};
 
-  let sentryInitContent: string[] = [
-    `    dsn="${dsn}",`,
-    `    integrations=[GcpIntegration()],`,
-  ];
+const docs: Docs = {
+  onboarding,
+};
 
-  if (activeProductSelection.includes(ProductSolution.PERFORMANCE_MONITORING)) {
-    otherConfigs.push(performanceConfiguration);
-  }
-
-  if (activeProductSelection.includes(ProductSolution.PROFILING)) {
-    otherConfigs.push(profilingConfiguration);
-  }
-
-  sentryInitContent = sentryInitContent.concat(otherConfigs);
-
-  return (
-    <Fragment>
-      <Layout
-        steps={steps({dsn, sentryInitContent: sentryInitContent.join('\n')})}
-        {...props}
-      />
-      <AlertWithMarginBottom type="info">
-        {tct(
-          'If you are using a web framework in your Cloud Function, the framework might catch those exceptions before we get to see them. Make sure to enable the framework specific integration as well, if one exists. See [link:Integrations] for more information.',
-          {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/platforms/python/#integrations" />
-            ),
-          }
-        )}
-      </AlertWithMarginBottom>
-    </Fragment>
-  );
-}
-
-export default GettingStartedWithGCPFunctions;
+export default docs;
 
 const AlertWithMarginBottom = styled(Alert)`
   margin-top: ${space(2)};

--- a/static/app/gettingStartedDocs/python/pylons.spec.tsx
+++ b/static/app/gettingStartedDocs/python/pylons.spec.tsx
@@ -1,18 +1,21 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './pylons';
 
-import {GettingStartedWithPylons, steps} from './pylons';
-
-describe('GettingStartedWithPylons', function () {
+describe('pylons onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithPylons dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps()) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Logger setup'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(textWithMarkupMatcher(/pip install raven --upgrade/))
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/pylons.tsx
+++ b/static/app/gettingStartedDocs/python/pylons.tsx
@@ -1,72 +1,25 @@
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import type {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 
-// Configuration Start
-export const steps = ({
-  dsn,
-}: Partial<Pick<ModuleProps, 'dsn'>> = {}): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: (
-      <p>
-        {tct(
-          'If you haven’t already, start by downloading Raven. The easiest way is with [code:pip]:',
-          {code: <code />}
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'bash',
-        code: 'pip install raven --upgrade',
-      },
-    ],
-  },
-  {
-    title: t('WSGI Middleware'),
-    configurations: [
-      {
-        language: 'python',
-        description: t(
-          'A Pylons-specific middleware exists to enable easy configuration from settings:'
-        ),
-        code: `
+type Params = DocsParams;
+
+const getMidlewareSetupSnippet = () => `
 from raven.contrib.pylons import Sentry
 
-application = Sentry(application, config)
-      `,
-      },
-      {
-        language: 'ini',
-        description: t('Configuration is handled via the sentry namespace:'),
-        code: `
+application = Sentry(application, config)`;
+
+const getConfigurationSnippet = (params: Params) => `
 [sentry]
-dsn=${dsn}
+dsn=${params.dsn}
 include_paths=my.package,my.other.package,
-exclude_paths=my.package.crud
-      `,
-      },
-    ],
-  },
-  {
-    title: t('Logger setup'),
-    configurations: [
-      {
-        language: 'python',
-        description: (
-          <p>
-            {tct(
-              'Add the following lines to your project’s [initCode:.ini] file to setup [sentryHandlerCode:SentryHandler]:',
-              {
-                initCode: <code />,
-                sentryHandlerCode: <code />,
-              }
-            )}
-          </p>
-        ),
-        code: `
+exclude_paths=my.package.crud`;
+
+const getLoggerSnippet = () => `
 [loggers]
 keys = root, sentry
 
@@ -100,17 +53,65 @@ formatter = generic
 
 [formatter_generic]
 format = %(asctime)s,%(msecs)03d %(levelname)-5.5s [%(name)s] %(message)s
-datefmt = %H:%M:%S
-      `,
-      },
-    ],
-    additionalInfo: t('You may want to set up other loggers as well.'),
-  },
-];
-// Configuration End
+datefmt = %H:%M:%S`;
 
-export function GettingStartedWithPylons({dsn, ...props}: ModuleProps) {
-  return <Layout steps={steps({dsn})} {...props} />;
-}
+const onboarding: OnboardingConfig = {
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'If you haven’t already, start by downloading Raven. The easiest way is with [code:pip]:',
+        {code: <code />}
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: 'pip install raven --upgrade',
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      configurations: [
+        {
+          language: 'python',
+          description: t(
+            'A Pylons-specific middleware exists to enable easy configuration from settings:'
+          ),
+          code: getMidlewareSetupSnippet(),
+        },
+        {
+          language: 'ini',
+          description: t('Configuration is handled via the sentry namespace:'),
+          code: getConfigurationSnippet(params),
+        },
+      ],
+    },
+    {
+      title: t('Logger setup'),
+      configurations: [
+        {
+          language: 'python',
+          description: tct(
+            'Add the following lines to your project’s [initCode:.ini] file to setup [sentryHandlerCode:SentryHandler]:',
+            {
+              initCode: <code />,
+              sentryHandlerCode: <code />,
+            }
+          ),
+          code: getLoggerSnippet(),
+        },
+      ],
+      additionalInfo: t('You may want to set up other loggers as well.'),
+    },
+  ],
+  verify: () => [],
+};
 
-export default GettingStartedWithPylons;
+const docs: Docs = {
+  onboarding,
+};
+
+export default docs;

--- a/static/app/gettingStartedDocs/python/python.spec.tsx
+++ b/static/app/gettingStartedDocs/python/python.spec.tsx
@@ -1,18 +1,37 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './python';
 
-import {GettingStartedWithPython, steps} from './python';
-
-describe('GettingStartedWithPython', function () {
+describe('python onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithPython dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps()) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
+    ).toBeInTheDocument();
+  });
+
+  it('renders without performance monitoring', function () {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [],
+    });
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profiles_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -1,110 +1,87 @@
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
+import type {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 
-// Configuration Start
-const performanceConfiguration = `    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,`;
+type Params = DocsParams;
 
-const profilingConfiguration = `    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,`;
-
-export const steps = ({
-  sentryInitContent,
-}: {
-  sentryInitContent?: string;
-} = {}): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: (
-      <p>
-        {tct('Install our Python SDK using [code:pip]:', {
-          code: <code />,
-        })}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'bash',
-        code: 'pip install --upgrade sentry-sdk',
-      },
-    ],
-  },
-  {
-    type: StepType.CONFIGURE,
-    description: t(
-      "Import and initialize the Sentry SDK early in your application's setup:"
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `
+const getSdkSetupSnippet = (params: Params) => `
+# settings.py
 import sentry_sdk
 
 sentry_sdk.init(
-${sentryInitContent}
-) `,
-      },
-    ],
-    additionalInfo: (
-      <p>
-        {tct(
-          'The above configuration captures both error and performance data. To reduce the volume of performance data captured, change [code:traces_sample_rate] to a value between 0 and 1.',
-          {code: <code />}
-        )}
-      </p>
-    ),
-  },
-  {
-    type: StepType.VERIFY,
-    description: t(
-      'One way to verify your setup is by intentionally causing an error that breaks your application.'
-    ),
-    configurations: [
-      {
-        language: 'python',
-        description: t(
-          'Raise an unhandled Python exception by inserting a divide by zero expression into your application:'
-        ),
-        code: 'division_by_zero = 1 / 0',
-      },
-    ],
-  },
-];
-// Configuration End
+    dsn="${params.dsn}",${
+      params.isPerformanceSelected
+        ? `
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,`
+        : ''
+    }${
+      params.isProfilingSelected
+        ? `
+    # Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production.
+    profiles_sample_rate=1.0,`
+        : ''
+    }
+)
+`;
 
-export function GettingStartedWithPython({
-  dsn,
-  activeProductSelection = [],
-  ...props
-}: ModuleProps) {
-  const otherConfigs: string[] = [];
+const onboarding: OnboardingConfig = {
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct('Install our Python SDK using [code:pip]:', {
+        code: <code />,
+      }),
+      configurations: [
+        {
+          language: 'bash',
+          code: 'pip install --upgrade sentry-sdk',
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      description: t(
+        "Import and initialize the Sentry SDK early in your application's setup:"
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: getSdkSetupSnippet(params),
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'One way to verify your setup is by intentionally causing an error that breaks your application.'
+      ),
+      configurations: [
+        {
+          language: 'python',
+          description: t(
+            'Raise an unhandled Python exception by inserting a divide by zero expression into your application:'
+          ),
+          code: 'division_by_zero = 1 / 0',
+        },
+      ],
+    },
+  ],
+};
 
-  let sentryInitContent: string[] = [`    dsn="${dsn}",`];
+const docs: Docs = {
+  onboarding,
+};
 
-  if (activeProductSelection.includes(ProductSolution.PERFORMANCE_MONITORING)) {
-    otherConfigs.push(performanceConfiguration);
-  }
-
-  if (activeProductSelection.includes(ProductSolution.PROFILING)) {
-    otherConfigs.push(profilingConfiguration);
-  }
-
-  sentryInitContent = sentryInitContent.concat(otherConfigs);
-
-  return (
-    <Layout
-      steps={steps({
-        sentryInitContent: sentryInitContent.join('\n'),
-      })}
-      {...props}
-    />
-  );
-}
-
-export default GettingStartedWithPython;
+export default docs;

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -9,7 +9,6 @@ import {t, tct} from 'sentry/locale';
 type Params = DocsParams;
 
 const getSdkSetupSnippet = (params: Params) => `
-# settings.py
 import sentry_sdk
 
 sentry_sdk.init(
@@ -29,8 +28,7 @@ sentry_sdk.init(
     profiles_sample_rate=1.0,`
         : ''
     }
-)
-`;
+)`;
 
 const onboarding: OnboardingConfig = {
   install: () => [

--- a/static/app/gettingStartedDocs/python/rq.spec.tsx
+++ b/static/app/gettingStartedDocs/python/rq.spec.tsx
@@ -1,18 +1,42 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './rq';
 
-import {GettingStartedWithRq, steps} from './rq';
-
-describe('GettingStartedWithRq', function () {
+describe('rq onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithRq dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({sentryInitContent: 'test-init-content'})) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Job definition'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {name: 'Settings for worker'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Main Python Script'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk\[rq\]/))
+    ).toBeInTheDocument();
+  });
+
+  it('renders without performance monitoring', function () {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [],
+    });
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profiles_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/rq.tsx
+++ b/static/app/gettingStartedDocs/python/rq.tsx
@@ -1,122 +1,61 @@
+import {Fragment} from 'react';
+
 import ExternalLink from 'sentry/components/links/externalLink';
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
+import {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 
-// Configuration Start
-const performanceConfiguration = `    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,`;
+type Params = DocsParams;
 
-const profilingConfiguration = `    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,`;
+const getInitCallSnippet = (params: Params) => `
+sentry_sdk.init(
+  dsn="${params.dsn}",${
+    params.isPerformanceSelected
+      ? `
+  # Set traces_sample_rate to 1.0 to capture 100%
+  # of transactions for performance monitoring.
+  traces_sample_rate=1.0,`
+      : ''
+  }${
+    params.isProfilingSelected
+      ? `
+  # Set profiles_sample_rate to 1.0 to profile 100%
+  # of sampled transactions.
+  # We recommend adjusting this value in production.
+  profiles_sample_rate=1.0,`
+      : ''
+  }
+)`;
 
-const introduction = (
-  <p>
-    {tct('The RQ integration adds support for the [link:RQ Job Queue System].', {
-      link: <ExternalLink href="https://python-rq.org/" />,
-    })}
-  </p>
-);
-
-export const steps = ({
-  sentryInitContent,
-}: {
-  sentryInitContent: string;
-}): LayoutProps['steps'] => [
-  {
-    type: StepType.CONFIGURE,
-    description: (
-      <span>
-        <p>
-          {tct(
-            'If you have the [codeRq:rq] package in your dependencies, the RQ integration will be enabled automatically when you initialize the Sentry SDK.',
-            {
-              codeRq: <code />,
-            }
-          )}
-        </p>
-        <p>
-          {tct('Create a file called [code:mysettings.py] with the following content:', {
-            code: <code />,
-          })}
-        </p>
-      </span>
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `
+const getSdkSetupSnippet = (params: Params) => `
 # mysettings.py
 import sentry_sdk
 
-sentry_sdk.init(
-${sentryInitContent}
-)
-      `,
-      },
-      {
-        description: t('Start your worker with:'),
-        language: 'shell',
-        code: `
+${getInitCallSnippet(params)}`;
+
+const getStartWorkerSnippet = () => `
 rq worker \
 -c mysettings \  # module name of mysettings.py
---sentry-dsn="..."  # only necessary for RQ < 1.0
-        `,
-      },
-    ],
-    additionalInfo: (
-      <p>
-        {tct(
-          'Generally, make sure that the call to [code:init] is loaded on worker startup, and not only in the module where your jobs are defined. Otherwise, the initialization happens too late and events might end up not being reported.',
-          {code: <code />}
-        )}
-      </p>
-    ),
-  },
-  {
-    type: StepType.VERIFY,
-    description: (
-      <p>
-        {' '}
-        {tct(
-          'To verify, create a simple job and a [code:main.py] script that enqueues the job in RQ, then start an RQ worker to run the job:',
-          {
-            code: <code />,
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        description: <h5>{t('Job definition')}</h5>,
-        language: 'python',
-        code: `# jobs.py
+--sentry-dsn="..."  # only necessary for RQ < 1.0`;
+
+const getJobDefinitionSnippet = () => `# jobs.py
 def hello(name):
     1/0  # raises an error
-    return "Hello %s!" % name
-        `,
-      },
-      {
-        description: <h5>{t('Settings for worker')}</h5>,
-        language: 'python',
-        code: `# mysettings.py
+    return "Hello %s!" % name`;
+
+const getWorkerSetupSnippet = (params: Params) => `
+# mysettings.py
 import sentry_sdk
 
 # Sentry configuration for RQ worker processes
-sentry_sdk.init(
-${sentryInitContent}
-)
-        `,
-      },
-      {
-        description: <h5>{t('Main Python Script')}</h5>,
-        language: 'python',
-        code: `# main.py
+${getInitCallSnippet(params)}`;
+
+const getMainPythonScriptSetupSnippet = (params: Params) => `
+# main.py
 from redis import Redis
 from rq import Queue
 
@@ -124,72 +63,132 @@ from jobs import hello
 
 import sentry_sdk
 
-# Sentry configuration for main.py process (same as above)
-sentry_sdk.init(
-${sentryInitContent}
-)
+#import { get } from 'lodash';
+Sentry configuration for main.py process (same as above)
+${getInitCallSnippet(params)}
 
 q = Queue(connection=Redis())
 with sentry_sdk.start_transaction(name="testing_sentry"):
-    result = q.enqueue(hello, "World")
-        `,
-      },
-    ],
-    additionalInfo: (
-      <div>
-        <p>
-          {tct(
-            'When you run [codeMain:python main.py] a transaction named [codeTrxName:testing_sentry] in the Performance section of Sentry will be created.',
-            {
-              codeMain: <code />,
-              codeTrxName: <code />,
-            }
-          )}
-        </p>
-        <p>
-          {tct(
-            'If you run the RQ worker with [codeWorker:rq worker -c mysettings] a transaction for the execution of [codeFunction:hello()] will be created. Additionally, an error event will be sent to Sentry and will be connected to the transaction.',
-            {
-              codeWorker: <code />,
-              codeFunction: <code />,
-            }
-          )}
-        </p>
-        <p>{t('It takes a couple of moments for the data to appear in Sentry.')}</p>
-      </div>
-    ),
-  },
-];
-// Configuration End
+    result = q.enqueue(hello, "World")`;
 
-export function GettingStartedWithRq({
-  dsn,
-  activeProductSelection = [],
-  ...props
-}: ModuleProps) {
-  const otherConfigs: string[] = [];
+const onboarding: OnboardingConfig = {
+  introduction: () =>
+    tct('The RQ integration adds support for the [link:RQ Job Queue System].', {
+      link: <ExternalLink href="https://python-rq.org/" />,
+    }),
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'Install [code:sentry-sdk] from PyPI with the [sentryRQCode:rq] extra:',
+        {
+          code: <code />,
+          sentryRQCode: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: 'pip install --upgrade sentry-sdk[rq]',
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      description: (
+        <Fragment>
+          <p>
+            {tct(
+              'If you have the [codeRq:rq] package in your dependencies, the RQ integration will be enabled automatically when you initialize the Sentry SDK.',
+              {
+                codeRq: <code />,
+              }
+            )}
+          </p>
+          <p>
+            {tct(
+              'Create a file called [code:mysettings.py] with the following content:',
+              {
+                code: <code />,
+              }
+            )}
+          </p>
+        </Fragment>
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: getSdkSetupSnippet(params),
+        },
+        {
+          description: t('Start your worker with:'),
+          language: 'shell',
+          code: getStartWorkerSnippet(),
+        },
+      ],
+      additionalInfo: tct(
+        'Generally, make sure that the call to [code:init] is loaded on worker startup, and not only in the module where your jobs are defined. Otherwise, the initialization happens too late and events might end up not being reported.',
+        {code: <code />}
+      ),
+    },
+  ],
+  verify: params => [
+    {
+      type: StepType.VERIFY,
+      description: tct(
+        'To verify, create a simple job and a [code:main.py] script that enqueues the job in RQ, then start an RQ worker to run the job:',
+        {
+          code: <code />,
+        }
+      ),
+      configurations: [
+        {
+          description: <h5>{t('Job definition')}</h5>,
+          language: 'python',
+          code: getJobDefinitionSnippet(),
+        },
+        {
+          description: <h5>{t('Settings for worker')}</h5>,
+          language: 'python',
+          code: getWorkerSetupSnippet(params),
+        },
+        {
+          description: <h5>{t('Main Python Script')}</h5>,
+          language: 'python',
+          code: getMainPythonScriptSetupSnippet(params),
+        },
+      ],
+      additionalInfo: (
+        <div>
+          <p>
+            {tct(
+              'When you run [codeMain:python main.py] a transaction named [codeTrxName:testing_sentry] in the Performance section of Sentry will be created.',
+              {
+                codeMain: <code />,
+                codeTrxName: <code />,
+              }
+            )}
+          </p>
+          <p>
+            {tct(
+              'If you run the RQ worker with [codeWorker:rq worker -c mysettings] a transaction for the execution of [codeFunction:hello()] will be created. Additionally, an error event will be sent to Sentry and will be connected to the transaction.',
+              {
+                codeWorker: <code />,
+                codeFunction: <code />,
+              }
+            )}
+          </p>
+          <p>{t('It takes a couple of moments for the data to appear in Sentry.')}</p>
+        </div>
+      ),
+    },
+  ],
+};
 
-  let sentryInitContent: string[] = [`    dsn="${dsn}",`];
+const docs: Docs = {
+  onboarding,
+};
 
-  if (activeProductSelection.includes(ProductSolution.PERFORMANCE_MONITORING)) {
-    otherConfigs.push(performanceConfiguration);
-  }
-
-  if (activeProductSelection.includes(ProductSolution.PROFILING)) {
-    otherConfigs.push(profilingConfiguration);
-  }
-
-  sentryInitContent = sentryInitContent.concat(otherConfigs);
-
-  return (
-    <Layout
-      introduction={introduction}
-      steps={steps({
-        sentryInitContent: sentryInitContent.join('\n'),
-      })}
-      {...props}
-    />
-  );
-}
-
-export default GettingStartedWithRq;
+export default docs;

--- a/static/app/gettingStartedDocs/python/serverless.spec.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.spec.tsx
@@ -1,18 +1,37 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './serverless';
 
-import {GettingStartedWithServerless, steps} from './serverless';
-
-describe('GettingStartedWithServerless', function () {
+describe('serverless onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithServerless dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({sentryInitContent: 'test-init-content'})) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
+    ).toBeInTheDocument();
+  });
+
+  it('renders without performance monitoring', function () {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [],
+    });
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profiles_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -1,138 +1,123 @@
 import {Fragment} from 'react';
 
 import ExternalLink from 'sentry/components/links/externalLink';
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
+import type {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 
-// Configuration Start
-const performanceConfiguration = `    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,`;
+type Params = DocsParams;
 
-const profilingConfiguration = `    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,`;
-
-export const steps = ({
-  sentryInitContent,
-}: {
-  sentryInitContent: string;
-}): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: (
-      <Fragment>
-        <p>
-          {tct(
-            'It is recommended to use an [link:integration for your particular serverless environment if available], as those are easier to use and capture more useful information.',
-            {
-              link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/python/#serverless" />
-              ),
-            }
-          )}
-        </p>
-        {t(
-          'If you use a serverless provider not directly supported by the SDK, you can use this generic integration.'
-        )}
-      </Fragment>
-    ),
-    configurations: [
-      {
-        language: 'python',
-        description: (
-          <p>
-            {tct(
-              'Apply the [code:serverless_function] decorator to each function that might throw errors:',
-              {code: <code />}
-            )}
-          </p>
-        ),
-        code: `
+const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 from sentry_sdk.integrations.serverless import serverless_function
 
 sentry_sdk.init(
-${sentryInitContent}
+    dsn="${params.dsn}",${
+      params.isPerformanceSelected
+        ? `
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,`
+        : ''
+    }${
+      params.isProfilingSelected
+        ? `
+    # Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production.
+    profiles_sample_rate=1.0,`
+        : ''
+    }
 )
 
 @serverless_function
-def my_function(...): ...
-        `,
-      },
-    ],
-  },
-  {
-    type: StepType.VERIFY,
-    description: (
-      <p>
-        {tct(
-          'Wrap a functions with the [code:serverless_function] that triggers an error:',
-          {
-            code: <code />,
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `import sentry_sdk
+def my_function(...): ...`;
+
+const getVerifySnippet = () => `import sentry_sdk
 from sentry_sdk.integrations.serverless import serverless_function
 
-sentry_sdk.init(
-${sentryInitContent}
-)
+sentry_sdk.init(...) # same as above
 
 @serverless_function
 def my_function(...):
-    1/0  # raises an error
-      `,
-      },
-    ],
-    additionalInfo: (
+    1/0  # raises an error`;
+
+const onboarding: OnboardingConfig = {
+  introduction: () => (
+    <Fragment>
       <p>
         {tct(
-          'Now deploy your function. When you now run your function an error event will be sent to Sentry.',
-          {}
+          'It is recommended to use an [link:integration for your particular serverless environment if available], as those are easier to use and capture more useful information.',
+          {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/python/#serverless" />
+            ),
+          }
         )}
       </p>
-    ),
-  },
-];
-// Configuration End
+      {t(
+        'If you use a serverless provider not directly supported by the SDK, you can use this generic integration.'
+      )}
+    </Fragment>
+  ),
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct('Install our Python SDK using [code:pip]:', {
+        code: <code />,
+      }),
+      configurations: [
+        {
+          language: 'bash',
+          code: 'pip install --upgrade sentry-sdk',
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      description: tct(
+        'Apply the [code:serverless_function] decorator to each function that might throw errors:',
+        {code: <code />}
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: getSdkSetupSnippet(params),
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: tct(
+        'Wrap a functions with the [code:serverless_function] that triggers an error:',
+        {
+          code: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: getVerifySnippet(),
+        },
+      ],
+      additionalInfo: tct(
+        'Now deploy your function. When you now run your function an error event will be sent to Sentry.',
+        {}
+      ),
+    },
+  ],
+};
 
-export function GettingStartedWithServerless({
-  dsn,
-  activeProductSelection = [],
-  ...props
-}: ModuleProps) {
-  const otherConfigs: string[] = [];
+const docs: Docs = {
+  onboarding,
+};
 
-  let sentryInitContent: string[] = [`    dsn="${dsn}",`];
-
-  if (activeProductSelection.includes(ProductSolution.PERFORMANCE_MONITORING)) {
-    otherConfigs.push(performanceConfiguration);
-  }
-
-  if (activeProductSelection.includes(ProductSolution.PROFILING)) {
-    otherConfigs.push(profilingConfiguration);
-  }
-
-  sentryInitContent = sentryInitContent.concat(otherConfigs);
-
-  return (
-    <Layout
-      steps={steps({
-        sentryInitContent: sentryInitContent.join('\n'),
-      })}
-      {...props}
-    />
-  );
-}
-
-export default GettingStartedWithServerless;
+export default docs;

--- a/static/app/gettingStartedDocs/python/tryton.spec.tsx
+++ b/static/app/gettingStartedDocs/python/tryton.spec.tsx
@@ -1,18 +1,30 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './django';
 
-import {GettingStartedWithTryton, steps} from './tryton';
-
-describe('GettingStartedWithTryton', function () {
+describe('django onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithTryton dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({sentryInitContent: 'test-init-content'})) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+  });
+
+  it('renders without performance monitoring', function () {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [],
+    });
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profiles_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/wsgi.spec.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.spec.tsx
@@ -1,18 +1,37 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './wsgi';
 
-import {GettingStartedWithWSGI, steps} from './wsgi';
-
-describe('GettingStartedWithWSGI', function () {
+describe('wsgi onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithWSGI dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({sentryInitContent: 'test-init-content'})) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
+    ).toBeInTheDocument();
+  });
+
+  it('renders without performance monitoring', function () {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [],
+    });
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profiles_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -1,78 +1,48 @@
 import {Fragment} from 'react';
 
 import ExternalLink from 'sentry/components/links/externalLink';
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
-import {ProductSolution} from 'sentry/components/onboarding/productSelection';
+import type {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 
-// Configuration Start
-const performanceConfiguration = `    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,`;
+type Params = DocsParams;
 
-const profilingConfiguration = `    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,`;
-
-export const steps = ({
-  sentryInitContent,
-}: {
-  sentryInitContent: string;
-}): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: (
-      <Fragment>
-        <p>
-          {tct(
-            'It is recommended to use an [link:integration for your particular WSGI framework if available], as those are easier to use and capture more useful information.',
-            {
-              link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/python/#web-frameworks" />
-              ),
-            }
-          )}
-        </p>
-        {t(
-          'If you use a WSGI framework not directly supported by the SDK, or wrote a raw WSGI app, you can use this generic WSGI middleware. It captures errors and attaches a basic amount of information for incoming requests.'
-        )}
-      </Fragment>
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `
+const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 
 from my_wsgi_app import app
 
 sentry_sdk.init(
-${sentryInitContent}
+    dsn="${params.dsn}",${
+      params.isPerformanceSelected
+        ? `
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,`
+        : ''
+    }${
+      params.isProfilingSelected
+        ? `
+    # Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production.
+    profiles_sample_rate=1.0,`
+        : ''
+    }
 )
 
-app = SentryWsgiMiddleware(app)
-        `,
-      },
-    ],
-  },
-  {
-    type: StepType.VERIFY,
-    description: t(
-      'You can easily verify your Sentry installation by creating a route that triggers an error:'
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `import sentry_sdk
+app = SentryWsgiMiddleware(app)`;
+
+const getVerifySnippet = () => `
+import sentry_sdk
 from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 
-sentry_sdk.init(
-${sentryInitContent}
-)
+sentry_sdk.init(...)  # same as above
 
 def app(env, start_response):
     start_response('200 OK', [('Content-Type', 'text/plain')])
@@ -84,58 +54,92 @@ app = SentryWsgiMiddleware(app)
 
 # Run the application in a mini WSGI server.
 from wsgiref.simple_server import make_server
-make_server('', 8000, app).serve_forever()
-        `,
-      },
-    ],
-    additionalInfo: (
-      <div>
-        <p>
-          {tct(
-            'When you point your browser to [link:http://localhost:8000/] a transaction in the Performance section of Sentry will be created.',
-            {
-              link: <ExternalLink href="http://localhost:8000/" />,
-            }
-          )}
-        </p>
-        <p>
-          {t(
-            'Additionally, an error event will be sent to Sentry and will be connected to the transaction.'
-          )}
-        </p>
-        <p>{t('It takes a couple of moments for the data to appear in Sentry.')}</p>
-      </div>
-    ),
-  },
-];
-// Configuration End
+make_server('', 8000, app).serve_forever()`;
 
-export function GettingStartedWithWSGI({
-  dsn,
-  activeProductSelection = [],
-  ...props
-}: ModuleProps) {
-  const otherConfigs: string[] = [];
+const onboarding: OnboardingConfig = {
+  introduction: () => (
+    <Fragment>
+      <p>
+        {tct(
+          'It is recommended to use an [link:integration for your particular WSGI framework if available], as those are easier to use and capture more useful information.',
+          {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/python/#web-frameworks" />
+            ),
+          }
+        )}
+      </p>
+      <p>
+        {t(
+          'If you use a WSGI framework not directly supported by the SDK, or wrote a raw WSGI app, you can use this generic WSGI middleware. It captures errors and attaches a basic amount of information for incoming requests.'
+        )}
+      </p>
+    </Fragment>
+  ),
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct('Install our Python SDK using [code:pip]:', {
+        code: <code />,
+      }),
+      configurations: [
+        {
+          language: 'bash',
+          code: 'pip install --upgrade sentry-sdk',
+        },
+      ],
+    },
+  ],
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      description: t(
+        'Then you can use this generic WSGI middleware. It captures errors and attaches a basic amount of information for incoming requests.'
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: getSdkSetupSnippet(params),
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: t(
+        'You can easily verify your Sentry installation by creating a route that triggers an error:'
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: getVerifySnippet(),
+        },
+      ],
+      additionalInfo: (
+        <Fragment>
+          <p>
+            {tct(
+              'When you point your browser to [link:http://localhost:8000/] a transaction in the Performance section of Sentry will be created.',
+              {
+                link: <ExternalLink href="http://localhost:8000/" />,
+              }
+            )}
+          </p>
+          <p>
+            {t(
+              'Additionally, an error event will be sent to Sentry and will be connected to the transaction.'
+            )}
+          </p>
+          <p>{t('It takes a couple of moments for the data to appear in Sentry.')}</p>
+        </Fragment>
+      ),
+    },
+  ],
+};
 
-  let sentryInitContent: string[] = [`    dsn="${dsn}",`];
+const docs: Docs = {
+  onboarding,
+};
 
-  if (activeProductSelection.includes(ProductSolution.PERFORMANCE_MONITORING)) {
-    otherConfigs.push(performanceConfiguration);
-  }
-
-  if (activeProductSelection.includes(ProductSolution.PROFILING)) {
-    otherConfigs.push(profilingConfiguration);
-  }
-
-  sentryInitContent = sentryInitContent.concat(otherConfigs);
-
-  return (
-    <Layout
-      steps={steps({
-        sentryInitContent: sentryInitContent.join('\n'),
-      })}
-      {...props}
-    />
-  );
-}
-export default GettingStartedWithWSGI;
+export default docs;


### PR DESCRIPTION
Refactor the remaining python platforms to follow the new structure.
Add install instructions to `python-wsgi`, `python-serverless` and `python-rq`.

- part of #56549
- relates to #60250