### PR TITLE
fix(hybridcloud) Return responses in apigateway instead of raising

### DIFF
--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -9,11 +9,11 @@ from urllib.parse import urljoin
 from wsgiref.util import is_hop_by_hop
 
 from django.conf import settings
-from django.http import HttpRequest, StreamingHttpResponse
+from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
+from django.http.response import HttpResponseBase
 from requests import Response as ExternalResponse
 from requests import request as external_request
 from requests.exceptions import Timeout
-from rest_framework.exceptions import NotFound
 
 from sentry.api.exceptions import RequestTimeout
 from sentry.models.integrations.sentry_app import SentryApp
@@ -77,52 +77,59 @@ class _body_with_length:
         return self.request.read(size)
 
 
-def proxy_request(request: HttpRequest, org_slug: str) -> StreamingHttpResponse:
+def proxy_request(request: HttpRequest, org_slug: str) -> HttpResponseBase:
     """Take a django request object and proxy it to a remote location given an org_slug"""
 
     try:
         region = get_region_for_organization(org_slug)
     except RegionResolutionError as e:
-        logger.info("region_resolution_error", extra={"org_slug": org_slug})
-        raise NotFound from e
+        logger.info("region_resolution_error", extra={"org_slug": org_slug, "error": str(e)})
+        return HttpResponse(status=404)
 
     return proxy_region_request(request, region)
 
 
 def proxy_sentryappinstallation_request(
     request: HttpRequest, installation_uuid: str
-) -> StreamingHttpResponse:
+) -> HttpResponseBase:
     """Take a django request object and proxy it to a remote location given a sentryapp installation uuid"""
     try:
         installation = SentryAppInstallation.objects.get(uuid=installation_uuid)
     except SentryAppInstallation.DoesNotExist as e:
-        logger.info("region_resolution_error", extra={"installation_uuid": installation_uuid})
-        raise NotFound from e
+        logger.info(
+            "region_resolution_error",
+            extra={"installation_uuid": installation_uuid, "error": str(e)},
+        )
+        return HttpResponse(status=404)
+
     try:
         organization_mapping = OrganizationMapping.objects.get(
             organization_id=installation.organization_id
         )
         region = get_region_by_name(organization_mapping.region_name)
     except (RegionResolutionError, OrganizationMapping.DoesNotExist) as e:
-        logger.info("region_resolution_error", extra={"installation_id": installation_uuid})
-        raise NotFound from e
+        logger.info(
+            "region_resolution_error", extra={"installation_id": installation_uuid, "error": str(e)}
+        )
+        return HttpResponse(status=404)
 
     return proxy_region_request(request, region)
 
 
-def proxy_sentryapp_request(request: HttpRequest, app_slug: str) -> StreamingHttpResponse:
+def proxy_sentryapp_request(request: HttpRequest, app_slug: str) -> HttpResponseBase:
     """Take a django request object and proxy it to the region of the organization that owns a sentryapp"""
     try:
         sentry_app = SentryApp.objects.get(slug=app_slug)
     except SentryApp.DoesNotExist as e:
-        logger.info("region_resolution_error", extra={"app_slug": app_slug})
-        raise NotFound from e
+        logger.info("region_resolution_error", extra={"app_slug": app_slug, "error": str(e)})
+        return HttpResponse(status=404)
+
     try:
         organization_mapping = OrganizationMapping.objects.get(organization_id=sentry_app.owner_id)
         region = get_region_by_name(organization_mapping.region_name)
     except (RegionResolutionError, OrganizationMapping.DoesNotExist) as e:
-        logger.info("region_resolution_error", extra={"app_slug": app_slug})
-        raise NotFound from e
+        logger.info("region_resolution_error", extra={"app_slug": app_slug, "error": str(e)})
+        return HttpResponse(status=404)
 
     return proxy_region_request(request, region)
 

--- a/tests/sentry/hybridcloud/apigateway/test_apigateway.py
+++ b/tests/sentry/hybridcloud/apigateway/test_apigateway.py
@@ -1,10 +1,8 @@
 from urllib.parse import urlencode
 
-import pytest
 import responses
 from django.test import override_settings
 from django.urls import reverse
-from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 
 from sentry.silo import SiloMode
@@ -200,11 +198,11 @@ class ApiGatewayTest(ApiGatewayTestCase):
 
         # No responses configured so that requests will fail if they are made.
         with override_settings(MIDDLEWARE=tuple(self.middleware)):
-            with pytest.raises(NotFound):
-                self.client.get("/sentry-app-installations/abc123/external-requests/")
+            resp = self.client.get("/sentry-app-installations/abc123/external-requests/")
+            assert resp.status_code == 404
 
-            with pytest.raises(NotFound):
-                self.client.get("/sentry-app-installations/abc123/external-issues/")
+            resp = self.client.get("/sentry-app-installations/abc123/external-issues/")
+            assert resp.status_code == 404
 
-            with pytest.raises(NotFound):
-                self.client.get("/sentry-app-installations/abc123/external-issue-actions/")
+            resp = self.client.get("/sentry-app-installations/abc123/external-issue-actions/")
+            assert resp.status_code == 404

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -1,10 +1,8 @@
 from urllib.parse import urlencode
 
-import pytest
 import responses
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.client import RequestFactory
-from rest_framework.exceptions import NotFound
 
 from sentry.hybridcloud.apigateway.proxy import proxy_request
 from sentry.silo.util import INVALID_OUTBOUND_HEADERS, PROXY_DIRECT_LOCATION_HEADER
@@ -61,8 +59,8 @@ class ProxyTestCase(ApiGatewayTestCase):
     @responses.activate
     def test_bad_org(self):
         request = RequestFactory().get("http://sentry.io/get")
-        with pytest.raises(NotFound):
-            proxy_request(request, "doesnotexist")
+        resp = proxy_request(request, "doesnotexist")
+        assert resp.status_code == 404
 
     @responses.activate
     def test_post(self):


### PR DESCRIPTION
If we raise exceptions from middleware the response ends up being a 500 as we're above the error handling that DRF provides in endpoints. Returning responses will remove noise from sentry as we aren't interested in requests that are for deleted organizations.

Fixes SENTRY-2BDC