### PR TITLE
fix(severity): Include GT and LT in severity filter match types

### DIFF
--- a/src/sentry/rules/filters/issue_severity.py
+++ b/src/sentry/rules/filters/issue_severity.py
@@ -12,7 +12,9 @@ from sentry.rules.filters import EventFilter
 from sentry.types.condition_activity import ConditionActivity
 
 SEVERITY_MATCH_CHOICES = {
+    MatchType.GREATER: "greater than",
     MatchType.GREATER_OR_EQUAL: "greater than or equal to",
+    MatchType.LESS_OR_EQUAL: "less than or equal to",
     MatchType.LESS: "less than",
 }
 CATEGORY_CHOICES = OrderedDict([(f"{gc.value}", str(gc.name).title()) for gc in GroupCategory])
@@ -49,11 +51,13 @@ class IssueSeverityFilter(EventFilter):
 
         match = self.get_option("match")
 
-        if match == MatchType.GREATER_OR_EQUAL:
+        if match == MatchType.GREATER:
+            return severity > value
+        elif match == MatchType.GREATER_OR_EQUAL:
             return severity >= value
-        elif (
-            match == MatchType.LESS or match == MatchType.LESS_OR_EQUAL
-        ):  # backwards compatibility, since this was changed from LTE to LT
+        elif match == MatchType.LESS_OR_EQUAL:
+            return severity <= value
+        elif match == MatchType.LESS:
             return severity < value
 
         return False

--- a/src/sentry/rules/filters/issue_severity.py
+++ b/src/sentry/rules/filters/issue_severity.py
@@ -13,7 +13,7 @@ from sentry.types.condition_activity import ConditionActivity
 
 SEVERITY_MATCH_CHOICES = {
     MatchType.GREATER_OR_EQUAL: "greater than or equal to",
-    MatchType.LESS_OR_EQUAL: "less than or equal to",
+    MatchType.LESS: "less than",
 }
 CATEGORY_CHOICES = OrderedDict([(f"{gc.value}", str(gc.name).title()) for gc in GroupCategory])
 
@@ -51,8 +51,10 @@ class IssueSeverityFilter(EventFilter):
 
         if match == MatchType.GREATER_OR_EQUAL:
             return severity >= value
-        elif match == MatchType.LESS_OR_EQUAL:
-            return severity <= value
+        elif (
+            match == MatchType.LESS or match == MatchType.LESS_OR_EQUAL
+        ):  # backwards compatibility, since this was changed from LTE to LT
+            return severity < value
 
         return False
 

--- a/tests/sentry/rules/filters/test_issue_severity.py
+++ b/tests/sentry/rules/filters/test_issue_severity.py
@@ -22,9 +22,9 @@ class IssueSeverityFilterTest(RuleTestCase):
         data_cases = [
             {"match": MatchType.GREATER_OR_EQUAL, "value": 0.5},
             {"match": MatchType.GREATER_OR_EQUAL, "value": 0.7},
-            {"match": MatchType.LESS_OR_EQUAL, "value": 0.7},
+            {"match": MatchType.LESS, "value": 0.9},
             {"match": MatchType.LESS_OR_EQUAL, "value": 0.9},
-            {"match": MatchType.LESS_OR_EQUAL, "value": "0.9"},
+            {"match": MatchType.LESS, "value": "0.9"},
         ]
 
         for data_case in data_cases:
@@ -61,8 +61,9 @@ class IssueSeverityFilterTest(RuleTestCase):
         data_cases = [
             {"match": MatchType.GREATER_OR_EQUAL, "value": 0.9},
             {"match": MatchType.GREATER_OR_EQUAL, "value": "0.9"},
-            {"match": MatchType.LESS_OR_EQUAL, "value": "0.5"},
-            {"match": MatchType.LESS_OR_EQUAL, "value": 0.5},
+            {"match": MatchType.LESS, "value": "0.5"},
+            {"match": MatchType.LESS, "value": 0.5},
+            {"match": MatchType.LESS_OR_EQUAL, "value": 0.7},
             {"value": 0.5},
             {"match": MatchType.GREATER_OR_EQUAL},
             {},

--- a/tests/sentry/rules/filters/test_issue_severity.py
+++ b/tests/sentry/rules/filters/test_issue_severity.py
@@ -20,11 +20,13 @@ class IssueSeverityFilterTest(RuleTestCase):
         mock_group.return_value = event.group
 
         data_cases = [
+            {"match": MatchType.GREATER, "value": 0.6},
             {"match": MatchType.GREATER_OR_EQUAL, "value": 0.5},
             {"match": MatchType.GREATER_OR_EQUAL, "value": 0.7},
-            {"match": MatchType.LESS, "value": 0.9},
+            {"match": MatchType.LESS_OR_EQUAL, "value": 0.7},
             {"match": MatchType.LESS_OR_EQUAL, "value": 0.9},
-            {"match": MatchType.LESS, "value": "0.9"},
+            {"match": MatchType.LESS_OR_EQUAL, "value": "0.9"},
+            {"match": MatchType.LESS, "value": 0.9},
         ]
 
         for data_case in data_cases:
@@ -59,11 +61,14 @@ class IssueSeverityFilterTest(RuleTestCase):
         mock_group.return_value = event.group
 
         data_cases = [
+            {"match": MatchType.GREATER, "value": 0.8},
+            {"match": MatchType.GREATER, "value": 0.7},
             {"match": MatchType.GREATER_OR_EQUAL, "value": 0.9},
             {"match": MatchType.GREATER_OR_EQUAL, "value": "0.9"},
-            {"match": MatchType.LESS, "value": "0.5"},
-            {"match": MatchType.LESS, "value": 0.5},
-            {"match": MatchType.LESS_OR_EQUAL, "value": 0.7},
+            {"match": MatchType.LESS_OR_EQUAL, "value": "0.5"},
+            {"match": MatchType.LESS_OR_EQUAL, "value": 0.5},
+            {"match": MatchType.LESS, "value": 0.6},
+            {"match": MatchType.LESS, "value": 0.7},
             {"value": 0.5},
             {"match": MatchType.GREATER_OR_EQUAL},
             {},


### PR DESCRIPTION
This PR changes the valid match types for the severity filter so that we can filter for greater than or less than severity scores, rather than just GTE or LTE.