### PR TITLE
ref(ts): Remove usage of `TestStubs.Frame`

### DIFF
--- a/fixtures/js-stubs/exceptionValue.tsx
+++ b/fixtures/js-stubs/exceptionValue.tsx
@@ -1,0 +1,16 @@
+import type {ExceptionValue as ExceptionValueType} from 'sentry/types';
+
+export function ExceptionValue(
+  props: Partial<ExceptionValueType> = {}
+): ExceptionValueType {
+  return {
+    mechanism: null,
+    rawStacktrace: null,
+    stacktrace: null,
+    threadId: null,
+    type: 'BadError',
+    value: 'message',
+    module: null,
+    ...props,
+  };
+}

--- a/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/rawContent.spec.tsx
@@ -1,3 +1,6 @@
+import {ExceptionValue as ExceptionValueFixture} from 'sentry-fixture/exceptionValue';
+import {Frame as FrameFixture} from 'sentry-fixture/frame';
+
 import displayRawContent, {
   getJavaFrame,
   getJavaPreamble,
@@ -9,7 +12,7 @@ describe('RawStacktraceContent', function () {
     it('should render java frames', function () {
       expect(
         getJavaFrame(
-          TestStubs.Frame({
+          FrameFixture({
             module: 'org.mortbay.thread.QueuedThreadPool$PoolThread',
             function: 'run',
             filename: 'QueuedThreadPool.java',
@@ -23,7 +26,7 @@ describe('RawStacktraceContent', function () {
       // without line number
       expect(
         getJavaFrame(
-          TestStubs.Frame({
+          FrameFixture({
             module: 'org.mortbay.thread.QueuedThreadPool$PoolThread',
             function: 'run',
             filename: 'QueuedThreadPool.java',
@@ -36,7 +39,7 @@ describe('RawStacktraceContent', function () {
       // without line number and filename
       expect(
         getJavaFrame(
-          TestStubs.Frame({
+          FrameFixture({
             module: 'org.mortbay.thread.QueuedThreadPool$PoolThread',
             function: 'run',
             filename: 'QueuedThreadPool.java',
@@ -52,7 +55,7 @@ describe('RawStacktraceContent', function () {
     it('takes a type and value', () => {
       expect(
         getJavaPreamble(
-          TestStubs.Frame({
+          ExceptionValueFixture({
             type: 'Baz',
             value: 'message',
             module: undefined,
@@ -64,7 +67,7 @@ describe('RawStacktraceContent', function () {
     it('takes a module name', () => {
       expect(
         getJavaPreamble(
-          TestStubs.Frame({
+          ExceptionValueFixture({
             module: 'foo.bar',
             type: 'Baz',
             value: 'message',
@@ -86,14 +89,14 @@ describe('RawStacktraceContent', function () {
       framesOmitted: null,
       registers: {},
       frames: [
-        TestStubs.Frame({
+        FrameFixture({
           function: 'main',
           module: 'example.application',
           lineNo: 1,
           filename: 'application',
           platform: undefined,
         }),
-        TestStubs.Frame({
+        FrameFixture({
           function: 'doThing',
           module: 'example.application',
           lineNo: 2,


### PR DESCRIPTION
- replace `TestStubs` reference with an import
- add correct fixture for `ExceptionValue`

https://github.com/getsentry/frontend-tsc/issues/49
