### PR TITLE
feat(replays): Optimize /replay-counts query by passing a narrowed set of project_ids

### DIFF
--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 from collections import defaultdict
 from collections.abc import Sequence
 from typing import Any
@@ -67,8 +68,8 @@ def _get_replay_id_mappings(
     # safety check is inexpensive and bad-actors (or malfunctioning clients) could
     # provide every project_id manually.
     if select_column == "issue.id":
-        queryset = Group.objects.select_related("project").filter(id__in=value)
-        snuba_params.projects = [group.project for group in queryset]
+        qs = Group.objects.select_related("project").filter(id__in=value)
+        snuba_params = dataclasses.replace(snuba_params, projects=[group.project for group in qs])
 
     builder = QueryBuilder(
         dataset=data_source,

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -68,8 +68,14 @@ def _get_replay_id_mappings(
     # safety check is inexpensive and bad-actors (or malfunctioning clients) could
     # provide every project_id manually.
     if select_column == "issue.id":
-        qs = Group.objects.select_related("project").filter(id__in=value)
-        snuba_params = dataclasses.replace(snuba_params, projects=[group.project for group in qs])
+        groups = Group.objects.select_related("project").filter(
+            project__organization_id=snuba_params.organization.id,
+            id__in=value,
+        )
+        snuba_params = dataclasses.replace(
+            snuba_params,
+            projects=[group.project for group in groups],
+        )
 
     builder = QueryBuilder(
         dataset=data_source,

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from sentry.api.event_search import parse_search_query
+from sentry.models.group import Group
 from sentry.replays.query import query_replays_count
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.types import QueryBuilderConfig, SnubaParams
@@ -55,6 +56,19 @@ def _get_replay_id_mappings(
         # just return a mapping of replay_id:replay_id instead of hitting discover
         # if we want to validate list of replay_ids existence
         return {v: [v] for v in value}
+
+    # The client may or may not have narrowed the request by project-id. We have a
+    # defined set of issue-ids and can efficiently look-up their project-ids if the
+    # client did not provide them. This optimization saves a significant amount of
+    # time and memory when querying ClickHouse.
+    #
+    # NOTE: Possible to skip this. If the client did not set project_id = -1 then
+    # we could trust the client narrowed the project-ids correctly. However, this
+    # safety check is inexpensive and bad-actors (or malfunctioning clients) could
+    # provide every project_id manually.
+    if select_column == "issue.id":
+        queryset = Group.objects.select_related("project").filter(id__in=value)
+        snuba_params.projects = [group.project for group in queryset]
 
     builder = QueryBuilder(
         dataset=data_source,

--- a/tests/sentry/replays/test_organization_replay_count.py
+++ b/tests/sentry/replays/test_organization_replay_count.py
@@ -8,6 +8,7 @@ import pytest
 from django.db.models import F
 from django.urls import reverse
 
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.replays.endpoints.organization_replay_count import project_in_org_has_sent_replay
 from sentry.replays.testutils import mock_replay
@@ -460,7 +461,6 @@ class OrganizationReplayCountEndpointTest(
             assert response.data["detail"] == "Too many values provided"
 
     def test_invalid_params_only_one_of_issue_and_transaction(self):
-
         query = {"query": "issue.id:[1] transaction:[2]"}
 
         with self.feature(self.features):
@@ -542,3 +542,64 @@ class OrganizationReplayCountEndpointTest(
         project.update(flags=F("flags").bitor(Project.flags.has_replays))
 
         assert project_in_org_has_sent_replay(org) is True
+
+    def test_cross_organization_lookups(self):
+        event_id_a = "a" * 32
+        event_id_b = "b" * 32
+        replay1_id = uuid.uuid4().hex
+        replay2_id = uuid.uuid4().hex
+
+        # Mock data for the user's organization.
+        self.store_replays(
+            mock_replay(
+                datetime.datetime.now() - datetime.timedelta(seconds=22),
+                self.project.id,
+                replay1_id,
+            )
+        )
+        event_a = self.store_event(
+            data={
+                "event_id": event_id_a,
+                "timestamp": iso_format(self.min_ago),
+                "tags": {"replayId": replay1_id},
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+
+        # Mock data for an organization the user does not have access to.
+        #
+        # There's a project-id mismatch between the replay and the event. This
+        # is intentional. If the replay has a project-id outside the user's
+        # organization then the endpoint is protected and will not return results
+        # for that issue-id. We pass an invalid database state to assert only
+        # issues belonging to the user will ever be fetched.
+        org = Organization.objects.create(slug="other-org")
+        project = Project.objects.create(organization=org, slug="other-project")
+
+        self.store_replays(
+            mock_replay(
+                datetime.datetime.now() - datetime.timedelta(seconds=22),
+                self.project.id,
+                replay2_id,
+            )
+        )
+        event_b = self.store_event(
+            data={
+                "event_id": event_id_b,
+                "timestamp": iso_format(self.min_ago),
+                "tags": {"replayId": replay2_id},
+                "fingerprint": ["group-2"],
+            },
+            project_id=project.id,
+        )
+
+        # IDs from both orgs are passed to the endpoint.
+        query = {"query": f"issue.id:[{event_a.group.id}, {event_b.group.id}]"}
+        with self.feature(self.features):
+            response = self.client.get(self.url, query, format="json")
+
+        # Assert the request succeeds but the event from another organization
+        # is not returned.
+        assert response.status_code == 200, response.content
+        assert response.data == {event_a.group.id: 1}


### PR DESCRIPTION
Adds a pre-processing step which looks up a set of project-ids given a set of issue-ids. This significantly reduces the number of rows we need to scan in ClickHouse and improves the performance of the query.