### PR TITLE
ref(hybrid-cloud): Makes integration and organization lookup failures explicit

### DIFF
--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -203,7 +203,9 @@ class BaseRequestParser(abc.ABC):
         )
 
         if organization_integrations.count() == 0:
-            logger.info("%s.no_organizations", self.provider, extra={"path": self.request.path})
+            logger.info(
+                "%s.no_organization_integrations", self.provider, extra={"path": self.request.path}
+            )
             raise OrganizationIntegration.DoesNotExist()
         organization_ids = [oi.organization_id for oi in organization_integrations]
         return organization_mapping_service.get_many(organization_ids=organization_ids)

--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -218,3 +218,6 @@ class BaseRequestParser(abc.ABC):
             organizations = self.get_organizations_from_integration()
 
         return [get_region_for_organization(organization.slug) for organization in organizations]
+
+    def get_default_missing_integration_response(self) -> HttpResponse:
+        return HttpResponse(status=400)

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -11,6 +11,7 @@ from sentry.integrations.github.webhook import (
 )
 from sentry.middleware.integrations.parsers.base import BaseRequestParser
 from sentry.models.integrations.integration import Integration
+from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
@@ -54,8 +55,17 @@ class GithubRequestParser(BaseRequestParser):
         if event.get("installation") and event.get("action") in {"created", "deleted"}:
             return self.get_response_from_control_silo()
 
-        regions = self.get_regions_from_organizations()
-        if len(regions) == 0:
-            logger.info("%s.no_regions", self.provider, extra={"path": self.request.path})
-            return self.get_response_from_control_silo()
+        try:
+            regions = self.get_regions_from_organizations()
+        except Integration.DoesNotExist:
+            logger.info("%s.no_integration_found", self.provider, extra={"path": self.request.path})
+            return self.get_default_missing_integration_response()
+        except OrganizationIntegration.DoesNotExist:
+            logger.info(
+                "%s.no_organization_integration_found",
+                self.provider,
+                extra={"path": self.request.path},
+            )
+            return self.get_default_missing_integration_response()
+
         return self.get_response_from_outbox_creation(regions=regions)

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -57,15 +57,7 @@ class GithubRequestParser(BaseRequestParser):
 
         try:
             regions = self.get_regions_from_organizations()
-        except Integration.DoesNotExist:
-            logger.info("%s.no_integration_found", self.provider, extra={"path": self.request.path})
-            return self.get_default_missing_integration_response()
-        except OrganizationIntegration.DoesNotExist:
-            logger.info(
-                "%s.no_organization_integration_found",
-                self.provider,
-                extra={"path": self.request.path},
-            )
+        except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
             return self.get_default_missing_integration_response()
 
         return self.get_response_from_outbox_creation(regions=regions)

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -10,6 +10,7 @@ from sentry.integrations.gitlab.webhooks import GitlabWebhookEndpoint, GitlabWeb
 from sentry.integrations.utils.scope import clear_tags_and_context
 from sentry.middleware.integrations.parsers.base import BaseRequestParser
 from sentry.models.integrations.integration import Integration
+from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
@@ -66,10 +67,10 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
         if isinstance(maybe_http_response, HttpResponseBase):
             return maybe_http_response
 
-        regions = self.get_regions_from_organizations()
-        if len(regions) == 0:
-            logger.info("%s.no_regions", self.provider, extra={"path": self.request.path})
-            return self.get_response_from_control_silo()
+        try:
+            regions = self.get_regions_from_organizations()
+        except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
+            return self.get_default_missing_integration_response()
 
         return self.get_response_from_outbox_creation(regions=regions)
 

--- a/src/sentry/middleware/integrations/parsers/msteams.py
+++ b/src/sentry/middleware/integrations/parsers/msteams.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from functools import cached_property
+from typing import Sequence
 
 import sentry_sdk
 from django.http.response import HttpResponseBase
@@ -13,7 +14,7 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
-from sentry.types.region import RegionResolutionError
+from sentry.types.region import Region, RegionResolutionError
 from sentry.utils import json
 
 logger = logging.getLogger(__name__)
