### PR TITLE
fix(crons): Remove environment limitation on details page

### DIFF
--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -16,7 +16,6 @@ import {space} from 'sentry/styles/space';
 import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
-import usePageFilters from 'sentry/utils/usePageFilters';
 import {CronDetailsTimeline} from 'sentry/views/monitors/components/cronDetailsTimeline';
 import DetailsSidebar from 'sentry/views/monitors/components/detailsSidebar';
 import {makeMonitorDetailsQueryKey} from 'sentry/views/monitors/utils';
@@ -39,18 +38,12 @@ function hasLastCheckIn(monitor: Monitor) {
 
 function MonitorDetails({params, location}: Props) {
   const api = useApi();
-  const {selection} = usePageFilters();
 
   const organization = useOrganization();
   const queryClient = useQueryClient();
 
-  // TODO(epurkhiser): For now we just use the fist environment OR production
-  // if we have all environments selected
-  const environment = selection.environments[0];
-
   const queryKey = makeMonitorDetailsQueryKey(organization, params.monitorSlug, {
     ...location.query,
-    environment,
   });
 
   const {data: monitor} = useApiQuery<Monitor>(queryKey, {


### PR DESCRIPTION
We can remove this filter as we support querying for information from multiple environments