### PR TITLE
test(hc): Set SENTRY_REGION to null when swapping into control mode

### DIFF
--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -363,11 +363,9 @@ def assume_test_silo_mode(desired_silo: SiloMode, can_be_monolith: bool = True) 
             region_dir = get_test_env_directory()
             with region_dir.swap_to_default_region():
                 yield
-        elif desired_silo == SiloMode.MONOLITH:
+        else:
             with override_settings(SENTRY_REGION=None):
                 yield
-        else:
-            yield
 
 
 @contextmanager


### PR DESCRIPTION
No tests are known to be affected, but this should reflect production reality a little better.