### PR TITLE
feat(app-startup): Add Cold/Warm start widgets on summary page

### DIFF
--- a/static/app/views/starfish/views/appStartup/screenSummary/deviceClassBreakdownBarChart.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/deviceClassBreakdownBarChart.tsx
@@ -4,6 +4,7 @@ import TransitionChart from 'sentry/components/charts/transitionChart';
 import LoadingContainer from 'sentry/components/loading/loadingContainer';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {Series} from 'sentry/types/echarts';
 import {
   axisLabelFormatter,
   getDurationUnit,
@@ -24,7 +25,7 @@ interface DeviceClassBreakdownBarChartProps {
   isLoading: boolean;
   title: string;
   yAxis: string;
-  data?: any;
+  data?: Series[];
 }
 
 function DeviceClassBreakdownBarChart({

--- a/static/app/views/starfish/views/appStartup/screenSummary/deviceClassBreakdownBarChart.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/deviceClassBreakdownBarChart.tsx
@@ -1,0 +1,119 @@
+import {BarChart} from 'sentry/components/charts/barChart';
+import ErrorPanel from 'sentry/components/charts/errorPanel';
+import TransitionChart from 'sentry/components/charts/transitionChart';
+import LoadingContainer from 'sentry/components/loading/loadingContainer';
+import {IconWarning} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {
+  axisLabelFormatter,
+  getDurationUnit,
+  tooltipFormatter,
+} from 'sentry/utils/discover/charts';
+import {aggregateOutputType} from 'sentry/utils/discover/fields';
+import {formatVersion} from 'sentry/utils/formatters';
+import {LoadingScreen} from 'sentry/views/starfish/components/chart';
+import MiniChartPanel from 'sentry/views/starfish/components/miniChartPanel';
+import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+
+const XAXIS_CATEGORIES = ['high', 'medium', 'low', 'Unknown'];
+const CHART_HEIGHT = 70;
+
+interface DeviceClassBreakdownBarChartProps {
+  isError: boolean;
+  isLoading: boolean;
+  title: string;
+  yAxis: string;
+  data?: any;
+}
+
+function DeviceClassBreakdownBarChart({
+  isLoading,
+  isError,
+  title,
+  data,
+  yAxis,
+}: DeviceClassBreakdownBarChartProps) {
+  const {
+    primaryRelease,
+    secondaryRelease,
+    isLoading: isReleasesLoading,
+  } = useReleaseSelection();
+
+  if (isReleasesLoading || isLoading) {
+    return <LoadingContainer isLoading />;
+  }
+
+  return (
+    <MiniChartPanel
+      title={title}
+      subtitle={
+        primaryRelease
+          ? t(
+              '%s v. %s',
+              formatVersionAndCenterTruncate(primaryRelease, 12),
+              secondaryRelease ? formatVersionAndCenterTruncate(secondaryRelease, 12) : ''
+            )
+          : ''
+      }
+    >
+      <TransitionChart
+        loading={Boolean(isLoading)}
+        reloading={Boolean(isLoading)}
+        height={`${CHART_HEIGHT}px`}
+      >
+        <LoadingScreen loading={Boolean(isLoading)} />
+        {isError ? (
+          <ErrorPanel height={`${CHART_HEIGHT}px`}>
+            <IconWarning color="gray300" size="lg" />
+          </ErrorPanel>
+        ) : (
+          <BarChart
+            height={CHART_HEIGHT}
+            series={
+              data?.map(series => ({
+                ...series,
+                name: formatVersion(series.seriesName),
+              })) ?? []
+            }
+            grid={{
+              left: '0',
+              right: '0',
+              top: '8px',
+              bottom: '0',
+              containLabel: true,
+            }}
+            xAxis={{
+              type: 'category',
+              axisTick: {show: true},
+              data: XAXIS_CATEGORIES,
+              truncate: 14,
+              axisLabel: {
+                interval: 0,
+              },
+            }}
+            yAxis={{
+              axisLabel: {
+                formatter(value: number) {
+                  return axisLabelFormatter(
+                    value,
+                    aggregateOutputType(yAxis),
+                    undefined,
+                    getDurationUnit(data ?? [])
+                  );
+                },
+              },
+            }}
+            tooltip={{
+              valueFormatter: (value, _seriesName) => {
+                return tooltipFormatter(value, aggregateOutputType(yAxis));
+              },
+            }}
+          />
+        )}
+      </TransitionChart>
+    </MiniChartPanel>
+  );
+}
+
+export default DeviceClassBreakdownBarChart;

--- a/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
@@ -72,7 +72,7 @@ function SummaryWidgets({additionalFilters}) {
       pageFilter.selection
     ),
     enabled: !isReleasesLoading,
-    referrer: 'api.starfish.mobile-startup-breakdown',
+    referrer: 'api.starfish.mobile-startup-bar-chart',
     initialData: {data: []},
   });
 

--- a/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
@@ -1,11 +1,128 @@
 import styled from '@emotion/styled';
 
+import {getInterval} from 'sentry/components/charts/utils';
+import {CHART_PALETTE} from 'sentry/constants/chartPalette';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {Series, SeriesDataUnit} from 'sentry/types/echarts';
+import {defined} from 'sentry/utils';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {prepareQueryForLandingPage} from 'sentry/views/performance/data';
+import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
+import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
+import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 import CountWidget from 'sentry/views/starfish/views/appStartup/screenSummary/countWidget';
+import DeviceClassBreakdownBarChart from 'sentry/views/starfish/views/appStartup/screenSummary/deviceClassBreakdownBarChart';
+import {YAxis, YAXIS_COLUMNS} from 'sentry/views/starfish/views/screens';
+import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
 import AppStartBreakdownWidget from './appStartBreakdownWidget';
 
+const YAXES = [YAxis.COLD_START, YAxis.WARM_START];
+
 function SummaryWidgets({additionalFilters}) {
+  const pageFilter = usePageFilters();
+  const location = useLocation();
+  const {query: locationQuery} = location;
+  const {
+    primaryRelease,
+    secondaryRelease,
+    isLoading: isReleasesLoading,
+  } = useReleaseSelection();
+
+  const query = new MutableSearch([...(additionalFilters ?? [])]);
+
+  const searchQuery = decodeScalar(locationQuery.query, '');
+  if (searchQuery) {
+    query.addStringFilter(prepareQueryForLandingPage(searchQuery, false));
+  }
+
+  const queryString = `${appendReleaseFilters(query, primaryRelease, secondaryRelease)}`;
+
+  // Use single query for cold and warm starts by device classification and release
+  const {
+    data: startupDataByDeviceClass,
+    isLoading,
+    isError,
+  } = useTableQuery({
+    eventView: EventView.fromNewQueryWithPageFilters(
+      {
+        name: '',
+        fields: [
+          'avg(measurements.app_start_cold)',
+          'avg(measurements.app_start_warm)',
+          'device.class',
+          'release',
+        ],
+        yAxis: YAXES.map(val => YAXIS_COLUMNS[val]),
+        topEvents: '2',
+        query: queryString,
+        dataset: DiscoverDatasets.METRICS,
+        version: 2,
+        interval: getInterval(
+          pageFilter.selection.datetime,
+          STARFISH_CHART_INTERVAL_FIDELITY
+        ),
+      },
+      pageFilter.selection
+    ),
+    enabled: !isReleasesLoading,
+    referrer: 'api.starfish.mobile-startup-breakdown',
+    initialData: {data: []},
+  });
+
+  const transformedData: {
+    [yAxisName: string]: {
+      [releaseVersion: string]: Series;
+    };
+  } = {};
+
+  YAXES.forEach(val => {
+    transformedData[YAXIS_COLUMNS[val]] = {};
+    if (primaryRelease) {
+      transformedData[YAXIS_COLUMNS[val]][primaryRelease] = {
+        seriesName: primaryRelease,
+        data: Array(['high', 'medium', 'low', 'Unknown'].length).fill(0),
+      };
+    }
+    if (secondaryRelease) {
+      transformedData[YAXIS_COLUMNS[val]][secondaryRelease] = {
+        seriesName: secondaryRelease,
+        data: Array(['high', 'medium', 'low', 'Unknown'].length).fill(0),
+      };
+    }
+  });
+
+  const deviceClassIndex = Object.fromEntries(
+    ['high', 'medium', 'low', 'Unknown'].map((e, i) => [e, i])
+  );
+
+  if (defined(startupDataByDeviceClass)) {
+    startupDataByDeviceClass.data?.forEach(row => {
+      const deviceClass = row['device.class'];
+      const index = deviceClassIndex[deviceClass];
+
+      const release = row.release;
+      const isPrimary = release === primaryRelease;
+      YAXES.forEach(val => {
+        if (transformedData[YAXIS_COLUMNS[val]][release]) {
+          transformedData[YAXIS_COLUMNS[val]][release].data[index] = {
+            name: deviceClass,
+            value: row[YAXIS_COLUMNS[val]],
+            itemStyle: {
+              color: isPrimary ? CHART_PALETTE[3][0] : CHART_PALETTE[3][1],
+            },
+          } as SeriesDataUnit;
+        }
+      });
+    });
+  }
+
   return (
     <WidgetLayout>
       <div style={{gridArea: '1 / 1 / 1 / 1'}}>
@@ -13,6 +130,24 @@ function SummaryWidgets({additionalFilters}) {
       </div>
       <div style={{gridArea: '2 / 1 / 2 / 1'}}>
         <CountWidget additionalFilters={additionalFilters} />
+      </div>
+      <div style={{gridArea: '1 / 2 / 1 / 2'}}>
+        <DeviceClassBreakdownBarChart
+          title={t('Cold Start')}
+          isLoading={isLoading}
+          isError={isError}
+          data={Object.values(transformedData[YAXIS_COLUMNS[YAxis.COLD_START]])}
+          yAxis={YAXIS_COLUMNS[YAxis.COLD_START]}
+        />
+      </div>
+      <div style={{gridArea: '2 / 2 / 2 / 2'}}>
+        <DeviceClassBreakdownBarChart
+          title={t('Warm Start')}
+          isLoading={isLoading}
+          isError={isError}
+          data={Object.values(transformedData[YAXIS_COLUMNS[YAxis.WARM_START]])}
+          yAxis={YAXIS_COLUMNS[YAxis.WARM_START]}
+        />
       </div>
     </WidgetLayout>
   );

--- a/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
@@ -42,7 +42,7 @@ function SummaryWidgets({additionalFilters}) {
     query.addStringFilter(prepareQueryForLandingPage(searchQuery, false));
   }
 
-  const queryString = `${appendReleaseFilters(query, primaryRelease, secondaryRelease)}`;
+  const queryString = appendReleaseFilters(query, primaryRelease, secondaryRelease);
 
   // Use single query for cold and warm starts by device classification and release
   const {

--- a/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/charts.tsx
@@ -32,6 +32,7 @@ import {
 } from 'sentry/views/starfish/views/screens';
 import {ScreensBarChart} from 'sentry/views/starfish/views/screens/screenBarChart';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
+import {transformDeviceClassEvents} from 'sentry/views/starfish/views/screens/utils';
 
 export enum YAxis {
   WARM_START,
@@ -167,52 +168,12 @@ export function ScreenCharts({yAxes, additionalFilters}: Props) {
     );
   }
 
-  const transformedEvents: {
-    [yAxisName: string]: {
-      [releaseVersion: string]: Series;
-    };
-  } = {};
-
-  yAxes.forEach(val => {
-    transformedEvents[YAXIS_COLUMNS[val]] = {};
-    if (primaryRelease) {
-      transformedEvents[YAXIS_COLUMNS[val]][primaryRelease] = {
-        seriesName: primaryRelease,
-        data: Array(['high', 'medium', 'low', 'Unknown'].length).fill(0),
-      };
-    }
-    if (secondaryRelease) {
-      transformedEvents[YAXIS_COLUMNS[val]][secondaryRelease] = {
-        seriesName: secondaryRelease,
-        data: Array(['high', 'medium', 'low', 'Unknown'].length).fill(0),
-      };
-    }
+  const transformedEvents = transformDeviceClassEvents({
+    yAxes,
+    primaryRelease,
+    secondaryRelease,
+    data: deviceClassEvents,
   });
-
-  const deviceClassIndex = Object.fromEntries(
-    ['high', 'medium', 'low', 'Unknown'].map((e, i) => [e, i])
-  );
-
-  if (defined(deviceClassEvents)) {
-    deviceClassEvents.data?.forEach(row => {
-      const deviceClass = row['device.class'];
-      const index = deviceClassIndex[deviceClass];
-
-      const release = row.release;
-      const isPrimary = release === primaryRelease;
-      yAxes.forEach(val => {
-        if (transformedEvents[YAXIS_COLUMNS[val]][release]) {
-          transformedEvents[YAXIS_COLUMNS[val]][release].data[index] = {
-            name: deviceClass,
-            value: row[YAXIS_COLUMNS[val]],
-            itemStyle: {
-              color: isPrimary ? CHART_PALETTE[3][0] : CHART_PALETTE[3][1],
-            },
-          } as SeriesDataUnit;
-        }
-      });
-    });
-  }
 
   function renderCharts() {
     return (

--- a/static/app/views/starfish/views/screens/utils.tsx
+++ b/static/app/views/starfish/views/screens/utils.tsx
@@ -1,7 +1,9 @@
 import Color from 'color';
 
+import {CHART_PALETTE} from 'sentry/constants/chartPalette';
 import {Series, SeriesDataUnit} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
+import {TableData} from 'sentry/utils/discover/discoverQuery';
 import {YAxis, YAXIS_COLUMNS} from 'sentry/views/starfish/views/screens';
 
 export function transformReleaseEvents({
@@ -61,4 +63,68 @@ export function transformReleaseEvents({
   }
 
   return transformedReleaseEvents;
+}
+
+export function transformDeviceClassEvents({
+  yAxes,
+  primaryRelease,
+  secondaryRelease,
+  data,
+}: {
+  yAxes: YAxis[];
+  data?: TableData;
+  primaryRelease?: string;
+  secondaryRelease?: string;
+}): {
+  [yAxisName: string]: {
+    [releaseVersion: string]: Series;
+  };
+} {
+  const transformedData = yAxes.reduce(
+    (acc, yAxis) => ({...acc, [YAXIS_COLUMNS[yAxis]]: {}}),
+    {}
+  );
+
+  yAxes.forEach(val => {
+    transformedData[YAXIS_COLUMNS[val]] = {};
+    if (primaryRelease) {
+      transformedData[YAXIS_COLUMNS[val]][primaryRelease] = {
+        seriesName: primaryRelease,
+        data: Array(['high', 'medium', 'low', 'Unknown'].length).fill(0),
+      };
+    }
+    if (secondaryRelease) {
+      transformedData[YAXIS_COLUMNS[val]][secondaryRelease] = {
+        seriesName: secondaryRelease,
+        data: Array(['high', 'medium', 'low', 'Unknown'].length).fill(0),
+      };
+    }
+  });
+
+  const deviceClassIndex = Object.fromEntries(
+    ['high', 'medium', 'low', 'Unknown'].map((e, i) => [e, i])
+  );
+
+  if (defined(data)) {
+    data.data?.forEach(row => {
+      const deviceClass = row['device.class'];
+      const index = deviceClassIndex[deviceClass];
+
+      const release = row.release;
+      const isPrimary = release === primaryRelease;
+      yAxes.forEach(val => {
+        if (transformedData[YAXIS_COLUMNS[val]][release]) {
+          transformedData[YAXIS_COLUMNS[val]][release].data[index] = {
+            name: deviceClass,
+            value: row[YAXIS_COLUMNS[val]],
+            itemStyle: {
+              color: isPrimary ? CHART_PALETTE[3][0] : CHART_PALETTE[3][1],
+            },
+          } as SeriesDataUnit;
+        }
+      });
+    });
+  }
+
+  return transformedData;
 }


### PR DESCRIPTION
Adds a query to get cold/warm start data from metrics and then plots it into two widgets that compares two releases. I reused code from the screens charts to transform the data into different y-axes by release and device class

<img width="542" alt="Screenshot 2024-01-02 at 1 11 25 PM" src="https://github.com/getsentry/sentry/assets/22846452/ee9f6123-7896-4df8-91f5-09a59ea7db94">
