### PR TITLE
remove unnecessary start and add filterparam type

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Iterable, Optional, Set, TypedDict
+from typing import Any, Optional, Set, TypedDict
 
 import sentry_sdk
 from django.core.cache import cache
@@ -242,12 +242,12 @@ class ControlSiloOrganizationEndpoint(Endpoint):
         return (args, kwargs)
 
 
-class FilterParams(TypedDict):
-    start: datetime
-    end: datetime
-    project_id: Iterable[int]
+class FilterParams(TypedDict, total=False):
+    start: datetime | None
+    end: datetime | None
+    project_id: list[int]
     project_objects: list[Project]
-    organization_id: str
+    organization_id: int
     environment: list[str] | None
     environment_objects: list[Environment] | None
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Optional, Set, TypedDict
+from typing import Any, Iterable, Optional, Set, TypedDict
 
 import sentry_sdk
 from django.core.cache import cache
@@ -243,9 +243,9 @@ class ControlSiloOrganizationEndpoint(Endpoint):
 
 
 class FilterParams(TypedDict):
-    start: datetime | None
-    end: datetime | None
-    project_id: set[int]
+    start: datetime
+    end: datetime
+    project_id: Iterable[int]
     project_objects: list[Project]
     organization_id: str
     environment: list[str] | None
@@ -442,7 +442,7 @@ class OrganizationEndpoint(Endpoint):
         sentry_sdk.set_tag("query.num_projects.grouped", format_grouped_length(len_projects))
         set_measurement("query.num_projects", len_projects)
 
-        params: dict[str, Any] = {
+        params: FilterParams = {
             "start": start,
             "end": end,
             "project_id": [p.id for p in projects],

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Set
+from datetime import datetime
+from typing import Any, Optional, Set, TypedDict
 
 import sentry_sdk
 from django.core.cache import cache
@@ -241,6 +242,16 @@ class ControlSiloOrganizationEndpoint(Endpoint):
         return (args, kwargs)
 
 
+class FilterParams(TypedDict):
+    start: datetime | None
+    end: datetime | None
+    project_id: set[int]
+    project_objects: list[Project]
+    organization_id: str
+    environment: list[str] | None
+    environment_objects: list[Environment] | None
+
+
 class OrganizationEndpoint(Endpoint):
     permission_classes: tuple[type[BasePermission], ...] = (OrganizationPermission,)
 
@@ -371,7 +382,7 @@ class OrganizationEndpoint(Endpoint):
         organization: Organization,
         date_filter_optional: bool = False,
         project_ids: list[int] | set[int] | None = None,
-    ) -> dict[str, Any]:
+    ) -> FilterParams:
         """
         Extracts common filter parameters from the request and returns them
         in a standard format.

--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -14,7 +14,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
-from sentry.api.utils import get_date_range_from_params, handle_query_errors
+from sentry.api.utils import handle_query_errors
 from sentry.exceptions import InvalidParams
 from sentry.models.organization import Organization
 from sentry.snuba.sessions_v2 import SNUBA_LIMIT, InvalidField, QueryDefinition
@@ -73,12 +73,11 @@ class OrganizationSessionsEndpoint(OrganizationEndpoint):
         if not release_health.backend.is_metrics_based() and request.GET.get("interval") == "10s":
             query_params["interval"] = "1m"
 
-        start, _ = get_date_range_from_params(query_params)
-        query_config = release_health.backend.sessions_query_config(organization, start)
+        query_config = release_health.backend.sessions_query_config(organization)
 
         return QueryDefinition(
-            query_params,
-            params,
+            query=query_params,
+            params=params,
             offset=offset,
             limit=limit,
             query_config=query_config,

--- a/src/sentry/api/endpoints/organization_user_reports.py
+++ b/src/sentry/api/endpoints/organization_user_reports.py
@@ -42,6 +42,7 @@ class OrganizationUserReportsEndpoint(OrganizationEndpoint):
             project_id__in=filter_params["project_id"], group_id__isnull=False
         )
         if "environment" in filter_params:
+            assert filter_params["environment_objects"]
             queryset = queryset.filter(
                 environment_id__in=[env.id for env in filter_params["environment_objects"]]
             )

--- a/src/sentry/release_health/base.py
+++ b/src/sentry/release_health/base.py
@@ -321,7 +321,7 @@ class ReleaseHealthBackend(Service):
 
         raise NotImplementedError()
 
-    def sessions_query_config(self, organization: Any, start: datetime) -> SessionsQueryConfig:
+    def sessions_query_config(self, organization: Any) -> SessionsQueryConfig:
         """Return the backend-dependent config for sessions_v2.QueryDefinition"""
         raise NotImplementedError()
 

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -405,7 +405,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         return rv
 
-    def sessions_query_config(self, organization: Any, start: datetime) -> SessionsQueryConfig:
+    def sessions_query_config(self, organization: Any) -> SessionsQueryConfig:
         return SessionsQueryConfig(
             allowed_resolution=AllowedResolution.ten_seconds,
             allow_session_status_query=True,

--- a/src/sentry/release_health/sessions.py
+++ b/src/sentry/release_health/sessions.py
@@ -80,9 +80,7 @@ class SessionsReleaseHealthBackend(ReleaseHealthBackend):
             project_releases=project_releases, environments=environments, now=now
         )
 
-    def sessions_query_config(
-        self, organization: Organization, start: datetime
-    ) -> SessionsQueryConfig:
+    def sessions_query_config(self, organization: Organization) -> SessionsQueryConfig:
         if features.has(
             "organizations:minute-resolution-sessions",
             organization,

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -59,6 +59,12 @@ class OrganizationReplayDetailsEndpoint(OrganizationEndpoint):
             return Response(status=404)
 
         try:
+            assert filter_params["start"]
+            assert filter_params["end"]
+        except Exception:
+            return Response(status=404)
+
+        try:
             replay_id = str(uuid.UUID(replay_id))
         except ValueError:
             return Response(status=404)

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -64,7 +64,7 @@ class OrganizationReplayDetailsEndpoint(OrganizationEndpoint):
             return Response(status=404)
 
         snuba_response = query_replay_instance(
-            project_id=[id for id in filter_params["project_id"]],
+            project_id=filter_params["project_id"],
             replay_id=replay_id,
             start=filter_params["start"],
             end=filter_params["end"],

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -64,7 +64,7 @@ class OrganizationReplayDetailsEndpoint(OrganizationEndpoint):
             return Response(status=404)
 
         snuba_response = query_replay_instance(
-            project_id=filter_params["project_id"],
+            project_id=[id for id in filter_params["project_id"]],
             replay_id=replay_id,
             start=filter_params["start"],
             end=filter_params["end"],

--- a/src/sentry/replays/endpoints/organization_replay_details.py
+++ b/src/sentry/replays/endpoints/organization_replay_details.py
@@ -58,10 +58,7 @@ class OrganizationReplayDetailsEndpoint(OrganizationEndpoint):
         except NoProjects:
             return Response(status=404)
 
-        try:
-            assert filter_params["start"]
-            assert filter_params["end"]
-        except Exception:
+        if not filter_params["start"] or not filter_params["end"]:
             return Response(status=404)
 
         try:


### PR DESCRIPTION
Currently we're deriving the start/end datetimes unnecessarily when we've already derived it in the `filter_params` AND it wasn't even being used anywhere.

This just removes that unnecessary step