### PR TITLE
fix(replays): add additional check in case replayId exists

### DIFF
--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -50,7 +50,7 @@ function EventReplayContent({
 
   const platform = group?.project.platform ?? 'other';
   const newOnboarding = organization.features.includes('session-replay-new-zero-state');
-  if (replayBackendPlatforms.includes(platform) && newOnboarding) {
+  if (replayBackendPlatforms.includes(platform) && newOnboarding && !replayId) {
     // if backend project, show new onboarding panel
     return (
       <ErrorBoundary mini>

--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -50,7 +50,7 @@ function EventReplayContent({
 
   const platform = group?.project.platform ?? 'other';
   const newOnboarding = organization.features.includes('session-replay-new-zero-state');
-  if (replayBackendPlatforms.includes(platform) && newOnboarding && !replayId) {
+  if (newOnboarding && !replayId && replayBackendPlatforms.includes(platform)) {
     // if backend project, show new onboarding panel
     return (
       <ErrorBoundary mini>


### PR DESCRIPTION
If there's a replay ID, we want to show the replay, not the setup banner