### PR TITLE
ref: prevent invalid BitField alters

### DIFF
--- a/src/sentry/migrations/0586_add_has_feedbacks_flag.py
+++ b/src/sentry/migrations/0586_add_has_feedbacks_flag.py
@@ -19,6 +19,8 @@ class Migration(CheckedMigration):
     #   change, it's completely safe to run the operation after the code has deployed.
     is_dangerous = False
 
+    skip_invalid_bitfield_change_check = True
+
     dependencies = [
         ("sentry", "0585_add_orgmember_partnership_restricted_flag"),
     ]

--- a/src/sentry/migrations/0620_add_has_new_feedbacks_flag.py
+++ b/src/sentry/migrations/0620_add_has_new_feedbacks_flag.py
@@ -19,6 +19,8 @@ class Migration(CheckedMigration):
     #   change, it's completely safe to run the operation after the code has deployed.
     is_dangerous = False
 
+    skip_invalid_bitfield_change_check = True
+
     dependencies = [
         ("sentry", "0619_monitors_migrate_is_muted"),
     ]

--- a/src/sentry/new_migrations/monkey/executor.py
+++ b/src/sentry/new_migrations/monkey/executor.py
@@ -1,11 +1,16 @@
+import difflib
 import logging
 import os
 
 from django.contrib.contenttypes.management import RenameContentType
 from django.db.migrations.executor import MigrationExecutor
-from django.db.migrations.operations import SeparateDatabaseAndState
+from django.db.migrations.migration import Migration
+from django.db.migrations.operations import AlterField, SeparateDatabaseAndState
 from django.db.migrations.operations.fields import FieldOperation
 from django.db.migrations.operations.models import IndexOperation, ModelOperation
+from django.db.migrations.state import ProjectState
+
+from bitfield.models import BitField
 
 logger = logging.getLogger(__name__)
 
@@ -17,9 +22,41 @@ class MissingDatabaseRoutingInfo(Exception):
     """
 
 
+def _check_bitfield_flags(name: str, old: list[str], new: list[str]) -> None:
+    deleted = set(old) - set(new)
+    if deleted:
+        raise ValueError(
+            f"migration `{name}` alters a BitField in an unsafe way!\n\n"
+            f'the following flags were removed: {", ".join(sorted(deleted))}\n\n'
+            f"unused flags must remain to preserve padding for future flags"
+        )
+
+    should_match_old = new[: len(old)]
+
+    inserted = set(should_match_old) - set(old)
+    if inserted:
+        raise ValueError(
+            f"migration `{name}` alters a BitField in an unsafe way!\n\n"
+            f'the following flags were inserted between old flags: {", ".join(sorted(inserted))}\n\n'
+            f"new flags must be added at the end or flags will change meaning"
+        )
+
+    if old != should_match_old:
+        diff = "\n".join(
+            difflib.unified_diff(old, should_match_old, fromfile="old", tofile="new", lineterm="")
+        )
+
+        raise ValueError(
+            f"migration `{name}` alters a BitField in an unsafe way!\n\n"
+            f"the following old flags were reordered:\n\n"
+            f"{diff}\n\n"
+            f"flags must retain historical order or flags will change meaning"
+        )
+
+
 class SentryMigrationExecutor(MigrationExecutor):
     @staticmethod
-    def _check_db_routing(migration):
+    def _check_db_routing(migration: Migration) -> None:
         """
         Make sure that operations in a given migration provide enough information
         for database router to select correct database connection/alias.
@@ -62,7 +99,25 @@ class SentryMigrationExecutor(MigrationExecutor):
                 f"\nOperations:\n{ops_msg}"
             )
 
