### PR TITLE
feat(backup): Add option for autopausing

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -5,14 +5,15 @@ from sentry.options import register
 from sentry.options.manager import (
     FLAG_ALLOW_EMPTY,
     FLAG_AUTOMATOR_MODIFIABLE,
+    FLAG_BOOL,
     FLAG_CREDENTIAL,
     FLAG_IMMUTABLE,
     FLAG_MODIFIABLE_BOOL,
     FLAG_MODIFIABLE_RATE,
-    FLAG_MODIFIABLE_SCALAR,
     FLAG_NOSTORE,
     FLAG_PRIORITIZE_DISK,
     FLAG_REQUIRED,
+    FLAG_SCALAR,
 )
 from sentry.utils.types import Any, Bool, Dict, Float, Int, Sequence, String
 
@@ -1816,16 +1817,22 @@ register(
 register(
     "relocation.enabled",
     default=False,
-    # TODO(getsentry/team-ospo#214): Eventually change this to `FLAG_BOOL |
-    # FLAG_AUTOMATOR_MODIFIABLE`, to enforce it only being toggled from code.
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# Relocation: the step at which new relocations should be autopaused, requiring admin approval
+# before continuing.
+register(
+    "relocation.autopause",
+    default="",
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 # Relocation: globally limits the number of small (<=10MB) relocations allowed per silo per day.
 register(
     "relocation.daily-limit.small",
     default=0,
-    flags=FLAG_MODIFIABLE_SCALAR | FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_SCALAR | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 # Relocation: globally limits the number of medium (>10MB && <=100MB) relocations allowed per silo
@@ -1833,12 +1840,12 @@ register(
 register(
     "relocation.daily-limit.medium",
     default=0,
-    flags=FLAG_MODIFIABLE_SCALAR | FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_SCALAR | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 # Relocation: globally limits the number of large (>100MB) relocations allowed per silo per day.
 register(
     "relocation.daily-limit.large",
     default=0,
-    flags=FLAG_MODIFIABLE_SCALAR | FLAG_AUTOMATOR_MODIFIABLE,
+    flags=FLAG_SCALAR | FLAG_AUTOMATOR_MODIFIABLE,
 )


### PR DESCRIPTION
Currently, an admin can set a scheduled pause before any named step in a relocation. This new option allows such pauses to be configured on a global or per-region basis automatically, so that every new relocation automatically pauses and waits until an admin approves it. This will be useful while we first roll out the feature and manually verify with users that their relocations succeeded.

Issue: getsentry/team-ospo#222