### PR TITLE
fix(replay): Don't emit an EventView from useReplaysFromIssue when no replayIds are in the fetched list

### DIFF
--- a/static/app/utils/replays/fetchReplayList.tsx
+++ b/static/app/utils/replays/fetchReplayList.tsx
@@ -24,8 +24,8 @@ type Props = {
   eventView: EventView;
   location: Location;
   organization: Organization;
+  queryReferrer: string;
   perPage?: number;
-  queryReferrer?: 'issueReplays';
 };
 
 async function fetchReplayList({

--- a/static/app/utils/replays/fetchReplayList.tsx
+++ b/static/app/utils/replays/fetchReplayList.tsx
@@ -59,7 +59,7 @@ async function fetchReplayList({
         // when queryReferrer === 'issueReplays' we override the global view check on the backend
         // we also require a project param otherwise we won't yield results
         queryReferrer,
-        project: queryReferrer === 'issueReplays' ? ALL_ACCESS_PROJECTS : payload.project,
+        project: ALL_ACCESS_PROJECTS,
       },
     });
 

--- a/static/app/utils/replays/hooks/useReplayList.tsx
+++ b/static/app/utils/replays/hooks/useReplayList.tsx
@@ -11,8 +11,8 @@ type Options = {
   eventView: EventView;
   location: Location<ReplayListLocationQuery>;
   organization: Organization;
+  queryReferrer: string;
   perPage?: number;
-  queryReferrer?: 'issueReplays';
 };
 
 type State = Awaited<ReturnType<typeof fetchReplayList>> & {isFetching: boolean};

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -120,37 +120,38 @@ describe('GroupReplays', () => {
             },
           })
         );
-        // Expect api path to have the correct query params
-        expect(mockReplayApi).toHaveBeenCalledWith(
-          mockReplayUrl,
-          expect.objectContaining({
-            query: expect.objectContaining({
-              environment: [],
-              field: [
-                'activity',
-                'browser',
-                'count_dead_clicks',
-                'count_errors',
-                'count_rage_clicks',
-                'duration',
-                'finished_at',
-                'id',
-                'is_archived',
-                'os',
-                'project_id',
-                'started_at',
-                'user',
-              ],
-              per_page: 50,
-              project: -1,
-              queryReferrer: 'issueReplays',
-              query: `id:[${REPLAY_ID_1},${REPLAY_ID_2}]`,
-              sort: '-started_at',
-              statsPeriod: '14d',
-            }),
-          })
-        );
       });
