### PR TITLE
fix: remove several lodash usages

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
@@ -1,5 +1,4 @@
 import {Fragment} from 'react';
-import isObject from 'lodash/isObject';
 
 import {EventGroupComponent} from 'sentry/types';
 
@@ -19,9 +18,9 @@ function GroupingComponentChildren({component, showNonContributing}: Props) {
     <Fragment>
       {(component.values as EventGroupComponent[])
         .filter(value => groupingComponentFilter(value, showNonContributing))
-        .map((value, idx) => (
-          <GroupingComponentListItem key={idx}>
-            {isObject(value) ? (
+        .map(value => (
+          <GroupingComponentListItem key={value.id}>
+            {typeof value === 'object' ? (
               <GroupingComponent
                 component={value}
                 showNonContributing={showNonContributing}

--- a/static/app/components/events/groupingInfo/utils.tsx
+++ b/static/app/components/events/groupingInfo/utils.tsx
@@ -1,5 +1,3 @@
-import isObject from 'lodash/isObject';
-
 import {EventGroupComponent} from 'sentry/types';
 
 export function hasNonContributingComponent(component: EventGroupComponent | undefined) {
@@ -12,7 +10,7 @@ export function hasNonContributingComponent(component: EventGroupComponent | und
   }
 
   for (const value of component.values) {
-    if (isObject(value) && hasNonContributingComponent(value)) {
+    if (value && typeof value === 'object' && hasNonContributingComponent(value)) {
       return true;
     }
   }
@@ -20,19 +18,21 @@ export function hasNonContributingComponent(component: EventGroupComponent | und
 }
 
 export function shouldInlineComponentValue(component: EventGroupComponent) {
-  return (component.values as EventGroupComponent[]).every(value => !isObject(value));
+  return (component.values as EventGroupComponent[]).every(
+    value => !value || typeof value !== 'object'
+  );
 }
 
 export function groupingComponentFilter(
   value: EventGroupComponent | string,
   showNonContributing: boolean
 ) {
-  if (isObject(value)) {
+  if (value && typeof value === 'object') {
     // no point rendering such nodes at all, we never show them
     if (!value.contributes && !value.hint && value.values.length === 0) {
       return false;
     }
-    // non contributing values are otherwise optional
+    // non-contributing values are otherwise optional
     if (!showNonContributing && !value.contributes) {
       return false;
     }

--- a/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
@@ -2,7 +2,6 @@ import {css, Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import forOwn from 'lodash/forOwn';
 import isNil from 'lodash/isNil';
-import isObject from 'lodash/isObject';
 
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import {Hovercard} from 'sentry/components/hovercard';
@@ -85,7 +84,7 @@ export function Mechanism({data: mechanism, meta: mechanismMeta}: Props) {
   }
 
   forOwn(data, (value, key) => {
-    if (!isObject(value)) {
+    if (!value || typeof value !== 'object') {
       pills.push(
         <Pill key={`data:${key}`} name={key}>
           {mechanismMeta?.data?.[key]?.[''] && !value ? (

--- a/static/app/components/events/meta/metaProxy.tsx
+++ b/static/app/components/events/meta/metaProxy.tsx
@@ -1,5 +1,4 @@
 import isEmpty from 'lodash/isEmpty';
-import isNull from 'lodash/isNull';
 import memoize from 'lodash/memoize';
 
 import {Meta} from 'sentry/types';
@@ -49,7 +48,7 @@ export class MetaProxy {
     }
 
     const value = Reflect.get(obj, prop, receiver);
-    if (!Reflect.has(obj, prop) || typeof value !== 'object' || isNull(value)) {
+    if (!Reflect.has(obj, prop) || typeof value !== 'object' || value === null) {
       return value;
     }
 

--- a/static/app/components/feedback/useMutateFeedback.tsx
+++ b/static/app/components/feedback/useMutateFeedback.tsx
@@ -1,5 +1,4 @@
 import {useCallback} from 'react';
-import first from 'lodash/first';
 
 import useFeedbackCache from 'sentry/components/feedback/useFeedbackCache';
 import useFeedbackQueryKeys from 'sentry/components/feedback/useFeedbackQueryKeys';
@@ -33,7 +32,7 @@ export default function useMutateFeedback({feedbackIds, organization}: Props) {
     mutationFn: ([ids, payload]) => {
       const isSingleId = ids !== 'all' && ids.length === 1;
       const url = isSingleId
-        ? `/organizations/${organization.slug}/issues/${first(ids)}/`
+        ? `/organizations/${organization.slug}/issues/${ids[0]}/`
         : `/organizations/${organization.slug}/issues/`;
 
       // TODO: it would be excellent if `PUT /issues/` could return the same data

--- a/static/app/components/replays/useQueryBasedSorting.tsx
+++ b/static/app/components/replays/useQueryBasedSorting.tsx
@@ -1,6 +1,5 @@
 import {useMemo} from 'react';
 import type {Location} from 'history';
-import first from 'lodash/first';
 
 import {GridColumnOrder} from 'sentry/components/gridEditable';
 import queryBasedSortLinkGenerator from 'sentry/components/replays/queryBasedSortLinkGenerator';
@@ -14,7 +13,7 @@ interface Props {
 
 export default function useQueryBasedSorting({location, defaultSort}: Props) {
   const sorts = useMemo(() => fromSorts(location.query.sort), [location.query.sort]);
-  const currentSort = useMemo(() => first(sorts) ?? defaultSort, [defaultSort, sorts]);
+  const currentSort = useMemo(() => sorts.at(0) ?? defaultSort, [defaultSort, sorts]);
 
   return {
     makeSortLinkGenerator: (column: GridColumnOrder) =>

--- a/static/app/components/replaysOnboarding/useCurrentProjectState.tsx
+++ b/static/app/components/replaysOnboarding/useCurrentProjectState.tsx
@@ -1,5 +1,4 @@
 import {useEffect, useMemo, useState} from 'react';
-import first from 'lodash/first';
 
 import {splitProjectsByReplaySupport} from 'sentry/components/replaysOnboarding/utils';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
@@ -70,7 +69,7 @@ function useCurrentProjectState({currentPanel}: {currentPanel: '' | SidebarPanel
       setCurrentProject(firstSelectedProject);
     } else {
       // We have no selection, so pick a project which we've found
-      setCurrentProject(first(projectsWithOnboarding) || first(projectWithReplaySupport));
+      setCurrentProject(projectsWithOnboarding.at(0) || projectWithReplaySupport.at(0));
     }
   }, [
     currentProject,

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -1,7 +1,6 @@
 import {cloneElement, Fragment, isValidElement} from 'react';
 import * as Sentry from '@sentry/react';
 import Jed from 'jed';
-import isObject from 'lodash/isObject';
 import {sprintf} from 'sprintf-js';
 
 import localStorage from 'sentry/utils/localStorage';
@@ -137,7 +136,7 @@ function argsInvolveReact(args: FormatArg[]): boolean {
     return true;
   }
 
-  if (args.length !== 1 || !isObject(args[0])) {
+  if (args.length !== 1 || !args[0] || typeof args[0] !== 'object') {
     return false;
   }
 

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -1,5 +1,4 @@
 import {Query} from 'history';
-import isObject from 'lodash/isObject';
 
 import ConfigStore from 'sentry/stores/configStore';
 import {Project} from 'sentry/types';
@@ -33,7 +32,10 @@ export function valueIsEqual(value?: any, other?: any, deep?: boolean): boolean 
     if (arrayIsEqual(value, other, deep)) {
       return true;
     }
-  } else if (isObject(value) || isObject(other)) {
+  } else if (
+    (value && typeof value === 'object') ||
+    (other && typeof other === 'object')
+  ) {
     if (objectMatchesSubset(value, other, deep)) {
       return true;
     }

--- a/static/app/utils/getRouteStringFromRoutes.tsx
+++ b/static/app/utils/getRouteStringFromRoutes.tsx
@@ -1,5 +1,4 @@
 import {PlainRoute} from 'react-router';
-import findLastIndex from 'lodash/findLastIndex';
 
 type RouteWithPath = Omit<PlainRoute, 'path'> & Required<Pick<PlainRoute, 'path'>>;
 
@@ -19,7 +18,7 @@ export default function getRouteStringFromRoutes(routes?: PlainRoute[]): string 
 
   const routesWithPaths = routes.filter((route): route is RouteWithPath => !!route.path);
 
-  const lastAbsolutePathIndex = findLastIndex(routesWithPaths, ({path}) =>
+  const lastAbsolutePathIndex = routesWithPaths.findLastIndex(({path}) =>
     path.startsWith('/')
   );
 

--- a/static/app/utils/recreateRoute.tsx
+++ b/static/app/utils/recreateRoute.tsx
@@ -1,6 +1,5 @@
 import {PlainRoute} from 'react-router';
 import {Location} from 'history';
-import findLastIndex from 'lodash/findLastIndex';
 
 import replaceRouterParams from 'sentry/utils/replaceRouterParams';
 
@@ -42,9 +41,9 @@ export default function recreateRoute(to: string | PlainRoute, options: Options)
   // TODO(ts): typescript things
   if (typeof to !== 'string') {
     routeIndex = routes.indexOf(to) + 1;
-    lastRootIndex = findLastIndex(paths.slice(0, routeIndex), path => path[0] === '/');
+    lastRootIndex = paths.slice(0, routeIndex).findLastIndex(path => path[0] === '/');
   } else {
-    lastRootIndex = findLastIndex(paths, path => path[0] === '/');
+    lastRootIndex = paths.findLastIndex(path => path[0] === '/');
   }
 
   let baseRoute = paths.slice(lastRootIndex, routeIndex);

--- a/static/app/utils/replays/getCurrentUrl.tsx
+++ b/static/app/utils/replays/getCurrentUrl.tsx
@@ -1,6 +1,3 @@
-import first from 'lodash/first';
-import last from 'lodash/last';
-
 import type {
   BreadcrumbFrame,
   NavigationFrame,
@@ -20,7 +17,7 @@ function getCurrentUrl(
     frame => frame.offsetMs < currentOffsetMS
   );
 
-  const mostRecentFrame = last(framesBeforeCurrentOffset) ?? first(frames);
+  const mostRecentFrame = framesBeforeCurrentOffset?.at(-1) ?? frames?.at(0);
   if (!mostRecentFrame) {
     return '';
   }

--- a/static/app/utils/replays/hooks/useInitialTimeOffsetMs.tsx
+++ b/static/app/utils/replays/hooks/useInitialTimeOffsetMs.tsx
@@ -1,5 +1,4 @@
 import {useEffect, useMemo, useState} from 'react';
-import first from 'lodash/first';
 
 import isValidDate from 'sentry/utils/date/isValidDate';
 import fetchReplayClicks from 'sentry/utils/replays/fetchReplayClicks';
@@ -137,7 +136,7 @@ async function fromListPageQuery({
     return ZERO_OFFSET;
   }
   try {
-    const firstResult = first(results.clicks)!;
+    const firstResult = results.clicks.at(0)!;
     const firstTimestamp = firstResult!.timestamp;
     const nodeId = firstResult!.node_id;
     const firstTimestmpMs = new Date(firstTimestamp).getTime();

--- a/static/app/views/ddm/ddmOnboarding/useCurrentProjectState.tsx
+++ b/static/app/views/ddm/ddmOnboarding/useCurrentProjectState.tsx
@@ -1,5 +1,4 @@
 import {useEffect, useMemo, useState} from 'react';
-import first from 'lodash/first';
 import partition from 'lodash/partition';
 
 import {
@@ -67,7 +66,7 @@ export function useCurrentProjectState({isActive}: {isActive: boolean}) {
       const firstSelectedProject = projects.find(p => selectedProjectIds.includes(p.id));
       setCurrentProject(firstSelectedProject);
     } else {
-      setCurrentProject(first(projectsWithOnboarding) || first(supportedProjects));
+      setCurrentProject(projectsWithOnboarding.at(0) || supportedProjects.at(0));
     }
   }, [
     currentProject,

--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
-import isObject from 'lodash/isObject';
 
 import type {OnAssignCallback} from 'sentry/components/assigneeSelectorDropdown';
 import AvatarList from 'sentry/components/avatar/avatarList';
@@ -117,7 +116,9 @@ export default function GroupSidebar({
         issues.push(
           <Fragment key={plugin.slug}>
             <span>{`${plugin.shortName || plugin.name || plugin.title}: `}</span>
-            <a href={issue.url}>{isObject(issue.label) ? issue.label.id : issue.label}</a>
+            <a href={issue.url}>
+              {typeof issue.label === 'object' ? issue.label.id : issue.label}
+            </a>
           </Fragment>
         );
       }

--- a/static/app/views/replays/detail/console/format.tsx
+++ b/static/app/views/replays/detail/console/format.tsx
@@ -20,15 +20,11 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 import {Fragment} from 'react';
-import isObject from 'lodash/isObject';
 
 import ObjectInspector, {OnExpandCallback} from 'sentry/components/objectInspector';
 
 const formatRegExp = /%[csdj%]/g;
 
-function isNull(arg: unknown) {
-  return arg === null;
-}
 interface FormatProps {
   args: any[];
   expandPaths?: string[];
@@ -134,7 +130,7 @@ export default function Format({onExpand, expandPaths, args}: FormatProps) {
   }
 
   for (let x = args[i]; i < len; x = args[++i]) {
-    if (isNull(x) || !isObject(x)) {
+    if (x === null || typeof x !== 'object') {
       pieces.push(' ' + x);
     } else {
       pieces.push(' ');

--- a/static/app/views/replays/detail/console/messageFormatter.tsx
+++ b/static/app/views/replays/detail/console/messageFormatter.tsx
@@ -1,8 +1,6 @@
 import {memo} from 'react';
-import isObject from 'lodash/isObject';
 
 import {OnExpandCallback} from 'sentry/components/objectInspector';
-import {objectIsEmpty} from 'sentry/utils';
 import type {BreadcrumbFrame, ConsoleFrame} from 'sentry/utils/replays/types';
 import {isConsoleFrame} from 'sentry/utils/replays/types';
 import Format from 'sentry/views/replays/detail/console/format';
@@ -25,8 +23,9 @@ function isSerializedError(frame: ConsoleFrame) {
     typeof frame.message === 'string' &&
     Array.isArray(args) &&
     args.length <= 2 &&
-    isObject(args[0]) &&
-    objectIsEmpty(args[0])
+    args[0] &&
+    typeof args[0] === 'object' &&
+    Object.keys(args[0]).length === 0
   );
 }
 


### PR DESCRIPTION
Removes:

- `lodash/isObject` usages with `value && typeof value === 'object'`
- `lodash/first` with `array.at(0)`
- `lodash/last` with `array.at(-1)`
- `lodash/findLastIndex` with `array.findLastIndex()`

Relates to: https://github.com/getsentry/frontend-tsc/issues/55