### PR TITLE
feat(webvitals): Unrevert perf score chart breakdown tooltip

### DIFF
--- a/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.spec.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.spec.tsx
@@ -1,0 +1,146 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {PerformanceScoreBreakdownChart} from 'sentry/views/performance/browser/webVitals/components/performanceScoreBreakdownChart';
+
+jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/usePageFilters');
+jest.mock('sentry/utils/useOrganization');
+
+describe('PerformanceScoreBreakdownChart', function () {
+  const organization = OrganizationFixture();
+  let eventsMock, eventsStatsMock;
+
+  beforeEach(function () {
+    jest.mocked(useLocation).mockReturnValue({
+      pathname: '',
+      search: '',
+      query: {},
+      hash: '',
+      state: undefined,
+      action: 'PUSH',
+      key: '',
+    });
+    jest.mocked(usePageFilters).mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    });
+    jest.mocked(useOrganization).mockReturnValue(organization);
+
+    eventsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [],
+      },
+    });
+    eventsStatsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      body: {},
+    });
+  });
+
+  afterEach(function () {
+    jest.resetAllMocks();
+  });
+
+  it('renders using frontend score calculation', async () => {
+    render(<PerformanceScoreBreakdownChart />);
+    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+    expect(eventsStatsMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        method: 'GET',
+        query: expect.objectContaining({
+          yAxis: [
+            'p75(measurements.lcp)',
+            'p75(measurements.fcp)',
+            'p75(measurements.cls)',
+            'p75(measurements.ttfb)',
+            'p75(measurements.fid)',
+            'count()',
+          ],
+        }),
+      })
+    );
+  });
+
+  it('renders using backend scores', async () => {
+    jest.mocked(useLocation).mockReturnValue({
+      pathname: '',
+      search: '',
+      query: {useStoredScores: 'true'},
+      hash: '',
+      state: undefined,
+      action: 'PUSH',
+      key: '',
+    });
+    render(<PerformanceScoreBreakdownChart />);
+    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+    expect(eventsMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      expect.objectContaining({
+        method: 'GET',
+        query: expect.objectContaining({
+          field: [
+            'performance_score(measurements.score.lcp)',
+            'performance_score(measurements.score.fcp)',
+            'performance_score(measurements.score.cls)',
+            'performance_score(measurements.score.fid)',
+            'performance_score(measurements.score.ttfb)',
+            'avg(measurements.score.total)',
+            'avg(measurements.score.weight.lcp)',
+            'avg(measurements.score.weight.fcp)',
+            'avg(measurements.score.weight.cls)',
+            'avg(measurements.score.weight.fid)',
+            'avg(measurements.score.weight.ttfb)',
+            'count()',
+            'count_scores(measurements.score.total)',
+            'count_scores(measurements.score.lcp)',
+            'count_scores(measurements.score.fcp)',
+            'count_scores(measurements.score.cls)',
+            'count_scores(measurements.score.ttfb)',
+            'count_scores(measurements.score.fid)',
+          ],
+        }),
+      })
+    );
+
+    expect(eventsStatsMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        method: 'GET',
+        query: expect.objectContaining({
+          yAxis: [
+            'weighted_performance_score(measurements.score.lcp)',
+            'weighted_performance_score(measurements.score.fcp)',
+            'weighted_performance_score(measurements.score.cls)',
+            'weighted_performance_score(measurements.score.fid)',
+            'weighted_performance_score(measurements.score.ttfb)',
+            'performance_score(measurements.score.lcp)',
+            'performance_score(measurements.score.fcp)',
+            'performance_score(measurements.score.cls)',
+            'performance_score(measurements.score.fid)',
+            'performance_score(measurements.score.ttfb)',
+            'count()',
+          ],
+        }),
+      })
+    );
+  });
+});

--- a/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
@@ -8,6 +8,9 @@ import {Series} from 'sentry/types/echarts';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {PERFORMANCE_SCORE_WEIGHTS} from 'sentry/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/calculatePerformanceScore';
 import {WebVitalsScoreBreakdown} from 'sentry/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsTimeseriesQuery';
