### PR TITLE
fix(suspect-commits): Allow rate_limit calls to fail for GitHub

### DIFF
--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1689,3 +1689,33 @@ class GitHubClientFileBlameRateLimitTest(GitHubClientFileBlameBase):
                 "organization_integration_id": self.github_client.org_integration_id,
             },
         )
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @responses.activate
+    def test_no_rate_limiting(self, get_jwt):
+        """
+        Tests that no error is thrown when GitHub isn't enforcing rate limits
+        """
+        responses.reset()
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/app/installations/1/access_tokens",
+            body='{"token": "12345token", "expires_at": "2030-01-01T00:00:00Z"}',
+            status=200,
+            content_type="application/json",
+        )
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/rate_limit",
+            status=404,
+        )
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/graphql",
+            json={
+                "data": {},
+            },
+            content_type="application/json",
+        )
+
+        assert self.github_client.get_blame_for_files([self.file], extra={}) == []


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/62478

Simple fix, noticed that suspect commits weren't working for GitHub enterprise because `/rate_limit` returned a 404. This simply ignores those failures and moves on.