### PR TITLE
ref(hc): Add support for excluding projects/teams

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -84,7 +84,13 @@ class DatabaseBackedOrganizationService(OrganizationService):
         return serialize(org, user=as_user)
 
     def get_organization_by_id(
-        self, *, id: int, user_id: Optional[int] = None, slug: Optional[str] = None
+        self,
+        *,
+        id: int,
+        user_id: Optional[int] = None,
+        slug: Optional[str] = None,
+        include_projects: Optional[bool] = True,
+        include_teams: Optional[bool] = True,
     ) -> Optional[RpcUserOrganizationContext]:
         membership: Optional[RpcOrganizationMember] = None
         if user_id is not None:
@@ -99,7 +105,11 @@ class DatabaseBackedOrganizationService(OrganizationService):
             return None
 
         return RpcUserOrganizationContext(
-            user_id=user_id, organization=serialize_rpc_organization(org), member=membership
+            user_id=user_id,
+            organization=serialize_rpc_organization(
+                org, include_projects=include_projects, include_teams=include_teams
+            ),
+            member=membership,
         )
 
     def get_org_by_slug(

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -67,7 +67,13 @@ class OrganizationService(RpcService):
     @regional_rpc_method(resolve=ByOrganizationId("id"), return_none_if_mapping_not_found=True)
     @abstractmethod
     def get_organization_by_id(
-        self, *, id: int, user_id: Optional[int] = None, slug: Optional[str] = None
+        self,
+        *,
+        id: int,
+        user_id: Optional[int] = None,
+        slug: Optional[str] = None,
+        include_projects: Optional[bool] = True,
+        include_teams: Optional[bool] = True,
     ) -> Optional[RpcUserOrganizationContext]:
         """
         Fetches the organization, team, and project data given by an organization id, regardless of its visibility


### PR DESCRIPTION
Most calls to `get_organization_by_id` don't use projects or teams which are both relatively expensive to load. This adds the ability to exclude them while maintaining existing functionality.

Once this change has been rolled out:
- Update `get` to exclude teams/projects by default
- Replace `get_organization_by_id` with `get` where context isn't used
- Rename `get_organization_by_id` to `get_user_organization_context_by_id`