### PR TITLE
Utilize decoupled handle query errors

### DIFF
--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -30,3 +30,4 @@ class ApiOwner(Enum):
     TELEMETRY_EXPERIENCE = "telemetry-experience"
     UNOWNED = "unowned"
     WEB_FRONTEND_SDKS = "team-web-sdk-frontend"
+    WEB_BACKEND_SDKS = "team-web-sdk-backend"

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -30,4 +30,3 @@ class ApiOwner(Enum):
     TELEMETRY_EXPERIENCE = "telemetry-experience"
     UNOWNED = "unowned"
     WEB_FRONTEND_SDKS = "team-web-sdk-frontend"
-    WEB_BACKEND_SDKS = "team-web-sdk-backend"

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
 from datetime import timedelta
-from typing import Any, Callable, Dict, Generator, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple
 from urllib.parse import quote as urlquote
 
 import sentry_sdk
 from django.utils import timezone
-from rest_framework.exceptions import APIException, ParseError, ValidationError
+from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.request import Request
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 
@@ -19,13 +18,14 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.helpers.mobile import get_readable_device_name
 from sentry.api.helpers.teams import get_teams
 from sentry.api.serializers.snuba import BaseSnubaSerializer, SnubaTSResultSerializer
-from sentry.discover.arithmetic import ArithmeticError, is_equation, strip_equation
-from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
+from sentry.api.utils import handle_query_errors
+from sentry.discover.arithmetic import is_equation, strip_equation
+from sentry.exceptions import InvalidSearchQuery
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
-from sentry.search.events.constants import DURATION_UNITS, SIZE_UNITS, TIMEOUT_ERROR_MESSAGE
+from sentry.search.events.constants import DURATION_UNITS, SIZE_UNITS
 from sentry.search.events.fields import get_function_alias
 from sentry.search.events.types import SnubaParams
 from sentry.snuba import (
@@ -206,68 +206,6 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 )
         return results
 
-    @contextmanager
-    def handle_query_errors(self) -> Generator[None, None, None]:
-        try:
-            yield
-        except discover.InvalidSearchQuery as error:
-            message = str(error)
-            # Special case the project message since it has so many variants so tagging is messy otherwise
-            if message.endswith("do not exist or are not actively selected."):
-                sentry_sdk.set_tag(
-                    "query.error_reason", "Project in query does not exist or not selected"
-                )
-            else:
-                sentry_sdk.set_tag("query.error_reason", message)
-            raise ParseError(detail=message)
-        except ArithmeticError as error:
-            message = str(error)
-            sentry_sdk.set_tag("query.error_reason", message)
-            raise ParseError(detail=message)
-        except snuba.QueryOutsideRetentionError as error:
-            sentry_sdk.set_tag("query.error_reason", "QueryOutsideRetentionError")
-            raise ParseError(detail=str(error))
-        except snuba.QueryIllegalTypeOfArgument:
-            message = "Invalid query. Argument to function is wrong type."
-            sentry_sdk.set_tag("query.error_reason", message)
-            raise ParseError(detail=message)
-        except IncompatibleMetricsQuery as error:
-            message = str(error)
-            sentry_sdk.set_tag("query.error_reason", f"Metric Error: {message}")
-            raise ParseError(detail=message)
-        except snuba.SnubaError as error:
-            message = "Internal error. Please try again."
-            if isinstance(
-                error,
-                (
-                    snuba.RateLimitExceeded,
-                    snuba.QueryMemoryLimitExceeded,
-                    snuba.QueryExecutionTimeMaximum,
-                    snuba.QueryTooManySimultaneous,
-                ),
-            ):
-                sentry_sdk.set_tag("query.error_reason", "Timeout")
-                raise ParseError(detail=TIMEOUT_ERROR_MESSAGE)
-            elif isinstance(error, (snuba.UnqualifiedQueryError)):
-                sentry_sdk.set_tag("query.error_reason", str(error))
-                raise ParseError(detail=str(error))
-            elif isinstance(
-                error,
-                (
-                    snuba.DatasetSelectionError,
-                    snuba.QueryConnectionFailed,
-                    snuba.QueryExecutionError,
-                    snuba.QuerySizeExceeded,
-                    snuba.SchemaValidationError,
-                    snuba.QueryMissingColumn,
-                ),
-            ):
-                sentry_sdk.capture_exception(error)
-                message = "Internal error. Your query failed to run."
-            else:
-                sentry_sdk.capture_exception(error)
-            raise APIException(detail=message)
-
 
 class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
     owner = ApiOwner.PERFORMANCE