+import {calculatePerformanceScoreFromStoredTableDataRow} from 'sentry/views/performance/browser/webVitals/utils/queries/storedScoreQueries/calculatePerformanceScoreFromStored';
+import {useProjectWebVitalsScoresQuery} from 'sentry/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery';
+import {UnweightedWebVitalsScoreBreakdown} from 'sentry/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery';
 import {useProjectWebVitalsTimeseriesQuery} from 'sentry/views/performance/browser/webVitals/utils/queries/useProjectWebVitalsTimeseriesQuery';
 import {useStoredScoresSetting} from 'sentry/views/performance/browser/webVitals/utils/useStoredScoresSetting';
 import Chart from 'sentry/views/starfish/components/chart';
@@ -93,9 +96,52 @@ export function PerformanceScoreBreakdownChart({transaction}: Props) {
   const pageFilters = usePageFilters();
 
   const {data, isLoading} = useProjectWebVitalsTimeseriesQuery({transaction});
+  const {data: projectScores, isLoading: isProjectScoresLoading} =
+    useProjectWebVitalsScoresQuery({transaction, enabled: shouldUseStoredScores});
+
+  const projectScore =
+    shouldUseStoredScores && isProjectScoresLoading
+      ? undefined
+      : calculatePerformanceScoreFromStoredTableDataRow(projectScores?.data?.[0]);
 
   const period = pageFilters.selection.datetime.period;
   const performanceScoreSubtext = (period && DEFAULT_RELATIVE_PERIODS[period]) ?? '';
+
+  const weightedTimeseries = formatTimeSeriesResultsToChartData(
+    data,
+    segmentColors,
+    !shouldUseStoredScores
+  );
+
+  const storedScores = data as WebVitalsScoreBreakdown &
+    UnweightedWebVitalsScoreBreakdown;
+
+  const unweightedTimeseries = formatTimeSeriesResultsToChartData(
+    shouldUseStoredScores
+      ? {
+          lcp: storedScores.unweightedLcp,
+          fcp: storedScores.unweightedFcp,
+          fid: storedScores.unweightedFid,
+          cls: storedScores.unweightedCls,
+          ttfb: storedScores.unweightedTtfb,
+          total: storedScores.total,
+        }
+      : data,
+    segmentColors,
+    false
+  );
+
+  const weights = !shouldUseStoredScores
+    ? PERFORMANCE_SCORE_WEIGHTS
+    : projectScore !== undefined
+    ? {
+        lcp: projectScore.lcpWeight,
+        fcp: projectScore.fcpWeight,
+        fid: projectScore.fidWeight,
+        cls: projectScore.clsWeight,
+        ttfb: projectScore.ttfbWeight,
+      }
+    : undefined;
 
   return (
     <ChartContainer>
@@ -104,13 +150,9 @@ export function PerformanceScoreBreakdownChart({transaction}: Props) {
       <Chart
         stacked
         height={180}
-        data={formatTimeSeriesResultsToChartData(
-          data,
-          segmentColors,
-          !shouldUseStoredScores
-        )}
+        data={weightedTimeseries}
         disableXAxis
-        loading={isLoading}
+        loading={isLoading || (shouldUseStoredScores && isProjectScoresLoading)}
         grid={{
           left: 5,
           right: 5,
@@ -120,6 +162,26 @@ export function PerformanceScoreBreakdownChart({transaction}: Props) {
         dataMax={100}
         chartColors={segmentColors}
         preserveIncompletePoints
+        tooltipFormatterOptions={{
+          nameFormatter: name => {
+            // nameFormatter expects a string an will wrap the output in an html string.
+            // Kind of a hack, but we can inject some html to escape styling for the subLabel.
+            const subLabel =
+              weights !== undefined
+                ? ` </strong>(${
+                    weights[name.toLocaleLowerCase()]
+                  }% of Perf Score)<strong>`
+                : '';
+            return `${name} Score${subLabel}`;
+          },
+          valueFormatter: (_value, _label, seriesParams: any) => {
+            const timestamp = seriesParams?.data[0];
+            const unweightedValue = unweightedTimeseries
+              .find(series => series.seriesName === seriesParams?.seriesName)
+              ?.data.find(dataPoint => dataPoint.name === timestamp)?.value;
+            return `<span class="tooltip-label-value">${unweightedValue}</span>`;
+          },
+        }}
       />
     </ChartContainer>
   );

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
@@ -10,20 +10,21 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {WebVitalsScoreBreakdown} from 'sentry/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsTimeseriesQuery';
 
 type Props = {
   enabled?: boolean;
   tag?: Tag;
   transaction?: string | null;
+  weighted?: boolean;
 };
 
-export type WebVitalsScoreBreakdown = {
-  cls: SeriesDataUnit[];
-  fcp: SeriesDataUnit[];
-  fid: SeriesDataUnit[];
-  lcp: SeriesDataUnit[];
-  total: SeriesDataUnit[];
-  ttfb: SeriesDataUnit[];
+export type UnweightedWebVitalsScoreBreakdown = {
+  unweightedCls: SeriesDataUnit[];
+  unweightedFcp: SeriesDataUnit[];
+  unweightedFid: SeriesDataUnit[];
+  unweightedLcp: SeriesDataUnit[];
+  unweightedTtfb: SeriesDataUnit[];
 };
 
 export const useProjectWebVitalsScoresTimeseriesQuery = ({
@@ -42,6 +43,11 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
         'weighted_performance_score(measurements.score.cls)',
         'weighted_performance_score(measurements.score.fid)',
         'weighted_performance_score(measurements.score.ttfb)',
+        'performance_score(measurements.score.lcp)',
+        'performance_score(measurements.score.fcp)',
+        'performance_score(measurements.score.cls)',
+        'performance_score(measurements.score.fid)',
+        'performance_score(measurements.score.ttfb)',
         'count()',
       ],
       name: 'Web Vitals',
@@ -85,22 +91,40 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
     referrer: 'api.performance.browser.web-vitals.timeseries-scores',
   });
 
-  const data: WebVitalsScoreBreakdown = {
+  const data: WebVitalsScoreBreakdown & UnweightedWebVitalsScoreBreakdown = {
     lcp: [],
     fcp: [],
     cls: [],
     ttfb: [],
     fid: [],
     total: [],
+    unweightedCls: [],
+    unweightedFcp: [],
+    unweightedFid: [],
+    unweightedLcp: [],
+    unweightedTtfb: [],
   };
 
   result?.data?.['weighted_performance_score(measurements.score.lcp)']?.data.forEach(
     (interval, index) => {
+      // Weighted data
       ['lcp', 'fcp', 'cls', 'ttfb', 'fid'].forEach(webVital => {
         data[webVital].push({
           value:
             result?.data?.[`weighted_performance_score(measurements.score.${webVital})`]
               ?.data[index][1][0].count * 100 ?? 0,
+          name: interval[0] * 1000,
+        });
+      });
+      // Unweighted data
+      ['lcp', 'fcp', 'cls', 'ttfb', 'fid'].forEach(webVital => {
+        // Capitalize first letter of webVital
+        const capitalizedWebVital = webVital.charAt(0).toUpperCase() + webVital.slice(1);
+        data[`unweighted${capitalizedWebVital}`].push({
+          value:
+            result?.data?.[`performance_score(measurements.score.${webVital})`]?.data[
+              index
+            ][1][0].count * 100 ?? 0,
           name: interval[0] * 1000,
         });
       });


### PR DESCRIPTION
Unreverts the following pr, with fixes to broken test import:
https://github.com/getsentry/sentry/pull/62057

Adds better tooltips for the Performance Score breakdown chart component.
Also adds some tests.
<img width="583" alt="image" src="https://github.com/getsentry/sentry/assets/83961295/39d88e1d-7029-4d7c-9bf6-b4d4b0dbe3e4">
