### PR TITLE
feat(ddm): Rework implementation of metric spans fetching to be extensible

### DIFF
--- a/src/sentry/sentry_metrics/querying/metadata/metric_spans.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metric_spans.py
@@ -1,16 +1,18 @@
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional, Sequence, Set
 
-from snuba_sdk import Column, Condition, Entity, Limit, Op, Query, Request, Timeseries
-from snuba_sdk.conditions import BooleanCondition, ConditionGroup
-from snuba_sdk.mql.mql import parse_mql
+from snuba_sdk import Column, Condition, Entity, Limit, Op, Query, Request
+from snuba_sdk.conditions import ConditionGroup
 
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.sentry_metrics.querying.api import InvalidMetricsQueryError
+from sentry.sentry_metrics.querying.metadata.utils import get_snuba_conditions_from_query
 from sentry.snuba import spans_indexed
 from sentry.snuba.dataset import Dataset, EntityKey
+from sentry.snuba.metrics.naming_layer.mri import is_mri
 from sentry.snuba.referrer import Referrer
 from sentry.utils.snuba import raw_snql_query
 
@@ -38,163 +40,175 @@ class MetricSpans:
         return hash(self.metric_mri)
 
 
-def _get_spans_by_ids(
-    span_ids: Set[str],
-    start: datetime,
-    end: datetime,
-    organization: Organization,
-    projects: Sequence[Project],
-) -> Sequence[Span]:
-    """
-    Returns multiple `Span`s given a set of `span_ids`.
+class SpansSource(ABC):
+    def __init__(
+        self,
+        organization: Organization,
+        projects: Sequence[Project],
+    ):
+        self._organization = organization
+        self._projects = projects
 
-    The rationale behind this query is that we want to query the main `spans` entity to get more information about the
-    span. Since this query is relatively inefficient due to the use of the `IN` operator, we might want to change the
-    data representation in the future.
-    """
-    if not span_ids:
-        return []
+    def get_spans(
+        self,
+        metric_mri: str,
+        query: Optional[str],
+        start: datetime,
+        end: datetime,
+        min_value: Optional[float],
+        max_value: Optional[float],
+    ) -> Sequence[Span]:
+        """
+        Returns multiple `Span`s given a set of `span_ids`.
 
-    data = spans_indexed.query(
-        selected_columns=[
-            "project_id",
-            "span_id",
-            "trace_id",
-            "transaction_id",
-            "profile_id",
-            "duration",
-            "timestamp",
-        ],
-        # We are interested in the most recent spans for now.
-        orderby=["-timestamp"],
-        params={
-            "organization_id": organization.id,
-            "project_objects": projects,
-            "start": start,
-            "end": end,
-        },
-        query=f"span_id:[{','.join(span_ids)}]",
-        referrer=Referrer.API_DDM_FETCH_SPANS.value,
-    )["data"]
-
-    return [
-        Span(
-            project_id=value["project_id"],
-            span_id=value["span_id"],
-            trace_id=value["trace_id"],
-            transaction_id=value["transaction_id"],
-            profile_id=value["profile_id"],
-            duration=value["duration"],
+        The rationale behind this query is that we want to query the main `spans` entity to get more information about the
+        span. Since this query is relatively inefficient due to the use of the `IN` operator, we might want to change the
+        data representation in the future.
+        """
+        span_ids = self.get_span_ids(
+            metric_mri=metric_mri,
+            conditions=get_snuba_conditions_from_query(query) if query else None,
+            start=start,
+            end=end,
+            min_value=min_value,
+            max_value=max_value,
         )
-        for value in data
-    ]
 
+        if not span_ids:
+            return []
 
