### PR TITLE
ref(hc): Look up org slug directly in auth channel login

### DIFF
--- a/src/sentry/web/frontend/auth_channel_login.py
+++ b/src/sentry/web/frontend/auth_channel_login.py
@@ -5,7 +5,7 @@ from django.views.decorators.cache import never_cache
 from sentry.auth.helper import CHANNEL_PROVIDER_MAP
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organization import Organization
-from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.utils.auth import is_valid_redirect
 from sentry.web.frontend.auth_organization_login import AuthOrganizationLoginView
 from sentry.web.frontend.base import control_silo_view
@@ -34,11 +34,9 @@ class AuthChannelLoginView(AuthOrganizationLoginView):
             return self.redirect(reverse("sentry-login"))
 
         organization_id = auth_provider_model[0].organization_id
-        organization_context = organization_service.get_organization_by_id(
-            id=organization_id,
-        )
-
-        if organization_context is None:
+        try:
+            slug = OrganizationMapping.objects.get(organization_id=organization_id).slug
+        except OrganizationMapping.DoesNotExist:
             return self.redirect(reverse("sentry-login"))
 
         next_uri = self.get_next_uri(request)
@@ -48,15 +46,11 @@ class AuthChannelLoginView(AuthOrganizationLoginView):
                 if self.active_organization.organization.id == organization_id:
                     if is_valid_redirect(next_uri, allowed_hosts=(request.get_host())):
                         return self.redirect(next_uri)
-                    return self.redirect(
-                        Organization.get_url(slug=organization_context.organization.slug)
-                    )
+                    return self.redirect(Organization.get_url(slug=slug))
 
         # If user doesn't have active session within the same organization redirect to login for the
         # organization in the url
-        org_auth_url = reverse(
-            "sentry-auth-organization", args=[organization_context.organization.slug]
-        )
+        org_auth_url = reverse("sentry-auth-organization", args=[slug])
         redirect_url = (
             org_auth_url + "?next=" + next_uri
             if is_valid_redirect(next_uri, allowed_hosts=(request.get_host()))

--- a/tests/sentry/web/frontend/test_auth_channel_login.py
+++ b/tests/sentry/web/frontend/test_auth_channel_login.py
@@ -14,13 +14,12 @@ class AuthOrganizationChannelLoginTest(TestCase):
             organization_id=sentry_org_id, provider="fly", config=config_data
         )
 
-    def setup(self):
+    def setUp(self):
         self.organization = self.create_organization(name="test org", owner=self.user)
         self.create_auth_provider("fly-test-org", self.organization.id)
         self.path = reverse("sentry-auth-channel", args=["fly", "fly-test-org"])
 
     def test_redirect_for_logged_in_user(self):
-        self.setup()
         self.login_as(self.user)
         response = self.client.get(self.path, follow=True)
         assert response.status_code == 200
@@ -29,7 +28,6 @@ class AuthOrganizationChannelLoginTest(TestCase):
         ]
 
     def test_redirect_for_logged_in_user_with_different_active_org(self):
-        self.setup()
         self.login_as(self.user)  # log in to "test org"
         another_org = self.create_organization(name="another org", owner=self.user)
         self.create_auth_provider("another-fly-org", another_org.id)
@@ -42,7 +40,6 @@ class AuthOrganizationChannelLoginTest(TestCase):
         ]
 
     def test_redirect_for_logged_out_user(self):
-        self.setup()
         response = self.client.get(self.path, follow=True)
         assert response.status_code == 200
         assert response.redirect_chain == [
@@ -50,7 +47,6 @@ class AuthOrganizationChannelLoginTest(TestCase):
         ]
 
     def test_with_next_uri(self):
-        self.setup()
         self.login_as(self.user)
         response = self.client.get(self.path + "?next=/projects/", follow=True)
         assert response.status_code == 200
@@ -59,7 +55,6 @@ class AuthOrganizationChannelLoginTest(TestCase):
         ]
 
     def test_subdomain_precedence(self):
-        self.setup()
         another_org = self.create_organization(name="another org")
         path = reverse("sentry-auth-channel", args=["fly", another_org.id])
         response = self.client.get(


### PR DESCRIPTION
Since we're only looking up the org slug in this control silo view, we can skip the expensive cross-silo RPC request.