### PR TITLE
ref(ts): Remove usage of `TestStubs.SentryApp*`

### DIFF
--- a/fixtures/js-stubs/sentryAppComponent.ts
+++ b/fixtures/js-stubs/sentryAppComponent.ts
@@ -1,11 +1,11 @@
 import {
   SentryAppComponent as TSentryAppComponent,
-  SentryAppSchemaElement,
+  SentryAppSchemaIssueLink,
 } from 'sentry/types';
 
 export function SentryAppComponent(
   params = {}
-): TSentryAppComponent<SentryAppSchemaElement> {
+): TSentryAppComponent<SentryAppSchemaIssueLink> {
   return {
     uuid: 'ed517da4-a324-44c0-aeea-1894cd9923fb',
     type: 'issue-link',
@@ -59,7 +59,7 @@ export function SentryAppComponent(
 }
 export function SentryAppComponentAsync(
   params = {}
-): TSentryAppComponent<SentryAppSchemaElement> {
+): TSentryAppComponent<SentryAppSchemaIssueLink> {
   return {
     uuid: 'ed517da4-a324-44c0-aeea-1894cd9923fb',
     type: 'issue-link',
@@ -101,7 +101,7 @@ export function SentryAppComponentAsync(
 
 export function SentryAppComponentDependent(
   params = {}
-): TSentryAppComponent<SentryAppSchemaElement> {
+): TSentryAppComponent<SentryAppSchemaIssueLink> {
   return {
     type: 'issue-link',
     uuid: 'ed517da4-a324-44c0-aeea-1894cd9923fb',

--- a/static/app/components/group/sentryAppExternalIssueActions.spec.tsx
+++ b/static/app/components/group/sentryAppExternalIssueActions.spec.tsx
@@ -2,6 +2,7 @@ import {Event as EventFixture} from 'sentry-fixture/event';
 import {Group as GroupFixture} from 'sentry-fixture/group';
 import {Organization} from 'sentry-fixture/organization';
 import {SentryApp} from 'sentry-fixture/sentryApp';
+import {SentryAppComponent} from 'sentry-fixture/sentryAppComponent';
 import {SentryAppInstallation} from 'sentry-fixture/sentryAppInstallation';
 
 import {
@@ -16,7 +17,7 @@ import SentryAppExternalIssueActions from 'sentry/components/group/sentryAppExte
 describe('SentryAppExternalIssueActions', () => {
   const group = GroupFixture();
   const sentryApp = SentryApp();
-  const component = TestStubs.SentryAppComponent({
+  const component = SentryAppComponent({
     sentryApp: {
       uuid: sentryApp.uuid,
       slug: sentryApp.slug,

--- a/static/app/components/group/sentryAppExternalIssueForm.spec.tsx
+++ b/static/app/components/group/sentryAppExternalIssueForm.spec.tsx
@@ -2,6 +2,11 @@ import selectEvent from 'react-select-event';
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {Group as GroupFixture} from 'sentry-fixture/group';
 import {SentryApp} from 'sentry-fixture/sentryApp';
+import {
+  SentryAppComponent,
+  SentryAppComponentAsync,
+  SentryAppComponentDependent,
+} from 'sentry-fixture/sentryAppComponent';
 import {SentryAppInstallation} from 'sentry-fixture/sentryAppInstallation';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -15,7 +20,7 @@ describe('SentryAppExternalIssueForm', () => {
     shortId: 'SEN123',
     permalink: 'https://sentry.io/organizations/sentry/issues/123/?project=1',
   });
-  const component = TestStubs.SentryAppComponent();
+  const component = SentryAppComponent();
   const sentryApp = SentryApp();
   const sentryAppInstallation = SentryAppInstallation({});
   const submitUrl = `/sentry-app-installations/${sentryAppInstallation.uuid}/external-issue-actions/`;
@@ -149,7 +154,7 @@ describe('SentryAppExternalIssueForm', () => {
 });
 
 describe('SentryAppExternalIssueForm Async Field', () => {
-  const component = TestStubs.SentryAppComponentAsync();
+  const component = SentryAppComponentAsync();
   const group = GroupFixture({
     title: 'ApiError: Broken',
     shortId: 'SEN123',
@@ -203,7 +208,7 @@ describe('SentryAppExternalIssueForm Dependent fields', () => {
   });
   const sentryApp = SentryApp();
   const sentryAppInstallation = SentryAppInstallation({});
-  const component = TestStubs.SentryAppComponentDependent();
+  const component = SentryAppComponentDependent();
 
   afterEach(() => {
     MockApiClient.clearMockResponses();

--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
@@ -27,8 +27,8 @@ export type FieldFromSchema = Omit<Field, 'choices' | 'type'> & {
 };
 
 export type SchemaFormConfig = {
-  description: string | null;
   uri: string;
+  description?: string;
   optional_fields?: FieldFromSchema[];
   required_fields?: FieldFromSchema[];
 };


### PR DESCRIPTION
This one was a little trickier. Some of the types seem to disagree with reality.

## Changes

- Fix typing in `SentryAppComponent` fixture
    
    The type is lying! It's saying it's an `Element` but it's in fact an
    `IssueLink`

- Adjust `SchemaFormConfig` type
    
    The `description` field is specified as `string | null` but as far as I
    can tell it isn't used, and this disagrees with how app schemas are
    defined.

https://github.com/getsentry/frontend-tsc/issues/49
