### PR TITLE
chore(hybrid-cloud): Remove un-used api_token field from Region dataclass

### DIFF
--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -61,9 +61,6 @@ class Region:
     category: RegionCategory
     """The region's category."""
 
-    api_token: Optional[str] = None
-    """Unused will be removed in the future"""
-
     def validate(self) -> None:
         from sentry.utils.snowflake import REGION_ID
 

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Collection, Container, Dict, Iterable, List, Optional, Set
+from typing import Any, Collection, Container, Dict, Iterable, List, Set
 from urllib.parse import urljoin
 
 import sentry_sdk

--- a/tests/sentry/hybridcloud/test_rpc.py
+++ b/tests/sentry/hybridcloud/test_rpc.py
@@ -31,8 +31,8 @@ from sentry.types.region import Region, RegionCategory
 from sentry.utils import json
 
 _REGIONS = [
-    Region("north_america", 1, "http://na.sentry.io", RegionCategory.MULTI_TENANT, "swordfish"),
-    Region("europe", 2, "http://eu.sentry.io", RegionCategory.MULTI_TENANT, "courage"),
+    Region("north_america", 1, "http://na.sentry.io", RegionCategory.MULTI_TENANT),
+    Region("europe", 2, "http://eu.sentry.io", RegionCategory.MULTI_TENANT),
 ]
 
 


### PR DESCRIPTION
We've never utilized `api_token` when we've sketched out the `Region` dataclass earlier this year. We've instead relied on `SENTRY_SUBNET_SECRET` in place of `api_token`.

So, I'm cleaning it up to clear up any confusion.