### PR TITLE
ref(open-pr-comments): remove is_handled

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -66,19 +66,19 @@ Your pull request is modifying functions with the following pre-existing issues:
 
 ISSUE_TABLE_TEMPLATE = """📄 File: **{filename}**
 
-| Function | Issue  |
+| Function | Unhandled Issue |
 | :------- | :----- |
 {issue_rows}"""
 
 ISSUE_TABLE_TOGGLE_TEMPLATE = """<details>
 <summary><b>📄 File: {filename} (Click to Expand)</b></summary>
 
-| Function | Issue  |
+| Function | Unhandled Issue |
 | :------- | :----- |
 {issue_rows}
 </details>"""
 
-ISSUE_ROW_TEMPLATE = "| **`{function_name}`** | [**{title}**]({url}) {subtitle} <br> `Handled:` **{is_handled}** `Event Count:` **{event_count}** |"
+ISSUE_ROW_TEMPLATE = "| **`{function_name}`** | [**{title}**]({url}) {subtitle} <br> `Event Count:` **{event_count}** |"
 
 ISSUE_DESCRIPTION_LENGTH = 52
 
@@ -101,7 +101,6 @@ def format_issue_table(diff_filename: str, issues: List[PullRequestIssue], toggl
                 title=issue.title,
                 subtitle=format_open_pr_comment_subtitle(len(issue.title), issue.subtitle),
                 url=format_comment_url(issue.url, GITHUB_OPEN_PR_BOT_REFERRER),
-                is_handled=str(issue.is_handled),
                 event_count=small_count(issue.event_count),
                 function_name=issue.function_name,
             )
@@ -131,7 +130,6 @@ def get_issue_table_contents(issue_list: List[Dict[str, Any]]) -> List[PullReque
             url=issue.get_absolute_url(),
             affected_users=issue.count_users_seen(),
             event_count=group_id_to_info[issue.id]["event_count"],
-            is_handled=bool(group_id_to_info[issue.id]["is_handled"]),
             function_name=group_id_to_info[issue.id]["function_name"],
         )
         for issue in issues
@@ -280,7 +278,6 @@ def get_top_5_issues_by_count_for_file(
                 [
                     Column("group_id"),
                     Function("count", [], "event_count"),
-                    Function("isHandled", [], "is_handled"),
                     Function(
                         "arrayElement", (Column("exception_frames.function"), -1), "function_name"
                     ),

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -46,7 +46,6 @@ class PullRequestIssue:
     url: str
     affected_users: Optional[int] = None
     event_count: Optional[int] = None
-    is_handled: Optional[bool] = None
     function_name: Optional[str] = None
 
 

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -449,12 +449,10 @@ class TestGetCommentIssues(CreateEventTestCase):
             [self.project], ["baz.py"], ["world", "planet"]
         )
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
-        is_handled = [issue["is_handled"] for issue in top_5_issues]
         function_names = [issue["function_name"] for issue in top_5_issues]
 
         # filters handled issues
         assert top_5_issue_ids == [self.group_id, group_id_1, group_id_3]
-        assert is_handled == [0, 0, 0]
         assert function_names == ["world", "planet", "world"]
 
     def test_get_issue_table_contents(self):
@@ -504,7 +502,6 @@ class TestGetCommentIssues(CreateEventTestCase):
         )
         affected_users = [6, 5, 4, 3, 2]
         event_count = [issue["event_count"] for issue in top_5_issues]
-        is_handled = [bool(issue["is_handled"]) for issue in top_5_issues]
         function_names = [issue["function_name"] for issue in top_5_issues]
 
         comment_table_contents = get_issue_table_contents(top_5_issues)
@@ -519,7 +516,6 @@ class TestGetCommentIssues(CreateEventTestCase):
                     url=f"http://testserver/organizations/{self.organization.slug}/issues/{group_ids[i]}/",
                     affected_users=affected_users[i],
                     event_count=event_count[i],
-                    is_handled=is_handled[i],
                     function_name=function_names[i],
                 )
                 in comment_table_contents
@@ -540,7 +536,6 @@ class TestFormatComment(TestCase):
                 url=f"http://testserver/organizations/{self.organization.slug}/issues/{str(i)}/",
                 affected_users=(5 - i) * 1000,
                 event_count=(5 - i) * 1000,
-                is_handled=True,
                 function_name="function_" + str(i),
             )
             for i in range(5)
