### PR TITLE
metrics(replays): Add canvas event size logging

### DIFF
--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -119,7 +119,7 @@ def log_canvas_size(
     project_id: int,
     replay_id: str,
     events: list[dict[str, Any]],
-):
+) -> None:
     for event in events:
         if event.get("type") == 3 and event.get("data", {}).get("source") == 9:
             logger.info(

--- a/src/sentry/replays/usecases/ingest/dom_index.py
+++ b/src/sentry/replays/usecases/ingest/dom_index.py
@@ -114,6 +114,30 @@ def create_replay_actions_payload(
     }
 
 
+def log_canvas_size(
+    org_id: int,
+    project_id: int,
+    replay_id: str,
+    events: list[dict[str, Any]],
+):
+    for event in events:
+        if event.get("type") == 3 and event.get("data", {}).get("source") == 9:
+            logger.info(
+                # Logging to the sentry.replays.slow_click namespace because
+                # its the only one configured to use BigQuery at the moment.
+                #
+                # NOTE: Needs an ops request to create a new dataset.
+                "sentry.replays.slow_click",
+                extra={
+                    "event_type": "canvas_size",
+                    "org_id": org_id,
+                    "project_id": project_id,
+                    "replay_id": replay_id,
+                    "size": len(json.dumps(event)),
+                },
+            )
+
+
 def get_user_actions(
     project_id: int,
     replay_id: str,

--- a/tests/sentry/replays/unit/test_ingest_dom_index.py
+++ b/tests/sentry/replays/unit/test_ingest_dom_index.py
@@ -9,6 +9,7 @@ from sentry.replays.usecases.ingest.dom_index import (
     _parse_classes,
     encode_as_uuid,
     get_user_actions,
+    log_canvas_size,
     parse_replay_actions,
 )
 from sentry.utils import json
@@ -632,3 +633,44 @@ def test_parse_classes():
     assert _parse_classes("  a b ") == ["a", "b"]
     assert _parse_classes("a  ") == ["a"]
     assert _parse_classes("  a") == ["a"]
+
+
+def test_log_canvas_size():
+    event = {
+        "type": 3,
+        "data": {
+            "source": 9,
+            "id": 2440,
+            "type": 0,
+            "commands": [
+                {"property": "clearRect", "args": [0, 0, 1342, 60]},
+                {
+                    "property": "drawImage",
+                    "args": [
+                        {
+                            "rr_type": "ImageBitmap",
+                            "args": [
+                                {
+                                    "rr_type": "Blob",
+                                    "data": [{"rr_type": "ArrayBuffer", "base64": "..."}],
+                                    "type": "image/png",
+                                }
+                            ],
+                        },
+                        0,
+                        0,
+                    ],
+                },
+            ],
+        },
+        "timestamp": 1704225903264,
+    }
+
+    # Valid event.
+    log_canvas_size(1, 1, "a", [event])
+
+    # Invalid event.
+    log_canvas_size(1, 1, "a", [{}])
+
+    # No events.
+    log_canvas_size(1, 1, "a", [])


### PR DESCRIPTION
Add canvas event logging.  Logs the following to BigQuery: org_id, project_id, replay_id, and the event size.

Closes: https://github.com/getsentry/team-replay/issues/338