### PR TITLE
feat(partnership): agreement restriction frontend

### DIFF
--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -166,7 +166,7 @@ export interface Config {
   partnershipAgreementPrompt: {
     agreements: Array<ParntershipAgreementType>;
     partnerDisplayName: string;
-  } | null;
+  } | undefined | null;
   privacyUrl: string | null;
   // The list of regions the current user has memberships in.
   regions: Region[];

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -163,10 +163,6 @@ export interface Config {
    */
   messages: {level: keyof Theme['alert']; message: string}[];
   needsUpgrade: boolean;
-  partnershipAgreementPrompt: {
-    agreements: Array<ParntershipAgreementType>;
-    partnerDisplayName: string;
-  } | undefined | null;
   privacyUrl: string | null;
   // The list of regions the current user has memberships in.
   regions: Region[];
@@ -199,6 +195,10 @@ export interface Config {
     latest: string;
     upgradeAvailable: boolean;
   };
+  partnershipAgreementPrompt?: {
+    agreements: Array<ParntershipAgreementType>;
+    partnerDisplayName: string;
+  } | null;
   statuspage?: {
     api_host: string;
     id: string;

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -2,6 +2,7 @@ import {Theme} from '@emotion/react';
 import type {FocusTrap} from 'focus-trap';
 
 import type {exportedGlobals} from 'sentry/bootstrap/exportGlobals';
+import {ParntershipAgreementType} from 'sentry/views/partnershipAgreement';
 
 import type {User} from './user';
 
@@ -162,6 +163,10 @@ export interface Config {
    */
   messages: {level: keyof Theme['alert']; message: string}[];
   needsUpgrade: boolean;
+  partnershipAgreementPrompt: {
+    agreements: Array<ParntershipAgreementType>;
+    partnerDisplayName: string;
+  } | null;
   privacyUrl: string | null;
   // The list of regions the current user has memberships in.
   regions: Region[];

--- a/static/app/views/app/index.spec.tsx
+++ b/static/app/views/app/index.spec.tsx
@@ -87,7 +87,7 @@ describe('App', function () {
   });
 
   it('does not render PartnerAgreement for non-partnered orgs', async function () {
-    ConfigStore.set('partnershipAgreementPrompt', null);
+    ConfigStore.set('partnershipAgreementPrompt', undefined);
     render(
       <App {...routerProps}>
         <div>placeholder content</div>

--- a/static/app/views/app/index.spec.tsx
+++ b/static/app/views/app/index.spec.tsx
@@ -87,18 +87,15 @@ describe('App', function () {
   });
 
   it('does not render PartnerAgreement for non-partnered orgs', async function () {
-    ConfigStore.set('partnershipAgreementPrompt', undefined);
+    ConfigStore.set('partnershipAgreementPrompt', null);
     render(
       <App {...routerProps}>
         <div>placeholder content</div>
       </App>
     );
 
-    const normalContent = await screen.findByText(
-      'placeholder content'
-    );
-    expect(normalContent).toBeInTheDocument();
-    expect(screen.queryByText(/This organization is created in partnership/)).not.toBeInTheDocument();
+    expect(screen.getByText('placeholder content')).toBeInTheDocument();
+    expect(await screen.queryByText(/This organization is created in partnership/)).not.toBeInTheDocument();
   });
 
   it('renders InstallWizard', async function () {

--- a/static/app/views/app/index.spec.tsx
+++ b/static/app/views/app/index.spec.tsx
@@ -69,6 +69,38 @@ describe('App', function () {
     user.flags.newsletter_consent_prompt = false;
   });
 
+  it('renders PartnershipAgreement', async function () {
+    ConfigStore.set('partnershipAgreementPrompt', {partnerDisplayName: 'Foo', agreements:['standard', 'partner_presence']});
+    render(
+      <App {...routerProps}>
+        <div>placeholder content</div>
+      </App>
+    );
+
+    expect(
+      await screen.findByText(/This organization is created in partnership with Foo/)
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(/and are aware of the partner's presence in the organization as a manager./)
+    ).toBeInTheDocument();
+    expect(screen.queryByText('placeholder content')).not.toBeInTheDocument();
+  });
+
+  it('does not render PartnerAgreement for non-partnered orgs', async function () {
+    ConfigStore.set('partnershipAgreementPrompt', null);
+    render(
+      <App {...routerProps}>
+        <div>placeholder content</div>
+      </App>
+    );
+
+    const normalContent = await screen.findByText(
+      'placeholder content'
+    );
+    expect(normalContent).toBeInTheDocument();
+    expect(screen.queryByText(/This organization is created in partnership/)).not.toBeInTheDocument();
+  });
+
   it('renders InstallWizard', async function () {
     ConfigStore.get('user').isSuperuser = true;
     ConfigStore.set('needsUpgrade', true);

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -36,6 +36,7 @@ const InstallWizard: React.FC<InstallWizardProps> = lazy(
   () => import('sentry/views/admin/installWizard')
 );
 const NewsletterConsent = lazy(() => import('sentry/views/newsletterConsent'));
+const PartnershipAgreement = lazy(() => import('sentry/views/partnershipAgreement'));
 
 /**
  * App is the root level container for all uathenticated routes.
@@ -160,12 +161,25 @@ function App({children, params}: Props) {
 
   const needsUpgrade = config.user?.isSuperuser && config.needsUpgrade;
   const newsletterConsentPrompt = config.user?.flags?.newsletter_consent_prompt;
+  const partnershipAgreementPrompt = config.partnershipAgreementPrompt;
 
   function renderBody() {
     if (needsUpgrade) {
       return (
         <Suspense fallback={null}>
           <InstallWizard onConfigured={clearUpgrade} />;
+        </Suspense>
+      );
+    }
+
+    if (partnershipAgreementPrompt) {
+      return (
+        <Suspense fallback={null}>
+          <PartnershipAgreement
+            partnerDisplayName={partnershipAgreementPrompt.partnerDisplayName}
+            agreements={partnershipAgreementPrompt.agreements}
+            onSubmitSuccess={() => ConfigStore.set('partnershipAgreementPrompt', null)
+          } />
         </Suspense>
       );
     }

--- a/static/app/views/partnershipAgreement/index.tsx
+++ b/static/app/views/partnershipAgreement/index.tsx
@@ -1,7 +1,7 @@
-import {Label} from 'sentry/components/editableText';
 import Form from 'sentry/components/forms/form';
+import ExternalLink from 'sentry/components/links/externalLink';
 import NarrowLayout from 'sentry/components/narrowLayout';
-import {t, tct} from 'sentry/locale';
+import {tct} from 'sentry/locale';
 
 export type ParntershipAgreementType = 'standard' | 'partner_presence';
 
@@ -12,25 +12,23 @@ type Props = {
 };
 
 export default function PartnershipAgreement({partnerDisplayName, agreements, onSubmitSuccess}: Props) {
-  const standardAgreement = tct(
-    'This organization is created in partnership with [partnerName]. By pressing continue, you acknowledge that you have agreed to Sentry’s [tosLink] and [ppLink] through the partner’s application[endOfSentence]',
-     {
-      partnerName: partnerDisplayName,
-      tosLink: <a href='https://sentry.io/terms/' target='blank'>terms of service</a>,
-      ppLink: <a href='https://sentry.io/privacy/' target='_blank' rel="noreferrer">privacy policy</a>,
-      endOfSentence: agreements.length === 1 ? '.' : "",
-     }
-    );
-  const withPartnerPresenceAgreement = <span>{standardAgreement}{t('and are aware of the partner’s presence in the organization as a manager.')}</span>;
-
+  const tos = <ExternalLink href='https://sentry.io/terms/'>terms of service</ExternalLink>;
+  const privacyPolicy = <ExternalLink href='https://sentry.io/privacy/'>privacy policy</ExternalLink>;
   // TODO @athena: Add API call to the form
   return (
     <NarrowLayout>
-      <Form submitLabel='Continue' onSubmitSuccess={onSubmitSuccess}>
-        <Label isDisabled={false}>
-          {agreements.includes('partner_presence') ? withPartnerPresenceAgreement : standardAgreement}
-        </Label>
-    </Form>
+      <Form submitLabel="Continue" onSubmitSuccess={onSubmitSuccess}>
+        {agreements.includes('partner_presence')
+          ? tct(
+              "This organization is created in partnership with [partnerDisplayName]. By pressing continue, you acknowledge that you have agreed to Sentry's [tos] and [privacyPolicy] through the partner's application and are aware of the partner's presence in the organization as a manager.",
+              {partnerDisplayName, tos, privacyPolicy}
+            )
+          : tct(
+              "This organization is created in partnership with [partnerDisplayName]. By pressing continue, you acknowledge that you have agreed to Sentry's [tos] and [privacyPolicy] through the partner's application.",
+              {partnerDisplayName, tos, privacyPolicy}
+            )
+        }
+      </Form>
     </NarrowLayout>
   );
 }

--- a/static/app/views/partnershipAgreement/index.tsx
+++ b/static/app/views/partnershipAgreement/index.tsx
@@ -1,0 +1,36 @@
+import {Label} from 'sentry/components/editableText';
+import Form from 'sentry/components/forms/form';
+import NarrowLayout from 'sentry/components/narrowLayout';
+import {t, tct} from 'sentry/locale';
+
+export type ParntershipAgreementType = 'standard' | 'partner_presence';
+
+type Props = {
+  agreements: Array<ParntershipAgreementType>,
+  partnerDisplayName: string,
+  onSubmitSuccess?: () => void;
+};
+
+export default function PartnershipAgreement({partnerDisplayName, agreements, onSubmitSuccess}: Props) {
+  const standardAgreement = tct(
+    'This organization is created in partnership with [partnerName]. By pressing continue, you acknowledge that you have agreed to Sentry’s [tosLink] and [ppLink] through the partner’s application[endOfSentence]',
+     {
+      partnerName: partnerDisplayName,
+      tosLink: <a href='https://sentry.io/terms/' target='blank'>terms of service</a>,
+      ppLink: <a href='https://sentry.io/privacy/' target='_blank' rel="noreferrer">privacy policy</a>,
+      endOfSentence: agreements.length === 1 ? '.' : "",
+     }
+    );
+  const withPartnerPresenceAgreement = <span>{standardAgreement}{t('and are aware of the partner’s presence in the organization as a manager.')}</span>;
+
+  // TODO @athena: Add API call to the form
+  return (
+    <NarrowLayout>
+      <Form submitLabel='Continue' onSubmitSuccess={onSubmitSuccess}>
+        <Label isDisabled={false}>
+          {agreements.includes('partner_presence') ? withPartnerPresenceAgreement : standardAgreement}
+        </Label>
+    </Form>
+    </NarrowLayout>
+  );
+}


### PR DESCRIPTION
Partnership agreements should restrict usage of sentry so this view shows up regardless of the url they're trying to navigate to. [Specs](https://www.notion.so/sentry/Nintendo-Partnership-Enablement-69b1259fc1f54015a0fd4e2091df9798?pvs=4#b8795bce63ed4920b72415b3ab370b41) for more context

Right now have 2 different types of agreements to show:
![Screenshot 2024-01-08 at 11 27 11 AM](https://github.com/getsentry/sentry/assets/132939361/6f25d0d0-f49a-4ee3-a574-8c6c4376752e)

![Screenshot 2024-01-08 at 11 26 37 AM](https://github.com/getsentry/sentry/assets/132939361/1a0084e3-c540-49f2-bf47-34f84ea11a7c)

