### PR TITLE
feat(integrations): Add integration details to activity created in status sync

### DIFF
--- a/src/sentry/tasks/integrations/sync_status_inbound.py
+++ b/src/sentry/tasks/integrations/sync_status_inbound.py
@@ -44,12 +44,20 @@ def sync_status_inbound(
     except Exception:
         return
 
+    provider = installation.model.get_provider()
+    activity_data = {
+        "provider": provider.name,
+        "provider_key": provider.key,
+        "integration_id": integration_id,
+    }
+
     if action == ResolveSyncAction.RESOLVE:
         Group.objects.update_group_status(
             groups=affected_groups,
             status=GroupStatus.RESOLVED,
             substatus=None,
             activity_type=ActivityType.SET_RESOLVED,
+            activity_data=activity_data,
         )
 
         for group in affected_groups:
@@ -69,4 +77,5 @@ def sync_status_inbound(
             status=GroupStatus.UNRESOLVED,
             substatus=GroupSubStatus.ONGOING,
             activity_type=ActivityType.SET_UNRESOLVED,
+            activity_data=activity_data,
         )


### PR DESCRIPTION
When an integration syncs status back via webhook, save details in the group activity about which integration triggered the status update.

This activity ideally would be able to say `jira server unresolved this issue` with a link to the integration page.

related #61878
somewhat related #62565