### PR TITLE
fix(stacktrace): Add more file extensions to syntax mapping

### DIFF
--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -299,6 +299,7 @@ const CodeWrapper = styled('div')`
   padding: 0;
 
   && pre {
+    font-size: ${p => p.theme.fontSizeSmall};
     white-space: pre-wrap;
     margin: 0;
     overflow: hidden;

--- a/static/app/utils/prism.tsx
+++ b/static/app/utils/prism.tsx
@@ -36,17 +36,23 @@ const PRISM_LANGUAGE_MAP: Record<string, string> = Object.fromEntries(
 // https://prismjs.com/#supported-languages
 const EXTRA_LANGUAGE_ALIASES: Record<string, string> = {
   erl: 'erlang',
-  ex: 'elixr',
+  ex: 'elixir',
   h: 'c',
+  pm: 'perl',
+  pyx: 'python',
+
+  // Ruby
+  jbuilder: 'ruby',
+  ru: 'ruby',
   rake: 'ruby',
 
-  // JS aliases
+  // JS
   cjs: 'javascript',
   mjs: 'javascript',
-
-  // No offical support for Vue SFC, but HTML gets pretty close
-  // https://github.com/PrismJS/prism/issues/1665
-  vue: 'html',
+  jsbundle: 'javascript',
+  bundle: 'javascript',
+  vue: 'javascript',
+  svelte: 'javascript',
 };
 
 export const getPrismLanguage = (lang: string) => {

--- a/static/app/utils/usePrismTokens.tsx
+++ b/static/app/utils/usePrismTokens.tsx
@@ -30,7 +30,7 @@ const useLoadPrismLanguage = (
   const organization = useOrganization({allowNull: true});
 
   useEffect(() => {
-    if (!language || !code) {
+    if (!language || !code || language.includes('/')) {
       return;
     }
 


### PR DESCRIPTION
- Add more file extensions to the mapping (from analytics which show that these are the top extensions with no matching prismjs language)
- Ignore file extensions with `/` (seem to be quite common but are clearly not valid)
- Fix font size (was 13px, should be 12px like before)