### PR TITLE
ref: replace memcached client with vendored copy

### DIFF
--- a/self-hosted/sentry.conf.py
+++ b/self-hosted/sentry.conf.py
@@ -115,7 +115,7 @@ if memcached:
     memcached_port = env("SENTRY_MEMCACHED_PORT") or "11211"
     CACHES = {
         "default": {
-            "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+            "BACKEND": "sentry.utils.memcached.MemcachedCache",
             "LOCATION": [memcached + ":" + memcached_port],
             "TIMEOUT": 3600,
         }

--- a/src/sentry/data/config/sentry.conf.py.default
+++ b/src/sentry/data/config/sentry.conf.py.default
@@ -46,7 +46,7 @@ DEBUG = %(debug_flag)s
 #
 # CACHES = {
 #     'default': {
-#         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+#         'BACKEND': 'sentry.utils.memcached.MemcachedCache',
 #         'LOCATION': ['127.0.0.1:11211'],
 #     }
 # }

--- a/src/sentry/monkey/__init__.py
+++ b/src/sentry/monkey/__init__.py
@@ -25,21 +25,5 @@ def patch_celery_imgcat():
     term.imgcat = lambda *a, **kw: b""
 
 
-def patch_memcached():
-    # Fixes a bug in Django 3.2
-    try:
-        from django.core.cache.backends.memcached import MemcachedCache
-    except ImportError:
-        return
-
-    def fixed_delete(self, key, version=None):
-        key = self.make_key(key, version=version)
-        self.validate_key(key)
-        return bool(self._cache.delete(key))
-
-    MemcachedCache.delete = fixed_delete  # type: ignore[method-assign]
-
-
 patch_celery_imgcat()
 patch_pickle_loaders()
-patch_memcached()

--- a/src/sentry/utils/settings.py
+++ b/src/sentry/utils/settings.py
@@ -3,7 +3,7 @@ from sentry.utils.imports import import_string
 PACKAGES = {
     "django.db.backends.postgresql_psycopg2": "psycopg2.extensions",
     "sentry.db.postgres": "psycopg2.extensions",
-    "django.core.cache.backends.memcached.MemcachedCache": "memcache",
+    "sentry.utils.memcached.MemcachedCache": "memcache",
     "django.core.cache.backends.memcached.PyLibMCCache": "pylibmc",
 }
 

--- a/tests/sentry/utils/test_settings.py
+++ b/tests/sentry/utils/test_settings.py
@@ -31,7 +31,7 @@ DEPENDENCY_TEST_DATA = {
         "django.core.cache.backends.memcached.MemcachedCache",
         {
             "default": {
-                "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+                "BACKEND": "sentry.utils.memcached.MemcachedCache",
                 "LOCATION": "127.0.0.1:11211",
             }
         },


### PR DESCRIPTION
it is removed in django 4.2

<!-- Describe your PR here. -->