### PR TITLE
chore(issue-platform): Add stats verify that `group_states` and the group info are the same in `post_process_group`

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -640,22 +640,27 @@ def post_process_group(
             ]
 
         try:
-            if not is_transaction_event:
-                if len(group_states) == 0:
-                    metrics.incr("sentry.tasks.post_process.error_empty_group_states")
-                elif len(group_states) > 1:
-                    metrics.incr("sentry.tasks.post_process.error_too_many_group_states")
-                elif group_id != group_states[0]["id"]:
-                    metrics.incr("sentry.tasks.post_process.error_group_states_dont_match_group")
-            else:
-                if len(group_states) == 1:
-                    metrics.incr("sentry.tasks.post_process.transaction_has_group_state")
-                    if group_id != group_states[0]["id"]:
+            if group_states is not None:
+                if not is_transaction_event:
+                    if len(group_states) == 0:
+                        metrics.incr("sentry.tasks.post_process.error_empty_group_states")
+                    elif len(group_states) > 1:
+                        metrics.incr("sentry.tasks.post_process.error_too_many_group_states")
+                    elif group_id != group_states[0]["id"]:
                         metrics.incr(
-                            "sentry.tasks.post_process.transaction_group_states_dont_match_group"
+                            "sentry.tasks.post_process.error_group_states_dont_match_group"
                         )
-                if len(group_states) > 1:
-                    metrics.incr("sentry.tasks.post_process.transaction_has_too_many_group_states")
+                else:
+                    if len(group_states) == 1:
+                        metrics.incr("sentry.tasks.post_process.transaction_has_group_state")
+                        if group_id != group_states[0]["id"]:
+                            metrics.incr(
+                                "sentry.tasks.post_process.transaction_group_states_dont_match_group"
+                            )
+                    if len(group_states) > 1:
+                        metrics.incr(
+                            "sentry.tasks.post_process.transaction_has_too_many_group_states"
+                        )
         except Exception:
             logger.exception(
                 "Error logging group_states stats. If this happens it's noisy but not critical, nothing is broken"

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -639,6 +639,28 @@ def post_process_group(
                 }
             ]
 
+        try:
+            if not is_transaction_event:
+                if len(group_states) == 0:
+                    metrics.incr("sentry.tasks.post_process.error_empty_group_states")
+                elif len(group_states) > 1:
+                    metrics.incr("sentry.tasks.post_process.error_too_many_group_states")
+                elif group_id != group_states[0]["id"]:
+                    metrics.incr("sentry.tasks.post_process.error_group_states_dont_match_group")
+            else:
+                if len(group_states) == 1:
+                    metrics.incr("sentry.tasks.post_process.transaction_has_group_state")
+                    if group_id != group_states[0]["id"]:
+                        metrics.incr(
+                            "sentry.tasks.post_process.transaction_group_states_dont_match_group"
+                        )
+                if len(group_states) > 1:
+                    metrics.incr("sentry.tasks.post_process.transaction_has_too_many_group_states")
+        except Exception:
+            logger.exception(
+                "Error logging group_states stats. If this happens it's noisy but not critical, nothing is broken"
+            )
+
         update_event_groups(event, group_states)
         bind_organization_context(event.project.organization)
         _capture_event_stats(event)


### PR DESCRIPTION
When we first introduced performance issues they were added to the transaction table, and there could be multiple groups associated with a single transaction. To handle this in post process group we passed along `group_state`, so that we could have multiple groups per event.

Since the introduction of the issue platform we now only ever handle one group at a time in `post_process_group`. Ideally we can just remove all the code that handles the states and rely on the individual `group_id` and related data instead. Just adding in stats on this to validate that it will work as expected.