### PR TITLE
fix: empty replays count badge

### DIFF
--- a/static/app/components/replays/replayCountBadge.tsx
+++ b/static/app/components/replays/replayCountBadge.tsx
@@ -2,6 +2,9 @@ import Badge from 'sentry/components/badge';
 
 function ReplayCountBadge({count}: {count: undefined | number}) {
   const display = count && count > 50 ? '50+' : count ?? null;
+  if (display === null) {
+    return null;
+  }
   return <Badge text={display} />;
 }
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
In my issues detail view, I saw the replays tab with an empty badge ( I was confused and thought it was a skeleton loader, but turns out it was just an empty badge. )

Checked the api, was returning an empty object. ( I am sure this will be handled by someone )

Quick frontend fix : **don't show badge when no count available!** 

images below : 

<img width="261" alt="Screenshot 2024-01-03 at 11 41 16 AM" src="https://github.com/getsentry/sentry/assets/136301926/b97d1e45-410b-401e-8ccc-9a941988db69">
<img width="794" alt="Screenshot 2024-01-03 at 11 41 48 AM" src="https://github.com/getsentry/sentry/assets/136301926/4f8d13a0-150f-4a26-a526-92701784d006">

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
