### PR TITLE
fix(slack): Make Ignore/Archive actually work with block kit

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -494,7 +494,9 @@ class SlackActionEndpoint(Endpoint):
         # Handle interaction actions
         for action in action_list:
             try:
-                if action.name == "status":
+                if action.name == "status" or (
+                    use_block_kit and action.name in ("ignored:forever", "ignored:until_escalating")
+                ):
                     self.on_status(request, identity_user, group, action)
                 elif action.name == "assign":
                     self.on_assign(request, identity_user, group, action)

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -76,7 +76,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
 
     def get_ignore_status_action(self, text, selection):
         return {
-            "action_id": "status",
+            "action_id": selection,
             "block_id": "bXwil",
             "text": {
                 "type": "plain_text",


### PR DESCRIPTION
Previously, when the block kit flag was enabled, pressing the ignore button on a Slack notification for an issue rendered the "Ignored by <user>" message, however, when you actually clicked the message, it wasn't really ignored. 

This occurred because the block kit changes included changing the name of an action to its value; beforehand the name of the ignore button had the name "status," whereas with block kit, it has the name "ignored:forever" (or "ignored:until_escalating" for archive until escalating). This PR takes that change into account so that the action is properly handled.