### PR TITLE
chore(sdk): Set `project_root` to `/usr/src`

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3071,6 +3071,7 @@ SENTRY_DEFAULT_INTEGRATIONS = (
 SENTRY_SDK_CONFIG: ServerSdkConfig = {
     "release": sentry.__semantic_version__,
     "environment": ENVIRONMENT,
+    "project_root": "/usr/src",
     "in_app_include": ["sentry", "sentry_plugins"],
     "debug": True,
     "send_default_pii": True,

--- a/src/sentry/conf/types/sdk_config.py
+++ b/src/sentry/conf/types/sdk_config.py
@@ -8,8 +8,8 @@ from typing_extensions import NotRequired, TypedDict
 class SdkConfig(TypedDict):
     release: str | None
     environment: str
-    in_app_include: list[str]
     project_root: str
+    in_app_include: list[str]
     debug: bool
     send_default_pii: bool
     auto_enabling_integrations: bool

--- a/src/sentry/conf/types/sdk_config.py
+++ b/src/sentry/conf/types/sdk_config.py
@@ -9,6 +9,7 @@ class SdkConfig(TypedDict):
     release: str | None
     environment: str
     in_app_include: list[str]
+    project_root: str
     debug: bool
     send_default_pii: bool
     auto_enabling_integrations: bool


### PR DESCRIPTION
Query source detection via the SDK isn't working properly in our sentry/getsentry production setup. This might be due to `project_root` not being set since our frame picking logic only takes into account frames coming from files that start with `project_root` (which, if unset, is set to current working directory when the SDK initializes). In this PR we're setting `project_root` explicitly to `/usr/src`.