### PR TITLE
ref(open-pr-comments): match filename and function for multiple stackframes

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -310,7 +310,7 @@ def get_top_5_issues_by_count_for_file(
                     Condition(Column("group_id"), Op.IN, group_ids),
                     Condition(Column("timestamp"), Op.GTE, datetime.now() - timedelta(days=14)),
                     Condition(Column("timestamp"), Op.LT, datetime.now()),
-                    # NOTE: this currently looks at the top frame of the stack trace (old suspect commit logic)
+                    # NOTE: ideally this would follow suspect commit logic
                     BooleanCondition(
                         BooleanOp.OR,
                         [

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -9,7 +9,18 @@ from typing import Any, Dict, List, Set, Tuple
 
 from django.db.models import Value
 from django.db.models.functions import StrIndex
-from snuba_sdk import Column, Condition, Direction, Entity, Function, Op, OrderBy, Query
+from snuba_sdk import (
+    BooleanCondition,
+    BooleanOp,
+    Column,
+    Condition,
+    Direction,
+    Entity,
+    Function,
+    Op,
+    OrderBy,
+    Query,
+)
 from snuba_sdk import Request as SnubaRequest
 
 from sentry.integrations.github.client import GitHubAppsClient
@@ -55,6 +66,9 @@ class PullRequestFile:
 OPEN_PR_MAX_FILES_CHANGED = 7
 # Caps the number of lines that can be modified in a PR to leave a comment
 OPEN_PR_MAX_LINES_CHANGED = 500
+
+# Number of stackframes to check for filename + function combo, starting from the top
+STACKFRAME_COUNT = 6
 
 COMMENT_BODY_TEMPLATE = """## 🔍 Existing Issues For Review
 Your pull request is modifying functions with the following pre-existing issues:
@@ -297,15 +311,32 @@ def get_top_5_issues_by_count_for_file(
                     Condition(Column("timestamp"), Op.GTE, datetime.now() - timedelta(days=14)),
                     Condition(Column("timestamp"), Op.LT, datetime.now()),
                     # NOTE: this currently looks at the top frame of the stack trace (old suspect commit logic)
-                    Condition(
-                        Function("arrayElement", (Column("exception_frames.filename"), -1)),
-                        Op.IN,
-                        sentry_filenames,
-                    ),
-                    Condition(
-                        Function("arrayElement", (Column("exception_frames.function"), -1)),
-                        Op.IN,
-                        function_names,
+                    BooleanCondition(
+                        BooleanOp.OR,
+                        [
+                            BooleanCondition(
+                                BooleanOp.AND,
+                                [
+                                    Condition(
+                                        Function(
+                                            "arrayElement",
+                                            (Column("exception_frames.filename"), i),
+                                        ),
+                                        Op.IN,
+                                        sentry_filenames,
+                                    ),
+                                    Condition(
+                                        Function(
+                                            "arrayElement",
+                                            (Column("exception_frames.function"), i),
+                                        ),
+                                        Op.IN,
+                                        function_names,
+                                    ),
+                                ],
+                            )
+                            for i in range(-STACKFRAME_COUNT, 0)  # first n frames
+                        ],
                     ),
                     Condition(Function("notHandled", []), Op.EQ, 1),
                 ]


### PR DESCRIPTION
For open PR comments, to match issues with filenames and functions modified in a pull request, we are currently only looking at the top frame of the stacktrace. We can expand this to the first `n` frames of the stacktrace (`n=6` for now) to get some more feedback.