### PR TITLE
feat(metrics_extraction): Support extracting multiple spec versions

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -57,6 +57,7 @@ from sentry.snuba.metrics.extraction import (
     QUERY_HASH_KEY,
     MetricSpecType,
     OnDemandMetricSpec,
+    get_spec_version,
     should_use_on_demand_metrics,
 )
 from sentry.snuba.metrics.fields import histogram as metrics_histogram
@@ -162,13 +163,14 @@ class MetricsQueryBuilder(QueryBuilder):
                 Organization.objects.get_from_cache(id=self.organization_id),
             )
 
+            spec_version = get_spec_version(1) if use_updated_env_logic else get_spec_version(0)
             return OnDemandMetricSpec(
                 field=field,
                 query=self.query,
                 environment=environment,
                 groupbys=groupby_columns,
                 spec_type=self.builder_config.on_demand_metrics_type,
-                use_updated_env_logic=use_updated_env_logic,
+                spec_version=spec_version,
             )
         except Exception as e:
             sentry_sdk.capture_exception(e)

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -71,7 +71,7 @@ SPEC_VERSIONS = [
 ]
 
 
-def get_spec_versions(min_version: int = 0) -> Sequence[SpecVersion]:
+def get_spec_versions(min_version: int = MIN_VERSION) -> Sequence[SpecVersion]:
     """Get all spec versions starting at a minimum version."""
     return [spec_version for spec_version in SPEC_VERSIONS if spec_version.version >= min_version]
 

--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -10,6 +10,7 @@ from typing import (
     Dict,
     List,
     Literal,
+    NamedTuple,
     Optional,
     Sequence,
     Tuple,
@@ -48,6 +49,41 @@ from sentry.snuba.metrics.utils import MetricOperationType
 from sentry.utils.snuba import is_measurement, is_span_op_breakdown, resolve_column
 
 logger = logging.getLogger(__name__)
+
+
+# This helps us control the different spec versions
+# in order to migrate customers from invalid specs
+class SpecVersion(NamedTuple):
+    version: int
+    flags: Sequence[str] = []
+
+    def has_flag(self, flag: str) -> bool:
+        return flag in self.flags
+
+
+# This is the lower spec version which we collect metrics for.
+# Once we're ready to abandon a version bump this value
+MIN_VERSION = 0
+
+SPEC_VERSIONS = [
+    SpecVersion(0),
+    SpecVersion(1, ["use_updated_env_logic"]),
+]
+
+
+def get_spec_versions(min_version: int = 0) -> Sequence[SpecVersion]:
+    """Get all spec versions starting at a minimum version."""
+    return [spec_version for spec_version in SPEC_VERSIONS if spec_version.version >= min_version]
+
+
+def get_spec_version(version: Optional[int] = None) -> SpecVersion:
+    """Get a specific spec version."""
+    if not version:
+        # Default to the latest version if none specified
+        version = len(SPEC_VERSIONS) - 1
+    assert version >= MIN_VERSION and version < len(SPEC_VERSIONS)
+    return SPEC_VERSIONS[version]
+
 
 # Name component of MRIs used for custom alert metrics.
 CUSTOM_ALERT_METRIC_NAME = "transactions/on_demand"
@@ -1027,6 +1063,7 @@ class OnDemandMetricSpec:
     query: str
     groupbys: Sequence[str]
     spec_type: MetricSpecType
+    spec_version: SpecVersion
 
     # Public fields.
     op: MetricOperationType
@@ -1042,12 +1079,12 @@ class OnDemandMetricSpec:
         environment: Optional[str] = None,
         groupbys: Optional[Sequence[str]] = None,
         spec_type: MetricSpecType = MetricSpecType.SIMPLE_QUERY,
-        use_updated_env_logic: bool = True,
+        spec_version: Optional[SpecVersion] = None,
     ):
         self.field = field
         self.query = query
         self.spec_type = spec_type
-        self.use_updated_env_logic = use_updated_env_logic
+        self.spec_version = spec_version if spec_version else get_spec_version()
 
         # Removes field if passed in selected_columns
         self.groupbys = [groupby for groupby in groupbys or () if groupby != field]
