### PR TITLE
feat(feedback): add tags to user feedback shim

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -239,6 +239,8 @@ def shim_to_feedback(
             feedback_event["platform"] = event.platform
             feedback_event["level"] = event.data["level"]
             feedback_event["environment"] = event.get_environment().name
+            feedback_event["tags"] = [list(item) for item in event.tags]
+
         else:
             feedback_event["timestamp"] = datetime.utcnow().timestamp()
             feedback_event["platform"] = "other"

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -381,6 +381,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
                 "event_id": "a" * 32,
                 "timestamp": self.min_ago,
                 "environment": self.environment.name,
+                "tags": {"foo": "bar"},
             },
             project_id=self.project.id,
         )
@@ -416,6 +417,11 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         assert mock_event_data["contexts"]["feedback"]["replay_id"] == replay_id
         assert mock_event_data["contexts"]["replay"]["replay_id"] == replay_id
         assert mock_event_data["environment"] == self.environment.name
+        assert mock_event_data["tags"] == [
+            ["environment", self.environment.name],
+            ["foo", "bar"],
+            ["level", "error"],
+        ]
 
         assert mock_event_data["platform"] == "other"
         assert (


### PR DESCRIPTION
Previously, tags from user reports were not being added to the tag values of the new feedback issues. This PR adds them.