-    def _check_fake(self, migration, fake):
+    @staticmethod
+    def _check_unsafe_bitfield_alter(state: ProjectState, migration: Migration) -> None:
+        if getattr(migration, "skip_invalid_bitfield_change_check", False):
+            return
+
+        for operation in migration.operations:
+            if isinstance(operation, AlterField) and isinstance(operation.field, BitField):
+                try:
+                    previous_flags = (
+                        state.models[(migration.app_label, operation.model_name)]
+                        .fields[operation.name]
+                        .flags
+                    )
+                except KeyError:  # this is a squashed migration
+                    continue
+
+                _check_bitfield_flags(migration.name, previous_flags, operation.field.flags)
+
+    def _check_fake(self, migration: Migration, fake: bool) -> bool:
         if (
             os.environ.get("MIGRATION_SKIP_DANGEROUS", "0") == "1"
             or os.environ.get("SOUTH_SKIP_DANGEROUS", "0") == "1"
@@ -73,12 +128,21 @@ class SentryMigrationExecutor(MigrationExecutor):
             logger.warning("(too dangerous)")
         return fake
 
-    def apply_migration(self, state, migration, fake=False, fake_initial=False):
+    def apply_migration(
+        self,
+        state: ProjectState,
+        migration: Migration,
+        fake: bool = False,
+        fake_initial: bool = False,
+    ) -> ProjectState:
         self._check_db_routing(migration)
+        self._check_unsafe_bitfield_alter(state, migration)
         fake = self._check_fake(migration, fake)
         return super().apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
 
-    def unapply_migration(self, state, migration, fake=False):
+    def unapply_migration(
+        self, state: ProjectState, migration: Migration, fake: bool = False
+    ) -> ProjectState:
         self._check_db_routing(migration)
         fake = self._check_fake(migration, fake)
         return super().unapply_migration(state, migration, fake=fake)

--- a/tests/sentry/new_migrations/monkey/test_executor.py
+++ b/tests/sentry/new_migrations/monkey/test_executor.py
@@ -4,6 +4,7 @@ from django.db import migrations, models
 from sentry.new_migrations.monkey.executor import (
     MissingDatabaseRoutingInfo,
     SentryMigrationExecutor,
+    _check_bitfield_flags,
 )
 from sentry.testutils.cases import TestCase
 
@@ -163,3 +164,64 @@ class SentryMigrationExecutorTest(TestCase):
             ]
 
         SentryMigrationExecutor._check_db_routing(TestMigration(name="test", app_label="auth"))
+
+
+@pytest.mark.parametrize(
+    ("before", "after"),
+    (
+        pytest.param(["a", "b", "c"], ["a", "b", "c"], id="noop"),
+        pytest.param(["a", "b", "c"], ["a", "b", "c", "d"], id="append"),
+    ),
+)
+def test_check_bitfield_flags_ok(before: list[str], after: list[str]) -> None:
+    _check_bitfield_flags("001_migration", before, after)
+
+
+def test_check_bitfield_flags_deletion() -> None:
+    expected = """\
+migration `001_migration` alters a BitField in an unsafe way!
+
+the following flags were removed: b
+
+unused flags must remain to preserve padding for future flags
+""".rstrip()
+    with pytest.raises(ValueError) as excinfo:
+        _check_bitfield_flags("001_migration", ["a", "b", "c"], ["a", "c"])
+    (msg,) = excinfo.value.args
+    assert msg == expected
+
+
+def test_check_bitfield_flags_insertion() -> None:
+    expected = """\
+migration `001_migration` alters a BitField in an unsafe way!
+
+the following flags were inserted between old flags: d
+
+new flags must be added at the end or flags will change meaning
+""".rstrip()
+    with pytest.raises(ValueError) as excinfo:
+        _check_bitfield_flags("001_migration", ["a", "b", "c"], ["a", "d", "b", "c"])
+    (msg,) = excinfo.value.args
+    assert msg == expected
+
+
+def test_check_bitfield_flags_reorder() -> None:
+    expected = """\
+migration `001_migration` alters a BitField in an unsafe way!
+
+the following old flags were reordered:
+
+--- old
++++ new
+@@ -1,3 +1,3 @@
++b
+ a
+-b
+ c
+
+flags must retain historical order or flags will change meaning
+""".rstrip()
+    with pytest.raises(ValueError) as excinfo:
+        _check_bitfield_flags("001_migration", ["a", "b", "c"], ["b", "a", "c"])
+    (msg,) = excinfo.value.args
+    assert msg == expected


### PR DESCRIPTION
example failures:

```
ValueError: migration `0586_add_has_feedbacks_flag` alters a BitField in an unsafe way!

the following flags were added between old flags: has_feedbacks

new flags must be added at the end or flags will change meaning
```

```
ValueError: migration `0620_add_has_new_feedbacks_flag` alters a BitField in an unsafe way!

the following flags were added between old flags: has_new_feedbacks

new flags must be added at the end or flags will change meaning
```

```
ValueError: migration `0625_wat2` alters a BitField in an unsafe way!

the following flags were removed: has_transactions

unused flags must remain to preserve padding for future flags
```

```
ValueError: migration `0625_wat3` alters a BitField in an unsafe way!

the following old flags were reordered:

--- old
+++ new
@@ -3,8 +3,8 @@
 has_transactions
 has_alert_filters
 has_sessions
+has_replays
 has_profiles
-has_replays
 has_feedbacks
 has_new_feedbacks
 spike_protection_error_currently_active

flags must retain historical order or flags will change meaning
```