### PR TITLE
feat(app-start): Add sampled events tables

### DIFF
--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.spec.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.spec.tsx
@@ -1,0 +1,103 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {EventSamples} from 'sentry/views/starfish/views/appStartup/screenSummary/eventSamples';
+import {
+  MobileCursors,
+  MobileSortKeys,
+} from 'sentry/views/starfish/views/screens/constants';
+
+jest.mock('sentry/utils/usePageFilters');
+
+describe('ScreenLoadEventSamples', function () {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+
+  let mockEventsRequest;
+  beforeEach(function () {
+    jest.mocked(usePageFilters).mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [parseInt(project.id, 10)],
+      },
+    });
+    mockEventsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        meta: {
+          fields: {
+            'span.description': 'string',
+            profile_id: 'string',
+            'transaction.id': 'string',
+            'span.duration': 'duration',
+            'project.name': 'string',
+            id: 'string',
+          },
+        },
+        data: [
+          {
+            'span.description': 'Warm Start',
+            profile_id: 'profile-id',
+            'transaction.id': '76af98a3ac9d4448b894e44b1819970e',
+            'span.duration': 131,
+            'project.name': 'sentry-cocoa',
+            id: 'f0587aad3de14aeb',
+          },
+        ],
+      },
+    });
+  });
+
+  it('makes a request for the release and transaction passed as props', async function () {
+    render(
+      <EventSamples
+        release="com.example.vu.android@2.10.5"
+        sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
+        cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
+        transaction="ErrorController"
+        showDeviceClassSelector
+      />
+    );
+
+    // Check that headers are set properly
+    expect(
+      screen.getByRole('columnheader', {name: 'Event ID (2.10.5)'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Profile'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Start Type'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Duration'})).toBeInTheDocument();
+
+    expect(mockEventsRequest).toHaveBeenCalledTimes(1);
+
+    // Check data is rendered properly
+    // Transaction is a link
+    expect(await screen.findByRole('link', {name: '76af98a3'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/performance/sentry-cocoa:76af98a3ac9d4448b894e44b1819970e'
+    );
+
+    // Profile is a button
+    expect(screen.getByRole('button', {name: 'View Profile'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/profiling/profile/sentry-cocoa/profile-id/flamegraph/'
+    );
+
+    // Start Type is the span description, "Warm Start"
+    expect(screen.getByText('Warm Start')).toBeInTheDocument();
+
+    expect(screen.getByText('131.00ms')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
@@ -1,38 +1,20 @@
-import {Fragment} from 'react';
-import {browserHistory} from 'react-router';
-import styled from '@emotion/styled';
-
-import {LinkButton} from 'sentry/components/button';
-import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
-import SortLink from 'sentry/components/gridEditable/sortLink';
-import Link from 'sentry/components/links/link';
-import Pagination, {CursorHandler} from 'sentry/components/pagination';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconProfiling} from 'sentry/icons/iconProfiling';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {NewQuery} from 'sentry/types';
-import {defined} from 'sentry/utils';
-import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
-import EventView, {
-  fromSorts,
-  isFieldSortable,
-  MetaType,
-} from 'sentry/utils/discover/eventView';
-import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
-import {fieldAlignment, Sort} from 'sentry/utils/discover/fields';
+import EventView, {fromSorts} from 'sentry/utils/discover/eventView';
+import {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {normalizeUrl} from 'sentry/utils/withDomainRequired';
-import {TableColumn} from 'sentry/views/discover/table/types';
 import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
-import {DeviceClassSelector} from 'sentry/views/starfish/views/screens/screenLoadSpans/deviceClassSelector';
+import {EventSamplesTable} from 'sentry/views/starfish/views/screens/screenLoadSpans/eventSamplesTable';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
+
+const DEFAULT_SORT: Sort = {
+  kind: 'desc',
+  field: 'span.duration',
+};
 
 type Props = {
   cursorName: string;
@@ -41,8 +23,6 @@ type Props = {
   transaction: string;
   showDeviceClassSelector?: boolean;
 };
-
-const ICON_FIELDS = ['profile_id'];
 
 export function EventSamples({
   cursorName,
@@ -53,7 +33,6 @@ export function EventSamples({
 }: Props) {
   const location = useLocation();
   const {selection} = usePageFilters();
-  const organization = useOrganization();
   const cursor = decodeScalar(location.query?.[cursorName]);
 
   const searchQuery = new MutableSearch([
@@ -77,10 +56,7 @@ export function EventSamples({
     }
   }
 
-  const sort = fromSorts(decodeScalar(location.query[sortKey]))[0] ?? {
-    kind: 'desc',
-    field: 'span.duration',
-  };
+  const sort = fromSorts(decodeScalar(location.query[sortKey]))[0] ?? DEFAULT_SORT;
 
   const columnNameMap = {
     'transaction.id': t('Event ID (%s)', formatVersionAndCenterTruncate(release)),
@@ -115,177 +91,19 @@ export function EventSamples({
     referrer: 'api.starfish.mobile-startup-event-samples',
   });
 
-  const eventViewColumns = eventView.getColumns();
-
-  // Had to change the keys for event ID and profile ID
-  function renderBodyCell(column, row): React.ReactNode {
-    if (!data?.meta || !data?.meta.fields) {
-      return row[column.key];
-    }
-
-    if (column.key === 'transaction.id') {
-      return (
-        <Link
-          to={normalizeUrl(
-            `/organizations/${organization.slug}/performance/${row['project.name']}:${row['transaction.id']}`
-          )}
-        >
-          {row['transaction.id'].slice(0, 8)}
-        </Link>
-      );
-    }
-
-    if (column.key === 'profile_id') {
-      const profileTarget =
-        defined(row['project.name']) && row.profile_id
-          ? generateProfileFlamechartRoute({
-              orgSlug: organization.slug,
-              projectSlug: row['project.name'],
-              profileId: String(row.profile_id),
-            })
-          : null;
-      return (
-        <IconWrapper>
-          {profileTarget && (
-            <Tooltip title={t('View Profile')}>
-              <LinkButton to={profileTarget} size="xs">
-                <IconProfiling size="xs" />
-              </LinkButton>
-            </Tooltip>
-          )}
-        </IconWrapper>
-      );
-    }
-
-    const renderer = getFieldRenderer(column.key, data?.meta.fields, false);
-    const rendered = renderer(row, {
-      location,
-      organization,
-      unit: data?.meta.units?.[column.key],
-    });
-    return rendered;
-  }
-
-  function renderHeadCell(
-    column: GridColumnHeader,
-    tableMeta?: MetaType
-  ): React.ReactNode {
-    const fieldType = tableMeta?.fields?.[column.key];
-    let alignment = fieldAlignment(column.key as string, fieldType);
-    if (ICON_FIELDS.includes(column.key as string)) {
-      alignment = 'right';
-    }
-    const field = {
-      field: column.key as string,
-      width: column.width,
-    };
-
-    function generateSortLink() {
-      if (!tableMeta) {
-        return undefined;
-      }
-
-      let newSortDirection: Sort['kind'] = 'desc';
-      if (sort?.field === column.key) {
-        if (sort.kind === 'desc') {
-          newSortDirection = 'asc';
-        }
-      }
-
-      const newSort = `${newSortDirection === 'desc' ? '-' : ''}${column.key}`;
-
-      return {
-        ...location,
-        query: {...location.query, [sortKey]: newSort},
-      };
-    }
-
-    const canSort = isFieldSortable(field, tableMeta?.fields, true);
-
-    const sortLink = (
-      <SortLink
-        align={alignment}
-        title={column.name}
-        direction={sort?.field === column.key ? sort.kind : undefined}
-        canSort={canSort}
-        generateSortLink={generateSortLink}
-      />
-    );
-    return sortLink;
-  }
-
-  const columnSortBy = eventView.getSorts();
-
-  const handleCursor: CursorHandler = (newCursor, pathname, query) => {
-    browserHistory.push({
-      pathname,
-      query: {...query, [cursorName]: newCursor},
-    });
-  };
-
   return (
-    <Fragment>
-      <Header>
-        {showDeviceClassSelector && <DeviceClassSelector />}
-        <StyledPagination size="xs" pageLinks={pageLinks} onCursor={handleCursor} />
-      </Header>
-      <GridContainer>
-        <GridEditable
-          isLoading={isLoading}
-          data={data?.data as TableDataRow[]}
-          columnOrder={eventViewColumns
-            .filter((col: TableColumn<React.ReactText>) => col.name !== 'project.name')
-            .map((col: TableColumn<React.ReactText>) => {
-              return {...col, name: columnNameMap[col.key]};
-            })}
-          columnSortBy={columnSortBy}
-          location={location}
-          grid={{
-            renderHeadCell: column => renderHeadCell(column, data?.meta),
-            renderBodyCell,
-          }}
-        />
-      </GridContainer>
-    </Fragment>
+    <EventSamplesTable
+      cursorName={cursorName}
+      eventIdKey="transaction.id"
+      eventView={eventView}
+      isLoading={isLoading}
+      profileIdKey="profile_id"
+      sortKey={sortKey}
+      data={data}
+      pageLinks={pageLinks}
+      showDeviceClassSelector={showDeviceClassSelector}
+      columnNameMap={columnNameMap}
+      sort={sort}
+    />
   );
 }
-
-const StyledPagination = styled(Pagination)`
-  margin: 0 0 0 ${space(1)};
-`;
-
-const Header = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr auto;
-  margin-bottom: ${space(1)};
-  align-items: center;
-  height: 26px;
-`;
-
-const IconWrapper = styled('div')`
-  text-align: right;
-  width: 100%;
-  height: 26px;
-`;
-
-// Not pretty but we need to override gridEditable styles since the original
-// styles have too much padding for small spaces
-const GridContainer = styled('div')`
-  margin-bottom: ${space(1)};
-  th {
-    padding: 0 ${space(1)};
-  }
-  th:first-child {
-    padding-left: ${space(2)};
-  }
-  th:last-child {
-    padding-right: ${space(2)};
-  }
-  td {
-    padding: ${space(0.5)} ${space(1)};
-  }
-  td:first-child {
-    padding-right: ${space(1)};
-    padding-left: ${space(2)};
-  }
-`;

--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
@@ -1,0 +1,291 @@
+import {Fragment} from 'react';
+import {browserHistory} from 'react-router';
+import styled from '@emotion/styled';
+
+import {LinkButton} from 'sentry/components/button';
+import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
+import SortLink from 'sentry/components/gridEditable/sortLink';
+import Link from 'sentry/components/links/link';
+import Pagination, {CursorHandler} from 'sentry/components/pagination';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconProfiling} from 'sentry/icons/iconProfiling';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {NewQuery} from 'sentry/types';
+import {defined} from 'sentry/utils';
+import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
+import EventView, {
+  fromSorts,
+  isFieldSortable,
+  MetaType,
+} from 'sentry/utils/discover/eventView';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {fieldAlignment, Sort} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {TableColumn} from 'sentry/views/discover/table/types';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {DeviceClassSelector} from 'sentry/views/starfish/views/screens/screenLoadSpans/deviceClassSelector';
+import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
+
+type Props = {
+  cursorName: string;
+  release: string;
+  sortKey: string;
+  transaction: string;
+  showDeviceClassSelector?: boolean;
+};
+
+const ICON_FIELDS = ['profile_id'];
+
+export function EventSamples({
+  cursorName,
+  transaction,
+  release,
+  sortKey,
+  showDeviceClassSelector,
+}: Props) {
+  const location = useLocation();
+  const {selection} = usePageFilters();
+  const organization = useOrganization();
+  const cursor = decodeScalar(location.query?.[cursorName]);
+
+  const searchQuery = new MutableSearch([
+    `transaction:${transaction}`,
+    `release:${release}`,
+    'span.op:[app.start.cold,app.start.warm]',
+    '(',
+    'span.description:"Cold Start"',
+    'OR',
+    'span.description:"Warm Start"',
+    ')',
+  ]);
+
+  const deviceClass = decodeScalar(location.query['device.class']);
+
+  if (deviceClass) {
+    if (deviceClass === 'Unknown') {
+      searchQuery.addFilterValue('!has', 'device.class');
+    } else {
+      searchQuery.addFilterValue('device.class', deviceClass);
+    }
+  }
+
+  const sort = fromSorts(decodeScalar(location.query[sortKey]))[0] ?? {
+    kind: 'desc',
+    field: 'span.duration',
+  };
+
+  const columnNameMap = {
+    'transaction.id': t('Event ID (%s)', formatVersionAndCenterTruncate(release)),
+    profile_id: t('Profile'),
+    'span.description': t('Start Type'),
+    'span.duration': t('Duration'),
+  };
+
+  const newQuery: NewQuery = {
+    name: '',
+    fields: [
+      'transaction.id',
+      'project.name',
+      'profile_id',
+      'span.description',
+      'span.duration',
+    ],
+    query: searchQuery.formatString(),
+    dataset: DiscoverDatasets.SPANS_INDEXED,
+    version: 2,
+    projects: selection.projects,
+  };
+
+  const eventView = EventView.fromNewQueryWithLocation(newQuery, location);
+  eventView.sorts = [sort];
+
+  const {data, isLoading, pageLinks} = useTableQuery({
+    eventView,
+    enabled: true,
+    limit: 4,
+    cursor,
+    referrer: 'api.starfish.mobile-startup-event-samples',
+  });
+
+  const eventViewColumns = eventView.getColumns();
+
+  // Had to change the keys for event ID and profile ID
+  function renderBodyCell(column, row): React.ReactNode {
+    if (!data?.meta || !data?.meta.fields) {
+      return row[column.key];
+    }
+
+    if (column.key === 'transaction.id') {
+      return (
+        <Link
+          to={normalizeUrl(
+            `/organizations/${organization.slug}/performance/${row['project.name']}:${row['transaction.id']}`
+          )}
+        >
+          {row['transaction.id'].slice(0, 8)}
+        </Link>
+      );
+    }
+
+    if (column.key === 'profile_id') {
+      const profileTarget =
+        defined(row['project.name']) && row.profile_id
+          ? generateProfileFlamechartRoute({
+              orgSlug: organization.slug,
+              projectSlug: row['project.name'],
+              profileId: String(row.profile_id),
+            })
+          : null;
+      return (
+        <IconWrapper>
+          {profileTarget && (
+            <Tooltip title={t('View Profile')}>
+              <LinkButton to={profileTarget} size="xs">
+                <IconProfiling size="xs" />
+              </LinkButton>
+            </Tooltip>
+          )}
+        </IconWrapper>
+      );
+    }
+
+    const renderer = getFieldRenderer(column.key, data?.meta.fields, false);
+    const rendered = renderer(row, {
+      location,
+      organization,
+      unit: data?.meta.units?.[column.key],
+    });
+    return rendered;
+  }
+
+  function renderHeadCell(
+    column: GridColumnHeader,
+    tableMeta?: MetaType
+  ): React.ReactNode {
+    const fieldType = tableMeta?.fields?.[column.key];
+    let alignment = fieldAlignment(column.key as string, fieldType);
+    if (ICON_FIELDS.includes(column.key as string)) {
+      alignment = 'right';
+    }
+    const field = {
+      field: column.key as string,
+      width: column.width,
+    };
+
+    function generateSortLink() {
+      if (!tableMeta) {
+        return undefined;
+      }
+
+      let newSortDirection: Sort['kind'] = 'desc';
+      if (sort?.field === column.key) {
+        if (sort.kind === 'desc') {
+          newSortDirection = 'asc';
+        }
+      }
+
+      const newSort = `${newSortDirection === 'desc' ? '-' : ''}${column.key}`;
+
+      return {
+        ...location,
+        query: {...location.query, [sortKey]: newSort},
+      };
+    }
+
+    const canSort = isFieldSortable(field, tableMeta?.fields, true);
+
+    const sortLink = (
+      <SortLink
+        align={alignment}
+        title={column.name}
+        direction={sort?.field === column.key ? sort.kind : undefined}
+        canSort={canSort}
+        generateSortLink={generateSortLink}
+      />
+    );
+    return sortLink;
+  }
+
+  const columnSortBy = eventView.getSorts();
+
+  const handleCursor: CursorHandler = (newCursor, pathname, query) => {
+    browserHistory.push({
+      pathname,
+      query: {...query, [cursorName]: newCursor},
+    });
+  };
+
+  return (
+    <Fragment>
+      <Header>
+        {showDeviceClassSelector && <DeviceClassSelector />}
+        <StyledPagination size="xs" pageLinks={pageLinks} onCursor={handleCursor} />
+      </Header>
+      <GridContainer>
+        <GridEditable
+          isLoading={isLoading}
+          data={data?.data as TableDataRow[]}
+          columnOrder={eventViewColumns
+            .filter((col: TableColumn<React.ReactText>) => col.name !== 'project.name')
+            .map((col: TableColumn<React.ReactText>) => {
+              return {...col, name: columnNameMap[col.key]};
+            })}
+          columnSortBy={columnSortBy}
+          location={location}
+          grid={{
+            renderHeadCell: column => renderHeadCell(column, data?.meta),
+            renderBodyCell,
+          }}
+        />
+      </GridContainer>
+    </Fragment>
+  );
+}
+
+const StyledPagination = styled(Pagination)`
+  margin: 0 0 0 ${space(1)};
+`;
+
+const Header = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr auto;
+  margin-bottom: ${space(1)};
+  align-items: center;
+  height: 26px;
+`;
+
+const IconWrapper = styled('div')`
+  text-align: right;
+  width: 100%;
+  height: 26px;
+`;
+
+// Not pretty but we need to override gridEditable styles since the original
+// styles have too much padding for small spaces
+const GridContainer = styled('div')`
+  margin-bottom: ${space(1)};
+  th {
+    padding: 0 ${space(1)};
+  }
+  th:first-child {
+    padding-left: ${space(2)};
+  }
+  th:last-child {
+    padding-right: ${space(2)};
+  }
+  td {
+    padding: ${space(0.5)} ${space(1)};
+  }
+  td:first-child {
+    padding-right: ${space(1)};
+    padding-left: ${space(2)};
+  }
+`;

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -21,7 +21,12 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {EventSamples} from 'sentry/views/starfish/views/appStartup/screenSummary/eventSamples';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
+import {
+  MobileCursors,
+  MobileSortKeys,
+} from 'sentry/views/starfish/views/screens/constants';
 
 import AppStartWidgets from './widgets';
 
@@ -36,7 +41,7 @@ function ScreenSummary() {
   const organization = useOrganization();
   const location = useLocation<Query>();
 
-  const {transaction: transactionName} = location.query;
+  const {primaryRelease, secondaryRelease, transaction: transactionName} = location.query;
 
   const startupModule: LocationDescriptor = {
     pathname: `/organizations/${organization.slug}/starfish/appStartup/`,
@@ -89,6 +94,29 @@ function ScreenSummary() {
                     additionalFilters={[`transaction:${transactionName}`]}
                   />
                 </ErrorBoundary>
+                <EventSamplesContainer>
+                  <ErrorBoundary mini>
+                    <div>
+                      <EventSamples
+                        cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
+                        sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
+                        release={primaryRelease}
+                        transaction={transactionName}
+                        showDeviceClassSelector
+                      />
+                    </div>
+                  </ErrorBoundary>
+                  <ErrorBoundary mini>
+                    <div>
+                      <EventSamples
+                        cursorName={MobileCursors.RELEASE_2_EVENT_SAMPLE_TABLE}
+                        sortKey={MobileSortKeys.RELEASE_2_EVENT_SAMPLE_TABLE}
+                        release={secondaryRelease}
+                        transaction={transactionName}
+                      />
+                    </div>
+                  </ErrorBoundary>
+                </EventSamplesContainer>
               </PageFiltersContainer>
             </Layout.Main>
           </Layout.Body>
@@ -110,4 +138,11 @@ const Container = styled('div')`
     grid-template-rows: auto;
     grid-template-columns: auto 1fr auto;
   }
+`;
+
+const EventSamplesContainer = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-top: ${space(2)};
+  gap: ${space(2)};
 `;

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.spec.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.spec.tsx
@@ -1,0 +1,102 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {
+  MobileCursors,
+  MobileSortKeys,
+} from 'sentry/views/starfish/views/screens/constants';
+import {ScreenLoadEventSamples} from 'sentry/views/starfish/views/screens/screenLoadSpans/eventSamples';
+
+jest.mock('sentry/utils/usePageFilters');
+
+describe('ScreenLoadEventSamples', function () {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+
+  let mockEventsRequest;
+  beforeEach(function () {
+    jest.mocked(usePageFilters).mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [parseInt(project.id, 10)],
+      },
+    });
+    mockEventsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        meta: {
+          fields: {
+            id: 'string',
+            'project.name': 'string',
+            'profile.id': 'string',
+            'measurements.time_to_initial_display': 'duration',
+            'measurements.time_to_full_display': 'duration',
+          },
+        },
+        data: [
+          {
+            id: '4142de70494989c04f023ce1727ac856f31b7f92',
+            'project.name': 'project1',
+            'profile.id': 'profile1',
+            'measurements.time_to_initial_display': 100.0,
+            'measurements.time_to_full_display': 200.0,
+          },
+        ],
+      },
+    });
+  });
+
+  it('makes a request for the release and transaction passed as props', async function () {
+    render(
+      <ScreenLoadEventSamples
+        release="com.example.vu.android@2.10.5"
+        sortKey={MobileSortKeys.RELEASE_1_EVENT_SAMPLE_TABLE}
+        cursorName={MobileCursors.RELEASE_1_EVENT_SAMPLE_TABLE}
+        transaction="ErrorController"
+        showDeviceClassSelector
+      />
+    );
+
+    // Check that headers are set properly
+    expect(
+      screen.getByRole('columnheader', {name: 'Event ID (2.10.5)'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Profile'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'TTID'})).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'TTFD'})).toBeInTheDocument();
+
+    expect(mockEventsRequest).toHaveBeenCalledTimes(1);
+
+    // Check data is rendered properly
+    // Transaction is a link
+    expect(await screen.findByRole('link', {name: '4142de70'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/performance/project1:4142de70494989c04f023ce1727ac856f31b7f92'
+    );
+
+    // Profile is a button
+    expect(screen.getByRole('button', {name: 'View Profile'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/profiling/profile/project1/profile1/flamegraph/'
+    );
+
+    // TTID is a duration
+    expect(screen.getByText('100.00ms')).toBeInTheDocument();
+
+    // TTFD is a duration
+    expect(screen.getByText('200.00ms')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.tsx
@@ -1,38 +1,19 @@
-import {Fragment} from 'react';
-import {browserHistory} from 'react-router';
-import styled from '@emotion/styled';
-
-import {LinkButton} from 'sentry/components/button';
-import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
-import SortLink from 'sentry/components/gridEditable/sortLink';
-import Link from 'sentry/components/links/link';
-import Pagination, {CursorHandler} from 'sentry/components/pagination';
-import {Tooltip} from 'sentry/components/tooltip';
-import {IconProfiling} from 'sentry/icons/iconProfiling';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {NewQuery} from 'sentry/types';
-import {defined} from 'sentry/utils';
-import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
-import EventView, {
-  fromSorts,
-  isFieldSortable,
-  MetaType,
-} from 'sentry/utils/discover/eventView';
-import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
-import {fieldAlignment, Sort} from 'sentry/utils/discover/fields';
+import EventView, {fromSorts} from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {normalizeUrl} from 'sentry/utils/withDomainRequired';
-import {TableColumn} from 'sentry/views/discover/table/types';
 import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
-import {DeviceClassSelector} from 'sentry/views/starfish/views/screens/screenLoadSpans/deviceClassSelector';
+import {EventSamplesTable} from 'sentry/views/starfish/views/screens/screenLoadSpans/eventSamplesTable';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
+
+const DEFAULT_SORT = {
+  kind: 'desc',
+  field: 'measurements.time_to_initial_display',
+};
 
 type Props = {
   cursorName: string;
@@ -41,8 +22,6 @@ type Props = {
   transaction: string;
   showDeviceClassSelector?: boolean;
 };
-
-const ICON_FIELDS = ['profile.id'];
 
 export function ScreenLoadEventSamples({
   cursorName,
@@ -53,7 +32,6 @@ export function ScreenLoadEventSamples({
 }: Props) {
   const location = useLocation();
   const {selection} = usePageFilters();
-  const organization = useOrganization();
   const cursor = decodeScalar(location.query?.[cursorName]);
 
   const searchQuery = new MutableSearch([
@@ -72,10 +50,7 @@ export function ScreenLoadEventSamples({
     }
   }
 
-  const sort = fromSorts(decodeScalar(location.query[sortKey]))[0] ?? {
-    kind: 'desc',
-    field: 'measurements.time_to_initial_display',
-  };
+  const sort = fromSorts(decodeScalar(location.query[sortKey]))[0] ?? DEFAULT_SORT;
 
   const columnNameMap = {
     id: t('Event ID (%s)', formatVersionAndCenterTruncate(release)),
@@ -110,176 +85,19 @@ export function ScreenLoadEventSamples({
     referrer: 'api.starfish.mobile-event-samples',
   });
 
-  const eventViewColumns = eventView.getColumns();
-
-  function renderBodyCell(column, row): React.ReactNode {
-    if (!data?.meta || !data?.meta.fields) {
-      return row[column.key];
-    }
-
-    if (column.key === 'id') {
-      return (
-        <Link
-          to={normalizeUrl(
-            `/organizations/${organization.slug}/performance/${row['project.name']}:${row.id}`
-          )}
-        >
-          {row.id.slice(0, 8)}
-        </Link>
-      );
-    }
-
-    if (column.key === 'profile.id') {
-      const profileTarget =
-        defined(row['project.name']) && defined(row['profile.id'])
-          ? generateProfileFlamechartRoute({
-              orgSlug: organization.slug,
-              projectSlug: row['project.name'],
-              profileId: String(row['profile.id']),
-            })
-          : null;
-      return (
-        <IconWrapper>
-          {profileTarget && (
-            <Tooltip title={t('View Profile')}>
-              <LinkButton to={profileTarget} size="xs">
-                <IconProfiling size="xs" />
-              </LinkButton>
-            </Tooltip>
-          )}
-        </IconWrapper>
-      );
-    }
-
-    const renderer = getFieldRenderer(column.key, data?.meta.fields, false);
-    const rendered = renderer(row, {
-      location,
-      organization,
-      unit: data?.meta.units?.[column.key],
-    });
-    return rendered;
-  }
-
-  function renderHeadCell(
-    column: GridColumnHeader,
-    tableMeta?: MetaType
-  ): React.ReactNode {
-    const fieldType = tableMeta?.fields?.[column.key];
-    let alignment = fieldAlignment(column.key as string, fieldType);
-    if (ICON_FIELDS.includes(column.key as string)) {
-      alignment = 'right';
-    }
-    const field = {
-      field: column.key as string,
-      width: column.width,
-    };
-
-    function generateSortLink() {
-      if (!tableMeta) {
-        return undefined;
-      }
-
-      let newSortDirection: Sort['kind'] = 'desc';
-      if (sort?.field === column.key) {
-        if (sort.kind === 'desc') {
-          newSortDirection = 'asc';
-        }
-      }
-
-      const newSort = `${newSortDirection === 'desc' ? '-' : ''}${column.key}`;
-
-      return {
-        ...location,
-        query: {...location.query, [sortKey]: newSort},
-      };
-    }
-
-    const canSort = isFieldSortable(field, tableMeta?.fields, true);
-
-    const sortLink = (
-      <SortLink
-        align={alignment}
-        title={column.name}
-        direction={sort?.field === column.key ? sort.kind : undefined}
-        canSort={canSort}
-        generateSortLink={generateSortLink}
-      />
-    );
-    return sortLink;
-  }
-
-  const columnSortBy = eventView.getSorts();
-
-  const handleCursor: CursorHandler = (newCursor, pathname, query) => {
-    browserHistory.push({
-      pathname,
-      query: {...query, [cursorName]: newCursor},
-    });
-  };
-
   return (
-    <Fragment>
-      <Header>
-        {showDeviceClassSelector && <DeviceClassSelector />}
-        <StyledPagination size="xs" pageLinks={pageLinks} onCursor={handleCursor} />
-      </Header>
-      <GridContainer>
-        <GridEditable
-          isLoading={isLoading}
-          data={data?.data as TableDataRow[]}
-          columnOrder={eventViewColumns
-            .filter((col: TableColumn<React.ReactText>) => col.name !== 'project.name')
-            .map((col: TableColumn<React.ReactText>) => {
-              return {...col, name: columnNameMap[col.key]};
-            })}
-          columnSortBy={columnSortBy}
-          location={location}
-          grid={{
-            renderHeadCell: column => renderHeadCell(column, data?.meta),
-            renderBodyCell,
-          }}
-        />
-      </GridContainer>
-    </Fragment>
+    <EventSamplesTable
+      eventIdKey="id"
+      profileIdKey="profile.id"
+      isLoading={isLoading}
+      cursorName={cursorName}
+      pageLinks={pageLinks}
+      eventView={eventView}
+      sortKey={sortKey}
+      data={data}
+      showDeviceClassSelector={showDeviceClassSelector}
+      columnNameMap={columnNameMap}
+      sort={sort}
+    />
   );
 }
-
-const StyledPagination = styled(Pagination)`
-  margin: 0 0 0 ${space(1)};
-`;
-
-const Header = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr auto;
-  margin-bottom: ${space(1)};
-  align-items: center;
-  height: 26px;
-`;
-
-const IconWrapper = styled('div')`
-  text-align: right;
-  width: 100%;
-  height: 26px;
-`;
-
-// Not pretty but we need to override gridEditable styles since the original
-// styles have too much padding for small spaces
-const GridContainer = styled('div')`
-  margin-bottom: ${space(1)};
-  th {
-    padding: 0 ${space(1)};
-  }
-  th:first-child {
-    padding-left: ${space(2)};
-  }
-  th:last-child {
-    padding-right: ${space(2)};
-  }
-  td {
-    padding: ${space(0.5)} ${space(1)};
-  }
-  td:first-child {
-    padding-right: ${space(1)};
-    padding-left: ${space(2)};
-  }
-`;

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.spec.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.spec.tsx
@@ -1,0 +1,239 @@
+import {browserHistory} from 'react-router';
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {NewQuery} from 'sentry/types';
+import EventView from 'sentry/utils/discover/eventView';
+import {EventSamplesTable} from 'sentry/views/starfish/views/screens/screenLoadSpans/eventSamplesTable';
+
+describe('EventSamplesTable', function () {
+  let mockLocation, mockQuery: NewQuery, mockEventView;
+  beforeEach(function () {
+    mockLocation = LocationFixture({
+      query: {
+        statsPeriod: '99d',
+      },
+    });
+
+    mockQuery = {
+      name: '',
+      fields: ['transaction.id'],
+      query: '',
+      version: 2,
+    };
+
+    mockEventView = EventView.fromNewQueryWithLocation(mockQuery, mockLocation);
+  });
+
+  it('uses a column name map to render column names', function () {
+    mockQuery = {
+      name: '',
+      fields: ['rawField'],
+      query: '',
+      version: 2,
+    };
+    mockEventView = EventView.fromNewQueryWithLocation(mockQuery, mockLocation);
+
+    render(
+      <EventSamplesTable
+        columnNameMap={{
+          rawField: 'Readable Column Name',
+        }}
+        cursorName=""
+        eventIdKey="transaction.id"
+        eventView={mockEventView}
+        isLoading={false}
+        profileIdKey="profile.id"
+        sort={{
+          field: '',
+          kind: 'desc',
+        }}
+        sortKey=""
+      />
+    );
+
+    expect(screen.getByText('Readable Column Name')).toBeInTheDocument();
+    expect(screen.queryByText('rawField')).not.toBeInTheDocument();
+  });
+
+  it('uses the event ID key to get the event ID from the data payload', function () {
+    mockQuery = {
+      name: '',
+      fields: ['transaction.id'],
+      query: '',
+      version: 2,
+    };
+    mockEventView = EventView.fromNewQueryWithLocation(mockQuery, mockLocation);
+
+    render(
+      <EventSamplesTable
+        eventIdKey="transaction.id"
+        columnNameMap={{'transaction.id': 'Event ID'}}
+        cursorName=""
+        eventView={mockEventView}
+        isLoading={false}
+        profileIdKey="profile.id"
+        sort={{
+          field: '',
+          kind: 'desc',
+        }}
+        sortKey=""
+        data={{data: [{id: '1', 'transaction.id': 'abc'}], meta: {}}}
+      />
+    );
+
+    // Test only one column to isolate event ID
+    expect(screen.getAllByRole('columnheader')).toHaveLength(1);
+    expect(screen.getByRole('columnheader', {name: 'Event ID'})).toBeInTheDocument();
+    expect(screen.getByText('abc')).toBeInTheDocument();
+    expect(screen.queryByText('1')).not.toBeInTheDocument();
+  });
+
+  it('uses the profile ID key to get the profile ID from the data payload and display an icon button', async function () {
+    mockQuery = {
+      name: '',
+      fields: ['profile.id', 'project.name'], // Project name is required to form the profile target
+      query: '',
+      version: 2,
+    };
+    mockEventView = EventView.fromNewQueryWithLocation(mockQuery, mockLocation);
+
+    render(
+      <EventSamplesTable
+        profileIdKey="profile.id"
+        columnNameMap={{'profile.id': 'Profile'}}
+        eventIdKey="transaction.id"
+        cursorName=""
+        eventView={mockEventView}
+        isLoading={false}
+        sort={{
+          field: '',
+          kind: 'desc',
+        }}
+        sortKey=""
+        data={{
+          data: [{id: '1', 'profile.id': 'abc', 'project.name': 'project'}],
+          meta: {fields: {'profile.id': 'string', 'project.name': 'string'}},
+        }}
+      />
+    );
+
+    // Test only one column to isolate profile column
+    expect(screen.getAllByRole('columnheader')).toHaveLength(1);
+    expect(screen.getByRole('columnheader', {name: 'Profile'})).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'View Profile'})).toBeInTheDocument();
+  });
+
+  it('updates URL params when device class selector is changed', async function () {
+    mockQuery = {
+      name: '',
+      fields: ['transaction.id'],
+      query: '',
+      version: 2,
+    };
+    mockEventView = EventView.fromNewQueryWithLocation(mockQuery, mockLocation);
+
+    render(
+      <EventSamplesTable
+        showDeviceClassSelector
+        eventIdKey="transaction.id"
+        columnNameMap={{'transaction.id': 'Event ID'}}
+        cursorName=""
+        eventView={mockEventView}
+        isLoading={false}
+        profileIdKey="profile.id"
+        sort={{
+          field: '',
+          kind: 'desc',
+        }}
+        sortKey=""
+        data={{data: [{id: '1', 'transaction.id': 'abc'}], meta: {}}}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: /device class all/i})).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: /device class all/i}));
+    await userEvent.click(screen.getByText('Medium'));
+    expect(browserHistory.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/mock-pathname/',
+        query: expect.objectContaining({
+          'device.class': 'medium',
+        }),
+      })
+    );
+  });
+
+  it('updates URL params when the table is paginated', async function () {
+    const pageLinks =
+      '<https://sentry.io/fake/previous>; rel="previous"; results="false"; cursor="0:0:1", ' +
+      '<https://sentry.io/fake/next>; rel="next"; results="true"; cursor="0:20:0"';
+    render(
+      <EventSamplesTable
+        showDeviceClassSelector
+        eventIdKey="transaction.id"
+        columnNameMap={{'transaction.id': 'Event ID'}}
+        cursorName="customCursorName"
+        eventView={mockEventView}
+        isLoading={false}
+        profileIdKey="profile.id"
+        sort={{
+          field: '',
+          kind: 'desc',
+        }}
+        sortKey=""
+        data={{data: [{id: '1', 'transaction.id': 'abc'}], meta: {}}}
+        pageLinks={pageLinks}
+      />
+    );
+    expect(screen.getByRole('button', {name: 'Next'})).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+    expect(browserHistory.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/mock-pathname/',
+        query: expect.objectContaining({
+          customCursorName: '0:20:0',
+        }),
+      })
+    );
+  });
+
+  it('uses a custom sort key for sortable headers', function () {
+    mockQuery = {
+      name: '',
+      fields: ['transaction.id', 'duration'],
+      query: '',
+      version: 2,
+    };
+
+    mockEventView = EventView.fromNewQueryWithLocation(mockQuery, mockLocation);
+    render(
+      <EventSamplesTable
+        showDeviceClassSelector
+        eventIdKey="transaction.id"
+        columnNameMap={{'transaction.id': 'Event ID', duration: 'Duration'}}
+        cursorName="customCursorName"
+        eventView={mockEventView}
+        isLoading={false}
+        profileIdKey="profile.id"
+        sort={{
+          field: 'transaction.id',
+          kind: 'desc',
+        }}
+        sortKey="customSortKey"
+        data={{data: [{id: '1', 'transaction.id': 'abc', duration: 'def'}], meta: {}}}
+      />
+    );
+
+    // Ascending sort in transaction ID because the default is descending
+    expect(screen.getByRole('link', {name: 'Event ID'})).toHaveAttribute(
+      'href',
+      '/mock-pathname/?customSortKey=transaction.id'
+    );
+    expect(screen.getByRole('link', {name: 'Duration'})).toHaveAttribute(
+      'href',
+      '/mock-pathname/?customSortKey=-duration'
+    );
+  });
+});

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.tsx
@@ -26,10 +26,10 @@ import {DeviceClassSelector} from 'sentry/views/starfish/views/screens/screenLoa
 type Props = {
   columnNameMap: Record<string, string>;
   cursorName: string;
-  eventIdKey: string;
+  eventIdKey: 'id' | 'transaction.id';
   eventView: EventView;
   isLoading: boolean;
-  profileIdKey: string;
+  profileIdKey: 'profile.id' | 'profile_id';
   sort: Sort;
   sortKey: string;
   data?: TableData;
@@ -87,7 +87,7 @@ export function EventSamplesTable({
         <IconWrapper>
           {profileTarget && (
             <Tooltip title={t('View Profile')}>
-              <LinkButton to={profileTarget} size="xs">
+              <LinkButton to={profileTarget} size="xs" aria-label={t('View Profile')}>
                 <IconProfiling size="xs" />
               </LinkButton>
             </Tooltip>

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamplesTable.tsx
@@ -1,0 +1,230 @@
+import {Fragment} from 'react';
+import {browserHistory} from 'react-router';
+import styled from '@emotion/styled';
+
+import {LinkButton} from 'sentry/components/button';
+import GridEditable, {GridColumnHeader} from 'sentry/components/gridEditable';
+import SortLink from 'sentry/components/gridEditable/sortLink';
+import Link from 'sentry/components/links/link';
+import Pagination, {CursorHandler} from 'sentry/components/pagination';
+import {Tooltip} from 'sentry/components/tooltip';
+import {IconProfiling} from 'sentry/icons/iconProfiling';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {defined} from 'sentry/utils';
+import {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
+import EventView, {isFieldSortable, MetaType} from 'sentry/utils/discover/eventView';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {fieldAlignment, Sort} from 'sentry/utils/discover/fields';
+import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {TableColumn} from 'sentry/views/discover/table/types';
+import {DeviceClassSelector} from 'sentry/views/starfish/views/screens/screenLoadSpans/deviceClassSelector';
+
+type Props = {
+  columnNameMap: Record<string, string>;
+  cursorName: string;
+  eventIdKey: string;
+  eventView: EventView;
+  isLoading: boolean;
+  profileIdKey: string;
+  sort: Sort;
+  sortKey: string;
+  data?: TableData;
+  pageLinks?: string;
+  showDeviceClassSelector?: boolean;
+};
+
+const ICON_FIELDS = ['profile.id', 'profile_id'];
+
+export function EventSamplesTable({
+  cursorName,
+  sortKey,
+  showDeviceClassSelector,
+  eventView,
+  data,
+  isLoading,
+  pageLinks,
+  eventIdKey,
+  profileIdKey,
+  columnNameMap,
+  sort,
+}: Props) {
+  const location = useLocation();
+  const organization = useOrganization();
+
+  const eventViewColumns = eventView.getColumns();
+
+  function renderBodyCell(column, row): React.ReactNode {
+    if (!data?.meta || !data?.meta.fields) {
+      return row[column.key];
+    }
+
+    if (column.key === eventIdKey) {
+      return (
+        <Link
+          to={normalizeUrl(
+            `/organizations/${organization.slug}/performance/${row['project.name']}:${row[eventIdKey]}`
+          )}
+        >
+          {row[eventIdKey].slice(0, 8)}
+        </Link>
+      );
+    }
+
+    if (column.key === profileIdKey) {
+      const profileTarget =
+        defined(row['project.name']) && defined(row[profileIdKey])
+          ? generateProfileFlamechartRoute({
+              orgSlug: organization.slug,
+              projectSlug: row['project.name'],
+              profileId: String(row[profileIdKey]),
+            })
+          : null;
+      return (
+        <IconWrapper>
+          {profileTarget && (
+            <Tooltip title={t('View Profile')}>
+              <LinkButton to={profileTarget} size="xs">
+                <IconProfiling size="xs" />
+              </LinkButton>
+            </Tooltip>
+          )}
+        </IconWrapper>
+      );
+    }
+
+    const renderer = getFieldRenderer(column.key, data?.meta.fields, false);
+    const rendered = renderer(row, {
+      location,
+      organization,
+      unit: data?.meta.units?.[column.key],
+    });
+    return rendered;
+  }
+
+  function renderHeadCell(
+    column: GridColumnHeader,
+    tableMeta?: MetaType
+  ): React.ReactNode {
+    const fieldType = tableMeta?.fields?.[column.key];
+    let alignment = fieldAlignment(column.key as string, fieldType);
+    if (ICON_FIELDS.includes(column.key as string)) {
+      alignment = 'right';
+    }
+    const field = {
+      field: column.key as string,
+      width: column.width,
+    };
+
+    function generateSortLink() {
+      if (!tableMeta) {
+        return undefined;
+      }
+
+      let newSortDirection: Sort['kind'] = 'desc';
+      if (sort?.field === column.key) {
+        if (sort.kind === 'desc') {
+          newSortDirection = 'asc';
+        }
+      }
+
+      const newSort = `${newSortDirection === 'desc' ? '-' : ''}${column.key}`;
+
+      return {
+        ...location,
+        query: {...location.query, [sortKey]: newSort},
+      };
+    }
+
+    const canSort = isFieldSortable(field, tableMeta?.fields, true);
+
+    const sortLink = (
+      <SortLink
+        align={alignment}
+        title={column.name}
+        direction={sort?.field === column.key ? sort.kind : undefined}
+        canSort={canSort}
+        generateSortLink={generateSortLink}
+      />
+    );
+    return sortLink;
+  }
+
+  const columnSortBy = eventView.getSorts();
+
+  const handleCursor: CursorHandler = (newCursor, pathname, query) => {
+    browserHistory.push({
+      pathname,
+      query: {...query, [cursorName]: newCursor},
+    });
+  };
+
+  return (
+    <Fragment>
+      <Header>
+        {showDeviceClassSelector && <DeviceClassSelector />}
+        <StyledPagination size="xs" pageLinks={pageLinks} onCursor={handleCursor} />
+      </Header>
+      <GridContainer>
+        <GridEditable
+          isLoading={isLoading}
+          data={data?.data as TableDataRow[]}
+          columnOrder={eventViewColumns
+            .filter((col: TableColumn<React.ReactText>) => col.name !== 'project.name')
+            .map((col: TableColumn<React.ReactText>) => {
+              return {...col, name: columnNameMap[col.key]};
+            })}
+          columnSortBy={columnSortBy}
+          location={location}
+          grid={{
+            renderHeadCell: column => renderHeadCell(column, data?.meta),
+            renderBodyCell,
+          }}
+        />
+      </GridContainer>
+    </Fragment>
+  );
+}
+
+const StyledPagination = styled(Pagination)`
+  margin: 0 0 0 ${space(1)};
+`;
+
+const Header = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr auto;
+  margin-bottom: ${space(1)};
+  align-items: center;
+  height: 26px;
+`;
+
+const IconWrapper = styled('div')`
+  text-align: right;
+  width: 100%;
+  height: 26px;
+`;
+
+// Not pretty but we need to override gridEditable styles since the original
+// styles have too much padding for small spaces
+const GridContainer = styled('div')`
+  margin-bottom: ${space(1)};
+  th {
+    padding: 0 ${space(1)};
+  }
+  th:first-child {
+    padding-left: ${space(2)};
+  }
+  th:last-child {
+    padding-right: ${space(2)};
+  }
+  td {
+    padding: ${space(0.5)} ${space(1)};
+  }
+  td:first-child {
+    padding-right: ${space(1)};
+    padding-left: ${space(2)};
+  }
+`;


### PR DESCRIPTION
Adds the sampled events tables to the app start screen summary page.

<img width="1483" alt="Screenshot 2024-01-04 at 12 56 56 PM" src="https://github.com/getsentry/sentry/assets/22846452/26fb6e50-9653-4ed2-8d4d-49397b1871c3">

The code to render the table was quite large, so I pulled it into a separate component where specific keys that differed between datasets (e.g. `id` in Discover vs `transaction.id` in indexed spans) could be passed down. Only transaction ID and profile ID differed so instead of making some generic key translation prop, I just passed those down explicitly. This way, we can separate the querying differences from the rendering portion that's the same.