### PR TITLE
ref(ts): Remove usage of `TestStubs.Event`

### DIFF
--- a/fixtures/js-stubs/event.ts
+++ b/fixtures/js-stubs/event.ts
@@ -1,4 +1,4 @@
-import {type Event as TEvent, EventOrGroupType} from 'sentry/types';
+import {type Event as TEvent, EventOrGroupType, EventTransaction} from 'sentry/types';
 
 export function Event(params = {}): TEvent {
   return {
@@ -24,6 +24,38 @@ export function Event(params = {}): TEvent {
     type: EventOrGroupType.ERROR,
     occurrence: null,
     resolvedWith: [],
+    contexts: {},
+    ...params,
+  };
+}
+
+export function TransactionEvent(
+  params: Partial<EventTransaction> = {}
+): EventTransaction {
+  return {
+    type: EventOrGroupType.TRANSACTION,
+    id: '1',
+    message: '',
+    crashFile: null,
+    culprit: '',
+    dateCreated: '2023-12-28T15:58:48.762Z',
+    dist: '',
+    errors: [],
+    occurrence: null,
+    dateReceived: '2023-12-28T15:58:48.762Z',
+    size: 0,
+    user: null,
+    title: '',
+    metadata: {},
+    entries: [],
+    projectID: '1',
+    groupID: '1',
+    eventID: '47829ecde95d42ac843f24592b7b7e46',
+    tags: [],
+    endTimestamp: 1703779100,
+    startTimestamp: 1703779101,
+    fingerprints: [],
+    location: '',
     contexts: {},
     ...params,
   };

--- a/static/app/components/events/interfaces/spans/traceErrorList.spec.tsx
+++ b/static/app/components/events/interfaces/spans/traceErrorList.spec.tsx
@@ -1,3 +1,4 @@
+import {TransactionEvent as EventFixture} from 'sentry-fixture/event';
 import {Span} from 'sentry-fixture/span';
 import {TraceError} from 'sentry-fixture/traceError';
 import {TracePerformanceIssue} from 'sentry-fixture/tracePerformanceIssue';
@@ -6,13 +7,14 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import TraceErrorList from 'sentry/components/events/interfaces/spans/traceErrorList';
 import {parseTrace} from 'sentry/components/events/interfaces/spans/utils';
+import {EntryType} from 'sentry/types';
 
 describe('TraceErrorList', () => {
   it('aggregates errors by span and level', () => {
-    const event = TestStubs.Event({
+    const event = EventFixture({
       entries: [
         {
-          type: 'spans',
+          type: EntryType.SPANS,
           data: [
             Span({
               op: '/api/fetchitems',
@@ -50,7 +52,7 @@ describe('TraceErrorList', () => {
   });
 
   it('groups span-less errors under the transaction', () => {
-    const event = TestStubs.Event({
+    const event = EventFixture({
       contexts: {
         trace: {
           op: '/path',
@@ -58,7 +60,7 @@ describe('TraceErrorList', () => {
       },
       entries: [
         {
-          type: 'spans',
+          type: EntryType.SPANS,
           data: [
             Span({
               op: '/api/fetchitems',
@@ -83,7 +85,7 @@ describe('TraceErrorList', () => {
   });
 
   it('groups performance issues separately', () => {
-    const event = TestStubs.Event({
+    const event = EventFixture({
       contexts: {
         trace: {
           op: '/path',
@@ -91,7 +93,7 @@ describe('TraceErrorList', () => {
       },
       entries: [
         {
-          type: 'spans',
+          type: EntryType.SPANS,
           data: [
             Span({
               op: '/api/fetchitems',


### PR DESCRIPTION
9EZ.

- Add `TransactionEvent` fixture
- Replace `TestStubs.Event` with import

https://github.com/getsentry/frontend-tsc/issues/49