### PR TITLE
fix(github-invite): match emails case insensitively

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_missing_org_members.py
+++ b/tests/sentry/api/endpoints/test_organization_missing_org_members.py
@@ -194,6 +194,28 @@ class OrganizationMissingMembersTestCase(APITestCase):
             {"email": "a@exampletwo.com", "externalId": "not", "commitCount": 1},
         ]
 
+    def test_case_insensitive(self):
+        # excludes author that has matching (case insensitive) email
+
+        member = self.create_member(user=self.create_user(), organization=self.organization)
+        member.user_email = "helloworld@example.com"
+        member.save()
+
+        commit_author = self.create_commit_author(
+            project=self.project, email="HelloWorld@example.com"
+        )
+        commit_author.external_id = "github:helloworld"
+        commit_author.save()
+
+        self.create_commit(repo=self.repo, author=commit_author)
+
+        response = self.get_success_response(self.organization.slug)
+        assert response.data[0]["integration"] == "github"
+        assert response.data[0]["users"] == [
+            {"email": "c@example.com", "externalId": "c", "commitCount": 2},
+            {"email": "d@example.com", "externalId": "d", "commitCount": 1},
+        ]
+
     def test_owners_invalid_domain_no_filter(self):
         OrganizationMember.objects.filter(role="owner", organization=self.organization).update(
             user_email="example"


### PR DESCRIPTION
Email addresses are not case sensitive.

If an organization member has a user email of `helloworld@example.com`, and the org has someone committing to a repo connected to the org with the email `HelloWorld@example.com`, these are the same user and we should filter the email out from the API response.