### PR TITLE
ref(hc): Look up org slug directly in publish request endpoint

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/publish_request.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/publish_request.py
@@ -59,7 +59,9 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
             status=SentryAppStatus.PUBLISH_REQUEST_INPROGRESS_STR,
         ).run(user=request.user)
 
-        org_mapping = OrganizationMapping.objects.filter(organization_id=sentry_app.owner_id)
+        org_mapping = OrganizationMapping.objects.filter(
+            organization_id=sentry_app.owner_id
+        ).first()
         org_slug = "<unknown>" if org_mapping is None else org_mapping.slug
         message = f"User {request.user.email} of organization {org_slug} wants to publish {sentry_app.slug}\n"
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/publish_request.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/publish_request.py
@@ -8,8 +8,8 @@ from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.sentryapps import COMPONENT_TYPES, SentryAppBaseEndpoint
 from sentry.constants import SentryAppStatus
 from sentry.models.avatars.sentry_app_avatar import SentryAppAvatar, SentryAppAvatarTypes
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.sentry_apps.apps import SentryAppUpdater
-from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.utils import email
 
 
@@ -59,10 +59,8 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
             status=SentryAppStatus.PUBLISH_REQUEST_INPROGRESS_STR,
         ).run(user=request.user)
 
-        org_context = organization_service.get_organization_by_id(
-            id=sentry_app.owner_id, user_id=None
-        )
-        org_slug = "<unknown>" if org_context is None else org_context.organization.slug
+        org_mapping = OrganizationMapping.objects.filter(organization_id=sentry_app.owner_id)
+        org_slug = "<unknown>" if org_mapping is None else org_mapping.slug
         message = f"User {request.user.email} of organization {org_slug} wants to publish {sentry_app.slug}\n"
 
         for question_pair in request.data.get("questionnaire"):


### PR DESCRIPTION
Since we're only looking up the org slug in this control silo endpoint, we can do the lookup locally and skip the expensive cross-silo RPC request which also loads team/project details.