### PR TITLE
fix(relocation): Change task scheduling to always be last action

### DIFF
--- a/src/sentry/testutils/helpers/task_runner.py
+++ b/src/sentry/testutils/helpers/task_runner.py
@@ -41,8 +41,8 @@ def BurstTaskRunner():
 
     job_queue = []
 
-    def apply_async(self, args=(), kwargs=(), countdown=None, queue=None):
-        job_queue.append((self, args, kwargs))
+    def apply_async(self, args=(), kwargs=None, countdown=None, queue=None):
+        job_queue.append((self, args, {} if kwargs is None else kwargs))
 
     def work(max_jobs=None):
         jobs = 0

--- a/tests/sentry/tasks/test_relocation.py
+++ b/tests/sentry/tasks/test_relocation.py
@@ -202,7 +202,7 @@ class RelocationTaskTestCase(TestCase):
 
 @region_silo_test
 @patch("sentry.utils.relocation.MessageBuilder")
-@patch("sentry.tasks.relocation.preprocessing_scan.delay")
+@patch("sentry.tasks.relocation.preprocessing_scan.apply_async")
 class UploadingCompleteTest(RelocationTaskTestCase):
     def test_success(
         self,
@@ -268,7 +268,7 @@ class UploadingCompleteTest(RelocationTaskTestCase):
     new_callable=lambda: FakeKeyManagementServiceClient,
 )
 @patch("sentry.utils.relocation.MessageBuilder")
-@patch("sentry.tasks.relocation.preprocessing_transfer.delay")
+@patch("sentry.tasks.relocation.preprocessing_transfer.apply_async")
 class PreprocessingScanTest(RelocationTaskTestCase):
     def setUp(self):
         super().setUp()
@@ -635,7 +635,7 @@ class PreprocessingScanTest(RelocationTaskTestCase):
 
 @region_silo_test
 @patch("sentry.utils.relocation.MessageBuilder")
-@patch("sentry.tasks.relocation.preprocessing_baseline_config.delay")
+@patch("sentry.tasks.relocation.preprocessing_baseline_config.apply_async")
 class PreprocessingTransferTest(RelocationTaskTestCase):
     def setUp(self):
         super().setUp()
@@ -745,7 +745,7 @@ class PreprocessingTransferTest(RelocationTaskTestCase):
     new_callable=lambda: FakeKeyManagementServiceClient,
 )
 @patch("sentry.utils.relocation.MessageBuilder")
-@patch("sentry.tasks.relocation.preprocessing_colliding_users.delay")
+@patch("sentry.tasks.relocation.preprocessing_colliding_users.apply_async")
 class PreprocessingBaselineConfigTest(RelocationTaskTestCase):
     def setUp(self):
         super().setUp()
@@ -852,7 +852,7 @@ class PreprocessingBaselineConfigTest(RelocationTaskTestCase):
     new_callable=lambda: FakeKeyManagementServiceClient,
 )
 @patch("sentry.utils.relocation.MessageBuilder")
-@patch("sentry.tasks.relocation.preprocessing_complete.delay")
+@patch("sentry.tasks.relocation.preprocessing_complete.apply_async")
 class PreprocessingCollidingUsersTest(RelocationTaskTestCase):
     def setUp(self):
         super().setUp()
@@ -961,7 +961,7 @@ class PreprocessingCollidingUsersTest(RelocationTaskTestCase):
 
 @region_silo_test
 @patch("sentry.utils.relocation.MessageBuilder")
-@patch("sentry.tasks.relocation.validating_start.delay")
+@patch("sentry.tasks.relocation.validating_start.apply_async")
 class PreprocessingCompleteTest(RelocationTaskTestCase):
     def setUp(self):
         super().setUp()
@@ -1089,7 +1089,7 @@ class PreprocessingCompleteTest(RelocationTaskTestCase):
     new_callable=lambda: FakeCloudBuildClient,
 )
 @patch("sentry.utils.relocation.MessageBuilder")
-@patch("sentry.tasks.relocation.validating_poll.delay")
+@patch("sentry.tasks.relocation.validating_poll.apply_async")
 class ValidatingStartTest(RelocationTaskTestCase):
     def setUp(self):
         super().setUp()
