### PR TITLE
ref(ts): Remove usage of `TestStubs.Incident`

### DIFF
--- a/static/app/views/alerts/rules/metric/details/utils.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/utils.spec.tsx
@@ -1,6 +1,7 @@
 import MockDate from 'mockdate';
 import moment from 'moment';
 import {Incident as IncidentFixture} from 'sentry-fixture/incident';
+import {MetricRule as MetricRuleFixture} from 'sentry-fixture/metricRule';
 
 import {buildMetricGraphDateRange} from 'sentry/views/alerts/rules/metric/details/utils';
 
@@ -18,7 +19,7 @@ describe('buildMetricGraphDateRange', () => {
     const incident = IncidentFixture({
       dateStarted: '2022-05-16T18:55:00Z',
       dateClosed: null,
-      alertRule: {timeWindow: 1},
+      alertRule: MetricRuleFixture({timeWindow: 1}),
     });
     const result = buildMetricGraphDateRange(incident);
     expect(result).toEqual({start: '2022-05-16T17:40:00', end: now});
@@ -29,7 +30,7 @@ describe('buildMetricGraphDateRange', () => {
     const incident = IncidentFixture({
       dateStarted: '2022-05-16T18:55:00Z',
       dateClosed: '2022-05-16T18:57:00Z',
-      alertRule: {timeWindow: 1},
+      alertRule: MetricRuleFixture({timeWindow: 1}),
     });
     const result = buildMetricGraphDateRange(incident);
     expect(result).toEqual({start: '2022-05-16T17:40:00', end: now});
@@ -41,7 +42,7 @@ describe('buildMetricGraphDateRange', () => {
     const incident = IncidentFixture({
       dateStarted: '2022-05-04T18:55:00Z',
       dateClosed: '2022-05-04T18:57:00Z',
-      alertRule: {timeWindow: 1},
+      alertRule: MetricRuleFixture({timeWindow: 1}),
     });
     const result = buildMetricGraphDateRange(incident);
     expect(result).toEqual({end: '2022-05-04T20:12:00', start: '2022-05-04T17:40:00'});
@@ -53,7 +54,7 @@ describe('buildMetricGraphDateRange', () => {
       dateStarted: '2022-04-20T20:28:00Z',
       dateClosed: null,
       // 1 day time window
-      alertRule: {timeWindow: 1440},
+      alertRule: MetricRuleFixture({timeWindow: 1440}),
     });
     const result = buildMetricGraphDateRange(incident);
     expect(result).toEqual({start: '2022-02-04T20:28:00', end: now});

--- a/static/app/views/alerts/rules/metric/details/utils.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/utils.spec.tsx
@@ -1,5 +1,6 @@
 import MockDate from 'mockdate';
 import moment from 'moment';
+import {Incident as IncidentFixture} from 'sentry-fixture/incident';
 
 import {buildMetricGraphDateRange} from 'sentry/views/alerts/rules/metric/details/utils';
 
@@ -14,7 +15,7 @@ describe('buildMetricGraphDateRange', () => {
   });
 
   it('should use current date for an active alert', () => {
-    const incident = TestStubs.Incident({
+    const incident = IncidentFixture({
       dateStarted: '2022-05-16T18:55:00Z',
       dateClosed: null,
       alertRule: {timeWindow: 1},
@@ -25,7 +26,7 @@ describe('buildMetricGraphDateRange', () => {
   });
 
   it('should use current date for a recently closed alert', () => {
-    const incident = TestStubs.Incident({
+    const incident = IncidentFixture({
       dateStarted: '2022-05-16T18:55:00Z',
       dateClosed: '2022-05-16T18:57:00Z',
       alertRule: {timeWindow: 1},
@@ -37,7 +38,7 @@ describe('buildMetricGraphDateRange', () => {
 
   it('should use a past date for an older alert', () => {
     // Incident is from over a week ago
-    const incident = TestStubs.Incident({
+    const incident = IncidentFixture({
       dateStarted: '2022-05-04T18:55:00Z',
       dateClosed: '2022-05-04T18:57:00Z',
       alertRule: {timeWindow: 1},
@@ -48,7 +49,7 @@ describe('buildMetricGraphDateRange', () => {
   });
 
   it('should handle large time windows', () => {
-    const incident = TestStubs.Incident({
+    const incident = IncidentFixture({
       dateStarted: '2022-04-20T20:28:00Z',
       dateClosed: null,
       // 1 day time window


### PR DESCRIPTION
2EZ.

- Replace `TestStubs.Incident` with import
- Use full `MetricRule` fixture

getsentry/frontend-tsc#49
