### PR TITLE
typing(metrics_extraction): Do not allow untyped functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -732,3 +732,15 @@ disable_error_code = [
     "var-annotated",
 ]
 # end: sentry modules with typing issues
+
+# begging: stronger typing
+[[tool.mypy.overrides]]
+module = [
+    "src.sentry.relay.config.metric_extraction.py",
+    "src.sentry.snuba.metrics.extraction.py",
+    "tests.sentry.relay.config.test_metric_extraction.py",
+    "tests.sentry.snuba.test_extraction.py",
+    "tests.sentry.tasks.test_on_demand_metrics.py",
+]
+disallow_untyped_defs = true
+# end: stronger typing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -739,8 +739,6 @@ module = [
     "src.sentry.relay.config.metric_extraction",
     "src.sentry.snuba.metrics.extraction",
     "tests.sentry.relay.config.test_metric_extraction",
-    "tests.sentry.snuba.test_extraction",
-    "tests.sentry.tasks.test_on_demand_metrics",
 ]
 disallow_untyped_defs = true
 # end: stronger typing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -733,14 +733,14 @@ disable_error_code = [
 ]
 # end: sentry modules with typing issues
 
-# begging: stronger typing
+# beginning: stronger typing
 [[tool.mypy.overrides]]
 module = [
-    "src.sentry.relay.config.metric_extraction.py",
-    "src.sentry.snuba.metrics.extraction.py",
-    "tests.sentry.relay.config.test_metric_extraction.py",
-    "tests.sentry.snuba.test_extraction.py",
-    "tests.sentry.tasks.test_on_demand_metrics.py",
+    "src.sentry.relay.config.metric_extraction",
+    "src.sentry.snuba.metrics.extraction",
+    "tests.sentry.relay.config.test_metric_extraction",
+    "tests.sentry.snuba.test_extraction",
+    "tests.sentry.tasks.test_on_demand_metrics",
 ]
 disallow_untyped_defs = true
 # end: stronger typing

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -339,7 +339,7 @@ def convert_widget_query_to_metric(
 
 def _can_widget_use_stateful_extraction(
     widget_query: DashboardWidgetQuery, metrics_specs: Sequence[HashedMetricSpec]
-):
+) -> bool:
     if not metrics_specs:
         return False
     spec_hashes = [hashed_spec[0] for hashed_spec in metrics_specs]

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -1274,7 +1274,7 @@ class OnDemandMetricSpec:
         return QueryParsingResult(conditions=extended_conditions)
 
     @staticmethod
-    def _aggregate_conditions(parsed_field) -> Optional[RuleCondition]:
+    def _aggregate_conditions(parsed_field: FieldParsingResult) -> Optional[RuleCondition]:
         # We have to handle the special case for the "count_if" function, however it may be better to build some
         # better abstracted code to handle third-party rule conditions injection.
         if parsed_field.function == "count_if":

--- a/tests/sentry/tasks/test_on_demand_metrics.py
+++ b/tests/sentry/tasks/test_on_demand_metrics.py
@@ -29,17 +29,17 @@ OnDemandExtractionState = DashboardWidgetQueryOnDemand.OnDemandExtractionState
 
 
 @pytest.fixture
-def owner():
+def owner() -> None:
     return Factories.create_user()
 
 
 @pytest.fixture
-def organization(owner):
+def organization(owner) -> None:
     return Factories.create_organization(owner=owner)
 
 
 @pytest.fixture
-def project(organization):
+def project(organization) -> None:
     return Factories.create_project(organization=organization)
 
 
@@ -205,7 +205,7 @@ def test_schedule_on_demand_check(
     expected_discover_queries_run,
     expected_cache_set,
     project,
-):
+) -> None:
     cache.clear()
     options = {
         "on_demand_metrics.check_widgets.enable": option_enable,
@@ -318,8 +318,7 @@ def test_process_widget_specs(
     expected_discover_queries_run,
     expected_low_cardinality,
     project,
-):
-
+) -> None:
     raw_snql_query.return_value = (
         _SNQL_DATA_HIGH_CARDINALITY if set_high_cardinality else _SNQL_DATA_LOW_CARDINALITY
     )
@@ -400,7 +399,7 @@ def assert_on_demand_model(
     has_features: bool,
     expected_applicable: bool,
     expected_hashes: Sequence[str],
-):
+) -> None:
     if not expected_applicable:
         assert model.extraction_state == OnDemandExtractionState.DISABLED_NOT_APPLICABLE
         assert model.spec_hashes == []


### PR DESCRIPTION
mypy does deeper type-checking when a function is fully typed. This change makes various extraction-related modules have stronger typing by adding the rule `disallow_untyped_defs = true`.

This change also fixes various errors that could not be seen without this rule.