### PR TITLE
feat(ddm): Sort metrics

### DIFF
--- a/static/app/components/compactSelect/utils.tsx
+++ b/static/app/components/compactSelect/utils.tsx
@@ -106,7 +106,7 @@ export function getHiddenOptions<Value extends React.Key>(
   // First, filter options using `search` value
   //
   const filterOption = (opt: SelectOption<Value>) =>
-    String(opt.label ?? '')
+    `${opt.label ?? ''}${opt.textValue ?? ''}`
       .toLowerCase()
       .includes(search.toLowerCase());
 

--- a/static/app/utils/metrics/useMetricsMeta.tsx
+++ b/static/app/utils/metrics/useMetricsMeta.tsx
@@ -1,4 +1,5 @@
 import {PageFilters} from 'sentry/types';
+import {formatMRI} from 'sentry/utils/metrics/mri';
 import {useApiQuery, UseApiQueryOptions} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -20,10 +21,6 @@ function useMetaUseCase(
       staleTime: 2000, // 2 seconds to cover page load
     }
   );
-
-  if (apiQueryResult.data && Array.isArray(apiQueryResult.data)) {
-    apiQueryResult.data = apiQueryResult.data.sort((a, b) => a.mri.localeCompare(b.mri));
-  }
 
   return apiQueryResult;
 }
@@ -47,13 +44,15 @@ export function useMetricsMeta(
     enabled: enabledUseCases.includes('spans'),
   });
 
+  const data = [
+    ...(enabledUseCases.includes('sessions') ? sessionMeta : []),
+    ...(enabledUseCases.includes('transactions') ? txnsMeta : []),
+    ...(enabledUseCases.includes('custom') ? customMeta : []),
+    ...(enabledUseCases.includes('spans') ? spansMeta : []),
+  ].sort((a, b) => formatMRI(a.mri).localeCompare(formatMRI(b.mri)));
+
   return {
-    data: [
-      ...(enabledUseCases.includes('sessions') ? sessionMeta : []),
-      ...(enabledUseCases.includes('transactions') ? txnsMeta : []),
-      ...(enabledUseCases.includes('custom') ? customMeta : []),
-      ...(enabledUseCases.includes('spans') ? spansMeta : []),
-    ],
+    data,
     isLoading:
       (sessionsReq.isLoading && sessionsReq.fetchStatus !== 'idle') ||
       (txnsReq.isLoading && txnsReq.fetchStatus !== 'idle') ||

--- a/static/app/views/ddm/queryBuilder.tsx
+++ b/static/app/views/ddm/queryBuilder.tsx
@@ -121,6 +121,8 @@ export function QueryBuilder({
             triggerProps={{prefix: t('Metric'), size: 'sm'}}
             options={displayedMetrics.map(metric => ({
               label: mriMode ? metric.mri : formatMRI(metric.mri),
+              // enable search by mri, name, unit (millisecond), type (c:), and readable type (counter)
+              textValue: `${metric.mri}${getReadableMetricType(metric.type)}`,
               value: metric.mri,
               trailingItems: mriMode
                 ? undefined

--- a/static/app/views/ddm/queryBuilder.tsx
+++ b/static/app/views/ddm/queryBuilder.tsx
@@ -81,7 +81,9 @@ export function QueryBuilder({
     }
 
     const isSelected = (metric: MetricMeta) => metric.mri === metricsQuery.mri;
-    return meta.filter(metric => isShownByDefault(metric) || isSelected(metric));
+    return meta
+      .filter(metric => isShownByDefault(metric) || isSelected(metric))
+      .sort(metric => (isSelected(metric) ? -1 : 1));
   }, [meta, metricsQuery.mri, mriMode]);
 
   const selectedMeta = useMemo(() => {

--- a/static/app/views/settings/projectMetrics/projectMetrics.tsx
+++ b/static/app/views/settings/projectMetrics/projectMetrics.tsx
@@ -48,14 +48,12 @@ function ProjectMetrics({project, location}: Props) {
     [location.pathname, location.query]
   );
 
-  const metrics = meta
-    .sort((a, b) => formatMRI(a.mri).localeCompare(formatMRI(b.mri)))
-    .filter(
-      ({mri, type, unit}) =>
-        mri.includes(query) ||
-        getReadableMetricType(type).includes(query) ||
-        unit.includes(query)
-    );
+  const metrics = meta.filter(
+    ({mri, type, unit}) =>
+      mri.includes(query) ||
+      getReadableMetricType(type).includes(query) ||
+      unit.includes(query)
+  );
 
   return (
     <Fragment>


### PR DESCRIPTION
We used to sort metrics, but this PR makes three improvements:
- sort all combined use cases, not one by one
- sort by formatted MRI (because that's what users are usually looking at, not raw MRI)
- surface the selected metric to the top

Relates to https://github.com/getsentry/sentry/issues/62383