### PR TITLE
ref(crons): Pass Promise return down for timelineTableRow actions

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -26,9 +26,9 @@ import {MonitorBucket} from './types';
 interface Props extends Omit<CheckInTimelineProps, 'bucketedData' | 'environment'> {
   monitor: Monitor;
   bucketedData?: MonitorBucket[];
-  onDeleteEnvironment?: (env: string) => void;
-  onToggleMuteEnvironment?: (env: string, isMuted: boolean) => void;
-  onToggleStatus?: (monitor: Monitor, status: ObjectStatus) => void;
+  onDeleteEnvironment?: (env: string) => Promise<void>;
+  onToggleMuteEnvironment?: (env: string, isMuted: boolean) => Promise<void>;
+  onToggleStatus?: (monitor: Monitor, status: ObjectStatus) => Promise<void>;
   /**
    * Whether only one monitor is being rendered in a larger view with this component
    * turns off things like zebra striping, hover effect, and showing monitor name

--- a/static/app/views/monitors/components/statusToggleButton.tsx
+++ b/static/app/views/monitors/components/statusToggleButton.tsx
@@ -7,7 +7,7 @@ import {Monitor} from 'sentry/views/monitors/types';
 
 interface StatusToggleButtonProps extends Omit<BaseButtonProps, 'onClick'> {
   monitor: Monitor;
-  onToggleStatus: (status: ObjectStatus) => void;
+  onToggleStatus: (status: ObjectStatus) => Promise<void>;
 }
 
 function SimpleStatusToggle({


### PR DESCRIPTION
This will make it a bit easier in the onToggleStatus component hook to
have additional things happen after the status toggle is completely.

Specifically, for sentry.io billing we need to reload the subscription
object after toggling the status of a monitor.