### PR TITLE
ref(ts): Remove usage of `TestStubs.MetricsRule`

### DIFF
--- a/fixtures/js-stubs/metricRule.ts
+++ b/fixtures/js-stubs/metricRule.ts
@@ -1,15 +1,16 @@
 import {IncidentTrigger} from 'sentry-fixture/incidentTrigger';
 
-import type {MetricRule as TMetricRule} from 'sentry/views/alerts/rules/metric/types';
+import type {SavedMetricRule as SavedMetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 
-export function MetricRule(params: Partial<TMetricRule> = {}): TMetricRule {
+export function MetricRule(params: Partial<SavedMetricRule> = {}): SavedMetricRule {
   return {
     status: 0,
     dateCreated: '2019-07-31T23:02:02.731Z',
     dataset: Dataset.ERRORS,
     query: '',
     id: '4',
+    snooze: false,
     name: 'My Incident Rule',
     timeWindow: 60,
     aggregate: 'count()',

--- a/static/app/views/alerts/rules/metric/details/index.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.spec.tsx
@@ -1,6 +1,7 @@
 import {EventsStats} from 'sentry-fixture/events';
 import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Incident} from 'sentry-fixture/incident';
+import {MetricRule as MetricRuleFixture} from 'sentry-fixture/metricRule';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -44,7 +45,7 @@ describe('MetricAlertDetails', () => {
   it('renders', async () => {
     const {routerContext, organization, routerProps} = initializeOrg();
     const incident = Incident();
-    const rule = TestStubs.MetricRule({
+    const rule = MetricRuleFixture({
       projects: [project.slug],
       latestIncident: incident,
     });
@@ -84,7 +85,7 @@ describe('MetricAlertDetails', () => {
 
   it('renders selected incident', async () => {
     const {routerContext, organization, router, routerProps} = initializeOrg();
-    const rule = TestStubs.MetricRule({projects: [project.slug]});
+    const rule = MetricRuleFixture({projects: [project.slug]});
     const incident = Incident();
 
     MockApiClient.addMockResponse({
@@ -132,7 +133,7 @@ describe('MetricAlertDetails', () => {
   it('renders mute button for metric alert', async () => {
     const {routerContext, organization, routerProps} = initializeOrg();
     const incident = Incident();
-    const rule = TestStubs.MetricRule({
+    const rule = MetricRuleFixture({
       projects: [project.slug],
       latestIncident: incident,
     });
@@ -179,7 +180,7 @@ describe('MetricAlertDetails', () => {
     const {routerContext, organization, routerProps} = initializeOrg({
       organization: {features: ['discover-basic', 'metric-alert-ignore-archived']},
     });
-    const rule = TestStubs.MetricRule({
+    const rule = MetricRuleFixture({
       projects: [project.slug],
       dataset: Dataset.ERRORS,
       query: 'is:unresolved',


### PR DESCRIPTION
8EZ.

- Replace `TestStubs.MetricRule` with import
- Fix types of `MetricRule` fixture

getsentry/frontend-tsc#49
