### PR TITLE
feat(performance-trace-details): Adding bug fixes from bug bash.

### DIFF
--- a/static/app/components/events/interfaces/spans/newTraceDetailsHeader.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsHeader.tsx
@@ -12,8 +12,6 @@ import toPercent from 'sentry/utils/number/toPercent';
 import {TraceType} from 'sentry/views/performance/traceDetails/newTraceDetailsContent';
 import {TraceInfo} from 'sentry/views/performance/traceDetails/types';
 
-import ReplayPreview from '../../eventReplay/replayPreview';
-
 import * as DividerHandlerManager from './dividerHandlerManager';
 
 type PropType = {
@@ -114,23 +112,6 @@ function TraceViewHeader(props: PropType) {
                   height: `100px`,
                 }}
               />
-              <div
-                style={{
-                  overflow: 'hidden',
-                  position: 'relative',
-                  height: '100px',
-                  width: `calc(${toPercent(1 - dividerPosition)} - 0.5px)`,
-                  left: `calc(${toPercent(dividerPosition)} + 0.5px)`,
-                }}
-              >
-                {event.contexts.replay?.replay_id && (
-                  <ReplayPreview
-                    replaySlug={event.contexts.replay?.replay_id ?? ''}
-                    orgSlug={props.organization.slug}
-                    eventTimestampMs={props.traceInfo.startTimestamp}
-                  />
-                )}
-              </div>
             </Fragment>
           );
         }}

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanBar.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanBar.tsx
@@ -168,6 +168,13 @@ export class NewTraceDetailsSpanBar extends Component<
     if (this.props.location.query !== prevProps.location.query) {
       this.updateHighlightedState();
     }
