### PR TITLE
feat(ddm): Add limit support in metrics api

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -26,6 +26,7 @@ from sentry.snuba.metrics import (
     get_tag_values,
 )
 from sentry.snuba.metrics.utils import DerivedMetricException, DerivedMetricParseException
+from sentry.snuba.referrer import Referrer
 from sentry.snuba.sessions_v2 import InvalidField
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.dates import parse_stats_period
@@ -169,8 +170,7 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
 
         try:
             limit = request.GET.get("limit")
-            # We then run the query and inject directly the field, query and groupBy, since they will be parsed
-            # internally.
+
             results = run_metrics_query(
                 fields=request.GET.getlist("field", []),
                 interval=interval,
@@ -179,8 +179,7 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
                 organization=organization,
                 projects=self.get_projects(request, organization),
                 environments=self.get_environments(request, organization),
-                # TODO: move referrers into a centralized place.
-                referrer="metrics.data.api",
+                referrer=Referrer.API_DDM_METRICS_DATA.value,
                 # Optional parameters.
                 query=request.GET.get("query"),
                 group_bys=request.GET.getlist("groupBy"),

--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -168,11 +168,11 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
         start, end = get_date_range_from_params(request.GET)
 
         try:
+            limit = request.GET.get("limit")
             # We then run the query and inject directly the field, query and groupBy, since they will be parsed
             # internally.
             results = run_metrics_query(
                 fields=request.GET.getlist("field", []),
-                query=request.GET.get("query"),
                 interval=interval,
                 start=start,
                 end=end,
@@ -182,8 +182,10 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
                 # TODO: move referrers into a centralized place.
                 referrer="metrics.data.api",
                 # Optional parameters.
+                query=request.GET.get("query"),
                 group_bys=request.GET.getlist("groupBy"),
                 order_by=request.GET.get("orderBy"),
+                limit=int(limit) if limit else None,
             )
         except InvalidMetricsQueryError as e:
             return Response(status=400, data={"detail": str(e)})

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -68,6 +68,7 @@ class Referrer(Enum):
     # DDM
     API_DDM_FETCH_SPANS = "api.ddm.fetch.spans"
     API_DDM_FETCH_METRICS_SUMMARIES = "api.ddm.fetch.metrics_summaries"
+    API_DDM_METRICS_DATA = "api.ddm.metrics.data"
 
     API_DISCOVER_TOTAL_COUNT_FIELD = "api.discover.total-events-field"
     API_DISCOVER_TOTAL_SUM_TRANSACTION_DURATION_FIELD = (

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -127,7 +127,7 @@ class OrganizationMetricsDataWithNewLayerTest(MetricsAPIBaseTestCase):
         response_new = responses[1].data
 
         for group_index in (0, 1):
-            # We want to only compare a subset of the fields, since the new integration doesn't have all features.
+            # We want to only compare a subset of the fields since the APIs have some differences.
             assert (
                 response_old["groups"][group_index]["by"]
                 == response_new["groups"][group_index]["by"]

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -98,18 +98,25 @@ class OrganizationMetricsDataWithNewLayerTest(MetricsAPIBaseTestCase):
         )
 
     def test_compare_query_with_transactions_metric(self):
-        self.store_performance_metric(
-            name=TransactionMRI.DURATION.value,
-            tags={"transaction": "/hello", "platform": "ios"},
-            value=10,
-        )
+        for transaction, value in (("/hello", 10), ("/world", 5), ("/foo", 3)):
+            self.store_performance_metric(
+                name=TransactionMRI.DURATION.value,
+                tags={"transaction": transaction},
+                value=value,
+            )
 
         responses = []
         for flag_value in False, True:
+            field = f"sum({TransactionMRI.DURATION.value})"
             response = self.get_response(
                 self.project.organization.slug,
-                field=f"sum({TransactionMRI.DURATION.value})",
+                field=field,
+                groupBy="transaction",
+                orderBy=field,
                 useCase="transactions",
+                # We test the limit in both.
+                limit="2",
+                per_page="2",
                 useNewMetricsLayer="true" if flag_value else "false",
                 statsPeriod="1h",
                 interval="1h",
@@ -119,14 +126,19 @@ class OrganizationMetricsDataWithNewLayerTest(MetricsAPIBaseTestCase):
         response_old = responses[0].data
         response_new = responses[1].data
 
-        # We want to only compare a subset of the fields, since the new integration doesn't have all features.
-        assert response_old["groups"][0]["by"] == response_new["groups"][0]["by"]
-        assert list(response_old["groups"][0]["series"].values()) == list(
-            response_new["groups"][0]["series"].values()
-        )
-        assert list(response_old["groups"][0]["totals"].values()) == list(
-            response_new["groups"][0]["totals"].values()
-        )
+        for group_index in (0, 1):
+            # We want to only compare a subset of the fields, since the new integration doesn't have all features.
+            assert (
+                response_old["groups"][group_index]["by"]
+                == response_new["groups"][group_index]["by"]
+            )
+            assert list(response_old["groups"][group_index]["series"].values()) == list(
+                response_new["groups"][group_index]["series"].values()
+            )
+            assert list(response_old["groups"][group_index]["totals"].values()) == list(
+                response_new["groups"][group_index]["totals"].values()
+            )
+
         assert response_old["intervals"] == response_new["intervals"]
         assert response_old["start"] == response_new["start"]
         assert response_old["end"] == response_new["end"]


### PR DESCRIPTION
This PR adds the support of the `limit` in the new metrics API. This limit has to be considered just a normal limit which doesn't have anything to do with pagination. Our goal is to use the limit to implement the `top-k` behavior.