### PR TITLE
feat(issues): Add integration details to resolve/unresolve

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -330,12 +330,55 @@ interface GroupActivityNote extends GroupActivityBase {
 }
 
 interface GroupActivitySetResolved extends GroupActivityBase {
-  data: Record<string, any>;
+  data: Record<string, unknown>;
+  type: GroupActivityType.SET_RESOLVED;
+}
+
+/**
+ * An integration marks an issue as resolved
+ */
+interface GroupActivitySetResolvedIntegration extends GroupActivityBase {
+  data: {
+    integration_id: number;
+    /**
+     * Human readable name of the integration
+     */
+    provider: string;
+    /**
+     * The key of the integration
+     */
+    provider_key: string;
+  };
   type: GroupActivityType.SET_RESOLVED;
 }
 
 interface GroupActivitySetUnresolved extends GroupActivityBase {
-  data: Record<string, any>;
+  data: Record<string, unknown>;
+  type: GroupActivityType.SET_UNRESOLVED;
+}
+
+interface GroupActivitySetUnresolvedForecast extends GroupActivityBase {
+  data: {
+    forecast: number;
+  };
+  type: GroupActivityType.SET_UNRESOLVED;
+}
+
+/**
+ * An integration marks an issue as unresolved
+ */
+interface GroupActivitySetUnresolvedIntegration extends GroupActivityBase {
+  data: {
+    integration_id: number;
+    /**
+     * Human readable name of the integration
+     */
+    provider: string;
+    /**
+     * The key of the integration
+     */
+    provider_key: string;
+  };
   type: GroupActivityType.SET_UNRESOLVED;
 }
 
@@ -516,7 +559,10 @@ export interface GroupActivityCreateIssue extends GroupActivityBase {
 export type GroupActivity =
   | GroupActivityNote
   | GroupActivitySetResolved
+  | GroupActivitySetResolvedIntegration
   | GroupActivitySetUnresolved
+  | GroupActivitySetUnresolvedForecast
+  | GroupActivitySetUnresolvedIntegration
   | GroupActivitySetIgnored
   | GroupActivitySetByAge
   | GroupActivitySetByResolvedInRelease

--- a/static/app/views/issueDetails/groupActivity.spec.tsx
+++ b/static/app/views/issueDetails/groupActivity.spec.tsx
@@ -21,11 +21,16 @@ import GroupStore from 'sentry/stores/groupStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
-import {Group, GroupActivityType, Organization as TOrganization} from 'sentry/types';
+import {
+  Group,
+  GroupActivityType,
+  Organization as TOrganization,
+  Project,
+} from 'sentry/types';
 import {GroupActivity} from 'sentry/views/issueDetails/groupActivity';
 
 describe('GroupActivity', function () {
-  let project;
+  let project!: Project;
   const dateCreated = '2021-10-01T15:31:38.950115Z';
 
   beforeEach(function () {
@@ -478,6 +483,50 @@ describe('GroupActivity', function () {
     });
     expect(screen.getAllByTestId('activity-item').at(-1)).toHaveTextContent(
       'Sentry flagged this issue as escalating because over 1 event happened in an hour'
+    );
+  });
+
+  it('renders issue unresvoled via jira', function () {
+    createWrapper({
+      activity: [
+        {
+          id: '123',
+          type: GroupActivityType.SET_UNRESOLVED,
+          project: ProjectFixture(),
+          data: {
+            integration_id: '1',
+            provider_key: 'jira',
+            provider: 'Jira',
+          },
+          user: null,
+          dateCreated,
+        },
+      ],
+    });
+    expect(screen.getAllByTestId('activity-item').at(-1)).toHaveTextContent(
+      'Sentry marked this issue as unresolved via Jira'
+    );
+  });
+
+  it('renders issue resolved via jira', function () {
+    createWrapper({
+      activity: [
+        {
+          id: '123',
+          type: GroupActivityType.SET_RESOLVED,
+          project: ProjectFixture(),
+          data: {
+            integration_id: '1',
+            provider_key: 'jira',
+            provider: 'Jira',
+          },
+          user: null,
+          dateCreated,
+        },
+      ],
+    });
+    expect(screen.getAllByTestId('activity-item').at(-1)).toHaveTextContent(
+      'Sentry marked this issue as resolved via Jira'
     );
   });
 

--- a/static/app/views/issueDetails/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/groupActivityItem.tsx
@@ -244,6 +244,18 @@ function GroupActivityItem({
       case GroupActivityType.NOTE:
         return tct('[author] left a comment', {author});
       case GroupActivityType.SET_RESOLVED:
+        if ('integration_id' in activity.data && activity.data.integration_id) {
+          return tct('[author] marked this issue as resolved via [integration]', {
+            integration: (
+              <Link
+                to={`/settings/${organization.slug}/integrations/${activity.data.provider_key}/${activity.data.integration_id}/`}
+              >
+                {activity.data.provider}
+              </Link>
+            ),
+            author,
+          });
+        }
         return tct('[author] marked this issue as resolved', {author});
       case GroupActivityType.SET_RESOLVED_BY_AGE:
         return tct('[author] marked this issue as resolved due to inactivity', {
@@ -366,7 +378,7 @@ function GroupActivityItem({
       case GroupActivityType.SET_UNRESOLVED: {
         // TODO(nisanthan): Remove after migrating records to SET_ESCALATING
         const {data} = activity;
-        if (data.forecast) {
+        if ('forecast' in data && data.forecast) {
           return tct(
             '[author] flagged this issue as escalating because over [forecast] [event] happened in an hour',
             {
@@ -375,6 +387,18 @@ function GroupActivityItem({
               event: data.forecast === 1 ? 'event' : 'events',
             }
           );
+        }
+        if ('integration_id' in data && data.integration_id) {
+          return tct('[author] marked this issue as unresolved via [integration]', {
+            integration: (
+              <Link
+                to={`/settings/${organization.slug}/integrations/${data.provider_key}/${data.integration_id}/`}
+              >
+                {data.provider}
+              </Link>
+            ),
+            author,
+          });
         }
         return tct('[author] marked this issue as unresolved', {author});
       }


### PR DESCRIPTION
in #62599 we added integration details to the unresolve/resolve activity for integrations that sync their status (jira).

This displays the integration on the issue activities

![image](https://github.com/getsentry/sentry/assets/1400464/04dcddcf-267d-4744-9b9d-995afa947646)

related https://github.com/getsentry/sentry/issues/61878
somewhat related https://github.com/getsentry/sentry/issues/62565