### PR TITLE
ref(ts:) Remove test stubs export aliases

### DIFF
--- a/fixtures/js-stubs/availableNotificationActions.tsx
+++ b/fixtures/js-stubs/availableNotificationActions.tsx
@@ -155,6 +155,3 @@ export function AvailableNotificationActionsFixture(
     ],
   };
 }
-
-// TODO(@gggritso): Remove this once the imports in `getsentry` are up-to-date
-export {AvailableNotificationActionsFixture as AvailableNotificationActions};

--- a/fixtures/js-stubs/config.tsx
+++ b/fixtures/js-stubs/config.tsx
@@ -68,6 +68,3 @@ export function ConfigFixture(params: Partial<ConfigType> = {}): ConfigType {
     ...params,
   };
 }
-
-// TODO(@gggritso): Remove this once the imports in `getsentry` are up-to-date
-export {ConfigFixture as Config};

--- a/fixtures/js-stubs/group.ts
+++ b/fixtures/js-stubs/group.ts
@@ -64,6 +64,3 @@ export function GroupFixture(params: Partial<GroupType> = {}): GroupType {
 
   return {...unresolvedGroup, ...params} as GroupType;
 }
-
-// TODO(@gggritso): Remove this once the imports in `getsentry` are up-to-date
-export {GroupFixture as Group};

--- a/fixtures/js-stubs/member.tsx
+++ b/fixtures/js-stubs/member.tsx
@@ -36,6 +36,3 @@ export function MemberFixture(params: Partial<MemberType> = {}): MemberType {
     ...params,
   };
 }
-
-// TODO(@gggritso): Remove this once the imports in `getsentry` are up-to-date
-export {MemberFixture as Member};

--- a/fixtures/js-stubs/organization.tsx
+++ b/fixtures/js-stubs/organization.tsx
@@ -85,7 +85,3 @@ export function OrganizationFixture(
     teamRoleList: TeamRoleListFixture(),
   };
 }
-
-// TODO(@gggritso): Remove this once the imports in `getsentry` are up-to-date
-export {OrganizationFixture as Organization};
-export default OrganizationFixture;

--- a/fixtures/js-stubs/project.tsx
+++ b/fixtures/js-stubs/project.tsx
@@ -51,7 +51,3 @@ export function ProjectFixture(params: Partial<TProject> = {}): TProject {
     ...params,
   };
 }
-
-// TODO(@gggritso): Remove this once the imports in `getsentry` are up-to-date
-export default ProjectFixture;
-export {ProjectFixture as Project};

--- a/fixtures/js-stubs/team.tsx
+++ b/fixtures/js-stubs/team.tsx
@@ -23,6 +23,3 @@ export function TeamFixture(params: Partial<TeamType> = {}): TeamType {
     ...params,
   };
 }
-
-// TODO(@gggritso): Remove this once the imports in `getsentry` are up-to-date
-export {TeamFixture as Team};

--- a/fixtures/js-stubs/user.tsx
+++ b/fixtures/js-stubs/user.tsx
@@ -38,7 +38,3 @@ export function UserFixture(params: Partial<UserType> = {}): UserType {
     ...params,
   };
 }
-
-// TODO(@gggritso): Remove this once the imports in `getsentry` are up-to-date
-export {UserFixture as User};
-export default UserFixture;


### PR DESCRIPTION
Alias and default export references were removed in `getsentry/getsentry#12467`, the exports are not needed anymore. https://github.com/getsentry/frontend-tsc/issues/49
