### PR TITLE
fix(issues): Allow all projects "-1" in query parameters

### DIFF
--- a/static/app/actionCreators/pageFilters.spec.tsx
+++ b/static/app/actionCreators/pageFilters.spec.tsx
@@ -333,6 +333,34 @@ describe('PageFilters ActionCreators', function () {
       );
     });
 
+    it('does invalidate all projects from query params if forced into single project', function () {
+      initializeUrlState({
+        organization,
+        queryParams: {
+          project: '-1',
+        },
+        memberProjects: organization.projects,
+        nonMemberProjects: [],
+        // User does not have access to global views
+        shouldEnforceSingleProject: true,
+        router,
+      });
+      expect(PageFiltersStore.onInitializeUrlState).toHaveBeenCalledWith(
+        {
+          datetime: {
+            start: null,
+            end: null,
+            period: '14d',
+            utc: null,
+          },
+          projects: [1],
+          environments: [],
+        },
+        new Set(),
+        true
+      );
+    });
+
     it('does not add non-pinned filters to query for pages with new page filters', function () {
       // Mock storage to have a saved value
       const pageFilterStorageMock = jest

--- a/static/app/actionCreators/pageFilters.spec.tsx
+++ b/static/app/actionCreators/pageFilters.spec.tsx
@@ -306,6 +306,33 @@ describe('PageFilters ActionCreators', function () {
       );
     });
 
+    it('does not invalidate all projects from query params', function () {
+      initializeUrlState({
+        organization,
+        queryParams: {
+          project: '-1',
+        },
+        memberProjects: organization.projects,
+        nonMemberProjects: [],
+        shouldEnforceSingleProject: false,
+        router,
+      });
+      expect(PageFiltersStore.onInitializeUrlState).toHaveBeenCalledWith(
+        {
+          datetime: {
+            start: null,
+            end: null,
+            period: '14d',
+            utc: null,
+          },
+          projects: [-1],
+          environments: [],
+        },
+        new Set(),
+        true
+      );
+    });
+
     it('does not add non-pinned filters to query for pages with new page filters', function () {
       // Mock storage to have a saved value
       const pageFilterStorageMock = jest

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -217,8 +217,8 @@ export function initializeUrlState({
    * shared links.
    */
   function validateProjectId(projectId: number): boolean {
-    if (projectId === ALL_ACCESS_PROJECTS && !shouldEnforceSingleProject) {
-      return true;
+    if (projectId === ALL_ACCESS_PROJECTS) {
+      return !shouldEnforceSingleProject;
     }
 
     return (

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -217,7 +217,7 @@ export function initializeUrlState({
    * shared links.
    */
   function validateProjectId(projectId: number): boolean {
-    if (projectId === ALL_ACCESS_PROJECTS) {
+    if (projectId === ALL_ACCESS_PROJECTS && !shouldEnforceSingleProject) {
       return true;
     }
 

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -16,7 +16,11 @@ import {
 } from 'sentry/components/organizations/pageFilters/persistence';
 import {PageFiltersStringified} from 'sentry/components/organizations/pageFilters/types';
 import {getDefaultSelection} from 'sentry/components/organizations/pageFilters/utils';
-import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/constants/pageFilters';
+import {
+  ALL_ACCESS_PROJECTS,
+  DATE_TIME_KEYS,
+  URL_PARAM,
+} from 'sentry/constants/pageFilters';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import {
@@ -212,10 +216,14 @@ export function initializeUrlState({
    * IDs (project was deleted/moved to another org) can still exist in local storage or
    * shared links.
    */
-  function validateProjectId(projectId: number) {
+  function validateProjectId(projectId: number): boolean {
+    if (projectId === ALL_ACCESS_PROJECTS) {
+      return true;
+    }
+
     return (
-      !!memberProjects?.find(mp => String(mp.id) === String(projectId)) ||
-      !!nonMemberProjects?.find(nmp => String(nmp.id) === String(projectId))
+      !!memberProjects?.some(mp => String(mp.id) === String(projectId)) ||
+      !!nonMemberProjects?.some(nmp => String(nmp.id) === String(projectId))
     );
   }
 
@@ -223,10 +231,10 @@ export function initializeUrlState({
    * Check to make sure that the environment exists. Invalid environments (due to being
    * hidden) can still exist in local storage or shared links.
    */
-  function validateEnvironment(env: string) {
+  function validateEnvironment(env: string): boolean {
     return (
-      !!memberProjects?.find(mp => mp.environments.includes(env)) ||
-      !!nonMemberProjects?.find(nmp => nmp.environments.includes(env))
+      !!memberProjects?.some(mp => mp.environments.includes(env)) ||
+      !!nonMemberProjects?.some(nmp => nmp.environments.includes(env))
     );
   }
 


### PR DESCRIPTION
Previously it was being overridden with "my projects" aka `[]` instead of `[-1]`

fixes #62089