### PR TITLE
ref(ts): Remove fixture type aliases

### DIFF
--- a/fixtures/js-stubs/accessRequest.tsx
+++ b/fixtures/js-stubs/accessRequest.tsx
@@ -1,11 +1,9 @@
 import {MemberFixture} from 'sentry-fixture/member';
 import {TeamFixture} from 'sentry-fixture/team';
 
-import {AccessRequest as AccessRequestType} from 'sentry/types';
+import {AccessRequest} from 'sentry/types';
 
-export function AccessRequestFixture(
-  params: Partial<AccessRequestType> = {}
-): AccessRequestType {
+export function AccessRequestFixture(params: Partial<AccessRequest> = {}): AccessRequest {
   return {
     id: '123',
     member: MemberFixture(),

--- a/fixtures/js-stubs/actor.tsx
+++ b/fixtures/js-stubs/actor.tsx
@@ -1,6 +1,6 @@
-import type {Actor as ActorType} from 'sentry/types';
+import type {Actor} from 'sentry/types';
 
-export function ActorFixture(params: Partial<ActorType> = {}): ActorType {
+export function ActorFixture(params: Partial<Actor> = {}): Actor {
   return {
     id: '1',
     email: 'foo@example.com',

--- a/fixtures/js-stubs/apiApplication.tsx
+++ b/fixtures/js-stubs/apiApplication.tsx
@@ -1,8 +1,8 @@
-import type {ApiApplication as ApiApplicationType} from 'sentry/types';
+import type {ApiApplication} from 'sentry/types';
 
 export function ApiApplicationFixture(
-  params: Partial<ApiApplicationType> = {}
-): ApiApplicationType {
+  params: Partial<ApiApplication> = {}
+): ApiApplication {
   return {
     allowedOrigins: [],
     clientID: 'aowekr12903i9i423094i23904j',

--- a/fixtures/js-stubs/apiToken.tsx
+++ b/fixtures/js-stubs/apiToken.tsx
@@ -1,8 +1,8 @@
-import type {InternalAppApiToken as InternalAppApiTokenType} from 'sentry/types';
+import type {InternalAppApiToken} from 'sentry/types';
 
 export function ApiTokenFixture(
-  params: Partial<InternalAppApiTokenType> = {}
-): InternalAppApiTokenType {
+  params: Partial<InternalAppApiToken> = {}
+): InternalAppApiToken {
   return {
     id: '1',
     token: 'apitoken123',

--- a/fixtures/js-stubs/auditLogs.tsx
+++ b/fixtures/js-stubs/auditLogs.tsx
@@ -1,8 +1,8 @@
 import {UserFixture} from 'sentry-fixture/user';
 
-import type {AuditLog as AuditLogType} from 'sentry/types';
+import type {AuditLog} from 'sentry/types';
 
-export function AuditLogsFixture(params: AuditLogType[] = []): AuditLogType[] {
+export function AuditLogsFixture(params: AuditLog[] = []): AuditLog[] {
   return [
     {
       note: 'edited project ludic-science',

--- a/fixtures/js-stubs/authProvider.tsx
+++ b/fixtures/js-stubs/authProvider.tsx
@@ -1,8 +1,6 @@
-import type {AuthProvider as AuthProviderType} from 'sentry/types';
+import type {AuthProvider} from 'sentry/types';
 
-export function AuthProviderFixture(
-  params: Partial<AuthProviderType> = {}
-): AuthProviderType {
+export function AuthProviderFixture(params: Partial<AuthProvider> = {}): AuthProvider {
   return {
     key: 'auth_provider_key',
     name: 'auth_provider_name',

--- a/fixtures/js-stubs/authProviders.tsx
+++ b/fixtures/js-stubs/authProviders.tsx
@@ -1,10 +1,8 @@
 import {AuthProviderFixture} from 'sentry-fixture/authProvider';
 
-import type {AuthProvider as AuthProviderType} from 'sentry/types';
+import type {AuthProvider} from 'sentry/types';
 
-export function AuthProvidersFixture(
-  params: AuthProviderType[] = []
-): AuthProviderType[] {
+export function AuthProvidersFixture(params: AuthProvider[] = []): AuthProvider[] {
   return [
     AuthProviderFixture({
       key: 'dummy',

--- a/fixtures/js-stubs/authenticators.tsx
+++ b/fixtures/js-stubs/authenticators.tsx
@@ -1,16 +1,16 @@
 import type {
-  RecoveryAuthenticator as RecoveryAuthenticatorType,
-  SmsAuthenticator as SmsAuthenticatorType,
-  TotpAuthenticator as TotpAuthenticatorType,
-  U2fAuthenticator as U2fAuthenticatorType,
-  UserEnrolledAuthenticator as UserEnrolledAuthenticatorType,
+  RecoveryAuthenticator,
+  SmsAuthenticator,
+  TotpAuthenticator,
+  U2fAuthenticator as U2fAuthenticator,
+  UserEnrolledAuthenticator,
 } from 'sentry/types';
 
 export function AuthenticatorsFixture(): {
-  Recovery: (props?: Partial<RecoveryAuthenticatorType>) => RecoveryAuthenticatorType;
-  Sms: (props?: Partial<SmsAuthenticatorType>) => SmsAuthenticatorType;
-  Totp: (props?: Partial<TotpAuthenticatorType>) => TotpAuthenticatorType;
-  U2f: (props?: Partial<U2fAuthenticatorType>) => U2fAuthenticatorType;
+  Recovery: (props?: Partial<RecoveryAuthenticator>) => RecoveryAuthenticator;
+  Sms: (props?: Partial<SmsAuthenticator>) => SmsAuthenticator;
+  Totp: (props?: Partial<TotpAuthenticator>) => TotpAuthenticator;
+  U2f: (props?: Partial<U2fAuthenticator>) => U2fAuthenticator;
 } {
   return {
     Totp: (p = {}) => ({
@@ -133,8 +133,8 @@ export function AllAuthenticatorsFixture() {
 }
 
 export function UserEnrolledAuthenticatorFixture(
-  params: Partial<UserEnrolledAuthenticatorType>
-): UserEnrolledAuthenticatorType {
+  params: Partial<UserEnrolledAuthenticator>
+): UserEnrolledAuthenticator {
   return {
     id: '1',
     type: 'totp',

--- a/fixtures/js-stubs/authenticators.tsx
+++ b/fixtures/js-stubs/authenticators.tsx
@@ -2,7 +2,7 @@ import type {
   RecoveryAuthenticator,
   SmsAuthenticator,
   TotpAuthenticator,
-  U2fAuthenticator as U2fAuthenticator,
+  U2fAuthenticator,
   UserEnrolledAuthenticator,
 } from 'sentry/types';
 

--- a/fixtures/js-stubs/availableNotificationActions.tsx
+++ b/fixtures/js-stubs/availableNotificationActions.tsx
@@ -1,8 +1,8 @@
-import type {AvailableNotificationAction as AvailableNotificationActionType} from 'sentry/types';
+import type {AvailableNotificationAction} from 'sentry/types';
 
 export function AvailableNotificationActionsFixture(
-  params: AvailableNotificationActionType[] = []
-): {actions: AvailableNotificationActionType[]} {
+  params: AvailableNotificationAction[] = []
+): {actions: AvailableNotificationAction[]} {
   return {
     actions: [
       {

--- a/fixtures/js-stubs/broadcast.tsx
+++ b/fixtures/js-stubs/broadcast.tsx
@@ -1,6 +1,6 @@
-import type {Broadcast as BroadcastType} from 'sentry/types';
+import type {Broadcast} from 'sentry/types';
 
-export function BroadcastFixture(params: Partial<BroadcastType> = {}): BroadcastType {
+export function BroadcastFixture(params: Partial<Broadcast> = {}): Broadcast {
   return {
     dateCreated: new Date().toISOString(),
     dateExpires: new Date().toISOString(),

--- a/fixtures/js-stubs/builtInSymbolSources.tsx
+++ b/fixtures/js-stubs/builtInSymbolSources.tsx
@@ -1,8 +1,8 @@
-import type {BuiltinSymbolSource as BuiltinSymbolSourceType} from 'sentry/types';
+import type {BuiltinSymbolSource} from 'sentry/types';
 
 export function BuiltInSymbolSourcesFixture(
-  params: BuiltinSymbolSourceType[] = []
-): BuiltinSymbolSourceType[] {
+  params: BuiltinSymbolSource[] = []
+): BuiltinSymbolSource[] {
   return [
     {
       sentry_key: 'amd',

--- a/fixtures/js-stubs/codeOwner.ts
+++ b/fixtures/js-stubs/codeOwner.ts
@@ -3,24 +3,19 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 import {RepositoryProjectPathConfigFixture} from 'sentry-fixture/repositoryProjectPathConfig';
 
-import type {
-  CodeOwner as TCodeOwner,
-  OrganizationIntegration,
-  Project as TProject,
-  Repository as TRepository,
-} from 'sentry/types';
+import type {CodeOwner, OrganizationIntegration, Project, Repository} from 'sentry/types';
 
-interface CodeOwnerParams extends Partial<TCodeOwner> {
+interface CodeOwnerParams extends Partial<CodeOwner> {
   integration?: OrganizationIntegration;
-  project?: TProject;
-  repo?: TRepository;
+  project?: Project;
+  repo?: Repository;
 }
 
 export function CodeOwnerFixture({
   project = ProjectFixture(),
   repo = RepositoryFixture(),
   ...params
-}: CodeOwnerParams = {}): TCodeOwner {
+}: CodeOwnerParams = {}): CodeOwner {
   const integration = GitHubIntegrationFixture();
 
   return {

--- a/fixtures/js-stubs/commit.ts
+++ b/fixtures/js-stubs/commit.ts
@@ -1,9 +1,9 @@
 import {CommitAuthorFixture} from 'sentry-fixture/commitAuthor';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 
-import {type Commit as TCommit} from 'sentry/types';
+import {type Commit} from 'sentry/types';
 
-export function CommitFixture(params = {}): TCommit {
+export function CommitFixture(params = {}): Commit {
   return {
     dateCreated: '2018-11-30T18:46:31Z',
     message:

--- a/fixtures/js-stubs/config.tsx
+++ b/fixtures/js-stubs/config.tsx
@@ -1,8 +1,8 @@
 import {UserFixture} from 'sentry-fixture/user';
 
-import {Config as ConfigType} from 'sentry/types';
+import type {Config} from 'sentry/types';
 
-export function ConfigFixture(params: Partial<ConfigType> = {}): ConfigType {
+export function ConfigFixture(params: Partial<Config> = {}): Config {
   return {
     theme: 'light',
     user: UserFixture(),

--- a/fixtures/js-stubs/dashboard.tsx
+++ b/fixtures/js-stubs/dashboard.tsx
@@ -1,17 +1,17 @@
 import type {
-  DashboardDetails as TDashboardDetails,
-  DashboardFilters as TDashboardFilters,
-  DashboardListItem as TDashboardListItem,
-  Widget as TWidget,
+  DashboardDetails,
+  DashboardFilters,
+  DashboardListItem,
+  Widget,
 } from 'sentry/views/dashboards/types';
 
 export function DashboardFixture(
-  widgets: TWidget[],
-  props: Partial<TDashboardDetails> = {}
-): TDashboardDetails {
+  widgets: Widget[],
+  props: Partial<DashboardDetails> = {}
+): DashboardDetails {
   return {
     id: '1',
-    filters: [] as TDashboardFilters,
+    filters: [] as DashboardFilters,
     dateCreated: new Date().toISOString(),
     projects: undefined,
     title: 'Dashboard',
@@ -21,8 +21,8 @@ export function DashboardFixture(
 }
 
 export function DashboardListItemFixture(
-  params: Partial<TDashboardListItem> = {}
-): TDashboardListItem {
+  params: Partial<DashboardListItem> = {}
+): DashboardListItem {
   return {
     id: '1',
     title: 'Dashboard',

--- a/fixtures/js-stubs/debugFile.ts
+++ b/fixtures/js-stubs/debugFile.ts
@@ -1,10 +1,6 @@
-import {
-  type DebugFile as TDebugFile,
-  DebugFileFeature,
-  DebugFileType,
-} from 'sentry/types';
+import {type DebugFile, DebugFileFeature, DebugFileType} from 'sentry/types';
 
-export function DebugFileFixture(params = {}): TDebugFile {
+export function DebugFileFixture(params = {}): DebugFile {
   return {
     objectName: 'libS.so',
     symbolType: 'elf',

--- a/fixtures/js-stubs/deprecatedApiKey.tsx
+++ b/fixtures/js-stubs/deprecatedApiKey.tsx
@@ -1,8 +1,8 @@
-import type {DeprecatedApiKey as DeprecatedApiKeyType} from 'sentry/views/settings/organizationApiKeys/types';
+import type {DeprecatedApiKey} from 'sentry/views/settings/organizationApiKeys/types';
 
 export function DeprecatedApiKeyFixture(
-  params: Partial<DeprecatedApiKeyType> = {}
-): DeprecatedApiKeyType {
+  params: Partial<DeprecatedApiKey> = {}
+): DeprecatedApiKey {
   return {
     allowed_origins: '',
     id: '1',

--- a/fixtures/js-stubs/docIntegration.ts
+++ b/fixtures/js-stubs/docIntegration.ts
@@ -1,6 +1,6 @@
-import {type DocIntegration as TDocIntegration} from 'sentry/types';
+import {type DocIntegration} from 'sentry/types';
 
-export function DocIntegrationFixture(params = {}): TDocIntegration {
+export function DocIntegrationFixture(params = {}): DocIntegration {
   return {
     name: 'Sample Doc',
     slug: 'sample-doc',

--- a/fixtures/js-stubs/entries.ts
+++ b/fixtures/js-stubs/entries.ts
@@ -1,8 +1,8 @@
 import {EventEntryFixture} from 'sentry-fixture/eventEntry';
 
-import {type Entry as TEntry, EntryType} from 'sentry/types';
+import {type Entry, EntryType} from 'sentry/types';
 
-export function Entries123Target(): TEntry[] {
+export function Entries123Target(): Entry[] {
   return [
     EventEntryFixture({
       type: EntryType.EXCEPTION,
@@ -590,7 +590,7 @@ export function Entries123Target(): TEntry[] {
   ];
 }
 
-export function Entries123Base(): TEntry[] {
+export function Entries123Base(): Entry[] {
   return [
     EventEntryFixture({
       type: EntryType.EXCEPTION,

--- a/fixtures/js-stubs/event.ts
+++ b/fixtures/js-stubs/event.ts
@@ -1,6 +1,6 @@
-import {type Event as TEvent, EventOrGroupType, EventTransaction} from 'sentry/types';
+import {type Event, EventOrGroupType, EventTransaction} from 'sentry/types';
 
-export function EventFixture(params = {}): TEvent {
+export function EventFixture(params = {}): Event {
   return {
     id: '1',
     message: 'ApiException',

--- a/fixtures/js-stubs/eventAttachment.ts
+++ b/fixtures/js-stubs/eventAttachment.ts
@@ -1,6 +1,6 @@
-import type {EventAttachment as TEventAttachment} from 'sentry/types';
+import type {EventAttachment} from 'sentry/types';
 
-export function EventAttachmentFixture(params = {}): TEventAttachment {
+export function EventAttachmentFixture(params = {}): EventAttachment {
   return {
     id: '1',
     name: 'screenshot.png',

--- a/fixtures/js-stubs/eventEntry.ts
+++ b/fixtures/js-stubs/eventEntry.ts
@@ -1,13 +1,13 @@
 import {ImageFixture} from 'sentry-fixture/image';
 
 import {
-  type Entry as TEntry,
-  type EntryDebugMeta as TEntryDebugMeta,
-  type EntryRequest as TEntryRequest,
+  type Entry,
+  type EntryDebugMeta,
+  type EntryRequest,
   EntryType,
 } from 'sentry/types';
 
-export function EventEntryFixture(params = {}): TEntry {
+export function EventEntryFixture(params = {}): Entry {
   return {
     type: EntryType.MESSAGE,
     data: {
@@ -17,7 +17,7 @@ export function EventEntryFixture(params = {}): TEntry {
   };
 }
 
-export function EntryRequestFixture(params: Partial<TEntryRequest> = {}): TEntryRequest {
+export function EntryRequestFixture(params: Partial<EntryRequest> = {}): EntryRequest {
   return {
     type: EntryType.REQUEST,
     data: {
@@ -30,8 +30,8 @@ export function EntryRequestFixture(params: Partial<TEntryRequest> = {}): TEntry
 }
 
 export function EntryDebugMetaFixture(
-  params: Partial<TEntryDebugMeta> = {}
-): TEntryDebugMeta {
+  params: Partial<EntryDebugMeta> = {}
+): EntryDebugMeta {
   return {
     type: EntryType.DEBUGMETA,
     data: {

--- a/fixtures/js-stubs/events.ts
+++ b/fixtures/js-stubs/events.ts
@@ -1,6 +1,6 @@
-import {type Event, EventOrGroupType, EventsStats as TEventsStats} from 'sentry/types';
+import {type Event, EventOrGroupType, EventsStats} from 'sentry/types';
 
-export function EventsStatsFixture(params = {}): TEventsStats {
+export function EventsStatsFixture(params = {}): EventsStats {
   return {
     data: [
       [new Date().getTime(), [{count: 321}, {count: 79}]],

--- a/fixtures/js-stubs/exceptionValue.tsx
+++ b/fixtures/js-stubs/exceptionValue.tsx
@@ -1,8 +1,8 @@
-import type {ExceptionValue as ExceptionValueType} from 'sentry/types';
+import type {ExceptionValue} from 'sentry/types';
 
 export function ExceptionValueFixture(
-  props: Partial<ExceptionValueType> = {}
-): ExceptionValueType {
+  props: Partial<ExceptionValue> = {}
+): ExceptionValue {
   return {
     mechanism: null,
     rawStacktrace: null,

--- a/fixtures/js-stubs/frame.tsx
+++ b/fixtures/js-stubs/frame.tsx
@@ -1,6 +1,6 @@
-import type {Frame as FrameType} from 'sentry/types';
+import type {Frame} from 'sentry/types';
 
-export function FrameFixture(props: Partial<FrameType> = {}): FrameType {
+export function FrameFixture(props: Partial<Frame> = {}): Frame {
   return {
     absPath: 'abs/path/to/file.js',
     colNo: null,

--- a/fixtures/js-stubs/group.ts
+++ b/fixtures/js-stubs/group.ts
@@ -2,14 +2,14 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {
   EventOrGroupType,
-  type Group as GroupType,
+  type Group,
   GroupStatus,
   GroupUnresolved,
   IssueCategory,
   IssueType,
 } from 'sentry/types';
 
-export function GroupFixture(params: Partial<GroupType> = {}): GroupType {
+export function GroupFixture(params: Partial<Group> = {}): Group {
   const unresolvedGroup: GroupUnresolved = {
     activity: [],
     annotations: [],
@@ -62,5 +62,5 @@ export function GroupFixture(params: Partial<GroupType> = {}): GroupType {
     userReportCount: 0,
   };
 
-  return {...unresolvedGroup, ...params} as GroupType;
+  return {...unresolvedGroup, ...params} as Group;
 }

--- a/fixtures/js-stubs/groupStats.ts
+++ b/fixtures/js-stubs/groupStats.ts
@@ -1,6 +1,6 @@
-import {GroupStats as GroupStatsType} from 'sentry/types';
+import {GroupStats} from 'sentry/types';
 
-export function GroupStatsFixture(params: Partial<GroupStatsType> = {}): GroupStatsType {
+export function GroupStatsFixture(params: Partial<GroupStats> = {}): GroupStats {
   return {
     count: '327482',
     firstSeen: '2019-04-05T19:44:05.963Z',

--- a/fixtures/js-stubs/image.tsx
+++ b/fixtures/js-stubs/image.tsx
@@ -1,11 +1,11 @@
 import {
   CandidateDownloadStatus,
   CandidateProcessingStatus,
-  type Image as TImage,
+  type Image,
   ImageStatus,
 } from 'sentry/types/debugImage';
 
-export function ImageFixture(params: Partial<TImage> = {}): TImage {
+export function ImageFixture(params: Partial<Image> = {}): Image {
   return {
     arch: 'x86_64',
     candidates: [

--- a/fixtures/js-stubs/incident.ts
+++ b/fixtures/js-stubs/incident.ts
@@ -1,9 +1,9 @@
 import {MetricRuleFixture} from 'sentry-fixture/metricRule';
 
-import type {Incident as TIncident} from 'sentry/views/alerts/types';
+import type {Incident} from 'sentry/views/alerts/types';
 import {IncidentStatus, IncidentStatusMethod} from 'sentry/views/alerts/types';
 
-export function IncidentFixture(params: Partial<TIncident> = {}): TIncident {
+export function IncidentFixture(params: Partial<Incident> = {}): Incident {
   return {
     id: '321',
     identifier: '123',

--- a/fixtures/js-stubs/incidentStats.ts
+++ b/fixtures/js-stubs/incidentStats.ts
@@ -1,8 +1,6 @@
-import {IncidentStats as IncidentStatsType} from 'sentry/views/alerts/types';
+import {IncidentStats} from 'sentry/views/alerts/types';
 
-export function IncidentStatsFixture(
-  params: Partial<IncidentStatsType> = {}
-): IncidentStatsType {
+export function IncidentStatsFixture(params: Partial<IncidentStats> = {}): IncidentStats {
   return {
     totalEvents: 100,
     uniqueUsers: 20,

--- a/fixtures/js-stubs/member.tsx
+++ b/fixtures/js-stubs/member.tsx
@@ -1,8 +1,8 @@
 import {UserFixture} from 'sentry-fixture/user';
 
-import type {Member as MemberType} from 'sentry/types';
+import type {Member} from 'sentry/types';
 
-export function MemberFixture(params: Partial<MemberType> = {}): MemberType {
+export function MemberFixture(params: Partial<Member> = {}): Member {
   return {
     id: '1',
     email: 'sentry1@test.com',

--- a/fixtures/js-stubs/members.tsx
+++ b/fixtures/js-stubs/members.tsx
@@ -1,9 +1,9 @@
 import {MemberFixture} from 'sentry-fixture/member';
 import {UserFixture} from 'sentry-fixture/user';
 
-import type {Member as MemberType} from 'sentry/types';
+import type {Member} from 'sentry/types';
 
-export function MembersFixture(params: MemberType[] = []): MemberType[] {
+export function MembersFixture(params: Member[] = []): Member[] {
   return [
     MemberFixture(),
     {

--- a/fixtures/js-stubs/organizations.tsx
+++ b/fixtures/js-stubs/organizations.tsx
@@ -1,10 +1,8 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {Organization as OrganizationType} from 'sentry/types';
+import {Organization} from 'sentry/types';
 
-export function OrganizationsFixture(
-  params: Partial<OrganizationType> = {}
-): OrganizationType[] {
+export function OrganizationsFixture(params: Partial<Organization> = {}): Organization[] {
   return [
     OrganizationFixture({
       id: '1',

--- a/fixtures/js-stubs/pageFilters.ts
+++ b/fixtures/js-stubs/pageFilters.ts
@@ -1,6 +1,6 @@
-import type {PageFilters as PageFilterType} from 'sentry/types';
+import type {PageFilters} from 'sentry/types';
 
-export function PageFiltersFixture(params: Partial<PageFilterType> = {}): PageFilterType {
+export function PageFiltersFixture(params: Partial<PageFilters> = {}): PageFilters {
   return {
     datetime: {
       end: null,

--- a/fixtures/js-stubs/platformExternalIssue.tsx
+++ b/fixtures/js-stubs/platformExternalIssue.tsx
@@ -1,8 +1,8 @@
-import {PlatformExternalIssue as PlatformExternalIssueType} from 'sentry/types';
+import {PlatformExternalIssue} from 'sentry/types';
 
 export function PlatformExternalIssueFixture(
-  params: Partial<PlatformExternalIssueType> = {}
-): PlatformExternalIssueType {
+  params: Partial<PlatformExternalIssue> = {}
+): PlatformExternalIssue {
   return {
     id: '1',
     serviceType: 'foo',

--- a/fixtures/js-stubs/plugin.tsx
+++ b/fixtures/js-stubs/plugin.tsx
@@ -1,6 +1,6 @@
-import {Plugin as PluginType} from 'sentry/types';
+import {Plugin} from 'sentry/types';
 
-export function PluginFixture(params: Partial<PluginType> = {}): PluginType {
+export function PluginFixture(params: Partial<Plugin> = {}): Plugin {
   return {
     author: {url: 'https://github.com/getsentry/sentry', name: 'Sentry Team'},
     enabled: false,

--- a/fixtures/js-stubs/plugins.tsx
+++ b/fixtures/js-stubs/plugins.tsx
@@ -1,8 +1,8 @@
 import {PluginFixture} from 'sentry-fixture/plugin';
 
-import {Plugin as PluginType} from 'sentry/types';
+import {Plugin} from 'sentry/types';
 
-export function PluginsFixture(params: PluginType[] = []): PluginType[] {
+export function PluginsFixture(params: Plugin[] = []): Plugin[] {
   return [
     PluginFixture(),
     PluginFixture({

--- a/fixtures/js-stubs/project.tsx
+++ b/fixtures/js-stubs/project.tsx
@@ -1,9 +1,9 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {TeamFixture} from 'sentry-fixture/team';
 
-import type {Project as TProject} from 'sentry/types';
+import type {Project} from 'sentry/types';
 
-export function ProjectFixture(params: Partial<TProject> = {}): TProject {
+export function ProjectFixture(params: Partial<Project> = {}): Project {
   const team = TeamFixture();
   return {
     id: '2',

--- a/fixtures/js-stubs/projectSdkUpdates.tsx
+++ b/fixtures/js-stubs/projectSdkUpdates.tsx
@@ -1,8 +1,8 @@
-import type {ProjectSdkUpdates as TProjectSdkUpdates} from 'sentry/types';
+import type {ProjectSdkUpdates} from 'sentry/types';
 
 export function ProjectSdkUpdatesFixture(
-  overrides?: Partial<TProjectSdkUpdates>
-): TProjectSdkUpdates {
+  overrides?: Partial<ProjectSdkUpdates>
+): ProjectSdkUpdates {
   return {
     projectId: '1',
     sdkName: 'sentry.javascript',

--- a/fixtures/js-stubs/pullRequest.tsx
+++ b/fixtures/js-stubs/pullRequest.tsx
@@ -1,10 +1,8 @@
 import {RepositoryFixture} from 'sentry-fixture/repository';
 
-import {PullRequest as PullRequestType} from 'sentry/types';
+import {PullRequest} from 'sentry/types';
 
-export function PullRequestFixture(
-  params: Partial<PullRequestType> = {}
-): PullRequestType {
+export function PullRequestFixture(params: Partial<PullRequest> = {}): PullRequest {
   return {
     id: '3',
     repository: RepositoryFixture(),

--- a/fixtures/js-stubs/releaseMeta.ts
+++ b/fixtures/js-stubs/releaseMeta.ts
@@ -1,10 +1,8 @@
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import type {ReleaseMeta as ReleaseMetaType} from 'sentry/types';
+import type {ReleaseMeta} from 'sentry/types';
 
-export function ReleaseMetaFixture(
-  params: Partial<ReleaseMetaType> = {}
-): ReleaseMetaType {
+export function ReleaseMetaFixture(params: Partial<ReleaseMeta> = {}): ReleaseMeta {
   const project = ProjectFixture();
   return {
     version: 'sentry-android-shop@1.2.0',

--- a/fixtures/js-stubs/replayList.ts
+++ b/fixtures/js-stubs/replayList.ts
@@ -1,10 +1,10 @@
 import {duration} from 'moment';
 
-import type {ReplayListRecord as TReplayListRecord} from 'sentry/views/replays/types';
+import type {ReplayListRecord} from 'sentry/views/replays/types';
 
 export function ReplayListFixture(
-  replayListRecords: TReplayListRecord[] = []
-): TReplayListRecord[] {
+  replayListRecords: ReplayListRecord[] = []
+): ReplayListRecord[] {
   if (replayListRecords.length) {
     return replayListRecords;
   }

--- a/fixtures/js-stubs/repository.ts
+++ b/fixtures/js-stubs/repository.ts
@@ -1,6 +1,6 @@
-import {Repository as RepositoryType, RepositoryStatus} from 'sentry/types';
+import {Repository, RepositoryStatus} from 'sentry/types';
 
-export function RepositoryFixture(params: Partial<RepositoryType> = {}): RepositoryType {
+export function RepositoryFixture(params: Partial<Repository> = {}): Repository {
   return {
     id: '4',
     name: 'example/repo-name',

--- a/fixtures/js-stubs/repositoryProjectPathConfig.ts
+++ b/fixtures/js-stubs/repositoryProjectPathConfig.ts
@@ -2,11 +2,10 @@ import type {
   Integration,
   Project,
   Repository,
-  RepositoryProjectPathConfig as RepositoryProjectPathConfigType,
+  RepositoryProjectPathConfig,
 } from 'sentry/types';
 
-interface RepositoryProjectPathConfigArgs
-  extends Partial<RepositoryProjectPathConfigType> {
+interface RepositoryProjectPathConfigArgs extends Partial<RepositoryProjectPathConfig> {
   integration: Pick<Integration, 'id' | 'provider'>;
   project: Pick<Project, 'id' | 'slug'>;
   repo: Pick<Repository, 'id' | 'name'>;
@@ -14,7 +13,7 @@ interface RepositoryProjectPathConfigArgs
 
 export function RepositoryProjectPathConfigFixture(
   params: RepositoryProjectPathConfigArgs
-): RepositoryProjectPathConfigType {
+): RepositoryProjectPathConfig {
   const {project, repo, integration, ...rest} = params;
   return {
     id: '2',

--- a/fixtures/js-stubs/sentryApp.tsx
+++ b/fixtures/js-stubs/sentryApp.tsx
@@ -1,6 +1,6 @@
-import {SentryApp as SentryAppType} from 'sentry/types';
+import {SentryApp} from 'sentry/types';
 
-export function SentryAppFixture(params: Partial<SentryAppType> = {}): SentryAppType {
+export function SentryAppFixture(params: Partial<SentryApp> = {}): SentryApp {
   return {
     name: 'Sample App',
     author: 'Sentry',

--- a/fixtures/js-stubs/sentryAppComponent.ts
+++ b/fixtures/js-stubs/sentryAppComponent.ts
@@ -1,11 +1,8 @@
-import {
-  SentryAppComponent as TSentryAppComponent,
-  SentryAppSchemaIssueLink,
-} from 'sentry/types';
+import {SentryAppComponent, SentryAppSchemaIssueLink} from 'sentry/types';
 
 export function SentryAppComponentFixture(
   params = {}
-): TSentryAppComponent<SentryAppSchemaIssueLink> {
+): SentryAppComponent<SentryAppSchemaIssueLink> {
   return {
     uuid: 'ed517da4-a324-44c0-aeea-1894cd9923fb',
     type: 'issue-link',
@@ -59,7 +56,7 @@ export function SentryAppComponentFixture(
 }
 export function SentryAppComponentAsyncFixture(
   params = {}
-): TSentryAppComponent<SentryAppSchemaIssueLink> {
+): SentryAppComponent<SentryAppSchemaIssueLink> {
   return {
     uuid: 'ed517da4-a324-44c0-aeea-1894cd9923fb',
     type: 'issue-link',
@@ -101,7 +98,7 @@ export function SentryAppComponentAsyncFixture(
 
 export function SentryAppComponentDependentFixture(
   params = {}
-): TSentryAppComponent<SentryAppSchemaIssueLink> {
+): SentryAppComponent<SentryAppSchemaIssueLink> {
   return {
     type: 'issue-link',
     uuid: 'ed517da4-a324-44c0-aeea-1894cd9923fb',

--- a/fixtures/js-stubs/sentryAppInstallation.tsx
+++ b/fixtures/js-stubs/sentryAppInstallation.tsx
@@ -1,8 +1,8 @@
-import {SentryAppInstallation as SentryAppInstallationType} from 'sentry/types';
+import {SentryAppInstallation} from 'sentry/types';
 
 export function SentryAppInstallationFixture(
-  params: Partial<SentryAppInstallationType> = {}
-): SentryAppInstallationType {
+  params: Partial<SentryAppInstallation> = {}
+): SentryAppInstallation {
   return {
     uuid: 'd950595e-cba2-46f6-8a94-b79e42806f98',
     app: {

--- a/fixtures/js-stubs/sentryAppWebhookRequest.tsx
+++ b/fixtures/js-stubs/sentryAppWebhookRequest.tsx
@@ -1,8 +1,8 @@
-import {SentryAppWebhookRequest as SentryAppWebhookRequestType} from 'sentry/types';
+import {SentryAppWebhookRequest} from 'sentry/types';
 
 export function SentryAppWebhookRequestFixture(
-  params: Partial<SentryAppWebhookRequestType> = {}
-): SentryAppWebhookRequestType {
+  params: Partial<SentryAppWebhookRequest> = {}
+): SentryAppWebhookRequest {
   return {
     webhookUrl: 'https://example.com/webhook',
     sentryAppSlug: 'sample-app',

--- a/fixtures/js-stubs/team.tsx
+++ b/fixtures/js-stubs/team.tsx
@@ -1,8 +1,8 @@
 import {uuid4} from '@sentry/utils';
 
-import type {DetailedTeam as TeamType} from 'sentry/types';
+import type {DetailedTeam} from 'sentry/types';
 
-export function TeamFixture(params: Partial<TeamType> = {}): TeamType {
+export function TeamFixture(params: Partial<DetailedTeam> = {}): DetailedTeam {
   return {
     id: '1',
     slug: 'team-slug',

--- a/fixtures/js-stubs/traceError.tsx
+++ b/fixtures/js-stubs/traceError.tsx
@@ -1,6 +1,6 @@
-import {TraceError as TraceErrorType} from 'sentry/utils/performance/quickTrace/types';
+import {TraceError} from 'sentry/utils/performance/quickTrace/types';
 
-export function TraceErrorFixture(params: Partial<TraceErrorType> = {}): TraceErrorType {
+export function TraceErrorFixture(params: Partial<TraceError> = {}): TraceError {
   return {
     event_id: '08384ee83c9145e79b5f6fbed5c37a51',
     issue_id: 62,

--- a/fixtures/js-stubs/user.tsx
+++ b/fixtures/js-stubs/user.tsx
@@ -1,6 +1,6 @@
-import type {User as UserType} from 'sentry/types';
+import type {User} from 'sentry/types';
 
-export function UserFixture(params: Partial<UserType> = {}): UserType {
+export function UserFixture(params: Partial<User> = {}): User {
   return {
     id: '1',
     username: 'foo@example.com',

--- a/fixtures/js-stubs/userFeedback.tsx
+++ b/fixtures/js-stubs/userFeedback.tsx
@@ -2,9 +2,9 @@ import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 import {UserFixture} from 'sentry-fixture/user';
 
-import type {UserReport as TUserReport} from 'sentry/types';
+import type {UserReport} from 'sentry/types';
 
-export function UserFeedbackFixture(params: Partial<TUserReport> = {}): TUserReport {
+export function UserFeedbackFixture(params: Partial<UserReport> = {}): UserReport {
   const event = EventFixture();
   return {
     id: '123',

--- a/fixtures/js-stubs/widget.tsx
+++ b/fixtures/js-stubs/widget.tsx
@@ -1,7 +1,7 @@
-import type {Widget as TWidget} from 'sentry/views/dashboards/types';
+import type {Widget} from 'sentry/views/dashboards/types';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
-export function WidgetFixture(params: Partial<TWidget> = {}): TWidget {
+export function WidgetFixture(params: Partial<Widget> = {}): Widget {
   return {
     displayType: DisplayType.LINE,
     interval: '1d',


### PR DESCRIPTION
Now that fixtures are all suffixed with `Fixture` this is not needed. https://github.com/getsentry/frontend-tsc/issues/49 💅🏻
