### PR TITLE
ref(ts): Remove usage of `TestStubs.Member`

### DIFF
--- a/static/app/types/role.tsx
+++ b/static/app/types/role.tsx
@@ -1,0 +1,26 @@
+import type {MemberRole, OrgRole, TeamRole} from 'sentry/types/organization';
+
+export function RoleFixture(params: Partial<MemberRole> = {}): MemberRole {
+  return {
+    id: 'member',
+    name: 'Member',
+    desc: '',
+    ...params,
+  };
+}
+
+export function TeamRoleFixture(params: Partial<TeamRole> = {}): TeamRole {
+  return {
+    ...RoleFixture(),
+    isMinimumRoleFor: 'admin',
+    ...params,
+  };
+}
+
+export function OrgRoleFixture(params: Partial<OrgRole> = {}): OrgRole {
+  return {
+    ...RoleFixture(),
+    minimumTeamRole: 'contributor',
+    ...params,
+  };
+}

--- a/static/app/views/issueList/overview.polling.spec.tsx
+++ b/static/app/views/issueList/overview.polling.spec.tsx
@@ -1,6 +1,7 @@
 import {Group as GroupFixture} from 'sentry-fixture/group';
 import {GroupStats} from 'sentry-fixture/groupStats';
 import LocationFixture from 'sentry-fixture/locationFixture';
+import {Member as MemberFixture} from 'sentry-fixture/member';
 import {Search} from 'sentry-fixture/search';
 import {Tags} from 'sentry-fixture/tags';
 