@@ -1259,7 +1296,7 @@ class OnDemandMetricSpec:
 
         extended_conditions = conditions
         if new_conditions:
-            if self.use_updated_env_logic:
+            if self.spec_version.has_flag("use_updated_env_logic"):
                 conditions = [ParenExpression(children=conditions)] if conditions else []
                 # This transformation is equivalent to (new_conditions) AND (conditions).
                 extended_conditions = [ParenExpression(children=new_conditions)] + conditions

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -252,7 +252,14 @@ def _get_widget_on_demand_specs(
 
     widget_specs = convert_widget_query_to_metric(project_for_query, widget_query, True)
 
-    return widget_specs
+    unique_specs = []
+    hashes = set()
+    for hashed_metric_spec in widget_specs:
+        if hashed_metric_spec[0] not in hashes:
+            unique_specs.append(hashed_metric_spec)
+            hashes.add(hashed_metric_spec[0])
+
+    return unique_specs
 
 
 def _set_widget_on_demand_state(
@@ -306,7 +313,6 @@ def _get_widget_query_low_cardinality(
     query_columns = widget_query.columns
 
     if not query_columns:
-
         return None
 
     with sentry_sdk.push_scope() as scope:

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -149,7 +149,7 @@ def test_get_metric_extraction_config_with_double_write_env_alert(
         assert len(config["metrics"]) == 2
         # The new way parenthesizes correctly the environment expression, making the original expression resolve first
         # and then AND with the injected environment.
-        assert config["metrics"][0] == {
+        assert config["metrics"][1] == {
             "category": "transaction",
             "condition": {
                 "inner": [
@@ -170,7 +170,7 @@ def test_get_metric_extraction_config_with_double_write_env_alert(
         }
         # The old way of generating the config has no parentheses, thus if we have lower binding in the original
         # expression, we will prioritize our filter.
-        assert config["metrics"][1] == {
+        assert config["metrics"][0] == {
             "category": "transaction",
             "condition": {
                 "inner": [

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import math
 from datetime import timezone
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 from unittest import mock
 
 import pytest
@@ -39,7 +39,7 @@ def _user_misery_formula(miserable_users: int, unique_users: int) -> float:
 
 
 def _metric_percentile_definition(
-    org_id, quantile, field="transaction.duration", alias=None
+    org_id: int, quantile: str, field: str = "transaction.duration", alias: Optional[str] = None
 ) -> Function:
     if alias is None:
         alias = f"p{quantile}_{field.replace('.', '_')}"
@@ -67,7 +67,7 @@ def _metric_percentile_definition(
     )
 
 
-def _metric_conditions(org_id, metrics) -> List[Condition]:
+def _metric_conditions(org_id: int, metrics: list[str]) -> List[Condition]:
     def _resolve_must_succeed(*a, **k):
         ret = indexer.resolve(*a, **k)
         assert ret is not None

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -10,6 +10,7 @@ from sentry.snuba.metrics.extraction import (
     apdex_tag_spec,
     cleanup_search_query,
     failure_tag_spec,
+    get_spec_version,
     query_tokens_to_string,
     should_use_on_demand_metrics,
     to_standard_metrics_query,
@@ -684,14 +685,18 @@ def test_cleanup_with_environment_injection(query) -> None:
     # We test with both new and old env logic, in this case queries should be identical in both logics since we
     # scrape away parentheses.
     for updated_env_logic in (True, False):
+        spec_version = get_spec_version(1) if updated_env_logic else get_spec_version(0)
         spec = OnDemandMetricSpec(
-            field, query, environment=environment, use_updated_env_logic=updated_env_logic
+            field,
+            query,
+            environment=environment,
+            spec_version=spec_version,
         )
         transformed_spec = OnDemandMetricSpec(
             field,
             transformed_query,
             environment=environment,
-            use_updated_env_logic=updated_env_logic,
+            spec_version=spec_version,
         )
 
         assert spec.query_hash == transformed_spec.query_hash


### PR DESCRIPTION
Adding new specification extraction versions is as simple as adding a new configuration to `SPEC_VERSIONS` and accessing `self.spec_version` within `OnDemandMetricSpec`.

We can use `MIN_VERSION` as a means of declaring which versions are still extracting.