@@ -439,7 +377,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         additional_query_column: Optional[str] = None,
         dataset: Optional[Any] = None,
     ) -> Dict[str, Any]:
-        with self.handle_query_errors():
+        with handle_query_errors():
             with sentry_sdk.start_span(
                 op="discover.endpoint", description="base.stats_query_creation"
             ):

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -7,6 +7,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.event import SqlFormatEventSerializer
+from sentry.api.utils import handle_query_errors
 from sentry.constants import ObjectStatus
 from sentry.models.project import Project
 
@@ -36,7 +37,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
 
         # We return the requested event if we find a match regardless of whether
         # it occurred within the range specified
-        with self.handle_query_errors():
+        with handle_query_errors():
             event = eventstore.backend.get_event_by_id(project.id, event_id)
 
         if event is None:

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -12,6 +12,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.utils import handle_query_errors
 from sentry.apidocs import constants as api_constants
 from sentry.apidocs.examples.discover_performance_examples import DiscoverAndPerformanceExamples
 from sentry.apidocs.parameters import GlobalParams, OrganizationParams, VisibilityParams
@@ -301,7 +302,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
                 on_demand_metrics_type=on_demand_metrics_type,
             )
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             # Don't include cursor headers if the client won't be using them
             if request.GET.get("noPagination"):
                 return Response(

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -9,6 +9,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.utils import handle_query_errors
 from sentry.search.utils import DEVICE_CLASS
 from sentry.snuba import discover
 
@@ -30,7 +31,7 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsV2EndpointBase):
 
         def data_fn(offset, limit):
             with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):