@@ -50,7 +51,7 @@ class MsTeamsRequestParser(BaseRequestParser, MsTeamsWebhookMixin):
         if not self.can_infer_integration(data=self.request_data):
             return self.get_response_from_control_silo()
 
-        regions = []
+        regions: Sequence[Region] = []
         try:
             regions = self.get_regions_from_organizations()
         except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):

--- a/src/sentry/middleware/integrations/parsers/msteams.py
+++ b/src/sentry/middleware/integrations/parsers/msteams.py
@@ -55,7 +55,7 @@ class MsTeamsRequestParser(BaseRequestParser, MsTeamsWebhookMixin):
         try:
             regions = self.get_regions_from_organizations()
         except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
-            pass
+            return self.get_default_missing_integration_response()
 
         if len(regions) == 0:
             with sentry_sdk.push_scope() as scope:

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -131,19 +131,10 @@ class SlackRequestParser(BaseRequestParser):
         try:
             regions = self.get_regions_from_organizations()
         except Integration.DoesNotExist:
-            logger.info(
-                "%s.no_integrations_found", self.provider, extra={"path": self.request.path}
-            )
-
             # Alert, as there may be a misconfiguration issue
             sentry_sdk.capture_exception()
             return self.get_default_missing_integration_response()
         except OrganizationIntegration.DoesNotExist:
-            logger.info(
-                "%s.no_organization_integration_found",
-                self.provider,
-                extra={"path": self.request.path},
-            )
             # Swallow this exception, as this is likely due to a user removing
             # their org's slack integration, and slack will continue to retry
             # this request until it succeeds.

--- a/src/sentry/middleware/integrations/parsers/slack.py
+++ b/src/sentry/middleware/integrations/parsers/slack.py
@@ -4,6 +4,7 @@ import dataclasses
 import logging
 from typing import Sequence
 
+import sentry_sdk
 from django.http.response import HttpResponse, HttpResponseBase
 from rest_framework import status
 from rest_framework.request import Request
@@ -129,11 +130,24 @@ class SlackRequestParser(BaseRequestParser):
 
         try:
             regions = self.get_regions_from_organizations()
-        except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
+        except Integration.DoesNotExist:
             logger.info(
                 "%s.no_integrations_found", self.provider, extra={"path": self.request.path}
             )
+
+            # Alert, as there may be a misconfiguration issue
+            sentry_sdk.capture_exception()
             return self.get_default_missing_integration_response()
+        except OrganizationIntegration.DoesNotExist:
+            logger.info(
+                "%s.no_organization_integration_found",
+                self.provider,
+                extra={"path": self.request.path},
+            )
+            # Swallow this exception, as this is likely due to a user removing
+            # their org's slack integration, and slack will continue to retry
+            # this request until it succeeds.
+            return HttpResponse(status=202)
 
         if self.view_class == SlackActionEndpoint:
             drf_request: Request = SlackDMEndpoint().initialize_request(self.request)

--- a/src/sentry/middleware/integrations/parsers/vsts.py
+++ b/src/sentry/middleware/integrations/parsers/vsts.py
@@ -8,6 +8,7 @@ from django.http.response import HttpResponseBase
 from sentry.integrations.vsts.webhooks import WorkItemWebhook, get_vsts_external_id
 from sentry.middleware.integrations.parsers.base import BaseRequestParser
 from sentry.models.integrations.integration import Integration
+from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.services.hybrid_cloud.util import control_silo_function
 from sentry.utils import json
@@ -35,9 +36,9 @@ class VstsRequestParser(BaseRequestParser):
         if self.view_class not in self.region_view_classes:
             return self.get_response_from_control_silo()
 
-        regions = self.get_regions_from_organizations()
-        if len(regions) == 0:
-            logger.error("%s.no_regions", self.provider, extra={"path": self.request.path})
-            return self.get_response_from_control_silo()
+        try:
+            regions = self.get_regions_from_organizations()
+        except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
+            return self.get_default_missing_integration_response()
 
         return self.get_response_from_outbox_creation(regions=regions)

