### PR TITLE
ref(ts): Remove usage of `TestStubs.GitHubIntegration`

### DIFF
--- a/fixtures/js-stubs/codeOwner.ts
+++ b/fixtures/js-stubs/codeOwner.ts
@@ -19,9 +19,10 @@ interface CodeOwnerParams extends Partial<TCodeOwner> {
 export function CodeOwner({
   project = Project(),
   repo = Repository(),
-  integration = GitHubIntegration(),
   ...params
 }: CodeOwnerParams = {}): TCodeOwner {
+  const integration = GitHubIntegration();
+
   return {
     id: '1225',
     raw: '',

--- a/fixtures/js-stubs/githubIntegration.tsx
+++ b/fixtures/js-stubs/githubIntegration.tsx
@@ -1,15 +1,13 @@
-import {OrganizationIntegration} from 'sentry/types';
+import {GroupIntegration} from 'sentry/types';
 
 export function GitHubIntegration(
-  params: Partial<OrganizationIntegration> = {}
-): OrganizationIntegration {
+  params: Partial<GroupIntegration> = {}
+): GroupIntegration {
   return {
     domainName: 'github.com/test-integration',
     icon: 'http://example.com/integration_icon.png',
     id: '1',
     name: 'Test Integration',
-    configOrganization: [],
-    configData: {},
     provider: {
       name: 'GitHub',
       key: 'github',
@@ -26,10 +24,9 @@ export function GitHubIntegration(
       canDisable: false,
       slug: '',
     },
+    externalIssues: [],
     accountType: '',
-    externalId: '',
     gracePeriodEnd: '',
-    organizationId: '',
     organizationIntegrationStatus: 'active',
     status: 'active',
     ...params,

--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -2,6 +2,7 @@ import {DataScrubbingRelayPiiConfig} from 'sentry-fixture/dataScrubbingRelayPiiC
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {EventEntryExceptionGroup as EventEntryExceptionGroupFixture} from 'sentry-fixture/eventEntryExceptionGroup';
 import {EventStacktraceFrame} from 'sentry-fixture/eventStacktraceFrame';
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {Organization} from 'sentry-fixture/organization';
 import {Project} from 'sentry-fixture/project';
 import {Repository} from 'sentry-fixture/repository';
@@ -19,7 +20,7 @@ import {StackType, StackView} from 'sentry/types/stacktrace';
 describe('Exception Content', function () {
   const organization = Organization();
   const project = Project({});
-  const integration = TestStubs.GitHubIntegration();
+  const integration = GitHubIntegrationFixture();
   const repo = Repository({integrationId: integration.id});
   const config = RepositoryProjectPathConfig({project, repo, integration});
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
@@ -1,6 +1,7 @@
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {EventEntryStacktrace} from 'sentry-fixture/eventEntryStacktrace';
 import {EventStacktraceFrame} from 'sentry-fixture/eventStacktraceFrame';
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {Repository} from 'sentry-fixture/repository';
@@ -16,7 +17,7 @@ import {StacktraceType} from 'sentry/types/stacktrace';
 const organization = Organization();
 const project = ProjectFixture({});
 
-const integration = TestStubs.GitHubIntegration();
+const integration = GitHubIntegrationFixture();
 const repo = Repository({integrationId: integration.id});
 
 const config = RepositoryProjectPathConfig({project, repo, integration});

--- a/static/app/components/events/interfaces/threads.spec.tsx
+++ b/static/app/components/events/interfaces/threads.spec.tsx
@@ -1,4 +1,5 @@
 import merge from 'lodash/merge';
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {Organization} from 'sentry-fixture/organization';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {Repository} from 'sentry-fixture/repository';
@@ -15,7 +16,7 @@ import {EntryType, Event} from 'sentry/types/event';
 describe('Threads', function () {
   const organization = Organization();
   const project = ProjectFixture({});
-  const integration = TestStubs.GitHubIntegration();
+  const integration = GitHubIntegrationFixture();
   const repo = Repository({integrationId: integration.id});
   const config = RepositoryProjectPathConfig({project, repo, integration});
 

--- a/static/app/components/group/externalIssueForm.spec.tsx
+++ b/static/app/components/group/externalIssueForm.spec.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 
@@ -32,7 +33,7 @@ describe('ExternalIssueForm', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     group = GroupFixture();
-    integration = TestStubs.GitHubIntegration({externalIssues: []});
+    integration = GitHubIntegrationFixture({externalIssues: []});
   });
 
   afterEach(() => {

--- a/static/app/components/group/externalIssuesList/externalIssueActions.spec.tsx
+++ b/static/app/components/group/externalIssuesList/externalIssueActions.spec.tsx
@@ -75,9 +75,12 @@ describe('ExternalIssueActions', function () {
   describe('with an external issue linked', function () {
     const externalIssues = [
       {
-        id: 100,
+        id: '100',
         url: 'https://github.com/MeredithAnya/testing/issues/2',
         key: 'getsentry/sentry#2',
+        title: 'SyntaxError: XYZ',
+        description: 'something else, sorry',
+        displayName: '',
       },
     ];
     const integration = GitHubIntegrationFixture({externalIssues});

--- a/static/app/components/group/externalIssuesList/externalIssueActions.spec.tsx
+++ b/static/app/components/group/externalIssuesList/externalIssueActions.spec.tsx
@@ -1,3 +1,4 @@
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {Group as GroupFixture} from 'sentry-fixture/group';
 
 import {
@@ -17,7 +18,7 @@ describe('ExternalIssueActions', function () {
   });
 
   describe('with no external issues linked', function () {
-    const integration = TestStubs.GitHubIntegration({externalIssues: []});
+    const integration = GitHubIntegrationFixture({externalIssues: []});
     const configurations = [integration];
 
     it('renders', function () {
@@ -79,7 +80,7 @@ describe('ExternalIssueActions', function () {
         key: 'getsentry/sentry#2',
       },
     ];
-    const integration = TestStubs.GitHubIntegration({externalIssues});
+    const integration = GitHubIntegrationFixture({externalIssues});
     const configurations = [integration];
     it('renders', function () {
       render(

--- a/static/app/components/group/externalIssuesList/index.spec.tsx
+++ b/static/app/components/group/externalIssuesList/index.spec.tsx
@@ -1,4 +1,5 @@
 import {Event} from 'sentry-fixture/event';
+import {GitHubIntegration as GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {Group} from 'sentry-fixture/group';
 import {JiraIntegration} from 'sentry-fixture/jiraIntegration';
 import {Organization} from 'sentry-fixture/organization';
@@ -77,7 +78,7 @@ describe('ExternalIssuesList', () => {
       url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,
       body: [
         JiraIntegration({status: 'active', externalIssues: []}),
-        TestStubs.GitHubIntegration({
+        GitHubIntegrationFixture({
           status: 'active',
           externalIssues: [
             {


### PR DESCRIPTION
4EZ.

- Replace `TestStubs.GitHubIntegration` with import
- Improve `GitHubIntegration` type
- Add missing properties

I made a type change, because as far as I can tell, this is more correct.

getsentry/frontend-tsc#49