-                with self.handle_query_errors():
+                with handle_query_errors():
                     facets = discover.get_facets(
                         query=request.GET.get("query"),
                         params=params,

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -14,6 +14,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.utils import handle_query_errors
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.fields import DateArg
 from sentry.snuba import discover
@@ -123,7 +124,7 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsFacetsPerfor
 
                 return results
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             return self.paginate(
                 request=request,
                 paginator=GenericOffsetPaginator(data_fn=data_fn),
@@ -223,7 +224,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpoint(
                 ),
             }
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             return self.paginate(
                 request=request,
                 paginator=HistogramPaginator(data_fn=data_fn),

--- a/src/sentry/api/endpoints/organization_events_has_measurements.py
+++ b/src/sentry/api/endpoints/organization_events_has_measurements.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
+from sentry.api.utils import handle_query_errors
 from sentry.snuba import discover
 from sentry.utils.hashlib import md5_text
 
@@ -93,7 +94,7 @@ class OrganizationEventsHasMeasurementsEndpoint(OrganizationEventsV2EndpointBase
 
         # cache miss, need to make the query again
         if has_measurements is None:
-            with self.handle_query_errors():
+            with handle_query_errors():
                 validated_data = serializer.validated_data
 
                 # generate the appropriate query for the selected type

--- a/src/sentry/api/endpoints/organization_events_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_histogram.py
@@ -8,6 +8,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
+from sentry.api.utils import handle_query_errors
 from sentry.snuba import discover
 
 # The maximum number of array columns allowed to be queried at at time
@@ -76,7 +77,7 @@ class OrganizationEventsHistogramEndpoint(OrganizationEventsV2EndpointBase):
             if serializer.is_valid():
                 data = serializer.validated_data
 
-                with self.handle_query_errors():
+                with handle_query_errors():
                     results = dataset.histogram_query(
                         data["field"],
                         data.get("query"),

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -13,6 +13,7 @@ from sentry.api.event_search import parse_search_query
 from sentry.api.helpers.group_index import build_query_params_from_request
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializer
+from sentry.api.utils import handle_query_errors
 from sentry.snuba import spans_indexed, spans_metrics
 from sentry.snuba.referrer import Referrer
 
@@ -31,7 +32,7 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
 
         dataset = self.get_dataset(request)
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             result = dataset.query(
                 selected_columns=["count()"],
                 params=params,
@@ -70,7 +71,7 @@ class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase, En
                     status=400,
                 )
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             with sentry_sdk.start_span(op="discover.endpoint", description="filter_creation"):
                 projects = self.get_projects(request, organization)
                 query_kwargs = build_query_params_from_request(

--- a/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
+++ b/src/sentry/api/endpoints/organization_events_root_cause_analysis.py
@@ -8,6 +8,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
 from sentry.api.endpoints.organization_events_spans_performance import EventID, get_span_description
+from sentry.api.utils import handle_query_errors
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.constants import METRICS_MAX_LIMIT
 from sentry.search.events.types import QueryBuilderConfig
@@ -260,7 +261,7 @@ class OrganizationEventsRootCauseAnalysisEndpoint(OrganizationEventsEndpointBase
 
         params = self.get_snuba_params(request, organization)
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             transaction_count_query = metrics_query(
                 ["count()"],
                 f'event.type:transaction transaction:"{transaction_name}"',

--- a/src/sentry/api/endpoints/organization_events_span_ops.py
+++ b/src/sentry/api/endpoints/organization_events_span_ops.py
@@ -7,6 +7,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.utils import handle_query_errors
 from sentry.models.organization import Organization
 from sentry.search.events.builder import QueryBuilder
 from sentry.snuba.dataset import Dataset
@@ -48,7 +49,7 @@ class OrganizationEventsSpanOpsEndpoint(OrganizationEventsEndpointBase):
             results = raw_snql_query(snql_query, "api.organization-events-span-ops")
             return [SpanOp(op=row["spans_op"], count=row["count"]) for row in results["data"]]
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             return self.paginate(
                 request,
                 paginator=GenericOffsetPaginator(data_fn=data_fn),

--- a/src/sentry/api/endpoints/organization_events_spans_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_spans_histogram.py
@@ -8,6 +8,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.endpoints.organization_events_spans_performance import Span
+from sentry.api.utils import handle_query_errors
 from sentry.snuba import discover
 
 DATA_FILTERS = ["all", "exclude_outliers"]
@@ -59,7 +60,7 @@ class OrganizationEventsSpansHistogramEndpoint(OrganizationEventsV2EndpointBase)
             if serializer.is_valid():
                 data = serializer.validated_data
 
-                with self.handle_query_errors():
+                with handle_query_errors():
                     results = discover.spans_histogram_query(
                         data["span"],
                         data.get("query"),

--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -19,6 +19,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.utils import handle_query_errors
 from sentry.discover.arithmetic import is_equation, strip_equation
 from sentry.models.organization import Organization
 from sentry.search.events.builder import QueryBuilder, TimeseriesQueryBuilder
@@ -190,7 +191,7 @@ class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsSpansEndpoint
 
             return [suspect.serialize() for suspect in suspects]
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             return self.paginate(
                 request,
                 paginator=GenericOffsetPaginator(data_fn=data_fn),
@@ -277,7 +278,7 @@ class OrganizationEventsSpansExamplesEndpoint(OrganizationEventsSpansEndpointBas
                 }
             ]
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             return self.paginate(
                 request,
                 paginator=SpanExamplesPaginator(data_fn=data_fn),

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -30,6 +30,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.serializers.models.event import get_tags_with_meta
+from sentry.api.utils import handle_query_errors
 from sentry.eventstore.models import Event
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.group import Group
@@ -551,7 +552,7 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
             organization,
             actor=request.user,
         )
-        with self.handle_query_errors():
+        with handle_query_errors():
             transactions, errors = query_trace_data(trace_id, params, limit)
             if len(transactions) == 0 and not tracing_without_performance_enabled:
                 return Response(status=404)
@@ -1023,7 +1024,7 @@ class OrganizationEventsTraceMetaEndpoint(OrganizationEventsTraceEndpointBase):
         except NoProjects:
             return Response(status=404)
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             result = discover.query(
                 selected_columns=[
                     "count_unique(project_id) as projects",

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -15,6 +15,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.event_search import AggregateFilter
 from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.utils import handle_query_errors
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.datasets import function_aliases
@@ -465,7 +466,7 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
         orderby = self.get_orderby(request)
         query = request.GET.get("query")
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             trend_query = TrendQueryBuilder(
                 dataset=Dataset.Discover,
                 params=params,
@@ -499,7 +500,7 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
             result = trend_query.process_results(result)
             return result
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             return self.paginate(
                 request=request,
                 paginator=GenericOffsetPaginator(data_fn=data_fn),

--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -14,6 +14,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.utils import handle_query_errors
 from sentry.search.events.constants import METRICS_GRANULARITIES
 from sentry.seer.utils import detect_breakpoints
 from sentry.snuba import metrics_performance
@@ -358,7 +359,7 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsV2EndpointBase)
                 else {},
             }
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             stats_data = self.get_event_stats_data(
                 request,
                 organization,

--- a/src/sentry/api/endpoints/organization_events_vitals.py
+++ b/src/sentry/api/endpoints/organization_events_vitals.py
@@ -7,6 +7,7 @@ from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
+from sentry.api.utils import handle_query_errors
 from sentry.search.events.fields import get_function_alias
 from sentry.snuba import discover
 
@@ -64,7 +65,7 @@ class OrganizationEventsVitalsEndpoint(OrganizationEventsV2EndpointBase):
                     ]
                 )
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             events_results = dataset.query(
                 selected_columns=selected_columns,
                 query=request.GET.get("query"),

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -12,7 +12,8 @@ from sentry import features, search
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import OrganizationEventPermission, OrganizationEventsEndpointBase
+from sentry.api.bases import OrganizationEventPermission
+from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.event_search import SearchFilter
 from sentry.api.helpers.group_index import (
     build_query_params_from_request,
@@ -136,7 +137,7 @@ def inbox_search(
 
 
 @region_silo_endpoint
-class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
+class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
     publish_status = {
         "DELETE": ApiPublishStatus.UNKNOWN,
         "GET": ApiPublishStatus.UNKNOWN,

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -4,7 +4,8 @@ from rest_framework.response import Response
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import OrganizationEventPermission, OrganizationEventsEndpointBase
+from sentry.api.bases import OrganizationEventPermission
+from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.endpoints.organization_group_index import ERR_INVALID_STATS_PERIOD
 from sentry.api.helpers.group_index import build_query_params_from_request, calculate_stats_period
 from sentry.api.serializers import serialize
@@ -16,7 +17,7 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 @region_silo_endpoint
-class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
+class OrganizationGroupIndexStatsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -2,6 +2,7 @@ from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventPermission
@@ -23,6 +24,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrganizationEventPermission,)
     enforce_rate_limit = True
+    owner = ApiOwner.PERFORMANCE
 
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/organization_issues_count.py
+++ b/src/sentry/api/endpoints/organization_issues_count.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from sentry_sdk import start_span
 
 from sentry import features, search
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
@@ -26,6 +27,7 @@ class OrganizationIssuesCountEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
+    owner = ApiOwner.PERFORMANCE
     enforce_rate_limit = True
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/organization_issues_count.py
+++ b/src/sentry/api/endpoints/organization_issues_count.py
@@ -6,7 +6,7 @@ from sentry_sdk import start_span
 from sentry import features, search
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import OrganizationEventsEndpointBase
+from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.helpers.group_index import validate_search_filter_permissions
 from sentry.api.helpers.group_index.validators import ValidationError
 from sentry.api.issue_search import convert_query_values, parse_search_query
@@ -22,7 +22,7 @@ ISSUES_COUNT_MAX_HITS_LIMIT = 100
 
 
 @region_silo_endpoint
-class OrganizationIssuesCountEndpoint(OrganizationEventsEndpointBase):
+class OrganizationIssuesCountEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }

--- a/src/sentry/api/endpoints/organization_measurements_meta.py
+++ b/src/sentry/api/endpoints/organization_measurements_meta.py
@@ -5,6 +5,7 @@ from sentry_sdk import start_span
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.api.utils import handle_query_errors
 from sentry.models.organization import Organization
 from sentry.search.events.constants import METRIC_FUNCTION_LIST_BY_TYPE
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
@@ -23,7 +24,7 @@ class OrganizationMeasurementsMeta(OrganizationEventsEndpointBase):
         except NoProjects:
             return Response({})
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             metric_meta = get_custom_measurements(
                 project_ids=params["project_id"],
                 organization_id=organization.id,

--- a/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
+++ b/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
@@ -56,7 +56,6 @@ class OrganizationMetricsEstimationStatsEndpoint(OrganizationEventsV2EndpointBas
     """Gets the estimated volume of an organization's metric events."""
 
     def get(self, request: Request, organization: Organization) -> Response:
-
         measurement = request.GET.get("yAxis")
 
         if measurement is None:

--- a/src/sentry/api/endpoints/organization_metrics_meta.py
+++ b/src/sentry/api/endpoints/organization_metrics_meta.py
@@ -5,6 +5,7 @@ from sentry_sdk import set_tag
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.api.utils import handle_query_errors
 from sentry.search.events.fields import get_function_alias
 from sentry.snuba import metrics_performance
 
@@ -36,7 +37,7 @@ class OrganizationMetricsCompatibility(OrganizationEventsEndpointBase):
             return Response(data)
         original_project_ids = params["project_id"].copy()
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             count_has_txn = "count_has_transaction_name()"
             count_null = "count_null_transactions()"
             compatible_results = metrics_performance.query(
@@ -88,7 +89,7 @@ class OrganizationMetricsCompatibilitySums(OrganizationEventsEndpointBase):
         except NoProjects:
             return Response(data)
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             sum_metrics = metrics_performance.query(
                 selected_columns=[COUNT_UNPARAM, COUNT_NULL, "count()"],
                 params=params,

--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -14,6 +14,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.utils import handle_query_errors
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.search.events.builder import ProfileTopFunctionsTimeseriesQueryBuilder
@@ -270,7 +271,7 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsV2EndpointBa
                 formatted_results.append(formatted_result)
             return formatted_results
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             return self.paginate(
                 request=request,
                 paginator=GenericOffsetPaginator(data_fn=paginate_trending_events),

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -13,6 +13,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.utils import handle_query_errors
 from sentry.sdk_updates import SdkIndexState, SdkSetupState, get_sdk_index, get_suggested_updates
 from sentry.snuba import discover
 from sentry.utils.numbers import format_grouped_length
@@ -85,7 +86,7 @@ class OrganizationSdkUpdatesEndpoint(OrganizationEventsEndpointBase):
         if len(projects) == 0:
             return Response([])
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             result = discover.query(
                 query="has:sdk.version",
                 selected_columns=[

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -71,7 +71,7 @@ def serialize(data, projects):
 
 @region_silo_endpoint
 class OrganizationSdkUpdatesEndpoint(OrganizationEndpoint):
-    owner = ApiOwner.WEB_BACKEND_SDKS
+    owner = ApiOwner.PERFORMANCE
 
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -11,7 +11,6 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.utils import handle_query_errors
 from sentry.sdk_updates import SdkIndexState, SdkSetupState, get_sdk_index, get_suggested_updates
@@ -71,7 +70,7 @@ def serialize(data, projects):
 
 
 @region_silo_endpoint
-class OrganizationSdkUpdatesEndpoint(OrganizationEventsEndpointBase):
+class OrganizationSdkUpdatesEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -71,6 +71,8 @@ def serialize(data, projects):
 
 @region_silo_endpoint
 class OrganizationSdkUpdatesEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.WEB_BACKEND_SDKS
+
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }

--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -11,18 +11,18 @@ from sentry import release_health
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.api.bases import NoProjects
+from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
-from sentry.api.utils import get_date_range_from_params
+from sentry.api.utils import get_date_range_from_params, handle_query_errors
 from sentry.exceptions import InvalidParams
 from sentry.models.organization import Organization
 from sentry.snuba.sessions_v2 import SNUBA_LIMIT, InvalidField, QueryDefinition
 from sentry.utils.cursors import Cursor, CursorResult
 
 
-# NOTE: this currently extends `OrganizationEventsEndpointBase` for `handle_query_errors` only, which should ideally be decoupled from the base class.
 @region_silo_endpoint
-class OrganizationSessionsEndpoint(OrganizationEventsEndpointBase):
+class OrganizationSessionsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
@@ -87,8 +87,8 @@ class OrganizationSessionsEndpoint(OrganizationEventsEndpointBase):
     @contextmanager
     def handle_query_errors(self):
         try:
-            # TODO: this context manager should be decoupled from `OrganizationEventsEndpointBase`?
-            with super().handle_query_errors():
+            # TODO: this context manager should be merged into util handle_query_error?
+            with handle_query_errors():
                 yield
         except (InvalidField, InvalidParams, NoProjects) as error:
             raise ParseError(detail=str(error))

--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -87,7 +87,6 @@ class OrganizationSessionsEndpoint(OrganizationEndpoint):
     @contextmanager
     def handle_query_errors(self):
         try:
-            # TODO: this context manager should be merged into util handle_query_error?
             with handle_query_errors():
                 yield
         except (InvalidField, InvalidParams, NoProjects) as error:

--- a/src/sentry/api/endpoints/organization_stats_summary.py
+++ b/src/sentry/api/endpoints/organization_stats_summary.py
@@ -15,7 +15,9 @@ from typing_extensions import TypedDict
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.api.bases import NoProjects
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.utils import handle_query_errors
 from sentry.apidocs.constants import RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
@@ -118,7 +120,7 @@ class StatsSummaryApiResponse(TypedDict):
 
 @extend_schema(tags=["Organizations"])
 @region_silo_endpoint
-class OrganizationStatsSummaryEndpoint(OrganizationEventsEndpointBase):
+class OrganizationStatsSummaryEndpoint(OrganizationEndpoint):
     publish_status = {"GET": ApiPublishStatus.PUBLIC}
     owner = ApiOwner.ENTERPRISE
 
@@ -253,8 +255,8 @@ class OrganizationStatsSummaryEndpoint(OrganizationEventsEndpointBase):
     @contextmanager
     def handle_query_errors(self):
         try:
-            # TODO: this context manager should be decoupled from `OrganizationEventsEndpointBase`?
-            with super().handle_query_errors():
+            # TODO: this context manager should be merged into util handle_query_error?
+            with handle_query_errors():
                 yield
         except (InvalidField, NoProjects, InvalidParams, InvalidQuery) as error:
             raise ParseError(detail=str(error))

--- a/src/sentry/api/endpoints/organization_stats_summary.py
+++ b/src/sentry/api/endpoints/organization_stats_summary.py
@@ -255,7 +255,6 @@ class OrganizationStatsSummaryEndpoint(OrganizationEndpoint):
     @contextmanager
     def handle_query_errors(self):
         try:
-            # TODO: this context manager should be merged into util handle_query_error?
             with handle_query_errors():
                 yield
         except (InvalidField, NoProjects, InvalidParams, InvalidQuery) as error:

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -216,7 +216,6 @@ class OrganizationStatsEndpointV2(OrganizationEndpoint):
     @contextmanager
     def handle_query_errors(self):
         try:
-            # TODO: this context manager should be decoupled from `OrganizationEventsEndpointBase`?
             with handle_query_errors():
                 yield
         except (InvalidField, NoProjects, InvalidParams, InvalidQuery) as error:

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -12,7 +12,9 @@ from typing_extensions import TypedDict
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.api.bases import NoProjects
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.utils import handle_query_errors
 from sentry.apidocs.constants import RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
@@ -131,7 +133,7 @@ class StatsApiResponse(TypedDict):
 
 @extend_schema(tags=["Organizations"])
 @region_silo_endpoint
-class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
+class OrganizationStatsEndpointV2(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
@@ -215,7 +217,7 @@ class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
     def handle_query_errors(self):
         try:
             # TODO: this context manager should be decoupled from `OrganizationEventsEndpointBase`?
-            with super().handle_query_errors():
+            with handle_query_errors():
                 yield
         except (InvalidField, NoProjects, InvalidParams, InvalidQuery) as error:
             raise ParseError(detail=str(error))

--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -9,6 +9,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
+from sentry.api.utils import handle_query_errors
 from sentry.tagstore.base import TAG_KEY_RE
 
 
@@ -36,7 +37,7 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
         except NoProjects:
             paginator = SequencePaginator([])
         else:
-            with self.handle_query_errors():
+            with handle_query_errors():
                 environment_ids = None
                 if "environment_objects" in filter_params:
                     environment_ids = [env.id for env in filter_params["environment_objects"]]

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -6,14 +6,16 @@ from sentry import tagstore
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.api.bases import NoProjects
+from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
+from sentry.api.utils import handle_query_errors
 from sentry.utils.numbers import format_grouped_length
 from sentry.utils.sdk import set_measurement
 
 
 @region_silo_endpoint
-class OrganizationTagsEndpoint(OrganizationEventsEndpointBase):
+class OrganizationTagsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
@@ -26,7 +28,7 @@ class OrganizationTagsEndpoint(OrganizationEventsEndpointBase):
             return Response([])
 
         with sentry_sdk.start_span(op="tagstore", description="get_tag_keys_for_projects"):
-            with self.handle_query_errors():
+            with handle_query_errors():
                 results = tagstore.backend.get_tag_keys_for_projects(
                     filter_params["project_id"],
                     filter_params.get("environment"),

--- a/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
+++ b/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
@@ -10,7 +10,7 @@ from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsEndpointBase
-from sentry.api.utils import get_date_range_from_params
+from sentry.api.utils import get_date_range_from_params, handle_query_errors
 from sentry.net.http import connection_from_url
 from sentry.snuba.metrics_enhanced_performance import timeseries_query
 from sentry.utils import json
@@ -129,7 +129,7 @@ class OrganizationTransactionAnomalyDetectionEndpoint(OrganizationEventsEndpoint
         query_params["start"] = time_params.query_start
         query_params["end"] = time_params.query_end
 
-        with self.handle_query_errors():
+        with handle_query_errors():
             snuba_response = timeseries_query(
                 selected_columns=["count()"],
                 query=query,

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -369,7 +369,7 @@ def get_auth_api_token_type(auth: object) -> str | None:
 
 
 @contextmanager
-def handle_query_errors(self) -> Generator[None, None, None]:
+def handle_query_errors() -> Generator[None, None, None]:
     try:
         yield
     except InvalidSearchQuery as error:

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -21,6 +21,7 @@ from sentry_sdk import Scope
 
 from sentry import options
 from sentry.auth.superuser import is_active_superuser
+from sentry.discover.arithmetic import ArithmeticError
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidParams, InvalidSearchQuery
 from sentry.models.apikey import is_api_key_auth
 from sentry.models.apitoken import is_api_token_auth

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -368,8 +368,6 @@ def get_auth_api_token_type(auth: object) -> str | None:
     return None
 
 
-# NOTE: This duplicates OrganizationEventsEndpointBase.handle_query_errors
-# TODO: move other references over to this implementation rather than the organization_events implementation
 @contextmanager
 def handle_query_errors(self) -> Generator[None, None, None]:
     try:

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -249,7 +249,7 @@ class HandleQueryErrorsTest:
         mock_parse_error.return_value = FooBarError()
         for ex in exceptions:
             try:
-                with handle_query_errors(self):
+                with handle_query_errors():
                     raise ex
             except Exception as e:
                 assert isinstance(e, (FooBarError, APIException))


### PR DESCRIPTION
Follow up from https://github.com/getsentry/sentry/pull/62232

Now that we've decoupled handle_query_errors from the `OrganizationEventsEndpointBase` class, we can stop extending it in a handful of classes and instead import the helper handler