### PR TITLE
chore(relocation): Add name to relocation url

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -393,10 +393,7 @@ urlpatterns += [
         generic_react_page_view,
     ),
     # Relocation
-    re_path(
-        r"^relocation/",
-        generic_react_page_view,
-    ),
+    re_path(r"^relocation/", generic_react_page_view, name="sentry-relocation"),
     # Admin
     re_path(
         r"^manage/",


### PR DESCRIPTION
This will allow us to use 
```
absolute_uri(reverse("sentry-relocation"))
```
