### PR TITLE
bug(replay): Fix useAggregatedQueryKeys (& useReplayCount) to support multiple hook instances

### DIFF
--- a/static/app/components/replays/replayCountBadge.tsx
+++ b/static/app/components/replays/replayCountBadge.tsx
@@ -2,9 +2,6 @@ import Badge from 'sentry/components/badge';
 
 function ReplayCountBadge({count}: {count: undefined | number}) {
   const display = count && count > 50 ? '50+' : count ?? null;
-  if (display === null) {
-    return null;
-  }
   return <Badge text={display} />;
 }
 

--- a/static/app/utils/api/useAggregatedQueryKeys.spec.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.spec.tsx
@@ -1,0 +1,159 @@
+import {ReactNode} from 'react';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import {ApiResult} from 'sentry/api';
+import useAggregatedQueryKeys from 'sentry/utils/api/useAggregatedQueryKeys';
+import {ApiQueryKey, QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
+
+function makeWrapper(queryClient: QueryClient) {
+  return function wrapper({children}: {children?: ReactNode}) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useAggregatedQueryKeys', () => {
+  let responseReducer;
+  let initialProps;
+
+  beforeEach(() => {
+    responseReducer = jest.fn((prevState: any, response: ApiResult) => {
+      return {
+        ...prevState,
+        ...response[0],
+      };
+    });
+
+    initialProps = {
+      getQueryKey: (ids: readonly string[]): ApiQueryKey => ['/api/test/', {query: ids}],
+      onError: () => {},
+      responseReducer,
+      bufferLimit: 50,
+    };
+  });
+
+  it('should convert multiple buffer calls into one fetch request after a timeout', async () => {
+    const mockRequest = MockApiClient.addMockResponse({
+      url: `/api/test/`,
+      body: {
+        '1111': 5,
+        '2222': 7,
+        '3333': 11,
+      },
+    });
+
+    const {result, waitFor} = reactHooks.renderHook(useAggregatedQueryKeys, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps,
+    });
+
+    result.current.buffer(['1111']);
+    result.current.buffer(['2222', '3333']);
+
+    await waitFor(() => {
+      expect(responseReducer).toHaveBeenCalled();
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      `/api/test/`,
+      expect.objectContaining({
+        query: expect.arrayContaining(['1111', '2222', '3333']),
+      })
+    );
+  });
+
+  it('should send a fetch request immediatly if the buffer is full', async () => {
+    const mockRequest = MockApiClient.addMockResponse({
+      url: `/api/test/`,
+    });
+
+    const {result, waitFor} = reactHooks.renderHook(useAggregatedQueryKeys, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps: {...initialProps, bufferLimit: 2},
+    });
+
+    result.current.buffer(['1111']);
+    expect(mockRequest).not.toHaveBeenCalled();
+
+    result.current.buffer(['2222', '3333']);
+    expect(mockRequest).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(responseReducer).toHaveBeenCalled();
+    });
+  });
+
+  it('should return cached data right away, if it exists in the cache', async () => {
+    const queryClient = makeTestQueryClient();
+    MockApiClient.addMockResponse({
+      url: `/api/test/`,
+      body: {
+        '1111': 5,
+        '2222': 7,
+        '3333': 11,
+      },
+    });
+
+    // Initial instance, nothing is cached yet
+    const {result: result1, waitFor} = reactHooks.renderHook(useAggregatedQueryKeys, {
+      wrapper: makeWrapper(queryClient),
+      initialProps,
+    });
+
+    // Nothing has been asked for yet:
+    expect(result1.current.data).toEqual(undefined);
+
+    result1.current.buffer(['1111']);
+    result1.current.buffer(['2222', '3333']);
+
+    // We asked for 3 things, but the cache is empty:
+    expect(result1.current.data).toEqual(undefined);
+
+    // Wait to full up the cache:
+    await waitFor(() => {
+      expect(responseReducer).toHaveBeenCalled();
+    });
+
+    // 2nd instance, re-uses the same cache
+    const {result: result2} = reactHooks.renderHook(useAggregatedQueryKeys, {
+      wrapper: makeWrapper(queryClient),
+      initialProps,
+    });
+
+    // The cache has data, no waiting!
+    expect(result2.current.data).toEqual({
+      '1111': 5,
+      '2222': 7,
+      '3333': 11,
+    });
+  });
+
+  it('should pass in the list of all aggregates to the reducer function', async () => {
+    const mockResponse = {
+      '1111': 5,
+    };
+    MockApiClient.addMockResponse({
+      url: `/api/test/`,
+      body: mockResponse,
+    });
+
+    const {result, waitFor} = reactHooks.renderHook(useAggregatedQueryKeys, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps,
+    });
+
+    result.current.buffer(['1111', '2222', '3333']);
+
+    await waitFor(() => {
+      expect(responseReducer).toHaveBeenCalled();
+    });
+
+    expect(responseReducer).toHaveBeenCalled();
+    expect(responseReducer).toHaveBeenCalledWith(
+      undefined,
+      expect.arrayContaining([mockResponse]),
+      ['1111', '2222', '3333']
+    );
+  });
+});

