### PR TITLE
ref: provide beacon stable version directly in sentry config

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -9,5 +9,9 @@ OLD_VERSION="$1"
 NEW_VERSION="$2"
 
 sed -i -e 's/^version = .*$/version = '"$NEW_VERSION/" setup.cfg
+# only bump this on tagged releases
+if [[ "$NEW_VERSION" != *.dev0 ]]; then
+  sed -i -e 's/^SELF_HOSTED_STABLE_VERSION = .*/SELF_HOSTED_STABLE_VERSION = "'"$NEW_VERSION"'"/' src/sentry/conf/server.py
+fi
 
 echo "New version: $NEW_VERSION"

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3033,6 +3033,9 @@ STATUS_PAGE_ID: str | None = None
 STATUS_PAGE_API_HOST = "statuspage.io"
 
 SENTRY_SELF_HOSTED = True
+# only referenced in getsentry to provide the stable beacon version
+# updated with scripts/bump-version.sh
+SELF_HOSTED_STABLE_VERSION = "23.12.0"
 
 # Whether we should look at X-Forwarded-For header or not
 # when checking REMOTE_ADDR ip addresses


### PR DESCRIPTION
we're currently retrieving the "stable" version from pypi json -- however we've stopped releasing sentry to pypi

this will bake the version into the sentry release that `getsentry` wraps -- and we'll access it directly from settings (and delete all the pypi scraping machinery)

<!-- Describe your PR here. -->