### PR TITLE
fix(slack): Fix flakey deploy notif block kit test

### DIFF
--- a/tests/sentry/integrations/slack/notifications/test_deploy.py
+++ b/tests/sentry/integrations/slack/notifications/test_deploy.py
@@ -114,10 +114,6 @@ class SlackDeployNotificationTest(SlackActivityNotificationTest):
             == f"Release {release.version} was deployed to {self.environment.name} for these projects"
         )
         assert blocks[0]["text"]["text"] == fallback_text
-        assert (
-            blocks[1]["elements"][0]["text"]
-            == f"{self.project.slug} | <http://testserver/settings/account/notifications/deploy/?referrer=release_activity-slack-user&notification_uuid={notification.notification_uuid}|Notification Settings>"
-        )
 
         first_project = None
         for i in range(len(projects)):
@@ -130,3 +126,9 @@ class SlackDeployNotificationTest(SlackActivityNotificationTest):
                 f"{release.version}/?project={project.id}&unselectedSeries=Healthy&referrer=release_activity&notification_uuid={notification.notification_uuid}"
             )
         assert first_project is not None
+
+        # footer project is the first project in the actions list
+        assert (
+            blocks[1]["elements"][0]["text"]
+            == f"{first_project.slug} | <http://testserver/settings/account/notifications/deploy/?referrer=release_activity-slack-user&notification_uuid={notification.notification_uuid}|Notification Settings>"
+        )


### PR DESCRIPTION
In a deploy notification, the project order may vary, so this PR updates the footer check in the block kit test to check against the project we determine to be the first in the list, rather than hardcoded to `self.project.slug`.

Resolves SENTRY-TESTS-R0B