### PR TITLE
fix(backup): Handle SavedSearch collisions

### DIFF
--- a/fixtures/backup/model_dependencies/detailed.json
+++ b/fixtures/backup/model_dependencies/detailed.json
@@ -1572,7 +1572,13 @@
       "Region"
     ],
     "table_name": "sentry_discoversavedquery",
-    "uniques": []
+    "uniques": [
+      [
+        "created_by_id",
+        "is_homepage",
+        "organization"
+      ]
+    ]
   },
   "sentry.discoversavedqueryproject": {
     "dangling": false,
@@ -3146,7 +3152,11 @@
       "Region"
     ],
     "table_name": "sentry_metricskeyindexer",
-    "uniques": []
+    "uniques": [
+      [
+        "string"
+      ]
+    ]
   },
   "sentry.monitor": {
     "dangling": false,
@@ -3889,7 +3899,13 @@
       "Region"
     ],
     "table_name": "sentry_perfstringindexer",
-    "uniques": []
+    "uniques": [
+      [
+        "organization_id",
+        "string",
+        "use_case_id"
+      ]
+    ]
   },
   "sentry.platformexternalissue": {
     "dangling": false,
@@ -5315,8 +5331,14 @@
     "table_name": "sentry_rulesnooze",
     "uniques": [
       [
+        "alert_rule"
+      ],
+      [
         "alert_rule",
         "user_id"
+      ],
+      [
+        "rule"
       ],
       [
         "rule",
@@ -5345,7 +5367,17 @@
       "Region"
     ],
     "table_name": "sentry_savedsearch",
-    "uniques": []
+    "uniques": [
+      [
+        "is_global",
+        "name"
+      ],
+      [
+        "organization",
+        "owner_id",
+        "type"
+      ]
+    ]
   },
   "sentry.scheduleddeletion": {
     "dangling": false,
@@ -5722,7 +5754,12 @@
       "Region"
     ],
     "table_name": "sentry_stringindexer",
-    "uniques": []
+    "uniques": [
+      [
+        "organization_id",
+        "string"
+      ]
+    ]
   },
   "sentry.team": {
     "dangling": false,

--- a/src/sentry/backup/dependencies.py
+++ b/src/sentry/backup/dependencies.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 from typing import NamedTuple, Optional, Tuple, Type
 
 from django.db import models
+from django.db.models import UniqueConstraint
 from django.db.models.fields.related import ForeignKey, OneToOneField
 
 from sentry.backup.helpers import EXCLUDED_APPS
@@ -402,6 +403,9 @@ def dependencies() -> dict[NormalizedModelName, ModelRelations]:
             uniques: set[frozenset[str]] = {
                 frozenset(combo) for combo in model._meta.unique_together
             }
+            for constraint in model._meta.constraints:
+                if isinstance(constraint, UniqueConstraint):
+                    uniques.add(frozenset(constraint.fields))
 
             # Now add a dependency for any FK relation visible to Django.
             for field in model._meta.get_fields():


### PR DESCRIPTION
Previously, when calculating which collisions we needed to test, we ignored `UniqueConstraint` clauses in model definition. Now that these have been added (see `detailed.json` for a list of which models were included), a new collision has been discovered: two `is_global=True` instances of the `SavedSearch` model cannot have the same `name`.

We resolve this here by ignoring `is_global=True` instances when importing in a non-`Global` scope.