### PR TITLE
introduce crash free sessions to release threhsolds

### DIFF
--- a/static/app/views/releases/thresholdsList/thresholdGroupRows.tsx
+++ b/static/app/views/releases/thresholdsList/thresholdGroupRows.tsx
@@ -15,7 +15,16 @@ import {getExactDuration, parseLargestSuffix} from 'sentry/utils/formatters';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
-import {NEW_THRESHOLD_PREFIX} from '../utils/constants';
+import {
+  _CRASH_FREE_USER_RATE_STR,
+  _FAILURE_RATE_STR,
+  _NEW_ISSUE_COUNT_STR,
+  _REGRESSED_ISSUE_COUNT_STR,
+  _UNHANDLED_ISSUE_COUNT_STR,
+  CRASH_FREE_SESSION_RATE_STR,
+  NEW_THRESHOLD_PREFIX,
+  TOTAL_ERROR_COUNT_STR,
+} from '../utils/constants';
 import {EditingThreshold, Threshold} from '../utils/types';
 
 type Props = {
@@ -304,9 +313,14 @@ export function ThresholdGroupRows({
                     }
                     options={[
                       {
-                        value: 'total_error_count',
+                        value: TOTAL_ERROR_COUNT_STR,
                         textValue: 'Errors',
                         label: 'Error Count',
+                      },
+                      {
+                        value: CRASH_FREE_SESSION_RATE_STR,
+                        textValue: 'Crash Free Sessions',
+                        label: 'Crash Free Sessions',
                       },
                     ]}
                   />

--- a/static/app/views/releases/thresholdsList/thresholdGroupRows.tsx
+++ b/static/app/views/releases/thresholdsList/thresholdGroupRows.tsx
@@ -16,14 +16,14 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {
-  _CRASH_FREE_USER_RATE_STR,
-  _FAILURE_RATE_STR,
-  _NEW_ISSUE_COUNT_STR,
-  _REGRESSED_ISSUE_COUNT_STR,
-  _UNHANDLED_ISSUE_COUNT_STR,
   CRASH_FREE_SESSION_RATE_STR,
+  CRASH_FREE_USER_RATE_STR as _CRASH_FREE_USER_RATE_STR,
+  FAILURE_RATE_STR as _FAILURE_RATE_STR,
+  NEW_ISSUE_COUNT_STR as _NEW_ISSUE_COUNT_STR,
   NEW_THRESHOLD_PREFIX,
+  REGRESSED_ISSUE_COUNT_STR as _REGRESSED_ISSUE_COUNT_STR,
   TOTAL_ERROR_COUNT_STR,
+  UNHANDLED_ISSUE_COUNT_STR as _UNHANDLED_ISSUE_COUNT_STR,
 } from '../utils/constants';
 import {EditingThreshold, Threshold} from '../utils/types';
 

--- a/static/app/views/releases/utils/constants.ts
+++ b/static/app/views/releases/utils/constants.ts
@@ -1,1 +1,9 @@
 export const NEW_THRESHOLD_PREFIX = 'newthreshold';
+
+export const TOTAL_ERROR_COUNT_STR = "total_error_count";
+export const NEW_ISSUE_COUNT_STR = "new_issue_count";
+export const UNHANDLED_ISSUE_COUNT_STR = "unhandled_issue_count";
+export const REGRESSED_ISSUE_COUNT_STR = "regressed_issue_count";
+export const FAILURE_RATE_STR = "failure_rate";
+export const CRASH_FREE_SESSION_RATE_STR = "crash_free_session_rate";
+export const CRASH_FREE_USER_RATE_STR = "crash_free_user_rate";


### PR DESCRIPTION
<img width="1415" alt="Screenshot 2024-01-05 at 11 04 59 AM" src="https://github.com/getsentry/sentry/assets/6186377/01202126-e978-44f9-a3c3-13045d10182e">

TODO:
we should modify the form input fields to be either a % or a number value depending on the threshold type