### PR TITLE
chore(stats-detector): Tune stats detector escalation

### DIFF
--- a/src/sentry/statistical_detectors/algorithm.py
+++ b/src/sentry/statistical_detectors/algorithm.py
@@ -71,7 +71,7 @@ class MovingAverageDetectorState(DetectorState):
         if change < min_change:
             return False
 
-        rel_change = change / baseline
+        rel_change = change / (regressed - baseline)
         if rel_change > rel_threshold:
             return True
 

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -163,7 +163,7 @@ class EndpointRegressionDetector(RegressionDetector):
     regression_type = RegressionType.ENDPOINT
     min_change = 200  # 200ms in ms
     resolution_rel_threshold = 0.1
-    escalation_rel_threshold = 0.3
+    escalation_rel_threshold = 0.75
 
     @classmethod
     def detector_algorithm_factory(cls) -> DetectorAlgorithm:
@@ -204,7 +204,7 @@ class FunctionRegressionDetector(RegressionDetector):
     regression_type = RegressionType.FUNCTION
     min_change = 100_000_000  # 100ms in ns
     resolution_rel_threshold = 0.1
-    escalation_rel_threshold = 0.3
+    escalation_rel_threshold = 0.75
 
     @classmethod
     def detector_algorithm_factory(cls) -> DetectorAlgorithm:


### PR DESCRIPTION
The current detection is too sensitive, increase the threshold and adjust the algorithm to be more restrictive.