### PR TITLE
chore(api): make actionable items endpoint private

### DIFF
--- a/src/sentry/api/endpoints/actionable_items.py
+++ b/src/sentry/api/endpoints/actionable_items.py
@@ -37,7 +37,7 @@ class SourceMapProcessingResponse(TypedDict):
 @region_silo_endpoint
 class ActionableItemsEndpoint(ProjectEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ISSUES
 


### PR DESCRIPTION
this pr makes the actionable items endpoint private. 

closes https://github.com/getsentry/sentry/issues/61481