--- a/static/app/utils/api/useAggregatedQueryKeys.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.tsx
@@ -1,5 +1,6 @@
-import {useCallback, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import first from 'lodash/first';
+import uniq from 'lodash/uniq';
 
 import {ApiResult} from 'sentry/api';
 import {defined} from 'sentry/utils';
@@ -8,7 +9,7 @@ import useApi from 'sentry/utils/useApi';
 
 const BUFFER_WAIT_MS = 20;
 
-interface Props<QueryKeyAggregate, Data> {
+interface Props<AggregatableQueryKey, Data> {
   /**
    * The queryKey reducer
    *
@@ -17,12 +18,16 @@ interface Props<QueryKeyAggregate, Data> {
    * The returned key must have a stable url in the first index of the returned
    * array. This is used as a cache id.
    */
-  getQueryKey: (ids: ReadonlyArray<QueryKeyAggregate>) => ApiQueryKey;
+  getQueryKey: (ids: ReadonlyArray<AggregatableQueryKey>) => ApiQueryKey;
 
   /**
    * Data reducer, to integrate new requests with the previous state
    */
-  responseReducer: (prev: undefined | Data, result: ApiResult<unknown>) => Data;
+  responseReducer: (
+    prevState: undefined | Data,
+    result: ApiResult,
+    aggregates: ReadonlyArray<AggregatableQueryKey>
+  ) => undefined | Data;
 
   /**
    * Maximun number of items to keep in the buffer before flushing
@@ -35,6 +40,10 @@ interface Props<QueryKeyAggregate, Data> {
    * Optional callback, should an error happen while fetching or reducing the data
    */
   onError?: (error: Error) => void;
+}
+
+function isQueryKeyInList<AggregatableQueryKey>(queryList: AggregatableQueryKey[]) {
+  return ({queryKey}) => queryList.includes(queryKey[3] as AggregatableQueryKey);
 }
 
 /**
@@ -62,25 +71,36 @@ interface Props<QueryKeyAggregate, Data> {
  * - You will implement `responseReducer(prev: Data, result: ApiResult)` which
  *   combines `defaultData` with the data that was fetched with the queryKey.
  */
-export default function useAggregatedQueryKeys<QueryKeyAggregate, Data>({
+export default function useAggregatedQueryKeys<AggregatableQueryKey, Data>({
   getQueryKey,
   onError,
   responseReducer,
   bufferLimit = 50,
-}: Props<QueryKeyAggregate, Data>) {
+}: Props<AggregatableQueryKey, Data>) {
   const api = useApi({persistInFlight: true});
   const queryClient = useQueryClient();
   const cache = queryClient.getQueryCache();
 
   const key = first(getQueryKey([]));
 
-  const [data, setData] = useState<undefined | Data>(() =>
-    cache
-      .findAll({queryKey: [key]})
-      .map(({queryKey}) => queryClient.getQueryData<ApiResult>(queryKey))
-      .filter(defined)
-      .reduce(responseReducer, undefined)
+  // The query keys that this instance cares about
+  const prevQueryKeys = useRef<AggregatableQueryKey[]>([]);
+
+  const readCache = useCallback(
+    () =>
+      cache
+        .findAll({queryKey: [key]})
+        .map(({queryKey}) => queryClient.getQueryData<ApiResult>(queryKey))
+        .filter(defined)
+        .reduce(
+          (prevValue, val) => responseReducer(prevValue, val, prevQueryKeys.current),
+          undefined as Data | undefined
+        ),
+    [cache, key, queryClient, responseReducer]
   );
+
+  // The counts for each query key that this instance cares about
+  const [data, setData] = useState<undefined | Data>(readCache);
 
   const timer = useRef<null | NodeJS.Timeout>(null);
 
@@ -89,60 +109,49 @@ export default function useAggregatedQueryKeys<QueryKeyAggregate, Data>({
       queryKey: ['aggregate', key, 'queued'],
     });
 
-    const selectedQueuedQueries = allQueuedQueries.slice(0, bufferLimit);
-    if (!selectedQueuedQueries.length) {
+    const queuedQueriesBatch = allQueuedQueries.slice(0, bufferLimit);
+    if (!queuedQueriesBatch.length) {
       return;
     }
 
-    const queuedAggregates = selectedQueuedQueries.map(
-      ({queryKey}) => queryKey[3] as QueryKeyAggregate
+    const queuedAggregatableBatch = queuedQueriesBatch.map(
+      ({queryKey}) => queryKey[3] as AggregatableQueryKey
     );
+
+    const isQueryKeyInBatch = isQueryKeyInList(queuedAggregatableBatch);
 
     try {
       queryClient.removeQueries({
         queryKey: ['aggregate', key, 'queued'],
-        predicate: ({queryKey}) =>
-          queuedAggregates.includes(queryKey[3] as QueryKeyAggregate),
+        predicate: isQueryKeyInBatch,
       });
-      selectedQueuedQueries.forEach(({queryKey}) => {
-        const inFlightQueryKey = ['aggregate', key, 'inFlight', queryKey[3]];
-        queryClient.setQueryData(inFlightQueryKey, true);
+      queuedAggregatableBatch.forEach(queryKey => {
+        queryClient.setQueryData(['aggregate', key, 'inFlight', queryKey], true);
       });
 
       const promise = queryClient.fetchQuery({
-        queryKey: getQueryKey(queuedAggregates),
+        queryKey: getQueryKey(queuedAggregatableBatch),
         queryFn: fetchDataQuery(api),
       });
 
-      if (allQueuedQueries.length > selectedQueuedQueries.length) {
+      if (allQueuedQueries.length > queuedQueriesBatch.length) {
         fetchData();
       }
 
-      setData(responseReducer(data, await promise));
+      // When the promise resolves, it will trigger the cache subscription to fire
+      await promise;
 
       queryClient.removeQueries({
         queryKey: ['aggregate', key, 'inFlight'],
-        predicate: ({queryKey}) =>
-          queuedAggregates.includes(queryKey[3] as QueryKeyAggregate),
+        predicate: isQueryKeyInBatch,
       });
-      selectedQueuedQueries.forEach(({queryKey}) => {
-        const doneQueryKey = ['aggregate', key, 'done', queryKey[3]];
-        queryClient.setQueryData(doneQueryKey, true);
+      queuedAggregatableBatch.forEach(queryKey => {
+        queryClient.setQueryData(['aggregate', key, 'done', queryKey], true);
       });
     } catch (error) {
       onError?.(error);
     }
-  }, [
-    api,
-    bufferLimit,
-    cache,
-    data,
-    getQueryKey,
-    key,
-    onError,
-    queryClient,
-    responseReducer,
-  ]);
+  }, [api, bufferLimit, cache, getQueryKey, key, onError, queryClient]);
 
   const clearTimer = useCallback(() => {
     if (timer.current) {
@@ -160,20 +169,37 @@ export default function useAggregatedQueryKeys<QueryKeyAggregate, Data>({
   }, [clearTimer, fetchData]);
 
   const buffer = useCallback(
-    (aggregates: ReadonlyArray<QueryKeyAggregate>) => {
-      const foundQueries = cache.findAll({
-        queryKey: ['aggregate', key],
-        predicate: ({queryKey}) => aggregates.includes(queryKey[3] as QueryKeyAggregate),
-      });
-      const foundAggregates = foundQueries.map(({queryKey}) => queryKey[3]);
+    (aggregates: readonly AggregatableQueryKey[]) => {
+      // Track AggregatableQueryKey that we care about in this hook instance
+      const queryKeys = uniq([...prevQueryKeys.current, ...aggregates]);
+      if (queryKeys.length === prevQueryKeys.current.length) {
+        return;
+      }
+      prevQueryKeys.current = queryKeys;
 
-      const newCacheKeys = aggregates
-        .filter(aggregate => !foundAggregates.includes(aggregate))
-        .map(aggregate => ['aggregate', key, 'queued', aggregate])
-        .map(queryKey => queryClient.setQueryData(queryKey, true));
+      // Get queryKeys for any cached data related to these aggregates.
+      const existingQueryKeys = cache
+        .findAll({
+          queryKey: ['aggregate', key],
+          predicate: isQueryKeyInList(prevQueryKeys.current),
+        })
+        .map(({queryKey}) => queryKey[3] as AggregatableQueryKey);
 
-      if (newCacheKeys.length) {
-        if (foundQueries.length + newCacheKeys.length >= bufferLimit) {
+      // Don't request aggregates multiple times.
+      const newQueryKeys = queryKeys.filter(agg => !existingQueryKeys.includes(agg));
+
+      // Cache sentinel data for the new cacheKeys
+      newQueryKeys
+        .map(agg => ['aggregate', key, 'queued', agg])
+        .forEach(queryKey => queryClient.setQueryData(queryKey, true));
+
+      if (newQueryKeys.length) {
+        setData(readCache());
+        // Grab anything in the queue, including the newQueryKeys
+        const existingQueuedQueries = cache.findAll({
+          queryKey: ['aggregate', key, 'queued'],
+        });
+        if (existingQueuedQueries.length >= bufferLimit) {
           clearTimer();
           fetchData();
         } else {
@@ -181,8 +207,17 @@ export default function useAggregatedQueryKeys<QueryKeyAggregate, Data>({
         }
       }
     },
-    [bufferLimit, cache, clearTimer, fetchData, key, queryClient, setTimer]
+    [bufferLimit, cache, clearTimer, fetchData, key, queryClient, readCache, setTimer]
   );
 
-  return {data, buffer};
+  useEffect(() => {
+    const unsubscribe = cache.subscribe(result => {
+      if (result.type === 'updated' && result.query.queryKey.at(0) === key) {
+        setData(readCache());
+      }
+    });
+    return unsubscribe;
+  }, [key, cache, queryClient, readCache]);
+
+  return useMemo(() => ({buffer, data}), [buffer, data]);
 }

--- a/static/app/utils/replayCount/useReplayCount.spec.tsx
+++ b/static/app/utils/replayCount/useReplayCount.spec.tsx
@@ -1,0 +1,176 @@
+import {ReactNode} from 'react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+import useReplayCount from 'sentry/utils/replayCount/useReplayCount';
+
+function wrapper({children}: {children?: ReactNode}) {
+  return (
+    <QueryClientProvider client={makeTestQueryClient()}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useReplayCount', () => {
+  const organization = OrganizationFixture();
+  const initialProps = {
+    bufferLimit: 100,
+    dataSource: 'discover',
+    fieldName: 'replay_id',
+    organization,
+    statsPeriod: '90d',
+  };
+  const getMockRequest = (body: Record<string, number>) =>
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replay-count/`,
+      body,
+    });
+
+  describe('getOne & hasOne', () => {
+    it('should return undefined to start, then the count after data is loaded', async () => {
+      const mockRequest = getMockRequest({
+        '1111': 5,
+        '2222': 7,
+        '3333': 0,
+      });
+
+      const {result, waitFor} = reactHooks.renderHook(useReplayCount, {
+        wrapper,
+        initialProps,
+      });
+
+      expect(result.current.getOne('1111')).toBe(undefined);
+      expect(result.current.getOne('2222')).toBe(undefined);
+      expect(result.current.getOne('3333')).toBe(undefined);
+      expect(result.current.hasOne('1111')).toBeFalsy();
+      expect(result.current.hasOne('2222')).toBeFalsy();
+      expect(result.current.hasOne('3333')).toBeFalsy();
+
+      await waitFor(() => {
+        expect(mockRequest).toHaveBeenCalledWith(
+          `/organizations/${organization.slug}/replay-count/`,
+          expect.objectContaining({
+            query: expect.objectContaining({
+              query: 'replay_id:[1111,2222,3333]',
+            }),
+          })
+        );
+      });
+
+      expect(result.current.getOne('1111')).toBe(5);
+      expect(result.current.getOne('2222')).toBe(7);
+      expect(result.current.getOne('3333')).toBe(0);
+      expect(result.current.hasOne('1111')).toBeTruthy();
+      expect(result.current.hasOne('2222')).toBeTruthy();
+      expect(result.current.hasOne('3333')).toBeFalsy();
+    });
+
+    it('should return 0 if the data is loaded but does not include a count for a requested id', async () => {
+      const mockRequest = getMockRequest({
+        '2222': 7,
+      });
+
+      const {result, waitFor} = reactHooks.renderHook(useReplayCount, {
+        wrapper,
+        initialProps,
+      });
+
+      expect(result.current.getOne('1111')).toBe(undefined);
+      expect(result.current.getOne('2222')).toBe(undefined);
+      expect(result.current.hasOne('1111')).toBeFalsy();
+      expect(result.current.hasOne('2222')).toBeFalsy();
+
+      await waitFor(() => {
+        expect(mockRequest).toHaveBeenCalledWith(
+          `/organizations/${organization.slug}/replay-count/`,
+          expect.objectContaining({
+            query: expect.objectContaining({
+              query: 'replay_id:[1111,2222]',
+            }),
+          })
+        );
+      });
+
+      expect(result.current.getOne('1111')).toBe(0);
+      expect(result.current.getOne('2222')).toBe(7);
+      expect(result.current.hasOne('1111')).toBeFalsy();
+      expect(result.current.hasOne('2222')).toBeTruthy();
+    });
+  });
+
+  describe('getMany & hasMany', () => {
+    it('should return undefined to start, then the count after data is loaded', async () => {
+      const mockRequest = getMockRequest({
+        '1111': 5,
+        '2222': 7,
+        '3333': 0,
+      });
+
+      const {result, waitFor} = reactHooks.renderHook(useReplayCount, {
+        wrapper,
+        initialProps,
+      });
+
+      expect(result.current.getMany(['1111', '2222', '3333'])).toStrictEqual({});
+      expect(result.current.hasMany(['1111', '2222', '3333'])).toStrictEqual({});
+
+      await waitFor(() => {
+        expect(mockRequest).toHaveBeenCalledWith(
+          `/organizations/${organization.slug}/replay-count/`,
+          expect.objectContaining({
+            query: expect.objectContaining({
+              query: 'replay_id:[1111,2222,3333]',
+            }),
+          })
+        );
+      });
+
+      expect(result.current.getMany(['1111', '2222', '3333'])).toStrictEqual({
+        '1111': 5,
+        '2222': 7,
+        '3333': 0,
+      });
+      expect(result.current.hasMany(['1111', '2222', '3333'])).toStrictEqual({
+        '1111': true,
+        '2222': true,
+        '3333': false,
+      });
+    });
+
+    it('should return 0 if the data is loaded but does not include a count for a requested id', async () => {
+      const mockRequest = getMockRequest({
+        '2222': 7,
+      });
+
+      const {result, waitFor} = reactHooks.renderHook(useReplayCount, {
+        wrapper,
+        initialProps,
+      });
+
+      expect(result.current.getMany(['1111', '2222'])).toStrictEqual({});
+      expect(result.current.hasMany(['1111', '2222'])).toStrictEqual({});
+
+      await waitFor(() => {
+        expect(mockRequest).toHaveBeenCalledWith(
+          `/organizations/${organization.slug}/replay-count/`,
+          expect.objectContaining({
+            query: expect.objectContaining({
+              query: 'replay_id:[1111,2222]',
+            }),
+          })
+        );
+      });
+
+      expect(result.current.getMany(['1111', '2222'])).toStrictEqual({
+        '1111': 0,
+        '2222': 7,
+      });
+      expect(result.current.hasMany(['1111', '2222'])).toStrictEqual({
+        '1111': false,
+        '2222': true,
+      });
+    });
+  });
+});

--- a/static/app/utils/replayCount/useReplayCount.tsx
+++ b/static/app/utils/replayCount/useReplayCount.tsx
@@ -17,7 +17,9 @@ type CountValue = undefined | number;
 type CountState = Record<string, CountValue>;
 
 function filterKeysInList<V>(obj: Record<string, V>, list: readonly string[]) {
-  return Object.fromEntries(Object.entries(obj).filter(([key, _value]) => key in list));
+  return Object.fromEntries(
+    Object.entries(obj).filter(([key, _value]) => list.includes(key))
+  );
 }
 
 function boolIfDefined(val: undefined | unknown) {
@@ -66,7 +68,14 @@ export default function useReplayCount({
       [dataSource, fieldName, organization, statsPeriod]
     ),
     responseReducer: useCallback(
-      (data: undefined | CountState, response: ApiResult) => ({...data, ...response[0]}),
+      (
+        prevState: undefined | CountState,
+        response: ApiResult,
+        aggregates: readonly string[]
+      ) => {
+        const defaults = Object.fromEntries(aggregates.map(id => [id, 0]));
+        return {...defaults, ...prevState, ...response[0]};
+      },
       []
     ),
   });
@@ -82,6 +91,7 @@ export default function useReplayCount({
   const getOne = useCallback(
     (id: string) => {
       cache.buffer([id]);
+
       return cache.data?.[id];
     },
     [cache]


### PR DESCRIPTION
Previously the each `useAggregatedQueryKeys()` wasn't built correctly, it didnt' handle cases where there are multiple instances of the hook on the page.
Before what happened was:
- You'd call buffer() against one hook instance.
- The hook would setup it own timeout
    - There could be N hooks with timeouts running now
- Eventually one one of the instances would fire off a request
    - The other instances would have their timeouts fire too, but there is no work to do because everything is `inFlight`
- The instance that sent the request will get the response too, and can update it's own state.
    - **The Problem** is that all the other instances don't get to update state, there's no signal sent to them. The queryCache has everything, it's waiting.


So this change brings in a `cache.subscribe` call, so each instance can listen to changes and update it's own state when requests are being resolved. 
To support that each instance directly tracks the params that have been sent into it's instance of `buffer()`, so we know what we're expected to be returning. This is the `prevQueryKeys` ref.

Along the way I wrote some tests and fixed some bugs. For example, now when a new hook instance is created it'll look at the cache and read anything that's already existing.

Also fixed the bug with `useReplayCount`, before if a count wasn't returned in the response, we assumed it to be zero. Now we have that behavior back. You'll see the value as `undefined` until the _next_ (not guaranteed to be the _correct_, but with the buffering it's a good chance) `/replay-count/` fetch calls returns.

I also did some manual testing just by visiting pages like `sentry.io/issues/` and seeing that most issues have some kind of replay count icon appearing again.

Fixes https://github.com/getsentry/sentry/issues/62617
Fixes https://github.com/getsentry/sentry/issues/62237
Related to https://github.com/getsentry/sentry/pull/62530