### PR TITLE
fix(feedback): Consolidate onChange and onClick callback for feedback list item checkbox

### DIFF
--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -83,8 +83,10 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
                 style={{gridArea: 'checkbox'}}
                 disabled={isSelected === 'all-selected'}
                 checked={isSelected !== false}
-                onChange={e => onSelect(e.target.checked)}
-                onClick={e => e.stopPropagation()}
+                onChange={e => {
+                  onSelect(e.target.checked);
+                  e.stopPropagation();
+                }}
                 invertColors={isOpen}
               />
             </Row>


### PR DESCRIPTION
Before:
- Open User Feedback page in Firefox.
- Click a checkbox to select an item in the list
- Notice how the whole page reloads (and will show you the details for the item that you checked)

After:
- None of that page reload stuff. Click to check the checkbox.

Fixes https://github.com/getsentry/team-replay/issues/343