### PR TITLE
bug(replay): Make sure replayId is valid before calling replayExists()

### DIFF
--- a/static/app/utils/discover/viewReplayLink.tsx
+++ b/static/app/utils/discover/viewReplayLink.tsx
@@ -17,7 +17,7 @@ function ViewReplayLink({
 }) {
   const {replayExists} = useReplayExists();
 
-  if (!replayExists(String(replayId))) {
+  if (!replayId || !replayExists(String(replayId))) {
     return (
       <Tooltip title={t('This replay may have been rate limited or deleted.')}>
         <EmptyValueContainer>{t('(missing)')}</EmptyValueContainer>


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry/issues/62549