### PR TITLE
fix(stories): Let the /stories/ filetree on the left scroll

### DIFF
--- a/static/app/views/stories/index.tsx
+++ b/static/app/views/stories/index.tsx
@@ -19,9 +19,9 @@ export default function Stories({location}: Props) {
   return (
     <Layout>
       <StoryHeader style={{gridArea: 'head'}} />
-      <aside style={{gridArea: 'aside'}}>
+      <Sidebar style={{gridArea: 'aside'}}>
         <StoryTree files={storiesContext().files()} />
-      </aside>
+      </Sidebar>
 
       {story.error ? (
         <VerticalScroll style={{gridArea: 'body'}}>
@@ -52,6 +52,10 @@ const Layout = styled('div')`
 
   height: 100vh;
   padding: var(--stories-grid-space);
+`;
+
+const Sidebar = styled('aside')`
+  overflow: auto;
 `;
 
 const VerticalScroll = styled('main')`


### PR DESCRIPTION
Some side-scrolling so we can read those really long names, and vertical scrolling so the page doesn't endup getting taller than 100vh.

<img width="307" alt="SCR-20240106-rwmn" src="https://github.com/getsentry/sentry/assets/187460/4f21a733-8f52-4b8f-943b-5b466abd0847">
