### PR TITLE
fix(crons): Enforce min of 1 for interval frequency

### DIFF
--- a/static/app/views/monitors/components/monitorForm.tsx
+++ b/static/app/views/monitors/components/monitorForm.tsx
@@ -358,6 +358,7 @@ function MonitorForm({
                       name="config.schedule.frequency"
                       placeholder="e.g. 1"
                       defaultValue="1"
+                      min={1}
                       required
                       stacked
                       inline={false}


### PR DESCRIPTION
Previously you could spin this box down below 0

<img alt="clipboard.png" width="398" src="https://i.imgur.com/hUu34Fq.png" />