### PR TITLE
ref(platform): add go-negroni as backend platform

### DIFF
--- a/src/sentry/utils/platform_categories.py
+++ b/src/sentry/utils/platform_categories.py
@@ -58,6 +58,7 @@ BACKEND = [
     "go-http",
     "go-iris",
     "go-martini",
+    "go-negroni",
     "java",
     "java-appengine",
     "java-log4j",


### PR DESCRIPTION
needed as a result of changes to `platformCategories.tsx` in https://github.com/getsentry/sentry/pull/62633