### PR TITLE
ref(tests): Remove TestStubs global from `integrationRepos` + fix Integration types

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -356,16 +356,19 @@ export interface OrganizationIntegrationProvider extends BaseIntegrationProvider
   aspects: IntegrationAspects;
 }
 
-export interface Integration {
-  accountType: string;
-  domainName: string;
-  gracePeriodEnd: string;
-  icon: string;
+interface CommonIntegration {
+  accountType: string | null;
+  domainName: string | null;
+  gracePeriodEnd: string | null;
+  icon: string | null;
   id: string;
   name: string;
   organizationIntegrationStatus: ObjectStatus;
   provider: OrganizationIntegrationProvider;
   status: ObjectStatus;
+}
+
+export interface Integration extends CommonIntegration {
   dynamicDisplayInformation?: {
     configure_integration?: {
       instructions: string[];
@@ -381,21 +384,12 @@ type ConfigData = {
   installationType?: string;
 };
 
-export type OrganizationIntegration = {
-  accountType: string | null;
+export interface OrganizationIntegration extends CommonIntegration {
   configData: ConfigData | null;
   configOrganization: Field[];
-  domainName: string | null;
   externalId: string;
-  gracePeriodEnd: string;
-  icon: string | null;
-  id: string;
-  name: string;
   organizationId: string;
-  organizationIntegrationStatus: ObjectStatus;
-  provider: OrganizationIntegrationProvider;
-  status: ObjectStatus;
-};
+}
 
 // we include the configOrganization when we need it
 export interface IntegrationWithConfig extends Integration {

--- a/static/app/views/settings/organizationIntegrations/addIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegration.tsx
@@ -14,7 +14,7 @@ type Props = {
   onInstall: (data: IntegrationWithConfig) => void;
   organization: Organization;
   provider: IntegrationProvider;
-  account?: string; // for analytics
+  account?: string | null; // for analytics
   analyticsParams?: {
     already_installed: boolean;
     view:

--- a/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/docIntegrationDetailedView.spec.tsx
@@ -1,3 +1,5 @@
+import {DocIntegration as DocIntegrationFixture} from 'sentry-fixture/docIntegration';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -5,7 +7,7 @@ import DocIntegrationDetailedView from 'sentry/views/settings/organizationIntegr
 
 describe('DocIntegrationDetailedView', function () {
   const {routerProps, organization} = initializeOrg();
-  const doc = TestStubs.DocIntegration();
+  const doc = DocIntegrationFixture();
 
   beforeEach(function () {});
 
@@ -32,13 +34,13 @@ describe('DocIntegrationDetailedView', function () {
     expect(screen.getByText(doc.author)).toBeInTheDocument();
     expect(screen.getByText(doc.description)).toBeInTheDocument();
 
-    for (const resource of doc.resources) {
+    for (const resource of doc.resources || []) {
       const link = screen.getByText(resource.title);
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute('href', resource.url);
     }
 
-    for (const feature of doc.features) {
+    for (const feature of doc.features || []) {
       expect(screen.getByText(feature.description)).toBeInTheDocument();
     }
   });

--- a/static/app/views/settings/organizationIntegrations/integrationCodeMappings.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationCodeMappings.spec.tsx
@@ -1,4 +1,5 @@
 import selectEvent from 'react-select-event';
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {Repository} from 'sentry-fixture/repository';
@@ -27,7 +28,7 @@ describe('IntegrationCodeMappings', function () {
   ];
 
   const org = Organization();
-  const integration = TestStubs.GitHubIntegration();
+  const integration = GitHubIntegrationFixture();
   const repos = [
     Repository({
       integrationId: integration.id,

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -203,6 +203,10 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
   onDisable = (integration: Integration) => {
     let url: string;
 
+    if (!integration.domainName) {
+      return;
+    }
+
     const [domainName, orgName] = integration.domainName.split('/');
     if (integration.accountType === 'User') {
       url = `https://${domainName}/settings/installations/`;

--- a/static/app/views/settings/organizationIntegrations/integrationExternalMappingForm.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalMappingForm.spec.tsx
@@ -1,3 +1,5 @@
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
+
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import IntegrationExternalMappingForm from './integrationExternalMappingForm';
@@ -5,7 +7,7 @@ import IntegrationExternalMappingForm from './integrationExternalMappingForm';
 describe('IntegrationExternalMappingForm', function () {
   const dataEndpoint = '/test/dataEndpoint/';
   const baseProps = {
-    integration: TestStubs.GitHubIntegration(),
+    integration: GitHubIntegrationFixture(),
     dataEndpoint,
     getBaseFormEndpoint: jest.fn(_mapping => dataEndpoint),
     sentryNamesMapper: mappings => mappings,

--- a/static/app/views/settings/organizationIntegrations/integrationExternalMappings.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalMappings.spec.tsx
@@ -1,3 +1,5 @@
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
@@ -73,7 +75,7 @@ describe('IntegrationExternalMappings', function () {
     const {container} = render(
       <IntegrationExternalMappings
         organization={organization}
-        integration={TestStubs.GitHubIntegration()}
+        integration={GitHubIntegrationFixture()}
         mappings={[]}
         type="user"
         onCreate={onCreateMock}
@@ -95,7 +97,7 @@ describe('IntegrationExternalMappings', function () {
     render(
       <IntegrationExternalMappings
         organization={organization}
-        integration={TestStubs.GitHubIntegration()}
+        integration={GitHubIntegrationFixture()}
         mappings={[]}
         type="user"
         onCreate={onCreateMock}
@@ -122,7 +124,7 @@ describe('IntegrationExternalMappings', function () {
     render(
       <IntegrationExternalMappings
         organization={organization}
-        integration={TestStubs.GitHubIntegration()}
+        integration={GitHubIntegrationFixture()}
         mappings={MOCK_TEAM_MAPPINGS}
         type="team"
         onCreate={onCreateMock}
@@ -155,7 +157,7 @@ describe('IntegrationExternalMappings', function () {
     render(
       <IntegrationExternalMappings
         organization={organization}
-        integration={TestStubs.GitHubIntegration()}
+        integration={GitHubIntegrationFixture()}
         mappings={MOCK_USER_MAPPINGS}
         type="user"
         onCreate={onCreateMock}

--- a/static/app/views/settings/organizationIntegrations/integrationIcon.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationIcon.tsx
@@ -33,7 +33,7 @@ class Icon extends Component<Props, State> {
     return (
       <StyledIcon
         size={size}
-        src={this.state.imgSrc}
+        src={this.state.imgSrc || undefined}
         onError={() => {
           this.setState({imgSrc: ICON_PATHS[integration.provider.key] || DEFAULT_ICON});
         }}

--- a/static/app/views/settings/organizationIntegrations/integrationRepos.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationRepos.spec.tsx
@@ -1,3 +1,4 @@
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {Organization} from 'sentry-fixture/organization';
 import {Repository} from 'sentry-fixture/repository';
 
@@ -8,7 +9,7 @@ import IntegrationRepos from 'sentry/views/settings/organizationIntegrations/int
 
 describe('IntegrationRepos', function () {
   const org = Organization();
-  const integration = TestStubs.GitHubIntegration();
+  const integration = GitHubIntegrationFixture();
   let resetReposSpy;
 
   beforeEach(() => {


### PR DESCRIPTION
* Refactored Integration + OrganizationIntegration -> CommonIntegration
  * See https://github.com/getsentry/sentry/blob/ff5ca49b4cef06805a540a73a47fceb5a351e379/src/sentry/api/serializers/models/integration.py#L24-L39
  * AFAICT these two types come from the same serializer
* Handle different null/undefined values

ref https://github.com/getsentry/frontend-tsc/issues/49