### PR TITLE
feat(ddm): Handle dashboard naming collision

### DIFF
--- a/static/app/views/ddm/useCreateDashboard.tsx
+++ b/static/app/views/ddm/useCreateDashboard.tsx
@@ -16,7 +16,7 @@ export function useCreateDashboard() {
   return useMemo(() => {
     return function (scratchpad?: {name: string}) {
       const newDashboard = {
-        title: scratchpad?.name || 'DDM Dashboard',
+        title: scratchpad?.name || 'Metrics Dashboard',
         description: '',
         widgets: widgets
           .filter(widget => !!widget.mri)


### PR DESCRIPTION
Add input for dashboard name.
Don't close the modal on errors.

![Screenshot 2023-12-21 at 13 21 33](https://github.com/getsentry/sentry/assets/7033940/a7dcb2ea-3d0e-44a9-8e67-5b11adae5db3)

- closes https://github.com/getsentry/sentry/issues/62160