### PR TITLE
chore(relocation): Disable org context for relocation page

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -279,19 +279,19 @@ function buildRoutes() {
         )}
         key="org-join-request"
       />
-      {usingCustomerDomain && (
+      <Route
+        path="/relocation/"
+        component={
+          make(() => import('sentry/views/relocation'))
+        }
+        key="orgless-relocation"
+      >
+        <IndexRedirect to="get-started/" />
         <Route
-          path="/relocation/"
-          component={errorHandler(withDomainRequired(OrganizationContextContainer))}
-          key="orgless-relocation"
-        >
-          <IndexRedirect to="get-started/" />
-          <Route
-            path=":step/"
-            component={make(() => import('sentry/views/relocation'))}
-          />
-        </Route>
-      )}
+          path=":step/"
+          component={make(() => import('sentry/views/relocation'))}
+        />
+      </Route>
       {usingCustomerDomain && (
         <Route
           path="/onboarding/"


### PR DESCRIPTION
users should now be able to access this page if they don't have an org set up