### PR TITLE
fix(replays): Remove column shadowing and eagerly exit when counting replays

### DIFF
--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -106,7 +106,11 @@ def query_replays_count(
         query=Query(
             match=Entity("replays"),
             select=[
-                _strip_uuid_dashes("replay_id", Column("replay_id")),
+                # The expression is explicitly aliased as "rid" to prevent the default
+                # alias "replay_id" from shadowing the replay_id column. When the column
+                # is shadowed our index is disabled in the WHERE and we waste a lot of
+                # compute parsing UUIDs we don't care about.
+                _strip_uuid_dashes("replay_id", Column("replay_id"), alias="rid"),
                 Function(
                     "ifNull",
                     parameters=[

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -26,6 +26,11 @@ def get_replay_counts(snuba_params: SnubaParams, query, return_ids, data_source)
 
     replay_ids_mapping = _get_replay_id_mappings(query, snuba_params, data_source)
 
+    # It's not guaranteed that any results will be returned by this query. If the result-set
+    # is empty exit early to save us a query.
+    if not replay_ids_mapping:
+        return {}
+
     replay_results = query_replays_count(
         project_ids=[p.id for p in snuba_params.projects],
         start=snuba_params.start,
@@ -43,7 +48,6 @@ def get_replay_counts(snuba_params: SnubaParams, query, return_ids, data_source)
 def _get_replay_id_mappings(
     query, snuba_params, data_source=Dataset.Discover
 ) -> dict[str, list[str]]:
-
     select_column, value = _get_select_column(query)
     query = query + FILTER_HAS_A_REPLAY if data_source == Dataset.Discover else query
 
@@ -73,7 +77,11 @@ def _get_replay_id_mappings(
 
     for row in discover_results["data"]:
         for replay_id in row["group_uniq_array_100_replayId"]:
-            replay_id_to_issue_map[replay_id].append(row[select_column])
+            # When no replay exists these strings are provided in their empty
+            # state rather than null. This can cause downstream problems so
+            # we filter them out.
+            if len(replay_id) == 32:
+                replay_id_to_issue_map[replay_id].append(row[select_column])
 
     return replay_id_to_issue_map
 
@@ -81,7 +89,7 @@ def _get_replay_id_mappings(
 def _get_counts(replay_results: Any, replay_ids_mapping: dict[str, list[str]]) -> dict[str, int]:
     ret: dict[str, int] = defaultdict(int)
     for row in replay_results["data"]:
-        identifiers = replay_ids_mapping[row["replay_id"]]
+        identifiers = replay_ids_mapping[row["rid"]]
         for identifier in identifiers:
             ret[identifier] = min(ret[identifier] + 1, MAX_REPLAY_COUNT)
     return ret
@@ -92,10 +100,10 @@ def _get_replay_ids(
 ) -> dict[str, list[str]]:
     ret: dict[str, list[str]] = defaultdict(list)
     for row in replay_results["data"]:
-        identifiers = replay_ids_mapping[row["replay_id"]]
+        identifiers = replay_ids_mapping[row["rid"]]
         for identifier in identifiers:
             if len(ret[identifier]) < MAX_REPLAY_COUNT:
-                ret[identifier].append(row["replay_id"])
+                ret[identifier].append(row["rid"])
     return ret
 
 

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -80,7 +80,7 @@ def _get_replay_id_mappings(
             # When no replay exists these strings are provided in their empty
             # state rather than null. This can cause downstream problems so
             # we filter them out.
-            if len(replay_id) == 32:
+            if replay_id != "":
                 replay_id_to_issue_map[replay_id].append(row[select_column])
 
     return replay_id_to_issue_map


### PR DESCRIPTION
This attempts to fix the performance issues we've seen from larger customers querying this endpoint.  When the column is shadowed the index is disabled.  By removing the shadow we should find the replays more quickly.