### PR TITLE
ref: add metrics to native and javascript stacktraces processing symbolicator requests

### DIFF
--- a/src/sentry/lang/javascript/processing.py
+++ b/src/sentry/lang/javascript/processing.py
@@ -236,6 +236,7 @@ def process_js_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
         metrics.incr("sourcemaps.symbolicator.events.skipped")
         return
 
+    metrics.incr("process.javascript.symbolicate.request")
     response = symbolicator.process_js(
         stacktraces=stacktraces,
         modules=modules,

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -23,6 +23,7 @@ from sentry.lang.native.utils import (
 from sentry.models.eventerror import EventError
 from sentry.stacktraces.functions import trim_function_name
 from sentry.stacktraces.processing import find_stacktraces_in_data
+from sentry.utils import metrics
 from sentry.utils.in_app import is_known_third_party, is_optional_package
 from sentry.utils.safe import get_path, set_path, setdefault_path, trim
 
@@ -279,6 +280,7 @@ def process_minidump(symbolicator: Symbolicator, data: Any) -> Any:
         logger.error("Missing minidump for minidump event")
         return
 
+    metrics.incr("process.native.symbolicate.request")
     response = symbolicator.process_minidump(minidump.data)
 
     if _handle_response_status(data, response):
@@ -293,6 +295,7 @@ def process_applecrashreport(symbolicator: Symbolicator, data: Any) -> Any:
         logger.error("Missing applecrashreport for event")
         return
 
+    metrics.incr("process.native.symbolicate.request")
     response = symbolicator.process_applecrashreport(report.data)
 
     if _handle_response_status(data, response):
@@ -399,6 +402,7 @@ def process_native_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
 
     signal = signal_from_data(data)
 
+    metrics.incr("process.native.symbolicate.request")
     response = symbolicator.process_payload(stacktraces=stacktraces, modules=modules, signal=signal)
 
     if not _handle_response_status(data, response):


### PR DESCRIPTION
Add metrics to track symbolicator requests in `javascript` and `native` stacktrace processing.

Profiling does that already.
