### PR TITLE
build(ui): Add NO_SPOTLIGHT env variable to webpack

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -79,7 +79,7 @@ const NO_DEV_SERVER = !!env.NO_DEV_SERVER; // Do not run webpack dev server
 const SHOULD_FORK_TS = DEV_MODE && !env.NO_TS_FORK; // Do not run fork-ts plugin (or if not dev env)
 const SHOULD_HOT_MODULE_RELOAD = DEV_MODE && !!env.SENTRY_UI_HOT_RELOAD;
 const SHOULD_LAZY_LOAD = DEV_MODE && !!env.SENTRY_UI_LAZY_LOAD;
-const SHOULD_RUN_SPOTLIGHT = DEV_MODE && !env.NO_SPOTLIGHT; // Do not run spotlight sidecar even in dev mode
+const SHOULD_RUN_SPOTLIGHT = DEV_MODE && !env.NO_SPOTLIGHT; // Do not run spotlight sidecar
 
 // Deploy previews are built using vercel. We can check if we're in vercel's
 // build process by checking the existence of the PULL_REQUEST env var.

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -79,7 +79,7 @@ const NO_DEV_SERVER = !!env.NO_DEV_SERVER; // Do not run webpack dev server
 const SHOULD_FORK_TS = DEV_MODE && !env.NO_TS_FORK; // Do not run fork-ts plugin (or if not dev env)
 const SHOULD_HOT_MODULE_RELOAD = DEV_MODE && !!env.SENTRY_UI_HOT_RELOAD;
 const SHOULD_LAZY_LOAD = DEV_MODE && !!env.SENTRY_UI_LAZY_LOAD;
-const NO_SPOTLIGHT = !env.NO_SPOTLIGHT; // Do not run spotlight sidecar even in dev mode
+const SHOULD_RUN_SPOTLIGHT = DEV_MODE && !env.NO_SPOTLIGHT; // Do not run spotlight sidecar even in dev mode
 
 // Deploy previews are built using vercel. We can check if we're in vercel's
 // build process by checking the existence of the PULL_REQUEST env var.
@@ -616,7 +616,7 @@ if (
 }
 
 // We want Spotlight only in Dev mode - Local and UI only
-if (DEV_MODE && !NO_SPOTLIGHT) {
+if (SHOULD_RUN_SPOTLIGHT) {
   appConfig.plugins?.push(
     new WebpackHookPlugin({
       onBuildStart: ['yarn run spotlight-sidecar'],

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -79,6 +79,7 @@ const NO_DEV_SERVER = !!env.NO_DEV_SERVER; // Do not run webpack dev server
 const SHOULD_FORK_TS = DEV_MODE && !env.NO_TS_FORK; // Do not run fork-ts plugin (or if not dev env)
 const SHOULD_HOT_MODULE_RELOAD = DEV_MODE && !!env.SENTRY_UI_HOT_RELOAD;
 const SHOULD_LAZY_LOAD = DEV_MODE && !!env.SENTRY_UI_LAZY_LOAD;
+const NO_SPOTLIGHT = !env.NO_SPOTLIGHT; // Do not run spotlight sidecar even in dev mode
 
 // Deploy previews are built using vercel. We can check if we're in vercel's
 // build process by checking the existence of the PULL_REQUEST env var.
@@ -615,7 +616,7 @@ if (
 }
 
 // We want Spotlight only in Dev mode - Local and UI only
-if (DEV_MODE) {
+if (DEV_MODE && !NO_SPOTLIGHT) {
   appConfig.plugins?.push(
     new WebpackHookPlugin({
       onBuildStart: ['yarn run spotlight-sidecar'],


### PR DESCRIPTION
`export NO_SPOTLIGHT=1` will disable spotlight sidecar even in dev mode
