### PR TITLE
fix(replay): Adjust hydration modal copy, tab underline

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -61,7 +61,7 @@ export default function ReplayComparisonModal({
         </ModalHeader>
       </Header>
       <Body>
-        <p>
+        <StyledParagraph>
           {tct(
             'This modal helps with debugging hydration errors by diffing the dom before and after the app hydrated. [boldBefore:Before Hydration] refers to the html rendered on the server. [boldAfter:After Hydration] refers to the html rendered on the client. This feature is actively being developed; please share any questions or feedback to the discussion linked above.',
             {
@@ -69,7 +69,7 @@ export default function ReplayComparisonModal({
               boldAfter: <strong />,
             }
           )}
-        </p>
+        </StyledParagraph>
         <Flex gap={space(1)} column>
           <TabList
             selectedKey={activeTab}
@@ -195,4 +195,8 @@ const DiffHeader = styled('div')`
   flex: 1;
   font-weight: 600;
   line-height: 1.2;
+`;
+
+const StyledParagraph = styled('p')`
+  margin-top: ${space(1)};
 `;

--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import beautify from 'js-beautify';
 
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
-import Alert from 'sentry/components/alert';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import FeatureBadge from 'sentry/components/featureBadge';
 import {GithubFeedbackButton} from 'sentry/components/githubFeedbackButton';
@@ -62,7 +61,7 @@ export default function ReplayComparisonModal({
         </ModalHeader>
       </Header>
       <Body>
-        <Alert showIcon>
+        <p>
           {tct(
             'This modal helps with debugging hydration errors by diffing the dom before and after the app hydrated. [boldBefore:Before Hydration] refers to the html rendered on the server. [boldAfter:After Hydration] refers to the html rendered on the client. This feature is actively being developed; please share any questions or feedback to the discussion linked above.',
             {
@@ -70,10 +69,9 @@ export default function ReplayComparisonModal({
               boldAfter: <strong />,
             }
           )}
-        </Alert>
+        </p>
         <Flex gap={space(1)} column>
           <TabList
-            hideBorder
             selectedKey={activeTab}
             onSelectionChange={tab => setActiveTab(tab as 'visual' | 'html')}
           >

--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -195,6 +195,10 @@ const DiffHeader = styled('div')`
   flex: 1;
   font-weight: 600;
   line-height: 1.2;
+
+  div:last-child {
+    padding-left: ${space(2)};
+  }
 `;
 
 const StyledParagraph = styled('p')`

--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -203,4 +203,5 @@ const DiffHeader = styled('div')`
 
 const StyledParagraph = styled('p')`
   padding-top: ${space(0.5)};
+  margin-bottom: ${space(1)};
 `;

--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -202,5 +202,5 @@ const DiffHeader = styled('div')`
 `;
 
 const StyledParagraph = styled('p')`
-  padding-top: ${space(1)};
+  padding-top: ${space(0.5)};
 `;

--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -202,5 +202,5 @@ const DiffHeader = styled('div')`
 `;
 
 const StyledParagraph = styled('p')`
-  margin-top: ${space(1)};
+  padding-top: ${space(1)};
 `;


### PR DESCRIPTION
just got more feedback

- not in an alert
- add underline to tabs

![image](https://github.com/getsentry/sentry/assets/1400464/18112029-e8c6-415f-97ba-21e170c8e5f5)
