### PR TITLE
feat(feature-flags): Endpoint to return EA'd features

### DIFF
--- a/src/sentry/api/endpoints/internal_ea_features.py
+++ b/src/sentry/api/endpoints/internal_ea_features.py
@@ -1,6 +1,8 @@
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationAdminPermission
 from sentry.conf.server import SENTRY_EARLY_FEATURES
@@ -10,6 +12,10 @@ from sentry.models.organization import Organization
 @region_silo_endpoint
 class InternalEAFeaturesEndpoint(Endpoint):
     permission_classes = (OrganizationAdminPermission,)
+    owner = ApiOwner.OPEN_SOURCE
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
 
     def get(self, request):
         features_dict = features.all()

--- a/src/sentry/api/endpoints/internal_ea_features.py
+++ b/src/sentry/api/endpoints/internal_ea_features.py
@@ -17,8 +17,10 @@ class InternalEAFeaturesEndpoint(Endpoint):
         ea_org = Organization()
         ea_org.flags.early_adopter = True
 
-        features_batch = features.batch_has(features_dict.keys(), organization=ea_org)
-        all_features_dict = features_batch[f"organization:{ea_org.id}"]
+        features_batch = features.batch_has(list(features_dict.keys()), organization=ea_org)
+        all_features_dict = (
+            features_batch.get(f"organization:{ea_org.id}", {}) if features_batch else {}
+        )
 
         ea_features = list(filter(lambda key: all_features_dict[key], all_features_dict))
 

--- a/src/sentry/api/endpoints/internal_ea_features.py
+++ b/src/sentry/api/endpoints/internal_ea_features.py
@@ -2,14 +2,14 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.base import Endpoint, region_silo_endpoint
-from sentry.api.permissions import SuperuserPermission
+from sentry.api.bases.organization import OrganizationAdminPermission
 from sentry.conf.server import SENTRY_EARLY_FEATURES
 from sentry.models.organization import Organization
 
 
 @region_silo_endpoint
 class InternalEAFeaturesEndpoint(Endpoint):
-    permission_classes = (SuperuserPermission,)
+    permission_classes = (OrganizationAdminPermission,)
 
     def get(self, request):
         features_dict = features.all()

--- a/src/sentry/api/endpoints/internal_ea_features.py
+++ b/src/sentry/api/endpoints/internal_ea_features.py
@@ -1,0 +1,30 @@
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.permissions import SuperuserPermission
+from sentry.conf.server import SENTRY_EARLY_FEATURES
+from sentry.models.organization import Organization
+
+
+@region_silo_endpoint
+class InternalEAFeaturesEndpoint(Endpoint):
+    permission_classes = (SuperuserPermission,)
+
+    def get(self, request):
+        features_dict = features.all()
+
+        ea_org = Organization()
+        ea_org.flags.early_adopter = True
+
+        ea_features = [
+            feature_name for feature_name in features_dict if features.has(feature_name, ea_org)
+        ]
+
+        missing_from_self_hosted = [
+            feature for feature in ea_features if feature not in SENTRY_EARLY_FEATURES
+        ]
+
+        return Response(
+            {"ea_features": ea_features, "missing_from_self_hosted": missing_from_self_hosted}
+        )

--- a/src/sentry/api/endpoints/internal_ea_features.py
+++ b/src/sentry/api/endpoints/internal_ea_features.py
@@ -17,9 +17,10 @@ class InternalEAFeaturesEndpoint(Endpoint):
         ea_org = Organization()
         ea_org.flags.early_adopter = True
 
-        ea_features = [
-            feature_name for feature_name in features_dict if features.has(feature_name, ea_org)
-        ]
+        features_batch = features.batch_has(features_dict.keys(), organization=ea_org)
+        all_features_dict = features_batch[f"organization:{ea_org.id}"]
+
+        ea_features = list(filter(lambda key: all_features_dict[key], all_features_dict))
 
         missing_from_self_hosted = [
             feature for feature in ea_features if feature not in SENTRY_EARLY_FEATURES

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -272,6 +272,7 @@ from .endpoints.internal import (
     InternalStatsEndpoint,
     InternalWarningsEndpoint,
 )
+from .endpoints.internal_ea_features import InternalEAFeaturesEndpoint
 from .endpoints.notification_defaults import NotificationDefaultsEndpoints
 from .endpoints.notifications import (
     NotificationActionsAvailableEndpoint,
@@ -2824,6 +2825,11 @@ INTERNAL_URLS = [
         r"^feature-flags/$",
         InternalFeatureFlagsEndpoint.as_view(),
         name="sentry-api-0-internal-feature-flags",
+    ),
+    re_path(
+        r"^feature-flags/ea-feature-flags$",
+        InternalEAFeaturesEndpoint.as_view(),
+        name="sentry-api-0-internal-ea-features",
     ),
 ]
 

--- a/tests/sentry/api/endpoints/test_internal_ea_features.py
+++ b/tests/sentry/api/endpoints/test_internal_ea_features.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from django.urls import reverse
+
+from sentry.models.organization import Organization
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class TestInternalEAFeaturesEndpoint(APITestCase):
+    def test_simple(self):
+        user = self.create_user(is_superuser=True)
+        path = reverse("sentry-api-0-internal-ea-features")
+
+        self.login_as(user=user, superuser=True)
+        response = self.client.get(path)
+
+        assert len(Organization.objects.all()) == 0
+        assert response.status_code == 200
+        assert response.data["ea_features"]
+        assert "organizations:discover" not in response.data["ea_features"]
+        assert response.data["missing_from_self_hosted"]


### PR DESCRIPTION
## Objective:

Endpoint to return all the feature flags that have been enabled for EA orgs in SaaS.

Moved the endpoint from getsentry to sentry. Related comment: https://github.com/getsentry/getsentry/pull/12432#discussion_r1442108097