### PR TITLE
ref(ts): Remove usage of `TestStubs.Dashboard`

### DIFF
--- a/fixtures/js-stubs/dashboard.tsx
+++ b/fixtures/js-stubs/dashboard.tsx
@@ -1,6 +1,7 @@
 import type {
   DashboardDetails as TDashboardDetails,
   DashboardFilters as TDashboardFilters,
+  DashboardListItem as TDashboardListItem,
   Widget as TWidget,
 } from 'sentry/views/dashboards/types';
 
@@ -16,5 +17,17 @@ export function Dashboard(
     title: 'Dashboard',
     widgets,
     ...props,
+  };
+}
+
+export function DashboardListItem(
+  params: Partial<TDashboardListItem> = {}
+): TDashboardListItem {
+  return {
+    id: '1',
+    title: 'Dashboard',
+    widgetDisplay: [],
+    widgetPreview: [],
+    ...params,
   };
 }

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import {Dashboard as DashboardFixture} from 'sentry-fixture/dashboard';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
@@ -45,13 +46,13 @@ describe('Dashboards > Detail', function () {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/',
         body: [
-          TestStubs.Dashboard([], {id: 'default-overview', title: 'Default'}),
-          TestStubs.Dashboard([], {id: '1', title: 'Custom Errors'}),
+          DashboardFixture([], {id: 'default-overview', title: 'Default'}),
+          DashboardFixture([], {id: '1', title: 'Custom Errors'}),
         ],
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/default-overview/',
-        body: TestStubs.Dashboard([], {id: 'default-overview', title: 'Default'}),
+        body: DashboardFixture([], {id: 'default-overview', title: 'Default'}),
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/visit/',
@@ -103,7 +104,7 @@ describe('Dashboards > Detail', function () {
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/default-overview/',
-        body: TestStubs.Dashboard(
+        body: DashboardFixture(
           [
             TestStubs.Widget(
               [
@@ -288,21 +289,25 @@ describe('Dashboards > Detail', function () {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/',
         body: [
-          TestStubs.Dashboard([], {
-            id: 'default-overview',
-            title: 'Default',
+          {
+            ...DashboardFixture([], {
+              id: 'default-overview',
+              title: 'Default',
+            }),
             widgetDisplay: ['area'],
-          }),
-          TestStubs.Dashboard([], {
-            id: '1',
-            title: 'Custom Errors',
+          },
+          {
+            ...DashboardFixture([], {
+              id: '1',
+              title: 'Custom Errors',
+            }),
             widgetDisplay: ['area'],
-          }),
+          },
         ],
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
-        body: TestStubs.Dashboard(widgets, {
+        body: DashboardFixture(widgets, {
           id: '1',
           title: 'Custom Errors',
           filters: {},
@@ -311,7 +316,7 @@ describe('Dashboards > Detail', function () {
       mockPut = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         method: 'PUT',
-        body: TestStubs.Dashboard(widgets, {id: '1', title: 'Custom Errors'}),
+        body: DashboardFixture(widgets, {id: '1', title: 'Custom Errors'}),
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/events-stats/',
@@ -365,7 +370,7 @@ describe('Dashboards > Detail', function () {
       const updateMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         method: 'PUT',
-        body: TestStubs.Dashboard([widgets[0]], {id: '1', title: 'Custom Errors'}),
+        body: DashboardFixture([widgets[0]], {id: '1', title: 'Custom Errors'}),
       });
       render(
         <OrganizationContext.Provider value={initialData.organization}>
@@ -412,7 +417,7 @@ describe('Dashboards > Detail', function () {
     it('appends dashboard-level filters to series request', async function () {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
-        body: TestStubs.Dashboard(widgets, {
+        body: DashboardFixture(widgets, {
           id: '1',
           title: 'Custom Errors',
           filters: {release: ['abc@1.2.0']},
@@ -535,7 +540,7 @@ describe('Dashboards > Detail', function () {
       // A case where someone has async added widgets to a dashboard
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
-        body: TestStubs.Dashboard(
+        body: DashboardFixture(
           [
             TestStubs.Widget(
               [
@@ -595,7 +600,7 @@ describe('Dashboards > Detail', function () {
     it('does not trigger request if layout not updated', async () => {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
-        body: TestStubs.Dashboard(
+        body: DashboardFixture(
           [
             TestStubs.Widget(
               [
@@ -642,7 +647,7 @@ describe('Dashboards > Detail', function () {
     it('renders the custom resize handler for a widget', async () => {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
-        body: TestStubs.Dashboard(
+        body: DashboardFixture(
           [
             TestStubs.Widget(
               [
@@ -691,7 +696,7 @@ describe('Dashboards > Detail', function () {
     it('does not trigger an alert when the widgets have no layout and user cancels without changes', async () => {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
-        body: TestStubs.Dashboard(
+        body: DashboardFixture(
           [
             TestStubs.Widget(
               [
@@ -756,7 +761,7 @@ describe('Dashboards > Detail', function () {
       );
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
-        body: TestStubs.Dashboard([widget], {id: '1', title: 'Custom Errors'}),
+        body: DashboardFixture([widget], {id: '1', title: 'Custom Errors'}),
       });
 
       render(
@@ -787,7 +792,7 @@ describe('Dashboards > Detail', function () {
       const openWidgetViewerModal = jest.spyOn(modals, 'openWidgetViewerModal');
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
-        body: TestStubs.Dashboard([], {id: '1', title: 'Custom Errors'}),
+        body: DashboardFixture([], {id: '1', title: 'Custom Errors'}),
       });
       render(
         <ViewEditDashboard
@@ -937,7 +942,7 @@ describe('Dashboards > Detail', function () {
       const openWidgetViewerModal = jest.spyOn(modals, 'openWidgetViewerModal');
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
-        body: TestStubs.Dashboard(widgets, {
+        body: DashboardFixture(widgets, {
           id: '1',
           filters: {release: ['sentry-android-shop@1.2.0']},
         }),
@@ -968,7 +973,7 @@ describe('Dashboards > Detail', function () {
       const openWidgetViewerModal = jest.spyOn(modals, 'openWidgetViewerModal');
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
-        body: TestStubs.Dashboard(widgets, {
+        body: DashboardFixture(widgets, {
           id: '1',
           filters: {release: ['sentry-android-shop@1.2.0']},
         }),
@@ -1057,7 +1062,7 @@ describe('Dashboards > Detail', function () {
     it('can clear dashboard filters in compact select', async () => {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
-        body: TestStubs.Dashboard(widgets, {
+        body: DashboardFixture(widgets, {
           id: '1',
           title: 'Custom Errors',
           filters: {release: ['sentry-android-shop@1.2.0']},
@@ -1289,7 +1294,7 @@ describe('Dashboards > Detail', function () {
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
-        body: TestStubs.Dashboard(widgets, {
+        body: DashboardFixture(widgets, {
           id: '1',
           title: 'Custom Errors',
           filters: {},
@@ -1384,7 +1389,7 @@ describe('Dashboards > Detail', function () {
     it('resets release in URL params', async function () {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
-        body: TestStubs.Dashboard(widgets, {
+        body: DashboardFixture(widgets, {
           id: '1',
           title: 'Custom Errors',
           filters: {

--- a/static/app/views/dashboards/manage/dashboardList.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardList.spec.tsx
@@ -1,4 +1,4 @@
-import {Dashboard as DashboardFixture} from 'sentry-fixture/dashboard';
+import {DashboardListItem as DashboardListItemFixture} from 'sentry-fixture/dashboard';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
@@ -15,9 +15,10 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import DashboardList from 'sentry/views/dashboards/manage/dashboardList';
+import {DisplayType} from 'sentry/views/dashboards/types';
 
 describe('Dashboards - DashboardList', function () {
-  let dashboards, widgets, deleteMock, dashboardUpdateMock, createMock;
+  let dashboards, deleteMock, dashboardUpdateMock, createMock;
   const organization = Organization({
     features: ['global-views', 'dashboards-basic', 'dashboards-edit', 'discover-query'],
     projects: [ProjectFixture()],
@@ -32,59 +33,26 @@ describe('Dashboards - DashboardList', function () {
       url: '/organizations/org-slug/projects/',
       body: [],
     });
-    widgets = [
-      TestStubs.Widget(
-        [{name: '', conditions: 'event.type:error', fields: ['count()']}],
-        {
-          title: 'Errors',
-          interval: '1d',
-          id: '1',
-        }
-      ),
-      TestStubs.Widget(
-        [{name: '', conditions: 'event.type:transaction', fields: ['count()']}],
-        {
-          title: 'Transactions',
-          interval: '1d',
-          id: '2',
-        }
-      ),
-      TestStubs.Widget(
-        [
-          {
-            name: '',
-            conditions: 'event.type:transaction transaction:/api/cats',
-            fields: ['p50()'],
-          },
-        ],
-        {
-          title: 'p50 of /api/cats',
-          interval: '1d',
-          id: '3',
-        }
-      ),
-    ];
     dashboards = [
-      DashboardFixture([], {
+      DashboardListItemFixture({
         id: '1',
         title: 'Dashboard 1',
         dateCreated: '2021-04-19T13:13:23.962105Z',
         createdBy: UserFixture({id: '1'}),
-        widgetPreview: [],
       }),
-      DashboardFixture(widgets, {
+      DashboardListItemFixture({
         id: '2',
         title: 'Dashboard 2',
         dateCreated: '2021-04-19T13:13:23.962105Z',
         createdBy: UserFixture({id: '1'}),
         widgetPreview: [
           {
-            displayType: 'line',
-            layout: {},
+            displayType: DisplayType.LINE,
+            layout: null,
           },
           {
-            displayType: 'table',
-            layout: {},
+            displayType: DisplayType.TABLE,
+            layout: null,
           },
         ],
       }),
@@ -230,7 +198,7 @@ describe('Dashboards - DashboardList', function () {
 
   it('cannot delete last dashboard', async function () {
     const singleDashboard = [
-      DashboardFixture([], {
+      DashboardListItemFixture({
         id: '1',
         title: 'Dashboard 1',
         dateCreated: '2021-04-19T13:13:23.962105Z',

--- a/static/app/views/dashboards/manage/dashboardList.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardList.spec.tsx
@@ -2,6 +2,7 @@ import {Dashboard as DashboardFixture} from 'sentry-fixture/dashboard';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+import {User as UserFixture} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
@@ -68,14 +69,14 @@ describe('Dashboards - DashboardList', function () {
         id: '1',
         title: 'Dashboard 1',
         dateCreated: '2021-04-19T13:13:23.962105Z',
-        createdBy: {id: '1'},
+        createdBy: UserFixture({id: '1'}),
         widgetPreview: [],
       }),
       DashboardFixture(widgets, {
         id: '2',
         title: 'Dashboard 2',
         dateCreated: '2021-04-19T13:13:23.962105Z',
-        createdBy: {id: '1'},
+        createdBy: UserFixture({id: '1'}),
         widgetPreview: [
           {
             displayType: 'line',
@@ -233,7 +234,7 @@ describe('Dashboards - DashboardList', function () {
         id: '1',
         title: 'Dashboard 1',
         dateCreated: '2021-04-19T13:13:23.962105Z',
-        createdBy: {id: '1'},
+        createdBy: UserFixture({id: '1'}),
         widgetPreview: [],
       }),
     ];

--- a/static/app/views/dashboards/manage/dashboardList.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardList.spec.tsx
@@ -1,3 +1,4 @@
+import {Dashboard as DashboardFixture} from 'sentry-fixture/dashboard';
 import LocationFixture from 'sentry-fixture/locationFixture';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
@@ -63,14 +64,14 @@ describe('Dashboards - DashboardList', function () {
       ),
     ];
     dashboards = [
-      TestStubs.Dashboard([], {
+      DashboardFixture([], {
         id: '1',
         title: 'Dashboard 1',
         dateCreated: '2021-04-19T13:13:23.962105Z',
         createdBy: {id: '1'},
         widgetPreview: [],
       }),
-      TestStubs.Dashboard(widgets, {
+      DashboardFixture(widgets, {
         id: '2',
         title: 'Dashboard 2',
         dateCreated: '2021-04-19T13:13:23.962105Z',
@@ -228,7 +229,7 @@ describe('Dashboards - DashboardList', function () {
 
   it('cannot delete last dashboard', async function () {
     const singleDashboard = [
-      TestStubs.Dashboard([], {
+      DashboardFixture([], {
         id: '1',
         title: 'Dashboard 1',
         dateCreated: '2021-04-19T13:13:23.962105Z',


### PR DESCRIPTION
3EZ.

- Replace `TestStubs.Dashboard` with import
- Use full `User` fixture
- Use more specific fixture

getsentry/frontend-tsc#49
