### PR TITLE
feat(setting): Add confirmation modal

### DIFF
--- a/static/app/views/settings/components/teamSelect/teamSelectForProject.tsx
+++ b/static/app/views/settings/components/teamSelect/teamSelectForProject.tsx
@@ -62,7 +62,9 @@ function TeamSelect({
       ? t(
           'This is the last team with access to this project. After removing this team, only organization owners and managers will be able to access the project pages.'
         )
-      : null;
+      : t(
+          'Removing this team from the project means that members of the team can no longer access this project. Do you want to continue?'
+        );
 
     return (
       <Fragment>
@@ -133,6 +135,7 @@ function TeamRow({
         bypass={!confirmMessage}
         onConfirm={() => onRemoveTeam(team.slug)}
         disabled={disabled}
+        confirmText="Remove Team"
       >
         <Button size="xs" icon={<IconSubtract isCircled />} disabled={disabled}>
           {t('Remove')}

--- a/static/app/views/settings/project/projectTeams.spec.tsx
+++ b/static/app/views/settings/project/projectTeams.spec.tsx
@@ -112,6 +112,11 @@ describe('ProjectTeams', function () {
     expect(mock1).not.toHaveBeenCalled();
 
     await userEvent.click(screen.getAllByRole('button', {name: 'Remove'})[0]);
+
+    renderGlobalModal();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Remove Team'));
     expect(mock1).toHaveBeenCalledWith(
       endpoint1,
       expect.objectContaining({
@@ -122,13 +127,7 @@ describe('ProjectTeams', function () {
 
     // Remove second team
     await userEvent.click(screen.getAllByRole('button', {name: 'Remove'})[0]);
-
-    // Modal opens because this is the last team in project
-    renderGlobalModal();
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
-
-    await userEvent.click(screen.getByTestId('confirm-button'));
-
+    await userEvent.click(screen.getByText('Remove Team'));
     expect(mock2).toHaveBeenCalledWith(
       endpoint2,
       expect.objectContaining({
@@ -169,6 +168,8 @@ describe('ProjectTeams', function () {
 
     // Remove first team
     await userEvent.click(screen.getAllByRole('button', {name: 'Remove'})[0]);
+    renderGlobalModal();
+    await userEvent.click(screen.getByText('Remove Team'));
     expect(mock1).toHaveBeenCalledWith(
       endpoint1,
       expect.objectContaining({
@@ -220,6 +221,8 @@ describe('ProjectTeams', function () {
 
     // Remove first team
     await userEvent.click(screen.getAllByRole('button', {name: 'Remove'})[0]);
+    renderGlobalModal();
+    await userEvent.click(screen.getByText('Remove Team'));
     expect(mock1).toHaveBeenCalledWith(
       endpoint1,
       expect.objectContaining({
@@ -232,11 +235,10 @@ describe('ProjectTeams', function () {
     await userEvent.click(screen.getAllByRole('button', {name: 'Remove'})[0]);
 
     // Modal opens because this is the last team in project
-    renderGlobalModal();
     expect(screen.getByRole('dialog')).toBeInTheDocument();
 
     // Click confirm
-    await userEvent.click(screen.getByTestId('confirm-button'));
+    await userEvent.click(screen.getByText('Remove Team'));
 
     expect(mock2).toHaveBeenCalledWith(
       endpoint2,


### PR DESCRIPTION
When removing a team from the project, add a confirmation modal before continuing. This PR adds a new modal when removing a team, and updates the button text.

https://github.com/getsentry/sentry/assets/5581484/28745438-5034-4da2-a477-653c11a70457

