### PR TITLE
Use zstd compression for `CachedAttachment`s

### DIFF
--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -1,5 +1,8 @@
 import zlib
 
+import zstandard
+
+from sentry import options
 from sentry.utils import metrics
 from sentry.utils.json import prune_empty_keys
 
@@ -62,6 +65,10 @@ class CachedAttachment:
 
         assert self._data is not UNINITIALIZED_DATA
         return self._data
+
+    @property
+    def zstd_data(self):
+        return self._cache.get_zstd_data(self)
 
     def delete(self):
         for key in self.chunk_keys:
@@ -130,11 +137,12 @@ class BaseAttachmentCache:
 
     def set_chunk(self, key, id, chunk_index, chunk_data, timeout=None):
         key = ATTACHMENT_DATA_CHUNK_KEY.format(key=key, id=id, chunk_index=chunk_index)
-        self.inner.set(key, zlib.compress(chunk_data), timeout, raw=True)
+        compressed = compress_chunk(chunk_data)
+        self.inner.set(key, compressed, timeout, raw=True)
 
     def set_unchunked_data(self, key, id, data, timeout=None, metrics_tags=None):
         key = ATTACHMENT_UNCHUNKED_DATA_KEY.format(key=key, id=id)
-        compressed = zlib.compress(data)
+        compressed = compress_chunk(data)
         metrics.distribution("attachments.blob-size.raw", len(data), tags=metrics_tags, unit="byte")
         metrics.distribution(
             "attachments.blob-size.compressed", len(compressed), tags=metrics_tags, unit="byte"
@@ -153,19 +161,45 @@ class BaseAttachmentCache:
             attachment.setdefault("key", key)
             yield CachedAttachment(cache=self, **attachment)
 
-    def get_data(self, attachment):
-        data = []
+    def get_data(self, attachment) -> bytes:
+        data = bytearray()
 
         for key in attachment.chunk_keys:
             raw_data = self.inner.get(key, raw=True)
             if raw_data is None:
                 raise MissingAttachmentChunks()
-            data.append(zlib.decompress(raw_data))
+            if raw_data.startswith(b"\x28\xb5\x2f\xfd"):
+                decompressed = zstandard.decompress(raw_data)
+            else:
+                decompressed = zlib.decompress(raw_data)
+            data.extend(decompressed)
 
-        return b"".join(data)
+        return bytes(data)
+
+    def get_zstd_data(self, attachment) -> bytes:
+        data = bytearray()
+
+        for key in attachment.chunk_keys:
+            raw_data = self.inner.get(key, raw=True)
+            if raw_data is None:
+                raise MissingAttachmentChunks()
+            if raw_data.startswith(b"\x28\xb5\x2f\xfd"):
+                data.extend(raw_data)
+            else:
+                decompressed = zlib.decompress(raw_data)
+                compressed = zstandard.compress(decompressed)
+                data.extend(compressed)
+
+        return bytes(data)
 
     def delete(self, key):
         for attachment in self.get(key):
             attachment.delete()
 
         self.inner.delete(ATTACHMENT_META_KEY.format(key=key))
+
+
+def compress_chunk(chunk_data: bytes) -> bytes:
+    if options.get("attachment-cache.use-zstd"):
+        zstandard.compress(chunk_data)
+    return zlib.compress(chunk_data)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -839,6 +839,9 @@ register(
     "processing.use-release-archives-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE
 )  # unused
 
+# Whether to use `zstd` instead of `zlib` for the attachment cache.
+register("attachment-cache.use-zstd", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # All Relay options (statically authenticated Relays can be registered here)
 register("relay.static_auth", default={}, flags=FLAG_NOSTORE)
 

--- a/tests/sentry/attachments/test_base.py
+++ b/tests/sentry/attachments/test_base.py
@@ -60,6 +60,7 @@ def test_meta_rate_limited():
     }
 
 
+@django_db_all
 def test_basic_chunked():
     data = InMemoryCache()
     cache = BaseAttachmentCache(data)
@@ -81,6 +82,7 @@ def test_basic_chunked():
     assert not list(cache.get("c:foo"))
 
 
+@django_db_all
 def test_basic_unchunked():
     data = InMemoryCache()
     cache = BaseAttachmentCache(data)
@@ -119,6 +121,7 @@ def test_zstd_chunks():
     assert not_chunked.data == b"Hello World! Bye."
 
 
+@django_db_all
 def test_basic_rate_limited():
     data = InMemoryCache()
     cache = BaseAttachmentCache(data)


### PR DESCRIPTION
So far this cache was zlib compressed which is not state of the art anymore. Zstd should provide better compression and performance across the board.