### PR TITLE
fix(crons): Properly query for environment

### DIFF
--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -79,7 +79,9 @@ class MonitorEndpoint(Endpoint):
 
         if environment:
             try:
-                environment_object = Environment.objects.get(name=environment)
+                environment_object = Environment.objects.get(
+                    organization_id=organization.id, name=environment
+                )
                 monitor_environment = MonitorEnvironment.objects.get(
                     monitor_id=monitor.id, environment_id=environment_object.id
                 )


### PR DESCRIPTION
Properly scopes `Environment` query by `organziation.id`

Fixes SENTRY-2BN4