### PR TITLE
feat(ddm): Implement dynamic interval calculation for metrics API

### DIFF
--- a/src/sentry/sentry_metrics/querying/api.py
+++ b/src/sentry/sentry_metrics/querying/api.py
@@ -436,7 +436,10 @@ class QueryExecutor:
                 return interval
 
         # If no suitable interval is found, we throw an error to unwind.
-        raise MetricsQueryExecutionError("Too many results returned by the query")
+        raise MetricsQueryExecutionError(
+            "Unable to find an interval to satisfy the query because too many results "
+            "are returned."
+        )
 
     def _serial_execute(self) -> Sequence[ExecutionResult]:
         if not self._scheduled_queries:

--- a/tests/sentry/sentry_metrics/querying/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/test_api.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 from django.utils import timezone as django_timezone
@@ -384,6 +385,42 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert groups[0]["by"] == {}
         assert groups[0]["series"] == {field: [0, 2, 0]}
         assert groups[0]["totals"] == {field: 2}
+
+    @patch("sentry.sentry_metrics.querying.api.SNUBA_QUERY_LIMIT", 5)
+    def test_query_with_too_many_results(self) -> None:
+        # Query with one aggregation and two group by.
+        field = f"sum({TransactionMRI.DURATION.value})"
+        results = run_metrics_query(
+            fields=[field],
+            query=None,
+            group_bys=["transaction", "platform"],
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=60,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        # We expect that the algorithm chooses an interval of 2 hours, since we are querying 3 timeseries and given
+        # a limit of 5, the best that we can do is to have one interval per timeseries 3 * 1 < 5. We can't have for
+        # example an interval of 1 hour, since this will result in 2 intervals for each group which is 3 * 2 < 5.
+        # Given the inner workings of query ranges, if we query from 09:30 to 11:30 with an interval of 2 hours, the
+        # system will approximate to the outer bounds that are a multiple of 2 hours, which in this case is:
+        # 08:00 - 10:00
+        # 10:00 - 12:00
+        assert results["intervals"] == [self.now() - timedelta(hours=2), self.now()]
+        groups = results["groups"]
+        assert len(groups) == 3
+        assert groups[0]["by"] == {"platform": "android", "transaction": "/hello"}
+        assert groups[0]["series"] == {field: [0.0, 3.0]}
+        assert groups[0]["totals"] == {field: 3.0}
+        assert groups[1]["by"] == {"platform": "ios", "transaction": "/hello"}
+        assert groups[1]["series"] == {field: [0.0, 6.0]}
+        assert groups[1]["totals"] == {field: 6.0}
+        assert groups[2]["by"] == {"platform": "windows", "transaction": "/world"}
+        assert groups[2]["series"] == {field: [0.0, 8.0]}
+        assert groups[2]["totals"] == {field: 8.0}
 
     @pytest.mark.skip(reason="sessions are not supported in the new metrics layer")
     def test_with_sessions(self) -> None:


### PR DESCRIPTION
This PR implements a new query execution algorithm that aims at minimizing the number of queries that can't be satisfied due to the resultset being over the snuba limit (10k results at the time being).

The algorithm works in the following way:
1. It tries to execute the first query (if you have many, otherwise it executes the single query and that's it).
2. If the results are < 10k, it continues executing the other queries (if any).
3. If the results are >= 10k, it tries to determine the optimal interval size given the time range. For example, 2 hours interval instead of the specified 30 minutes.
4. It tries to run the query with the new optimal interval and tries other bigger intervals until there is no more choice.

Since the number of possibilities for the intervals is bounded, the number of queries that can be emitted has a known upper bound but we should track how many interval trials are performed, to make sure we know if the system is incurring into this edge case quite a lot.

Closes https://github.com/getsentry/sentry/issues/62466