### PR TITLE
feat(apis): Make auth related apis private

### DIFF
--- a/src/sentry/api/endpoints/api_application_rotate_secret.py
+++ b/src/sentry/api/endpoints/api_application_rotate_secret.py
@@ -14,7 +14,7 @@ from sentry.models.apiapplication import ApiApplication, ApiApplicationStatus, g
 @control_silo_endpoint
 class ApiApplicationRotateSecretEndpoint(Endpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     authentication_classes = (SessionAuthentication,)

--- a/src/sentry/api/endpoints/api_authorizations.py
+++ b/src/sentry/api/endpoints/api_authorizations.py
@@ -18,8 +18,8 @@ from sentry.models.outbox import outbox_context
 @control_silo_endpoint
 class ApiAuthorizationsEndpoint(Endpoint):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     authentication_classes = (SessionAuthentication,)

--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -28,9 +28,9 @@ class ApiTokenSerializer(serializers.Serializer):
 class ApiTokensEndpoint(Endpoint):
     owner = ApiOwner.SECURITY
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     authentication_classes = (SessionNoAuthTokenAuthentication,)
     permission_classes = (IsAuthenticated,)

--- a/src/sentry/api/endpoints/auth_config.py
+++ b/src/sentry/api/endpoints/auth_config.py
@@ -24,7 +24,7 @@ from sentry.web.frontend.base import OrganizationMixin
 @control_silo_endpoint
 class AuthConfigEndpoint(Endpoint, OrganizationMixin):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     # Disable authentication and permission requirements.

--- a/src/sentry/api/endpoints/auth_login.py
+++ b/src/sentry/api/endpoints/auth_login.py
@@ -19,7 +19,7 @@ from sentry.web.frontend.base import OrganizationMixin
 @control_silo_endpoint
 class AuthLoginEndpoint(Endpoint, OrganizationMixin):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     # Disable authentication and permission requirements.

--- a/src/sentry/api/endpoints/authenticator_index.py
+++ b/src/sentry/api/endpoints/authenticator_index.py
@@ -13,7 +13,7 @@ from sentry.models.authenticator import Authenticator
 @control_silo_endpoint
 class AuthenticatorIndexEndpoint(Endpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (IsAuthenticated,)

--- a/src/sentry/api/endpoints/check_am2_compatibility.py
+++ b/src/sentry/api/endpoints/check_am2_compatibility.py
@@ -19,7 +19,7 @@ from sentry.tasks.check_am2_compatibility import (
 class CheckAM2CompatibilityEndpoint(Endpoint):
     owner = ApiOwner.BILLING
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (SuperuserPermission,)
 

--- a/src/sentry/api/endpoints/oauth_userinfo.py
+++ b/src/sentry/api/endpoints/oauth_userinfo.py
@@ -20,7 +20,7 @@ class InsufficientScopesError(SentryAPIException):
 @control_silo_endpoint
 class OAuthUserInfoEndpoint(Endpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     authentication_classes = ()

--- a/src/sentry/api/endpoints/org_auth_token_details.py
+++ b/src/sentry/api/endpoints/org_auth_token_details.py
@@ -19,9 +19,9 @@ from sentry.services.hybrid_cloud.organization.model import (
 @control_silo_endpoint
 class OrgAuthTokenDetailsEndpoint(ControlSiloOrganizationEndpoint):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrgAuthTokenPermission,)

--- a/src/sentry/api/endpoints/org_auth_tokens.py
+++ b/src/sentry/api/endpoints/org_auth_tokens.py
@@ -35,8 +35,8 @@ from sentry.utils.security.orgauthtoken_token import (
 @control_silo_endpoint
 class OrgAuthTokensEndpoint(ControlSiloOrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrgAuthTokenPermission,)

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -47,8 +47,8 @@ class AccessRequestSerializer(serializers.Serializer):
 @region_silo_endpoint
 class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (AccessRequestPermission,)

--- a/src/sentry/api/endpoints/organization_auth_provider_details.py
+++ b/src/sentry/api/endpoints/organization_auth_provider_details.py
@@ -15,7 +15,7 @@ from sentry.services.hybrid_cloud.auth.service import auth_service
 @region_silo_endpoint
 class OrganizationAuthProviderDetailsEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrganizationAuthProviderPermission,)

--- a/src/sentry/api/endpoints/organization_auth_provider_send_reminders.py
+++ b/src/sentry/api/endpoints/organization_auth_provider_send_reminders.py
@@ -18,7 +18,7 @@ ERR_NO_SSO = _("The SSO feature is not enabled for this organization.")
 @region_silo_endpoint
 class OrganizationAuthProviderSendRemindersEndpoint(OrganizationEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrganizationAdminPermission,)

--- a/src/sentry/api/endpoints/organization_auth_providers.py
+++ b/src/sentry/api/endpoints/organization_auth_providers.py
@@ -12,7 +12,7 @@ from sentry.auth import manager
 @region_silo_endpoint
 class OrganizationAuthProvidersEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrganizationAuthProviderPermission,)

--- a/src/sentry/api/endpoints/user_authenticator_details.py
+++ b/src/sentry/api/endpoints/user_authenticator_details.py
@@ -21,9 +21,9 @@ from sentry.utils.auth import MFA_SESSION_KEY
 @control_silo_endpoint
 class UserAuthenticatorDetailsEndpoint(UserEndpoint):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (OrganizationUserPermission,)

--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -110,8 +110,8 @@ def get_serializer_field_metadata(serializer, fields=None):
 @control_silo_endpoint
 class UserAuthenticatorEnrollEndpoint(UserEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
 

--- a/src/sentry/api/endpoints/user_authenticator_index.py
+++ b/src/sentry/api/endpoints/user_authenticator_index.py
@@ -12,7 +12,7 @@ from sentry.models.authenticator import Authenticator
 @control_silo_endpoint
 class UserAuthenticatorIndexEndpoint(UserEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
 

--- a/src/sentry/api/endpoints/user_password.py
+++ b/src/sentry/api/endpoints/user_password.py
@@ -48,7 +48,7 @@ class UserPasswordSerializer(serializers.Serializer):
 class UserPasswordEndpoint(UserEndpoint):
     owner = ApiOwner.SECURITY
     publish_status = {
-        "PUT": ApiPublishStatus.UNKNOWN,
+        "PUT": ApiPublishStatus.PRIVATE,
     }
 
     def put(self, request: Request, user) -> Response:

--- a/src/sentry/api/endpoints/user_permission_details.py
+++ b/src/sentry/api/endpoints/user_permission_details.py
@@ -19,9 +19,9 @@ audit_logger = logging.getLogger("sentry.audit.user")
 @control_silo_endpoint
 class UserPermissionDetailsEndpoint(UserEndpoint):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (SuperuserPermission,)

--- a/src/sentry/api/endpoints/user_permissions.py
+++ b/src/sentry/api/endpoints/user_permissions.py
@@ -12,7 +12,7 @@ from sentry.models.userpermission import UserPermission
 @control_silo_endpoint
 class UserPermissionsEndpoint(UserEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (SuperuserPermission,)

--- a/src/sentry/api/endpoints/user_permissions_config.py
+++ b/src/sentry/api/endpoints/user_permissions_config.py
@@ -12,7 +12,7 @@ from sentry.api.permissions import SuperuserPermission
 @control_silo_endpoint
 class UserPermissionsConfigEndpoint(UserEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
     permission_classes = (SuperuserPermission,)

--- a/src/sentry/api/endpoints/user_social_identities_index.py
+++ b/src/sentry/api/endpoints/user_social_identities_index.py
@@ -12,7 +12,7 @@ from social_auth.models import UserSocialAuth
 @control_silo_endpoint
 class UserSocialIdentitiesIndexEndpoint(UserEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
 

--- a/src/sentry/api/endpoints/user_social_identity_details.py
+++ b/src/sentry/api/endpoints/user_social_identity_details.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("sentry.accounts")
 @control_silo_endpoint
 class UserSocialIdentityDetailsEndpoint(UserEndpoint):
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ENTERPRISE
 


### PR DESCRIPTION
I'm marking all auth/identity related apis private. My logic is that if you're building automations using apis you need an api token that you got through the app so documenting these don't make sense. Please correct me if I'm wrong.