@@ -555,7 +550,6 @@ class TestFormatComment(TestCase):
                 url=f"http://testserver/organizations/{self.organization.slug}/issues/{str(i+5)}/",
                 affected_users=(2 - i) * 10000,
                 event_count=(2 - i) * 10000,
-                is_handled=False,
                 function_name="function_" + str(i),
             )
             for i in range(2)
@@ -572,20 +566,20 @@ Your pull request is modifying functions with the following pre-existing issues:
 
 📄 File: **tests/sentry/tasks/integrations/github/test_open_pr_comment.py**
 
-| Function | Issue  |
+| Function | Unhandled Issue |
 | :------- | :----- |
-| **`function_0`** | [**file1 0**](http://testserver/organizations/baz/issues/0/?referrer=github-open-pr-bot) subtitle0 <br> `Handled:` **True** `Event Count:` **5k** |
-| **`function_1`** | [**file1 1**](http://testserver/organizations/baz/issues/1/?referrer=github-open-pr-bot) subtitle1 <br> `Handled:` **True** `Event Count:` **4k** |
-| **`function_2`** | [**file1 2**](http://testserver/organizations/baz/issues/2/?referrer=github-open-pr-bot) subtitle2 <br> `Handled:` **True** `Event Count:` **3k** |
-| **`function_3`** | [**file1 3**](http://testserver/organizations/baz/issues/3/?referrer=github-open-pr-bot) subtitle3 <br> `Handled:` **True** `Event Count:` **2k** |
-| **`function_4`** | [**file1 4**](http://testserver/organizations/baz/issues/4/?referrer=github-open-pr-bot) subtitle4 <br> `Handled:` **True** `Event Count:` **1k** |
+| **`function_0`** | [**file1 0**](http://testserver/organizations/baz/issues/0/?referrer=github-open-pr-bot) subtitle0 <br> `Event Count:` **5k** |
+| **`function_1`** | [**file1 1**](http://testserver/organizations/baz/issues/1/?referrer=github-open-pr-bot) subtitle1 <br> `Event Count:` **4k** |
+| **`function_2`** | [**file1 2**](http://testserver/organizations/baz/issues/2/?referrer=github-open-pr-bot) subtitle2 <br> `Event Count:` **3k** |
+| **`function_3`** | [**file1 3**](http://testserver/organizations/baz/issues/3/?referrer=github-open-pr-bot) subtitle3 <br> `Event Count:` **2k** |
+| **`function_4`** | [**file1 4**](http://testserver/organizations/baz/issues/4/?referrer=github-open-pr-bot) subtitle4 <br> `Event Count:` **1k** |
 <details>
 <summary><b>📄 File: tests/sentry/tasks/integrations/github/test_pr_comment.py (Click to Expand)</b></summary>
 
-| Function | Issue  |
+| Function | Unhandled Issue |
 | :------- | :----- |
-| **`function_0`** | [**SoftTimeLimitExceeded 0**](http://testserver/organizations/baz/issues/5/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Handled:` **False** `Event Count:` **20k** |
-| **`function_1`** | [**SoftTimeLimitExceeded 1**](http://testserver/organizations/baz/issues/6/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Handled:` **False** `Event Count:` **10k** |
+| **`function_0`** | [**SoftTimeLimitExceeded 0**](http://testserver/organizations/baz/issues/5/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **20k** |
+| **`function_1`** | [**SoftTimeLimitExceeded 1**](http://testserver/organizations/baz/issues/6/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **10k** |
 </details>
 ---
 
@@ -629,7 +623,6 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
             {
                 "group_id": g.id,
                 "event_count": 1000 * (i + 1),
-                "is_handled": False,
                 "function_name": "function_" + str(i),
             }
             for i, g in enumerate(Group.objects.all())
@@ -678,7 +671,7 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
 
         assert (
             responses.calls[0].request.body
-            == f'{{"body": "## \\ud83d\\udd0d Existing Issues For Review\\nYour pull request is modifying functions with the following pre-existing issues:\\n\\n\\ud83d\\udcc4 File: **foo.py**\\n\\n| Function | Issue  |\\n| :------- | :----- |\\n| **`function_1`** | [**Error**](http://testserver/organizations/baz/issues/{self.group_id_2}/?referrer=github-open-pr-bot) issue2 <br> `Handled:` **False** `Event Count:` **2k** |\\n| **`function_0`** | [**Error**](http://testserver/organizations/baz/issues/{self.group_id_1}/?referrer=github-open-pr-bot) issue1 <br> `Handled:` **False** `Event Count:` **1k** |\\n<details>\\n<summary><b>\\ud83d\\udcc4 File: bar.py (Click to Expand)</b></summary>\\n\\n| Function | Issue  |\\n| :------- | :----- |\\n| **`function_1`** | [**Error**](http://testserver/organizations/baz/issues/{self.group_id_2}/?referrer=github-open-pr-bot) issue2 <br> `Handled:` **False** `Event Count:` **2k** |\\n| **`function_0`** | [**Error**](http://testserver/organizations/baz/issues/{self.group_id_1}/?referrer=github-open-pr-bot) issue1 <br> `Handled:` **False** `Event Count:` **1k** |\\n</details>\\n---\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e or let us know in #proj-github-pr-comments</sub>"}}'.encode()
+            == f'{{"body": "## \\ud83d\\udd0d Existing Issues For Review\\nYour pull request is modifying functions with the following pre-existing issues:\\n\\n\\ud83d\\udcc4 File: **foo.py**\\n\\n| Function | Unhandled Issue |\\n| :------- | :----- |\\n| **`function_1`** | [**Error**](http://testserver/organizations/baz/issues/{self.group_id_2}/?referrer=github-open-pr-bot) issue2 <br> `Event Count:` **2k** |\\n| **`function_0`** | [**Error**](http://testserver/organizations/baz/issues/{self.group_id_1}/?referrer=github-open-pr-bot) issue1 <br> `Event Count:` **1k** |\\n<details>\\n<summary><b>\\ud83d\\udcc4 File: bar.py (Click to Expand)</b></summary>\\n\\n| Function | Unhandled Issue |\\n| :------- | :----- |\\n| **`function_1`** | [**Error**](http://testserver/organizations/baz/issues/{self.group_id_2}/?referrer=github-open-pr-bot) issue2 <br> `Event Count:` **2k** |\\n| **`function_0`** | [**Error**](http://testserver/organizations/baz/issues/{self.group_id_1}/?referrer=github-open-pr-bot) issue1 <br> `Event Count:` **1k** |\\n</details>\\n---\\n\\n<sub>Did you find this useful? React with a \\ud83d\\udc4d or \\ud83d\\udc4e or let us know in #proj-github-pr-comments</sub>"}}'.encode()
         )
 
         pull_request_comment_query = PullRequestComment.objects.all()


### PR DESCRIPTION
All the issues we post in the comment are unhandled, so we can remove fetching the related column in Snuba (but keep the `WHERE` clause) and populating each row with the same information (`Handled:` **False**). Also changes the header to be **Unhandled Issues** instead of **Issues** to showcase this.

Example comment

## 🔍 Existing Issues For Review
Your pull request is modifying functions with the following pre-existing issues:

📄 File: **tests/sentry/tasks/integrations/github/test_open_pr_comment.py**

| Function | Unhandled Issue |
| :------- | :----- |
| **`function_0`** | [**file1 0**](http://testserver/organizations/baz/issues/0/?referrer=github-open-pr-bot) subtitle0 <br> `Event Count:` **5k** |
| **`function_1`** | [**file1 1**](http://testserver/organizations/baz/issues/1/?referrer=github-open-pr-bot) subtitle1 <br> `Event Count:` **4k** |
| **`function_2`** | [**file1 2**](http://testserver/organizations/baz/issues/2/?referrer=github-open-pr-bot) subtitle2 <br> `Event Count:` **3k** |
| **`function_3`** | [**file1 3**](http://testserver/organizations/baz/issues/3/?referrer=github-open-pr-bot) subtitle3 <br> `Event Count:` **2k** |
| **`function_4`** | [**file1 4**](http://testserver/organizations/baz/issues/4/?referrer=github-open-pr-bot) subtitle4 <br> `Event Count:` **1k** |
<details>
<summary><b>📄 File: tests/sentry/tasks/integrations/github/test_pr_comment.py (Click to Expand)</b></summary>

| Function | Unhandled Issue |
| :------- | :----- |
| **`function_0`** | [**SoftTimeLimitExceeded 0**](http://testserver/organizations/baz/issues/5/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **20k** |
| **`function_1`** | [**SoftTimeLimitExceeded 1**](http://testserver/organizations/baz/issues/6/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **10k** |
</details>
---

<sub>Did you find this useful? React with a 👍 or 👎 or let us know in #proj-github-pr-comments</sub>