### PR TITLE
ref(high-priority-alerts): add a floor for number of events + better tests

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1352,6 +1352,7 @@ def should_postprocess_feedback(job: PostProcessJob) -> bool:
 
 
 MAX_NEW_ESCALATION_AGE_HOURS = 24
+MIN_EVENTS_FOR_NEW_ESCALATION = 10
 
 
 def detect_new_escalation(job: PostProcessJob):
@@ -1383,7 +1384,11 @@ def detect_new_escalation(job: PostProcessJob):
     group_age_hours = group_age_seconds / 3600 if group_age_seconds >= 3600 else 1
     times_seen = group.times_seen_with_pending
     has_valid_status = group.substatus == GroupSubStatus.NEW
-    if group_age_hours >= MAX_NEW_ESCALATION_AGE_HOURS or not has_valid_status or times_seen <= 1:
+    if (
+        group_age_hours >= MAX_NEW_ESCALATION_AGE_HOURS
+        or not has_valid_status
+        or times_seen < MIN_EVENTS_FOR_NEW_ESCALATION
+    ):
         logger.warning(
             "tasks.post_process.detect_new_escalation.skipping_detection",
             extra={

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2038,11 +2038,11 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
     def test_has_escalated(self, mock_run_post_process_job):
         event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
-        group.update(first_seen=django_timezone.now() - timedelta(hours=1), times_seen=10000)
+        group.update(first_seen=django_timezone.now() - timedelta(hours=1), times_seen=10)
         event.group = Group.objects.get(id=group.id)
 
         with self.feature("projects:first-event-severity-new-escalation"):
-            with patch("sentry.issues.issue_velocity.calculate_threshold", return_value=9999):
+            with patch("sentry.issues.issue_velocity.calculate_threshold", return_value=9):
                 self.call_post_process_group(
                     is_new=True,
                     is_regression=False,
@@ -2092,12 +2092,12 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
         group.refresh_from_db()
         assert group.substatus == GroupSubStatus.NEW
 
-    @patch("sentry.issues.issue_velocity.get_latest_threshold", return_value=2)
+    @patch("sentry.issues.issue_velocity.get_latest_threshold", return_value=11)
     @patch("sentry.tasks.post_process.run_post_process_job", side_effect=run_post_process_job)
     def test_has_not_escalated(self, mock_run_post_process_job, mock_threshold):
         event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
-        group.update(first_seen=django_timezone.now() - timedelta(hours=1), times_seen=1)
+        group.update(first_seen=django_timezone.now() - timedelta(hours=1), times_seen=10)
 
         with self.feature("projects:first-event-severity-new-escalation"):
             self.call_post_process_group(
@@ -2182,14 +2182,36 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
         assert group.status == GroupStatus.IGNORED
         assert group.substatus == GroupSubStatus.UNTIL_ESCALATING
 
-    @patch("sentry.issues.issue_velocity.get_latest_threshold", return_value=3)
+    @patch("sentry.issues.issue_velocity.get_latest_threshold", return_value=8)
+    @patch("sentry.tasks.post_process.run_post_process_job", side_effect=run_post_process_job)
+    def test_no_escalation_less_than_min_event_count(
+        self, mock_run_post_process_job, mock_threshold
+    ):
+        event = self.create_event(data={}, project_id=self.project.id)
+        group = event.group
+        group.update(first_seen=django_timezone.now() - timedelta(hours=1), times_seen=9)
+        event.group = Group.objects.get(id=group.id)
+
+        with self.feature("projects:first-event-severity-new-escalation"):
+            self.call_post_process_group(
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                event=event,
+            )
+        mock_threshold.assert_not_called()
+        job = mock_run_post_process_job.call_args[0][0]
+        assert not job["has_escalated"]
+        group.refresh_from_db()
+        assert group.substatus == GroupSubStatus.NEW
+
+    @patch("sentry.issues.issue_velocity.get_latest_threshold", return_value=11)
     @patch("sentry.tasks.post_process.run_post_process_job", side_effect=run_post_process_job)
     def test_has_not_escalated_less_than_an_hour(self, mock_run_post_process_job, mock_threshold):
         event = self.create_event(data={}, project_id=self.project.id)
         group = event.group
-        # if we use 2 event / 1 minute to get the hourly event rate, the rate would be 120 events/hour
-        # but we want to use 60 minutes, so the rate comes out to 2 events/hour
-        group.update(first_seen=django_timezone.now() - timedelta(minutes=1), times_seen=2)
+        # the group is less than an hour old, but we use 1 hr for the hourly event rate anyway
+        group.update(first_seen=django_timezone.now() - timedelta(minutes=1), times_seen=10)
         event.group = Group.objects.get(id=group.id)
 
         with self.feature("projects:first-event-severity-new-escalation"):
@@ -2217,27 +2239,6 @@ class DetectNewEscalationTestMixin(BasePostProgressGroupMixin):
                 is_new_group_environment=True,
                 event=event,
             )
-        job = mock_run_post_process_job.call_args[0][0]
-        assert not job["has_escalated"]
-        group.refresh_from_db()
-        assert group.substatus == GroupSubStatus.NEW
-
-    @patch("sentry.issues.issue_velocity.get_latest_threshold")
-    @patch("sentry.tasks.post_process.run_post_process_job", side_effect=run_post_process_job)
-    def test_no_escalation_on_first_event(self, mock_run_post_process_job, mock_threshold):
-        event = self.create_event(data={}, project_id=self.project.id)
-        group = event.group
-        group.update(first_seen=django_timezone.now() - timedelta(hours=1), times_seen=1)
-        event.group = Group.objects.get(id=group.id)
-
-        with self.feature("projects:first-event-severity-new-escalation"):
-            self.call_post_process_group(
-                is_new=True,
-                is_regression=False,
-                is_new_group_environment=True,
-                event=event,
-            )
-        mock_threshold.assert_not_called()
         job = mock_run_post_process_job.call_args[0][0]
         assert not job["has_escalated"]
         group.refresh_from_db()


### PR DESCRIPTION
Right now the minimum number of events an issue can escalate on is 2. This PR increases that minimum to 10. I also refactored a few tests to be more thorough.