### PR TITLE
fix(issues): Repeat issues request if project id changes

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -188,6 +188,8 @@ class IssueListOverview extends Component<Props, State> {
     ) {
       const loadedFromCache = this.loadFromCache();
       if (!loadedFromCache) {
+        // It's possible the projects query parameter is not yet ready and this
+        // request will be repeated in componentDidUpdate
         this.fetchData();
       }
     }
@@ -216,14 +218,9 @@ class IssueListOverview extends Component<Props, State> {
     }
 
     // Wait for saved searches to load before we attempt to fetch stream data
-    if (this.props.savedSearchLoading) {
-      return;
-    }
-
     if (
-      prevProps.savedSearchLoading &&
-      !this.props.savedSearchLoading &&
-      this.props.organization.features.includes('issue-stream-performance')
+      this.props.savedSearchLoading &&
+      !this.props.organization.features.includes('issue-stream-performance')
     ) {
       return;
     }
@@ -263,8 +260,10 @@ class IssueListOverview extends Component<Props, State> {
       prevUrlQuery.cursor !== newUrlQuery.cursor ||
       prevUrlQuery.statsPeriod !== newUrlQuery.statsPeriod ||
       prevUrlQuery.groupStatsPeriod !== newUrlQuery.groupStatsPeriod ||
-      prevQuery !== newQuery ||
-      prevSort !== newSort
+      prevSort !== newSort ||
+      // Ignore query changes when issue-stream-performance is live
+      (!this.props.organization.features.includes('issue-stream-performance') &&
+        prevQuery !== newQuery)
     ) {
       this.fetchData(selectionChanged);
     } else if (

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -217,10 +217,19 @@ class IssueListOverview extends Component<Props, State> {
       this.fetchTags();
     }
 
+    const selectionChanged = !isEqual(prevProps.selection, this.props.selection);
+
     // Wait for saved searches to load before we attempt to fetch stream data
+    // Selection changing could indicate that the projects query parameter has populated
+    // and we should refetch data.
+    if (this.props.savedSearchLoading && !selectionChanged) {
+      return;
+    }
+
     if (
-      this.props.savedSearchLoading &&
-      !this.props.organization.features.includes('issue-stream-performance')
+      prevProps.savedSearchLoading &&
+      !this.props.savedSearchLoading &&
+      this.props.organization.features.includes('issue-stream-performance')
     ) {
       return;
     }
@@ -251,8 +260,6 @@ class IssueListOverview extends Component<Props, State> {
     });
     const newSort = this.getSort();
 
-    const selectionChanged = !isEqual(prevProps.selection, this.props.selection);
-
     // If any important url parameter changed or saved search changed
     // reload data.
     if (
@@ -260,10 +267,8 @@ class IssueListOverview extends Component<Props, State> {
       prevUrlQuery.cursor !== newUrlQuery.cursor ||
       prevUrlQuery.statsPeriod !== newUrlQuery.statsPeriod ||
       prevUrlQuery.groupStatsPeriod !== newUrlQuery.groupStatsPeriod ||
-      prevSort !== newSort ||
-      // Ignore query changes when issue-stream-performance is live
-      (!this.props.organization.features.includes('issue-stream-performance') &&
-        prevQuery !== newQuery)
+      prevQuery !== newQuery ||
+      prevSort !== newSort
     ) {
       this.fetchData(selectionChanged);
     } else if (


### PR DESCRIPTION
When navigating to issues from another page via the sidebar:
- The project id is not present on component mount, but we start the first request without it
- The project id gets set but we're exiting early in component did mount https://github.com/getsentry/sentry/blob/0970ab84f7275506d828c1b1c40b10275af93f40/static/app/views/issueList/overview.tsx#L223-L229
- The page then errors as the project id does not match groups that were presented

fixes #61823
