### PR TITLE
ref(ts): Remove usage of `TestStubs.route*`

### DIFF
--- a/static/app/actionCreators/pageFilters.spec.tsx
+++ b/static/app/actionCreators/pageFilters.spec.tsx
@@ -1,3 +1,5 @@
+import RouterFixture from 'sentry-fixture/routerFixture';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act} from 'sentry-test/reactTestingLibrary';
 
@@ -34,7 +36,7 @@ describe('PageFilters ActionCreators', function () {
     const key = `global-selection:${organization.slug}`;
 
     beforeEach(() => {
-      router = TestStubs.router();
+      router = RouterFixture();
       localStorage.setItem(
         key,
         JSON.stringify({
@@ -424,7 +426,7 @@ describe('PageFilters ActionCreators', function () {
     });
 
     it('updates history when queries are different', function () {
-      const router = TestStubs.router({
+      const router = RouterFixture({
         location: {
           pathname: '/test/',
           query: {project: '2'},
@@ -440,7 +442,7 @@ describe('PageFilters ActionCreators', function () {
       });
     });
     it('does not update history when queries are the same', function () {
-      const router = TestStubs.router({
+      const router = RouterFixture({
         location: {
           pathname: '/test/',
           query: {project: '1'},
@@ -455,7 +457,7 @@ describe('PageFilters ActionCreators', function () {
     });
 
     it('updates history when queries are different with replace', function () {
-      const router = TestStubs.router({
+      const router = RouterFixture({
         location: {
           pathname: '/test/',
           query: {project: '2'},
@@ -470,7 +472,7 @@ describe('PageFilters ActionCreators', function () {
     });
 
     it('does not update history when queries are the same with replace', function () {
-      const router = TestStubs.router({
+      const router = RouterFixture({
         location: {
           pathname: '/test/',
           query: {project: '1'},
@@ -482,7 +484,7 @@ describe('PageFilters ActionCreators', function () {
     });
 
     it('does not override an absolute date selection', function () {
-      const router = TestStubs.router({
+      const router = RouterFixture({
         location: {
           pathname: '/test/',
           query: {project: '1', start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38'},
@@ -499,7 +501,7 @@ describe('PageFilters ActionCreators', function () {
 
   describe('updateEnvironments()', function () {
     it('updates single', function () {
-      const router = TestStubs.router({
+      const router = RouterFixture({
         location: {
           pathname: '/test/',
           query: {environment: 'test'},
@@ -514,7 +516,7 @@ describe('PageFilters ActionCreators', function () {
     });
 
     it('updates multiple', function () {
-      const router = TestStubs.router({
+      const router = RouterFixture({
         location: {
           pathname: '/test/',
           query: {environment: 'test'},
@@ -529,7 +531,7 @@ describe('PageFilters ActionCreators', function () {
     });
 
     it('removes environment', function () {
-      const router = TestStubs.router({
+      const router = RouterFixture({
         location: {
           pathname: '/test/',
           query: {environment: 'test'},
@@ -543,7 +545,7 @@ describe('PageFilters ActionCreators', function () {
     });
 
     it('does not override an absolute date selection', function () {
-      const router = TestStubs.router({
+      const router = RouterFixture({
         location: {
           pathname: '/test/',
           query: {
@@ -568,7 +570,7 @@ describe('PageFilters ActionCreators', function () {
 
   describe('updateDateTime()', function () {
     it('updates statsPeriod when there is no existing stats period', function () {
-      const router = TestStubs.router({
+      const router = RouterFixture({
         location: {
           pathname: '/test/',
           query: {},
@@ -585,7 +587,7 @@ describe('PageFilters ActionCreators', function () {
     });
 
     it('updates statsPeriod when there is an existing stats period', function () {
-      const router = TestStubs.router({
+      const router = RouterFixture({
         location: {
           pathname: '/test/',
           query: {statsPeriod: '14d'},
@@ -602,7 +604,7 @@ describe('PageFilters ActionCreators', function () {
     });
 
     it('changes to absolute date', function () {
-      const router = TestStubs.router({
+      const router = RouterFixture({
         location: {
           pathname: '/test/',
           query: {statsPeriod: '24h'},
@@ -622,7 +624,7 @@ describe('PageFilters ActionCreators', function () {
 
   describe('revertToPinnedFilters()', function () {
     it('reverts all filters that are desynced from localStorage', function () {
-      const router = TestStubs.router({
+      const router = RouterFixture({
         location: {
           pathname: '/test/',
           query: {},

--- a/static/app/components/charts/releaseSeries.spec.tsx
+++ b/static/app/components/charts/releaseSeries.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -25,7 +26,7 @@ describe('ReleaseSeries', function () {
     });
   });
 
-  const router = TestStubs.router();
+  const router = RouterFixture();
   const baseSeriesProps: ReleaseSeriesProps = {
     api: new MockApiClient(),
     organization: Organization(),

--- a/static/app/components/globalSelectionLink.spec.tsx
+++ b/static/app/components/globalSelectionLink.spec.tsx
@@ -1,4 +1,5 @@
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -10,7 +11,7 @@ describe('GlobalSelectionLink', function () {
   const getContext = (query?: {environment: string; project: string[]}) =>
     RouterContextFixture([
       {
-        router: TestStubs.router({
+        router: RouterFixture({
           location: {query},
         }),
       },

--- a/static/app/components/modals/commandPalette.spec.tsx
+++ b/static/app/components/modals/commandPalette.spec.tsx
@@ -2,6 +2,7 @@ import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import RouterFixture from 'sentry-fixture/routerFixture';
 import {Team} from 'sentry-fixture/team';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -97,7 +98,7 @@ describe('Command Palette Modal', function () {
       {
         context: RouterContextFixture([
           {
-            router: TestStubs.router({
+            router: RouterFixture({
               params: {orgId: 'org-slug'},
             }),
           },

--- a/static/app/views/acceptOrganizationInvite/index.spec.tsx
+++ b/static/app/views/acceptOrganizationInvite/index.spec.tsx
@@ -1,6 +1,7 @@
 import {browserHistory} from 'react-router';
 import {Config as ConfigFixture} from 'sentry-fixture/config';
 import {Organization} from 'sentry-fixture/organization';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -43,7 +44,7 @@ describe('AcceptOrganizationInvite', function () {
 
     render(
       <AcceptOrganizationInvite
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
       />
     );
@@ -84,7 +85,7 @@ describe('AcceptOrganizationInvite', function () {
 
     render(
       <AcceptOrganizationInvite
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{memberId: '1', token: 'abc'}}
       />
     );
@@ -113,7 +114,7 @@ describe('AcceptOrganizationInvite', function () {
 
     render(
       <AcceptOrganizationInvite
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
       />
     );
@@ -144,7 +145,7 @@ describe('AcceptOrganizationInvite', function () {
 
     render(
       <AcceptOrganizationInvite
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
       />
     );
@@ -176,7 +177,7 @@ describe('AcceptOrganizationInvite', function () {
 
     render(
       <AcceptOrganizationInvite
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
       />
     );
@@ -208,7 +209,7 @@ describe('AcceptOrganizationInvite', function () {
 
     render(
       <AcceptOrganizationInvite
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
       />
     );
@@ -240,7 +241,7 @@ describe('AcceptOrganizationInvite', function () {
 
     render(
       <AcceptOrganizationInvite
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
       />
     );
@@ -266,7 +267,7 @@ describe('AcceptOrganizationInvite', function () {
 
     render(
       <AcceptOrganizationInvite
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
       />
     );
@@ -288,7 +289,7 @@ describe('AcceptOrganizationInvite', function () {
 
     render(
       <AcceptOrganizationInvite
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
       />
     );
@@ -312,7 +313,7 @@ describe('AcceptOrganizationInvite', function () {
 
     render(
       <AcceptOrganizationInvite
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{orgId: 'org-slug', memberId: '1', token: 'abc'}}
       />
     );

--- a/static/app/views/alerts/create.spec.tsx
+++ b/static/app/views/alerts/create.spec.tsx
@@ -5,6 +5,7 @@ import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {ProjectAlertRule} from 'sentry-fixture/projectAlertRule';
 import {ProjectAlertRuleConfiguration} from 'sentry-fixture/projectAlertRuleConfiguration';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -86,13 +87,13 @@ describe('ProjectAlertsCreate', function () {
     const wrapper = render(
       <AlertsContainer>
         <AlertBuilderProjectProvider
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={params}
           organization={organization}
           hasMetricAlerts={false}
         >
           <ProjectAlertsCreate
-            {...TestStubs.routeComponentProps()}
+            {...RouteComponentPropsFixture()}
             hasMetricAlerts={false}
             members={[]}
             params={params}

--- a/static/app/views/alerts/list/header.spec.tsx
+++ b/static/app/views/alerts/list/header.spec.tsx
@@ -1,4 +1,5 @@
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -30,7 +31,7 @@ describe('AlertHeader', () => {
   });
 
   it('should pass global selection project to create alert button', () => {
-    render(<AlertHeader activeTab="stream" router={TestStubs.router()} />, {
+    render(<AlertHeader activeTab="stream" router={RouterFixture()} />, {
       context: routerContext,
       organization,
     });

--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -5,6 +5,7 @@ import {Environments as EnvironmentsFixture} from 'sentry-fixture/environments';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {ProjectAlertRule} from 'sentry-fixture/projectAlertRule';
 import {ProjectAlertRuleConfiguration} from 'sentry-fixture/projectAlertRuleConfiguration';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -88,14 +89,14 @@ const createWrapper = (props = {}) => {
   const onChangeTitleMock = jest.fn();
   const wrapper = render(
     <ProjectAlerts
-      {...TestStubs.routeComponentProps()}
+      {...RouteComponentPropsFixture()}
       organization={organization}
       project={project}
       params={params}
     >
       <IssueRuleEditor
-        route={TestStubs.routeComponentProps().route}
-        routeParams={TestStubs.routeComponentProps().routeParams}
+        route={RouteComponentPropsFixture().route}
+        routeParams={RouteComponentPropsFixture().routeParams}
         params={params}
         location={router.location}
         routes={projectAlertRuleDetailsRoutes}

--- a/static/app/views/alerts/rules/metric/create.spec.tsx
+++ b/static/app/views/alerts/rules/metric/create.spec.tsx
@@ -1,5 +1,6 @@
 import {EventsStats} from 'sentry-fixture/events';
 import LocationFixture from 'sentry-fixture/locationFixture';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render} from 'sentry-test/reactTestingLibrary';
@@ -50,7 +51,7 @@ describe('Incident Rules Create', function () {
 
     render(
       <MetricRulesCreate
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         eventView={EventView.fromLocation(LocationFixture())}
         params={{projectId: project.slug}}
         organization={organization}

--- a/static/app/views/alerts/rules/metric/edit.spec.tsx
+++ b/static/app/views/alerts/rules/metric/edit.spec.tsx
@@ -1,5 +1,6 @@
 import {Member as MemberFixture} from 'sentry-fixture/member';
 import {MetricRule as MetricRuleFixture} from 'sentry-fixture/metricRule';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -81,7 +82,7 @@ describe('MetricRulesEdit', function () {
 
     render(
       <MetricRulesEdit
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{
           projectId: project.slug,
           ruleId: rule.id!,
@@ -176,7 +177,7 @@ describe('MetricRulesEdit', function () {
 
     render(
       <MetricRulesEdit
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{
           projectId: project.slug,
           ruleId: rule.id!,
@@ -235,7 +236,7 @@ describe('MetricRulesEdit', function () {
 
     render(
       <MetricRulesEdit
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         userTeamIds={[]}
         onChangeTitle={() => {}}
         params={{

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -148,7 +149,7 @@ describe('Dashboards > Detail', function () {
       render(
         <OrganizationContext.Provider value={initialData.organization}>
           <ViewEditDashboard
-            {...TestStubs.routeComponentProps()}
+            {...RouteComponentPropsFixture()}
             organization={initialData.organization}
             params={{orgId: 'org-slug', dashboardId: 'default-overview'}}
             router={initialData.router}
@@ -169,7 +170,7 @@ describe('Dashboards > Detail', function () {
 
       render(
         <CreateDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={initialData.organization}
           params={{templateId: 'default-template', widgetId: '2'}}
           router={initialData.router}
@@ -369,7 +370,7 @@ describe('Dashboards > Detail', function () {
       render(
         <OrganizationContext.Provider value={initialData.organization}>
           <ViewEditDashboard
-            {...TestStubs.routeComponentProps()}
+            {...RouteComponentPropsFixture()}
             organization={initialData.organization}
             params={{orgId: 'org-slug', dashboardId: '1'}}
             router={initialData.router}
@@ -425,7 +426,7 @@ describe('Dashboards > Detail', function () {
       render(
         <OrganizationContext.Provider value={initialData.organization}>
           <ViewEditDashboard
-            {...TestStubs.routeComponentProps()}
+            {...RouteComponentPropsFixture()}
             organization={initialData.organization}
             params={{orgId: 'org-slug', dashboardId: '1'}}
             router={initialData.router}
@@ -453,7 +454,7 @@ describe('Dashboards > Detail', function () {
       render(
         <OrganizationContext.Provider value={initialData.organization}>
           <ViewEditDashboard
-            {...TestStubs.routeComponentProps()}
+            {...RouteComponentPropsFixture()}
             organization={initialData.organization}
             params={{orgId: 'org-slug', dashboardId: '1'}}
             router={initialData.router}
@@ -491,7 +492,7 @@ describe('Dashboards > Detail', function () {
       render(
         <OrganizationContext.Provider value={initialData.organization}>
           <ViewEditDashboard
-            {...TestStubs.routeComponentProps()}
+            {...RouteComponentPropsFixture()}
             organization={initialData.organization}
             params={{orgId: 'org-slug', dashboardId: '1'}}
             router={initialData.router}
@@ -513,7 +514,7 @@ describe('Dashboards > Detail', function () {
       render(
         <OrganizationContext.Provider value={initialData.organization}>
           <ViewEditDashboard
-            {...TestStubs.routeComponentProps()}
+            {...RouteComponentPropsFixture()}
             organization={initialData.organization}
             params={{orgId: 'org-slug', dashboardId: '1'}}
             router={initialData.router}
@@ -576,7 +577,7 @@ describe('Dashboards > Detail', function () {
 
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={initialData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={initialData.router}
@@ -620,7 +621,7 @@ describe('Dashboards > Detail', function () {
 
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={initialData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={initialData.router}
@@ -667,7 +668,7 @@ describe('Dashboards > Detail', function () {
 
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={initialData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={initialData.router}
@@ -716,7 +717,7 @@ describe('Dashboards > Detail', function () {
 
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={initialData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={initialData.router}
@@ -760,7 +761,7 @@ describe('Dashboards > Detail', function () {
 
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={initialData.organization}
           params={{orgId: 'org-slug', dashboardId: '1', widgetId: 1}}
           router={initialData.router}
@@ -790,7 +791,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={initialData.organization}
           params={{orgId: 'org-slug', dashboardId: '1', widgetId: 123}}
           router={initialData.router}
@@ -820,7 +821,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <CreateDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={initialData.organization}
           params={{templateId: undefined}}
           router={initialData.router}
@@ -863,7 +864,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <CreateDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={initialData.organization}
           params={{templateId: 'default-template'}}
           router={initialData.router}
@@ -910,7 +911,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <CreateDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={initialData.organization}
           params={{templateId: 'default-template'}}
           router={initialData.router}
@@ -943,7 +944,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={initialData.organization}
           params={{orgId: 'org-slug', dashboardId: '1', widgetId: 1}}
           router={initialData.router}
@@ -974,7 +975,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={initialData.organization}
           params={{orgId: 'org-slug', dashboardId: '1', widgetId: 1}}
           router={initialData.router}
@@ -1029,7 +1030,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={testData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={testData.router}
@@ -1092,7 +1093,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={testData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={testData.router}
@@ -1141,7 +1142,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={testData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={testData.router}
@@ -1197,7 +1198,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={testData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={testData.router}
@@ -1259,7 +1260,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={testData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={testData.router}
@@ -1316,7 +1317,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={testData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={testData.router}
@@ -1364,7 +1365,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={testData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={testData.router}
@@ -1411,7 +1412,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={testData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={testData.router}
@@ -1465,7 +1466,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={testData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={testData.router}
@@ -1528,7 +1529,7 @@ describe('Dashboards > Detail', function () {
       });
       render(
         <ViewEditDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           organization={testData.organization}
           params={{orgId: 'org-slug', dashboardId: '1'}}
           router={testData.router}

--- a/static/app/views/dashboards/manage/index.spec.tsx
+++ b/static/app/views/dashboards/manage/index.spec.tsx
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router';
 import selectEvent from 'react-select-event';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -46,7 +47,7 @@ describe('Dashboards > Detail', function () {
   it('denies access on missing feature', function () {
     render(
       <ManageDashboards
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         organization={mockUnauthorizedOrg}
       />
     );
@@ -59,7 +60,7 @@ describe('Dashboards > Detail', function () {
 
     render(
       <ManageDashboards
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         organization={mockAuthorizedOrg}
       />
     );
@@ -72,7 +73,7 @@ describe('Dashboards > Detail', function () {
   it('creates new dashboard', async function () {
     const org = Organization({features: FEATURES});
 
-    render(<ManageDashboards {...TestStubs.routeComponentProps()} organization={org} />);
+    render(<ManageDashboards {...RouteComponentPropsFixture()} organization={org} />);
 
     await userEvent.click(screen.getByTestId('dashboard-create'));
 
@@ -85,7 +86,7 @@ describe('Dashboards > Detail', function () {
   it('can sort', async function () {
     const org = Organization({features: FEATURES});
 
-    render(<ManageDashboards {...TestStubs.routeComponentProps()} organization={org} />);
+    render(<ManageDashboards {...RouteComponentPropsFixture()} organization={org} />);
 
     await selectEvent.select(
       screen.getByRole('button', {name: /sort by/i}),

--- a/static/app/views/dataExport/dataDownload.spec.tsx
+++ b/static/app/views/dataExport/dataDownload.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
@@ -25,9 +26,7 @@ describe('DataDownload', function () {
   it('should send a request to the data export endpoint', function () {
     const getValid = getDataExportDetails(DownloadStatus.VALID);
 
-    render(
-      <DataDownload {...TestStubs.routeComponentProps()} params={mockRouteParams} />
-    );
+    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
     expect(getValid).toHaveBeenCalledTimes(1);
   });
 
@@ -43,9 +42,7 @@ describe('DataDownload', function () {
     };
     getDataExportDetails({errors}, 403);
 
-    render(
-      <DataDownload {...TestStubs.routeComponentProps()} params={mockRouteParams} />
-    );
+    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
     expect(screen.getByText('403 -')).toBeInTheDocument(); // Either the code or the mock is mistaken about the data return format
   });
 
@@ -53,9 +50,7 @@ describe('DataDownload', function () {
     const status = DownloadStatus.EARLY;
     getDataExportDetails({status});
 
-    render(
-      <DataDownload {...TestStubs.routeComponentProps()} params={mockRouteParams} />
-    );
+    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
     expect(
       screen.getByText(textWithMarkupMatcher('What are you doing here?'))
     ).toBeInTheDocument();
@@ -67,9 +62,7 @@ describe('DataDownload', function () {
     const response = {status, query: {type: ExportQueryType.ISSUES_BY_TAG}};
     getDataExportDetails(response);
 
-    render(
-      <DataDownload {...TestStubs.routeComponentProps()} params={mockRouteParams} />
-    );
+    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
     expect(screen.getByText('This is awkward.')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Start a New Download'})).toHaveAttribute(
       'href',
@@ -81,9 +74,7 @@ describe('DataDownload', function () {
     const status = DownloadStatus.VALID;
     getDataExportDetails({dateExpired, status});
 
-    render(
-      <DataDownload {...TestStubs.routeComponentProps()} params={mockRouteParams} />
-    );
+    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
     expect(screen.getByText('All done.')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Download CSV'})).toHaveAttribute(
       'href',
@@ -107,9 +98,7 @@ describe('DataDownload', function () {
       },
     });
 
-    render(
-      <DataDownload {...TestStubs.routeComponentProps()} params={mockRouteParams} />
-    );
+    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
     expect(screen.getByRole('button', {name: 'Open in Discover'})).toBeInTheDocument();
   });
 
@@ -124,9 +113,7 @@ describe('DataDownload', function () {
       },
     });
 
-    render(
-      <DataDownload {...TestStubs.routeComponentProps()} params={mockRouteParams} />
-    );
+    render(<DataDownload {...RouteComponentPropsFixture()} params={mockRouteParams} />);
     expect(
       screen.queryByRole('button', {name: 'Open in Discover'})
     ).not.toBeInTheDocument();

--- a/static/app/views/discover/eventDetails/index.spec.tsx
+++ b/static/app/views/discover/eventDetails/index.spec.tsx
@@ -2,6 +2,7 @@ import {Group as GroupFixture} from 'sentry-fixture/group';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
@@ -109,7 +110,7 @@ describe('Discover > EventDetails', function () {
   it('renders', async function () {
     render(
       <EventDetails
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         organization={Organization()}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{
@@ -124,7 +125,7 @@ describe('Discover > EventDetails', function () {
   it('renders a 404', async function () {
     render(
       <EventDetails
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         organization={Organization()}
         params={{eventSlug: 'project-slug:abad1'}}
         location={{
@@ -140,7 +141,7 @@ describe('Discover > EventDetails', function () {
   it('renders a chart in grouped view', async function () {
     render(
       <EventDetails
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         organization={Organization()}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{
@@ -161,7 +162,7 @@ describe('Discover > EventDetails', function () {
     });
     render(
       <EventDetails
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         organization={Organization()}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{
@@ -189,7 +190,7 @@ describe('Discover > EventDetails', function () {
     });
     render(
       <EventDetails
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         organization={organization}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{
@@ -232,7 +233,7 @@ describe('Discover > EventDetails', function () {
     });
     render(
       <EventDetails
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         organization={organization}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={router.location}
@@ -272,7 +273,7 @@ describe('Discover > EventDetails', function () {
     });
     render(
       <EventDetails
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         organization={organization}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{
@@ -315,7 +316,7 @@ describe('Discover > EventDetails', function () {
 
     render(
       <EventDetails
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         organization={organization}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={router.location}

--- a/static/app/views/discover/index.spec.tsx
+++ b/static/app/views/discover/index.spec.tsx
@@ -1,6 +1,7 @@
 import selectEvent from 'react-select-event';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -74,10 +75,7 @@ describe('Discover > Landing', function () {
 
   it('denies access on missing feature', function () {
     render(
-      <DiscoverLanding
-        organization={Organization()}
-        {...TestStubs.routeComponentProps()}
-      />
+      <DiscoverLanding organization={Organization()} {...RouteComponentPropsFixture()} />
     );
 
     expect(screen.getByText("You don't have access to this feature")).toBeInTheDocument();
@@ -86,7 +84,7 @@ describe('Discover > Landing', function () {
   it('has the right sorts', function () {
     const org = Organization({features});
 
-    render(<DiscoverLanding organization={org} {...TestStubs.routeComponentProps()} />);
+    render(<DiscoverLanding organization={org} {...RouteComponentPropsFixture()} />);
 
     const expectedSorts = [
       'My Queries',
@@ -111,7 +109,7 @@ describe('Discover > Landing', function () {
   it('links back to the homepage', () => {
     const org = Organization({features});
 
-    render(<DiscoverLanding organization={org} {...TestStubs.routeComponentProps()} />, {
+    render(<DiscoverLanding organization={org} {...RouteComponentPropsFixture()} />, {
       context: RouterContextFixture(),
     });
 

--- a/static/app/views/discover/queryList.spec.tsx
+++ b/static/app/views/discover/queryList.spec.tsx
@@ -1,6 +1,7 @@
 import {browserHistory} from 'react-router';
 import {DiscoverSavedQuery} from 'sentry-fixture/discover';
 import {Organization} from 'sentry-fixture/organization';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -89,7 +90,7 @@ describe('Discover > QueryList', function () {
   it('renders an empty list', function () {
     render(
       <QueryList
-        router={TestStubs.router()}
+        router={RouterFixture()}
         organization={organization}
         savedQueries={[]}
         savedQuerySearchQuery="no matches"
@@ -107,7 +108,7 @@ describe('Discover > QueryList', function () {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={TestStubs.router()}
+        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries}
         renderPrebuilt
@@ -124,7 +125,7 @@ describe('Discover > QueryList', function () {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={TestStubs.router()}
+        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries}
         pageLinks=""
@@ -157,7 +158,7 @@ describe('Discover > QueryList', function () {
       <QueryList
         savedQuerySearchQuery=""
         renderPrebuilt={false}
-        router={TestStubs.router()}
+        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries}
         pageLinks=""
@@ -183,7 +184,7 @@ describe('Discover > QueryList', function () {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={TestStubs.router()}
+        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries}
         pageLinks=""
@@ -205,7 +206,7 @@ describe('Discover > QueryList', function () {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={TestStubs.router()}
+        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries.slice(1)}
         renderPrebuilt={false}
@@ -241,7 +242,7 @@ describe('Discover > QueryList', function () {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={TestStubs.router()}
+        router={RouterFixture()}
         organization={featuredOrganization}
         savedQueries={savedQueries.slice(1)}
         pageLinks=""
@@ -272,7 +273,7 @@ describe('Discover > QueryList', function () {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={TestStubs.router()}
+        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries.slice(1)}
         pageLinks=""
@@ -312,7 +313,7 @@ describe('Discover > QueryList', function () {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={TestStubs.router()}
+        router={RouterFixture()}
         organization={featuredOrganization}
         savedQueries={[savedQueryWithMultiYAxis]}
         pageLinks=""
@@ -338,7 +339,7 @@ describe('Discover > QueryList', function () {
     render(
       <QueryList
         savedQuerySearchQuery=""
-        router={TestStubs.router()}
+        router={RouterFixture()}
         organization={organization}
         savedQueries={savedQueries.slice(1)}
         renderPrebuilt={false}
@@ -366,7 +367,7 @@ describe('Discover > QueryList', function () {
       render(
         <QueryList
           savedQuerySearchQuery=""
-          router={TestStubs.router()}
+          router={RouterFixture()}
           organization={featuredOrganization}
           renderPrebuilt={false}
           savedQueries={[
@@ -432,7 +433,7 @@ describe('Discover > QueryList', function () {
       render(
         <QueryList
           savedQuerySearchQuery=""
-          router={TestStubs.router()}
+          router={RouterFixture()}
           renderPrebuilt={false}
           organization={featuredOrganization}
           savedQueries={[

--- a/static/app/views/discover/resultsChart.spec.tsx
+++ b/static/app/views/discover/resultsChart.spec.tsx
@@ -1,6 +1,7 @@
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -46,7 +47,7 @@ describe('Discover > ResultsChart', function () {
   it('only allows default, daily, previous period, and bar display modes when multiple y axis are selected', async function () {
     render(
       <ResultsChart
-        router={TestStubs.router()}
+        router={RouterFixture()}
         organization={organization}
         eventView={eventView}
         location={location}
@@ -80,7 +81,7 @@ describe('Discover > ResultsChart', function () {
   it('does not display a chart if no y axis is selected', function () {
     render(
       <ResultsChart
-        router={TestStubs.router()}
+        router={RouterFixture()}
         organization={organization}
         eventView={eventView}
         location={location}

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -6,6 +6,7 @@ import {Event as EventFixture} from 'sentry-fixture/event';
 import {Group as GroupFixture} from 'sentry-fixture/group';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import RouterFixture from 'sentry-fixture/routerFixture';
 import {SentryApp} from 'sentry-fixture/sentryApp';
 import {SentryAppComponent} from 'sentry-fixture/sentryAppComponent';
 
@@ -39,7 +40,7 @@ const makeDefaultMockData = (
     organization: organization ?? initializeOrg().organization,
     project: project ?? initializeOrg().project,
     group: GroupFixture(),
-    router: TestStubs.router({
+    router: RouterFixture({
       location: LocationFixture({
         query: {
           environment: environments,

--- a/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
@@ -1,6 +1,7 @@
 import {Groups} from 'sentry-fixture/groups';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {
   render,
@@ -27,7 +28,7 @@ describe('Issues Similar View', function () {
   const routerContext = RouterContextFixture([
     {
       router: {
-        ...TestStubs.router(),
+        ...RouterFixture(),
         params: {orgId: 'org-slug', projectId: 'project-slug', groupId: 'group-id'},
       },
     },
@@ -44,7 +45,7 @@ describe('Issues Similar View', function () {
     similar: Groups().map((issue, i) => [issue, scores[i]]),
   };
 
-  const router = TestStubs.router();
+  const router = RouterFixture();
 
   beforeEach(function () {
     mock = MockApiClient.addMockResponse({

--- a/static/app/views/organizationJoinRequest/index.spec.tsx
+++ b/static/app/views/organizationJoinRequest/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -22,7 +23,7 @@ describe('OrganizationJoinRequest', function () {
   it('renders', function () {
     render(
       <OrganizationJoinRequest
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{orgId: org.slug}}
       />
     );
@@ -40,7 +41,7 @@ describe('OrganizationJoinRequest', function () {
 
     render(
       <OrganizationJoinRequest
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{orgId: org.slug}}
       />
     );
@@ -70,7 +71,7 @@ describe('OrganizationJoinRequest', function () {
 
     render(
       <OrganizationJoinRequest
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{orgId: org.slug}}
       />
     );
@@ -92,7 +93,7 @@ describe('OrganizationJoinRequest', function () {
     const spy = jest.spyOn(window.location, 'assign').mockImplementation(() => {});
     render(
       <OrganizationJoinRequest
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{orgId: org.slug}}
       />
     );

--- a/static/app/views/performance/transactionDetails/index.spec.tsx
+++ b/static/app/views/performance/transactionDetails/index.spec.tsx
@@ -1,6 +1,7 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -54,9 +55,7 @@ describe('EventDetails', () => {
     });
 
     render(
-      <EventDetails
-        {...TestStubs.routeComponentProps({params: {eventSlug: 'latest'}})}
-      />,
+      <EventDetails {...RouteComponentPropsFixture({params: {eventSlug: 'latest'}})} />,
       {organization}
     );
     expect(screen.getByText(alertText)).toBeInTheDocument();
@@ -77,9 +76,7 @@ describe('EventDetails', () => {
     });
 
     render(
-      <EventDetails
-        {...TestStubs.routeComponentProps({params: {eventSlug: 'latest'}})}
-      />,
+      <EventDetails {...RouteComponentPropsFixture({params: {eventSlug: 'latest'}})} />,
       {organization}
     );
     expect(screen.queryByText(alertText)).not.toBeInTheDocument();

--- a/static/app/views/projectsDashboard/index.spec.tsx
+++ b/static/app/views/projectsDashboard/index.spec.tsx
@@ -1,5 +1,6 @@
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 import {Team} from 'sentry-fixture/team';
 
 import {
@@ -68,7 +69,7 @@ describe('ProjectsDashboard', function () {
           loadingTeams={false}
           teams={noProjectTeams}
           organization={org}
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
         />
       );
 
@@ -88,7 +89,7 @@ describe('ProjectsDashboard', function () {
           loadingTeams={false}
           teams={teamsWithOneProject}
           organization={org}
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
         />
       );
 
@@ -132,7 +133,7 @@ describe('ProjectsDashboard', function () {
           loadingTeams={false}
           organization={org}
           teams={teamsWithTwoProjects}
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
         />
       );
       expect(screen.getByText('My Teams')).toBeInTheDocument();
@@ -212,7 +213,7 @@ describe('ProjectsDashboard', function () {
           loadingTeams={false}
           teams={teamsWithSpecificProjects}
           organization={org}
-          {...TestStubs.routeComponentProps({
+          {...RouteComponentPropsFixture({
             location: {
               pathname: '',
               hash: '',
@@ -262,7 +263,7 @@ describe('ProjectsDashboard', function () {
           loadingTeams={false}
           teams={teamsWithTwoProjects}
           organization={org}
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
         />
       );
       await userEvent.type(
@@ -346,7 +347,7 @@ describe('ProjectsDashboard', function () {
           loadingTeams={false}
           organization={org}
           teams={teamsWithFavProjects}
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
         />
       );
 
@@ -433,7 +434,7 @@ describe('ProjectsDashboard', function () {
           loadingTeams={false}
           teams={teamsWithStatTestProjects}
           organization={org}
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
         />
       );
 
@@ -499,7 +500,7 @@ describe('ProjectsDashboard', function () {
           error={Error('uhoh')}
           organization={org}
           teams={[]}
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
         />
       );
 

--- a/static/app/views/releases/detail/header/releaseActions.spec.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.spec.tsx
@@ -2,6 +2,7 @@ import {browserHistory} from 'react-router';
 import {Location} from 'history';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {
@@ -90,7 +91,7 @@ describe('ReleaseActions', function () {
 
     render(
       <ReleaseActions
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         organization={organization}
         projectSlug={release.projects[0].slug}
         release={{...release, status: 'archived'}}

--- a/static/app/views/sentryAppExternalInstallation/index.spec.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.spec.tsx
@@ -1,6 +1,7 @@
 import selectEvent from 'react-select-event';
 import pick from 'lodash/pick';
 import {Organization} from 'sentry-fixture/organization';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 import {SentryApp} from 'sentry-fixture/sentryApp';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -81,7 +82,7 @@ describe('SentryAppExternalInstallation', () => {
     it('sets the org automatically', () => {
       render(
         <SentryAppExternalInstallation
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{sentryAppSlug: sentryApp.slug}}
         />
       );
@@ -114,7 +115,7 @@ describe('SentryAppExternalInstallation', () => {
 
       render(
         <SentryAppExternalInstallation
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{sentryAppSlug: sentryApp.slug}}
         />
       );
@@ -149,7 +150,7 @@ describe('SentryAppExternalInstallation', () => {
     it('renders org dropdown', () => {
       render(
         <SentryAppExternalInstallation
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{sentryAppSlug: sentryApp.slug}}
         />
       );
@@ -172,7 +173,7 @@ describe('SentryAppExternalInstallation', () => {
 
       render(
         <SentryAppExternalInstallation
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{sentryAppSlug: sentryApp.slug}}
         />
       );

--- a/static/app/views/settings/account/accountAuthorizations.spec.tsx
+++ b/static/app/views/settings/account/accountAuthorizations.spec.tsx
@@ -1,5 +1,6 @@
 import LocationFixture from 'sentry-fixture/locationFixture';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {render} from 'sentry-test/reactTestingLibrary';
 
@@ -17,7 +18,7 @@ describe('AccountAuthorizations', function () {
       body: [],
     });
 
-    const router = TestStubs.router({});
+    const router = RouterFixture({});
     render(
       <AccountAuthorizations
         location={LocationFixture()}

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.tsx
@@ -1,5 +1,6 @@
 import {Authenticators} from 'sentry-fixture/authenticators';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -25,7 +26,7 @@ describe('AccountSecurityEnroll', function () {
     const routerContext = RouterContextFixture([
       {
         router: {
-          ...TestStubs.router(),
+          ...RouterFixture(),
           params: {authId: authenticator.authId},
         },
       },
@@ -86,7 +87,7 @@ describe('AccountSecurityEnroll', function () {
       const routerContextWithMock = RouterContextFixture([
         {
           router: {
-            ...TestStubs.router({push: pushMock}),
+            ...RouterFixture({push: pushMock}),
             params: {authId: authenticator.authId},
           },
         },

--- a/static/app/views/settings/account/accountSecurity/index.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.spec.tsx
@@ -2,6 +2,7 @@ import {AccountEmails} from 'sentry-fixture/accountEmails';
 import {Authenticators} from 'sentry-fixture/authenticators';
 import {Organizations} from 'sentry-fixture/organizations';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {
   render,
@@ -21,7 +22,7 @@ const ACCOUNT_EMAILS_ENDPOINT = '/users/me/emails/';
 const AUTH_ENDPOINT = '/auth/';
 
 describe('AccountSecurity', function () {
-  const router = TestStubs.router();
+  const router = RouterFixture();
   beforeEach(function () {
     jest.spyOn(window.location, 'assign').mockImplementation(() => {});
 

--- a/static/app/views/settings/components/settingsSearch/index.spec.tsx
+++ b/static/app/views/settings/components/settingsSearch/index.spec.tsx
@@ -2,6 +2,7 @@ import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import RouterFixture from 'sentry-fixture/routerFixture';
 import {Team} from 'sentry-fixture/team';
 
 import {fireEvent, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -18,7 +19,7 @@ describe('SettingsSearch', function () {
   let orgsMock: jest.Mock;
   const routerContext = RouterContextFixture([
     {
-      router: TestStubs.router({
+      router: RouterFixture({
         params: {},
       }),
     },

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.spec.tsx
@@ -1,3 +1,4 @@
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 import {SentryApp as SentryAppFixture} from 'sentry-fixture/sentryApp';
 import {SentryAppWebhookRequest} from 'sentry-fixture/sentryAppWebhookRequest';
 
@@ -72,7 +73,7 @@ describe('Sentry Application Dashboard', function () {
     it('shows the total install/uninstall stats', () => {
       render(
         <SentryApplicationDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{appSlug: sentryApp.slug}}
         />
       );
@@ -83,7 +84,7 @@ describe('Sentry Application Dashboard', function () {
     it('shows the request log', () => {
       render(
         <SentryApplicationDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{appSlug: sentryApp.slug}}
         />
       );
@@ -105,7 +106,7 @@ describe('Sentry Application Dashboard', function () {
 
       render(
         <SentryApplicationDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{appSlug: sentryApp.slug}}
         />
       );
@@ -118,7 +119,7 @@ describe('Sentry Application Dashboard', function () {
     it('shows integration and interactions chart', () => {
       render(
         <SentryApplicationDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{appSlug: sentryApp.slug}}
         />
       );
@@ -171,7 +172,7 @@ describe('Sentry Application Dashboard', function () {
     it('shows the request log', () => {
       render(
         <SentryApplicationDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{appSlug: sentryApp.slug}}
         />
       );
@@ -195,7 +196,7 @@ describe('Sentry Application Dashboard', function () {
 
       render(
         <SentryApplicationDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{appSlug: sentryApp.slug}}
         />
       );
@@ -207,7 +208,7 @@ describe('Sentry Application Dashboard', function () {
     it('shows the component interactions in a line chart', () => {
       render(
         <SentryApplicationDashboard
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{appSlug: sentryApp.slug}}
         />
       );

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -1,6 +1,7 @@
 import selectEvent from 'react-select-event';
 import {Organization} from 'sentry-fixture/organization';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import RouterFixture from 'sentry-fixture/routerFixture';
 import {SentryApp} from 'sentry-fixture/sentryApp';
 import {SentryAppToken} from 'sentry-fixture/sentryAppToken';
 
@@ -17,7 +18,7 @@ describe('Sentry Application Details', function () {
 
   const maskedValue = '*'.repeat(64);
 
-  const router = TestStubs.router();
+  const router = RouterFixture();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
@@ -1,6 +1,7 @@
 import {OpsgenieIntegration} from 'sentry-fixture/opsgenieIntegration';
 import {OpsgenieIntegrationProvider} from 'sentry-fixture/opsgenieIntegrationProvider';
 import {Organization} from 'sentry-fixture/organization';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {
   render,
@@ -58,7 +59,7 @@ describe('OpsgenieMigrationButton', function () {
 
     render(
       <ConfigureIntegration
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{integrationId, providerKey: 'opsgenie'}}
       />,
       {organization: org}

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -2,6 +2,7 @@ import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/gith
 import {GitHubIntegrationProvider} from 'sentry-fixture/githubIntegrationProvider';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -81,7 +82,7 @@ describe('IntegrationDetailedView', function () {
   it('shows integration name, status, and install button', function () {
     render(
       <IntegrationDetailedView
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{integrationSlug: 'bitbucket'}}
         location={LocationFixture({query: {}})}
       />
@@ -94,7 +95,7 @@ describe('IntegrationDetailedView', function () {
   it('view configurations', function () {
     render(
       <IntegrationDetailedView
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{integrationSlug: 'bitbucket'}}
         location={LocationFixture({query: {tab: 'configurations'}})}
       />
@@ -109,7 +110,7 @@ describe('IntegrationDetailedView', function () {
   it('disables configure for members without access', function () {
     render(
       <IntegrationDetailedView
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{integrationSlug: 'bitbucket'}}
         location={LocationFixture({query: {tab: 'configurations'}})}
       />,
@@ -153,7 +154,7 @@ describe('IntegrationDetailedView', function () {
 
     render(
       <IntegrationDetailedView
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{integrationSlug: 'github'}}
         location={LocationFixture({query: {tab: 'configurations'}})}
       />,
@@ -197,7 +198,7 @@ describe('IntegrationDetailedView', function () {
 
     render(
       <IntegrationDetailedView
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{integrationSlug: 'github'}}
         organization={org}
         location={LocationFixture({query: {}})}
@@ -221,7 +222,7 @@ describe('IntegrationDetailedView', function () {
 
     render(
       <IntegrationDetailedView
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{integrationSlug: 'github'}}
         organization={org}
         location={LocationFixture({query: {}})}
@@ -256,7 +257,7 @@ describe('IntegrationDetailedView', function () {
     });
     render(
       <IntegrationDetailedView
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{integrationSlug: 'github'}}
         organization={org}
         location={LocationFixture({query: {}})}

--- a/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -108,7 +109,7 @@ describe('SentryAppDetailedView', function () {
     it('renders a published sentry app', () => {
       render(
         <SentryAppDetailedView
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{integrationSlug: 'clickup'}}
         />
       );
@@ -133,7 +134,7 @@ describe('SentryAppDetailedView', function () {
     it('installs and uninstalls', async function () {
       render(
         <SentryAppDetailedView
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{integrationSlug: 'clickup'}}
         />
       );
@@ -208,7 +209,7 @@ describe('SentryAppDetailedView', function () {
     it('should get redirected to Developer Settings', () => {
       render(
         <SentryAppDetailedView
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{integrationSlug: 'my-headband-washer-289499'}}
           router={router}
         />
@@ -289,7 +290,7 @@ describe('SentryAppDetailedView', function () {
     it('shows the Integration name and install status', function () {
       render(
         <SentryAppDetailedView
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{integrationSlug: 'la-croix-monitor'}}
         />
       );
@@ -300,7 +301,7 @@ describe('SentryAppDetailedView', function () {
     it('installs and uninstalls', async function () {
       render(
         <SentryAppDetailedView
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{integrationSlug: 'la-croix-monitor'}}
         />
       );
@@ -372,7 +373,7 @@ describe('SentryAppDetailedView', function () {
     it('shows the Integration name and install status', function () {
       render(
         <SentryAppDetailedView
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{integrationSlug: 'go-to-google'}}
         />
       );
@@ -385,7 +386,7 @@ describe('SentryAppDetailedView', function () {
     it('onClick: redirects url', async function () {
       render(
         <SentryAppDetailedView
-          {...TestStubs.routeComponentProps()}
+          {...RouteComponentPropsFixture()}
           params={{integrationSlug: 'go-to-google'}}
         />
       );

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -4,6 +4,7 @@ import {AuthProvider} from 'sentry-fixture/authProvider';
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import RouterFixture from 'sentry-fixture/routerFixture';
 import {Team} from 'sentry-fixture/team';
 import {User} from 'sentry-fixture/user';
 
@@ -88,7 +89,7 @@ describe('OrganizationMembersList', function () {
       name: 'active',
     },
   });
-  const router = TestStubs.router();
+  const router = RouterFixture();
   const defaultProps = {
     organization,
     router,

--- a/static/app/views/settings/organizationRateLimits/organizationRateLimits.spec.tsx
+++ b/static/app/views/settings/organizationRateLimits/organizationRateLimits.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -21,7 +22,7 @@ describe('Organization Rate Limits', function () {
   const renderComponent = (props?: Partial<OrganizationRateLimitProps>) =>
     render(
       <OrganizationRateLimits
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         organization={organization}
         {...props}
       />

--- a/static/app/views/settings/organizationRepositories/organizationRepositories.spec.tsx
+++ b/static/app/views/settings/organizationRepositories/organizationRepositories.spec.tsx
@@ -1,5 +1,6 @@
 import {Organization} from 'sentry-fixture/organization';
 import {Repository} from 'sentry-fixture/repository';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {render} from 'sentry-test/reactTestingLibrary';
 
@@ -7,7 +8,7 @@ import OrganizationRepositories from 'sentry/views/settings/organizationReposito
 
 describe('OrganizationRepositories', function () {
   const org = Organization();
-  const router = TestStubs.router();
+  const router = RouterFixture();
   const location = router.location;
 
   const routerProps = {router, location, routeParams: {}, routes: [], route: {}};

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.tsx
@@ -1,6 +1,7 @@
 import {Member as MemberFixture} from 'sentry-fixture/member';
 import {Members} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
+import RouterFixture from 'sentry-fixture/routerFixture';
 import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -30,7 +31,7 @@ describe('TeamMembers', function () {
     name: 'Sentry 9 Name',
   });
 
-  const router = TestStubs.router();
+  const router = RouterFixture();
 
   const routerProps = {
     router,

--- a/static/app/views/settings/project/projectTeams.spec.tsx
+++ b/static/app/views/settings/project/projectTeams.spec.tsx
@@ -1,3 +1,4 @@
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -71,7 +72,7 @@ describe('ProjectTeams', function () {
   it('renders', function () {
     render(
       <ProjectTeams
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{projectId: project.slug}}
         organization={org}
         project={project}
@@ -102,7 +103,7 @@ describe('ProjectTeams', function () {
 
     render(
       <ProjectTeams
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{projectId: project.slug}}
         organization={org}
         project={project}
@@ -159,7 +160,7 @@ describe('ProjectTeams', function () {
 
     render(
       <ProjectTeams
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{projectId: project.slug}}
         organization={org}
         project={project}
@@ -210,7 +211,7 @@ describe('ProjectTeams', function () {
 
     render(
       <ProjectTeams
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{projectId: project.slug}}
         organization={org}
         project={project}
@@ -258,7 +259,7 @@ describe('ProjectTeams', function () {
 
     render(
       <ProjectTeams
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{projectId: project.slug}}
         organization={org}
         project={project}
@@ -304,7 +305,7 @@ describe('ProjectTeams', function () {
 
     render(
       <ProjectTeams
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         params={{projectId: project.slug}}
         project={project}
         organization={org}

--- a/static/app/views/settings/projectAlerts/settings.spec.tsx
+++ b/static/app/views/settings/projectAlerts/settings.spec.tsx
@@ -1,12 +1,13 @@
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import Settings from 'sentry/views/settings/projectAlerts/settings';
 
 describe('ProjectAlertSettings', () => {
-  const router = TestStubs.router();
+  const router = RouterFixture();
   const organization = Organization();
   // 12 minutes
   const digestsMinDelay = 12 * 60;

--- a/static/app/views/settings/projectGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.spec.tsx
@@ -5,6 +5,7 @@ import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {
   act,
@@ -44,7 +45,7 @@ describe('projectGeneralSettings', function () {
   let routerContext;
   let putMock;
 
-  const router = TestStubs.router();
+  const router = RouterFixture();
   const routerProps = {
     location: LocationFixture(),
     routes: router.routes,
@@ -57,7 +58,7 @@ describe('projectGeneralSettings', function () {
     jest.spyOn(window.location, 'assign');
     routerContext = RouterContextFixture([
       {
-        router: TestStubs.router({
+        router: RouterFixture({
           params: {
             projectId: project.slug,
           },

--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
@@ -1,6 +1,7 @@
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {
   render,
@@ -26,7 +27,7 @@ describe('projectPerformance', function () {
   const configUrl = '/projects/org-slug/project-slug/transaction-threshold/configure/';
   let getMock, postMock, deleteMock;
 
-  const router = TestStubs.router();
+  const router = RouterFixture();
   const routerProps = {
     router,
     location: LocationFixture(),

--- a/static/app/views/settings/projectPlugins/index.spec.tsx
+++ b/static/app/views/settings/projectPlugins/index.spec.tsx
@@ -2,6 +2,7 @@ import {Organization} from 'sentry-fixture/organization';
 import {Plugin as PluginFixture} from 'sentry-fixture/plugin';
 import {Plugins as PluginsFixture} from 'sentry-fixture/plugins';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {getByRole, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -62,7 +63,7 @@ describe('ProjectPluginsContainer', function () {
     });
     render(
       <ProjectPluginsContainer
-        {...TestStubs.routeComponentProps()}
+        {...RouteComponentPropsFixture()}
         plugins={{plugins, loading: false, error: undefined}}
         params={params}
         organization={org}

--- a/static/app/views/settings/projectPlugins/projectPluginDetails.spec.tsx
+++ b/static/app/views/settings/projectPlugins/projectPluginDetails.spec.tsx
@@ -2,6 +2,7 @@ import {Organization} from 'sentry-fixture/organization';
 import {Plugin} from 'sentry-fixture/plugin';
 import {Plugins} from 'sentry-fixture/plugins';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import RouteComponentPropsFixture from 'sentry-fixture/routeComponentPropsFixture';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -15,7 +16,7 @@ describe('ProjectPluginDetails', function () {
   const project = ProjectFixture();
   const plugins = Plugins();
   const plugin = Plugin();
-  const routerProps = TestStubs.routeComponentProps();
+  const routerProps = RouteComponentPropsFixture();
 
   beforeAll(function () {
     jest.spyOn(console, 'info').mockImplementation(() => {});

--- a/static/app/views/settings/settingsIndex.spec.tsx
+++ b/static/app/views/settings/settingsIndex.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {BreadcrumbContextProvider} from 'sentry-test/providers/breadcrumbContextProvider';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -10,7 +11,7 @@ import SettingsIndex from 'sentry/views/settings/settingsIndex';
 
 describe('SettingsIndex', function () {
   const props = {
-    router: TestStubs.router(),
+    router: RouterFixture(),
     location: {} as any,
     routes: [],
     route: {},

--- a/static/app/views/sharedGroupDetails/index.spec.tsx
+++ b/static/app/views/sharedGroupDetails/index.spec.tsx
@@ -4,6 +4,7 @@ import {EventStacktraceException as EventStacktraceExceptionFixture} from 'sentr
 import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import RouterFixture from 'sentry-fixture/routerFixture';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -14,7 +15,7 @@ describe('SharedGroupDetails', function () {
   const eventEntry = EventEntryFixture();
   const exception = EventStacktraceExceptionFixture().entries[0];
   const params = {shareId: 'a'};
-  const router = TestStubs.router({params});
+  const router = RouterFixture({params});
 
   beforeEach(function () {
     MockApiClient.addMockResponse({
@@ -62,7 +63,7 @@ describe('SharedGroupDetails', function () {
 
   it('renders with org slug in path', async function () {
     const params_with_slug = {shareId: 'a', orgId: 'test-org'};
-    const router_with_slug = TestStubs.router({params_with_slug});
+    const router_with_slug = RouterFixture({params_with_slug});
     render(
       <RouteContext.Provider value={{router, ...router}}>
         <SharedGroupDetails


### PR DESCRIPTION
No actual test changes were needed, sweet.

- Replace `TestStubs.router` with import
- Replace `TestStubs.routeComponentProps` with import

https://github.com/getsentry/frontend-tsc/issues/49
