### PR TITLE
ref(ts): Remove usage of `TestStubs.Repository`

### DIFF
--- a/static/app/components/pullRequestLink.spec.tsx
+++ b/static/app/components/pullRequestLink.spec.tsx
@@ -21,6 +21,7 @@ describe('PullRequestLink', () => {
   it('renders github links for integrations:github repositories', () => {
     const repository = RepositoryFixture({
       provider: {
+        name: 'GitHub',
         id: 'integrations:github',
       },
     });
@@ -37,6 +38,7 @@ describe('PullRequestLink', () => {
   it('renders github links for github repositories', () => {
     const repository = RepositoryFixture({
       provider: {
+        name: 'GitHub',
         id: 'github',
       },
     });
@@ -52,6 +54,7 @@ describe('PullRequestLink', () => {
   it('renders gitlab links for integrations:gitlab repositories', () => {
     const repository = RepositoryFixture({
       provider: {
+        name: 'GitLab',
         id: 'integrations:gitlab',
       },
     });
@@ -67,6 +70,7 @@ describe('PullRequestLink', () => {
   it('renders github links for gitlab repositories', () => {
     const repository = RepositoryFixture({
       provider: {
+        name: 'GitLab',
         id: 'gitlab',
       },
     });

--- a/static/app/components/pullRequestLink.spec.tsx
+++ b/static/app/components/pullRequestLink.spec.tsx
@@ -7,7 +7,9 @@ import PullRequestLink from 'sentry/components/pullRequestLink';
 
 describe('PullRequestLink', () => {
   it('renders no url on missing externalUrl', () => {
-    const repository = RepositoryFixture({provider: null});
+    const repository = RepositoryFixture({
+      provider: {id: 'unknown', name: 'Unknown Provider'},
+    });
     const pullRequest = PullRequest({
       repository,
       externalUrl: undefined,

--- a/static/app/components/pullRequestLink.spec.tsx
+++ b/static/app/components/pullRequestLink.spec.tsx
@@ -1,4 +1,5 @@
 import {PullRequest} from 'sentry-fixture/pullRequest';
+import {Repository as RepositoryFixture} from 'sentry-fixture/repository';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -6,7 +7,7 @@ import PullRequestLink from 'sentry/components/pullRequestLink';
 
 describe('PullRequestLink', () => {
   it('renders no url on missing externalUrl', () => {
-    const repository = TestStubs.Repository({provider: null});
+    const repository = RepositoryFixture({provider: null});
     const pullRequest = PullRequest({
       repository,
       externalUrl: undefined,
@@ -18,7 +19,7 @@ describe('PullRequestLink', () => {
   });
 
   it('renders github links for integrations:github repositories', () => {
-    const repository = TestStubs.Repository({
+    const repository = RepositoryFixture({
       provider: {
         id: 'integrations:github',
       },
@@ -34,7 +35,7 @@ describe('PullRequestLink', () => {
   });
 
   it('renders github links for github repositories', () => {
-    const repository = TestStubs.Repository({
+    const repository = RepositoryFixture({
       provider: {
         id: 'github',
       },
@@ -49,7 +50,7 @@ describe('PullRequestLink', () => {
   });
 
   it('renders gitlab links for integrations:gitlab repositories', () => {
-    const repository = TestStubs.Repository({
+    const repository = RepositoryFixture({
       provider: {
         id: 'integrations:gitlab',
       },
@@ -64,7 +65,7 @@ describe('PullRequestLink', () => {
   });
 
   it('renders github links for gitlab repositories', () => {
-    const repository = TestStubs.Repository({
+    const repository = RepositoryFixture({
       provider: {
         id: 'gitlab',
       },


### PR DESCRIPTION
EZ.

- Replace `TestStubs.Repository` with import
- Add missing name property
- Remove impossible case

getsentry/frontend-tsc#49
