### PR TITLE
disable cursor query from release-threshold api query

### DIFF
--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -120,11 +120,12 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
         'releases', // stateKey
         `/organizations/${organization.slug}/releases/`, // endpoint
         {query}, // params
-        {disableEntireQuery: true}, // options
+        {disableEntireQuery: true}, // options - prevent cursor from being passed into query
       ],
     ];
 
     if (this.hasV2ReleaseUIEnabled) {
+      // prefetch all thresholds so we know whether to expect a threshold or not
       const thresholdQuery: ThresholdQuery = {};
       if (selection.projects.length) {
         thresholdQuery.project = selection.projects;
@@ -139,6 +140,7 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
         'thresholds',
         `/organizations/${organization.slug}/release-thresholds/`,
         {query: thresholdQuery},
+        {disableEntireQuery: true}, // options to prevent cursor from being passed
       ]);
     }
 


### PR DESCRIPTION
Currently page2 of releases is not showing thresholds because the cursor query param is affecting the listed results (release-thresholds is not a paginated api)

This clears that query param so what we're passing in on the UI is the expected query that is received in the BE