### PR TITLE
fix(hybrid-cloud): Encode outbox webhooks payloads into bytes 

### DIFF
--- a/src/sentry/middleware/integrations/tasks.py
+++ b/src/sentry/middleware/integrations/tasks.py
@@ -37,7 +37,7 @@ def convert_to_async_slack_response(
             method=webhook_payload.method,
             path=webhook_payload.path,
             headers=webhook_payload.headers,
-            data=webhook_payload.body,
+            data=webhook_payload.body.encode("utf-8"),
             json=False,
             raw_response=True,
         )

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -99,7 +99,7 @@ def process_async_webhooks(
                 path=webhook_payload.path,
                 headers=webhook_payload.headers,
                 # We need to send the body as raw bytes to avoid interfering with webhook signatures
-                data=webhook_payload.body,
+                data=webhook_payload.body.encode("utf-8"),
                 json=False,
                 prefix_hash=sha1(f"{shard_identifier}{object_identifier}".encode()).hexdigest(),
             )


### PR DESCRIPTION
Fixes [SENTRY-2BD4](https://sentry.sentry.io/issues/4742425761/)