### PR TITLE
feat(backup): Add EqualOrRemovedComparator

### DIFF
--- a/src/sentry/backup/findings.py
+++ b/src/sentry/backup/findings.py
@@ -75,6 +75,12 @@ class ComparatorFindingKind(FindingKind):
     # `None`.
     EmailObfuscatingComparatorExistenceCheck = auto()
 
+    # The fields were both present but unequal.
+    EqualOrRemovedComparator = auto()
+
+    # The left field does not exist.
+    EqualOrRemovedComparatorExistenceCheck = auto()
+
     # Hash equality comparison failed.
     HashObfuscatingComparator = auto()
 


### PR DESCRIPTION
Recently, we've added a couple of import handlers where we selectively null out fields based on certain conditions (see: PRs #62665 and #62526). This commit adds comparator support for this condition, allowing us to define comparators that say "make sure these fields are either equal or have been removed on the right side".