--- a/tests/sentry/middleware/integrations/parsers/test_discord.py
+++ b/tests/sentry/middleware/integrations/parsers/test_discord.py
@@ -139,8 +139,7 @@ class DiscordRequestParserTest(TestCase):
 
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 200
-        assert response.content == b"passthrough"
+        assert response.status_code == 400
         assert len(responses.calls) == 0
         assert_no_webhook_outboxes()
 

--- a/tests/sentry/middleware/integrations/parsers/test_github_enterprise.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github_enterprise.py
@@ -1,5 +1,5 @@
 import responses
-from django.db import router
+from django.db import router, transaction
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
@@ -7,9 +7,13 @@ from django.urls import reverse
 from sentry.middleware.integrations.parsers.github_enterprise import GithubEnterpriseRequestParser
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
-from sentry.models.outbox import ControlOutbox, OutboxCategory, WebhookProviderIdentifier
+from sentry.models.outbox import (
+    ControlOutbox,
+    OutboxCategory,
+    WebhookProviderIdentifier,
+    outbox_context,
+)
 from sentry.silo.base import SiloMode
-from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import assert_no_webhook_outboxes, assert_webhook_outboxes
 from sentry.testutils.region import override_regions
@@ -52,34 +56,37 @@ class GithubEnterpriseRequestParserTest(TestCase):
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_regions(region_config)
     @responses.activate
-    def test_routing_properly_no_regions(self):
+    def test_routing_no_organization_integrations_found(self):
         integration = self.get_integration()
-        with unguarded_write(using=router.db_for_write(OrganizationIntegration)):
+        with outbox_context(transaction.atomic(using=router.db_for_write(OrganizationIntegration))):
             # Remove all organizations from integration
             OrganizationIntegration.objects.filter(integration=integration).delete()
 
-        request = self.factory.post(self.path, data={}, content_type="application/json")
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": self.external_identifier}},
+            content_type="application/json",
+            HTTP_X_GITHUB_ENTERPRISE_HOST=self.external_host,
+        )
         parser = GithubEnterpriseRequestParser(request=request, response_handler=self.get_response)
 
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 200
-        assert response.content == b"passthrough"
+        assert response.status_code == 400
         assert len(responses.calls) == 0
         assert_no_webhook_outboxes()
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_regions(region_config)
     @responses.activate
-    def test_routing_properly_with_regions(self):
+    def test_routing_no_integrations_found(self):
         self.get_integration()
         request = self.factory.post(self.path, data={}, content_type="application/json")
         parser = GithubEnterpriseRequestParser(request=request, response_handler=self.get_response)
 
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
-        assert response.status_code == 200
-        assert response.content == b"passthrough"
+        assert response.status_code == 400
         assert len(responses.calls) == 0
         assert_no_webhook_outboxes()
 

--- a/tests/sentry/middleware/integrations/parsers/test_slack.py
+++ b/tests/sentry/middleware/integrations/parsers/test_slack.py
@@ -4,8 +4,8 @@ import dataclasses
 from unittest.mock import patch
 from urllib.parse import urlencode
 
-from django.db import router, transaction
 import responses
+from django.db import router, transaction
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory
 from django.urls import reverse

--- a/tests/sentry/middleware/integrations/parsers/test_slack.py
+++ b/tests/sentry/middleware/integrations/parsers/test_slack.py
@@ -4,6 +4,7 @@ import dataclasses
 from unittest.mock import patch
 from urllib.parse import urlencode
 
+from django.db import router, transaction
 import responses
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory
@@ -12,11 +13,12 @@ from rest_framework import status
 
 from sentry.integrations.slack.utils.auth import _encode_data
 from sentry.middleware.integrations.parsers.slack import SlackRequestParser
-from sentry.models.outbox import ControlOutbox
+from sentry.models.integrations.organization_integration import OrganizationIntegration
+from sentry.models.outbox import ControlOutbox, outbox_context
 from sentry.testutils.cases import TestCase
 from sentry.testutils.outbox import assert_no_webhook_outboxes
 from sentry.testutils.region import override_regions
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test
 from sentry.types.region import Region, RegionCategory
 from sentry.utils import json
 from sentry.utils.signing import sign
