### PR TITLE
Compress whole Attachment in memory

### DIFF
--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -154,8 +154,7 @@ class EventAttachment(Model):
             blob_path = "eventattachments/v1/" + FileBlob.generate_unique_path()
 
             storage = get_storage()
-            cctx = zstandard.ZstdCompressor()
-            compressed_blob = cctx.stream_reader(blob)
+            compressed_blob = BytesIO(zstandard.compress(attachment.data))
             storage.save(blob_path, compressed_blob)
 
             return PutfileResult(


### PR DESCRIPTION
The `storage.save` abstraction expects the IO object to be seekable. We cannot use a zstd stream for that reason, and rather compress the whole attachment at once before saving.

Fixes SENTRY-2CPS