### PR TITLE
ref(ts): Remove usage of `TestStubs.Project`

### DIFF
--- a/static/app/actionCreators/events.spec.tsx
+++ b/static/app/actionCreators/events.spec.tsx
@@ -1,11 +1,12 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Project as ProjectFixture} from 'sentry-fixture/project';
 
 import {doEventsRequest} from 'sentry/actionCreators/events';
 
 describe('Events ActionCreator', function () {
   const api = new MockApiClient();
   const organization = Organization();
-  const project = TestStubs.Project();
+  const project = ProjectFixture();
   const opts = {
     organization,
     project: [project.id],

--- a/static/app/actionCreators/events.spec.tsx
+++ b/static/app/actionCreators/events.spec.tsx
@@ -9,7 +9,7 @@ describe('Events ActionCreator', function () {
   const project = ProjectFixture();
   const opts = {
     organization,
-    project: [project.id],
+    project: [parseInt(project.id, 10)],
     environment: [],
   };
 
@@ -44,7 +44,7 @@ describe('Events ActionCreator', function () {
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
-          project: [project.id],
+          project: [parseInt(project.id, 10)],
           environment: [],
           statsPeriod: '7d',
         }),
@@ -64,7 +64,7 @@ describe('Events ActionCreator', function () {
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
-          project: [project.id],
+          project: [parseInt(project.id, 10)],
           environment: [],
           statsPeriod: '14d',
         }),
@@ -88,7 +88,7 @@ describe('Events ActionCreator', function () {
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
-          project: [project.id],
+          project: [parseInt(project.id, 10)],
           environment: [],
           start: '2017-10-12T12:00:00',
           end: '2017-10-17T00:00:00',
@@ -112,7 +112,7 @@ describe('Events ActionCreator', function () {
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
-          project: [project.id],
+          project: [parseInt(project.id, 10)],
           environment: [],
           start: '2017-10-08T00:00:00',
           end: '2017-10-17T00:00:00',
@@ -132,7 +132,7 @@ describe('Events ActionCreator', function () {
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
         query: expect.objectContaining({
-          project: [project.id],
+          project: [parseInt(project.id, 10)],
           environment: [],
           useOnDemandMetrics: 'true',
         }),

--- a/static/app/components/createAlertButton.spec.tsx
+++ b/static/app/components/createAlertButton.spec.tsx
@@ -111,13 +111,13 @@ describe('CreateAlertFromViewButton', () => {
         ...ProjectFixture(),
         id: '1',
         slug: 'admin-team',
-        access: ['alerts:write'],
+        access: ['alerts:write' as const],
       },
       {
         ...ProjectFixture(),
         id: '2',
         slug: 'contributor-team',
-        access: ['alerts:read'],
+        access: ['alerts:read' as const],
       },
     ];
 

--- a/static/app/components/createAlertButton.spec.tsx
+++ b/static/app/components/createAlertButton.spec.tsx
@@ -109,13 +109,13 @@ describe('CreateAlertFromViewButton', () => {
     const projects = [
       {
         ...ProjectFixture(),
-        id: 1,
+        id: '1',
         slug: 'admin-team',
         access: ['alerts:write'],
       },
       {
         ...ProjectFixture(),
-        id: 2,
+        id: '2',
         slug: 'contributor-team',
         access: ['alerts:read'],
       },

--- a/static/app/components/createAlertButton.spec.tsx
+++ b/static/app/components/createAlertButton.spec.tsx
@@ -1,4 +1,5 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Project as ProjectFixture} from 'sentry-fixture/project';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -34,7 +35,7 @@ describe('CreateAlertFromViewButton', () => {
       <CreateAlertFromViewButton
         organization={organization}
         eventView={eventView}
-        projects={[TestStubs.Project()]}
+        projects={[ProjectFixture()]}
         onClick={onClickMock}
       />,
       {context}
@@ -52,7 +53,7 @@ describe('CreateAlertFromViewButton', () => {
       access: [],
     };
     const noAccessProj = {
-      ...TestStubs.Project(),
+      ...ProjectFixture(),
       access: [],
     };
 
@@ -77,7 +78,7 @@ describe('CreateAlertFromViewButton', () => {
       ...DEFAULT_EVENT_VIEW,
     });
     const noAccessProj = {
-      ...TestStubs.Project(),
+      ...ProjectFixture(),
       access: [],
     };
 
@@ -107,13 +108,13 @@ describe('CreateAlertFromViewButton', () => {
     };
     const projects = [
       {
-        ...TestStubs.Project(),
+        ...ProjectFixture(),
         id: 1,
         slug: 'admin-team',
         access: ['alerts:write'],
       },
       {
-        ...TestStubs.Project(),
+        ...ProjectFixture(),
         id: 2,
         slug: 'contributor-team',
         access: ['alerts:read'],
@@ -200,7 +201,7 @@ describe('CreateAlertFromViewButton', () => {
       <CreateAlertFromViewButton
         organization={organization}
         eventView={eventView}
-        projects={[TestStubs.Project()]}
+        projects={[ProjectFixture()]}
         onClick={onClickMock}
       />,
       {context}

--- a/static/app/components/onboardingWizard/useOnboardingDocs.spec.tsx
+++ b/static/app/components/onboardingWizard/useOnboardingDocs.spec.tsx
@@ -1,3 +1,5 @@
+import {Project as ProjectFixture} from 'sentry-fixture/project';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
@@ -22,7 +24,7 @@ describe('useOnboardingDocs', function () {
         {children}
       </OrganizationContext.Provider>
     );
-    const project = TestStubs.Project({
+    const project = ProjectFixture({
       platform: 'javascript-react',
       firstTransactionEvent: false,
     });
@@ -76,7 +78,7 @@ describe('useOnboardingDocs', function () {
         {children}
       </OrganizationContext.Provider>
     );
-    const project = TestStubs.Project({
+    const project = ProjectFixture({
       platform: 'javascript-angular',
       firstTransactionEvent: false,
     });
@@ -125,7 +127,7 @@ describe('useOnboardingDocs', function () {
         {children}
       </OrganizationContext.Provider>
     );
-    const project = TestStubs.Project({
+    const project = ProjectFixture({
       platform: 'elixir',
       firstTransactionEvent: false,
     });

--- a/static/app/components/onboardingWizard/useOnboardingDocs.spec.tsx
+++ b/static/app/components/onboardingWizard/useOnboardingDocs.spec.tsx
@@ -8,7 +8,7 @@ import {
   generateDocKeys,
   isPlatformSupported,
 } from 'sentry/components/performanceOnboarding/utils';
-import {PlatformIntegration} from 'sentry/types';
+import {PlatformIntegration, PlatformKey, Project} from 'sentry/types';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 describe('useOnboardingDocs', function () {
@@ -27,7 +27,7 @@ describe('useOnboardingDocs', function () {
     const project = ProjectFixture({
       platform: 'javascript-react',
       firstTransactionEvent: false,
-    });
+    }) as Project & {platform: PlatformKey};
 
     const apiMocks: any = {};
 
@@ -81,7 +81,7 @@ describe('useOnboardingDocs', function () {
     const project = ProjectFixture({
       platform: 'javascript-angular',
       firstTransactionEvent: false,
-    });
+    }) as Project & {platform: PlatformKey};
 
     const apiMocks: any = {};
 
@@ -130,7 +130,7 @@ describe('useOnboardingDocs', function () {
     const project = ProjectFixture({
       platform: 'elixir',
       firstTransactionEvent: false,
-    });
+    }) as Project & {platform: PlatformKey};
 
     const apiMocks: any = {};
 

--- a/static/app/components/performanceOnboarding/utils.spec.tsx
+++ b/static/app/components/performanceOnboarding/utils.spec.tsx
@@ -1,5 +1,6 @@
-import {PlatformIntegration} from 'sentry/types';
 import {Project as ProjectFixture} from 'sentry-fixture/project';
+
+import {PlatformIntegration, PlatformKey, Project} from 'sentry/types';
 
 import {generateDocKeys, isPlatformSupported} from './utils';
 
@@ -8,7 +9,7 @@ describe('performanceOnboarding/utils/generateDocKeys()', () => {
     const project = ProjectFixture({
       platform: 'javascript-react',
       firstTransactionEvent: false,
-    });
+    }) as Project & {platform: PlatformKey};
 
     const docKeys = generateDocKeys(project.platform);
 
@@ -23,7 +24,7 @@ describe('performanceOnboarding/utils/generateDocKeys()', () => {
     const project = ProjectFixture({
       platform: 'javascript-angular',
       firstTransactionEvent: false,
-    });
+    }) as Project & {platform: PlatformKey};
 
     const docKeys = generateDocKeys(project.platform);
 
@@ -38,7 +39,7 @@ describe('performanceOnboarding/utils/generateDocKeys()', () => {
     const project = ProjectFixture({
       platform: 'elixir',
       firstTransactionEvent: false,
-    });
+    }) as Project & {platform: PlatformKey};
 
     const docKeys = generateDocKeys(project.platform);
 

--- a/static/app/components/performanceOnboarding/utils.spec.tsx
+++ b/static/app/components/performanceOnboarding/utils.spec.tsx
@@ -1,10 +1,11 @@
 import {PlatformIntegration} from 'sentry/types';
+import {Project as ProjectFixture} from 'sentry-fixture/project';
 
 import {generateDocKeys, isPlatformSupported} from './utils';
 
 describe('performanceOnboarding/utils/generateDocKeys()', () => {
   it('should generate the correct onboarding keys for a React project', () => {
-    const project = TestStubs.Project({
+    const project = ProjectFixture({
       platform: 'javascript-react',
       firstTransactionEvent: false,
     });
@@ -19,7 +20,7 @@ describe('performanceOnboarding/utils/generateDocKeys()', () => {
   });
 
   it('should generate the correct onboarding keys for an Angular project', () => {
-    const project = TestStubs.Project({
+    const project = ProjectFixture({
       platform: 'javascript-angular',
       firstTransactionEvent: false,
     });
@@ -34,7 +35,7 @@ describe('performanceOnboarding/utils/generateDocKeys()', () => {
   });
 
   it('should generate the correct onboarding keys for an Elixir project', () => {
-    const project = TestStubs.Project({
+    const project = ProjectFixture({
       platform: 'elixir',
       firstTransactionEvent: false,
     });

--- a/static/app/utils/replays/hooks/useInitialTimeOffsetMs.spec.tsx
+++ b/static/app/utils/replays/hooks/useInitialTimeOffsetMs.spec.tsx
@@ -117,7 +117,7 @@ describe('useInitialTimeOffsetMs', () => {
             orgSlug: organization.slug,
             projectSlug: project.slug,
             replayId: replay.id,
-            replayStartTimestampMs: undefined,
+            replayStartTimestampMs: undefined as number | undefined,
           },
         }
       );
@@ -226,7 +226,7 @@ describe('useInitialTimeOffsetMs', () => {
             orgSlug: organization.slug,
             projectSlug: project.slug,
             replayId: replay.id,
-            replayStartTimestampMs: undefined,
+            replayStartTimestampMs: undefined as number | undefined,
           },
         }
       );

--- a/static/app/views/alerts/utils/utils.spec.tsx
+++ b/static/app/views/alerts/utils/utils.spec.tsx
@@ -1,3 +1,4 @@
+import {Incident as IncidentFixture} from 'sentry-fixture/incident';
 import {MetricRule} from 'sentry-fixture/metricRule';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -7,7 +8,7 @@ import {
   Datasource,
   SessionsAggregate,
 } from 'sentry/views/alerts/rules/metric/types';
-import {Incident, IncidentStats} from 'sentry/views/alerts/types';
+import {IncidentStats} from 'sentry/views/alerts/types';
 import {
   alertAxisFormatter,
   alertTooltipValueFormatter,
@@ -33,17 +34,16 @@ describe('Alert utils', function () {
 
   describe('getIncidentDiscoverUrl', function () {
     it('creates a discover query url for errors', function () {
-      // TODO(ts): Add a TestStub for Incident
-      const incident: Incident = {
+      const incident = IncidentFixture({
         title: 'Test error alert',
         discoverQuery: 'id:test',
-        projects,
+        projects: projects.map(project => project.id),
         alertRule: MetricRule({
           timeWindow: 1,
           dataset: Dataset.ERRORS,
           aggregate: 'count()',
         }),
-      } as Incident;
+      });
 
       const to = getIncidentDiscoverUrl({
         orgSlug: organization.slug,
@@ -68,17 +68,16 @@ describe('Alert utils', function () {
     });
 
     it('creates a discover query url for transactions', function () {
-      // TODO(ts): Add a TestStub for Incident
-      const incident = {
+      const incident = IncidentFixture({
         title: 'Test transaction alert',
         discoverQuery: 'id:test',
-        projects,
+        projects: projects.map(project => project.id),
         alertRule: MetricRule({
           timeWindow: 1,
           dataset: Dataset.TRANSACTIONS,
           aggregate: 'p90()',
         }),
-      } as Incident;
+      });
 
       const to = getIncidentDiscoverUrl({
         orgSlug: organization.slug,

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -5,6 +5,7 @@ import {CommitAuthor} from 'sentry-fixture/commitAuthor';
 import {Event as EventFixture} from 'sentry-fixture/event';
 import {Group as GroupFixture} from 'sentry-fixture/group';
 import LocationFixture from 'sentry-fixture/locationFixture';
+import {Project as ProjectFixture} from 'sentry-fixture/project';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 import RouterFixture from 'sentry-fixture/routerFixture';
 import {SentryApp} from 'sentry-fixture/sentryApp';
@@ -468,7 +469,7 @@ describe('EventCause', () => {
   it('renders suspect commit', async function () {
     const props = makeDefaultMockData(
       undefined,
-      TestStubs.Project({firstEvent: EventFixture()})
+      ProjectFixture({firstEvent: EventFixture().dateCreated})
     );
 
     mockGroupApis(

--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -6,7 +6,7 @@ import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestin
 import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
 import {ProductSolution} from 'sentry/components/onboarding/productSelection';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {Organization, Project} from 'sentry/types';
+import {OnboardingRecentCreatedProject, Organization, Project} from 'sentry/types';
 import SetupDocs from 'sentry/views/onboarding/setupDocs';
 
 const PROJECT_KEY = ProjectKeys()[0];
@@ -84,7 +84,7 @@ describe('Onboarding Setup Docs', function () {
           genSkipOnboardingLink={() => ''}
           orgId={organization.slug}
           search=""
-          recentCreatedProject={project}
+          recentCreatedProject={project as OnboardingRecentCreatedProject}
         />
       </OnboardingContextProvider>,
       {
@@ -132,7 +132,7 @@ describe('Onboarding Setup Docs', function () {
           genSkipOnboardingLink={() => ''}
           orgId={organization.slug}
           search=""
-          recentCreatedProject={project}
+          recentCreatedProject={project as OnboardingRecentCreatedProject}
         />
       </OnboardingContextProvider>,
       {
@@ -188,7 +188,7 @@ describe('Onboarding Setup Docs', function () {
             genSkipOnboardingLink={() => ''}
             orgId={organization.slug}
             search=""
-            recentCreatedProject={project}
+            recentCreatedProject={project as OnboardingRecentCreatedProject}
           />
         </OnboardingContextProvider>,
         {
@@ -242,7 +242,7 @@ describe('Onboarding Setup Docs', function () {
             genSkipOnboardingLink={() => ''}
             orgId={organization.slug}
             search=""
-            recentCreatedProject={project}
+            recentCreatedProject={project as OnboardingRecentCreatedProject}
           />
         </OnboardingContextProvider>,
         {
@@ -292,7 +292,7 @@ describe('Onboarding Setup Docs', function () {
             genSkipOnboardingLink={() => ''}
             orgId={organization.slug}
             search=""
-            recentCreatedProject={project}
+            recentCreatedProject={project as OnboardingRecentCreatedProject}
           />
         </OnboardingContextProvider>,
         {
@@ -342,7 +342,7 @@ describe('Onboarding Setup Docs', function () {
             genSkipOnboardingLink={() => ''}
             orgId={organization.slug}
             search=""
-            recentCreatedProject={project}
+            recentCreatedProject={project as OnboardingRecentCreatedProject}
           />
         </OnboardingContextProvider>,
         {
@@ -407,7 +407,7 @@ describe('Onboarding Setup Docs', function () {
             genSkipOnboardingLink={() => ''}
             orgId={organization.slug}
             search=""
-            recentCreatedProject={project}
+            recentCreatedProject={project as OnboardingRecentCreatedProject}
           />
         </OnboardingContextProvider>,
         {
@@ -453,7 +453,7 @@ describe('Onboarding Setup Docs', function () {
             genSkipOnboardingLink={() => ''}
             orgId={organization.slug}
             search=""
-            recentCreatedProject={project}
+            recentCreatedProject={project as OnboardingRecentCreatedProject}
           />
         </OnboardingContextProvider>
       );
@@ -506,7 +506,7 @@ describe('Onboarding Setup Docs', function () {
             genSkipOnboardingLink={() => ''}
             orgId={organization.slug}
             search=""
-            recentCreatedProject={project}
+            recentCreatedProject={project as OnboardingRecentCreatedProject}
           />
         </OnboardingContextProvider>,
         {

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -271,7 +271,7 @@ describe('Performance > Landing > Index', function () {
     expect(screen.getByTestId('frontend-other-view')).toBeInTheDocument();
 
     const updatedData = initializeData({
-      projects: [ProjectFixture({id: '123', platform: 'unknown})],
+      projects: [ProjectFixture({id: '123', platform: undefined})],
       selectedProject: 123,
     });
 

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import {Project as ProjectFixture} from 'sentry-fixture/project';
 
 import {addMetricsDataMock} from 'sentry-test/performance/addMetricsDataMock';
 import {initializeData} from 'sentry-test/performance/initializePerformanceData';
@@ -182,7 +183,7 @@ describe('Performance > Landing > Index', function () {
   });
 
   it('renders react-native table headers in mobile view', async function () {
-    const project = TestStubs.Project({platform: 'react-native'});
+    const project = ProjectFixture({platform: 'react-native'});
     const projects = [project];
     const data = initializeData({
       query: {landingDisplay: LandingDisplayField.MOBILE},
@@ -270,7 +271,7 @@ describe('Performance > Landing > Index', function () {
     expect(screen.getByTestId('frontend-other-view')).toBeInTheDocument();
 
     const updatedData = initializeData({
-      projects: [TestStubs.Project({id: 123, platform: 'unknown'})],
+      projects: [ProjectFixture({id: 123, platform: 'unknown'})],
       selectedProject: 123,
     });
 
@@ -281,7 +282,7 @@ describe('Performance > Landing > Index', function () {
 
   it('View correctly defaults based on project without url param', function () {
     const data = initializeData({
-      projects: [TestStubs.Project({id: 99, platform: 'javascript-react'})],
+      projects: [ProjectFixture({id: 99, platform: 'javascript-react'})],
       selectedProject: 99,
     });
 

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -271,7 +271,7 @@ describe('Performance > Landing > Index', function () {
     expect(screen.getByTestId('frontend-other-view')).toBeInTheDocument();
 
     const updatedData = initializeData({
-      projects: [ProjectFixture({id: 123, platform: 'unknown'})],
+      projects: [ProjectFixture({id: '123', platform: 'unknown})],
       selectedProject: 123,
     });
 
@@ -282,7 +282,7 @@ describe('Performance > Landing > Index', function () {
 
   it('View correctly defaults based on project without url param', function () {
     const data = initializeData({
-      projects: [ProjectFixture({id: 99, platform: 'javascript-react'})],
+      projects: [ProjectFixture({id: '99', platform: 'javascript-react'})],
       selectedProject: 99,
     });
 

--- a/static/app/views/performance/transactionSummary/header.spec.tsx
+++ b/static/app/views/performance/transactionSummary/header.spec.tsx
@@ -1,20 +1,22 @@
 import {Organization} from 'sentry-fixture/organization';
+import {Project as ProjectFixture} from 'sentry-fixture/project';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {PlatformKey} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import TransactionHeader from 'sentry/views/performance/transactionSummary/header';
 import Tab from 'sentry/views/performance/transactionSummary/tabs';
 
 type InitialOpts = {
   features?: string[];
-  platform?: string;
+  platform?: PlatformKey;
 };
 
 function initializeData(opts?: InitialOpts) {
   const {features, platform} = opts ?? {};
-  const project = TestStubs.Project({platform});
+  const project = ProjectFixture({platform});
   const organization = Organization({
     projects: [project],
     features: features ?? [],

--- a/static/app/views/performance/transactionSummary/header.spec.tsx
+++ b/static/app/views/performance/transactionSummary/header.spec.tsx
@@ -31,7 +31,7 @@ function initializeData(opts?: InitialOpts) {
         },
       },
     },
-    project: project.id,
+    project,
     projects: [],
   });
   const router = initialData.router;

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -662,7 +662,7 @@ describe('Performance > TransactionSummary', function () {
         {
           context: routerContext,
           organization,
-          projects,
+          projects: projects.map(project => project.id),
         }
       );
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -1,5 +1,6 @@
 import {browserHistory, InjectedRouter} from 'react-router';
 import {Organization} from 'sentry-fixture/organization';
+import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {Team} from 'sentry-fixture/team';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -43,7 +44,7 @@ function initializeData({
   query?: Record<string, any>;
 } = {}) {
   const features = ['discover-basic', 'performance-view', ...additionalFeatures];
-  const project = prj ?? TestStubs.Project({teams});
+  const project = prj ?? ProjectFixture({teams});
   const organization = Organization({
     features,
     projects: projects ? projects : [project],
@@ -541,7 +542,7 @@ describe('Performance > TransactionSummary', function () {
 
     it('renders Web Vitals widget', async function () {
       const {organization, router, routerContext} = initializeData({
-        project: TestStubs.Project({teams, platform: 'javascript'}),
+        project: ProjectFixture({teams, platform: 'javascript'}),
         query: {
           query:
             'transaction.duration:<15m transaction.op:pageload event.type:transaction transaction:/organizations/:orgId/issues/',
@@ -632,12 +633,12 @@ describe('Performance > TransactionSummary', function () {
       });
 
       const projects = [
-        TestStubs.Project({
+        ProjectFixture({
           slug: 'proj-slug-1',
           id: '1',
           name: 'Project Name 1',
         }),
-        TestStubs.Project({
+        ProjectFixture({
           slug: 'proj-slug-2',
           id: '2',
           name: 'Project Name 2',

--- a/static/app/views/projectInstall/platform.spec.tsx
+++ b/static/app/views/projectInstall/platform.spec.tsx
@@ -8,7 +8,11 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import {Project} from 'sentry/types';
 import {ProjectInstallPlatform} from 'sentry/views/projectInstall/platform';
 
-function mockProjectApiResponses(projects: Project[]) {
+type ProjectWithBadPlatform = Omit<Project, 'platform'> & {
+  platform: string;
+};
+
+function mockProjectApiResponses(projects: Array<Project | ProjectWithBadPlatform>) {
   MockApiClient.addMockResponse({
     method: 'GET',
     url: '/organizations/org-slug/projects/',

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
@@ -8,14 +8,23 @@ import {
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import {ReleaseProject} from 'sentry/types';
 import ReleaseComparisonChart from 'sentry/views/releases/detail/overview/releaseComparisonChart';
 
 describe('Releases > Detail > Overview > ReleaseComparison', () => {
-  const {routerContext, organization, project} = initializeOrg();
+  const {routerContext, organization, project: rawProject} = initializeOrg();
   const api = new MockApiClient();
   const release = ReleaseFixture();
   const releaseSessions = SessionUserCountByStatus();
   const allSessions = SessionUserCountByStatus2();
+
+  const project: ReleaseProject = {
+    ...rawProject,
+    id: parseInt(rawProject.id, 10),
+    newGroups: 0,
+    platform: 'java',
+    platforms: ['java'],
+  };
 
   it('displays correct all/release/change data', () => {
     render(

--- a/tests/js/sentry-test/initializeOrg.tsx
+++ b/tests/js/sentry-test/initializeOrg.tsx
@@ -1,6 +1,7 @@
 import type {RouteComponent, RouteComponentProps} from 'react-router';
 import type {Location} from 'history';
 import {Organization} from 'sentry-fixture/organization';
+import {Project as ProjectFixture} from 'sentry-fixture/project';
 import {OrgRoleList, TeamRoleList} from 'sentry-fixture/roleList';
 import RouterContextFixture from 'sentry-fixture/routerContextFixture';
 
@@ -44,7 +45,7 @@ export function initializeOrg<RouterParams = {orgId: string; projectId: string}>
   const projects = (
     additionalProjects ||
     (additionalProject && [additionalProject]) || [{}]
-  ).map(p => TestStubs.Project(p));
+  ).map(p => ProjectFixture(p));
   const [project] = projects;
   const organization = Organization({
     projects,


### PR DESCRIPTION
- Replace `TestStubs.Project` with import
- Parse project ID
- Declare scopes as cosnt
- Clarify fixture types
- Fix incorrect platform declaration
- Fix incorrect project objects in setup

getsentry/frontend-tsc#49