+
+    if(this.props.quickTrace !== prevProps.quickTrace){
+      const relatedErrors = this.getRelatedErrors(this.props.quickTrace);
+      if(this.isHighlighted && this.props.onRowClick && relatedErrors && relatedErrors.length > 0){
+        this.props.onRowClick(this.getSpanDetailsProps());
+      }
+    }
   }
 
   componentWillUnmount() {

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanTree.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanTree.tsx
@@ -23,7 +23,7 @@ import {Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {QuickTraceContextChildrenProps} from 'sentry/utils/performance/quickTrace/quickTraceContext';
 import {setGroupedEntityTag} from 'sentry/utils/performanceForSentry';
-import {TraceInfo} from 'sentry/views/performance/traceDetails/types';
+import {TraceInfo, TreeDepth} from 'sentry/views/performance/traceDetails/types';
 
 import {ActiveOperationFilter} from './filter';
 import {NewTraceDetailsProfiledSpanBar} from './newTraceDetailsSpanBar';
@@ -51,9 +51,10 @@ type PropType = ScrollbarManagerChildrenProps & {
   location: Location;
   operationNameFilters: ActiveOperationFilter;
   organization: Organization;
+  parentContinuingDepths: TreeDepth[];
   parentGeneration: number;
-  parentHasContinuingDepths: boolean;
   parentIsLast: boolean;
+  parentIsOrphan: boolean;
   quickTrace: QuickTraceContextChildrenProps;
   spanContextProps: SpanContext.SpanContextProps;
   spans: EnhancedProcessedSpanType[];
@@ -481,16 +482,22 @@ class NewTraceDetailsSpanTree extends Component<PropType> {
         });
 
         if (!this.props.parentIsLast) {
-          continuingTreeDepthPastParent.push(this.props.parentGeneration);
+          const value: TreeDepthType = this.props.parentIsOrphan ? {depth: this.props.parentGeneration, type: "orphan"} : this.props.parentGeneration;
+          continuingTreeDepthPastParent.push(value);
         }
 
         // Add continuing depths from the trace level to to span rows.
+        const {parentContinuingDepths, parentGeneration} = this.props;
         const minDepth = traceHasMultipleRoots ? 1 : 2;
         if (
-          (this.props.parentGeneration > 2 || traceHasMultipleRoots) &&
-          this.props.parentHasContinuingDepths
+          (parentGeneration > 2 || traceHasMultipleRoots) &&
+          parentContinuingDepths.length > 0
         ) {
-          let i = this.props.parentGeneration - 1;
+          // To avoid an extra connector line, skip a step of continuing depths if the parent txn is at least 2 generations deep
+          // and it's a last child.
+          const generationOffset = parentContinuingDepths.length === 1
+            && parentContinuingDepths[0].depth === 0 && parentGeneration > 2 ? 2 : 1;
+          let i = parentGeneration - generationOffset;
           while (i >= minDepth) {
             const value: TreeDepthType =
               traceHasMultipleRoots && i === 1 ? {depth: i, type: 'orphan'} : i;
@@ -789,22 +796,24 @@ class NewTraceDetailsSpanTree extends Component<PropType> {
     return (
       <TraceViewContainer>
         <WindowScroller onScroll={this.throttledOnScroll}>
-          {({height, isScrolling, onChildScroll, scrollTop}) => (
+          {({height, isScrolling, onChildScroll, scrollTop, registerChild}) => (
             <AutoSizer disableHeight>
               {({width}) => (
-                <ReactVirtualizedList
-                  autoHeight
-                  isScrolling={isScrolling}
-                  onScroll={onChildScroll}
-                  scrollTop={scrollTop}
-                  deferredMeasurementCache={this.cache}
-                  height={height}
-                  width={width}
-                  rowHeight={this.cache.rowHeight}
-                  rowCount={spanTree.length}
-                  rowRenderer={props => this.renderRow(props, spanTree)}
-                  ref={listRef}
-                />
+                <div ref={el => registerChild(el)}>
+                  <ReactVirtualizedList
+                    autoHeight
+                    isScrolling={isScrolling}
+                    onScroll={onChildScroll}
+                    scrollTop={scrollTop}
+                    deferredMeasurementCache={this.cache}
+                    height={height}
+                    width={width}
+                    rowHeight={this.cache.rowHeight}
+                    rowCount={spanTree.length}
+                    rowRenderer={props => this.renderRow(props, spanTree)}
+                    ref={listRef}
+                  />
+                </div>
               )}
             </AutoSizer>
           )}

--- a/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
@@ -418,6 +418,7 @@ function NewTraceDetailsTransactionBar(props: Props) {
         }
         position="top"
         containerDisplayMode="block"
+        delay={400}
       >
         <StyledZoomIcon
           isZoomIn={!showEmbeddedChildren}
@@ -494,12 +495,11 @@ function NewTraceDetailsTransactionBar(props: Props) {
                                   traceInfo={traceInfo}
                                   traceViewHeaderRef={traceViewRef}
                                   traceViewRef={traceViewRef}
-                                  parentHasContinuingDepths={
-                                    props.continuingDepths.length > 0
-                                  }
+                                  parentContinuingDepths={props.continuingDepths}
                                   traceHasMultipleRoots={props.continuingDepths.some(
                                     c => c.depth === 0 && c.isOrphanDepth
                                   )}
+                                  parentIsOrphan={props.isOrphan}
                                   parentIsLast={isLast}
                                   parentGeneration={transaction.generation ?? 0}
                                   organization={organization}
@@ -946,7 +946,7 @@ const StyledRowRectangle = styled(RowRectangle)`
 
 export const StyledZoomIcon = styled(IconZoom)`
   position: absolute;
-  left: -7px;
+  left: -20px;
   top: 4px;
   height: 16px;
   width: 18px;


### PR DESCRIPTION
This PR adds the following fixes for the performance trace view v0 project under the feature flag `organizations:performance-trace-details`: 

1. Loads issue section for anchored span detail. Try [link](https://sentry.dev.getsentry.net:7999/performance/trace/a96915a997c642ada39bfec9cb75f2da/?limit=100&pageEnd=2024-01-09T07%3A36%3A15.761&pageStart=2024-01-08T07%3A36%3A13.092#txn-57a514c50bf64658bfb45f2e927493c0#span-ac9e1840c0eb46bf), issue section should load in sync with when the error badge loads in the span bar.
<img width="1275" alt="Screenshot 2024-01-08 at 3 51 03 PM" src="https://github.com/getsentry/sentry/assets/60121741/f79303d4-b0a5-42a9-a583-7c92197edf7d">

2. Multiple react virtualized list open lag. Try zooming into 2 txns in the trace view and un zooming the first/top one. The other list of embedded spans should load seamlessly now. 
<img width="1273" alt="Screenshot 2024-01-08 at 3 43 29 PM" src="https://github.com/getsentry/sentry/assets/60121741/f26790bf-1e51-43d7-a7da-828a3fbdf632">

3. Removed replay preview and added replay link to trace view header. 
4. Added delay to zoom icon tooltips and pushed them to the left of the divider in the trace view. 
<img width="804" alt="Screenshot 2024-08-04 at 11 37 39 PM" src="https://github.com/user-attachments/assets/c2f5a120-5493-44ac-9951-92ad95248bf0">
