### PR TITLE
fix(mql): Set correct Dataset based on use case ID

### DIFF
--- a/src/sentry/snuba/metrics_layer/query.py
+++ b/src/sentry/snuba/metrics_layer/query.py
@@ -181,6 +181,8 @@ def mql_query(request: Request, start: datetime, end: datetime) -> Mapping[str, 
         # using it.
         if metrics_query.scope.use_case_id == UseCaseID.SESSIONS.value:
             request.dataset = Dataset.Metrics.value
+        else:
+            request.dataset = Dataset.PerformanceMetrics.value
     except Exception as e:
         metrics.incr(
             "metrics_layer.query",

--- a/tests/snuba/test_metrics_layer.py
+++ b/tests/snuba/test_metrics_layer.py
@@ -542,6 +542,49 @@ class MQLTest(TestCase, BaseMetricsTestCase):
                 ).isoformat()
             )
 
+    def test_dataset_correctness(self) -> None:
+        query = MetricsQuery(
+            query=Timeseries(
+                metric=Metric(
+                    "transaction.duration",
+                    TransactionMRI.DURATION.value,
+                ),
+                aggregate="quantiles",
+                aggregate_params=[0.5, 0.99],
+                groupby=[Column("transaction")],
+                filters=[
+                    Condition(Column("transaction"), Op.IN, ["transaction_0", "transaction_1"])
+                ],
+            ),
+            start=self.hour_ago,
+            end=self.now,
+            rollup=Rollup(interval=60, granularity=60),
+            scope=MetricsScope(
+                org_ids=[self.org_id],
+                project_ids=[self.project.id],
+                use_case_id=UseCaseID.TRANSACTIONS.value,
+            ),
+        )
+
+        request = Request(
+            dataset="metrics",
+            app_id="tests",
+            query=query,
+            tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
+        )
+        result = self.run_query(request)
+        assert len(result["data"]) == 10
+        rows = result["data"]
+        for i in range(10):
+            assert rows[i]["aggregate_value"] == [i, i]
+            assert rows[i]["transaction"] == f"transaction_{i % 2}"
+            assert (
+                rows[i]["time"]
+                == (
+                    self.hour_ago.replace(second=0, microsecond=0) + timedelta(minutes=1 * i)
+                ).isoformat()
+            )
+
 
 class SnQLTest(MQLTest):
     @property


### PR DESCRIPTION
The code would correctly change the Dataset to` metrics` for sessions data, but
would not correct the Dataset to `generic_metrics` for the other use cases. This
was causing Snuba to break, since Snuba uses the Dataset to determine how to
resolve the tag columns. Now the default will always be `generic_metrics`
regardless of what is passed into the query layer.

https://sentry.sentry.io/issues/4796939908/?end=2024-01-03T10%3A31%3A50&project=1&query=is%3Aunresolved+snuba&referrer=issue-stream&start=2024-01-03T08%3A31%3A50&stream_index=13&utc=true