### PR TITLE
fix(hybridcloud) Simplify tests and fix jira multi region handling

### DIFF
--- a/src/sentry/middleware/integrations/parsers/jira.py
+++ b/src/sentry/middleware/integrations/parsers/jira.py
@@ -66,7 +66,6 @@ class JiraRequestParser(BaseRequestParser):
                 self.provider,
                 extra={"path": self.request.path, "regions": regions},
             )
-            return self.get_response_from_control_silo()
 
         if self.view_class in self.immediate_response_region_classes:
             return self.get_response_from_region_silo(region=regions[0])

--- a/tests/sentry/middleware/integrations/parsers/test_jira.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira.py
@@ -31,14 +31,6 @@ class JiraRequestParserTest(TestCase):
     def get_response(self, req: HttpRequest) -> HttpResponse:
         return HttpResponse(status=200, content="passthrough")
 
-    def assert_outbox_created(self, region: str | None = None):
-        outboxes = ControlOutbox.objects.filter(category=OutboxCategory.WEBHOOK_PROXY).all()
-        assert len(outboxes) > 1
-        for outbox in outboxes:
-            assert outbox.payload, "Should have a payload"
-            if region:
-                assert outbox.payload["region_name"] == region
-
     def assert_no_outbox_created(self):
         outboxes = ControlOutbox.objects.filter(category=OutboxCategory.WEBHOOK_PROXY).all()
         assert len(outboxes) == 0, "No outboxes should be created"

--- a/tests/sentry/middleware/integrations/parsers/test_jira.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira.py
@@ -1,43 +1,70 @@
-from unittest.mock import MagicMock, patch
+from __future__ import annotations
 
+from unittest.mock import patch
+
+import responses
+from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, override_settings
 
 from sentry.middleware.integrations.classifications import IntegrationClassification
 from sentry.middleware.integrations.parsers.jira import JiraRequestParser
-from sentry.models.outbox import ControlOutbox, WebhookProviderIdentifier
+from sentry.models.integrations.integration import Integration
+from sentry.models.outbox import ControlOutbox, OutboxCategory, WebhookProviderIdentifier
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.outbox import assert_webhook_outboxes, outbox_runner
+from sentry.testutils.outbox import assert_webhook_outboxes
+from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
+
+region = Region("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT)
+eu_region = Region("eu", 1, "http://eu.testserver", RegionCategory.MULTI_TENANT)
+
+region_config = (region, eu_region)
 
 
 @control_silo_test
 class JiraRequestParserTest(TestCase):
-    get_response = MagicMock()
     factory = RequestFactory()
     path_base = f"{IntegrationClassification.integration_prefix}jira"
-    region = Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)
 
