### PR TITLE
metrics(replay): Set org and project-id tags in the recording consumer

### DIFF
--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -8,7 +8,7 @@ from typing import Optional, TypedDict, cast
 
 from django.conf import settings
 from sentry_kafka_schemas.schema_types.ingest_replay_recordings_v1 import ReplayRecording
-from sentry_sdk import Hub
+from sentry_sdk import Hub, set_tag
 from sentry_sdk.tracing import Span
 
 from sentry import options
@@ -83,6 +83,9 @@ def ingest_recording(message_dict: ReplayRecording, transaction: Span, current_h
 
 def _ingest_recording(message: RecordingIngestMessage, transaction: Span) -> None:
     """Ingest recording messages."""
+    set_tag("org_id", message.org_id)
+    set_tag("project_id", message.project_id)
+
     try:
         headers, recording_segment = process_headers(message.payload_with_headers)
     except MissingRecordingSegmentHeaders:


### PR DESCRIPTION
Right now if an error occurs these values do not exist and don't allow us to easily categorize problematic customers.  With this change we'll be able to see at a glance how many orgs and affected and how heavily.