### PR TITLE
ref(replays): make faq accordion collapsible

### DIFF
--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -9,7 +9,6 @@ import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import ExternalLink from 'sentry/components/links/externalLink';
-import OnboardingPanel from 'sentry/components/onboardingPanel';
 import {useProjectCreationAccess} from 'sentry/components/projects/useProjectCreationAccess';
 import {Tooltip} from 'sentry/components/tooltip';
 import {replayPlatforms} from 'sentry/data/platformCategories';
@@ -23,6 +22,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
 import {HeaderContainer, WidgetContainer} from 'sentry/views/profiling/landing/styles';
+import ReplayPanel from 'sentry/views/replays/list/replayPanel';
 
 type Breakpoints = {
   large: string;
@@ -117,9 +117,7 @@ export default function ReplayOnboardingPanel() {
           </Alert>
         )}
       </OnboardingAlertHook>
-      <OnboardingPanel
-        image={<HeroImage src={emptyStateImg} breakpoints={breakpoints} />}
-      >
+      <ReplayPanel image={<HeroImage src={emptyStateImg} breakpoints={breakpoints} />}>
         <OnboardingCTAHook organization={organization}>
           <SetupReplaysCTA
             orgSlug={organization.slug}
@@ -127,7 +125,7 @@ export default function ReplayOnboardingPanel() {
             disabled={primaryActionDisabled}
           />
         </OnboardingCTAHook>
-      </OnboardingPanel>
+      </ReplayPanel>
     </Fragment>
   );
 }
@@ -144,7 +142,7 @@ export function SetupReplaysCTA({
   orgSlug,
 }: SetupReplaysCTAProps) {
   const {activateSidebar} = useReplayOnboardingSidebarPanel();
-  const [expanded, setExpanded] = useState(0);
+  const [expanded, setExpanded] = useState(-1);
   const FAQ = [
     {
       header: () => (
@@ -304,7 +302,6 @@ export function SetupReplaysCTA({
           expandedIndex={expanded}
           setExpandedIndex={setExpanded}
           buttonOnLeft
-          collapsible={false}
         />
       </StyledWidgetContainer>
     </CenteredContent>

--- a/static/app/views/replays/list/replayPanel.tsx
+++ b/static/app/views/replays/list/replayPanel.tsx
@@ -1,0 +1,69 @@
+import styled from '@emotion/styled';
+
+import Panel from 'sentry/components/panels/panel';
+import {space} from 'sentry/styles/space';
+
+interface Props extends React.ComponentProps<typeof Panel> {
+  children: React.ReactNode;
+  image?: React.ReactNode;
+  noCenter?: boolean;
+}
+
+function ReplayPanel({image, noCenter, children, ...props}: Props) {
+  return (
+    <Panel {...props}>
+      <Container>
+        {image ? <IlloBox>{image}</IlloBox> : null}
+        <StyledBox centered={!image && !noCenter}>{children}</StyledBox>
+      </Container>
+    </Panel>
+  );
+}
+
+const Container = styled('div')`
+  padding: ${space(3)};
+  position: relative;
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    display: flex;
+    align-items: flex-start;
+    flex-direction: row;
+    justify-content: center;
+    flex-wrap: wrap;
+    min-height: 300px;
+    max-width: 1000px;
+    margin: 0 auto;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    min-height: 350px;
+  }
+`;
+
+const StyledBox = styled('div')<{centered?: boolean}>`
+  min-width: 0;
+  z-index: 1;
+
+  ${p => (p.centered ? 'text-align: center;' : '')}
+  ${p => (p.centered ? 'max-width: 600px;' : '')}
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    flex: 2;
+  }
+`;
+
+const IlloBox = styled(StyledBox)`
+  position: relative;
+  min-height: 100px;
+  max-width: 300px;
+  min-width: 150px;
+  margin: ${space(2)} auto;
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    flex: 1;
+    margin: 120px ${space(3)} ${space(3)} ${space(3)};
+    max-width: auto;
+  }
+`;
+
+export default ReplayPanel;


### PR DESCRIPTION
Created a new `ReplayPanel` component (based closely on `OnboardingLayout`) since I needed to tweak some `OnboardingLayout` styles layers deep.

Basically main CSS change here is that items are aligned `flex-start` so that the image doesn't shift around when the onboarding box expands/collapses.

The FAQ accordion is collapsed by default and also now collapsible.
 
https://github.com/getsentry/sentry/assets/56095982/d0d5f67e-4f7c-4369-bdbd-64b1e02a0862

