### PR TITLE
fix(typing): Remove bad work around

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -76,10 +76,6 @@ class EventsMeta(TypedDict):
 
 # When calling make build-spectacular-docs we hit this issue
 # https://github.com/tfranzel/drf-spectacular/issues/1041
-# This is a work around
-EventsMeta.__annotations__["datasetReason"] = str
-EventsMeta.__annotations__["isMetricsData"] = bool
-EventsMeta.__annotations__["isMetricsExtractedData"] = bool
 
 
 class EventsResponse(TypedDict):

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -74,10 +74,6 @@ class EventsMeta(TypedDict):
     isMetricsExtractedData: NotRequired[bool]
 
 
-# When calling make build-spectacular-docs we hit this issue
-# https://github.com/tfranzel/drf-spectacular/issues/1041
-
-
 class EventsResponse(TypedDict):
     data: List[Dict[str, Any]]
     meta: EventsMeta


### PR DESCRIPTION
In #60614 a bad typing workaround was introduced. Something got fixed since then and we can now remove it.