### PR TITLE
feat(ddm): Explicitly pass codeLocations to the ddm/meta endopint

### DIFF
--- a/static/app/utils/metrics/useMetricsCodeLocations.tsx
+++ b/static/app/utils/metrics/useMetricsCodeLocations.tsx
@@ -18,6 +18,7 @@ export function useMetricsCodeLocations(mri: string | undefined) {
         query: {
           metric: mri,
           project: selection.projects,
+          codeLocations: true,
           ...getDateTimeParams(selection.datetime),
         },
       },


### PR DESCRIPTION
This PR explicitly passes `codeLocations=true` in the query params to support the new endpoint for ddm meta which requires the frontend to specify the metadata to return.

Related to: https://github.com/getsentry/sentry/pull/61925