### PR TITLE
feat(setting): Add audit log to add team

### DIFF
--- a/src/sentry/api/endpoints/project_team_details.py
+++ b/src/sentry/api/endpoints/project_team_details.py
@@ -61,6 +61,13 @@ class ProjectTeamDetailsEndpoint(ProjectEndpoint):
 
         # A user with project:write can grant access to this project to other user/teams
         project.add_team(team)
+        self.create_audit_entry(
+            request=self.request,
+            organization_id=project.organization_id,
+            target_object=project.id,
+            event=audit_log.get_event_id("PROJECT_TEAM_ADD"),
+            data={"team_slug": team_slug, "project_slug": project.slug},
+        )
         return Response(serialize(project, request.user, ProjectWithTeamSerializer()), status=201)
 
     @extend_schema(

--- a/src/sentry/audit_log/register.py
+++ b/src/sentry/audit_log/register.py
@@ -410,3 +410,11 @@ default_manager.add(
         template="removed team {team_slug} from project {project_slug}",
     )
 )
+default_manager.add(
+    AuditLogEvent(
+        event_id=181,
+        name="PROJECT_TEAM_ADD",
+        api_name="project-team.add",
+        template="added team {team_slug} to project {project_slug}",
+    )
+)

--- a/tests/sentry/audit_log/test_register.py
+++ b/tests/sentry/audit_log/test_register.py
@@ -84,6 +84,7 @@ class AuditLogEventRegisterTest(TestCase):
             "org-auth-token.create",
             "org-auth-token.remove",
             "project-team.remove",
+            "project-team.add",
         ]
 
         assert set(audit_log.get_api_names()) == set(audit_log_api_name_list)


### PR DESCRIPTION
When a team is added to the project, have an audit log to help see which team was added. [In a previous PR](https://github.com/getsentry/sentry/pull/62066) we added the functionality when it was removed.


https://github.com/getsentry/sentry/assets/5581484/c7c9bd7f-8615-40e5-b74c-938c4b341984