@@ -1262,7 +1262,7 @@ class ValidatingPollTest(RelocationTaskTestCase):
             )
         )
 
-    @patch("sentry.tasks.relocation.validating_complete.delay")
+    @patch("sentry.tasks.relocation.validating_complete.apply_async")
     def test_success(
         self,
         validating_complete_mock: Mock,
@@ -1284,7 +1284,7 @@ class ValidatingPollTest(RelocationTaskTestCase):
         assert self.relocation_validation.status == ValidationStatus.IN_PROGRESS.value
         assert self.relocation.latest_task == "VALIDATING_POLL"
 
-    @patch("sentry.tasks.relocation.validating_start.delay")
+    @patch("sentry.tasks.relocation.validating_start.apply_async")
     def test_timeout_starts_new_validation_attempt(
         self,
         validating_start_mock: Mock,
@@ -1310,7 +1310,7 @@ class ValidatingPollTest(RelocationTaskTestCase):
             assert self.relocation_validation.status == ValidationStatus.IN_PROGRESS.value
             assert self.relocation_validation_attempt.status == ValidationStatus.TIMEOUT.value
 
-    @patch("sentry.tasks.relocation.validating_start.delay")
+    @patch("sentry.tasks.relocation.validating_start.apply_async")
     def test_failure_starts_new_validation_attempt(
         self,
         validating_start_mock: Mock,
@@ -1457,7 +1457,7 @@ def mock_invalid_finding(storage: Storage, uuid: str):
 
 @region_silo_test
 @patch("sentry.utils.relocation.MessageBuilder")
-@patch("sentry.tasks.relocation.importing.delay")
+@patch("sentry.tasks.relocation.importing.apply_async")
 class ValidatingCompleteTest(RelocationTaskTestCase):
     def setUp(self):
         super().setUp()
@@ -1602,7 +1602,7 @@ class ValidatingCompleteTest(RelocationTaskTestCase):
     "sentry.backup.helpers.KeyManagementServiceClient",
     new_callable=lambda: FakeKeyManagementServiceClient,
 )
-@patch("sentry.tasks.relocation.postprocessing.delay")
+@patch("sentry.tasks.relocation.postprocessing.apply_async")
 class ImportingTest(RelocationTaskTestCase, TransactionTestCase):
     def setUp(self):
         RelocationTaskTestCase.setUp(self)
@@ -1667,7 +1667,7 @@ class ImportingTest(RelocationTaskTestCase, TransactionTestCase):
 @region_silo_test
 @patch("sentry.utils.relocation.MessageBuilder")
 @patch("sentry.signals.relocated.send_robust")
-@patch("sentry.tasks.relocation.notifying_users.delay")
+@patch("sentry.tasks.relocation.notifying_users.apply_async")
 class PostprocessingTest(RelocationTaskTestCase):
     def setUp(self):
         RelocationTaskTestCase.setUp(self)
@@ -1813,7 +1813,7 @@ class PostprocessingTest(RelocationTaskTestCase):
 
 @region_silo_test
 @patch("sentry.utils.relocation.MessageBuilder")
-@patch("sentry.tasks.relocation.notifying_owner.delay")
+@patch("sentry.tasks.relocation.notifying_owner.apply_async")
 class NotifyingUsersTest(RelocationTaskTestCase):
     def setUp(self):
         RelocationTaskTestCase.setUp(self)
@@ -1935,7 +1935,7 @@ class NotifyingUsersTest(RelocationTaskTestCase):
 
 @region_silo_test
 @patch("sentry.utils.relocation.MessageBuilder")
-@patch("sentry.tasks.relocation.completed.delay")
+@patch("sentry.tasks.relocation.completed.apply_async")
 class NotifyingOwnerTest(RelocationTaskTestCase):
     def setUp(self):
         RelocationTaskTestCase.setUp(self)


### PR DESCRIPTION
This ensures that the current task is marked "done" in the database before the next task is kicked off. Since this is handled by the `retry_or_fail_relocation` context manager, all next task calls must be moved outside of said context manager, becoming the very last procedures completed in their owning task.

Because this change required genericizing over the "schedule the next task" operation, all such operations have been converted in `.apply_async()` calls, and a new `NextTask` class has been added to track task invocations that we want to kick off at the end of the current task.

Issue: getsentry/team-ospo#214