### PR TITLE
ref(tests): Codemod out TestStubs that don't break TS

### DIFF
--- a/fixtures/js-stubs/release.tsx
+++ b/fixtures/js-stubs/release.tsx
@@ -1,8 +1,8 @@
 import {Health, ReleaseStatus, ReleaseWithHealth} from 'sentry/types';
 
 export function Release(
-  params: Partial<ReleaseWithHealth>,
-  healthParams: Health
+  params?: Partial<ReleaseWithHealth>,
+  healthParams?: Health
 ): ReleaseWithHealth {
   return {
     newGroups: 0,
@@ -104,6 +104,7 @@ export function Release(
         platform: 'android',
         newGroups: 3,
         platforms: [],
+        hasHealthData: true,
         ...healthParams,
       },
     ],

--- a/fixtures/js-stubs/release.tsx
+++ b/fixtures/js-stubs/release.tsx
@@ -1,8 +1,8 @@
 import {Health, ReleaseStatus, ReleaseWithHealth} from 'sentry/types';
 
 export function Release(
-  params?: Partial<ReleaseWithHealth>,
-  healthParams?: Health
+  params: Partial<ReleaseWithHealth>,
+  healthParams: Health
 ): ReleaseWithHealth {
   return {
     newGroups: 0,

--- a/fixtures/js-stubs/release.tsx
+++ b/fixtures/js-stubs/release.tsx
@@ -1,8 +1,8 @@
 import {Health, ReleaseStatus, ReleaseWithHealth} from 'sentry/types';
 
 export function Release(
-  params: Partial<ReleaseWithHealth>,
-  healthParams: Health
+  params?: Partial<ReleaseWithHealth>,
+  healthParams?: Health
 ): ReleaseWithHealth {
   return {
     newGroups: 0,

--- a/static/app/components/acl/access.spec.tsx
+++ b/static/app/components/acl/access.spec.tsx
@@ -1,3 +1,4 @@
+import {Config as ConfigFixture} from 'sentry-fixture/config';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
@@ -134,8 +135,8 @@ describe('Access', function () {
 
     it('handles no user', function () {
       // Regression test for the share sheet.
-      ConfigStore.config = TestStubs.Config({
-        user: null,
+      ConfigStore.config = ConfigFixture({
+        user: undefined,
       });
 
       render(<Access>{childrenMock}</Access>, {context: routerContext, organization});
@@ -147,7 +148,7 @@ describe('Access', function () {
     });
 
     it('is superuser', function () {
-      ConfigStore.config = TestStubs.Config({
+      ConfigStore.config = ConfigFixture({
         user: User({isSuperuser: true}),
       });
 
@@ -163,7 +164,7 @@ describe('Access', function () {
     });
 
     it('is not superuser', function () {
-      ConfigStore.config = TestStubs.Config({
+      ConfigStore.config = ConfigFixture({
         user: User({isSuperuser: false}),
       });
 
@@ -203,7 +204,7 @@ describe('Access', function () {
     });
 
     it('has superuser', function () {
-      ConfigStore.config = TestStubs.Config({
+      ConfigStore.config = ConfigFixture({
         user: User({isSuperuser: true}),
       });
 
@@ -218,7 +219,7 @@ describe('Access', function () {
     });
 
     it('has no superuser', function () {
-      ConfigStore.config = TestStubs.Config({
+      ConfigStore.config = ConfigFixture({
         user: User({isSuperuser: false}),
       });
 

--- a/static/app/components/acl/feature.spec.tsx
+++ b/static/app/components/acl/feature.spec.tsx
@@ -1,3 +1,4 @@
+import {Config as ConfigFixture} from 'sentry-fixture/config';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
@@ -176,7 +177,7 @@ describe('Feature', function () {
     });
 
     it('checks ConfigStore.config.features (e.g. `organizations:create`)', function () {
-      ConfigStore.config = TestStubs.Config({
+      ConfigStore.config = ConfigFixture({
         features: new Set(['organizations:create']),
       });
 

--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -1,4 +1,5 @@
 import selectEvent from 'react-select-event';
+import {Release as ReleaseFixture} from 'sentry-fixture/release';
 
 import {
   render,
@@ -140,7 +141,7 @@ describe('ResolveActions', function () {
     const onUpdate = jest.fn();
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/releases/',
-      body: [TestStubs.Release()],
+      body: [ReleaseFixture()],
     });
     render(<ResolveActions hasRelease projectSlug="project-slug" onUpdate={onUpdate} />);
     renderGlobalModal();

--- a/static/app/components/assistant/guideAnchor.spec.tsx
+++ b/static/app/components/assistant/guideAnchor.spec.tsx
@@ -1,3 +1,4 @@
+import {Config as ConfigFixture} from 'sentry-fixture/config';
 import {User} from 'sentry-fixture/user';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -15,7 +16,7 @@ describe('GuideAnchor', function () {
   ];
 
   beforeEach(function () {
-    ConfigStore.config = TestStubs.Config({
+    ConfigStore.config = ConfigFixture({
       user: User({
         isSuperuser: false,
         dateJoined: '2020-01-01T00:00:00',

--- a/static/app/components/dateTime.spec.tsx
+++ b/static/app/components/dateTime.spec.tsx
@@ -1,3 +1,4 @@
+import {Config as ConfigFixture} from 'sentry-fixture/config';
 import {User} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -15,7 +16,7 @@ describe('DateTime', () => {
   });
 
   beforeAll(() => {
-    ConfigStore.loadInitialData(TestStubs.Config({user}));
+    ConfigStore.loadInitialData(ConfigFixture({user}));
   });
 
   it('renders a date', () => {

--- a/static/app/components/eventOrGroupHeader.spec.tsx
+++ b/static/app/components/eventOrGroupHeader.spec.tsx
@@ -1,4 +1,5 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {User} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -8,7 +9,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import EventOrGroupHeader from 'sentry/components/eventOrGroupHeader';
 import {EventOrGroupType} from 'sentry/types';
 
-const group = TestStubs.Group({
+const group = GroupFixture({
   level: 'error',
   metadata: {
     type: 'metadata type',

--- a/static/app/components/events/eventEntries.spec.tsx
+++ b/static/app/components/events/eventEntries.spec.tsx
@@ -1,4 +1,6 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {EventEntry as EventEntryFixture} from 'sentry-fixture/eventEntry';
+import {EventEntryDebugMeta as EventEntryDebugMetaFixture} from 'sentry-fixture/eventEntryDebugMeta';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
@@ -36,7 +38,7 @@ describe('EventEntries', function () {
       <EventEntries
         {...defaultProps}
         event={EventFixture({
-          entries: [TestStubs.EventEntry(), TestStubs.EventEntryDebugMeta()],
+          entries: [EventEntryFixture(), EventEntryDebugMetaFixture()],
           contexts: {
             replay_id: 1,
           },

--- a/static/app/components/events/eventEvidence.spec.tsx
+++ b/static/app/components/events/eventEvidence.spec.tsx
@@ -1,4 +1,5 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -28,7 +29,7 @@ describe('EventEvidence', () => {
 
   const defaultProps = {
     event,
-    group: TestStubs.Group(),
+    group: GroupFixture(),
     project: ProjectFixture({slug: 'project-slug'}),
   };
 

--- a/static/app/components/events/eventStatisticalDetector/regressionMessage.spec.tsx
+++ b/static/app/components/events/eventStatisticalDetector/regressionMessage.spec.tsx
@@ -1,4 +1,5 @@
 import {Event as MockEvent} from 'sentry-fixture/event';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -44,7 +45,7 @@ describe('Regression message', () => {
       },
     });
 
-    const mockGroup = TestStubs.Group({
+    const mockGroup = GroupFixture({
       issueType: IssueType.PERFORMANCE_DURATION_REGRESSION,
     });
 
@@ -78,7 +79,7 @@ describe('Regression message', () => {
       },
     });
 
-    const mockGroup = TestStubs.Group({
+    const mockGroup = GroupFixture({
       issueType: IssueType.PERFORMANCE_DURATION_REGRESSION,
     });
 

--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -1,5 +1,6 @@
 import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {EventEntryExceptionGroup as EventEntryExceptionGroupFixture} from 'sentry-fixture/eventEntryExceptionGroup';
 import {EventStacktraceFrame} from 'sentry-fixture/eventStacktraceFrame';
 import {Project, Project as ProjectFixture} from 'sentry-fixture/project';
 
@@ -199,7 +200,7 @@ describe('Exception Content', function () {
   });
 
   describe('exception groups', function () {
-    const event = EventFixture({entries: [TestStubs.EventEntryExceptionGroup()]});
+    const event = EventFixture({entries: [EventEntryExceptionGroupFixture()]});
     const project = ProjectFixture();
     beforeEach(() => {
       const promptResponse = {

--- a/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.spec.tsx
@@ -1,4 +1,5 @@
 import cloneDeep from 'lodash/cloneDeep';
+import {EventStacktraceException as EventStacktraceExceptionFixture} from 'sentry-fixture/eventStacktraceException';
 
 import {EntryException, Event} from 'sentry/types';
 
@@ -18,7 +19,7 @@ describe('getUniqueFilesFromException', () => {
   const props = {eventId: '0', orgSlug: '0', projectSlug: '0'};
 
   it('returns an array of frame filenames with required props', function () {
-    const event = TestStubs.EventStacktraceException({
+    const event = EventStacktraceExceptionFixture({
       platform: 'javascript',
     });
     const result = getUniqueFilesFromException(
@@ -41,7 +42,7 @@ describe('getUniqueFilesFromException', () => {
 
   it('does NOT use frames if all filenames are anonymous', function () {
     const event = modifyEventFrames(
-      TestStubs.EventStacktraceException({
+      EventStacktraceExceptionFixture({
         platform: 'javascript',
       }),
       {filename: '<anonymous>'}
@@ -56,7 +57,7 @@ describe('getUniqueFilesFromException', () => {
 
   it('uses frames that are relative to home directory', function () {
     const event = modifyEventFrames(
-      TestStubs.EventStacktraceException({
+      EventStacktraceExceptionFixture({
         platform: 'javascript',
       }),
       {absPath: '~/myfile.js', filename: '~/myfile.js'}

--- a/static/app/components/events/interfaces/frame/openInContextLine.spec.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.spec.tsx
@@ -1,3 +1,4 @@
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {SentryAppInstallation} from 'sentry-fixture/sentryAppInstallation';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -8,7 +9,7 @@ import {addQueryParamsToExistingUrl} from 'sentry/utils/queryString';
 
 describe('OpenInContextLine', function () {
   const filename = '/sentry/app.py';
-  const group = TestStubs.Group();
+  const group = GroupFixture();
   const install = SentryAppInstallation();
   const components: SentryAppComponent<SentryAppSchemaStacktraceLink>[] = [
     {

--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -1,7 +1,9 @@
 import {Commit} from 'sentry-fixture/commit';
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import {Release as ReleaseFixture} from 'sentry-fixture/release';
 import {Repository} from 'sentry-fixture/repository';
 import {RepositoryProjectPathConfig} from 'sentry-fixture/repositoryProjectPathConfig';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
@@ -21,10 +23,10 @@ describe('StacktraceLink', function () {
   const project = ProjectFixture({});
   const event = EventFixture({
     projectID: project.id,
-    release: TestStubs.Release({lastCommit: Commit()}),
+    release: ReleaseFixture({lastCommit: Commit()}),
     platform,
   });
-  const integration = TestStubs.GitHubIntegration();
+  const integration = GitHubIntegrationFixture();
   const repo = Repository({integrationId: integration.id});
 
   const frame = {filename: '/sentry/app.py', lineNo: 233} as Frame;

--- a/static/app/components/events/profileEventEvidence.spec.tsx
+++ b/static/app/components/events/profileEventEvidence.spec.tsx
@@ -1,4 +1,5 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -20,7 +21,7 @@ describe('ProfileEventEvidence', function () {
         },
       },
     }),
-    group: TestStubs.Group({
+    group: GroupFixture({
       issueCategory: IssueCategory.PROFILE,
       issueType: IssueType.PROFILE_FILE_IO_MAIN_THREAD,
     }),

--- a/static/app/components/group/tagDistributionMeter.spec.tsx
+++ b/static/app/components/group/tagDistributionMeter.spec.tsx
@@ -1,3 +1,4 @@
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 import {Tags} from 'sentry-fixture/tags';
 
@@ -16,7 +17,7 @@ describe('TagDistributionMeter', function () {
         name="Browser"
         topValues={[]}
         onTagClick={jest.fn()}
-        group={TestStubs.Group({id: '1337'})}
+        group={GroupFixture({id: '1337'})}
         organization={organization}
         projectId="456"
         totalValues={0}
@@ -31,7 +32,7 @@ describe('TagDistributionMeter', function () {
         tag="browser"
         name="Browser"
         onTagClick={jest.fn()}
-        group={TestStubs.Group({id: '1337'})}
+        group={GroupFixture({id: '1337'})}
         organization={organization}
         projectId="456"
         totalValues={tags[0].totalValues}

--- a/static/app/components/idBadge/memberBadge.spec.tsx
+++ b/static/app/components/idBadge/memberBadge.spec.tsx
@@ -1,3 +1,4 @@
+import {Member as MemberFixture} from 'sentry-fixture/member';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {User} from 'sentry-fixture/user';
 
@@ -9,7 +10,7 @@ describe('MemberBadge', function () {
   let member;
   const routerContext = RouterContextFixture();
   beforeEach(() => {
-    member = TestStubs.Member();
+    member = MemberFixture();
   });
 
   it('renders with link when member and orgId are supplied', function () {

--- a/static/app/components/modals/reprocessEventModal.spec.tsx
+++ b/static/app/components/modals/reprocessEventModal.spec.tsx
@@ -1,3 +1,5 @@
+import {Group as GroupFixture} from 'sentry-fixture/group';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -10,7 +12,7 @@ import {
 } from 'sentry/components/globalModal/components';
 import {ReprocessingEventModal} from 'sentry/components/modals/reprocessEventModal';
 
-const group = TestStubs.Group({
+const group = GroupFixture({
   id: '1337',
   pluginActions: [],
   pluginIssues: [],

--- a/static/app/components/modals/teamAccessRequestModal.spec.tsx
+++ b/static/app/components/modals/teamAccessRequestModal.spec.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import {Member as MemberFixture} from 'sentry-fixture/member';
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
 
@@ -14,7 +15,7 @@ describe('TeamAccessRequestModal', function () {
 
   const closeModal = jest.fn();
   const orgId = Organization().slug;
-  const memberId = TestStubs.Member().id;
+  const memberId = MemberFixture().id;
   const teamId = Team().slug;
 
   const styledWrapper = styled(c => c.children);

--- a/static/app/components/notificationActions/notificationActionManager.spec.tsx
+++ b/static/app/components/notificationActions/notificationActionManager.spec.tsx
@@ -1,3 +1,5 @@
+import {AvailableNotificationActions as AvailableNotificationActionsFixture} from 'sentry-fixture/availableNotificationActions';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
@@ -12,7 +14,7 @@ import type {NotificationAction} from 'sentry/types';
 
 describe('Adds, deletes, and updates notification actions', function () {
   const {project, organization} = initializeOrg();
-  const availableActions = TestStubs.AvailableNotificationActions().actions;
+  const availableActions = AvailableNotificationActionsFixture().actions;
   MockApiClient.addMockResponse({
     url: `/organizations/${organization.slug}/notifications/available-actions/`,
     body: availableActions,

--- a/static/app/components/organizations/pageFilters/container.spec.tsx
+++ b/static/app/components/organizations/pageFilters/container.spec.tsx
@@ -1,3 +1,4 @@
+import {Config as ConfigFixture} from 'sentry-fixture/config';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {User} from 'sentry-fixture/user';
@@ -564,7 +565,7 @@ describe('PageFiltersContainer', function () {
     it('selects a project if user is superuser and belongs to no projects', function () {
       ConfigStore.init();
       ConfigStore.loadInitialData(
-        TestStubs.Config({
+        ConfigFixture({
           user: User({isSuperuser: true}),
         })
       );

--- a/static/app/components/sidebar/sidebarDropdown/index.spec.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.spec.tsx
@@ -1,3 +1,4 @@
+import {Config as ConfigFixture} from 'sentry-fixture/config';
 import {Organization} from 'sentry-fixture/organization';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import {User} from 'sentry-fixture/user';
@@ -9,7 +10,7 @@ import ConfigStore from 'sentry/stores/configStore';
 
 function renderDropdown(props: any = {}) {
   const user = User();
-  const config = TestStubs.Config();
+  const config = ConfigFixture();
   const organization = Organization({orgRole: 'member'});
   const routerContext = RouterContextFixture([
     {
@@ -37,7 +38,7 @@ describe('SidebarDropdown', function () {
     renderDropdown({hideOrgLinks: true});
   });
   it('renders open sidebar', async function () {
-    const config = TestStubs.Config({
+    const config = ConfigFixture({
       singleOrganization: false,
     });
     renderDropdown({collapsed: false, config});
@@ -46,7 +47,7 @@ describe('SidebarDropdown', function () {
   });
   it('sandbox/demo mode render open sidebar', async function () {
     ConfigStore.set('demoMode', true);
-    const config = TestStubs.Config({singleOrganization: false});
+    const config = ConfigFixture({singleOrganization: false});
     renderDropdown({collapsed: false, config});
     await userEvent.click(screen.getByTestId('sidebar-dropdown'));
     expect(screen.queryByText('Switch organization')).not.toBeInTheDocument();

--- a/static/app/stores/groupStore.spec.tsx
+++ b/static/app/stores/groupStore.spec.tsx
@@ -1,4 +1,5 @@
 import {Actor} from 'sentry-fixture/actor';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Project, Project as ProjectFixture} from 'sentry-fixture/project';
 
 import GroupStore from 'sentry/stores/groupStore';
@@ -7,7 +8,7 @@ import {Group, GroupActivityType, GroupStats, TimeseriesValue} from 'sentry/type
 const MOCK_PROJECT = ProjectFixture();
 
 const g = (id: string, params?: Partial<Group>): Group => {
-  return TestStubs.Group({id, project: MOCK_PROJECT, ...params});
+  return GroupFixture({id, project: MOCK_PROJECT, ...params});
 };
 
 describe('GroupStore', function () {

--- a/static/app/stores/guideStore.spec.tsx
+++ b/static/app/stores/guideStore.spec.tsx
@@ -1,3 +1,4 @@
+import {Config as ConfigFixture} from 'sentry-fixture/config';
 import {User} from 'sentry-fixture/user';
 
 import ConfigStore from 'sentry/stores/configStore';
@@ -12,7 +13,7 @@ describe('GuideStore', function () {
 
   beforeEach(function () {
     jest.clearAllMocks();
-    ConfigStore.config = TestStubs.Config({
+    ConfigStore.config = ConfigFixture({
       user: User({
         id: '5',
         isSuperuser: false,

--- a/static/app/utils/discover/fieldRenderers.spec.tsx
+++ b/static/app/utils/discover/fieldRenderers.spec.tsx
@@ -1,3 +1,4 @@
+import {Config as ConfigFixture} from 'sentry-fixture/config';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {User} from 'sentry-fixture/user';
 
@@ -107,7 +108,7 @@ describe('getFieldRenderer', function () {
   describe('date', function () {
     beforeEach(function () {
       ConfigStore.loadInitialData(
-        TestStubs.Config({
+        ConfigFixture({
           user: User({
             options: {
               ...User().options,
@@ -148,7 +149,7 @@ describe('getFieldRenderer', function () {
   it('can render timestamp.to_day', function () {
     // Set timezone
     ConfigStore.loadInitialData(
-      TestStubs.Config({
+      ConfigFixture({
         user: User({
           options: {
             ...User().options,

--- a/static/app/utils/displayReprocessEventAction.spec.tsx
+++ b/static/app/utils/displayReprocessEventAction.spec.tsx
@@ -1,4 +1,7 @@
-import {EventStacktraceMessage} from 'sentry-fixture/eventStacktraceException';
+import {
+  EventStacktraceException as EventStacktraceExceptionFixture,
+  EventStacktraceMessage,
+} from 'sentry-fixture/eventStacktraceException';
 
 import {displayReprocessEventAction} from 'sentry/utils/displayReprocessEventAction';
 
@@ -20,7 +23,7 @@ describe('DisplayReprocessEventAction', function () {
   });
 
   it('returns false if the event is not a mini-dump event or an Apple crash report event or a Native event', function () {
-    const event = TestStubs.EventStacktraceException();
+    const event = EventStacktraceExceptionFixture();
     expect(displayReprocessEventAction(orgFeatures, event)).toBe(false);
   });
 
@@ -28,7 +31,7 @@ describe('DisplayReprocessEventAction', function () {
     describe('native event', function () {
       describe('event with defined platform', function () {
         it('native', function () {
-          const event = TestStubs.EventStacktraceException({
+          const event = EventStacktraceExceptionFixture({
             platform: 'native',
           });
 
@@ -36,7 +39,7 @@ describe('DisplayReprocessEventAction', function () {
         });
 
         it('cocoa', function () {
-          const event = TestStubs.EventStacktraceException({
+          const event = EventStacktraceExceptionFixture({
             platform: 'cocoa',
           });
 
@@ -46,7 +49,7 @@ describe('DisplayReprocessEventAction', function () {
 
       describe('event with undefined platform, but stack trace has platform', function () {
         it('native', function () {
-          const event = TestStubs.EventStacktraceException({
+          const event = EventStacktraceExceptionFixture({
             platform: undefined,
           });
 
@@ -56,7 +59,7 @@ describe('DisplayReprocessEventAction', function () {
         });
 
         it('cocoa', function () {
-          const event = TestStubs.EventStacktraceException({
+          const event = EventStacktraceExceptionFixture({
             platform: undefined,
           });
 
@@ -68,7 +71,7 @@ describe('DisplayReprocessEventAction', function () {
     });
 
     it('mini-dump event', function () {
-      const event = TestStubs.EventStacktraceException({
+      const event = EventStacktraceExceptionFixture({
         platform: undefined,
       });
 
@@ -83,7 +86,7 @@ describe('DisplayReprocessEventAction', function () {
     });
 
     it('apple crash report event', function () {
-      const event = TestStubs.EventStacktraceException({
+      const event = EventStacktraceExceptionFixture({
         platform: undefined,
       });
 

--- a/static/app/utils/getStacktraceBody.spec.tsx
+++ b/static/app/utils/getStacktraceBody.spec.tsx
@@ -1,10 +1,13 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
-import {EventStacktraceMessage} from 'sentry-fixture/eventStacktraceException';
+import {
+  EventStacktraceException as EventStacktraceExceptionFixture,
+  EventStacktraceMessage,
+} from 'sentry-fixture/eventStacktraceException';
 
 import getStacktraceBody from 'sentry/utils/getStacktraceBody';
 
 describe('getStacktraceBody', function () {
-  const eventException = TestStubs.EventStacktraceException({platform: 'python'});
+  const eventException = EventStacktraceExceptionFixture({platform: 'python'});
   const eventMessage = EventStacktraceMessage({platform: 'python'});
 
   it('formats with an exception', function () {

--- a/static/app/utils/releases/releasesProvider.spec.tsx
+++ b/static/app/utils/releases/releasesProvider.spec.tsx
@@ -1,3 +1,5 @@
+import {Release as ReleaseFixture} from 'sentry-fixture/release';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -33,15 +35,15 @@ describe('useReleases', function () {
     const mockReleases = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/releases/',
       body: [
-        TestStubs.Release({
+        ReleaseFixture({
           shortVersion: 'sentry-android-shop@1.2.0',
           version: 'sentry-android-shop@1.2.0',
         }),
-        TestStubs.Release({
+        ReleaseFixture({
           shortVersion: 'sentry-android-shop@1.3.0',
           version: 'sentry-android-shop@1.3.0',
         }),
-        TestStubs.Release({
+        ReleaseFixture({
           shortVersion: 'sentry-android-shop@1.4.0',
           version: 'sentry-android-shop@1.4.0',
         }),

--- a/static/app/views/acceptOrganizationInvite/index.spec.tsx
+++ b/static/app/views/acceptOrganizationInvite/index.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import {Config as ConfigFixture} from 'sentry-fixture/config';
 import {Organization} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -60,7 +61,7 @@ describe('AcceptOrganizationInvite', function () {
   });
 
   it('can accept invitation on customer-domains', async function () {
-    window.__initialData = TestStubs.Config({
+    window.__initialData = ConfigFixture({
       customerDomain: {
         subdomain: 'org-slug',
         organizationUrl: 'https://org-slug.sentry.io',

--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -1,4 +1,5 @@
 import selectEvent from 'react-select-event';
+import {Environments as EnvironmentsFixture} from 'sentry-fixture/environments';
 import {Groups} from 'sentry-fixture/groups';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
@@ -52,7 +53,7 @@ describe('ProjectAlertsCreate', function () {
     });
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/environments/',
-      body: TestStubs.Environments(),
+      body: EnvironmentsFixture(),
     });
     MockApiClient.addMockResponse({
       url: `/projects/org-slug/project-slug/?expand=hasAlertIntegration`,

--- a/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.spec.tsx
@@ -3,7 +3,10 @@ import LocationFixture from 'sentry-fixture/locationFixture';
 import {MetricRule} from 'sentry-fixture/metricRule';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
-import {ProjectAlertRule} from 'sentry-fixture/projectAlertRule';
+import {
+  ProjectAlertRule,
+  ProjectAlertRule as ProjectAlertRuleFixture,
+} from 'sentry-fixture/projectAlertRule';
 import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -176,7 +179,7 @@ describe('AlertRulesList', () => {
       url: '/organizations/org-slug/combined-rules/',
       headers: {Link: pageLinks},
       body: [
-        TestStubs.ProjectAlertRule({
+        ProjectAlertRuleFixture({
           id: '123',
           name: deletedRuleName,
           projects: ['earth'],

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.tsx
@@ -1,8 +1,13 @@
 import {browserHistory} from 'react-router';
 import moment from 'moment';
+import {Group as GroupFixture} from 'sentry-fixture/group';
+import {Member as MemberFixture} from 'sentry-fixture/member';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
-import {ProjectAlertRule} from 'sentry-fixture/projectAlertRule';
+import {
+  ProjectAlertRule,
+  ProjectAlertRule as ProjectAlertRuleFixture,
+} from 'sentry-fixture/projectAlertRule';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -18,7 +23,7 @@ describe('AlertRuleDetails', () => {
   const rule = ProjectAlertRule({
     lastTriggered: moment().subtract(2, 'day').format(),
   });
-  const member = TestStubs.Member();
+  const member = MemberFixture();
 
   const createWrapper = (props: any = {}, newContext?: any, org = organization) => {
     const router = newContext ? newContext.router : context.router;
@@ -56,7 +61,7 @@ describe('AlertRuleDetails', () => {
       body: [
         {
           count: 1,
-          group: TestStubs.Group(),
+          group: GroupFixture(),
           lastTriggered: moment('Apr 11, 2019 1:08:59 AM UTC').format(),
           eventId: 'eventId',
         },
@@ -97,7 +102,7 @@ describe('AlertRuleDetails', () => {
       expect.stringMatching(
         RegExp(
           `/organizations/${organization.slug}/issues/${
-            TestStubs.Group().id
+            GroupFixture().id
           }/events/eventId.*`
         )
       )
@@ -161,7 +166,7 @@ describe('AlertRuleDetails', () => {
   });
 
   it('renders incompatible rule filter', async () => {
-    const incompatibleRule = TestStubs.ProjectAlertRule({
+    const incompatibleRule = ProjectAlertRuleFixture({
       conditions: [
         {id: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition'},
         {id: 'sentry.rules.conditions.regression_event.RegressionEventCondition'},
@@ -347,7 +352,7 @@ describe('AlertRuleDetails', () => {
 
   it('inserts user email into rule notify action', async () => {
     // Alert rule with "send a notification to member" action
-    const sendNotificationRule = TestStubs.ProjectAlertRule({
+    const sendNotificationRule = ProjectAlertRuleFixture({
       actions: [
         {
           id: 'sentry.mail.actions.NotifyEmailAction',

--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -1,6 +1,7 @@
 import {browserHistory, PlainRoute} from 'react-router';
 import selectEvent from 'react-select-event';
 import moment from 'moment';
+import {Environments as EnvironmentsFixture} from 'sentry-fixture/environments';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {ProjectAlertRule} from 'sentry-fixture/projectAlertRule';
 import {ProjectAlertRuleConfiguration} from 'sentry-fixture/projectAlertRuleConfiguration';
@@ -129,7 +130,7 @@ describe('IssueRuleEditor', function () {
     });
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/environments/',
-      body: TestStubs.Environments(),
+      body: EnvironmentsFixture(),
     });
     MockApiClient.addMockResponse({
       url: `/projects/org-slug/project-slug/?expand=hasAlertIntegration`,

--- a/static/app/views/dashboards/create.spec.tsx
+++ b/static/app/views/dashboards/create.spec.tsx
@@ -1,3 +1,4 @@
+import {Dashboard as DashboardFixture} from 'sentry-fixture/dashboard';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 
@@ -42,7 +43,7 @@ describe('Dashboards > Create', function () {
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/',
-        body: [TestStubs.Dashboard([], {id: 'default-overview', title: 'Default'})],
+        body: [DashboardFixture([], {id: 'default-overview', title: 'Default'})],
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/events-stats/',
@@ -73,7 +74,7 @@ describe('Dashboards > Create', function () {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/',
         method: 'POST',
-        body: TestStubs.Dashboard([], {id: '1', title: 'Custom Errors'}),
+        body: DashboardFixture([], {id: '1', title: 'Custom Errors'}),
       });
 
       render(

--- a/static/app/views/dashboards/datasetConfig/issues.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.spec.tsx
@@ -1,4 +1,5 @@
 import {GlobalSelection} from 'sentry-fixture/globalSelection';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 
@@ -10,7 +11,7 @@ describe('transformIssuesResponseToTable', function () {
     expect(
       transformIssuesResponseToTable(
         [
-          TestStubs.Group({
+          GroupFixture({
             id: '1',
             title: 'Error: Failed',
             project: ProjectFixture({

--- a/static/app/views/dashboards/releasesSelectControl.spec.tsx
+++ b/static/app/views/dashboards/releasesSelectControl.spec.tsx
@@ -1,3 +1,5 @@
+import {Release as ReleaseFixture} from 'sentry-fixture/release';
+
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ReleasesContext} from 'sentry/utils/releases/releasesProvider';
@@ -15,17 +17,17 @@ function renderReleasesSelect({
     <ReleasesContext.Provider
       value={{
         releases: [
-          TestStubs.Release({
+          ReleaseFixture({
             id: '1',
             shortVersion: 'sentry-android-shop@1.2.0',
             version: 'sentry-android-shop@1.2.0',
           }),
-          TestStubs.Release({
+          ReleaseFixture({
             id: '2',
             shortVersion: 'sentry-android-shop@1.3.0',
             version: 'sentry-android-shop@1.3.0',
           }),
-          TestStubs.Release({
+          ReleaseFixture({
             id: '3',
             shortVersion: 'sentry-android-shop@1.4.0',
             version: 'sentry-android-shop@1.4.0',

--- a/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/widgetBuilder.spec.tsx
@@ -1,6 +1,7 @@
 import selectEvent from 'react-select-event';
 import {urlEncode} from '@sentry/utils';
 import {MetricsField} from 'sentry-fixture/metrics';
+import {Release as ReleaseFixture} from 'sentry-fixture/release';
 import {SessionsField} from 'sentry-fixture/sessions';
 import {Tags} from 'sentry-fixture/tags';
 
@@ -1060,7 +1061,7 @@ describe('WidgetBuilder', function () {
   it('renders page filters in the filter step', async () => {
     const mockReleases = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/releases/',
-      body: [TestStubs.Release()],
+      body: [ReleaseFixture()],
     });
 
     renderTestComponent({
@@ -1080,7 +1081,7 @@ describe('WidgetBuilder', function () {
   it('appends dashboard filters to widget builder fetch data request', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/releases/',
-      body: [TestStubs.Release()],
+      body: [ReleaseFixture()],
     });
 
     const mock = MockApiClient.addMockResponse({

--- a/static/app/views/discover/eventDetails/index.spec.tsx
+++ b/static/app/views/discover/eventDetails/index.spec.tsx
@@ -1,3 +1,4 @@
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
@@ -73,7 +74,7 @@ describe('Discover > EventDetails', function () {
     MockApiClient.addMockResponse({
       url: '/issues/123/',
       method: 'GET',
-      body: TestStubs.Group({id: '123'}),
+      body: GroupFixture({id: '123'}),
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',

--- a/static/app/views/issueDetails/actions/shareModal.spec.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.spec.tsx
@@ -1,3 +1,4 @@
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 
@@ -24,7 +25,7 @@ describe('shareModal', () => {
   });
 
   it('should share on open', async () => {
-    const group = TestStubs.Group();
+    const group = GroupFixture();
     GroupStore.add([group]);
 
     const issuesApi = MockApiClient.addMockResponse({
@@ -53,7 +54,7 @@ describe('shareModal', () => {
   });
 
   it('should unshare', async () => {
-    const group = TestStubs.Group({isPublic: true, shareId: '12345'});
+    const group = GroupFixture({isPublic: true, shareId: '12345'});
     GroupStore.add([group]);
 
     const issuesApi = MockApiClient.addMockResponse({

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -1,4 +1,7 @@
+import {Config as ConfigFixture} from 'sentry-fixture/config';
+import {Environments as EnvironmentsFixture} from 'sentry-fixture/environments';
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {Team} from 'sentry-fixture/team';
@@ -21,7 +24,7 @@ const SAMPLE_EVENT_ALERT_TEXT =
   'You are viewing a sample error. Configure Sentry to start viewing real errors.';
 
 describe('groupDetails', () => {
-  const group = TestStubs.Group({issueCategory: IssueCategory.ERROR});
+  const group = GroupFixture({issueCategory: IssueCategory.ERROR});
   const event = EventFixture();
   const project = ProjectFixture({teams: [Team()]});
 
@@ -144,7 +147,7 @@ describe('groupDetails', () => {
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${defaultInit.organization.slug}/environments/`,
-      body: TestStubs.Environments(),
+      body: EnvironmentsFixture(),
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/tags/`,
@@ -319,7 +322,7 @@ describe('groupDetails', () => {
   });
 
   it('uses /latest endpoint when default is set to latest', async function () {
-    ConfigStore.loadInitialData(TestStubs.Config({user: latestUser}));
+    ConfigStore.loadInitialData(ConfigFixture({user: latestUser}));
     const latestMock = MockApiClient.addMockResponse({
       url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/events/latest/`,
       statusCode: 200,
@@ -332,7 +335,7 @@ describe('groupDetails', () => {
   });
 
   it('uses /oldest endpoint when default is set to oldest', async function () {
-    ConfigStore.loadInitialData(TestStubs.Config({user: oldestUser}));
+    ConfigStore.loadInitialData(ConfigFixture({user: oldestUser}));
     const oldestMock = MockApiClient.addMockResponse({
       url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/events/oldest/`,
       statusCode: 200,
@@ -345,7 +348,7 @@ describe('groupDetails', () => {
   });
 
   it('uses /recommended endpoint when default is set to recommended', async function () {
-    ConfigStore.loadInitialData(TestStubs.Config({user: recommendedUser}));
+    ConfigStore.loadInitialData(ConfigFixture({user: recommendedUser}));
     const recommendedMock = MockApiClient.addMockResponse({
       url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/events/recommended/`,
       statusCode: 200,

--- a/static/app/views/issueDetails/groupEventCarousel.spec.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.spec.tsx
@@ -1,5 +1,7 @@
 import {browserHistory} from 'react-router';
+import {Config as ConfigFixture} from 'sentry-fixture/config';
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 import {User} from 'sentry-fixture/user';
 
@@ -25,7 +27,7 @@ describe('GroupEventCarousel', () => {
 
   const defaultProps = {
     event: testEvent,
-    group: TestStubs.Group({id: 'group-id'}),
+    group: GroupFixture({id: 'group-id'}),
     projectSlug: 'project-slug',
   };
 
@@ -116,7 +118,7 @@ describe('GroupEventCarousel', () => {
     });
 
     it('if user default is recommended, it will show it as default', async () => {
-      ConfigStore.loadInitialData(TestStubs.Config({user: recommendedUser}));
+      ConfigStore.loadInitialData(ConfigFixture({user: recommendedUser}));
       jest.spyOn(useMedia, 'default').mockReturnValue(true);
 
       render(<GroupEventCarousel {...singleEventProps} />);
@@ -125,7 +127,7 @@ describe('GroupEventCarousel', () => {
     });
 
     it('if user default is latest, it will show it as default', async () => {
-      ConfigStore.loadInitialData(TestStubs.Config({user: latestUser}));
+      ConfigStore.loadInitialData(ConfigFixture({user: latestUser}));
       jest.spyOn(useMedia, 'default').mockReturnValue(true);
 
       render(<GroupEventCarousel {...singleEventProps} />);
@@ -134,7 +136,7 @@ describe('GroupEventCarousel', () => {
     });
 
     it('if user default is oldest, it will show it as default', async () => {
-      ConfigStore.loadInitialData(TestStubs.Config({user: oldestUser}));
+      ConfigStore.loadInitialData(ConfigFixture({user: oldestUser}));
       jest.spyOn(useMedia, 'default').mockReturnValue(true);
 
       render(<GroupEventCarousel {...singleEventProps} />);

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -1,3 +1,4 @@
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -62,7 +63,7 @@ describe('GroupReplays', () => {
   });
 
   describe('Replay Feature Disabled', () => {
-    const mockGroup = TestStubs.Group();
+    const mockGroup = GroupFixture();
 
     const {router, organization, routerContext} = init({
       organizationProps: {features: []},
@@ -85,7 +86,7 @@ describe('GroupReplays', () => {
     const {router, organization, routerContext} = init({});
 
     it('should query the replay-count endpoint with the fetched replayIds', async () => {
-      const mockGroup = TestStubs.Group();
+      const mockGroup = GroupFixture();
 
       const mockReplayCountApi = MockApiClient.addMockResponse({
         url: mockReplayCountUrl,
@@ -154,7 +155,7 @@ describe('GroupReplays', () => {
     });
 
     it('should show empty message when no replays are found', async () => {
-      const mockGroup = TestStubs.Group();
+      const mockGroup = GroupFixture();
 
       const mockReplayCountApi = MockApiClient.addMockResponse({
         url: mockReplayCountUrl,
@@ -184,7 +185,7 @@ describe('GroupReplays', () => {
     });
 
     it('should display error message when api call fails', async () => {
-      const mockGroup = TestStubs.Group();
+      const mockGroup = GroupFixture();
 
       const mockReplayCountApi = MockApiClient.addMockResponse({
         url: mockReplayCountUrl,
@@ -217,7 +218,7 @@ describe('GroupReplays', () => {
     });
 
     it('should display default error message when api call fails without a body', async () => {
-      const mockGroup = TestStubs.Group();
+      const mockGroup = GroupFixture();
 
       const mockReplayCountApi = MockApiClient.addMockResponse({
         url: mockReplayCountUrl,
@@ -250,7 +251,7 @@ describe('GroupReplays', () => {
     });
 
     it('should show loading indicator when loading replays', async () => {
-      const mockGroup = TestStubs.Group();
+      const mockGroup = GroupFixture();
 
       const mockReplayCountApi = MockApiClient.addMockResponse({
         url: mockReplayCountUrl,
@@ -281,7 +282,7 @@ describe('GroupReplays', () => {
     });
 
     it('should show a list of replays and have the correct values', async () => {
-      const mockGroup = TestStubs.Group();
+      const mockGroup = GroupFixture();
 
       const mockReplayCountApi = MockApiClient.addMockResponse({
         url: mockReplayCountUrl,

--- a/static/app/views/issueDetails/groupReplays/useReplaysForRegressionIssue.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysForRegressionIssue.spec.tsx
@@ -1,5 +1,6 @@
 import {Location} from 'history';
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
@@ -47,7 +48,7 @@ describe('useReplaysForRegressionIssue', () => {
   };
 
   it('should fetch a list of replay ids', async () => {
-    const MOCK_GROUP = TestStubs.Group({issueCategory: IssueCategory.PERFORMANCE});
+    const MOCK_GROUP = GroupFixture({issueCategory: IssueCategory.PERFORMANCE});
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/replay-count/`,
@@ -87,7 +88,7 @@ describe('useReplaysForRegressionIssue', () => {
   });
 
   it('should return an empty EventView when there are no replay_ids returned from the count endpoint', async () => {
-    const MOCK_GROUP = TestStubs.Group({issueCategory: IssueCategory.PERFORMANCE});
+    const MOCK_GROUP = GroupFixture({issueCategory: IssueCategory.PERFORMANCE});
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/replay-count/`,
@@ -125,7 +126,7 @@ describe('useReplaysForRegressionIssue', () => {
   });
 
   it('queries using start and end date strings if passed in', async () => {
-    const MOCK_GROUP = TestStubs.Group({issueCategory: IssueCategory.PERFORMANCE});
+    const MOCK_GROUP = GroupFixture({issueCategory: IssueCategory.PERFORMANCE});
     const replayCountRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/replay-count/`,
       method: 'GET',
@@ -159,7 +160,7 @@ describe('useReplaysForRegressionIssue', () => {
   });
 
   it('queries the transaction name with event type and duration filters', async () => {
-    const MOCK_GROUP = TestStubs.Group({issueCategory: IssueCategory.PERFORMANCE});
+    const MOCK_GROUP = GroupFixture({issueCategory: IssueCategory.PERFORMANCE});
     const replayCountRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/replay-count/`,
       method: 'GET',

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
@@ -1,4 +1,5 @@
 import {Location} from 'history';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
@@ -26,7 +27,7 @@ describe('useReplaysFromIssue', () => {
   });
 
   it('should fetch a list of replay ids', async () => {
-    const MOCK_GROUP = TestStubs.Group();
+    const MOCK_GROUP = GroupFixture();
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/replay-count/`,
@@ -62,7 +63,7 @@ describe('useReplaysFromIssue', () => {
   });
 
   it('should fetch a list of replay ids for a performance issue', async () => {
-    const MOCK_GROUP = TestStubs.Group({issueCategory: IssueCategory.PERFORMANCE});
+    const MOCK_GROUP = GroupFixture({issueCategory: IssueCategory.PERFORMANCE});
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/replay-count/`,
@@ -98,7 +99,7 @@ describe('useReplaysFromIssue', () => {
   });
 
   it('should return an empty EventView when there are no replay_ids returned from the count endpoint', async () => {
-    const MOCK_GROUP = TestStubs.Group();
+    const MOCK_GROUP = GroupFixture();
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/replay-count/`,

--- a/static/app/views/issueDetails/groupTags.spec.tsx
+++ b/static/app/views/issueDetails/groupTags.spec.tsx
@@ -1,3 +1,4 @@
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Tags} from 'sentry-fixture/tags';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -8,7 +9,7 @@ import GroupTags from 'sentry/views/issueDetails/groupTags';
 
 describe('GroupTags', function () {
   const {routerProps, routerContext, router, organization} = initializeOrg();
-  const group = TestStubs.Group();
+  const group = GroupFixture();
   let tagsMock;
   beforeEach(function () {
     tagsMock = MockApiClient.addMockResponse({

--- a/static/app/views/issueDetails/header.spec.tsx
+++ b/static/app/views/issueDetails/header.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {Team} from 'sentry-fixture/team';
@@ -20,7 +21,7 @@ describe('groupDetails', () => {
     const defaultProps = {
       organization,
       baseUrl,
-      group: TestStubs.Group({issueCategory: IssueCategory.ERROR}),
+      group: GroupFixture({issueCategory: IssueCategory.ERROR}),
       groupReprocessingStatus: ReprocessingStatus.NO_STATUS,
       project,
     };
@@ -34,7 +35,7 @@ describe('groupDetails', () => {
         platform: 'javascript',
       });
 
-      const MOCK_GROUP = TestStubs.Group();
+      const MOCK_GROUP = GroupFixture();
 
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/replay-count/`,
@@ -88,7 +89,7 @@ describe('groupDetails', () => {
     const defaultProps = {
       organization,
       baseUrl,
-      group: TestStubs.Group({issueCategory: IssueCategory.ERROR}),
+      group: GroupFixture({issueCategory: IssueCategory.ERROR}),
       groupReprocessingStatus: ReprocessingStatus.NO_STATUS,
       project,
     };
@@ -102,7 +103,7 @@ describe('groupDetails', () => {
         platform: 'apple-ios',
       });
 
-      const MOCK_GROUP = TestStubs.Group();
+      const MOCK_GROUP = GroupFixture();
 
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/replay-count/`,
@@ -132,7 +133,7 @@ describe('groupDetails', () => {
     const defaultProps = {
       organization,
       baseUrl,
-      group: TestStubs.Group({issueCategory: IssueCategory.PERFORMANCE}),
+      group: GroupFixture({issueCategory: IssueCategory.PERFORMANCE}),
       groupReprocessingStatus: ReprocessingStatus.NO_STATUS,
       project,
     };
@@ -146,7 +147,7 @@ describe('groupDetails', () => {
         features: ['similarity-view'],
       });
 
-      const MOCK_GROUP = TestStubs.Group({issueCategory: IssueCategory.PERFORMANCE});
+      const MOCK_GROUP = GroupFixture({issueCategory: IssueCategory.PERFORMANCE});
 
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/replay-count/`,

--- a/static/app/views/issueDetails/quickTrace/index.spec.tsx
+++ b/static/app/views/issueDetails/quickTrace/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 
@@ -10,7 +11,7 @@ describe('IssueQuickTrace', () => {
   const defaultProps = {
     organization: Organization({features: ['performance-view']}),
     event: EventFixture({contexts: {trace: {trace_id: 100}}}),
-    group: TestStubs.Group(),
+    group: GroupFixture(),
     location: LocationFixture(),
   };
 

--- a/static/app/views/issueDetails/shortIdBreadcrumb.spec.tsx
+++ b/static/app/views/issueDetails/shortIdBreadcrumb.spec.tsx
@@ -1,3 +1,5 @@
+import {Group as GroupFixture} from 'sentry-fixture/group';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -5,7 +7,7 @@ import {ShortIdBreadrcumb} from './shortIdBreadcrumb';
 
 describe('ShortIdBreadrcumb', function () {
   const {organization, project} = initializeOrg();
-  const group = TestStubs.Group({shortId: 'ABC-123'});
+  const group = GroupFixture({shortId: 'ABC-123'});
 
   beforeEach(() => {
     Object.assign(navigator, {

--- a/static/app/views/issueList/actions/index.spec.tsx
+++ b/static/app/views/issueList/actions/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 
@@ -307,9 +308,9 @@ describe('IssueListActions', function () {
     jest.spyOn(GroupStore, 'get').mockImplementation(id => {
       switch (id) {
         case '1':
-          return TestStubs.Group({project: ProjectFixture({slug: 'project-1'})});
+          return GroupFixture({project: ProjectFixture({slug: 'project-1'})});
         default:
-          return TestStubs.Group({project: ProjectFixture({slug: 'project-2'})});
+          return GroupFixture({project: ProjectFixture({slug: 'project-2'})});
       }
     });
 
@@ -333,7 +334,7 @@ describe('IssueListActions', function () {
         .spyOn(SelectedGroupStore, 'getSelectedIds')
         .mockImplementation(() => new Set(['1', '2', '3']));
       jest.spyOn(GroupStore, 'get').mockImplementation(id => {
-        return TestStubs.Group({
+        return GroupFixture({
           id,
           inbox: {
             date_added: '2020-11-24T13:17:42.248751Z',
@@ -354,7 +355,7 @@ describe('IssueListActions', function () {
     it('mark reviewed disabled for group that is already reviewed', function () {
       SelectedGroupStore.add(['1']);
       SelectedGroupStore.toggleSelectAll();
-      GroupStore.loadInitialData([TestStubs.Group({id: '1', inbox: null})]);
+      GroupStore.loadInitialData([GroupFixture({id: '1', inbox: null})]);
 
       render(<WrappedComponent {...defaultProps} />);
 
@@ -383,11 +384,11 @@ describe('IssueListActions', function () {
       jest.spyOn(GroupStore, 'get').mockImplementation(id => {
         switch (id) {
           case '1':
-            return TestStubs.Group({
+            return GroupFixture({
               issueCategory: IssueCategory.ERROR,
             });
           default:
-            return TestStubs.Group({
+            return GroupFixture({
               issueCategory: IssueCategory.PERFORMANCE,
             });
         }
@@ -472,9 +473,7 @@ describe('IssueListActions', function () {
         // Ensure that all issues have the same project so we can merge
         jest
           .spyOn(GroupStore, 'get')
-          .mockReturnValue(
-            TestStubs.Group({project: ProjectFixture({slug: 'project-1'})})
-          );
+          .mockReturnValue(GroupFixture({project: ProjectFixture({slug: 'project-1'})}));
 
         render(
           <Fragment>

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -1,7 +1,9 @@
 import {browserHistory} from 'react-router';
 import merge from 'lodash/merge';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {GroupStats} from 'sentry-fixture/groupStats';
 import LocationFixture from 'sentry-fixture/locationFixture';
+import {Member as MemberFixture} from 'sentry-fixture/member';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {Search} from 'sentry-fixture/search';
@@ -64,7 +66,7 @@ describe('IssueList', function () {
   let props;
 
   const tags = Tags();
-  const group = TestStubs.Group({project});
+  const group = GroupFixture({project});
   const groupStats = GroupStats();
   const savedSearch = Search({
     id: '789',
@@ -133,7 +135,7 @@ describe('IssueList', function () {
     fetchMembersRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/users/',
       method: 'GET',
-      body: [TestStubs.Member({projects: [project.slug]})],
+      body: [MemberFixture({projects: [project.slug]})],
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/sent-first-event/',

--- a/static/app/views/organizationStats/teamInsights/teamIssuesAge.spec.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesAge.spec.tsx
@@ -1,3 +1,4 @@
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
 
@@ -25,7 +26,7 @@ describe('TeamIssuesAge', () => {
     });
     const issuesApi = MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${team.slug}/issues/old/`,
-      body: [TestStubs.Group()],
+      body: [GroupFixture()],
     });
     render(<TeamIssuesAge organization={organization} teamSlug={team.slug} />);
 

--- a/static/app/views/projectDetail/projectIssues.spec.tsx
+++ b/static/app/views/projectDetail/projectIssues.spec.tsx
@@ -1,3 +1,5 @@
+import {Group as GroupFixture} from 'sentry-fixture/group';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -17,17 +19,17 @@ describe('ProjectDetail > ProjectIssues', function () {
   beforeEach(function () {
     endpointMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/?limit=5&query=error.unhandled%3Atrue%20is%3Aunresolved&sort=freq&statsPeriod=14d`,
-      body: [TestStubs.Group(), TestStubs.Group({id: '2'})],
+      body: [GroupFixture(), GroupFixture({id: '2'})],
     });
 
     filteredEndpointMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/?environment=staging&limit=5&query=error.unhandled%3Atrue%20is%3Aunresolved&sort=freq&statsPeriod=7d`,
-      body: [TestStubs.Group(), TestStubs.Group({id: '2'})],
+      body: [GroupFixture(), GroupFixture({id: '2'})],
     });
 
     newIssuesEndpointMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/?limit=5&query=is%3Aunresolved%20is%3Afor_review&sort=freq&statsPeriod=14d`,
-      body: [TestStubs.Group(), TestStubs.Group({id: '2'})],
+      body: [GroupFixture(), GroupFixture({id: '2'})],
     });
 
     MockApiClient.addMockResponse({
@@ -54,7 +56,7 @@ describe('ProjectDetail > ProjectIssues', function () {
   it('renders a list', async function () {
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/?limit=5&query=error.unhandled%3Atrue%20is%3Aunresolved&sort=freq&statsPeriod=14d`,
-      body: [TestStubs.Group(), TestStubs.Group({id: '2'})],
+      body: [GroupFixture(), GroupFixture({id: '2'})],
     });
     render(
       <ProjectIssues

--- a/static/app/views/projectDetail/projectLatestReleases.spec.tsx
+++ b/static/app/views/projectDetail/projectLatestReleases.spec.tsx
@@ -1,4 +1,5 @@
 import LocationFixture from 'sentry-fixture/locationFixture';
+import {Release as ReleaseFixture} from 'sentry-fixture/release';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -18,14 +19,11 @@ describe('ProjectDetail > ProjectLatestReleases', function () {
   beforeEach(function () {
     endpointMock = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/releases/`,
-      body: [
-        TestStubs.Release({version: '1.0.0'}),
-        TestStubs.Release({version: '1.0.1'}),
-      ],
+      body: [ReleaseFixture({version: '1.0.0'}), ReleaseFixture({version: '1.0.1'})],
     });
     endpointOlderReleasesMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/releases/stats/`,
-      body: [TestStubs.Release({version: '1.0.0'})],
+      body: [ReleaseFixture({version: '1.0.0'})],
     });
   });
 

--- a/static/app/views/projectInstall/platform.spec.tsx
+++ b/static/app/views/projectInstall/platform.spec.tsx
@@ -1,3 +1,4 @@
+import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {ProjectKeys} from 'sentry-fixture/projectKeys';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -52,7 +53,7 @@ describe('ProjectInstallPlatform', function () {
 
   it('should render NotFound if no matching integration/platform', async function () {
     const routeParams = {
-      projectId: TestStubs.Project().slug,
+      projectId: ProjectFixture().slug,
     };
     const {organization, routerProps, project, routerContext} = initializeOrg({
       router: {
@@ -75,7 +76,7 @@ describe('ProjectInstallPlatform', function () {
 
   it('should display info for a non-supported platform', async function () {
     const routeParams = {
-      projectId: TestStubs.Project().slug,
+      projectId: ProjectFixture().slug,
     };
 
     const {organization, routerProps, project} = initializeOrg({
@@ -102,7 +103,7 @@ describe('ProjectInstallPlatform', function () {
   });
 
   it('should render getting started docs for correct platform', async function () {
-    const project = TestStubs.Project({platform: 'javascript'});
+    const project = ProjectFixture({platform: 'javascript'});
 
     const routeParams = {
       projectId: project.slug,

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import {Release as ReleaseFixture} from 'sentry-fixture/release';
 import {
   SessionUserCountByStatus,
   SessionUserCountByStatus2,
@@ -12,7 +13,7 @@ import ReleaseComparisonChart from 'sentry/views/releases/detail/overview/releas
 describe('Releases > Detail > Overview > ReleaseComparison', () => {
   const {routerContext, organization, project} = initializeOrg();
   const api = new MockApiClient();
-  const release = TestStubs.Release();
+  const release = ReleaseFixture();
   const releaseSessions = SessionUserCountByStatus();
   const allSessions = SessionUserCountByStatus2();
 

--- a/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.spec.tsx
@@ -1,5 +1,7 @@
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
+import {Release as ReleaseFixture} from 'sentry-fixture/release';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -19,7 +21,7 @@ describe('ReleaseIssues', function () {
     organization: Organization(),
     version: '1.0.0',
     location: LocationFixture({query: {}}),
-    releaseBounds: getReleaseBounds(TestStubs.Release({version: '1.0.0'})),
+    releaseBounds: getReleaseBounds(ReleaseFixture({version: '1.0.0'})),
   };
 
   beforeEach(function () {
@@ -171,7 +173,7 @@ describe('ReleaseIssues', function () {
   it('includes release context when linking to issue', async function () {
     newIssuesEndpoint = MockApiClient.addMockResponse({
       url: `/organizations/${props.organization.slug}/issues/?end=2020-03-24T02%3A04%3A59Z&groupStatsPeriod=auto&limit=10&query=first-release%3A1.0.0%20is%3Aunresolved&sort=freq&start=2020-03-23T01%3A02%3A00Z`,
-      body: [TestStubs.Group({id: '123'})],
+      body: [GroupFixture({id: '123'})],
     });
 
     const {routerContext} = initializeOrg();

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.spec.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.spec.tsx
@@ -1,3 +1,4 @@
+import {Release as ReleaseFixture} from 'sentry-fixture/release';
 import {ReleaseMeta} from 'sentry-fixture/releaseMeta';
 
 import {render} from 'sentry-test/reactTestingLibrary';
@@ -6,7 +7,7 @@ import ProjectReleaseDetails from './projectReleaseDetails';
 
 describe('ProjectReleaseDetails', () => {
   it('should dislay if the release is using semver', () => {
-    const release = TestStubs.Release();
+    const release = ReleaseFixture();
     const releaseMeta = ReleaseMeta({});
     const {container} = render(
       <ProjectReleaseDetails

--- a/static/app/views/releases/detail/utils.spec.tsx
+++ b/static/app/views/releases/detail/utils.spec.tsx
@@ -1,3 +1,5 @@
+import {Release as ReleaseFixture} from 'sentry-fixture/release';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import {lightTheme} from 'sentry/utils/theme';
@@ -10,7 +12,7 @@ describe('releases/detail/utils', () => {
   describe('generateReleaseMarkLines', () => {
     const {created, adopted, unadopted} = releaseMarkLinesLabels;
     const {router} = initializeOrg();
-    const release = TestStubs.Release();
+    const release = ReleaseFixture();
     const project = release.projects[0];
 
     it('generates "Created" markline', () => {

--- a/static/app/views/settings/account/apiTokenRow.spec.tsx
+++ b/static/app/views/settings/account/apiTokenRow.spec.tsx
@@ -1,22 +1,24 @@
+import {ApiToken as ApiTokenFixture} from 'sentry-fixture/apiToken';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ApiTokenRow from 'sentry/views/settings/account/apiTokenRow';
 
 describe('ApiTokenRow', () => {
   it('renders', () => {
-    render(<ApiTokenRow onRemove={() => {}} token={TestStubs.ApiToken()} />);
+    render(<ApiTokenRow onRemove={() => {}} token={ApiTokenFixture()} />);
   });
 
   it('calls onRemove callback when trash can is clicked', async () => {
     const cb = jest.fn();
-    render(<ApiTokenRow onRemove={cb} token={TestStubs.ApiToken()} />);
+    render(<ApiTokenRow onRemove={cb} token={ApiTokenFixture()} />);
 
     await userEvent.click(screen.getByLabelText('Remove'));
     expect(cb).toHaveBeenCalled();
   });
 
   it('uses NewTokenHandler when lastTokenCharacters field is found', () => {
-    const token = TestStubs.ApiToken();
+    const token = ApiTokenFixture();
     token.tokenLastCharacters = 'a1b2c3d4';
 
     const cb = jest.fn();
@@ -25,7 +27,7 @@ describe('ApiTokenRow', () => {
   });
 
   it('uses old logic when lastTokenCharacters field is not found', () => {
-    const token = TestStubs.ApiToken();
+    const token = ApiTokenFixture();
 
     const cb = jest.fn();
     render(<ApiTokenRow onRemove={cb} token={token} />);

--- a/static/app/views/settings/account/apiTokens.spec.tsx
+++ b/static/app/views/settings/account/apiTokens.spec.tsx
@@ -1,3 +1,4 @@
+import {ApiToken as ApiTokenFixture} from 'sentry-fixture/apiToken';
 import {Organization} from 'sentry-fixture/organization';
 
 import {fireEvent, render, screen} from 'sentry-test/reactTestingLibrary';
@@ -23,7 +24,7 @@ describe('ApiTokens', function () {
   it('renders with result', function () {
     MockApiClient.addMockResponse({
       url: '/api-tokens/',
-      body: [TestStubs.ApiToken()],
+      body: [ApiTokenFixture()],
     });
 
     render(<ApiTokens organization={organization} />);
@@ -32,7 +33,7 @@ describe('ApiTokens', function () {
   it('can delete token', function () {
     MockApiClient.addMockResponse({
       url: '/api-tokens/',
-      body: [TestStubs.ApiToken()],
+      body: [ApiTokenFixture()],
     });
 
     const mock = MockApiClient.addMockResponse({

--- a/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 
@@ -43,7 +44,7 @@ describe('OrganizationGeneralSettings', function () {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/?provider_key=github`,
       method: 'GET',
-      body: [TestStubs.GitHubIntegration()],
+      body: [GitHubIntegrationFixture()],
     });
   });
 

--- a/static/app/views/settings/organizationIntegrations/addIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegration.spec.tsx
@@ -1,3 +1,4 @@
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {GitHubIntegrationProvider} from 'sentry-fixture/githubIntegrationProvider';
 import {Organization} from 'sentry-fixture/organization';
 
@@ -8,7 +9,7 @@ import AddIntegration from 'sentry/views/settings/organizationIntegrations/addIn
 
 describe('AddIntegration', function () {
   const provider = GitHubIntegrationProvider();
-  const integration = TestStubs.GitHubIntegration();
+  const integration = GitHubIntegrationFixture();
 
   function interceptMessageEvent(event: MessageEvent) {
     if (event.origin === '') {

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -1,3 +1,4 @@
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {GitHubIntegrationProvider} from 'sentry-fixture/githubIntegrationProvider';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
@@ -251,7 +252,7 @@ describe('IntegrationDetailedView', function () {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/integrations/?provider_key=github&includeConfig=0`,
-      body: [TestStubs.GitHubIntegration()],
+      body: [GitHubIntegrationFixture()],
     });
     render(
       <IntegrationDetailedView

--- a/static/app/views/settings/organizationIntegrations/integrationListDirectory.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationListDirectory.spec.tsx
@@ -1,3 +1,4 @@
+import {DocIntegration as DocIntegrationFixture} from 'sentry-fixture/docIntegration';
 import {
   BitbucketIntegrationConfig,
   OrgOwnedApps,
@@ -30,7 +31,7 @@ describe('IntegrationListDirectory', function () {
         [`/organizations/${org.slug}/integrations/`, [BitbucketIntegrationConfig()]],
         [`/organizations/${org.slug}/sentry-apps/`, OrgOwnedApps()],
         ['/sentry-apps/', PublishedApps()],
-        ['/doc-integrations/', [TestStubs.DocIntegration()]],
+        ['/doc-integrations/', [DocIntegrationFixture()]],
         [`/organizations/${org.slug}/sentry-app-installations/`, SentryAppInstalls()],
         [`/organizations/${org.slug}/plugins/configs/`, PluginListConfig()],
         [`/organizations/${org.slug}/repos/?status=unmigratable`, []],

--- a/static/app/views/settings/organizationMembers/organizationMembersWrapper.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersWrapper.spec.tsx
@@ -1,3 +1,4 @@
+import {Member as MemberFixture} from 'sentry-fixture/member';
 import {Organization} from 'sentry-fixture/organization';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -15,7 +16,7 @@ jest.mock('sentry/actionCreators/modal', () => ({
 describe('OrganizationMembersWrapper', function () {
   const {routerProps} = initializeOrg();
 
-  const member = TestStubs.Member();
+  const member = MemberFixture();
   const organization = Organization({
     features: ['invite-members'],
     access: ['member:admin', 'org:admin', 'member:write'],

--- a/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.spec.tsx
@@ -1,4 +1,5 @@
 import selectEvent from 'react-select-event';
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {Repository} from 'sentry-fixture/repository';
@@ -17,7 +18,7 @@ import {AddCodeOwnerModal} from 'sentry/views/settings/project/projectOwnership/
 describe('AddCodeOwnerModal', function () {
   const org = Organization({features: ['integrations-codeowners']});
   const project = ProjectFixture();
-  const integration = TestStubs.GitHubIntegration();
+  const integration = GitHubIntegrationFixture();
   const repo = Repository({
     integrationId: integration.id,
     id: '5',

--- a/static/app/views/settings/project/projectOwnership/codeOwnerFileTable.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeOwnerFileTable.spec.tsx
@@ -1,3 +1,4 @@
+import {CodeOwner as CodeOwnerFixture} from 'sentry-fixture/codeOwner';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 
@@ -8,7 +9,7 @@ import {CodeOwnerFileTable} from './codeOwnerFileTable';
 describe('CodeOwnerFileTable', () => {
   const organization = Organization();
   const project = ProjectFixture();
-  const codeowner = TestStubs.CodeOwner();
+  const codeowner = CodeOwnerFixture();
 
   it('renders empty', () => {
     const {container} = render(

--- a/static/app/views/sharedGroupDetails/index.spec.tsx
+++ b/static/app/views/sharedGroupDetails/index.spec.tsx
@@ -1,4 +1,7 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
+import {EventEntry as EventEntryFixture} from 'sentry-fixture/eventEntry';
+import {EventStacktraceException as EventStacktraceExceptionFixture} from 'sentry-fixture/eventStacktraceException';
+import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 
@@ -8,15 +11,15 @@ import {RouteContext} from 'sentry/views/routeContext';
 import SharedGroupDetails from 'sentry/views/sharedGroupDetails';
 
 describe('SharedGroupDetails', function () {
-  const eventEntry = TestStubs.EventEntry();
-  const exception = TestStubs.EventStacktraceException().entries[0];
+  const eventEntry = EventEntryFixture();
+  const exception = EventStacktraceExceptionFixture().entries[0];
   const params = {shareId: 'a'};
   const router = TestStubs.router({params});
 
   beforeEach(function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/shared/issues/a/',
-      body: TestStubs.Group({
+      body: GroupFixture({
         title: 'ZeroDivisionError',
         latestEvent: EventFixture({
           entries: [eventEntry, exception],
@@ -26,7 +29,7 @@ describe('SharedGroupDetails', function () {
     });
     MockApiClient.addMockResponse({
       url: '/shared/issues/a/',
-      body: TestStubs.Group({
+      body: GroupFixture({
         title: 'ZeroDivisionError',
         latestEvent: EventFixture({
           entries: [eventEntry, exception],

--- a/static/app/views/userFeedback/index.spec.tsx
+++ b/static/app/views/userFeedback/index.spec.tsx
@@ -1,3 +1,4 @@
+import {Environments as EnvironmentsFixture} from 'sentry-fixture/environments';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {UserFeedback as UserFeedbackFixture} from 'sentry-fixture/userFeedback';
@@ -35,7 +36,7 @@ describe('UserFeedback', function () {
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/environments/',
-      body: TestStubs.Environments(),
+      body: EnvironmentsFixture(),
     });
   });
 


### PR DESCRIPTION
Ran a codemod that refactors out TestStubs that do not break types.

ref https://github.com/getsentry/frontend-tsc/issues/49