### PR TITLE
ref(tests): Remove TestStubs global from `sentryApplicationDashboard`

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.spec.tsx
@@ -1,3 +1,4 @@
+import {SentryApp as SentryAppFixture} from 'sentry-fixture/sentryApp';
 import {SentryAppWebhookRequest} from 'sentry-fixture/sentryAppWebhookRequest';
 
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
@@ -21,11 +22,11 @@ describe('Sentry Application Dashboard', function () {
 
   describe('Viewing the Sentry App Dashboard for a published integration', () => {
     beforeEach(() => {
-      sentryApp = TestStubs.SentryApp({
+      sentryApp = SentryAppFixture({
         status: 'published',
         schema: {
           elements: [
-            {type: 'stacktrace-link', uri: '/test'},
+            {type: 'stacktrace-link', uri: '/test', url: '/test'},
             {
               type: 'issue-link',
               create: {uri: '/test', required_fields: []},
@@ -128,10 +129,10 @@ describe('Sentry Application Dashboard', function () {
 
   describe('Viewing the Sentry App Dashboard for an internal integration', () => {
     beforeEach(() => {
-      sentryApp = TestStubs.SentryApp({
+      sentryApp = SentryAppFixture({
         status: 'internal',
         schema: {
-          elements: [{type: 'stacktrace-link', uri: '/test'}],
+          elements: [{type: 'stacktrace-link', uri: '/test', url: '/test'}],
         },
       });
       webhookRequest = SentryAppWebhookRequest();


### PR DESCRIPTION
* Added `url` key

ref https://github.com/getsentry/frontend-tsc/issues/49