### PR TITLE
feat(ddm): Clean top right icons

### DIFF
--- a/static/app/views/ddm/layout.tsx
+++ b/static/app/views/ddm/layout.tsx
@@ -6,7 +6,7 @@ import emptyStateImg from 'sentry-images/spot/custom-metrics-empty-state.svg';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeatureBadge from 'sentry/components/featureBadge';
-import FeedbackWidgetButton from 'sentry/components/feedback/widget/feedbackWidgetButton';
+import FloatingFeedbackWidget from 'sentry/components/feedback/widget/floatingFeedbackWidget';
 import {GithubFeedbackButton} from 'sentry/components/githubFeedbackButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -49,7 +49,6 @@ export const DDMLayout = memo(() => {
                 {t('Add Custom Metric')}
               </Button>
             )}
-            <FeedbackWidgetButton />
             <GithubFeedbackButton
               href="https://github.com/getsentry/sentry/discussions/58584"
               label={t('Discussion')}
@@ -59,6 +58,7 @@ export const DDMLayout = memo(() => {
         </Layout.HeaderActions>
       </Layout.Header>
       <Layout.Body>
+        <FloatingFeedbackWidget />
         <Layout.Main fullWidth>
           <PaddedContainer>
             <PageFilterBar condensed>

--- a/static/app/views/ddm/scratchpadSelector.tsx
+++ b/static/app/views/ddm/scratchpadSelector.tsx
@@ -245,7 +245,7 @@ export function ScratchpadSelector() {
         icon={<IconDashboard />}
         onClick={() => createDashboard(selectedScratchpad)}
       >
-        {t('Save to Dashboard')}
+        {t('Add to Dashboard')}
       </Button>
       <SaveAsDropdown
         onSave={name => {


### PR DESCRIPTION
We might have to do a bit more cleaning once we decide what to do with scratchpads but for now this is enough.

Closes https://github.com/getsentry/sentry/issues/62313