### PR TITLE
fix(celery): Implement Kafka producer shutdown correctly

### DIFF
--- a/src/sentry/usage_accountant/accountant.py
+++ b/src/sentry/usage_accountant/accountant.py
@@ -17,7 +17,7 @@ from django.conf import settings
 from usageaccountant import UsageAccumulator, UsageUnit
 
 from sentry.options import get
-from sentry.utils.celery import register_shutdown
+from sentry.utils.celery import register_celery_shutdown
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 logger = logging.getLogger(__name__)
@@ -84,6 +84,7 @@ def record(
         )
 
         _accountant_backend = UsageAccumulator(producer=producer)
-        register_shutdown(_shutdown)
+        register_celery_shutdown(_shutdown)
+        atexit.register(_shutdown)
 
     _accountant_backend.record(resource_id, app_feature, amount, usage_type)

--- a/src/sentry/usage_accountant/accountant.py
+++ b/src/sentry/usage_accountant/accountant.py
@@ -17,6 +17,7 @@ from django.conf import settings
 from usageaccountant import UsageAccumulator, UsageUnit
 
 from sentry.options import get
+from sentry.utils.celery import register_shutdown
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,7 @@ def _shutdown() -> None:
         _accountant_backend.flush()
         _accountant_backend.close()
         logger.info("Usage accountant flushed and closed.")
+        reset_backend()
 
 
 def record(
@@ -82,6 +84,6 @@ def record(
         )
 
         _accountant_backend = UsageAccumulator(producer=producer)
-        atexit.register(_shutdown)
+        register_shutdown(_shutdown)
 
     _accountant_backend.record(resource_id, app_feature, amount, usage_type)

--- a/src/sentry/utils/arroyo_producer.py
+++ b/src/sentry/utils/arroyo_producer.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import atexit
 from collections import deque
 from concurrent import futures
 from typing import TYPE_CHECKING, Callable, Deque, Optional, Union
 
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from arroyo.types import BrokerValue, Partition, Topic
+
+from sentry.utils.shutdown import register_shutdown
 
 if TYPE_CHECKING:
     ProducerFuture = futures.Future[BrokerValue[KafkaPayload]]
@@ -38,7 +39,8 @@ class SingletonProducer:
     def _get(self) -> KafkaProducer:
         if self._producer is None:
             self._producer = self._factory()
-            atexit.register(self._shutdown)
+
+            register_shutdown(self._shutdown)
 
         return self._producer
 

--- a/src/sentry/utils/arroyo_producer.py
+++ b/src/sentry/utils/arroyo_producer.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Callable, Deque, Optional, Union
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer
 from arroyo.types import BrokerValue, Partition, Topic
 
-from sentry.utils.shutdown import register_shutdown
+from sentry.utils.celery import register_shutdown
 
 if TYPE_CHECKING:
     ProducerFuture = futures.Future[BrokerValue[KafkaPayload]]

--- a/src/sentry/utils/celery.py
+++ b/src/sentry/utils/celery.py
@@ -23,13 +23,16 @@ def run_shutdown(*args, **kwargs):
             logger.warning("celery.shutdown.failed", exc_info=True)
 
 
-def register_shutdown(func: Callable[[], Any]) -> None:
+def register_celery_shutdown(func: Callable[[], Any]) -> None:
     """
     Register a callback to be run when celery subprocess shuts down. This is
     not 100% failsafe (in case the Celery task OOMs, experiences hard-timeouts
     or segfaults) but makes it relatively easy to produce to Kafka from celery
     tasks, reuse the producer across tasks and only flush the batch when the
     worker subprocess is being shut down (see max_tasks_per_child)
+
+    This is specific to celery, in other environments such as uwsgi, other
+    hooks need to be used.
 
     The Sentry Python SDK has a more robust and battle-tested variant of this
     in its Celery integration, but that one is more complicated as it is

--- a/src/sentry/utils/celery.py
+++ b/src/sentry/utils/celery.py
@@ -1,8 +1,39 @@
+import logging
 from random import randint
+from typing import Any, Callable, List
 
 from celery.schedules import crontab
+
+logger = logging.getLogger(__name__)
 
 
 def crontab_with_minute_jitter(*args, **kwargs):
     kwargs["minute"] = randint(0, 59)
     return crontab(*args, **kwargs)
+
+
+_celery_shutdown_handlers: List[Callable[[], None]] = []
+
+
+def run_shutdown(*args, **kwargs):
+    for handler in _celery_shutdown_handlers:
+        try:
+            handler()
+        except Exception:
+            logger.warning("celery.shutdown.failed", exc_info=True)
+
+
+def register_shutdown(func: Callable[[], Any]) -> None:
+    """
+    Register a callback to be run when celery subprocess shuts down. This is
+    not 100% failsafe (in case the Celery task OOMs, experiences hard-timeouts
+    or segfaults) but makes it relatively easy to produce to Kafka from celery
+    tasks, reuse the producer across tasks and only flush the batch when the
+    worker subprocess is being shut down (see max_tasks_per_child)
+
+    The Sentry Python SDK has a more robust and battle-tested variant of this
+    in its Celery integration, but that one is more complicated as it is
+    supposed to work under Celery 3.
+    """
+
+    _celery_shutdown_handlers.append(func)


### PR DESCRIPTION
There are a few uses of atexit in our codebase to reuse an object like a
Kafka producer across multiple tasks. It turns out that atexit works in
only a few circumstances, even in Celery 5. This particularly
matters in two cases:

1. an exception ending the worker process
2. celery main process deciding to reap the subprocess via SIGTERM (such
   as when hitting max_tasks_per_child) -- this actually happens very
   often.

It is more reliable to patch the worker loop to run shutdown reliably,
like we do in the SDK.

I tested this change manually and have a rough idea how to write an
automated test for it, just putting this PR up for discussion for now.
