### PR TITLE
decouple handle_query_errors and move into api utils

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -355,6 +355,7 @@ def get_auth_api_token_type(auth: object) -> str | None:
 
 
 # NOTE: This duplicates OrganizationEventsEndpointBase.handle_query_errors
+# TODO: move other references over to this implementation rather than the organization_events implementation
 @contextmanager
 def handle_query_errors(self) -> Generator[None, None, None]:
     try:

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -5,24 +5,28 @@ import logging
 import re
 import sys
 import traceback
+from contextlib import contextmanager
 from datetime import timedelta
-from typing import Any, List, Literal, Mapping, Tuple, overload
+from typing import Any, Generator, List, Literal, Mapping, Tuple, overload
 from urllib.parse import urlparse
 
+import sentry_sdk
 from django.conf import settings
 from django.http import HttpResponseNotAllowed
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
+from rest_framework.exceptions import APIException, ParseError
 from rest_framework.request import Request
 from sentry_sdk import Scope
 
 from sentry import options
 from sentry.auth.superuser import is_active_superuser
-from sentry.exceptions import InvalidParams
+from sentry.exceptions import IncompatibleMetricsQuery, InvalidParams
 from sentry.models.apikey import is_api_key_auth
 from sentry.models.apitoken import is_api_token_auth
 from sentry.models.organization import Organization
 from sentry.models.orgauthtoken import is_org_auth_token_auth
+from sentry.search.events.constants import TIMEOUT_ERROR_MESSAGE
 from sentry.search.utils import InvalidQuery, parse_datetime_string
 from sentry.services.hybrid_cloud import extract_id_from
 from sentry.services.hybrid_cloud.organization import (
@@ -31,6 +35,8 @@ from sentry.services.hybrid_cloud.organization import (
     RpcUserOrganizationContext,
     organization_service,
 )
+from sentry.snuba import discover
+from sentry.utils import snuba
 from sentry.utils.dates import parse_stats_period
 from sentry.utils.sdk import capture_exception, merge_context_into_scope
 
@@ -346,3 +352,67 @@ def get_auth_api_token_type(auth: object) -> str | None:
     if is_api_key_auth(auth):
         return "api_key"
     return None
+
+
+# NOTE: This duplicates OrganizationEventsEndpointBase.handle_query_errors
+@contextmanager
+def handle_query_errors(self) -> Generator[None, None, None]:
+    try:
+        yield
+    except discover.InvalidSearchQuery as error:
+        message = str(error)
+        # Special case the project message since it has so many variants so tagging is messy otherwise
+        if message.endswith("do not exist or are not actively selected."):
+            sentry_sdk.set_tag(
+                "query.error_reason", "Project in query does not exist or not selected"
+            )
+        else:
+            sentry_sdk.set_tag("query.error_reason", message)
+        raise ParseError(detail=message)
+    except ArithmeticError as error:
+        message = str(error)
+        sentry_sdk.set_tag("query.error_reason", message)
+        raise ParseError(detail=message)
+    except snuba.QueryOutsideRetentionError as error:
+        sentry_sdk.set_tag("query.error_reason", "QueryOutsideRetentionError")
+        raise ParseError(detail=str(error))
+    except snuba.QueryIllegalTypeOfArgument:
+        message = "Invalid query. Argument to function is wrong type."
+        sentry_sdk.set_tag("query.error_reason", message)
+        raise ParseError(detail=message)
+    except IncompatibleMetricsQuery as error:
+        message = str(error)
+        sentry_sdk.set_tag("query.error_reason", f"Metric Error: {message}")
+        raise ParseError(detail=message)
+    except snuba.SnubaError as error:
+        message = "Internal error. Please try again."
+        if isinstance(
+            error,
+            (
+                snuba.RateLimitExceeded,
+                snuba.QueryMemoryLimitExceeded,
+                snuba.QueryExecutionTimeMaximum,
+                snuba.QueryTooManySimultaneous,
+            ),
+        ):
+            sentry_sdk.set_tag("query.error_reason", "Timeout")
+            raise ParseError(detail=TIMEOUT_ERROR_MESSAGE)
+        elif isinstance(error, (snuba.UnqualifiedQueryError)):
+            sentry_sdk.set_tag("query.error_reason", str(error))
+            raise ParseError(detail=str(error))
+        elif isinstance(
+            error,
+            (
+                snuba.DatasetSelectionError,
+                snuba.QueryConnectionFailed,
+                snuba.QueryExecutionError,
+                snuba.QuerySizeExceeded,
+                snuba.SchemaValidationError,
+                snuba.QueryMissingColumn,
+            ),
+        ):
+            sentry_sdk.capture_exception(error)
+            message = "Internal error. Your query failed to run."
+        else:
+            sentry_sdk.capture_exception(error)
+        raise APIException(detail=message)

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -220,7 +220,7 @@ def test_customer_domain_path():
         assert expected == customer_domain_path(input_path)
 
 
-class TestException(Exception):
+class FooBarError(Exception):
     pass
 
 
@@ -246,10 +246,10 @@ class HandleQueryErrorsTest:
             SnubaError,
             UnqualifiedQueryError,
         ]
-        mock_parse_error.return_value = TestException()
+        mock_parse_error.return_value = FooBarError()
         for ex in exceptions:
             try:
                 with handle_query_errors(self):
                     raise ex
             except Exception as e:
-                assert isinstance(e, (TestException, APIException))
+                assert isinstance(e, (FooBarError, APIException))

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -249,7 +249,7 @@ class HandleQueryErrorsTest:
         mock_parse_error.return_value = FooBar()
         for ex, idx in enumerate(exceptions):
             try:
-                with handle_query_errors():
+                with handle_query_errors(self):
                     raise ex
             except Exception as e:
-                assert isinstance(e, [FooBar, APIException])
+                assert isinstance(e, (FooBar, APIException))


### PR DESCRIPTION
In many places we're extending the `OrganizationEventsEndpointBase` purely for access to the `handle_query_errors` helper.

There are notes in multiple area's mentioning that this helper should be decoupled from the base class implementations.
such as [here](https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/organization_stats_v2.py#L217) and [here](https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/organization_sessions.py#L22)