### PR TITLE
ref(hc): Simplify organization check

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -141,10 +141,10 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
 
         gh_org = domain_name.split("github.com/")[1]
         extra.update({"gh_org": gh_org})
-        organization_context = organization_service.get_organization_by_id(
-            id=self.org_integration.organization_id, user_id=None
+        org_exists = organization_service.check_organization_by_id(
+            id=self.org_integration.organization_id, only_visible=False
         )
-        if not organization_context:
+        if not org_exists:
             logger.error(
                 "No organization information was found. Continuing execution.", extra=extra
             )


### PR DESCRIPTION
The get_organization_by_id RPC method is pretty expensive, since this call site only cares about the presence of an org we can use check_organization_by_id here.

At a glance, it looks like this check might not be strictly required but I'm leaning toward keeping existing functionality in place for now since this check will be fully resolved locally without an RPC request.