### PR TITLE
fix(feedback): Fix alignment of Assign dropdown menu in feedback details

### DIFF
--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -91,6 +91,7 @@ export interface AssigneeSelectorDropdownProps {
   children: (props: RenderProps) => React.ReactNode;
   id: string;
   organization: Organization;
+  alignMenu?: 'left' | 'right' | undefined;
   assignedTo?: Actor | null;
   disabled?: boolean;
   group?: Group | FeedbackIssue;
@@ -539,7 +540,7 @@ export class AssigneeSelectorDropdown extends Component<
   }
 
   render() {
-    const {disabled, children, assignedTo} = this.props;
+    const {alignMenu, disabled, children, assignedTo} = this.props;
     const {loading} = this.state;
     const memberList = this.memberList();
 
@@ -554,7 +555,7 @@ export class AssigneeSelectorDropdown extends Component<
           memberList !== undefined ? this.renderNewDropdownItems.bind(this) : () => null
         }
         onSelect={this.handleAssign}
-        alignMenu="right"
+        alignMenu={alignMenu ?? 'right'}
         itemSize="small"
         searchPlaceholder={t('Filter teams and people')}
         menuFooter={

--- a/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackAssignedTo.tsx
@@ -64,6 +64,7 @@ export default function FeedbackAssignedTo({feedbackIssue, feedbackEvent}: Props
       }}
       owners={owners}
       group={feedbackIssue}
+      alignMenu="left"
     >
       {({isOpen, getActorProps}) => (
         <Button size="xs" aria-label={t('Assigned dropdown')} {...getActorProps({})}>


### PR DESCRIPTION
IMO this is a quick fix. It'd be better if the dropdown component itself could control it's left/right position automatically. Or if it used a portal and could float above everything... alas.
So because it's a quick fix we really rely on the buttons to the right "Resolve" and "Mark unread" so that there's enough room for the dropdown to fly out to the right and not touch the edge. If we removed those buttons then we've got the same problem again.

| Desc | Before | After |
| --- | --- | --- |
| Narrow Screen | ![SCR-20240103-ifjz](https://github.com/getsentry/sentry/assets/187460/6afdaf1f-d948-4e4a-b95f-fd31f6e925ea) | <img width="520" alt="SCR-20240106-jdkk" src="https://github.com/getsentry/sentry/assets/187460/583b9139-d8d9-4ac7-8f09-e0a249cf438f"> |
| Wide Screen | <img width="801" alt="SCR-20240106-jdqp" src="https://github.com/getsentry/sentry/assets/187460/63abbcd6-8bd4-4616-8d96-aec1a90f2f5a"> | <img width="798" alt="SCR-20240106-jdpq" src="https://github.com/getsentry/sentry/assets/187460/420729d9-6ec9-4a89-b682-5936fa08b2e5"> |


Fixes https://github.com/getsentry/sentry/issues/62560