### PR TITLE
feat(issue-details): Add syntax highlighting to SQL code in breadcrumbs

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.tsx
@@ -1,10 +1,7 @@
-import styled from '@emotion/styled';
-
 import type {BreadcrumbTransactionEvent} from 'sentry/components/events/interfaces/breadcrumbs/types';
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import Highlight from 'sentry/components/highlight';
 import Link from 'sentry/components/links/link';
-import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {BreadcrumbTypeDefault, BreadcrumbTypeNavigation} from 'sentry/types/breadcrumbs';
 import {Event} from 'sentry/types/event';
@@ -111,18 +108,6 @@ function FormatMessage({
 
     return description;
   }
-  switch (breadcrumb.messageFormat) {
-    case 'sql':
-      return <FormattedCode>{content}</FormattedCode>;
-    default:
-      return content;
-  }
-}
 
-const FormattedCode = styled('div')`
-  padding: ${space(1)};
-  background: ${p => p.theme.backgroundSecondary};
-  border-radius: ${p => p.theme.borderRadius};
-  overflow-x: auto;
-  white-space: pre;
-`;
+  return content;
+}

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
@@ -36,8 +36,12 @@ export function Data({
     return <Http breadcrumb={breadcrumb} searchTerm={searchTerm} meta={meta} />;
   }
 
-  if (breadcrumb.message && breadcrumb.messageFormat === BreadcrumbMessageFormat.SQL) {
-    return <Sql breadcrumb={breadcrumb} searchTerm={searchTerm} meta={meta} />;
+  if (
+    !meta &&
+    breadcrumb.message &&
+    breadcrumb.messageFormat === BreadcrumbMessageFormat.SQL
+  ) {
+    return <Sql breadcrumb={breadcrumb} searchTerm={searchTerm} />;
   }
 
   if (

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
@@ -36,12 +36,8 @@ export function Data({
     return <Http breadcrumb={breadcrumb} searchTerm={searchTerm} meta={meta} />;
   }
 
-  if (
-    breadcrumb.type === BreadcrumbType.DEFAULT &&
-    breadcrumb.message &&
-    breadcrumb.messageFormat === BreadcrumbMessageFormat.SQL
-  ) {
-    return <Sql message={breadcrumb.message} searchTerm={searchTerm} />;
+  if (breadcrumb.message && breadcrumb.messageFormat === BreadcrumbMessageFormat.SQL) {
+    return <Sql breadcrumb={breadcrumb} searchTerm={searchTerm} meta={meta} />;
   }
 
   if (

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
@@ -41,7 +41,7 @@ export function Data({
     breadcrumb.message &&
     breadcrumb.messageFormat === BreadcrumbMessageFormat.SQL
   ) {
-    return <Sql message={breadcrumb.message} />;
+    return <Sql message={breadcrumb.message} searchTerm={searchTerm} />;
   }
 
   if (

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
@@ -1,7 +1,12 @@
+import {Sql} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/data/sql';
 import type {BreadcrumbTransactionEvent} from 'sentry/components/events/interfaces/breadcrumbs/types';
 import {BreadcrumbMeta} from 'sentry/components/events/interfaces/breadcrumbs/types';
 import {Organization} from 'sentry/types';
-import {BreadcrumbType, RawCrumb} from 'sentry/types/breadcrumbs';
+import {
+  BreadcrumbMessageFormat,
+  BreadcrumbType,
+  RawCrumb,
+} from 'sentry/types/breadcrumbs';
 import {Event} from 'sentry/types/event';
 
 import {Default} from './default';
@@ -29,6 +34,14 @@ export function Data({
 
   if (breadcrumb.type === BreadcrumbType.HTTP) {
     return <Http breadcrumb={breadcrumb} searchTerm={searchTerm} meta={meta} />;
+  }
+
+  if (
+    breadcrumb.type === BreadcrumbType.DEFAULT &&
+    breadcrumb.message &&
+    breadcrumb.messageFormat === BreadcrumbMessageFormat.SQL
+  ) {
+    return <Sql message={breadcrumb.message} />;
   }
 
   if (

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.spec.tsx
@@ -1,18 +1,13 @@
-import {Project} from 'sentry-fixture/project';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {Sql} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/data/sql';
 
 describe('Breadcrumb Data SQL', function () {
-  const project = Project({id: '0'});
-
   const {organization, router} = initializeOrg({
     router: {
-      location: {query: {project: project.id}},
+      location: {query: {project: '0'}},
     },
-    projects: [project],
   });
 
   it('displays formatted SQL message', function () {

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.spec.tsx
@@ -31,64 +31,11 @@ FOR
 UPDATE NOWAIT`,
         }}
         searchTerm=""
-        meta={
-          {
-            // data: {
-            //   url: {
-            //     '': {
-            //       rem: [['project:0', 's', 0, 0]],
-            //       len: 19,
-            //       chunks: [
-            //         {
-            //           type: 'redaction',
-            //           text: '',
-            //           rule_id: 'project:0',
-            //           remark: 's',
-            //         },
-            //       ],
-            //     },
-            //   },
-            // },
-          }
-        }
       />,
       {organization, router}
     );
 
     expect(screen.getByText('SELECT db.id, db.project_id,')).toBeInTheDocument();
     expect(screen.getByText('ORDER BY db.id ASC')).toBeInTheDocument();
-  });
-
-  it('normalizes the message when annotatedText is present', function () {
-    render(
-      <Sql
-        breadcrumb={{
-          type: BreadcrumbType.WARNING,
-          level: BreadcrumbLevelType.WARNING,
-          message: 'Text...',
-        }}
-        searchTerm=""
-        meta={{
-          message: {
-            '': {
-              len: 2,
-              chunks: [
-                {
-                  type: 'redaction',
-                  text: '...',
-                  rule_id: '!limit',
-                  remark: 'x',
-                },
-              ],
-            },
-          },
-        }}
-      />,
-      {organization, router}
-    );
-
-    expect(screen.getByText('Text')).toBeInTheDocument();
-    expect(screen.getByText('...')).toBeInTheDocument();
-    expect(screen.queryByText('Text...')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.spec.tsx
@@ -1,0 +1,36 @@
+import {Project} from 'sentry-fixture/project';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {Sql} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/data/sql';
+
+describe('Breadcrumb Data SQL', function () {
+  const project = Project({id: '0'});
+
+  const {organization, router} = initializeOrg({
+    router: {
+      location: {query: {project: project.id}},
+    },
+    projects: [project],
+  });
+
+  it('displays formatted SQL message', function () {
+    const message = `
+SELECT db.id, db.project_id,
+       db.release_name, db.dist_name,
+       db.date_added
+FROM db
+WHERE (db.dist_name = %s
+       AND db.project_id = %s
+       AND db.release_name = %s)
+ORDER BY db.id ASC
+LIMIT 1
+FOR
+UPDATE NOWAIT`;
+    render(<Sql searchTerm="" message={message} />, {organization, router});
+
+    expect(screen.getByText('SELECT db.id, db.project_id,')).toBeInTheDocument();
+    expect(screen.getByText('ORDER BY db.id ASC')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.spec.tsx
@@ -2,6 +2,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {Sql} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/data/sql';
+import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
 
 describe('Breadcrumb Data SQL', function () {
   const {organization, router} = initializeOrg({
@@ -11,7 +12,12 @@ describe('Breadcrumb Data SQL', function () {
   });
 
   it('displays formatted SQL message', function () {
-    const message = `
+    render(
+      <Sql
+        breadcrumb={{
+          type: BreadcrumbType.WARNING,
+          level: BreadcrumbLevelType.WARNING,
+          message: `
 SELECT db.id, db.project_id,
        db.release_name, db.dist_name,
        db.date_added
@@ -22,10 +28,67 @@ WHERE (db.dist_name = %s
 ORDER BY db.id ASC
 LIMIT 1
 FOR
-UPDATE NOWAIT`;
-    render(<Sql searchTerm="" message={message} />, {organization, router});
+UPDATE NOWAIT`,
+        }}
+        searchTerm=""
+        meta={
+          {
+            // data: {
+            //   url: {
+            //     '': {
+            //       rem: [['project:0', 's', 0, 0]],
+            //       len: 19,
+            //       chunks: [
+            //         {
+            //           type: 'redaction',
+            //           text: '',
+            //           rule_id: 'project:0',
+            //           remark: 's',
+            //         },
+            //       ],
+            //     },
+            //   },
+            // },
+          }
+        }
+      />,
+      {organization, router}
+    );
 
     expect(screen.getByText('SELECT db.id, db.project_id,')).toBeInTheDocument();
     expect(screen.getByText('ORDER BY db.id ASC')).toBeInTheDocument();
+  });
+
+  it('normalizes the message when annotatedText is present', function () {
+    render(
+      <Sql
+        breadcrumb={{
+          type: BreadcrumbType.WARNING,
+          level: BreadcrumbLevelType.WARNING,
+          message: 'Text...',
+        }}
+        searchTerm=""
+        meta={{
+          message: {
+            '': {
+              len: 2,
+              chunks: [
+                {
+                  type: 'redaction',
+                  text: '...',
+                  rule_id: '!limit',
+                  remark: 'x',
+                },
+              ],
+            },
+          },
+        }}
+      />,
+      {organization, router}
+    );
+
+    expect(screen.getByText('Text')).toBeInTheDocument();
+    expect(screen.getByText('...')).toBeInTheDocument();
+    expect(screen.queryByText('Text...')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
@@ -39,7 +39,12 @@ export function Sql({breadcrumb, meta, searchTerm}: Props) {
                     <span key={j} className={token.className}>
                       {token.children === '\u2026' || token.children === 'Filtered' ? (
                         <AnnotatedText
-                          value={`[${token.children}]`}
+                          value={
+                            // Puts the '[]' back if 'Filtered' present
+                            token.children === '\u2026'
+                              ? token.children
+                              : `[${token.children}]`
+                          }
                           meta={meta?.message?.['']}
                         />
                       ) : (

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
@@ -1,7 +1,4 @@
-import styled from '@emotion/styled';
-
 import Highlight from 'sentry/components/highlight';
-import {prismStyles} from 'sentry/styles/prism';
 import {BreadcrumbTypeDefault, BreadcrumbTypeNavigation} from 'sentry/types/breadcrumbs';
 import {usePrismTokens} from 'sentry/utils/usePrismTokens';
 
@@ -18,35 +15,21 @@ export function Sql({breadcrumb, searchTerm}: Props) {
 
   return (
     <Summary kvData={data}>
-      <Wrapper>
-        <pre className="language-sql">
-          <code>
-            {tokens.map((line, i) => (
-              <div key={i}>
-                <div>
-                  {line.map((token, j) => (
-                    <span key={j} className={token.className}>
-                      <Highlight text={searchTerm}>{token.children}</Highlight>
-                    </span>
-                  ))}
-                </div>
+      <pre className="language-sql">
+        <code>
+          {tokens.map((line, i) => (
+            <div key={i}>
+              <div>
+                {line.map((token, j) => (
+                  <span key={j} className={token.className}>
+                    <Highlight text={searchTerm}>{token.children}</Highlight>
+                  </span>
+                ))}
               </div>
-            ))}
-          </code>
-        </pre>
-      </Wrapper>
+            </div>
+          ))}
+        </code>
+      </pre>
     </Summary>
   );
 }
-
-const Wrapper = styled('div')`
-  background: var(--prism-block-background);
-
-  ${p => prismStyles(p.theme)}
-
-  pre {
-    margin: 0;
-    padding: 0;
-    font-size: ${p => p.theme.fontSizeSmall};
-  }
-`;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
@@ -41,9 +41,7 @@ export function Sql({breadcrumb, meta, searchTerm}: Props) {
                         <AnnotatedText
                           value={
                             // Puts the '[]' back if 'Filtered' present
-                            token.children === '\u2026'
-                              ? token.children
-                              : `[${token.children}]`
+                            token.children === '\u2026' ? '...' : `[${token.children}]`
                           }
                           meta={meta?.message?.['']}
                         />

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import Highlight from 'sentry/components/highlight';
 import {prismStyles} from 'sentry/styles/prism';
 import {BreadcrumbTypeDefault, BreadcrumbTypeNavigation} from 'sentry/types/breadcrumbs';
@@ -11,34 +10,14 @@ import Summary from './summary';
 type Props = {
   breadcrumb: BreadcrumbTypeNavigation | BreadcrumbTypeDefault;
   searchTerm: string;
-  meta?: Record<any, any>;
 };
 
-export function Sql({breadcrumb, meta, searchTerm}: Props) {
+export function Sql({breadcrumb, searchTerm}: Props) {
   const {data, message} = breadcrumb;
-  /**
-   * Normalize the message by replacing '...' with '\n\u2026' and '[Filtered]' with 'Filtered'.
-   * This is done to ensure '.' and '[]' are NOT labeled as punctuation by usePrismTokens
-   * and instead are special cases where we apply AnnotatedText
-   */
-  const messageFormatted = message?.replace(/\.\.\.|(\[Filtered\])/g, (_match, p1) => {
-    return p1 ? 'Filtered' : '\n\u2026';
-  });
-
-  /**
-   * If annotated text is a size limit tooltip, we need to remove the extra copy of the text
-   * from the meta.
-   */
-  meta?.message?.[''].chunks?.forEach(element => {
-    if (element.type === 'text') {
-      delete element.text;
-    }
-  });
-
-  const tokens = usePrismTokens({code: messageFormatted!, language: 'sql'});
+  const tokens = usePrismTokens({code: message ?? '', language: 'sql'});
 
   return (
-    <Summary kvData={data} meta={meta}>
+    <Summary kvData={data}>
       <Wrapper>
         <pre className="language-sql">
           <code>
@@ -47,17 +26,7 @@ export function Sql({breadcrumb, meta, searchTerm}: Props) {
                 <div>
                   {line.map((token, j) => (
                     <span key={j} className={token.className}>
-                      {token.children === '\u2026' || token.children === 'Filtered' ? (
-                        <AnnotatedText
-                          value={
-                            // Puts the '[]' back if 'Filtered' present
-                            token.children === '\u2026' ? '...' : '[Filtered]'
-                          }
-                          meta={meta?.message?.['']}
-                        />
-                      ) : (
-                        <Highlight text={searchTerm}>{token.children}</Highlight>
-                      )}
+                      <Highlight text={searchTerm}>{token.children}</Highlight>
                     </span>
                   ))}
                 </div>

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
@@ -1,4 +1,7 @@
+import styled from '@emotion/styled';
+
 import Highlight from 'sentry/components/highlight';
+import {prismStyles} from 'sentry/styles/prism';
 import {usePrismTokens} from 'sentry/utils/usePrismTokens';
 
 import Summary from './summary';
@@ -12,19 +15,35 @@ export function Sql({message, searchTerm}: Props) {
   const tokens = usePrismTokens({code: message, language: 'sql'});
   return (
     <Summary>
-      <pre className="language-sql">
-        {tokens.map((line, i) => (
-          <div key={i}>
-            <div>
-              {line.map((token, j) => (
-                <span key={j} className={token.className}>
-                  <Highlight text={searchTerm}>{token.children}</Highlight>
-                </span>
-              ))}
-            </div>
-          </div>
-        ))}
-      </pre>
+      <Wrapper>
+        <pre className="language-sql">
+          <code>
+            {tokens.map((line, i) => (
+              <div key={i}>
+                <div>
+                  {line.map((token, j) => (
+                    <span key={j} className={token.className}>
+                      <Highlight text={searchTerm}>{token.children}</Highlight>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </code>
+        </pre>
+      </Wrapper>
     </Summary>
   );
 }
+
+const Wrapper = styled('div')`
+  background: var(--prism-block-background);
+
+  ${p => prismStyles(p.theme)}
+
+  pre {
+    margin: 0;
+    padding: 0;
+    font-size: ${p => p.theme.fontSizeSmall};
+  }
+`;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+
+import {CodeSnippet} from 'sentry/components/codeSnippet';
+import {space} from 'sentry/styles/space';
+import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatter';
+
+import Summary from './summary';
+
+const formatter = new SQLishFormatter();
+
+type Props = {
+  message: string;
+};
+
+export function Sql({message}: Props) {
+  return (
+    <Summary>
+      <FormattedCode>
+        <StyledCodeSnippet language="sql">
+          {formatter.toString(message)}
+        </StyledCodeSnippet>
+      </FormattedCode>
+    </Summary>
+  );
+}
+
+const StyledCodeSnippet = styled(CodeSnippet)`
+  pre {
+    /* overflow is set to visible in global styles so need to enforce auto here */
+    overflow: auto !important;
+  }
+
+  z-index: 0;
+`;
+
+const FormattedCode = styled('div')`
+  padding: ${space(1)};
+  background: ${p => p.theme.backgroundSecondary};
+  border-radius: ${p => p.theme.borderRadius};
+  overflow-x: auto;
+  white-space: pre;
+`;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
@@ -1,42 +1,30 @@
-import styled from '@emotion/styled';
-
-import {CodeSnippet} from 'sentry/components/codeSnippet';
-import {space} from 'sentry/styles/space';
-import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatter';
+import Highlight from 'sentry/components/highlight';
+import {usePrismTokens} from 'sentry/utils/usePrismTokens';
 
 import Summary from './summary';
 
-const formatter = new SQLishFormatter();
-
 type Props = {
   message: string;
+  searchTerm: string;
 };
 
-export function Sql({message}: Props) {
+export function Sql({message, searchTerm}: Props) {
+  const tokens = usePrismTokens({code: message, language: 'sql'});
   return (
     <Summary>
-      <FormattedCode>
-        <StyledCodeSnippet language="sql">
-          {formatter.toString(message)}
-        </StyledCodeSnippet>
-      </FormattedCode>
+      <pre className="language-sql">
+        {tokens.map((line, i) => (
+          <div key={i}>
+            <div>
+              {line.map((token, j) => (
+                <span key={j} className={token.className}>
+                  <Highlight text={searchTerm}>{token.children}</Highlight>
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </pre>
     </Summary>
   );
 }
-
-const StyledCodeSnippet = styled(CodeSnippet)`
-  pre {
-    /* overflow is set to visible in global styles so need to enforce auto here */
-    overflow: auto !important;
-  }
-
-  z-index: 0;
-`;
-
-const FormattedCode = styled('div')`
-  padding: ${space(1)};
-  background: ${p => p.theme.backgroundSecondary};
-  border-radius: ${p => p.theme.borderRadius};
-  overflow-x: auto;
-  white-space: pre;
-`;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/sql.tsx
@@ -25,6 +25,16 @@ export function Sql({breadcrumb, meta, searchTerm}: Props) {
     return p1 ? 'Filtered' : '\n\u2026';
   });
 
+  /**
+   * If annotated text is a size limit tooltip, we need to remove the extra copy of the text
+   * from the meta.
+   */
+  meta?.message?.[''].chunks?.forEach(element => {
+    if (element.type === 'text') {
+      delete element.text;
+    }
+  });
+
   const tokens = usePrismTokens({code: messageFormatted!, language: 'sql'});
 
   return (
@@ -41,7 +51,7 @@ export function Sql({breadcrumb, meta, searchTerm}: Props) {
                         <AnnotatedText
                           value={
                             // Puts the '[]' back if 'Filtered' present
-                            token.children === '\u2026' ? '...' : `[${token.children}]`
+                            token.children === '\u2026' ? '...' : '[Filtered]'
                           }
                           meta={meta?.message?.['']}
                         />

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/summary.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/summary.tsx
@@ -52,6 +52,13 @@ const Wrapper = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   font-family: ${p => p.theme.text.familyMono};
   overflow: hidden;
+
+  pre,
+  code {
+    margin: 0;
+    padding: 0;
+    font-size: ${p => p.theme.fontSizeSmall};
+  }
 `;
 
 const ContextDataWrapper = styled('div')`

--- a/static/app/types/breadcrumbs.tsx
+++ b/static/app/types/breadcrumbs.tsx
@@ -29,13 +29,17 @@ export enum BreadcrumbType {
   INIT = 'init',
 }
 
+export enum BreadcrumbMessageFormat {
+  SQL = 'sql',
+}
+
 interface BreadcrumbTypeBase {
   level: BreadcrumbLevelType;
   // it's recommended
   category?: string | null;
   event_id?: string | null;
   message?: string;
-  messageFormat?: 'sql';
+  messageFormat?: BreadcrumbMessageFormat.SQL;
   messageRaw?: string;
   timestamp?: string;
 }


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/52929

Before:
<img width="1015" alt="Screenshot 2024-01-05 at 9 08 51 AM" src="https://github.com/getsentry/sentry/assets/22582037/f1c984c1-d0b7-478d-b522-77875e6a9dff">


After:
<img width="1015" alt="Screenshot 2024-01-05 at 9 08 16 AM" src="https://github.com/getsentry/sentry/assets/22582037/afe50179-fa2e-4144-8cfe-7f7cad6fa29e">


After with Highlighting:
<img width="1015" alt="Screenshot 2024-01-05 at 9 09 43 AM" src="https://github.com/getsentry/sentry/assets/22582037/1ef9941c-64f0-4b9b-a0d6-ce4d71e6422b">

NOTE: This PR does not include cases with annotated/filtered text:
![Screenshot 2024-01-09 at 9 24 01 AM](https://github.com/getsentry/sentry/assets/22582037/95315d06-9229-4d6b-8cdc-24b1dd51c423)



