### PR TITLE
feat(ddm): Add order by support for the new metrics API

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -173,7 +173,6 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
             results = run_metrics_query(
                 fields=request.GET.getlist("field", []),
                 query=request.GET.get("query"),
-                group_bys=request.GET.getlist("groupBy"),
                 interval=interval,
                 start=start,
                 end=end,
@@ -182,6 +181,9 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
                 environments=self.get_environments(request, organization),
                 # TODO: move referrers into a centralized place.
                 referrer="metrics.data.api",
+                # Optional parameters.
+                group_bys=request.GET.getlist("groupBy"),
+                order_by=request.GET.get("orderBy"),
             )
         except InvalidMetricsQueryError as e:
             return Response(status=400, data={"detail": str(e)})

--- a/src/sentry/sentry_metrics/querying/api.py
+++ b/src/sentry/sentry_metrics/querying/api.py
@@ -110,6 +110,14 @@ class ExecutableQuery:
         self,
         groups_collection: Optional[GroupsCollection],
     ) -> "ExecutableQuery":
+        """
+        Adds a series of filters to the query which will make sure that the results returned only belong to the supplied
+        groups.
+
+        The need for this filter arises because when executing multiple queries, we want to have the same groups
+        returned, in order to make results consistent. Note that in case queries have different groups, some results
+        might be missing, since the reference query dictates which values are returned during the alignment process.
+        """
         if not groups_collection:
             return self
 

--- a/src/sentry/sentry_metrics/querying/api.py
+++ b/src/sentry/sentry_metrics/querying/api.py
@@ -553,9 +553,10 @@ class QueryExecutor:
                     if executable_query.order_by.startswith("-"):
                         order_by_direction = Direction.DESC
 
-                    totals_executable_query = executable_query.replace_order_by(order_by_direction)
+                    totals_executable_query = totals_executable_query.replace_order_by(
+                        order_by_direction
+                    )
 
