### PR TITLE
fix(integrations) Make social auth user update silo safe

### DIFF
--- a/src/social_auth/backends/pipeline/user.py
+++ b/src/social_auth/backends/pipeline/user.py
@@ -105,9 +105,9 @@ def update_user_details(backend, details, response, user=None, is_new=False, *ar
         # do not update username, it was already generated, do not update
         # configured fields if user already existed
         if not _ignore_field(name, is_new):
-            if value and value != getattr(user, name, None):
+            if hasattr(user, name) and value and value != getattr(user, name, None):
                 setattr(user, name, value)
                 changed = True
 
-    if changed:
+    if changed and hasattr(user, "save"):
         user.save()


### PR DESCRIPTION
We shouldn't set attributes that don't exist on RpcUser as it causes errors, same with saving. I've not removed the User update entirely as I'm not confident that this isn't sometimes called with User instances that can be updated.

Fixes SENTRY-198W
