### PR TITLE
ref(ts): Remove usage of `TestStubs.SentryAppInstallation`

### DIFF
--- a/static/app/views/alerts/rules/issue/sentryAppRuleModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/sentryAppRuleModal.spec.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import {SentryApp} from 'sentry-fixture/sentryApp';
+import {SentryAppInstallation as SentryAppInstallationFixture} from 'sentry-fixture/sentryAppInstallation';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -21,7 +22,7 @@ describe('SentryAppRuleModal', function () {
 
   beforeEach(function () {
     sentryApp = SentryApp();
-    sentryAppInstallation = TestStubs.SentryAppInstallation({sentryApp});
+    sentryAppInstallation = SentryAppInstallationFixture({sentryApp});
   });
 
   const _submit = async () => {

--- a/static/app/views/alerts/rules/issue/sentryAppRuleModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/sentryAppRuleModal.spec.tsx
@@ -22,7 +22,7 @@ describe('SentryAppRuleModal', function () {
 
   beforeEach(function () {
     sentryApp = SentryApp();
-    sentryAppInstallation = SentryAppInstallationFixture({sentryApp});
+    sentryAppInstallation = SentryAppInstallationFixture();
   });
 
   const _submit = async () => {

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -9,6 +9,7 @@ import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import RouterFixture from 'sentry-fixture/routerFixture';
 import {SentryApp} from 'sentry-fixture/sentryApp';
 import {SentryAppComponent} from 'sentry-fixture/sentryAppComponent';
+import {SentryAppInstallation as SentryAppInstallationFixture} from 'sentry-fixture/sentryAppInstallation';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -516,14 +517,14 @@ describe('Platform Integrations', () => {
     const unpublishedIntegration = SentryApp({status: 'unpublished'});
     const internalIntegration = SentryApp({status: 'internal'});
 
-    const unpublishedInstall = TestStubs.SentryAppInstallation({
+    const unpublishedInstall = SentryAppInstallationFixture({
       app: {
         slug: unpublishedIntegration.slug,
         uuid: unpublishedIntegration.uuid,
       },
     });
 
-    const internalInstall = TestStubs.SentryAppInstallation({
+    const internalInstall = SentryAppInstallationFixture({
       app: {
         slug: internalIntegration.slug,
         uuid: internalIntegration.uuid,


### PR DESCRIPTION
6EZ.

- Replace `TestStubs.SentryAppInstallation` with import
- Remove unnecessary property

getsentry/frontend-tsc#49
