### PR TITLE
chore: Add warnings for bitfield additions

### DIFF
--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -70,6 +70,11 @@ class AuthProvider(ReplicatedControlModel):
         )
 
     class flags(TypedClassBitField):
+        # WARNING: Only add flags to the bottom of this list
+        # bitfield flags are dependent on their order and inserting/removing
+        # flags from the middle of the list will cause bits to shift corrupting
+        # existing data.
+
         # Grant access to members who have not linked SSO accounts.
         allow_unlinked: bool
         # Enable SCIM for member and team provisioning and syncing.

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -181,6 +181,11 @@ class Organization(
     is_test = models.BooleanField(default=False)
 
     class flags(TypedClassBitField):
+        # WARNING: Only add flags to the bottom of this list
+        # bitfield flags are dependent on their order and inserting/removing
+        # flags from the middle of the list will cause bits to shift corrupting
+        # existing data.
+
         # Allow members to join and leave teams without requiring approval
         allow_joinleave: bool
 

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -237,6 +237,11 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
     first_event = models.DateTimeField(null=True)
 
     class flags(TypedClassBitField):
+        # WARNING: Only add flags to the bottom of this list
+        # bitfield flags are dependent on their order and inserting/removing
+        # flags from the middle of the list will cause bits to shift corrupting
+        # existing data.
+
         # This Project has sent release data
         has_releases: bool
         # This Project has issue alerts targeting

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -62,6 +62,11 @@ class ProjectKey(Model):
     secret_key = models.CharField(max_length=32, unique=True, null=True)
 
     class roles(TypedClassBitField):
+        # WARNING: Only add flags to the bottom of this list
+        # bitfield flags are dependent on their order and inserting/removing
+        # flags from the middle of the list will cause bits to shift corrupting
+        # existing data.
+
         # access to post events to the store endpoint
         store: bool
         # read/write access to rest API

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -159,6 +159,11 @@ class User(BaseModel, AbstractBaseUser):
     )
 
     class flags(TypedClassBitField):
+        # WARNING: Only add flags to the bottom of this list
+        # bitfield flags are dependent on their order and inserting/removing
+        # flags from the middle of the list will cause bits to shift corrupting
+        # existing data.
+
         # Do we need to ask this user for newsletter consent?
         newsletter_consent_prompt: bool
 


### PR DESCRIPTION
Adding to the middle of a bitfield will corrupt data and should be avoided.

Refs INC-590
