### PR TITLE
fix(csv-export): Handle the need for escape characters

### DIFF
--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -102,7 +102,9 @@ def assemble_download(
                 # file handle to a stream writer that will encode to utf8.
                 tfw = codecs.getwriter("utf-8")(tf)
 
-                writer = csv.DictWriter(tfw, processor.header_fields, extrasaction="ignore")
+                writer = csv.DictWriter(
+                    tfw, processor.header_fields, escapechar="\\", extrasaction="ignore"
+                )
                 if first_page:
                     writer.writeheader()
 


### PR DESCRIPTION
- Fixes SENTRY-2BDZ
- Fixes #62309
- This fixes an issue where if the results has characters that need escaping the entire export would fail