-def _convert_to_tags(conditions: Optional[ConditionGroup]) -> Optional[ConditionGroup]:
-    """
-    Converts all the conditions to work on tags, by wrapping each `Column` name with 'tags[x]'.
+        data = spans_indexed.query(
+            selected_columns=[
+                "project_id",
+                "span_id",
+                "trace_id",
+                "transaction_id",
+                "profile_id",
+                "duration",
+                "timestamp",
+            ],
+            # We are interested in the most recent spans for now.
+            orderby=["-timestamp"],
+            params={
+                "organization_id": self._organization.id,
+                "project_objects": self._projects,
+                "start": start,
+                "end": end,
+            },
+            query=f"span_id:[{','.join(span_ids)}]",
+            referrer=Referrer.API_DDM_FETCH_SPANS.value,
+        )["data"]
 
-    This function assumes that the query of a metric only refers to tags.
-    """
-    if conditions is None:
-        return None
-
-    new_conditions = []
-    for condition in conditions:
-        if isinstance(condition, BooleanCondition):
-            new_conditions.append(
-                BooleanCondition(op=condition.op, conditions=_convert_to_tags(condition.conditions))
+        return [
+            Span(
+                project_id=value["project_id"],
+                span_id=value["span_id"],
+                trace_id=value["trace_id"],
+                transaction_id=value["transaction_id"],
+                profile_id=value["profile_id"],
+                duration=value["duration"],
             )
-        elif isinstance(condition, Condition) and isinstance(condition.lhs, Column):
-            # We assume that all incoming conditions are on tags, since we do not allow filtering by project in the
-            # query filters.
-            tag_column = f"tags[{condition.lhs.name}]"
-            new_conditions.append(
-                Condition(lhs=Column(name=tag_column), op=condition.op, rhs=condition.rhs)
-            )
-
-    return new_conditions
-
-
-def _get_snuba_conditions_from_query(query: str) -> Optional[ConditionGroup]:
-    """
-    Returns a set of Snuba conditions from a query string which is assumed to contain filters in the MQL grammar.
-
-    Since MQL does not support parsing only filters, we have to create a phantom query to feed the parser, in order for
-    it to correctly resolve a `Timeseries` out of which we extract the `filters`.
-    """
-    # We want to create a phantom query to feed into the parser in order to be able to extract the conditions from the
-    # returned timeseries.
-    phantom_query = f"count(phantom){{{query}}}"
-
-    # TODO: find a way to directly use only filters grammar to avoid making a phantom query.
-    parsed_phantom_query = parse_mql(phantom_query).query
-    if not isinstance(parsed_phantom_query, Timeseries):
-        # For now, we reuse data from `api` but we will soon lift out common components from that file.
-        raise InvalidMetricsQueryError("The supplied query is not valid")
-
-    return _convert_to_tags(parsed_phantom_query.filters)
-
-
-def _get_metrics_summaries(
-    metric_mri: str,
-    query: Optional[str],
-    start: datetime,
-    end: datetime,
-    min_value: Optional[float],
-    max_value: Optional[float],
-    organization: Organization,
-    projects: Sequence[Project],
-) -> Set[str]:
-    """
-    Returns a set of cardinality at most `MAX_NUMBER_OF_SPANS` containing the ids of the spans in which `metric_mri`
-    was emitted.
-
-    In order to honor the filters that the user has in a widget, we take the `query` and parse it to extract a
-    series of Snuba conditions that we apply on the tags of the metric summary. For example, if you are filtering by
-    tag device:iPhone, we will only show you the spans in which the metric with tag device:iPhone was emitted.
-    """
-    project_ids = [project.id for project in projects]
-
-    where = []
-    if min_value is not None:
-        where.append(Condition(Column("min"), Op.GTE, min_value))
-
-    if max_value is not None:
-        where.append(Condition(Column("max"), Op.LTE, max_value))
-
-    if query is not None:
-        snuba_conditions = _get_snuba_conditions_from_query(query)
-        if snuba_conditions:
-            where += snuba_conditions
-
-    query = Query(
-        match=Entity(EntityKey.MetricsSummaries.value),
-        select=[Column("span_id")],
-        where=[
-            Condition(Column("project_id"), Op.IN, project_ids),
-            Condition(Column("end_timestamp"), Op.GTE, start),
-            Condition(Column("end_timestamp"), Op.LT, end),
-            Condition(Column("metric_mri"), Op.EQ, metric_mri),
+            for value in data
         ]
-        + where,
-        # We group by to deduplicate the span id and apply the limit.
-        groupby=[Column("span_id")],
-        limit=Limit(MAX_NUMBER_OF_SPANS),
-    )
 
-    request = Request(
-        dataset=Dataset.SpansIndexed.value,
-        app_id="metrics",
-        query=query,
-        tenant_ids={"organization_id": organization.id},
-    )
+    @classmethod
+    @abstractmethod
+    def supports(cls, metric_mri: str) -> bool:
+        raise NotImplementedError
 
-    data = raw_snql_query(request, Referrer.API_DDM_FETCH_METRICS_SUMMARIES.value, use_cache=True)[
-        "data"
-    ]
+    @abstractmethod
+    def get_span_ids(
+        self,
+        metric_mri: str,
+        conditions: Optional[ConditionGroup],
+        start: datetime,
+        end: datetime,
+        min_value: Optional[float],
+        max_value: Optional[float],
+    ) -> Set[str]:
+        raise NotImplementedError
 
-    return {value["span_id"] for value in data}
+
+class MetricsSummariesSpansSource(SpansSource):
+    @classmethod
+    def supports(cls, metric_mri: str) -> bool:
+        return is_mri(metric_mri)
+
+    def get_span_ids(
+        self,
+        metric_mri: str,
+        conditions: Optional[ConditionGroup],
+        start: datetime,
+        end: datetime,
+        min_value: Optional[float],
+        max_value: Optional[float],
+    ) -> Set[str]:
+        """
+        Returns a set of cardinality at most `MAX_NUMBER_OF_SPANS` containing the ids of the spans in which `metric_mri`
+        was emitted.
+
+        In order to honor the filters that the user has in a widget, we take the `query` and parse it to extract a
+        series of Snuba conditions that we apply on the tags of the metric summary. For example, if you are filtering by
+        tag device:iPhone, we will only show you the spans in which the metric with tag device:iPhone was emitted.
+        """
+        project_ids = [project.id for project in self._projects]
+
+        where = []
+        if min_value is not None:
+            where.append(Condition(Column("min"), Op.GTE, min_value))
+
+        if max_value is not None:
+            where.append(Condition(Column("max"), Op.LTE, max_value))
+
+        if conditions:
+            where += conditions
+
+        query = Query(
+            match=Entity(EntityKey.MetricsSummaries.value),
+            select=[Column("span_id")],
+            where=[
+                Condition(Column("project_id"), Op.IN, project_ids),
+                Condition(Column("end_timestamp"), Op.GTE, start),
+                Condition(Column("end_timestamp"), Op.LT, end),
+                Condition(Column("metric_mri"), Op.EQ, metric_mri),
+            ]
+            + where,
+            # We group by to deduplicate the span id and apply the limit.
+            groupby=[Column("span_id")],
+            limit=Limit(MAX_NUMBER_OF_SPANS),
+        )
+
+        request = Request(
+            dataset=Dataset.SpansIndexed.value,
+            app_id="metrics",
+            query=query,
+            tenant_ids={"organization_id": self._organization.id},
+        )
+
+        data = raw_snql_query(
+            request, Referrer.API_DDM_FETCH_METRICS_SUMMARIES.value, use_cache=True
+        )["data"]
+
+        return {value["span_id"] for value in data}
+
+
+# List of span sources that are currently supported. The highest priority ones should be placed on the top of the list.
+SUPPORTED_SPANS_SOURCES = [MetricsSummariesSpansSource]
+
+
+def get_spans_source(
+    metric_mri: str, organization: Organization, projects: Sequence[Project]
+) -> Optional[SpansSource]:
+    """
+    Finds the first spans source that supports the `metric_mri`.
+
+    In case multiple sources would apply to a `metric_mri` the first one is chosen.
+    """
+    for source_clazz in SUPPORTED_SPANS_SOURCES:
+        if source_clazz.supports(metric_mri):
+            return source_clazz(organization=organization, projects=projects)
+
+    return None
 
 
 def get_spans_of_metric(
@@ -213,10 +227,14 @@ def get_spans_of_metric(
     The metric can be emitted within a span with different tag values. These are uniquely stored in the
     metrics_summaries entity.
     """
-    span_ids = _get_metrics_summaries(
-        metric_mri, query, start, end, min_value, max_value, organization, projects
+    spans_source = get_spans_source(metric_mri, organization, projects)
+    if not spans_source:
+        raise InvalidMetricsQueryError(
+            f"The supplied metric {metric_mri} does not support fetching correlated spans"
+        )
+
+    spans = spans_source.get_spans(metric_mri, query, start, end, min_value, max_value)
+    return MetricSpans(
+        metric_mri=metric_mri,
+        spans=spans,
     )
-
-    spans = _get_spans_by_ids(span_ids, start, end, organization, projects)
-
-    return MetricSpans(metric_mri=metric_mri, spans=spans)

--- a/src/sentry/sentry_metrics/querying/metadata/metric_spans.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metric_spans.py
@@ -59,6 +59,8 @@ class SpansSource(ABC):
     ) -> Sequence[Span]:
         return self._get_spans(
             metric_mri=metric_mri,
+            # TODO: when the environment support is added, inject here the environment condition after the AST is
+            #   generated.
             conditions=get_snuba_conditions_from_query(query) if query else None,
             start=start,
             end=end,
@@ -190,7 +192,7 @@ class TransactionDurationSpansSource(SpansSource):
         # TODO: implement transaction.duration handling by looking for:
         #   is_segment: 1
         #   duration >= min and duration <= max
-        #   sentry_tags as values from the query string
+        #   sentry_tags and tags as values from the query string
         return []
 
 

--- a/src/sentry/sentry_metrics/querying/metadata/utils.py
+++ b/src/sentry/sentry_metrics/querying/metadata/utils.py
@@ -1,0 +1,55 @@
+from typing import Optional
+
+from snuba_sdk import Column, Condition, Timeseries
+from snuba_sdk.conditions import BooleanCondition, ConditionGroup
+from snuba_sdk.mql.mql import parse_mql
+
+from sentry.sentry_metrics.querying.api import InvalidMetricsQueryError
+
+
+def transform_to_tags(conditions: Optional[ConditionGroup]) -> Optional[ConditionGroup]:
+    """
+    Transforms all the conditions to work on tags, by wrapping each `Column` name with 'tags[x]'.
+
+    This function assumes that the query of a metric only refers to tags, since it can't be inferred that it's not
+    referring to tags by just looking at the string. The values that are not tags, are specific to the data layer.
+    """
+    if conditions is None:
+        return None
+
+    transformed_conditions = []
+    for condition in conditions:
+        if isinstance(condition, BooleanCondition):
+            transformed_conditions.append(
+                BooleanCondition(
+                    op=condition.op, conditions=transform_to_tags(condition.conditions)
+                )
+            )
+        elif isinstance(condition, Condition) and isinstance(condition.lhs, Column):
+            # We assume that all incoming conditions are on tags, since we do not allow filtering by project in the
+            # query filters.
+            tag_column = f"tags[{condition.lhs.name}]"
+            transformed_conditions.append(
+                Condition(lhs=Column(name=tag_column), op=condition.op, rhs=condition.rhs)
+            )
+
+    return transformed_conditions
+
+
+def get_snuba_conditions_from_query(query: str) -> Optional[ConditionGroup]:
+    """
+    Returns a set of Snuba conditions from a query string which is assumed to contain filters in the MQL grammar.
+
+    Since MQL does not support parsing only filters, we have to create a phantom query to feed the parser,
+    in order for it to correctly resolve a `Timeseries` out of which we extract the `filters`.
+    """
+    # We want to create a phantom query to feed into the parser in order to be able to extract the conditions
+    # from the returned timeseries.
+    phantom_query = f"count(phantom){{{query}}}"
+
+    parsed_phantom_query = parse_mql(phantom_query).query
+    if not isinstance(parsed_phantom_query, Timeseries):
+        # For now, we reuse data from `api` but we will soon lift out common components from that file.
+        raise InvalidMetricsQueryError("The supplied query is not valid")
+
+    return transform_to_tags(parsed_phantom_query.filters)

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1415,10 +1415,10 @@ class BaseSpansTestCase(SnubaTestCase):
             "event_id": transaction_id,
             "profile_id": profile_id,
             "tags": tags,
-            # "sentry_tags": sentry_tags,
-            # "is_segment": is_segment,
+            "is_segment": is_segment,
         }
-
+        if sentry_tags:
+            payload["sentry_tags"] = sentry_tags
         if metrics_summary:
             payload["_metrics_summary"] = metrics_summary
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1400,7 +1400,10 @@ class BaseSpansTestCase(SnubaTestCase):
         metrics_summary: Optional[Mapping[str, Sequence[Mapping[str, Any]]]] = None,
         timestamp: datetime = None,
         tags: Mapping[str, Any] = None,
+        sentry_tags: Mapping[str, Any] = None,
         store_only_summary: bool = False,
+        is_segment: int = 0,
+        duration_ms: int = 10,
     ):
         payload = {
             "start_timestamp_ms": int(timestamp.timestamp() * 1000),
@@ -1412,7 +1415,8 @@ class BaseSpansTestCase(SnubaTestCase):
             "event_id": transaction_id,
             "profile_id": profile_id,
             "tags": tags,
-            "is_segment": 0,
+            # "sentry_tags": sentry_tags,
+            # "is_segment": is_segment,
         }
 
         if metrics_summary:

--- a/tests/sentry/api/endpoints/test_organization_ddm_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_ddm_meta.py
@@ -611,6 +611,7 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             status_code=500,
         )
 
+    @pytest.mark.skip(reason="transaction.duration is currently not supported")
     def test_get_metric_spans_with_transaction_duration(self):
         mri = TransactionMRI.DURATION.value
 

--- a/tests/sentry/api/endpoints/test_organization_ddm_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_ddm_meta.py
@@ -620,7 +620,7 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             timestamp=before_now(minutes=5),
             span_id=span_id,
             is_segment=1,
-            duration_ms=100
+            duration_ms=100,
         )
 
         response = self.get_success_response(
@@ -629,6 +629,8 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             project=[self.project.id],
             statsPeriod="1d",
             metricSpans="true",
+            min="50",
+            max="150",
         )
 
         metric_spans = response.data["metricSpans"]

--- a/tests/sentry/api/endpoints/test_organization_ddm_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_ddm_meta.py
@@ -9,6 +9,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.sentry_metrics.querying.metadata.code_locations import get_cache_key_for_code_location
 from sentry.sentry_metrics.querying.utils import get_redis_client_for_metrics_meta
+from sentry.snuba.metrics import TransactionMRI
 from sentry.testutils.cases import APITestCase, BaseSpansTestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.silo import region_silo_test
@@ -609,3 +610,27 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             query="device:something XOR device:something_else",
             status_code=500,
         )
+
+    def test_get_metric_spans_with_transaction_duration(self):
+        mri = TransactionMRI.DURATION.value
+
+        span_id = "98230207e6e4a6ad"
+        self.store_span(
+            project_id=self.project.id,
+            timestamp=before_now(minutes=5),
+            span_id=span_id,
+            is_segment=1,
+            duration_ms=100
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            metric=[mri],
+            project=[self.project.id],
+            statsPeriod="1d",
+            metricSpans="true",
+        )
+
+        metric_spans = response.data["metricSpans"]
+        assert len(metric_spans) == 1
+        assert metric_spans[0]["spanId"] == span_id


### PR DESCRIPTION
This PR is the first step towards making the spans endpoint for extensible since it requires special handling of certain metrics for which spans need to be fetched in a completely different way.

The PR also removes the dependency from query builders and instead queries natively the `spans` table, since we need more control to the data access for future queries.

In this code change, there is a blue print of how the `transaction.duration` fetching might look like, but it's not functional. It will be implemented in a follow up PR, to keep the diff more legible.