### PR TITLE
fix(onboarding-docs): Prism console warning language text

### DIFF
--- a/static/app/gettingStartedDocs/apple/apple-macos.tsx
+++ b/static/app/gettingStartedDocs/apple/apple-macos.tsx
@@ -84,7 +84,7 @@ const onboarding: OnboardingConfig = {
       ),
       configurations: [
         {
-          language: 'text',
+          language: 'url',
           code: `https://github.com/getsentry/sentry-cocoa.git`,
         },
         {

--- a/static/app/gettingStartedDocs/unreal/unreal.tsx
+++ b/static/app/gettingStartedDocs/unreal/unreal.tsx
@@ -58,7 +58,7 @@ export const steps = ({
     ),
     configurations: [
       {
-        language: 'text',
+        language: 'url',
         code: dsn,
       },
     ],


### PR DESCRIPTION
Remove language `text` as prism fails to load a language file for it and therefore emits a console warning in our tests.