### PR TITLE
ref(auth): Create base authindex endpoint class

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -38,19 +38,10 @@ DISABLE_SU_FORM_U2F_CHECK_FOR_LOCAL = getattr(
 
 
 @control_silo_endpoint
-class AuthIndexEndpoint(Endpoint):
-    publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
-    }
+class AuthIndexBaseEndpoint(Endpoint):
     """
-    Manage session authentication
-
-    Intended to be used by the internal Sentry application to handle
-    authentication methods from JS endpoints by relying on internal sessions
-    and simple HTTP authentication.
+    Base endpoint to manage session authentication. Shared between
+    AuthIndexEndpoint and StaffAuthIndexEndpoint (in getsentry)
     """
 
     owner = ApiOwner.ENTERPRISE
@@ -58,8 +49,15 @@ class AuthIndexEndpoint(Endpoint):
 
     permission_classes = ()
 
+    def get(self, request: Request) -> Response:
+        if not request.user.is_authenticated:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        user = promote_request_rpc_user(request)
+        return Response(serialize(user, user, DetailedSelfUserSerializer()))
+
     @staticmethod
-    def _reauthenticate_with_sso(request, org_id):
+    def _reauthenticate_with_sso(request: Request, org_id: int) -> None:
         """
         If a user without a password is hitting this, it means they need to re-identify with SSO.
         """
@@ -75,7 +73,7 @@ class AuthIndexEndpoint(Endpoint):
         )
 
     @staticmethod
-    def _verify_user_via_inputs(validator, request):
+    def _verify_user_via_inputs(validator: AuthVerifyValidator, request: Request) -> bool:
         # See if we have a u2f challenge/response
         if "challenge" in validator.validated_data and "response" in validator.validated_data:
             try:
@@ -113,9 +111,26 @@ class AuthIndexEndpoint(Endpoint):
             return authenticated
         return False
 
+
+@control_silo_endpoint
+class AuthIndexEndpoint(AuthIndexBaseEndpoint):
+    publish_status = {
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+    """
+    Manage session authentication
+
+    Intended to be used by the internal Sentry application to handle
+    authentication methods from JS endpoints by relying on internal sessions
+    and simple HTTP authentication.
+    """
+
     def _validate_superuser(
         self, validator: AuthVerifyValidator, request: Request, verify_authenticator: bool
-    ):
+    ) -> bool:
         """
         For a superuser, they need to be validated before we can grant an active superuser session.
         If the user has a password or u2f device, authenticate the password/challenge that was sent is valid.
@@ -144,13 +159,6 @@ class AuthIndexEndpoint(Endpoint):
                 self._reauthenticate_with_sso(request, Superuser.org_id)
 
         return authenticated
-
-    def get(self, request: Request) -> Response:
-        if not request.user.is_authenticated:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
-
-        user = promote_request_rpc_user(request)
-        return Response(serialize(user, user, DetailedSelfUserSerializer()))
 
     def post(self, request: Request) -> Response:
         """
@@ -197,7 +205,7 @@ class AuthIndexEndpoint(Endpoint):
 
         return self.get(request)
 
-    def put(self, request: Request):
+    def put(self, request: Request) -> Response:
         """
         Verify a User
         `````````````
@@ -252,12 +260,10 @@ class AuthIndexEndpoint(Endpoint):
             auth.login(request._request, promote_request_rpc_user(request))
             metrics.incr(
                 "sudo_modal.success",
-                sample_rate=1.0,
             )
         except auth.AuthUserPasswordExpired:
             metrics.incr(
                 "sudo_modal.failure",
-                sample_rate=1.0,
             )
             return Response(
                 {

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -38,7 +38,7 @@ DISABLE_SU_FORM_U2F_CHECK_FOR_LOCAL = getattr(
 
 
 @control_silo_endpoint
-class AuthIndexBaseEndpoint(Endpoint):
+class BaseAuthIndexEndpoint(Endpoint):
     """
     Base endpoint to manage session authentication. Shared between
     AuthIndexEndpoint and StaffAuthIndexEndpoint (in getsentry)
@@ -113,7 +113,7 @@ class AuthIndexBaseEndpoint(Endpoint):
 
 
 @control_silo_endpoint
-class AuthIndexEndpoint(AuthIndexBaseEndpoint):
+class AuthIndexEndpoint(BaseAuthIndexEndpoint):
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,
         "GET": ApiPublishStatus.PRIVATE,

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -177,7 +177,7 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
             curl -X ###METHOD### -u username:password ###URL###
         """
         if not request.user.is_authenticated:
-            return Response(status=status.HTTP_401_UNAUTHORIZED)
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
         # If 2fa login is enabled then we cannot sign in with username and
         # password through this api endpoint.

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -177,7 +177,7 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
             curl -X ###METHOD### -u username:password ###URL###
         """
         if not request.user.is_authenticated:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
 
         # If 2fa login is enabled then we cannot sign in with username and
         # password through this api endpoint.


### PR DESCRIPTION
Refactor `AuthIndexEndpoint` to subclass a new base class `BaseAuthIndexEndpoint`. The base class contains shared:
1. shared helper functions
   - `_reauthenticate_with_sso`
   - `_verify_user_via_inputs`
3. auth classes
4. permission classes
5. GET

The new staff endpoint differs b/c:
1. Does not contain a POST
2. The delete does not logout, it only kills the superuser and staff session
3. PUT validates normal requests and grants staff instead of superuser