### PR TITLE
fix(issue-stream): Fix typo in no issues matched page

### DIFF
--- a/static/app/views/issueList/noGroupsHandler/noIssuesMatched.tsx
+++ b/static/app/views/issueList/noGroupsHandler/noIssuesMatched.tsx
@@ -31,7 +31,7 @@ function NoIssuesMatched() {
           </li>
           <li>
             {tct(
-              "Check your [filterSettings: inbound data filter] to make sure the events aren't being filtered out",
+              "Check your [filterSettings: inbound data filters] to make sure the events aren't being filtered out",
               {
                 filterSettings: (
                   <a


### PR DESCRIPTION
this pr fixes a typo on the page shows when a search has no matching issues 