### PR TITLE
fix(replay): Dont emit an EventView from useReplaysFromIssue when no replayIds are in the fetched list

### DIFF
--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -31,7 +31,7 @@ function GroupReplays({group}: Props) {
   const organization = useOrganization();
   const location = useLocation<ReplayListLocationQuery>();
 
-  const {eventView, fetchError, pageLinks} = useReplaysFromIssue({
+  const {eventView, fetchError, isFetching, pageLinks} = useReplaysFromIssue({
     group,
     location,
     organization,
@@ -52,7 +52,7 @@ function GroupReplays({group}: Props) {
       <StyledLayoutPage withPadding>
         <ReplayTable
           fetchError={fetchError}
-          isFetching
+          isFetching={isFetching}
           replays={[]}
           sort={undefined}
           visibleColumns={VISIBLE_COLUMNS}

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.spec.tsx
@@ -48,6 +48,7 @@ describe('useReplaysFromIssue', () => {
     expect(result.current).toEqual({
       eventView: null,
       fetchError: undefined,
+      isFetching: true,
       pageLinks: null,
     });
 
@@ -58,6 +59,7 @@ describe('useReplaysFromIssue', () => {
         query: 'id:[replay42,replay256]',
       }),
       fetchError: undefined,
+      isFetching: false,
       pageLinks: null,
     });
   });
@@ -84,6 +86,7 @@ describe('useReplaysFromIssue', () => {
     expect(result.current).toEqual({
       eventView: null,
       fetchError: undefined,
+      isFetching: true,
       pageLinks: null,
     });
 
@@ -94,6 +97,7 @@ describe('useReplaysFromIssue', () => {
         query: 'id:[replay42,replay256]',
       }),
       fetchError: undefined,
+      isFetching: false,
       pageLinks: null,
     });
   });
@@ -118,16 +122,16 @@ describe('useReplaysFromIssue', () => {
     expect(result.current).toEqual({
       eventView: null,
       fetchError: undefined,
+      isFetching: true,
       pageLinks: null,
     });
 
     await waitForNextUpdate();
 
     expect(result.current).toEqual({
-      eventView: expect.objectContaining({
-        query: 'id:[]',
-      }),
+      eventView: null,
       fetchError: undefined,
+      isFetching: false,
       pageLinks: null,
     });
   });

--- a/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
+++ b/static/app/views/issueDetails/groupReplays/useReplaysFromIssue.tsx
@@ -11,7 +11,7 @@ import useApi from 'sentry/utils/useApi';
 import useCleanQueryParamsOnRouteLeave from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
 import {REPLAY_LIST_FIELDS} from 'sentry/views/replays/types';
 
-function useReplayFromIssue({
+export default function useReplayFromIssue({
   group,
   location,
   organization,
@@ -51,7 +51,7 @@ function useReplayFromIssue({
   }, [api, organization.slug, group.id, dataSource]);
 
   const eventView = useMemo(() => {
-    if (!replayIds) {
+    if (!replayIds || !replayIds.length) {
       return null;
     }
     return EventView.fromSavedQuery({
@@ -59,7 +59,7 @@ function useReplayFromIssue({
       name: '',
       version: 2,
       fields: REPLAY_LIST_FIELDS,
-      query: `id:[${String(replayIds)}]`,
+      query: replayIds.length ? `id:[${String(replayIds)}]` : `id:1`,
       range: '14d',
       projects: [],
       orderby: decodeScalar(location.query.sort, DEFAULT_SORT),
@@ -77,8 +77,7 @@ function useReplayFromIssue({
   return {
     eventView,
     fetchError,
+    isFetching: replayIds === undefined,
     pageLinks: null,
   };
 }
-
-export default useReplayFromIssue;


### PR DESCRIPTION
Note: This is a retry of https://github.com/getsentry/sentry/pull/62119
The difference is that this PR doesn't mess around with `queryReferrer` or send `ALL_ACCESS_PROJECTS` unconditionally. Doing that causes problems for people on Free& Team plans (it's a fine idea, but needs a backend change to support it, so we can do it as a followup).

When we fetch the `/replay-count/` (list of replayIds) inside of `useReplaysFromIssue`, we need to guard against the empty list being returned. If the list is empty then there are no replayIds and we can skip the next fetch altogether.

Also I updated all the `queryReferrer` prop values to make stuff like this easier to track down.

<img width="939" alt="SCR-20231220-oein" src="https://github.com/getsentry/sentry/assets/187460/d4d5ee24-61eb-4300-b75c-f04cc17868b1">

Fixes https://github.com/getsentry/sentry/issues/62166