### PR TITLE
feat(crons): Feature flag for disabling crons in new projects

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1473,6 +1473,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enable creating organizations within sentry
     # (if SENTRY_SINGLE_ORGANIZATION is not enabled).
     "organizations:create": True,
+    # Disables projects with zero monitors to create new ones
+    "organizations:crons-disable-new-projects": False,
     # Enable the new crons monitor form
     "organizations:crons-new-monitor-form": False,
     # Metrics: Enable ingestion and storage of custom metrics. See ddm-ui for UI.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -81,7 +81,7 @@ default_manager.add("organizations:api-keys", OrganizationFeature, FeatureHandle
 default_manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:cleanup-project-serializer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:codecov-commit-sha-from-git-blame", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:crons-disable-new-projects", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:crons-disable-new-projects", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:crons-new-monitor-form", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:dashboard-widget-indicators", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:dashboards-import", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -81,6 +81,7 @@ default_manager.add("organizations:api-keys", OrganizationFeature, FeatureHandle
 default_manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:cleanup-project-serializer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:codecov-commit-sha-from-git-blame", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:crons-disable-new-projects", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:crons-new-monitor-form", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:dashboard-widget-indicators", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:dashboards-import", OrganizationFeature, FeatureHandlerStrategy.REMOTE)


### PR DESCRIPTION
Feature flag that will eventually disable the creation of cron monitors in projects that have previously no cron monitors. This is in preparation for roll out as we give these existing beta orgs trials.

Backed by option here: https://github.com/getsentry/getsentry/pull/12460