### PR TITLE
feat(inframe-stacktrace-links): Only show for frames with valid filepaths

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -296,6 +296,7 @@ describe('StacktraceLink', function () {
 
   it('renders the link using a valid sourceLink for a .NET project', async function () {
     const dotnetFrame = {
+      filename: 'path/to/file.py',
       sourceLink: 'https://www.github.com/username/path/to/file.py#L100',
       lineNo: '100',
     } as unknown as Frame;
@@ -325,7 +326,8 @@ describe('StacktraceLink', function () {
 
   it('renders the link using sourceUrl instead of sourceLink if it exists for a .NET project', async function () {
     const dotnetFrame = {
-      sourceLink: 'https://www.github.com/source/link/url#L1',
+      filename: 'link/url.py',
+      sourceLink: 'https://www.github.com/source/link/url.py#L1',
       lineNo: '1',
     } as unknown as Frame;
     MockApiClient.addMockResponse({

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -194,7 +194,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
   const hasStacktraceLinkFeatureFlag =
     organization?.features?.includes('issue-details-stacktrace-link-in-frame') ?? false;
   const [isQueryEnabled, setIsQueryEnabled] = useState(!hasStacktraceLinkFeatureFlag);
-  const validFilePath = hasFileExtension(frame.absPath || '');
+  const validFilePath = hasFileExtension(frame.absPath || frame.filename || '');
   const project = useMemo(
     () => projects.find(p => p.id === event.projectID),
     [projects, event]

--- a/static/app/components/events/interfaces/frame/utils.spec.tsx
+++ b/static/app/components/events/interfaces/frame/utils.spec.tsx
@@ -10,7 +10,7 @@ describe('hasFileExtension', () => {
 
   test('returns false for file names without extensions', () => {
     expect(hasFileExtension('example')).toBe(false);
-    expect(hasFileExtension('<anoymous>')).toBe(false);
+    expect(hasFileExtension('<anonymous>')).toBe(false);
     expect(hasFileExtension('example.')).toBe(false);
     expect(hasFileExtension('https://sentry.sentry.io/issues/')).toBe(false);
   });

--- a/static/app/components/events/interfaces/frame/utils.spec.tsx
+++ b/static/app/components/events/interfaces/frame/utils.spec.tsx
@@ -1,0 +1,25 @@
+import {hasFileExtension} from 'sentry/components/events/interfaces/frame/utils';
+
+describe('hasFileExtension', () => {
+  test('returns true for valid file names with extensions', () => {
+    expect(hasFileExtension('example.tsx')).toBe(true);
+    expect(hasFileExtension('document.py')).toBe(true);
+    expect(hasFileExtension('photo.jpeg')).toBe(true);
+    expect(hasFileExtension('archive.tar.gz')).toBe(true); // Testing for multi-part extensions
+  });
+
+  test('returns false for file names without extensions', () => {
+    expect(hasFileExtension('example')).toBe(false);
+    expect(hasFileExtension('<anoymous>')).toBe(false);
+    expect(hasFileExtension('example.')).toBe(false);
+    expect(hasFileExtension('https://sentry.sentry.io/issues/')).toBe(false);
+  });
+
+  test('handles edge cases and special characters correctly', () => {
+    expect(hasFileExtension('.htaccess')).toBe(true); // Starting with a dot
+    expect(hasFileExtension('example.TXT')).toBe(true); // Uppercase extension
+    expect(hasFileExtension('example.tar.gz')).toBe(true); // Multi-part extension
+    expect(hasFileExtension('')).toBe(false); // Empty string
+    expect(hasFileExtension('example@.py')).toBe(true); // Special characters
+  });
+});

--- a/static/app/components/events/interfaces/frame/utils.tsx
+++ b/static/app/components/events/interfaces/frame/utils.tsx
@@ -138,3 +138,11 @@ function isAnrEvent(event: Event) {
     mechanismTag === 'mx_hang_diagnostic';
   return isANR;
 }
+
+export function hasFileExtension(filepath: string) {
+  // Regular expression to match a file extension
+  const fileExtensionPattern = /\.[0-9a-z]+$/i;
+
+  // Check if the filepath matches the pattern
+  return fileExtensionPattern.test(filepath);
+}


### PR DESCRIPTION
## Objective:

We should not show for frames that won’t result in a working stacktrace link.

Some stack traces have URLs instead of file paths: https://sentry.sentry.io/issues/4775101863/
This issue has various `div` and `<anonymous>` https://sentry.sentry.io/issues/4807229778/