### PR TITLE
fix(backup): Fix mis-migrated AlertRule imports

### DIFF
--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -4,7 +4,7 @@ import io
 import os
 import tarfile
 import tempfile
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Tuple, Type
 from unittest.mock import patch
@@ -29,6 +29,8 @@ from sentry.backup.imports import (
     import_in_user_scope,
 )
 from sentry.backup.scopes import ExportScope, ImportScope, RelocationScope
+from sentry.incidents.models import AlertRule, AlertRuleThresholdType
+from sentry.models.actor import ACTOR_TYPES, Actor
 from sentry.models.apitoken import DEFAULT_EXPIRATION, ApiToken, generate_token
 from sentry.models.authenticator import Authenticator
 from sentry.models.email import Email
@@ -62,7 +64,9 @@ from sentry.monitors.models import Monitor
 from sentry.receivers import create_default_projects
 from sentry.services.hybrid_cloud.import_export.model import RpcImportErrorKind
 from sentry.silo.base import SiloMode
-from sentry.snuba.models import QuerySubscription, SnubaQuery
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.subscriptions import create_snuba_query
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.backups import (
@@ -2150,6 +2154,119 @@ class CollisionTests(ImportTestCase):
                 assert len(useremail_chunk.existing_map) == 0
                 assert UserEmail.objects.filter(email__icontains="existing@").exists()
                 assert UserEmail.objects.filter(email__icontains="importing@").exists()
+
+            with open(tmp_path, "rb") as tmp_file:
+                verify_models_in_output(expected_models, json.load(tmp_file))
+
+
+CUSTOM_IMPORT_BEHAVIOR_TESTED: set[NormalizedModelName] = set()
+
+
+# There is no need to in both monolith and region mode for model-level unit tests - region mode
+# testing along should suffice.
+@region_silo_test
+class CustomImportBehaviorTests(ImportTestCase):
+    """
+    Test bespoke, per-model behavior. Since these tests are relatively expensive to set up and tear
+    down (think on the order of 5-10 seconds per test case), we encourage combining model test cases
+    as much as reasonably possible.
+    """
+
+    # TODO(hybrid-cloud): actor refactor. Remove this test case when done.
+    @expect_models(CUSTOM_IMPORT_BEHAVIOR_TESTED, Actor, AlertRule)
+    def test_alert_rule_with_owner_id(self, expected_models: list[Type[Model]]):
+        user = self.create_user()
+        org = self.create_organization(name="test-org", owner=user)
+        team = self.create_team(name="test-team", organization=org)
+
+        def create_fake_snuba_query() -> SnubaQuery:
+            return create_snuba_query(
+                query_type=SnubaQuery.Type.ERROR,
+                dataset=Dataset.Events,
+                query="level:error",
+                aggregate="count()",
+                time_window=timedelta(minutes=10),
+                resolution=timedelta(minutes=1),
+                environment=None,
+                event_types=[SnubaQueryEventType.EventType.ERROR],
+            )
+
+        # Create four `AlertRule`. Both of them fell through the `owner_id` migration, and therefore
+        # DO have an `owner_id`, but have NEITHER a `team_id` nor `user_id`.
+        #
+        # For the first two `AlertRule` rules, we'll include an `Actor` model with the correct data,
+        # meaning we just have to do a DB lookup, but the model import should go ahead as if the
+        # migration had been successful. For the third `AlertRule`, the `Actor` will also have both
+        # `team` and `user` set to null. Finally, the last instance will have no `Actor` at all.
+        #
+        # The expected result is that the first two instances succeed, while the last two are
+        # ignored.]
+        common_alert_rule_args = {
+            "organization": org,
+            "threshold_type": AlertRuleThresholdType.ABOVE.value,
+            "resolve_threshold": 10,
+            "threshold_period": 1,
+            "include_all_projects": False,
+            "comparison_delta": None,
+        }
+
+        # Use `bulk_create` to avoid the `.save()` checks that catch some otherwise invalid data -
+        # the whole point of this test is to ensure we gracefully recover when importing such data!
+        AlertRule.objects.bulk_create(
+            [
+                AlertRule(
+                    name="user-alert-rule",
+                    owner=Actor.objects.create(user_id=user.id, type=ACTOR_TYPES["user"]),
+                    snuba_query=create_fake_snuba_query(),
+                    **common_alert_rule_args,
+                ),
+                AlertRule(
+                    name="team-alert-rule",
+                    owner=Actor.objects.get(team=team, type=ACTOR_TYPES["team"]),
+                    snuba_query=create_fake_snuba_query(),
+                    **common_alert_rule_args,
+                ),
+                AlertRule(
+                    name="null-alert-rule",
+                    owner=Actor.objects.create(team=None, user_id=None, type=ACTOR_TYPES["team"]),
+                    snuba_query=create_fake_snuba_query(),
+                    **common_alert_rule_args,
+                ),
+                AlertRule(
+                    name="unowned-alert-rule",
+                    owner=None,
+                    snuba_query=create_fake_snuba_query(),
+                    **common_alert_rule_args,
+                ),
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path, "rb") as tmp_file:
+                import_in_organization_scope(
+                    tmp_file,
+                    printer=NOOP_PRINTER,
+                )
+
+            user_alert_rule: AlertRule = AlertRule.objects.get(name="user-alert-rule")
+            user_actor: Actor = Actor.objects.get(id=user_alert_rule.owner_id)
+            assert user_alert_rule.owner is not None
+            assert user_alert_rule.user_id == user_actor.user_id
+            assert user_alert_rule.team is None
+            assert user_actor.team is None
+
+            team_alert_rule: AlertRule = AlertRule.objects.get(name="team-alert-rule")
+            team_actor: Actor = Actor.objects.get(id=team_alert_rule.owner_id)
+            assert team_alert_rule.owner is not None
+            assert team_alert_rule.team == team_actor.team
+            assert team_alert_rule.user_id is None
+            assert team_actor.user_id is None
+
+            null_alert_rule: AlertRule = AlertRule.objects.get(name="null-alert-rule")
+            unowned_alert_rule: AlertRule = AlertRule.objects.get(name="unowned-alert-rule")
+            assert null_alert_rule.owner is None
+            assert unowned_alert_rule.owner is None
 
             with open(tmp_path, "rb") as tmp_file:
                 verify_models_in_output(expected_models, json.load(tmp_file))


### PR DESCRIPTION
In theory, as part of the ongoing "actor refactor", all `AlertRule` instances with an `owner_id` pointing to a non-null `Actor` should have that `Actor` instance's populated `user_id` or `team_id` field hoisted into the `AlertRule` model (see https://github.com/getsentry/sentry/pull/58667 for more). In practice, we've seen some failing relocations of real self-hosted data, implying that there have been some misses in the migration, causing newly imported models to fail validation.

In the long term, we'd like to implement a migration that fixes all of the missing edge cases. Until that happens, this import-time fix should allow us to work around the issue. The basic logic is to manually do the hoisting at import-time if possible. If not possible (either due to a missing `owner_id`, or because the `Actor` being pointed to both `team` and `user` set to null), we ensure that the `owner_id` is nulled out.