### PR TITLE
feat(crons): Disable new monitors in projects without monitors in BE

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -18,7 +18,7 @@ from arroyo.types import BrokerValue, Commit, Message, Partition
 from django.db import router, transaction
 from sentry_sdk.tracing import Span, Transaction
 
-from sentry import quotas, ratelimits
+from sentry import features, quotas, ratelimits
 from sentry.constants import DataCategory, ObjectStatus
 from sentry.killswitches import killswitch_matches_context
 from sentry.models.project import Project
@@ -61,7 +61,6 @@ def _ensure_monitor_with_config(
     config: Optional[Dict],
     quotas_outcome: PermitCheckInStatus,
 ):
-
     try:
         monitor = Monitor.objects.get(
             slug=monitor_slug,
@@ -87,6 +86,12 @@ def _ensure_monitor_with_config(
 
     validated_config = validator.validated_data
     created = False
+
+    if (
+        features.has("organizations:crons-disable-new-projects", project.organization)
+        and not project.flags.has_cron_monitors
+    ):
+        return monitor
 
     # Create monitor
     if not monitor:

--- a/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
+++ b/src/sentry/monitors/endpoints/monitor_ingest_checkin_index.py
@@ -10,7 +10,7 @@ from rest_framework.exceptions import Throttled
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import ratelimits
+from sentry import features, ratelimits
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -150,11 +150,21 @@ class MonitorIngestCheckInIndexEndpoint(MonitorIngestEndpoint):
             monitor_data = result.get("monitor")
             create_monitor = monitor_data and not monitor
             update_monitor = monitor_data and monitor
+            disable_creation = (
+                features.has("organizations:crons-disable-new-projects", project.organization)
+                and not project.flags.has_cron_monitors
+            )
 
             # Create a new monitor during checkin. Uses update_or_create to
             # protect against races.
             try:
                 if create_monitor:
+                    if disable_creation:
+                        return self.respond(
+                            "Creating monitors in projects without pre-existing monitors is temporarily disabled",
+                            status=400,
+                        )
+
                     monitor, created = Monitor.objects.update_or_create(
                         organization_id=project.organization_id,
                         slug=monitor_data["slug"],

--- a/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
+++ b/tests/sentry/monitors/endpoints/test_monitor_ingest_checkin_index.py
@@ -546,3 +546,57 @@ class CreateMonitorCheckInTest(MonitorIngestTestCase):
             assert checkin.status == CheckInStatus.OK
             # Monitor config will not be saved because it is missing margin and max runtime
             assert not checkin.monitor_config
+
+    def test_monitor_upsert_via_checkin_disabled_new_monitors(self):
+        for i, path_func in enumerate(self._get_path_functions()):
+            slug = f"my-new-monitor-{i}"
+            path = path_func(slug)
+
+            with self.feature("organizations:crons-disable-new-projects"):
+                resp = self.client.post(
+                    path,
+                    {
+                        "status": "ok",
+                        "monitor_config": {
+                            "schedule_type": "crontab",
+                            "schedule": "5 * * * *",
+                            "checkin_margin": 5,
+                        },
+                    },
+                    **self.dsn_auth_headers,
+                )
+
+            assert resp.status_code == 400
+            assert (
+                resp.data
+                == "Creating monitors in projects without pre-existing monitors is temporarily disabled"
+            )
+
+    def test_monitor_upsert_via_checkin_disabled_existing_monitors(self):
+        for i, path_func in enumerate(self._get_path_functions()):
+            slug = f"my-new-monitor-{i}"
+            path = path_func(slug)
+            self.project.flags.has_cron_monitors = True
+            self.project.save()
+
+            with self.feature("organizations:crons-disable-new-projects"):
+                resp = self.client.post(
+                    path,
+                    {
+                        "status": "ok",
+                        "monitor_config": {
+                            "schedule_type": "crontab",
+                            "schedule": "5 * * * *",
+                            "checkin_margin": 5,
+                        },
+                    },
+                    **self.dsn_auth_headers,
+                )
+
+            assert resp.status_code == 201, resp.content
+            monitor = Monitor.objects.get(slug=slug)
+            assert monitor.config["schedule"] == "5 * * * *"
+            assert monitor.config["checkin_margin"] == 5
+
+            checkins = MonitorCheckIn.objects.filter(monitor=monitor)
+            assert len(checkins) == 1

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -344,3 +344,35 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
         assert assign_monitor_seat.called
         assert response.data["status"] == "disabled"
         assert monitor.status == ObjectStatus.DISABLED
+
+    def test_disabled_creating_new_monitor(self):
+        data = {
+            "project": self.project.slug,
+            "name": "My Monitor",
+            "slug": "my-monitor",
+            "type": "cron_job",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+        }
+        with self.feature("organizations:crons-disable-new-projects"):
+            response = self.get_error_response(self.organization.slug, **data, status_code=400)
+
+        assert (
+            response.data
+            == "Creating monitors in projects without pre-existing monitors is temporarily disabled"
+        )
+
+    def test_disabled_creating_with_existing_monitors(self):
+        data = {
+            "project": self.project.slug,
+            "name": "My Monitor",
+            "slug": "my-monitor",
+            "type": "cron_job",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+        }
+        self.project.flags.has_cron_monitors = True
+        self.project.save()
+
+        with self.feature("organizations:crons-disable-new-projects"):
+            response = self.get_success_response(self.organization.slug, **data)
+
+        assert response.data["slug"] == "my-monitor"


### PR DESCRIPTION
As we cut over existing beta users to trials we will need to stop new orgs/projects from creating monitors.

Disabled in:
- OrganizationMonitorIndexEndpoint
- Consumer (upsert)
- MonitorIngestEndpoint (upsert)

Frontend will also be disabled with appropriate messaging