### PR TITLE
ref(tests): Remove TestStubs global from `relatedExceptions`

### DIFF
--- a/fixtures/js-stubs/eventEntryExceptionGroup.tsx
+++ b/fixtures/js-stubs/eventEntryExceptionGroup.tsx
@@ -1,18 +1,27 @@
-export function EventEntryExceptionGroup() {
+import {EntryException, EntryType} from 'sentry/types';
+
+export function EventEntryExceptionGroup(): EntryException {
   return {
-    type: 'exception',
+    type: EntryType.EXCEPTION,
     data: {
+      excOmitted: null,
+      hasSystemFrames: false,
       values: [
         {
           type: 'ValueError',
           value: 'test',
           mechanism: {
+            handled: true,
+            type: '',
             exception_id: 4,
             is_exception_group: false,
             parent_id: 3,
             source: 'exceptions[2]',
           },
           stacktrace: {
+            framesOmitted: null,
+            hasSystemFrames: false,
+            registers: null,
             frames: [
               {
                 function: 'func4',
@@ -23,22 +32,36 @@ export function EventEntryExceptionGroup() {
                 colNo: null,
                 context: [[50, 'raise ValueError("test")']],
                 inApp: true,
-                data: {},
+                rawFunction: null,
+                package: null,
+                platform: null,
+                instructionAddr: null,
+                symbol: null,
+                symbolAddr: null,
+                trust: null,
+                vars: null,
               },
             ],
           },
+          module: 'helpers',
+          threadId: null,
           rawStacktrace: null,
         },
         {
           type: 'ExceptionGroup 2',
           value: 'child',
           mechanism: {
+            handled: true,
+            type: '',
             exception_id: 3,
             is_exception_group: true,
             parent_id: 1,
             source: 'exceptions[1]',
           },
           stacktrace: {
+            framesOmitted: null,
+            hasSystemFrames: false,
+            registers: null,
             frames: [
               {
                 function: 'func3',
@@ -49,22 +72,36 @@ export function EventEntryExceptionGroup() {
                 colNo: null,
                 context: [],
                 inApp: true,
-                data: {},
+                rawFunction: null,
+                package: null,
+                platform: null,
+                instructionAddr: null,
+                symbol: null,
+                symbolAddr: null,
+                trust: null,
+                vars: null,
               },
             ],
           },
+          module: 'helpers',
           rawStacktrace: null,
+          threadId: null,
         },
         {
           type: 'TypeError',
           value: 'nested',
           mechanism: {
+            handled: true,
+            type: '',
             exception_id: 2,
             is_exception_group: false,
             parent_id: 1,
             source: 'exceptions[0]',
           },
           stacktrace: {
+            framesOmitted: null,
+            hasSystemFrames: false,
+            registers: null,
             frames: [
               {
                 function: 'func2',
@@ -75,21 +112,35 @@ export function EventEntryExceptionGroup() {
                 colNo: null,
                 context: [[50, 'raise TypeError("int")']],
                 inApp: true,
-                data: {},
+                rawFunction: null,
+                package: null,
+                platform: null,
+                instructionAddr: null,
+                symbol: null,
+                symbolAddr: null,
+                trust: null,
+                vars: null,
               },
             ],
           },
+          module: 'helpers',
+          threadId: null,
           rawStacktrace: null,
         },
         {
           type: 'ExceptionGroup 1',
           value: 'parent',
           mechanism: {
+            handled: true,
+            type: '',
             exception_id: 1,
             is_exception_group: true,
             source: '__context__',
           },
           stacktrace: {
+            framesOmitted: null,
+            hasSystemFrames: false,
+            registers: null,
             frames: [
               {
                 function: 'func1',
@@ -100,10 +151,19 @@ export function EventEntryExceptionGroup() {
                 colNo: null,
                 context: [[50, 'raise ExceptionGroup("parent")']],
                 inApp: true,
-                data: {},
+                rawFunction: null,
+                package: null,
+                platform: null,
+                instructionAddr: null,
+                symbol: null,
+                symbolAddr: null,
+                trust: null,
+                vars: null,
               },
             ],
           },
+          module: 'helpers',
+          threadId: null,
           rawStacktrace: null,
         },
       ],

--- a/static/app/components/events/interfaces/crashContent/exception/relatedExceptions.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/relatedExceptions.spec.tsx
@@ -1,9 +1,11 @@
+import {EventEntryExceptionGroup as EventEntryExceptionGroupFixture} from 'sentry-fixture/eventEntryExceptionGroup';
+
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
 
 import {RelatedExceptions} from 'sentry/components/events/interfaces/crashContent/exception/relatedExceptions';
 
 describe('ExceptionGroupContext', function () {
-  const entry = TestStubs.EventEntryExceptionGroup();
+  const entry = EventEntryExceptionGroupFixture();
 
   const exceptionGroup1Mechanism = entry.data.values?.find(
     ({type}) => type === 'ExceptionGroup 1'

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
@@ -1,3 +1,4 @@
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {Repository} from 'sentry-fixture/repository';
@@ -21,7 +22,7 @@ jest.mock('sentry/utils/analytics');
 describe('StacktraceLinkModal', () => {
   const org = Organization();
   const project = ProjectFixture();
-  const integration = TestStubs.GitHubIntegration();
+  const integration = GitHubIntegrationFixture();
   const filename = '/sentry/app.py';
   const repo = Repository({integrationId: integration.id});
   const config = RepositoryProjectPathConfig({project, repo, integration});


### PR DESCRIPTION
* stacktraceLinkModal = free
* fill out required attributes of EventEntryExceptionGroup

ref https://github.com/getsentry/frontend-tsc/issues/49
