### PR TITLE
ref(tests): Remove TestStubs global from `newTokenHandler`

### DIFF
--- a/static/app/views/settings/components/newTokenHandler.spec.tsx
+++ b/static/app/views/settings/components/newTokenHandler.spec.tsx
@@ -1,3 +1,5 @@
+import {ApiToken as ApiTokenFixture} from 'sentry-fixture/apiToken';
+
 import {render} from 'sentry-test/reactTestingLibrary';
 
 import NewTokenHandler from 'sentry/views/settings/components/newTokenHandler';
@@ -5,6 +7,6 @@ import NewTokenHandler from 'sentry/views/settings/components/newTokenHandler';
 describe('NewTokenHandler', () => {
   it('renders', () => {
     const callback = ({}) => {};
-    render(<NewTokenHandler token={TestStubs.ApiToken()} handleGoBack={callback} />);
+    render(<NewTokenHandler token={ApiTokenFixture().token} handleGoBack={callback} />);
   });
 });


### PR DESCRIPTION
... this is also kind of a useless test.

ref https://github.com/getsentry/frontend-tsc/issues/49
