### PR TITLE
feat(browser-starfish): add initial ui to enable image view

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -21,7 +21,7 @@ const {SPAN_GROUP, SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH} = SpanIndexed
 const imageWidth = '200px';
 
 function SampleImages({groupId}: Props) {
-  const isImagesEnabled = false; // TODO - this is temporary, this will be controlled by a project setting
+  const isImagesEnabled = true; // TODO - this is temporary, this will be controlled by a project setting
   const [showImages, setShowImages] = useState(isImagesEnabled);
 
   const imageResources = useIndexedResourcesQuery({
@@ -44,7 +44,7 @@ function SampleImages({groupId}: Props) {
     .splice(0, 5);
 
   return (
-    <ChartPanel title={showImages ? t('Example Images') : undefined}>
+    <ChartPanel title={showImages ? t('Largest Images') : undefined}>
       {showImages ? (
         <ImageWrapper>
           {filteredResources.map(resource => {
@@ -106,6 +106,7 @@ function ImageContainer(props: {
   src: string;
 }) {
   const theme = useTheme();
+  const [hasError, setHasError] = useState(false);
 
   const {fileName, size, src, showImage = true} = props;
   const fileSize = getDynamicText({
@@ -119,8 +120,8 @@ function ImageContainer(props: {
     <div style={{width: '100%', wordWrap: 'break-word'}}>
       {
         // TODO - this is temporary, this will be controlled by a project setting
-        showImage ? (
-          <img src={src} style={commonStyles} />
+        showImage && !hasError ? (
+          <img onError={() => setHasError(true)} src={src} style={commonStyles} />
         ) : (
           <div style={{...commonStyles, backgroundColor: theme.gray100}} />
         )

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -118,14 +118,11 @@ function ImageContainer(props: {
 
   return (
     <div style={{width: '100%', wordWrap: 'break-word'}}>
-      {
-        // TODO - this is temporary, this will be controlled by a project setting
-        showImage && !hasError ? (
-          <img onError={() => setHasError(true)} src={src} style={commonStyles} />
-        ) : (
-          <div style={{...commonStyles, backgroundColor: theme.gray100}} />
-        )
-      }
+      {showImage && !hasError ? (
+        <img onError={() => setHasError(true)} src={src} style={commonStyles} />
+      ) : (
+        <div style={{...commonStyles, backgroundColor: theme.gray100}} />
+      )}
       {fileName} ({fileSize})
     </div>
   );

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -1,8 +1,14 @@
 import styled from '@emotion/styled';
 
+import {Button} from 'sentry/components/button';
+import Link from 'sentry/components/links/link';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {formatBytesBase2} from 'sentry/utils';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import useProjects from 'sentry/utils/useProjects';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {useIndexedResourcesQuery} from 'sentry/views/performance/browser/resources/utils/useIndexedResourceQuery';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
@@ -13,10 +19,13 @@ const {SPAN_GROUP, SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH} = SpanIndexed
 const imageWidth = '200px';
 
 function SampleImages({groupId}: Props) {
+  const isImagesEnabled = true; // TODO - this is temporary, this will be controlled by a project setting
+
   const imageResources = useIndexedResourcesQuery({
     queryConditions: [`${SPAN_GROUP}:${groupId}`],
     sorts: [{field: `measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`, kind: 'desc'}],
     limit: 100,
+    enabled: isImagesEnabled,
   });
 
   const uniqueResources = new Set();
@@ -34,19 +43,54 @@ function SampleImages({groupId}: Props) {
 
   return (
     <ChartPanel title={t('Example Images')}>
-      <ImageWrapper>
-        {filteredResources.map(resource => {
-          return (
-            <ImageContainer
-              src={resource[SPAN_DESCRIPTION]}
-              fileName={getFileNameFromDescription(resource[SPAN_DESCRIPTION])}
-              size={resource[`measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`]}
-              key={resource[SPAN_DESCRIPTION]}
-            />
-          );
-        })}
-      </ImageWrapper>
+      {isImagesEnabled ? (
+        <ImageWrapper>
+          {filteredResources.map(resource => {
+            return (
+              <ImageContainer
+                src={resource[SPAN_DESCRIPTION]}
+                fileName={getFileNameFromDescription(resource[SPAN_DESCRIPTION])}
+                size={resource[`measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`]}
+                key={resource[SPAN_DESCRIPTION]}
+              />
+            );
+          })}
+        </ImageWrapper>
+      ) : (
+        <DisabledImages />
+      )}
     </ChartPanel>
+  );
+}
+
+function DisabledImages() {
+  const {
+    selection: {projects: selectedProjects},
+  } = usePageFilters();
+  const {projects} = useProjects();
+  const firstProjectSelected = projects.find(
+    project => project.id === selectedProjects[0].toString()
+  );
+
+  return (
+    <div>
+      <DisabledImageTextContainer>
+        <h6>{t('Images not shown')}</h6>
+        {t(
+          'You know, you can see the actual images that are on your site if you opt into this feature.'
+        )}
+      </DisabledImageTextContainer>
+      <ButtonContainer>
+        <Button>Only show links</Button>
+        <Link
+          to={normalizeUrl(
+            `/settings/projects/${firstProjectSelected?.slug}/performance/`
+          )}
+        >
+          <Button priority="primary">Enable in Settings</Button>
+        </Link>
+      </ButtonContainer>
+    </div>
   );
 }
 
@@ -72,12 +116,6 @@ function ImageContainer({
   );
 }
 
-const ImageWrapper = styled('div')`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, ${imageWidth});
-  gap: 30px;
-`;
-
 const getFileNameFromDescription = (description: string) => {
   try {
     const url = new URL(description);
@@ -86,5 +124,26 @@ const getFileNameFromDescription = (description: string) => {
     return description;
   }
 };
+
+const ImageWrapper = styled('div')`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, ${imageWidth});
+  gap: 30px;
+`;
+
+const ButtonContainer = styled('div')`
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  gap: ${space(1)};
+  justify-content: center;
+  align-items: center;
+  padding-top: ${space(2)};
+`;
+
+const DisabledImageTextContainer = styled('div')`
+  text-align: center;
+  width: 300px;
+  margin: auto;
+`;
 
 export default SampleImages;

--- a/static/app/views/performance/browser/resources/utils/useIndexedResourceQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useIndexedResourceQuery.ts
@@ -10,6 +10,7 @@ import {SpanIndexedField} from 'sentry/views/starfish/types';
 const {SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH} = SpanIndexedField;
 
 type Options = {
+  enabled?: boolean;
   limit?: number;
   queryConditions?: string[];
   referrer?: string;
@@ -21,6 +22,7 @@ export const useIndexedResourcesQuery = ({
   limit = 50,
   sorts,
   referrer,
+  enabled = true,
 }: Options) => {
   const pageFilters = usePageFilters();
   const location = useLocation();
@@ -55,6 +57,7 @@ export const useIndexedResourcesQuery = ({
     orgSlug,
     referrer,
     options: {
+      enabled,
       refetchOnWindowFocus: false,
     },
   });


### PR DESCRIPTION
Work for #60482 

1. Adds a basic UI to enable disable image view.

<img width="1264" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/a58d6ce6-7bc0-4edf-9a9f-5491fb1fac66">

2. When you select show only links the following is shown
<img width="1255" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/a804efe5-4481-4c4b-bc61-43fb72659d87">

3. If you select go to settings, you go to the performance page settings.

4. If an image has an error, we will display the grey box again
<img width="753" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/2654013d-e9b3-4891-86c2-2ba48d6c2030">

A couple TODOs to actually use this
1. We don't have an image icon, going to work on that in a future PR, an SVG is probably okay here?
2. We need to merge in #62131 and #62025 to have the actual setting 
