### PR TITLE
fix(issues): Hide stacktrace link button for unminify

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -429,7 +429,7 @@ export class DeprecatedLine extends Component<Props, State> {
                 </SourceMapDebuggerModalButton>
               </Fragment>
             ) : null}
-            {showStacktraceLinkInFrame && (
+            {showStacktraceLinkInFrame && !shouldShowSourceMapDebuggerButton && (
               <ErrorBoundary>
                 <StacktraceLink
                   frame={data}
@@ -438,7 +438,7 @@ export class DeprecatedLine extends Component<Props, State> {
                 />
               </ErrorBoundary>
             )}
-            {showSentryAppStacktraceLinkInFrame && (
+            {showSentryAppStacktraceLinkInFrame && !shouldShowSourceMapDebuggerButton && (
               <ErrorBoundary mini>
                 <OpenInContextLine
                   lineNo={data.lineNo}


### PR DESCRIPTION
hides the stacktrace links when the "unminify code" button is present

before
![Screenshot 2024-01-08 at 3 00 04 PM](https://github.com/getsentry/sentry/assets/1400464/175e064a-c716-4a14-89bc-88f2b0c6a63e)


after
![Screenshot 2024-01-08 at 2 59 25 PM](https://github.com/getsentry/sentry/assets/1400464/78e05139-2bfe-4920-b3b4-d48c6b1762eb)
