### PR TITLE
feat(crons): Call ANALYZE after MonitorCheckIn deletes

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -46,6 +46,8 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
     # Configure within each Process
     import logging
 
+    from sentry.db.analyze import AnalyzeQuery
+    from sentry.monitors import models as monitor_models
     from sentry.utils.imports import import_string
 
     logger = logging.getLogger("sentry.cleanup")
@@ -93,6 +95,12 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
             while True:
                 if not task.chunk():
                     break
+
+            # special case for MonitorCheckIn to protect against index slippage
+            # run ANALYZE on the table
+            if model == monitor_models.MonitorCheckIn:
+                q = AnalyzeQuery(model=model)
+                q.execute()
         except Exception as e:
             logger.exception(e)
         finally:

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -98,7 +98,7 @@ def multiprocess_worker(task_queue: _WorkQueue) -> None:
 
             # special case for MonitorCheckIn to protect against index slippage
             # run ANALYZE on the table
-            if model == monitor_models.MonitorCheckIn:
+            if model is monitor_models.MonitorCheckIn:
                 q = AnalyzeQuery(model=model)
                 q.execute()
         except Exception as e:


### PR DESCRIPTION
Calls `ANALYZE` query after `MonitorCheckIn` objects are cleaned up

Need to test the `AnalyzeQuery` first in a live environment