### PR TITLE
ref(js): Better error in useTeams for missing org context

### DIFF
--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -267,7 +267,9 @@ export function useTeams({limit, slugs, provideUserTeams}: Options = {}) {
 
       if (orgId === undefined) {
         // eslint-disable-next-line no-console
-        console.error('Cannot fetch teams without an organization in context');
+        console.error(
+          'Cannot fetch teams without an organization in context and in the Store'
+        );
         return;
       }
 


### PR DESCRIPTION
It's not just that it's not in context. It can also be that the organizxation isn't set in the store (usually happens in tests)