### PR TITLE
fix(stacktrace): Add token aliases when applying syntax highlight class names

### DIFF
--- a/static/app/utils/usePrismTokens.spec.tsx
+++ b/static/app/utils/usePrismTokens.spec.tsx
@@ -98,7 +98,7 @@ describe('usePrismTokens', () => {
         {children: 'p', className: 'token tag'},
         {children: ' ', className: 'token tag'},
         {children: 'class', className: 'token tag attr-name'},
-        {children: '=', className: 'token tag attr-value punctuation'},
+        {children: '=', className: 'token tag attr-value punctuation attr-equals'},
         {children: '"', className: 'token tag attr-value punctuation'},
         {children: 'hey', className: 'token tag attr-value'},
         {children: '"', className: 'token tag attr-value punctuation'},

--- a/static/app/utils/usePrismTokens.tsx
+++ b/static/app/utils/usePrismTokens.tsx
@@ -106,6 +106,11 @@ const splitTokenContentByLine = (
   }
 
   types.add(token.type);
+  if (typeof token.alias === 'string') {
+    types.add(token.alias);
+  } else if (Array.isArray(token.alias)) {
+    token.alias.forEach(alias => types.add(alias));
+  }
 
   if (Array.isArray(token.content)) {
     return splitMultipleTokensByLine(token.content, new Set(types));


### PR DESCRIPTION
This is only applicable for token types that aren't standard, but the token `alias` should be applied as a class name as well.

For example, python has a token type `triple-quoted-string` which is aliased as `string`. Since we don't have any specific styles for triple quoted strings, we need the string classname for this to look right. See https://prismjs.com/tokens.html#non-standard-tokens

Before:

![CleanShot 2023-12-28 at 11 08 28](https://github.com/getsentry/sentry/assets/10888943/38213620-443e-4ddf-806e-dd5ec73644f6)

After:

![CleanShot 2023-12-28 at 11 08 40](https://github.com/getsentry/sentry/assets/10888943/cc027ada-d2c3-4591-beff-a25f469214e1)
