### PR TITLE
fix(relocation): Repair routes and `owner` field

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -285,21 +285,13 @@ function buildRoutes() {
           component={errorHandler(withDomainRequired(OrganizationContextContainer))}
           key="orgless-relocation"
         >
-          <IndexRedirect to="welcome/" />
+          <IndexRedirect to="get-started/" />
           <Route
             path=":step/"
             component={make(() => import('sentry/views/relocation'))}
           />
         </Route>
       )}
-      <Route
-        path="/relocation/:orgId/"
-        component={withDomainRedirect(errorHandler(OrganizationContextContainer))}
-        key="org-relocation"
-      >
-        <IndexRedirect to="welcome/" />
-        <Route path=":step/" component={make(() => import('sentry/views/relocation'))} />
-      </Route>
       {usingCustomerDomain && (
         <Route
           path="/onboarding/"

--- a/static/app/views/relocation/uploadBackup.tsx
+++ b/static/app/views/relocation/uploadBackup.tsx
@@ -87,7 +87,7 @@ export function UploadBackup(__props: StepProps) {
     const formData = new FormData();
     formData.set('orgs', orgSlugs);
     formData.set('file', file);
-    formData.set('owner', user.email);
+    formData.set('owner', user.username);
     try {
       await api.requestPromise(`/relocations/`, {
         method: 'POST',


### PR DESCRIPTION
We want the `owner` field of the POST API to be a username, not email.

An unused route is also removed.

Issue: getsentry/team-ospo#214