### PR TITLE
feat(stacktrace): Add analytics for when the hierarchical grouping stacktrace is shown

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -593,6 +593,7 @@ function useTrackView({
   tab: Tab;
   project?: Project;
 }) {
+  const organization = useOrganization();
   const location = useLocation();
   const {alert_date, alert_rule_id, alert_type, ref_fallback, stream_index, query} =
     location.query;
@@ -613,6 +614,9 @@ function useTrackView({
     alert_type: typeof alert_type === 'string' ? alert_type : undefined,
     ref_fallback,
     group_event_type: groupEventType,
+    has_hierarchical_grouping:
+      !!organization.features?.includes('grouping-stacktrace-ui') &&
+      !!(event?.metadata?.current_tree_label || event?.metadata?.finest_tree_label),
   });
   // Set default values for properties that may be updated in subcomponents.
   // Must be separate from the above values, otherwise the actual values filled in


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/61731

We want to remove this extra stack trace component, but first need to ensure that it's not being used by any customers.