-    def setUp(self):
-        super().setUp()
-        self.integration = self.create_integration(
+    def get_response(self, req: HttpRequest) -> HttpResponse:
+        return HttpResponse(status=200, content="passthrough")
+
+    def assert_outbox_created(self, region: str | None = None):
+        outboxes = ControlOutbox.objects.filter(category=OutboxCategory.WEBHOOK_PROXY).all()
+        assert len(outboxes) > 1
+        for outbox in outboxes:
+            assert outbox.payload, "Should have a payload"
+            if region:
+                assert outbox.payload["region_name"] == region
+
+    def assert_no_outbox_created(self):
+        outboxes = ControlOutbox.objects.filter(category=OutboxCategory.WEBHOOK_PROXY).all()
+        assert len(outboxes) == 0, "No outboxes should be created"
+
+    def get_integration(self) -> Integration:
+        self.organization = self.create_organization(owner=self.user, region="us")
+        return self.create_integration(
             organization=self.organization, external_id="jira:1", provider="jira"
         )
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
     def test_get_integration_from_request(self):
         request = self.factory.post(path=f"{self.path_base}/issue-updated/")
         parser = JiraRequestParser(request, self.get_response)
         assert parser.get_integration_from_request() is None
+        integration = self.get_integration()
 
         with patch(
             "sentry.middleware.integrations.parsers.jira.parse_integration_from_request"
         ) as mock_parse:
-            mock_parse.return_value = self.integration
-            assert parser.get_integration_from_request() == self.integration
+            mock_parse.return_value = integration
+            assert parser.get_integration_from_request() == integration
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
     def test_get_response_routing_to_control(self):
         paths = [
             "/ui-hook/",
@@ -50,86 +77,100 @@ class JiraRequestParserTest(TestCase):
         for path in paths:
             request = self.factory.post(path=f"{self.path_base}{path}")
             parser = JiraRequestParser(request, self.get_response)
-            with patch.object(
-                parser, "get_response_from_outbox_creation"
-            ) as get_response_from_outbox_creation, patch.object(
-                parser, "get_response_from_control_silo"
-            ) as mock_from_control:
-                assert not get_response_from_outbox_creation.called
-                assert not mock_from_control.called
-                parser.get_response()
-                assert mock_from_control.called
 
+            response = parser.get_response()
+            assert isinstance(response, HttpResponse)
+            assert response.status_code == 200
+            assert response.content == b"passthrough"
+            self.assert_no_outbox_created()
+
+    @responses.activate
     @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
     def test_get_response_routing_to_region_sync(self):
+        responses.add(
+            responses.POST,
+            region.to_url("/extensions/jira/issue/LR-123/"),
+            body="region response",
+            status=200,
+        )
         request = self.factory.post(path=f"{self.path_base}/issue/LR-123/")
         parser = JiraRequestParser(request, self.get_response)
-        with patch.object(
-            parser, "get_regions_from_organizations", return_value=[self.region]
-        ), patch.object(parser, "get_response_from_region_silo") as mock_from_region:
-            parser.get_response()
-            mock_from_region.assert_called_once_with(region=self.region)
 
+        with patch.object(parser, "get_integration_from_request") as method:
+            method.return_value = self.get_integration()
+            response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 200
+        assert response.content == b"region response"
+        self.assert_no_outbox_created()
+
+    @responses.activate
     @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
     def test_get_response_routing_to_region_async(self):
         request = self.factory.post(path=f"{self.path_base}/issue-updated/")
         parser = JiraRequestParser(request, self.get_response)
-        with patch.object(
-            parser, "get_regions_from_organizations", return_value=[self.region]
-        ), patch.object(parser, "get_response_from_outbox_creation") as mock_from_outbox:
-            parser.get_response()
-            mock_from_outbox.assert_called_once_with(regions=[self.region])
 
+        self.assert_no_outbox_created()
+        with patch.object(parser, "get_integration_from_request") as method:
+            method.return_value = self.get_integration()
+            response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 202
+        assert response.content == b""
+
+        assert len(responses.calls) == 0
+        assert_webhook_outboxes(
+            factory_request=request,
+            webhook_identifier=WebhookProviderIdentifier.JIRA,
+            region_names=[region.name],
+        )
+
+    @override_regions(region_config)
     @override_settings(SILO_MODE=SiloMode.CONTROL)
-    def test_get_response_invalid(self):
-        with patch(
-            "sentry.middleware.integrations.parsers.jira.parse_integration_from_request"
-        ) as mock_parse:
-            mock_parse.return_value = self.integration
-            # Invalid path
-            request = self.factory.post(path="/new-route/for/no/reason/")
-            parser = JiraRequestParser(request, self.get_response)
-            with patch.object(
-                parser, "get_response_from_outbox_creation"
-            ) as get_response_from_outbox_creation, patch.object(
-                parser, "get_response_from_control_silo"
-            ) as mock_from_control:
-                parser.get_response()
-                assert mock_from_control.called
-                assert not get_response_from_outbox_creation.called
-
-            # Too many regions
-            request = self.factory.post(path="/issue/LR-123/")
-            parser = JiraRequestParser(request, self.get_response)
-            with patch.object(
-                parser, "get_response_from_outbox_creation"
-            ) as get_response_from_outbox_creation, patch.object(
-                parser, "get_response_from_control_silo"
-            ) as mock_from_control, patch.object(
-                parser,
-                "get_regions_from_organizations",
-                return_value=[
-                    Region("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT),
-                    Region("eu", 2, "https://eu.testserver", RegionCategory.MULTI_TENANT),
-                ],
-            ) as mock_get_regions:
-                parser.get_response()
-                assert mock_from_control.called
-                assert mock_get_regions.called
-                assert not get_response_from_outbox_creation.called
-
-    @override_settings(SILO_MODE=SiloMode.CONTROL)
-    def test_webhook_outbox_creation(self):
-        path = f"{self.path_base}/issue-updated/"
-        with outbox_runner():
-            request = self.factory.post(path=path)
+    @responses.activate
+    def test_get_response_invalid_path(self):
+        # Invalid path
+        request = self.factory.post(path="/new-route/for/no/reason/")
         parser = JiraRequestParser(request, self.get_response)
 
-        assert ControlOutbox.objects.count() == 0
-        with patch.object(parser, "get_regions_from_organizations", return_value=[self.region]):
-            parser.get_response()
-            assert_webhook_outboxes(
-                factory_request=request,
-                webhook_identifier=WebhookProviderIdentifier.JIRA,
-                region_names=[self.region.name],
-            )
+        with patch.object(parser, "get_integration_from_request") as method:
+            method.return_value = self.get_integration()
+            response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 200
+        assert response.content == b"passthrough"
+        assert len(responses.calls) == 0
+
+    @override_regions(region_config)
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @responses.activate
+    def test_get_response_multiple_regions(self):
+        responses.add(
+            responses.POST,
+            eu_region.to_url("/extensions/jira/issue/LR-123/"),
+            body="region response",
+            status=200,
+        )
+        request = self.factory.post(path=f"{self.path_base}/issue/LR-123/")
+        parser = JiraRequestParser(request, self.get_response)
+
+        # Add a second organization. Jira only supports single regions.
+        other_org = self.create_organization(owner=self.user, region="eu")
+        integration = self.get_integration()
+        integration.add_organization(other_org.id)
+
+        with patch.object(parser, "get_integration_from_request") as method:
+            method.return_value = integration
+            response = parser.get_response()
+
+        # Response should go to first region
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == 200
+        assert response.content == b"region response"
+        assert len(responses.calls) == 1
+        self.assert_no_outbox_created()


### PR DESCRIPTION
- Update tests to use less object mocking and exercise more of the real code, and responses to validate outbond requests.
- Fix mistake in multi-region jira handling. Instead of forwarding to the first region like the comments stated we would forward to none of the regions. Now we can forward webhooks to multiple regions, but synchronous API calls only go to the first region.

If folks prefer this style of tests for parser, I can update tests for the other integration parsers.