-                # TODO: check why limit is not working.
                 totals_result = run_query(
                     request=self._build_request(
                         totals_executable_query.to_totals_query().metrics_query

--- a/src/sentry/sentry_metrics/querying/api.py
+++ b/src/sentry/sentry_metrics/querying/api.py
@@ -240,7 +240,7 @@ class QueryResult:
     @property
     def query_name(self) -> str:
         timeseries = (
-            self.series_executable_query or self.totals_executable_query
+            cast(ExecutableQuery, self.series_executable_query or self.totals_executable_query)
         ).metrics_query.query
 
         aggregate = timeseries.aggregate
@@ -292,7 +292,9 @@ class QueryResult:
         # that we can correctly render groups in case they are not returned from the db.
         return cast(
             Optional[List[str]],
-            (self.series_executable_query or self.totals_executable_query).group_bys,
+            (
+                cast(ExecutableQuery, self.series_executable_query or self.totals_executable_query)
+            ).group_bys,
         )
 
     @property

--- a/tests/sentry/sentry_metrics/querying/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/test_api.py
@@ -364,7 +364,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert groups[0]["totals"] == {field_2: 6.0, field_1: 1.0}
 
     def test_query_with_multiple_aggregations_and_single_group_by(self) -> None:
-        # Query with two aggregations.
         field_1 = f"min({TransactionMRI.DURATION.value})"
         field_2 = f"max({TransactionMRI.DURATION.value})"
         results = run_metrics_query(
@@ -410,7 +409,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         ]
 
     def test_query_with_multiple_aggregations_and_single_group_by_and_order_by(self) -> None:
-        # Query with two aggregations.
         field_1 = f"min({TransactionMRI.DURATION.value})"
         field_2 = f"max({TransactionMRI.DURATION.value})"
         results = run_metrics_query(
@@ -459,7 +457,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
     def test_query_with_multiple_aggregations_and_single_group_by_and_order_by_with_limit(
         self,
     ) -> None:
-        # Query with two aggregations.
         field_1 = f"min({TransactionMRI.DURATION.value})"
         field_2 = f"max({TransactionMRI.DURATION.value})"
         results = run_metrics_query(
@@ -496,6 +493,28 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             (field_2, 6.0),
             (field_1, 3.0),
         ]
+
+    def test_query_with_invalid_order_by(
+        self,
+    ) -> None:
+        field_1 = f"min({TransactionMRI.DURATION.value})"
+        field_2 = f"max({TransactionMRI.DURATION.value})"
+        field_3 = f"avg({TransactionMRI.DURATION.value})"
+        with pytest.raises(InvalidMetricsQueryError):
+            run_metrics_query(
+                fields=[field_1, field_2],
+                query=None,
+                group_bys=["platform"],
+                order_by=f"{field_3}",
+                limit=2,
+                start=self.now() - timedelta(minutes=30),
+                end=self.now() + timedelta(hours=1, minutes=30),
+                interval=3600,
+                organization=self.project.organization,
+                projects=[self.project],
+                environments=[],
+                referrer="metrics.data.api",
+            )
 
     def test_query_with_invalid_filters(self) -> None:
         # Query with one aggregation, one group by and two filters.

--- a/tests/sentry/sentry_metrics/querying/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/test_api.py
@@ -336,6 +336,29 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         )
         groups = results["groups"]
         assert len(groups) == 3
+        assert groups[0]["by"] == {"platform": "ios"}
+        assert groups[0]["series"] == {field_2: [0.0, 3.0, 3.0], field_1: [0.0, 3.0, 3.0]}
+        assert groups[0]["totals"] == {field_2: 3.0, field_1: 3.0}
+
+    def test_query_with_multiple_aggregations_and_single_group_by_and_order_by(self) -> None:
+        # Query with two aggregations.
+        field_1 = f"min({TransactionMRI.DURATION.value})"
+        field_2 = f"max({TransactionMRI.DURATION.value})"
+        results = run_metrics_query(
+            fields=[field_1, field_2],
+            query=None,
+            group_bys=["platform"],
+            order_by=f"-{field_1}",
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        groups = results["groups"]
+        assert len(groups) == 3
         assert groups[0]["by"] == {}
         assert groups[0]["series"] == {field_2: [0.0, 5.0, 3.0], field_1: [0.0, 1.0, 2.0]}
         assert groups[0]["totals"] == {field_2: 5.0, field_1: 1.0}

--- a/tests/sentry/sentry_metrics/querying/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/test_api.py
@@ -318,6 +318,28 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert groups[0]["series"] == {field_2: [0.0, 5.0, 3.0], field_1: [0.0, 1.0, 2.0]}
         assert groups[0]["totals"] == {field_2: 5.0, field_1: 1.0}
 
+    def test_query_with_multiple_aggregations_and_single_group_by(self) -> None:
+        # Query with two aggregations.
+        field_1 = f"min({TransactionMRI.DURATION.value})"
+        field_2 = f"max({TransactionMRI.DURATION.value})"
+        results = run_metrics_query(
+            fields=[field_1, field_2],
+            query=None,
+            group_bys=["platform"],
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        groups = results["groups"]
+        assert len(groups) == 3
+        assert groups[0]["by"] == {}
+        assert groups[0]["series"] == {field_2: [0.0, 5.0, 3.0], field_1: [0.0, 1.0, 2.0]}
+        assert groups[0]["totals"] == {field_2: 5.0, field_1: 1.0}
+
     def test_query_with_invalid_filters(self) -> None:
         # Query with one aggregation, one group by and two filters.
         field = f"sum({TransactionMRI.DURATION.value})"


### PR DESCRIPTION
This PR adds support for order by and limit in the layer. It's important to note that the support, is for a single order by only one of the aggregates in the query. This limitation is given by the metrics layer, which supports ordering in totals query and only on the aggregate value.

The engine for executing queries works in the following way (suppose you ask for `transaction`, `sum(x)`, `sum(y)` and you order by `sum(x)`):
1. The reference query is found by looking at the query whose `field` is `sum(x)`. A reference query is a query that is used by the following queries to align to, in order to maintain the sort order.
1. A totals query for `transaction`, `sum(x)` is executed.
2. The groups returned by that query are applied on the series query for `transaction`, `sum(x)`.
3. The reference query series component is aligned on the totals, since the layer doesn't allow ordering on series. Now the state is that we have a reference query with both totals and series ordered correctly (based on `sum(x)`).
4. The groups returned by totals reference query are applied as filters on the following queries, in this case the query `transaction`, `sum(y)` will be executed.
5. Once the query is executed, the values will be aligned to the ones of the reference query, effectively resulting in two lists were the `transaction` is used to define order (because it's the only common value between the two queries).
6. The values of the queries are now added together and returned as a list of `QueryResult` that are going to be stiched together by the translation layer.

In conclusion, a query with `n` aggregates, will result in `n * 2` queries. If you also consider the dynamic interval calculation in place, we could reach a maximum of `(2 * 2) + (n - 1) * 2` since we will have to first run at most 2 times the totals and series query until we find a good interval bigger than the optimal.

Closes https://github.com/getsentry/sentry/issues/60785