### PR TITLE
feat(hybrid-cloud): Add vercel request parser

### DIFF
--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -71,6 +71,7 @@ class IntegrationClassification(BaseClassification):
             JiraServerRequestParser,
             MsTeamsRequestParser,
             SlackRequestParser,
+            VercelRequestParser,
             VstsRequestParser,
         )
 
@@ -85,6 +86,7 @@ class IntegrationClassification(BaseClassification):
             JiraServerRequestParser,
             MsTeamsRequestParser,
             SlackRequestParser,
+            VercelRequestParser,
             VstsRequestParser,
         ]
         return {cast(str, parser.provider): parser for parser in active_parsers}

--- a/src/sentry/middleware/integrations/parsers/__init__.py
+++ b/src/sentry/middleware/integrations/parsers/__init__.py
@@ -9,6 +9,7 @@ from .jira_server import JiraServerRequestParser
 from .msteams import MsTeamsRequestParser
 from .plugin import PluginRequestParser
 from .slack import SlackRequestParser
+from .vercel import VercelRequestParser
 from .vsts import VstsRequestParser
 
 __all__ = (
@@ -23,5 +24,6 @@ __all__ = (
     "MsTeamsRequestParser",
     "PluginRequestParser",
     "SlackRequestParser",
+    "VercelRequestParser",
     "VstsRequestParser",
 )

--- a/src/sentry/middleware/integrations/parsers/vercel.py
+++ b/src/sentry/middleware/integrations/parsers/vercel.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import logging
+
+from sentry.middleware.integrations.parsers.base import BaseRequestParser
+from sentry.models.outbox import WebhookProviderIdentifier
+
+logger = logging.getLogger(__name__)
+
+
+class VercelRequestParser(BaseRequestParser):
+    provider = "vercel"
+    webhook_identifier = WebhookProviderIdentifier.VERCEL
+
+    def get_response(self):
+        return self.get_response_from_control_silo()

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -407,6 +407,7 @@ class WebhookProviderIdentifier(IntEnum):
     LEGACY_PLUGIN = 10
     GETSENTRY = 11
     DISCORD = 12
+    VERCEL = 13
 
 
 def _ensure_not_null(k: str, v: Any) -> Any:

--- a/tests/sentry/middleware/integrations/parsers/test_vercel.py
+++ b/tests/sentry/middleware/integrations/parsers/test_vercel.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock, patch
+
+from django.http import HttpResponse
+from django.test import RequestFactory
+from django.urls import reverse
+
+from sentry.middleware.integrations.parsers.vercel import VercelRequestParser
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test
+class VercelRequestParserTest(TestCase):
+    get_response = MagicMock()
+    factory = RequestFactory()
+    vercel_dummy_requests = [
+        factory.get(reverse("sentry-extensions-vercel-configure")),
+        factory.post(reverse("sentry-extensions-vercel-delete"), data={}),
+        factory.post(reverse("sentry-extensions-vercel-webhook"), data={}),
+    ]
+
+    def test_routing_webhooks_to_control(self):
+        for request in self.vercel_dummy_requests:
+            parser = VercelRequestParser(request=request, response_handler=self.get_response)
+
+            expected_response = HttpResponse({"ok": True})
+            with patch.object(
+                parser, "get_response_from_outbox_creation"
+            ) as mock_response_from_outbox, patch.object(
+                parser, "get_responses_from_region_silos"
+            ) as mock_response_from_region, patch.object(
+                parser, "get_response_from_control_silo", return_value=expected_response
+            ) as mock_response_from_control:
+                actual_response = parser.get_response()
+                assert not mock_response_from_outbox.called
+                assert not mock_response_from_region.called
+                assert mock_response_from_control.called
+                assert actual_response == expected_response

--- a/tests/sentry/middleware/integrations/parsers/test_vercel.py
+++ b/tests/sentry/middleware/integrations/parsers/test_vercel.py
@@ -19,7 +19,7 @@ class VercelRequestParserTest(TestCase):
         factory.post(reverse("sentry-extensions-vercel-webhook"), data={}),
     ]
 
-    def test_routing_webhooks_to_control(self):
+    def test_routing_all_to_control(self):
         for request in self.vercel_dummy_requests:
             parser = VercelRequestParser(request=request, response_handler=self.get_response)
 


### PR DESCRIPTION
Even though all the requests can be handled at control, we still need a parser so that we don't raise `unknown_provider` errors.

Fixes [SENTRY-2BD9](https://sentry.sentry.io/issues/4742426529/)