### PR TITLE
feat(db): Add AnalyzeQuery

### DIFF
--- a/src/sentry/db/analyze.py
+++ b/src/sentry/db/analyze.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from django.db import connections, router
+
+
+class AnalyzeQuery:
+    def __init__(self, model):
+        self.model = model
+        self.using = router.db_for_write(model)
+
+    def execute(self):
+        query = """
+            analyze {table};
+        """.format(
+            table=self.model._meta.db_table,
+        )
+
+        return connections[self.using].cursor().execute(query)

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -93,7 +93,6 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
             while True:
                 if not task.chunk():
                     break
-
         except Exception as e:
             logger.exception(e)
         finally:

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -46,8 +46,6 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
     # Configure within each Process
     import logging
 
-    from sentry.db.analyze import AnalyzeQuery
-    from sentry.monitors import models as monitor_models
     from sentry.utils.imports import import_string
 
     logger = logging.getLogger("sentry.cleanup")
@@ -96,12 +94,6 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
                 if not task.chunk():
                     break
 
-            # special case for MonitorCheckIn to protect against index slippage
-            # run ANALYZE on the table
-            if model == monitor_models.MonitorCheckIn:
-                logger.info("Analyzing MonitorCheckIn table")
-                q = AnalyzeQuery(model=model)
-                q.execute()
         except Exception as e:
             logger.exception(e)
         finally:

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -99,6 +99,7 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
             # special case for MonitorCheckIn to protect against index slippage
             # run ANALYZE on the table
             if model == monitor_models.MonitorCheckIn:
+                logger.info("Analyzing MonitorCheckIn table")
                 q = AnalyzeQuery(model=model)
                 q.execute()
         except Exception as e:


### PR DESCRIPTION
Add `AnalyzeQuery` to be used later for the `sentry_monitorcheckin` table after bulk deletions are run to prevent index slipping.