### PR TITLE
chore(hybrid-cloud): Add destination_region tag to integration_proxy metrics capture

### DIFF
--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -85,7 +85,9 @@ class BaseRequestParser(abc.ABC):
 
     def get_response_from_region_silo(self, region: Region) -> HttpResponseBase:
         with metrics.timer(
-            "integration_proxy.control.get_response_from_region_silo", sample_rate=1.0
+            "integration_proxy.control.get_response_from_region_silo",
+            tags={"destination_region": region.name},
+            sample_rate=1.0,
         ):
             region_client = RegionSiloClient(region)
             return region_client.proxy_request(incoming_request=self.request)

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -93,7 +93,11 @@ def process_async_webhooks(
 
     try:
         client = RegionSiloClient(region=region)
-        with metrics.timer("integration_proxy.control.process_async_webhooks", sample_rate=1.0):
+        with metrics.timer(
+            "integration_proxy.control.process_async_webhooks",
+            tags={"destination_region": region.name},
+            sample_rate=1.0,
+        ):
             response = client.request(
                 method=webhook_payload.method,
                 path=webhook_payload.path,


### PR DESCRIPTION
This lets us segment webhook proxy latencies by `destination_region` on our metrics dashboards.