### PR TITLE
test(hc): Break generate_region_url's dependence on SENTRY_REGION

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -11,7 +11,6 @@ from typing import Any, Generator, List, Literal, Mapping, Tuple, overload
 from urllib.parse import urlparse
 
 import sentry_sdk
-from django.conf import settings
 from django.http import HttpResponseNotAllowed
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
@@ -36,6 +35,8 @@ from sentry.services.hybrid_cloud.organization import (
     RpcUserOrganizationContext,
     organization_service,
 )
+from sentry.silo import SiloMode
+from sentry.types.region import get_local_region
 from sentry.utils.dates import parse_stats_period
 from sentry.utils.sdk import capture_exception, merge_context_into_scope
 from sentry.utils.snuba import (
@@ -278,8 +279,8 @@ def generate_organization_url(org_slug: str) -> str:
 
 def generate_region_url(region_name: str | None = None) -> str:
     region_url_template: str | None = options.get("system.region-api-url-template")
-    if region_name is None:
-        region_name = settings.SENTRY_REGION
+    if region_name is None and SiloMode.get_current_mode() == SiloMode.REGION:
+        region_name = get_local_region().name
     if not region_url_template or not region_name:
         return options.get("system.url-prefix")
     return region_url_template.replace("{region}", region_name)

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -240,7 +240,7 @@ def get_region_by_name(name: str) -> Region:
     if region is not None:
         return region
     else:
-        region_names = global_regions.get_region_names(RegionCategory.MULTI_TENANT)
+        region_names = list(global_regions.get_region_names(RegionCategory.MULTI_TENANT))
         raise RegionResolutionError(
             f"No region with name: {name!r} "
             f"(expected one of {region_names!r} or a single-tenant name)"

--- a/tests/sentry/models/test_projectkey.py
+++ b/tests/sentry/models/test_projectkey.py
@@ -7,10 +7,10 @@ from sentry.models.projectkey import ProjectKey, ProjectKeyManager, ProjectKeySt
 from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.testutils.silo import region_silo_test
+from sentry.testutils.silo import create_test_regions, region_silo_test
 
 
-@region_silo_test(include_monolith_run=True)
+@region_silo_test(regions=create_test_regions("us"), include_monolith_run=True)
 class ProjectKeyTest(TestCase):
     model = ProjectKey
 

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -312,7 +312,7 @@ class ClientConfigViewTest(TestCase):
             assert data["lastOrganization"] == self.organization.slug
             assert data["links"] == {
                 "organizationUrl": f"http://{self.organization.slug}.testserver",
-                "regionUrl": "http://eu.testserver",
+                "regionUrl": generate_region_url(),
                 "sentryUrl": "http://testserver",
             }
 


### PR DESCRIPTION
If we use get_local_region, it behaves better when single_process_silo_mode_state has a temporary region swapped in. This should simplify other, upcoming improvements to the test environment.