### PR TITLE
feat(ddm): Add python onboarding

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/utils/metricsOnboarding.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/metricsOnboarding.tsx
@@ -6,7 +6,7 @@ import type {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 
-const getJSInstallSnippet = (params: DocsParams) => `
+const getJSConfigureSnippet = (params: DocsParams) => `
 Sentry.init({
   dsn: "${params.dsn}",
   integrations: [
@@ -53,7 +53,7 @@ export const getJSMetricsOnboarding = ({
               label: 'JavaScript',
               value: 'javascript',
               language: 'javascript',
-              code: getJSInstallSnippet(params),
+              code: getJSConfigureSnippet(params),
             },
           ],
         },
@@ -81,6 +81,110 @@ export const getJSMetricsOnboarding = ({
               value: 'javascript',
               language: 'javascript',
               code: getJSVerifySnippet(),
+            },
+          ],
+        },
+        {
+          description: t(
+            'With a bit of delay you can see the data appear in the Sentry UI.'
+          ),
+        },
+        {
+          description: tct(
+            'Learn more about metrics and how to configure them, by reading the [docsLink:docs].',
+            {
+              docsLink: (
+                <ExternalLink href="https://develop.sentry.dev/delightful-developer-metrics/sending-metrics-sdk/" />
+              ),
+            }
+          ),
+        },
+      ],
+    },
+  ],
+});
+
+const getPythonConfigureSnippet = () => `
+import sentry_sdk
+
+sentry_sdk.init(
+    ...
+    _experiments={
+        # Turns on the metrics module (required)
+        "enable_metrics": True,
+        # Enables sending of code locations for metrics (recommended)
+        "metric_code_locations": True,
+    },
+)`;
+
+const getPythonVerifySnippet = () => `
+# Increment a metric to see how it works
+metrics.incr("drank-drinks", 1, tags={"kind": "coffee"})`;
+
+export const getPythonMetricsOnboarding = ({
+  installSnippet,
+}: {
+  installSnippet: string;
+}): OnboardingConfig => ({
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        "You need a minimum version [codeVersion:1.38.0] of the [codePackage:sentry-python] SDK and add that as your dependency. You don't need to install any additional packages",
+        {
+          codeVersion: <code />,
+          codePackage: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: installSnippet,
+        },
+      ],
+    },
+  ],
+  configure: () => [
+    {
+      type: StepType.CONFIGURE,
+      description: t(
+        'Once the SDK is installed or updated you have to add experimental flag into your SDK init:'
+      ),
+      configurations: [
+        {
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              code: getPythonConfigureSnippet(),
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      description: tct(
+        "Then you'll be able to add metrics as [codeCounters:counters], [codeSets:sets], [codeDistribution:distributions], and [codeGauge:gauges]. Try out this example:",
+        {
+          codeCounters: <code />,
+          codeSets: <code />,
+          codeDistribution: <code />,
+          codeGauge: <code />,
+          codeNamespace: <code />,
+        }
+      ),
+      configurations: [
+        {
+          code: [
+            {
+              label: 'JavaScript',
+              value: 'javascript',
+              language: 'javascript',
+              code: getPythonVerifySnippet(),
             },
           ],
         },

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -379,24 +379,28 @@ const customMetricBackendPlatforms: readonly PlatformKey[] = [
   'php-monolog',
   'php-symfony',
   'python',
-  'python-django',
-  'python-flask',
-  'python-fastapi',
-  'python-starlette',
-  'python-sanic',
-  'python-celery',
+  'python-aiohttp',
+  'python-asgi',
+  'python-awslambda',
   'python-bottle',
+  'python-celery',
+  'python-chalice',
+  'python-django',
+  'python-falcon',
+  'python-fastapi',
+  'python-flask',
+  'python-gcpfunctions',
+  'python-pymongo',
   'python-pylons',
   'python-pyramid',
-  'python-tornado',
-  'python-rq',
-  'python-aiohttp',
-  'python-chalice',
-  'python-falcon',
   'python-quart',
+  'python-rq',
+  'python-sanic',
+  'python-serverless',
+  'python-starlette',
+  'python-tornado',
   'python-tryton',
   'python-wsgi',
-  'python-serverless',
   'rust',
 ];
 
@@ -432,11 +436,14 @@ export const customMetricOnboardingPlatforms = new Set(
   [...customMetricPlatforms].filter(
     p =>
       // Legacy platforms that do not have in-product docs
-      !['javascript-backbone', 'javascript-capacitor', 'javascript-electron'].includes(
-        p
-      ) &&
+      ![
+        'javascript-backbone',
+        'javascript-capacitor',
+        'javascript-electron',
+        'python-pylons',
+        'python-tryton',
+      ].includes(p) &&
       // TODO: Remove this once we have onboarding instructions for these platforms
-      !p.includes('php') &&
-      !p.includes('python')
+      !p.includes('php')
   )
 );

--- a/static/app/gettingStartedDocs/python/aiohttp.spec.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.spec.tsx
@@ -15,7 +15,7 @@ describe('aiohttp onboarding docs', function () {
 
     // Renders install instructions
     expect(
-      screen.getByText(textWithMarkupMatcher(/\$ pip install --upgrade sentry-sdk/))
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
     ).toBeInTheDocument();
   });
 

--- a/static/app/gettingStartedDocs/python/aiohttp.tsx
+++ b/static/app/gettingStartedDocs/python/aiohttp.tsx
@@ -5,10 +5,13 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 from aiohttp import web
@@ -52,7 +55,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: '$ pip install --upgrade sentry-sdk',
+          code: getInstallSnippet(),
         },
         {
           description: tct(
@@ -62,7 +65,7 @@ const onboarding: OnboardingConfig = {
             }
           ),
           language: 'bash',
-          code: '$ pip install --upgrade aiocontextvars',
+          code: 'pip install --upgrade aiocontextvars',
         },
       ],
     },
@@ -141,6 +144,9 @@ web.run_app(app)`,
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/asgi.spec.tsx
+++ b/static/app/gettingStartedDocs/python/asgi.spec.tsx
@@ -1,18 +1,37 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './asgi';
 
-import {GettingStartedWithASGI, steps} from './asgi';
-
-describe('GettingStartedWithASGI', function () {
+describe('asgi onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithASGI dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps({sentryInitContent: 'test-init-content'})) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
+    ).toBeInTheDocument();
+  });
+
+  it('renders without performance monitoring', function () {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [],
+    });
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/traces_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
+
+    // Does not render config option
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/profiles_sample_rate: 1\.0,/))
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/awslambda.tsx
+++ b/static/app/gettingStartedDocs/python/awslambda.tsx
@@ -8,10 +8,13 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -65,7 +68,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: 'pip install --upgrade sentry-sdk',
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -135,6 +138,9 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/bottle.tsx
+++ b/static/app/gettingStartedDocs/python/bottle.tsx
@@ -5,12 +5,16 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
 
-const getSdkSetupSnippet = (params: Params) => `import sentry_sdk
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk[bottle]`;
+
+const getSdkSetupSnippet = (params: Params) => `
+import sentry_sdk
 
 sentry_sdk.init(
     dsn="${params.dsn}",${
@@ -50,7 +54,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: 'pip install --upgrade sentry-sdk[bottle]',
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -124,6 +128,9 @@ run(app, host='localhost', port=8000)
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/celery.tsx
+++ b/static/app/gettingStartedDocs/python/celery.tsx
@@ -10,10 +10,13 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk[celery]`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -54,7 +57,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: 'pip install --upgrade sentry-sdk[celery]',
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -179,6 +182,9 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/chalice.tsx
+++ b/static/app/gettingStartedDocs/python/chalice.tsx
@@ -4,9 +4,12 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk[chalice]`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -60,7 +63,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: 'pip install --upgrade sentry-sdk[chalice]',
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -101,6 +104,9 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/django.tsx
+++ b/static/app/gettingStartedDocs/python/django.tsx
@@ -5,10 +5,13 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk[django]`;
 
 const getSdkSetupSnippet = (params: Params) => `
 # settings.py
@@ -62,7 +65,7 @@ const onboarding: OnboardingConfig = {
               )}
             </p>
           ),
-          code: 'pip install --upgrade sentry-sdk[django]',
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -137,6 +140,9 @@ urlpatterns = [
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/falcon.spec.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.spec.tsx
@@ -16,7 +16,7 @@ describe('falcon onboarding docs', function () {
     // Renders install instructions
     expect(
       screen.getByText(
-        textWithMarkupMatcher(/\$ pip install --upgrade 'sentry-sdk\[falcon\]'/)
+        textWithMarkupMatcher(/pip install --upgrade sentry-sdk\[falcon\]/)
       )
     ).toBeInTheDocument();
   });

--- a/static/app/gettingStartedDocs/python/falcon.tsx
+++ b/static/app/gettingStartedDocs/python/falcon.tsx
@@ -5,10 +5,13 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk[falcon]`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import falcon
@@ -52,7 +55,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: "$ pip install --upgrade 'sentry-sdk[falcon]'",
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -128,6 +131,9 @@ app.add_route('/', HelloWorldResource())
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/fastapi.spec.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.spec.tsx
@@ -16,7 +16,7 @@ describe('flask onboarding docs', function () {
     // Renders install instructions
     expect(
       screen.getByText(
-        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[fastapi\]'/)
+        textWithMarkupMatcher(/pip install --upgrade sentry-sdk\[fastapi\]/)
       )
     ).toBeInTheDocument();
   });

--- a/static/app/gettingStartedDocs/python/fastapi.tsx
+++ b/static/app/gettingStartedDocs/python/fastapi.tsx
@@ -5,10 +5,13 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk[fastapi]`;
 
 const getSdkSetupSnippet = (params: Params) => `
 from fastapi import FastAPI
@@ -52,7 +55,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: "pip install --upgrade 'sentry-sdk[fastapi]'",
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -129,6 +132,9 @@ async def trigger_error():
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/flask.spec.tsx
+++ b/static/app/gettingStartedDocs/python/flask.spec.tsx
@@ -15,9 +15,7 @@ describe('flask onboarding docs', function () {
 
     // Renders install instructions
     expect(
-      screen.getByText(
-        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[flask\]'/)
-      )
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk\[flask\]/))
     ).toBeInTheDocument();
   });
 

--- a/static/app/gettingStartedDocs/python/flask.tsx
+++ b/static/app/gettingStartedDocs/python/flask.tsx
@@ -5,10 +5,13 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk[flask]`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -52,7 +55,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: "pip install --upgrade 'sentry-sdk[flask]'",
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -128,6 +131,9 @@ def hello_world():
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/gcpfunctions.tsx
+++ b/static/app/gettingStartedDocs/python/gcpfunctions.tsx
@@ -8,10 +8,13 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -58,7 +61,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: 'pip install --upgrade sentry-sdk',
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -128,6 +131,9 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/mongo.spec.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.spec.tsx
@@ -1,18 +1,22 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {renderWithOnboardingLayout} from 'sentry-test/onboarding/renderWithOnboardingLayout';
+import {screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {StepTitle} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import docs from './mongo';
 
-import {GettingStartedWithMongo, steps} from './mongo';
-
-describe('GettingStartedWithMongo', function () {
+describe('mongo onboarding docs', function () {
   it('renders doc correctly', function () {
-    render(<GettingStartedWithMongo dsn="test-dsn" projectSlug="test-project" />);
+    renderWithOnboardingLayout(docs);
 
-    // Steps
-    for (const step of steps()) {
-      expect(
-        screen.getByRole('heading', {name: step.title ?? StepTitle[step.type]})
-      ).toBeInTheDocument();
-    }
+    // Renders main headings
+    expect(screen.getByRole('heading', {name: 'Install'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
+
+    // Renders install instructions
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(/pip install --upgrade sentry-sdk\[pymongo\]/)
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/mongo.tsx
+++ b/static/app/gettingStartedDocs/python/mongo.tsx
@@ -1,59 +1,22 @@
 import ExternalLink from 'sentry/components/links/externalLink';
-import {Layout, LayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/layout';
-import {ModuleProps} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/step';
+import type {
+  Docs,
+  DocsParams,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {t, tct} from 'sentry/locale';
 
-// Configuration Start
-const introduction = (
-  <p>
-    {tct(
-      'The PyMongo integration adds support for [link:PyMongo], the official MongoDB driver. It adds breadcrumbs and performace traces for all queries.',
-      {
-        link: <ExternalLink href="https://www.mongodb.com/docs/drivers/pymongo/" />,
-      }
-    )}
-  </p>
-);
+type Params = DocsParams;
 
-export const steps = ({
-  dsn,
-}: Partial<Pick<ModuleProps, 'dsn'>> = {}): LayoutProps['steps'] => [
-  {
-    type: StepType.INSTALL,
-    description: (
-      <p>
-        {tct(
-          'Install [sentrySdkCode:sentry-sdk] from PyPI with the [pymongoCode:pymongo] extra:',
-          {
-            sentrySdkCode: <code />,
-            pymongoCode: <code />,
-          }
-        )}
-      </p>
-    ),
-    configurations: [
-      {
-        language: 'bash',
-        code: `pip install --upgrade 'sentry-sdk[pymongo]'`,
-      },
-    ],
-  },
-  {
-    type: StepType.CONFIGURE,
-    description: t(
-      "To configure the SDK, initialize it before creating any of PyMongo's MongoClient instances:"
-    ),
-    configurations: [
-      {
-        language: 'python',
-        code: `
+const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
 from sentry_sdk.integrations.pymongo import PyMongoIntegration
 
 
 sentry_sdk.init(
-    dsn="${dsn}",
+    dsn="${params.dsn}",
     integrations=[
         PyMongoIntegration(),
     ],
@@ -62,24 +25,62 @@ sentry_sdk.init(
     # of transactions for performance monitoring.
     # We recommend adjusting this value in production,
     traces_sample_rate=1.0,
-)
-      `,
-      },
-    ],
-    additionalInfo: (
-      <p>
-        {tct(
-          'The above configuration captures both breadcrumbs and performance data. To reduce the volume of performance data captured, change [code:traces_sample_rate] to a value between 0 and 1.',
-          {code: <code />}
-        )}
-      </p>
+)`;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk[pymongo]`;
+
+const onboarding: OnboardingConfig = {
+  introduction: () =>
+    tct(
+      'The PyMongo integration adds support for [link:PyMongo], the official MongoDB driver. It adds breadcrumbs and performace traces for all queries.',
+      {
+        link: <ExternalLink href="https://www.mongodb.com/docs/drivers/pymongo/" />,
+      }
     ),
-  },
-];
-// Configuration End
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      description: tct(
+        'Install [sentrySdkCode:sentry-sdk] from PyPI with the [pymongoCode:pymongo] extra:',
+        {
+          sentrySdkCode: <code />,
+          pymongoCode: <code />,
+        }
+      ),
+      configurations: [
+        {
+          language: 'bash',
+          code: getInstallSnippet(),
+        },
+      ],
+    },
+  ],
+  configure: (params: Params) => [
+    {
+      type: StepType.CONFIGURE,
+      description: t(
+        "To configure the SDK, initialize it before creating any of PyMongo's MongoClient instances:"
+      ),
+      configurations: [
+        {
+          language: 'python',
+          code: getSdkSetupSnippet(params),
+        },
+      ],
+      additionalInfo: tct(
+        'The above configuration captures both breadcrumbs and performance data. To reduce the volume of performance data captured, change [code:traces_sample_rate] to a value between 0 and 1.',
+        {code: <code />}
+      ),
+    },
+  ],
+  verify: () => [],
+};
 
-export function GettingStartedWithMongo({dsn, ...props}: ModuleProps) {
-  return <Layout steps={steps({dsn})} introduction={introduction} {...props} />;
-}
+const docs: Docs = {
+  onboarding,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
+};
 
-export default GettingStartedWithMongo;
+export default docs;

--- a/static/app/gettingStartedDocs/python/pyramid.spec.tsx
+++ b/static/app/gettingStartedDocs/python/pyramid.spec.tsx
@@ -15,7 +15,7 @@ describe('aiohttp onboarding docs', function () {
 
     // Renders install instructions
     expect(
-      screen.getByText(textWithMarkupMatcher(/\$ pip install --upgrade sentry-sdk/))
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
     ).toBeInTheDocument();
   });
 

--- a/static/app/gettingStartedDocs/python/pyramid.tsx
+++ b/static/app/gettingStartedDocs/python/pyramid.tsx
@@ -5,10 +5,13 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 from pyramid.config import Configurator
@@ -31,7 +34,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: '$ pip install --upgrade sentry-sdk',
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -98,6 +101,9 @@ if __name__ == '__main__':
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/python.tsx
+++ b/static/app/gettingStartedDocs/python/python.tsx
@@ -4,9 +4,12 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -40,7 +43,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: 'pip install --upgrade sentry-sdk',
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -80,6 +83,9 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/quart.spec.tsx
+++ b/static/app/gettingStartedDocs/python/quart.spec.tsx
@@ -15,9 +15,7 @@ describe('quart onboarding docs', function () {
 
     // Renders install instructions
     expect(
-      screen.getByText(
-        textWithMarkupMatcher(/\$ pip install --upgrade sentry-sdk\[quart\]/)
-      )
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk\[quart\]/))
     ).toBeInTheDocument();
   });
 

--- a/static/app/gettingStartedDocs/python/quart.tsx
+++ b/static/app/gettingStartedDocs/python/quart.tsx
@@ -5,10 +5,13 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk[quart]`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -54,7 +57,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: '$ pip install --upgrade sentry-sdk[quart]',
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -125,6 +128,9 @@ app.run()
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/rq.tsx
+++ b/static/app/gettingStartedDocs/python/rq.tsx
@@ -7,9 +7,12 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk[rq]`;
 
 const getInitCallSnippet = (params: Params) => `
 sentry_sdk.init(
@@ -89,7 +92,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: 'pip install --upgrade sentry-sdk[rq]',
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -189,6 +192,9 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/sanic.spec.tsx
+++ b/static/app/gettingStartedDocs/python/sanic.spec.tsx
@@ -15,9 +15,7 @@ describe('sanic onboarding docs', function () {
 
     // Renders install instructions
     expect(
-      screen.getByText(
-        textWithMarkupMatcher(/\$ pip install --upgrade sentry-sdk\[sanic\]/)
-      )
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk\[sanic\]/))
     ).toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/python/sanic.tsx
+++ b/static/app/gettingStartedDocs/python/sanic.tsx
@@ -53,7 +53,7 @@ const onboarding: OnboardingConfig = {
             </p>
           ),
           language: 'bash',
-          code: '$ pip install --upgrade aiocontextvars',
+          code: 'pip install --upgrade aiocontextvars',
         },
       ],
     },

--- a/static/app/gettingStartedDocs/python/sanic.tsx
+++ b/static/app/gettingStartedDocs/python/sanic.tsx
@@ -5,10 +5,13 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk[sanic]`;
 
 const getSdkSetupSnippet = (params: Params) => `from sanic import Sanic
 import sentry_sdk
@@ -36,7 +39,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: '$ pip install --upgrade sentry-sdk[sanic]',
+          code: getInstallSnippet(),
         },
         {
           description: (
@@ -109,6 +112,9 @@ async def hello_world(request):
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/serverless.tsx
+++ b/static/app/gettingStartedDocs/python/serverless.tsx
@@ -7,9 +7,12 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -73,7 +76,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: 'pip install --upgrade sentry-sdk',
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -118,6 +121,9 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/starlette.spec.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.spec.tsx
@@ -16,7 +16,7 @@ describe('starlette onboarding docs', function () {
     // Renders install instructions
     expect(
       screen.getByText(
-        textWithMarkupMatcher(/pip install --upgrade 'sentry-sdk\[starlette\]'/)
+        textWithMarkupMatcher(/pip install --upgrade sentry-sdk\[starlette\]/)
       )
     ).toBeInTheDocument();
   });

--- a/static/app/gettingStartedDocs/python/starlette.tsx
+++ b/static/app/gettingStartedDocs/python/starlette.tsx
@@ -5,10 +5,13 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk[starlette]`;
 
 const getSdkSetupSnippet = (
   params: Params
@@ -53,7 +56,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: "pip install --upgrade 'sentry-sdk[starlette]'",
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -125,6 +128,9 @@ app = Starlette(routes=[
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/tornado.spec.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.spec.tsx
@@ -15,7 +15,7 @@ describe('tornado onboarding docs', function () {
 
     // Renders install instructions
     expect(
-      screen.getByText(textWithMarkupMatcher(/\$ pip install --upgrade sentry-sdk/))
+      screen.getByText(textWithMarkupMatcher(/pip install --upgrade sentry-sdk/))
     ).toBeInTheDocument();
   });
 

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -5,10 +5,13 @@ import {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import replayOnboardingJsLoader from 'sentry/gettingStartedDocs/javascript/jsLoader/jsLoader';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `import sentry_sdk
 
@@ -50,7 +53,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: '$ pip install --upgrade sentry-sdk',
+          code: getInstallSnippet(),
         },
         {
           description: tct(
@@ -144,6 +147,9 @@ asyncio.run(main())
 const docs: Docs = {
   onboarding,
   replayOnboardingJsLoader,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/python/tornado.tsx
+++ b/static/app/gettingStartedDocs/python/tornado.tsx
@@ -63,7 +63,7 @@ const onboarding: OnboardingConfig = {
             }
           ),
           language: 'bash',
-          code: '$ pip install --upgrade aiocontextvars',
+          code: 'pip install --upgrade aiocontextvars',
         },
       ],
     },

--- a/static/app/gettingStartedDocs/python/wsgi.tsx
+++ b/static/app/gettingStartedDocs/python/wsgi.tsx
@@ -7,9 +7,12 @@ import type {
   DocsParams,
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {getPythonMetricsOnboarding} from 'sentry/components/onboarding/gettingStartedDoc/utils/metricsOnboarding';
 import {t, tct} from 'sentry/locale';
 
 type Params = DocsParams;
+
+const getInstallSnippet = () => `pip install --upgrade sentry-sdk`;
 
 const getSdkSetupSnippet = (params: Params) => `
 import sentry_sdk
@@ -85,7 +88,7 @@ const onboarding: OnboardingConfig = {
       configurations: [
         {
           language: 'bash',
-          code: 'pip install --upgrade sentry-sdk',
+          code: getInstallSnippet(),
         },
       ],
     },
@@ -140,6 +143,9 @@ const onboarding: OnboardingConfig = {
 
 const docs: Docs = {
   onboarding,
+  customMetricsOnboarding: getPythonMetricsOnboarding({
+    installSnippet: getInstallSnippet(),
+  }),
 };
 
 export default docs;


### PR DESCRIPTION
Add onboarding instructions for python.
Refactor docs for `python-asgi` & `python-pymongo`.

- part of https://github.com/getsentry/sentry/issues/60250