### PR TITLE
doc(sessions): Max number of data points

### DIFF
--- a/api-docs/paths/releases/sessions.json
+++ b/api-docs/paths/releases/sessions.json
@@ -1,7 +1,7 @@
 {
   "get": {
     "tags": ["Releases"],
-    "description": "Returns a time series of release health session statistics for projects bound to an organization.\n\nThe interval and date range are subject to certain restrictions and rounding rules.\n\nThe date range is rounded to align with the interval, and is rounded to at least one hour. The interval can at most be one day and at least one hour currently. It has to cleanly divide one day, for rounding reasons.\n\nApart from the query parameters listed below, this endpoint also supports the usual [pagination parameters](https://docs.sentry.io/api/pagination/).",
+    "description": "Returns a time series of release health session statistics for projects bound to an organization.\n\nThe interval and date range are subject to certain restrictions and rounding rules.\n\nThe date range is rounded to align with the interval, and is rounded to at least one hour. The interval can at most be one day and at least one hour currently. It has to cleanly divide one day, for rounding reasons.\n\nBecause of technical limitations, this endpoint returns at most 10000 data points. For example, if you select a 90 day window grouped by releases, you will see at most `floor(10k / (90 + 1)) = 109` releases. To get more results, reduce the `statsPeriod`.",
     "operationId": "Retrieve Release Health Session Statistics",
     "parameters": [
       {


### PR DESCRIPTION
Document the maximum number of data points on the sessions API.

This PR also removes the note about pagination. Pagination has some pitfalls for this endpoint and should be considered an internal feature for now.

Fixes https://github.com/getsentry/sentry-docs/issues/6794.