### PR TITLE
ref(hybrid-cloud): Updates the integration proxy to use overridable request method

### DIFF
--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -151,7 +151,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         ).prepare()
         # Third-party authentication headers will be added in client.authorize_request which runs
         # in IntegrationProxyClient.finalize_request.
-        raw_response: Response = self.client._request(
+        raw_response: Response = self.client.request(
             request.method,
             self.proxy_path,
             allow_text=True,

--- a/tests/sentry/api/endpoints/internal/test_integration_proxy.py
+++ b/tests/sentry/api/endpoints/internal/test_integration_proxy.py
@@ -117,12 +117,12 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
 
         mock_client.base_url = "https://example.com/api"
         mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
-        mock_client._request = MagicMock(return_value=mock_response)
+        mock_client.request = MagicMock(return_value=mock_response)
         mock_get_client.return_value = mock_client
 
         proxy_response = self.client.get(self.path, **headers)
 
-        prepared_request = mock_client._request.call_args.kwargs["prepared_request"]
+        prepared_request = mock_client.request.call_args.kwargs["prepared_request"]
         assert prepared_request.url == "https://example.com/api/chat.postMessage"
         assert prepared_request.headers == {
             "Cookie": "",
@@ -167,12 +167,12 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
 
         mock_client.base_url = "https://example.com/api"
         mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
-        mock_client._request = MagicMock(return_value=mock_response)
+        mock_client.request = MagicMock(return_value=mock_response)
         mock_get_client.return_value = mock_client
 
         proxy_response = self.client.get(self.path, **headers)
 
-        prepared_request = mock_client._request.call_args.kwargs["prepared_request"]
+        prepared_request = mock_client.request.call_args.kwargs["prepared_request"]
         assert prepared_request.url == "https://foobar.example.com/api/chat.postMessage"
         assert prepared_request.headers == {
             "Cookie": "",


### PR DESCRIPTION
Updates integration proxy code to invoke the full `request` method instead of the `_request` method to ensure that subclass override logic is run in control silo.

This should alleviate token refresh issues we've seen in Gitlab.
