### PR TITLE
feat(grouping): Substitute SQL quoted value

### DIFF
--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -103,6 +103,9 @@ _parameterization_regex = re.compile(
         ='([^']+)' |
         ="([^"]+)"
     ) |
+    (?P<quoted_identifier>
+        "([a-z0-9_])+"
+    ) |
     (?P<bool>
         # The `=` here guarantees we'll only match the value half of key-value pairs,
         # rather than all instances of the words 'true' and 'false'.

--- a/tests/sentry/grouping/grouping_inputs/database_error.json
+++ b/tests/sentry/grouping/grouping_inputs/database_error.json
@@ -1,0 +1,20 @@
+{
+  "issue_id": "4721800324",
+  "project": 1,
+  "platform": "python",
+  "exception": {
+    "values": [
+      {
+        "type": "InFailedSqlTransaction",
+        "NOTE": "This event only tests the regex substitution for the value, thus, no frames are included",
+        "value": "InFailedSqlTransaction('current transaction is aborted, commands ignored until end of transaction block\\n')\nSQL: RELEASE SAVEPOINT \"s140078941939520_x761\"",
+        "stacktrace": {
+          "frames": []
+        },
+        "mechanism": {"type": "generic", "handled": true}
+      }
+    ]
+  },
+  "title": "DatabaseError: ((<class 'psycopg2.errors.InFailedSqlTransaction'>, InFailedSqlTransaction('InFailedSqlTransactio...",
+  "type": "error"
+}

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/database_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/database_error.pysnap
@@ -1,0 +1,24 @@
+---
+created: '2023-12-20T19:23:20.061832Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because hash matches system variant)
+        type*
+          "InFailedSqlTransaction"
+        value*
+          "InFailedSqlTransaction('current transaction is aborted, commands ignored until end of transaction block\\n')\nSQL: RELEASE SAVEPOINT \"s140078941939520_x761\""
+--------------------------------------------------------------------------
+system:
+  hash: "d5cbe52354e9865c0de7d87ee21dc75f"
+  component:
+    system*
+      exception*
+        type*
+          "InFailedSqlTransaction"
+        value*
+          "InFailedSqlTransaction('current transaction is aborted, commands ignored until end of transaction block\\n')\nSQL: RELEASE SAVEPOINT \"s140078941939520_x761\""

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/database_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/database_error.pysnap
@@ -1,0 +1,14 @@
+---
+created: '2023-12-20T19:23:28.447927Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "3b544b7297810e16a7e6701fd2b03b26"
+  component:
+    app*
+      exception*
+        type*
+          "InFailedSqlTransaction"
+        value* (stripped event-specific values)
+          "InFailedSqlTransaction('current transaction is aborted, commands ignored until end of transaction block\\n')\nSQL: RELEASE SAVEPOINT <quoted_identifier>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/database_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/database_error.pysnap
@@ -1,0 +1,12 @@
+---
+created: '2023-12-20T19:23:35.271112Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "6574b37fdbcfb92d79fab43fb1c20f6b"
+  component:
+    app*
+      exception*
+        type*
+          "InFailedSqlTransaction"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/database_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/database_error.pysnap
@@ -1,0 +1,14 @@
+---
+created: '2023-12-20T19:23:37.990637Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "3b544b7297810e16a7e6701fd2b03b26"
+  component:
+    app*
+      exception*
+        type*
+          "InFailedSqlTransaction"
+        value* (stripped event-specific values)
+          "InFailedSqlTransaction('current transaction is aborted, commands ignored until end of transaction block\\n')\nSQL: RELEASE SAVEPOINT <quoted_identifier>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/database_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/database_error.pysnap
@@ -1,0 +1,14 @@
+---
+created: '2023-12-20T19:23:22.610891Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "3b544b7297810e16a7e6701fd2b03b26"
+  component:
+    app*
+      exception*
+        type*
+          "InFailedSqlTransaction"
+        value* (stripped event-specific values)
+          "InFailedSqlTransaction('current transaction is aborted, commands ignored until end of transaction block\\n')\nSQL: RELEASE SAVEPOINT <quoted_identifier>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/database_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/database_error.pysnap
@@ -1,0 +1,14 @@
+---
+created: '2023-12-20T19:23:25.268209Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "3b544b7297810e16a7e6701fd2b03b26"
+  component:
+    app*
+      exception*
+        type*
+          "InFailedSqlTransaction"
+        value* (stripped event-specific values)
+          "InFailedSqlTransaction('current transaction is aborted, commands ignored until end of transaction block\\n')\nSQL: RELEASE SAVEPOINT <quoted_identifier>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/database_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/database_error.pysnap
@@ -1,0 +1,14 @@
+---
+created: '2023-12-20T19:21:23.754251Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "3b544b7297810e16a7e6701fd2b03b26"
+  component:
+    app*
+      exception*
+        type*
+          "InFailedSqlTransaction"
+        value* (stripped event-specific values)
+          "InFailedSqlTransaction('current transaction is aborted, commands ignored until end of transaction block\\n')\nSQL: RELEASE SAVEPOINT <quoted_identifier>"


### PR DESCRIPTION
Every failed SQL transaction which includes an identifier creates a new group. This change substitutes the identifier for the string `<quoted_identifier>`. See below the effects of this regex:

```diff
diff --git a/src/sentry/grouping/strategies/message.py b/src/sentry/grouping/strategies/message.py
index 46e36d10b4..c7399d84a0 100644
--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -103,6 +103,9 @@ _parameterization_regex = re.compile(
         ='([^']+)' |
         ="([^"]+)"
     ) |
+    (?P<quoted_identifier>
+        "([a-z0-9_])+"
+    ) |
     (?P<bool>
         # The `=` here guarantees we'll only match the value half of key-value pairs,
         # rather than all instances of the words 'true' and 'false'.
diff --git a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/database_error.pysnap b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/database_error.pysnap
index af40bb471d..5c96de8a3a 100644
--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/database_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2023_01_11/database_error.pysnap
@@ -1,14 +1,14 @@
 ---
-created: '2023-12-20T19:20:59.121051Z'
+created: '2023-12-20T19:21:23.754251Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "d5cbe52354e9865c0de7d87ee21dc75f"
+  hash: "3b544b7297810e16a7e6701fd2b03b26"
   component:
     app*
       exception*
         type*
           "InFailedSqlTransaction"
-        value*
-          "InFailedSqlTransaction('current transaction is aborted, commands ignored until end of transaction block\\n')\nSQL: RELEASE SAVEPOINT \"s140078941939520_x761\""
+        value* (stripped event-specific values)
+          "InFailedSqlTransaction('current transaction is aborted, commands ignored until end of transaction block\\n')\nSQL: RELEASE SAVEPOINT <quoted_identifier>"
```