### PR TITLE
fix(crons): Only resolve issues for OK check-ins

### DIFF
--- a/src/sentry/monitors/logic/mark_ok.py
+++ b/src/sentry/monitors/logic/mark_ok.py
@@ -25,6 +25,7 @@ def mark_ok(checkin: MonitorCheckIn, ts: datetime):
         not monitor_env.monitor.is_muted
         and not monitor_env.is_muted
         and monitor_env.status != MonitorStatus.OK
+        and checkin.status == CheckInStatus.OK
     ):
         params["status"] = MonitorStatus.OK
         recovery_threshold = monitor_env.monitor.config.get("recovery_threshold", 1)

--- a/tests/sentry/monitors/logic/test_mark_ok.py
+++ b/tests/sentry/monitors/logic/test_mark_ok.py
@@ -118,6 +118,17 @@ class MarkOkTestCase(TestCase):
             )
             mark_ok(checkin, checkin.date_added)
 
+        # create an in-progress check-in to make sure that we don't resolve anything
+        now = now + timedelta(minutes=1)
+        checkin = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.IN_PROGRESS,
+            date_added=now,
+        )
+        mark_ok(checkin, checkin.date_added)
+
         # failure has not hit threshold, monitor should be in an OK status
         incident.refresh_from_db()
         monitor_environment.refresh_from_db()


### PR DESCRIPTION
Do not resolve open issues or update a monitor environment status when check-ins with `IN_PROGRESS` status are consumed