@@ -113,7 +114,7 @@ describe('IssueList -> Polling', function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/users/',
       method: 'GET',
-      body: [TestStubs.Member({projects: [project.slug]})],
+      body: [MemberFixture({projects: [project.slug]})],
     });
 
     MockApiClient.addMockResponse({

--- a/static/app/views/settings/organizationMembers/inviteRequestRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteRequestRow.spec.tsx
@@ -51,7 +51,6 @@ describe('InviteRequestRow', function () {
   const inviteRequest = MemberFixture({
     user: null,
     inviterName: User().name,
-    inviterId: User().id,
     inviteStatus: 'requested_to_be_invited',
     role: 'member',
     teams: ['myteam'],
@@ -169,7 +168,6 @@ describe('InviteRequestRow', function () {
     const adminInviteRequest = MemberFixture({
       user: null,
       inviterName: User().name,
-      inviterId: User().id,
       inviteStatus: 'requested_to_be_invited',
       role: 'admin',
       teams: ['myteam'],
@@ -208,7 +206,6 @@ describe('InviteRequestRow', function () {
     const ownerInviteRequest = MemberFixture({
       user: null,
       inviterName: User().name,
-      inviterId: User().id,
       inviteStatus: 'requested_to_be_invited',
       role: 'owner',
       teams: ['myteam'],

--- a/static/app/views/settings/organizationMembers/inviteRequestRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteRequestRow.spec.tsx
@@ -1,4 +1,5 @@
 import selectEvent from 'react-select-event';
+import {Member as MemberFixture} from 'sentry-fixture/member';
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
 import {User} from 'sentry-fixture/user';
@@ -47,7 +48,7 @@ describe('InviteRequestRow', function () {
   });
   const inviteRequestBusy: Record<string, boolean> = {};
 
-  const inviteRequest = TestStubs.Member({
+  const inviteRequest = MemberFixture({
     user: null,
     inviterName: User().name,
     inviterId: User().id,
@@ -56,7 +57,7 @@ describe('InviteRequestRow', function () {
     teams: ['myteam'],
   });
 
-  const joinRequest = TestStubs.Member({
+  const joinRequest = MemberFixture({
     user: null,
     inviteStatus: 'requested_to_join',
     role: 'member',
@@ -165,7 +166,7 @@ describe('InviteRequestRow', function () {
   });
 
   it('admin can change role and teams', async function () {
-    const adminInviteRequest = TestStubs.Member({
+    const adminInviteRequest = MemberFixture({
       user: null,
       inviterName: User().name,
       inviterId: User().id,
@@ -204,7 +205,7 @@ describe('InviteRequestRow', function () {
   });
 
   it('cannot be approved when invitee role is not allowed', function () {
-    const ownerInviteRequest = TestStubs.Member({
+    const ownerInviteRequest = MemberFixture({
       user: null,
       inviterName: User().name,
       inviterId: User().id,

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
@@ -1,3 +1,4 @@
+import {Member as MemberFixture} from 'sentry-fixture/member';
 import {Organization} from 'sentry-fixture/organization';
 import {Team} from 'sentry-fixture/team';
 import {User} from 'sentry-fixture/user';
@@ -7,7 +8,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import OrganizationMemberRow from 'sentry/views/settings/organizationMembers/organizationMemberRow';
 
 describe('OrganizationMemberRow', function () {
-  const member = TestStubs.Member({
+  const member = MemberFixture({
     id: '1',
     email: '',
     name: '',
@@ -29,7 +30,7 @@ describe('OrganizationMemberRow', function () {
     orgRole: 'manager',
   });
 
-  const memberOnManagerTeam = TestStubs.Member({
+  const memberOnManagerTeam = MemberFixture({
     id: '2',
     orgRole: 'member',
     teams: [managerTeam.slug],
@@ -81,7 +82,7 @@ describe('OrganizationMemberRow', function () {
       render(
         <OrganizationMemberRow
           {...defaultProps}
-          member={TestStubs.Member({
+          member={MemberFixture({
             ...member,
             user: User({...member.user, has2fa: true}),
           })}

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
@@ -5,6 +5,7 @@ import {User} from 'sentry-fixture/user';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {OrgRoleFixture} from 'sentry/types/role';
 import OrganizationMemberRow from 'sentry/views/settings/organizationMembers/organizationMemberRow';
 
 describe('OrganizationMemberRow', function () {
@@ -23,11 +24,11 @@ describe('OrganizationMemberRow', function () {
       'partnership:restricted': false,
       'sso:invalid': false,
     },
-    user: {
+    user: User({
       id: '',
       has2fa: false,
       name: 'sentry@test.com',
-    },
+    }),
     groupOrgRoles: [],
   });
 
@@ -42,7 +43,7 @@ describe('OrganizationMemberRow', function () {
     groupOrgRoles: [
       {
         teamSlug: managerTeam.slug,
-        role: {name: 'Manager'},
+        role: OrgRoleFixture({name: 'Manager'}),
       },
     ],
   });

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
@@ -105,7 +105,7 @@ describe('OrganizationMemberRow', function () {
           {...defaultProps}
           member={{
             ...member,
-            user: {...member.user, has2fa: false},
+            user: User({...member.user, has2fa: false}),
           }}
         />
       );
@@ -218,7 +218,7 @@ describe('OrganizationMemberRow', function () {
           member={{
             ...member,
             flags: {'sso:linked': true},
-            user: {...member.user, has2fa: false},
+            user: User({...member.user, has2fa: false}),
           }}
         />
       );
@@ -307,7 +307,7 @@ describe('OrganizationMemberRow', function () {
       render(
         <OrganizationMemberRow
           {...defaultProps}
-          member={{...member, user: {...member.user}}}
+          member={{...member, user: User({...member.user})}}
         />
       );
 
@@ -322,7 +322,7 @@ describe('OrganizationMemberRow', function () {
     render(
       <OrganizationMemberRow
         {...defaultProps}
-        member={{...memberOnManagerTeam, user: {...memberOnManagerTeam.user}}}
+        member={{...memberOnManagerTeam, user: User({...memberOnManagerTeam.user})}}
       />
     );
 

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
@@ -17,6 +17,11 @@ describe('OrganizationMemberRow', function () {
     pending: false,
     flags: {
       'sso:linked': false,
+      'idp:provisioned': false,
+      'idp:role-restricted': false,
+      'member-limit:restricted': false,
+      'partnership:restricted': false,
+      'sso:invalid': false,
     },
     user: {
       id: '',

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
@@ -217,7 +217,14 @@ describe('OrganizationMemberRow', function () {
           {...defaultProps}
           member={{
             ...member,
-            flags: {'sso:linked': true},
+            flags: {
+              'sso:linked': true,
+              'idp:provisioned': false,
+              'idp:role-restricted': false,
+              'member-limit:restricted': false,
+              'partnership:restricted': false,
+              'sso:invalid': false,
+            },
             user: User({...member.user, has2fa: false}),
           }}
         />

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -1,7 +1,8 @@
 import {browserHistory} from 'react-router';
 import selectEvent from 'react-select-event';
 import {AuthProvider} from 'sentry-fixture/authProvider';
-import {Members} from 'sentry-fixture/members';
+import {Member as MemberFixture} from 'sentry-fixture/member';
+import {Members as MembersFixture} from 'sentry-fixture/members';
 import {Organization} from 'sentry-fixture/organization';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import RouterFixture from 'sentry-fixture/routerFixture';
@@ -57,10 +58,10 @@ const roles = [
 // ];
 
 describe('OrganizationMembersList', function () {
-  const members = TestStubs.Members();
+  const members = MembersFixture();
 
   const ownerTeam = Team({slug: 'owner-team', orgRole: 'owner'});
-  const member = TestStubs.Member({
+  const member = MemberFixture({
     id: '5',
     email: 'member@sentry.io',
     teams: [ownerTeam.slug],
@@ -116,7 +117,7 @@ describe('OrganizationMembersList', function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/',
       method: 'GET',
-      body: [...Members(), member],
+      body: [...MembersFixture(), member],
     });
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/members/${member.id}/`,
@@ -448,7 +449,7 @@ describe('OrganizationMembersList', function () {
   });
 
   describe('OrganizationInviteRequests', function () {
-    const inviteRequest = TestStubs.Member({
+    const inviteRequest = MemberFixture({
       id: '123',
       user: null,
       inviteStatus: 'requested_to_be_invited',
@@ -456,7 +457,7 @@ describe('OrganizationMembersList', function () {
       role: 'member',
       teams: [],
     });
-    const joinRequest = TestStubs.Member({
+    const joinRequest = MemberFixture({
       id: '456',
       user: null,
       email: 'test@gmail.com',

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -453,7 +453,7 @@ describe('OrganizationMembersList', function () {
       id: '123',
       user: null,
       inviteStatus: 'requested_to_be_invited',
-      inviter: User(),
+      inviterName: User().name,
       role: 'member',
       teams: [],
     });

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -21,6 +21,7 @@ import {
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
+import {OrgRoleFixture} from 'sentry/types/role';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import OrganizationMembersList from 'sentry/views/settings/organizationMembers/organizationMembersList';
 
@@ -82,7 +83,7 @@ describe('OrganizationMembersList', function () {
     groupOrgRoles: [
       {
         teamSlug: ownerTeam.slug,
-        role: {id: 'owner'},
+        role: OrgRoleFixture({id: 'owner'}),
       },
     ],
   });

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -89,6 +89,7 @@ describe('OrganizationMembersList', function () {
   });
 
   const currentUser = members[1];
+  currentUser.user = User({...currentUser, flags: {newsletter_consent_prompt: true}});
   const organization = Organization({
     access: ['member:admin', 'org:admin', 'member:write'],
     status: {
@@ -107,7 +108,7 @@ describe('OrganizationMembersList', function () {
     routeParams: router.params,
   };
 
-  jest.spyOn(ConfigStore, 'get').mockImplementation(() => currentUser);
+  jest.spyOn(ConfigStore, 'get').mockImplementation(() => currentUser.user);
 
   afterAll(function () {
     (ConfigStore.get as jest.Mock).mockRestore();

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -73,6 +73,11 @@ describe('OrganizationMembersList', function () {
     ],
     flags: {
       'sso:linked': true,
+      'idp:provisioned': false,
+      'idp:role-restricted': false,
+      'member-limit:restricted': false,
+      'partnership:restricted': false,
+      'sso:invalid': false,
     },
     groupOrgRoles: [
       {


### PR DESCRIPTION
This one was a little annoying, but not too many changes!

- Replace `TestStubs.Member*` with import
- Remove unknown property
- Fully mock member flags
- Use full `Role` fixtures
- Set up full `User` fixture
- Fully set up flags
- Fix incorrect `ConfigStore` setup

getsentry/frontend-tsc#49