@@ -134,3 +136,28 @@ class SlackRequestParserTest(TestCase):
             }
         )
         assert response.status_code == status.HTTP_202_ACCEPTED
+
+    @patch("sentry.middleware.integrations.parsers.slack.convert_to_async_slack_response")
+    @patch.object(
+        SlackRequestParser,
+        "get_regions_from_organizations",
+        side_effect=OrganizationIntegration.DoesNotExist(),
+    )
+    def test_skips_async_response_if_org_integration_missing(
+        self, mock_slack_task, mock_get_regions
+    ):
+        response_url = "https://hooks.slack.com/commands/TXXXXXXX1/1234567890123/something"
+        data = {
+            "payload": json.dumps(
+                {"team_id": self.integration.external_id, "response_url": response_url}
+            )
+        }
+        with assume_test_silo_mode_of(OrganizationIntegration), outbox_context(
+            transaction.atomic(using=router.db_for_write(OrganizationIntegration))
+        ):
+            OrganizationIntegration.objects.filter(organization_id=self.organization.id).delete()
+        request = self.factory.post(reverse("sentry-integration-slack-action"), data=data)
+        parser = SlackRequestParser(request, self.get_response)
+        response = parser.get_response()
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert mock_slack_task.apply_async.call_count == 0

--- a/tests/sentry/middleware/integrations/parsers/test_vsts.py
+++ b/tests/sentry/middleware/integrations/parsers/test_vsts.py
@@ -56,8 +56,9 @@ class VstsRequestParserTest(TestCase):
         ) as get_response_from_control_silo, mock.patch.object(
             parser, "get_regions_from_organizations", return_value=[]
         ):
-            parser.get_response()
-            assert get_response_from_control_silo.called
+            response = parser.get_response()
+            assert not get_response_from_control_silo.called
+            assert response.status_code == 202
 
         # Regions found
         with mock.patch.object(
@@ -78,7 +79,7 @@ class VstsRequestParserTest(TestCase):
                 reverse("vsts-extension-configuration"), data={"targetId": "1", "targetName": "foo"}
             )
             parser.get_response()
-            assert get_response_from_control_silo.called
+            assert not get_response_from_control_silo.called
             assert not get_response_from_outbox_creation.called
 
             parser.request = self.factory.get(
@@ -88,7 +89,7 @@ class VstsRequestParserTest(TestCase):
                 ),
             )
             parser.get_response()
-            assert get_response_from_control_silo.called
+            assert not get_response_from_control_silo.called
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     def test_get_integration_from_request(self):

--- a/tests/sentry/middleware/integrations/parsers/test_vsts.py
+++ b/tests/sentry/middleware/integrations/parsers/test_vsts.py
@@ -10,6 +10,7 @@ from fixtures.vsts import WORK_ITEM_UNASSIGNED, WORK_ITEM_UPDATED, WORK_ITEM_UPD
 from sentry.middleware.integrations.classifications import IntegrationClassification
 from sentry.middleware.integrations.parsers.vsts import VstsRequestParser
 from sentry.models.integrations.integration import Integration
+from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.outbox import ControlOutbox, WebhookProviderIdentifier
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
@@ -54,11 +55,13 @@ class VstsRequestParserTest(TestCase):
         with mock.patch.object(
             parser, "get_response_from_control_silo"
         ) as get_response_from_control_silo, mock.patch.object(
-            parser, "get_regions_from_organizations", return_value=[]
+            parser,
+            "get_regions_from_organizations",
+            side_effect=OrganizationIntegration.DoesNotExist(),
         ):
             response = parser.get_response()
             assert not get_response_from_control_silo.called
-            assert response.status_code == 202
+            assert response.status_code == 400
 
         # Regions found
         with mock.patch.object(


### PR DESCRIPTION
Currently, when we fail to find an integration or organization integration in our parsers, we return an empty list. While this may seem like good default behavior, it makes handling these scenarios non-obvious. In some of our parsers, a lack of found organizations/regions will result in the request falling back to the original view while still running in Control Silo. This can result in unexpected cross-silo code being executed.

This PR adds explicit exception raising and handling when no integration or org integration is found, leaving it up to the specific parser implementation to explicitly handle both of these exceptions.


