### PR TITLE
fix(stacktrace): Consistently use 12px font size

### DIFF
--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -301,7 +301,8 @@ const CodeWrapper = styled('div')`
   position: relative;
   padding: 0;
 
-  && pre {
+  && pre,
+  && code {
     font-size: ${p => p.theme.fontSizeSmall};
     white-space: pre-wrap;
     margin: 0;

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -524,7 +524,7 @@ const RowHeader = styled('span')<{
     !p.isInAppFrame && p.isSubFrame
       ? `${p.theme.surface100}`
       : `${p.theme.bodyBackground}`};
-  font-size: ${p => p.theme.codeFontSize};
+  font-size: ${p => p.theme.fontSizeSmall};
   padding: ${space(1)};
   color: ${p => (!p.isInAppFrame ? p.theme.subText : '')};
   font-style: ${p => (!p.isInAppFrame ? 'italic' : '')};

--- a/static/less/group-detail.less
+++ b/static/less/group-detail.less
@@ -320,7 +320,7 @@ div.traceback > ul {
 
     .title {
       padding: 6px 20px;
-      font-size: 13px;
+      font-size: 12px;
       margin: 0;
       line-height: 16px;
       background: #faf9fb;
@@ -344,7 +344,7 @@ div.traceback > ul {
       padding-left: 15px;
 
       .package {
-        font-size: 13px;
+        font-size: 12px;
         font-weight: bold;
         .truncate;
         flex-basis: 120px;
@@ -1068,7 +1068,7 @@ ul.crumbs {
     }
 
     .meta {
-      font-size: 13px;
+      font-size: 12px;
     }
 
     .short-id-box {


### PR DESCRIPTION
Stack traces were a mix of 12px and 13px fonts before. This changes makes it 12px everywhere.

Before/After python stacktrace:

![CleanShot 2024-01-05 at 10 55 18](https://github.com/getsentry/sentry/assets/10888943/fe0bf88a-b4ca-4d9e-aba0-ada30992b3a0)

![CleanShot 2024-01-05 at 10 55 01](https://github.com/getsentry/sentry/assets/10888943/06724aac-02d7-4e2e-ad20-1fae3926e0ec)

Before/after native stacktrace:

![CleanShot 2024-01-05 at 10 53 46](https://github.com/getsentry/sentry/assets/10888943/f13e2a53-568b-49f9-a020-7292bc62db33)

![CleanShot 2024-01-05 at 10 53 41](https://github.com/getsentry/sentry/assets/10888943/eee004df-87d8-49c5-b9b9-1e00d8514606)
