### PR TITLE
fix(ddm): Metrics meta stale time

### DIFF
--- a/static/app/utils/metrics/useMetricsMeta.tsx
+++ b/static/app/utils/metrics/useMetricsMeta.tsx
@@ -17,7 +17,7 @@ function useMetaUseCase(
     [`/organizations/${slug}/metrics/meta/`, {query: {useCase, project: projects}}],
     {
       ...options,
-      staleTime: Infinity,
+      staleTime: 2000, // 2 seconds to cover page load
     }
   );
 

--- a/static/app/views/alerts/rules/metric/mriField.tsx
+++ b/static/app/views/alerts/rules/metric/mriField.tsx
@@ -66,8 +66,12 @@ function MriField({aggregate, project, onChange}: Props) {
 
   const handleMriChange = useCallback(
     option => {
+      const selectedMeta = meta.find(metric => metric.mri === option.value);
+      if (!selectedMeta) {
+        return;
+      }
       // Make sure that the selected operation matches the new metric
-      const availableOps = filterAndSortOperations(meta[option.value].operations);
+      const availableOps = filterAndSortOperations(selectedMeta.operations);
       const selectedOp =
         selectedValues.op && availableOps.includes(selectedValues.op)
           ? selectedValues.op


### PR DESCRIPTION
Update stale time of metrics meta from `Infinity` to `2000ms`.
Fix broken `onchange` in MriField.

- closes https://github.com/getsentry/sentry/issues/62161