### PR TITLE
feat(revenue): Add monitor seats data category

### DIFF
--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -79,6 +79,7 @@ export enum DataCategory {
   ATTACHMENTS = 'attachments',
   PROFILES = 'profiles',
   REPLAYS = 'replays',
+  MONITOR_SEATS = 'monitorSeats',
 }
 
 /**


### PR DESCRIPTION
While DataCategory is deprecated, it is still used in a _lot_ of places within getsentry.

See: https://github.com/getsentry/getsentry/pull/12445