### PR TITLE
feat(issue-details): remove browser context for some nextjs runtimes

### DIFF
--- a/static/app/components/events/contextSummary/utils.tsx
+++ b/static/app/components/events/contextSummary/utils.tsx
@@ -21,6 +21,16 @@ export const makeContextFilter = (event: Event) =>
       }
     }
 
+    if (event.sdk?.name === 'sentry.javascript.nextjs') {
+      if (context.keys.includes('browser')) {
+        const runtime = event.contexts?.runtime;
+
+        if (runtime?.name !== 'browser') {
+          return false;
+        }
+      }
+    }
+
     // do not show the context summary if only runtime raw_description is defined
     // (without name or version)
     if (


### PR DESCRIPTION
this pr removes the browser context for non-browser runtimes on events from the nextjs sdk. for these server errors, we don't need to show the browser as the first context with an icon, and now it is much more clear where the error is happening. if a user wants to know this information, they can still find it in the tags. 

before: 
<img width="1138" alt="Screenshot 2023-12-22 at 11 03 55 AM" src="https://github.com/getsentry/sentry/assets/46740234/5e8b55a1-a8eb-4ca8-9b8f-33fbfa7cfc21">

after:
<img width="1086" alt="Screenshot 2023-12-22 at 11 04 14 AM" src="https://github.com/getsentry/sentry/assets/46740234/b8f8e8d5-2c92-44fa-915d-d92777c1b8fc">

