### PR TITLE
fix(integrations): Prevent warning for new integrations

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.spec.tsx
@@ -15,6 +15,7 @@ describe('PermissionsObserver', () => {
         <PermissionsObserver
           scopes={['project:read', 'project:write', 'project:releases', 'org:admin']}
           events={['issue']}
+          newApp={false}
         />
       </Form>
     );

--- a/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
@@ -20,6 +20,7 @@ type DefaultProps = {
 
 type Props = DefaultProps & {
   events: WebhookEvent[];
+  newApp: boolean;
   scopes: Scope[];
 };
 
@@ -87,7 +88,7 @@ export default class PermissionsObserver extends Component<Props, State> {
   renderCallout() {
     const {elevating} = this.state;
 
-    if (elevating === true) {
+    if (!this.props.newApp && elevating === true) {
       return (
         <Alert type="warning" showIcon>
           {t(

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -435,6 +435,7 @@ class SentryApplicationDetails extends DeprecatedAsyncView<Props, State> {
                     appPublished={app ? app.status === 'published' : false}
                     scopes={scopes}
                     events={events}
+                    newApp={!app}
                   />
                 </Fragment>
               );


### PR DESCRIPTION
Only show elevating permission warning for existing integrations.
My FE knowledge is limited so please let me know if this is a good way of doing this :|

https://github.com/getsentry/sentry/assets/67301797/e38405dd-ee4e-4694-ae5f-8479d79d8805

Fixes https://github.com/getsentry/sentry/issues/62619