### PR TITLE
fix(replays): Cap the number of aggregation targets we'll search for to match the number of aggregations we'll return

### DIFF
--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -56,6 +56,13 @@ def _get_replay_id_mappings(
         # if we want to validate list of replay_ids existence
         return {v: [v] for v in value}
 
+    # Any number of issues can be specified however we're only going to return at
+    # most 25 of them. Cap the lists length to 25. The other ids are silently
+    # dropped.
+    #
+    # NOTE: Should this be an error?
+    value = value[:25]
+
     builder = QueryBuilder(
         dataset=data_source,
         params={},

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from collections.abc import Sequence
 from typing import Any
@@ -18,6 +19,9 @@ MAX_VALS_PROVIDED = {
 }
 
 FILTER_HAS_A_REPLAY = " AND !replayId:''"
+
+
+logger = logging.getLogger()
 
 
 def get_replay_counts(snuba_params: SnubaParams, query, return_ids, data_source) -> dict[str, Any]:
@@ -59,9 +63,9 @@ def _get_replay_id_mappings(
     # Any number of issues can be specified however we're only going to return at
     # most 25 of them. Cap the lists length to 25. The other ids are silently
     # dropped.
-    #
-    # NOTE: Should this be an error?
-    value = value[:25]
+    if len(value) > 25:
+        logger.warning("Received more than 25 ids: %d", len(value))
+        value = value[:25]
 
     builder = QueryBuilder(
         dataset=data_source,


### PR DESCRIPTION
Sometimes the client will send more aggregation keys than the endpoint is capable of returning. We should handle these situations gracefully. The proposed solution is to cap the list and silently drop extra aggregation keys which matches current production behavior without the wild memory usage.

Addresses: https://sentry.sentry.io/issues/4802777330