+
+      // Expect api path to have the correct query params
+      expect(mockReplayApi).toHaveBeenCalledWith(
+        mockReplayUrl,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            environment: [],
+            field: [
+              'activity',
+              'browser',
+              'count_dead_clicks',
+              'count_errors',
+              'count_rage_clicks',
+              'duration',
+              'finished_at',
+              'id',
+              'is_archived',
+              'os',
+              'project_id',
+              'started_at',
+              'user',
+            ],
+            per_page: 50,
+            project: -1,
+            queryReferrer: 'groupReplays',
+            query: `id:[${REPLAY_ID_1},${REPLAY_ID_2}]`,
+            sort: '-started_at',
+            statsPeriod: '14d',
+          }),
+        })
+      );
     });
 
     it('should show empty message when no replays are found', async () => {
@@ -209,11 +210,12 @@ describe('GroupReplays', () => {
 
       await waitFor(() => {
         expect(mockReplayCountApi).toHaveBeenCalledTimes(1);
-        expect(mockReplayApi).toHaveBeenCalledTimes(1);
-        expect(
-          screen.getByText('Invalid number: asdf. Expected number.')
-        ).toBeInTheDocument();
       });
+
+      expect(mockReplayApi).toHaveBeenCalledTimes(1);
+      expect(
+        screen.getByText('Invalid number: asdf. Expected number.')
+      ).toBeInTheDocument();
     });
 
     it('should display default error message when api call fails without a body', async () => {
@@ -240,13 +242,13 @@ describe('GroupReplays', () => {
 
       await waitFor(() => {
         expect(mockReplayCountApi).toHaveBeenCalledTimes(1);
-        expect(mockReplayApi).toHaveBeenCalledTimes(1);
-        expect(
-          screen.getByText(
-            'Sorry, the list of replays could not be loaded. This could be due to invalid search parameters or an internal systems error.'
-          )
-        ).toBeInTheDocument();
       });
+      expect(mockReplayApi).toHaveBeenCalledTimes(1);
+      expect(
+        screen.getByText(
+          'Sorry, the list of replays could not be loaded. This could be due to invalid search parameters or an internal systems error.'
+        )
+      ).toBeInTheDocument();
     });
 
     it('should show loading indicator when loading replays', async () => {
@@ -276,8 +278,8 @@ describe('GroupReplays', () => {
       expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
       await waitFor(() => {
         expect(mockReplayCountApi).toHaveBeenCalledTimes(1);
-        expect(mockReplayApi).toHaveBeenCalledTimes(1);
       });
+      expect(mockReplayApi).toHaveBeenCalledTimes(1);
     });
 
     it('should show a list of replays and have the correct values', async () => {
@@ -339,8 +341,8 @@ describe('GroupReplays', () => {
 
       await waitFor(() => {
         expect(mockReplayCountApi).toHaveBeenCalledTimes(1);
-        expect(mockReplayApi).toHaveBeenCalledTimes(1);
       });
+      expect(mockReplayApi).toHaveBeenCalledTimes(1);
 
       // Expect the table to have 2 rows
       expect(screen.getAllByText('testDisplayName')).toHaveLength(2);

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -31,7 +31,7 @@ function GroupReplays({group}: Props) {
   const organization = useOrganization();
   const location = useLocation<ReplayListLocationQuery>();
 
-  const {eventView, fetchError, pageLinks} = useReplaysFromIssue({
+  const {eventView, fetchError, isFetching, pageLinks} = useReplaysFromIssue({
     group,
     location,
     organization,
@@ -52,7 +52,7 @@ function GroupReplays({group}: Props) {
       <StyledLayoutPage withPadding>
         <ReplayTable
           fetchError={fetchError}
-          isFetching
+          isFetching={isFetching}
           replays={[]}
           sort={undefined}
           visibleColumns={VISIBLE_COLUMNS}

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -87,7 +87,7 @@ function GroupReplaysTable({
     eventView,
     location,
     organization,
-    queryReferrer: 'issueReplays',
+    queryReferrer: 'groupReplays',
   });
 
   return (

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
@@ -47,6 +47,7 @@ describe('useReplaysFromIssue', () => {
     expect(result.current).toEqual({
       eventView: null,
       fetchError: undefined,
+      isFetching: true,
       pageLinks: null,
     });
 
@@ -57,6 +58,7 @@ describe('useReplaysFromIssue', () => {
         query: 'id:[replay42,replay256]',
       }),
       fetchError: undefined,
+      isFetching: false,
       pageLinks: null,
     });
   });
@@ -83,6 +85,7 @@ describe('useReplaysFromIssue', () => {
     expect(result.current).toEqual({
       eventView: null,
       fetchError: undefined,
+      isFetching: true,
       pageLinks: null,
     });
 
@@ -93,6 +96,7 @@ describe('useReplaysFromIssue', () => {
         query: 'id:[replay42,replay256]',
       }),
       fetchError: undefined,
+      isFetching: false,
       pageLinks: null,
     });
   });
@@ -117,16 +121,16 @@ describe('useReplaysFromIssue', () => {
     expect(result.current).toEqual({
       eventView: null,
       fetchError: undefined,
+      isFetching: true,
       pageLinks: null,
     });
 
     await waitForNextUpdate();
 
     expect(result.current).toEqual({
-      eventView: expect.objectContaining({
-        query: 'id:[]',
-      }),
+      eventView: null,
       fetchError: undefined,
+      isFetching: false,
       pageLinks: null,
     });
   });

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -59,7 +59,7 @@ export default function useReplaysFromIssue({
       name: '',
       version: 2,
       fields: REPLAY_LIST_FIELDS,
-      query: `id:[${String(replayIds)}]`,
+      query: replayIds.length ? `id:[${String(replayIds)}]` : `id:1`,
       range: '14d',
       projects: [],
       orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
@@ -76,6 +76,7 @@ export default function useReplaysFromIssue({
 
   return {
     eventView,
+    isFetching: replayIds === undefined,
     fetchError,
     pageLinks: null,
   };

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -11,7 +11,7 @@ import useApi from 'sentry/utils/useApi';
 import useCleanQueryParamsOnRouteLeave from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
 import {REPLAY_LIST_FIELDS} from 'sentry/views/replays/types';
 
-function useReplayFromIssue({
+export default function useReplaysFromIssue({
   group,
   location,
   organization,
@@ -51,7 +51,7 @@ function useReplayFromIssue({
   }, [api, organization.slug, group.id, dataSource]);
 
   const eventView = useMemo(() => {
-    if (!replayIds) {
+    if (!replayIds || !replayIds.length) {
       return null;
     }
     return EventView.fromSavedQuery({
@@ -80,5 +80,3 @@ function useReplayFromIssue({
     pageLinks: null,
   };
 }
-
-export default useReplayFromIssue;

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -144,6 +144,7 @@ function ReplaysContent({
     eventView,
     location,
     organization,
+    queryReferrer: 'transactionReplays',
   });
 
   const replaysWithTx = useReplaysWithTxData({

--- a/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
+++ b/static/app/views/replays/deadRageClick/exampleReplaysList.tsx
@@ -68,6 +68,7 @@ export default function ExampleReplaysList({
     location: emptyLocation,
     organization,
     perPage: 3,
+    queryReferrer: 'exampleReplaysList',
   });
 
   const routes = useRoutes();

--- a/static/app/views/replays/list/replaysList.tsx
+++ b/static/app/views/replays/list/replaysList.tsx
@@ -67,6 +67,7 @@ function ReplaysListTable({
     eventView,
     location,
     organization,
+    queryReferrer: 'replaysList',
   });
 
   const {


### PR DESCRIPTION
When we fetch the `/replay-count/` (list of replayIds) inside of `useReplaysFromIssue`, we need to guard against the empty list being returned. If the list is empty then there are no replayIds and we can skip the next fetch altogether.

Also I updated all the `queryReferrer` prop values to make stuff like this easier to track down.

<img width="939" alt="SCR-20231220-oein" src="https://github.com/getsentry/sentry/assets/187460/d4d5ee24-61eb-4300-b75c-f04cc17868b1">

Fixes https://github.com/getsentry/sentry/issues/62166