### PR TITLE
feat(breadcrumbs): Add tooltip to Sentry Transaction that cannot be found

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.tsx
@@ -4,6 +4,8 @@ import type {BreadcrumbTransactionEvent} from 'sentry/components/events/interfac
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import Highlight from 'sentry/components/highlight';
 import Link from 'sentry/components/links/link';
+import {Tooltip} from 'sentry/components/tooltip';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {BreadcrumbTypeDefault, BreadcrumbTypeNavigation} from 'sentry/types/breadcrumbs';
@@ -106,7 +108,12 @@ function FormatMessage({
         <Highlight text={searchTerm}>{transactionData.title}</Highlight>
       </Link>
     ) : (
-      content
+      <Tooltip
+        showUnderline
+        title={t('This transaction cannot be found due to sampling.')}
+      >
+        {content}
+      </Tooltip>
     );
 
     return description;


### PR DESCRIPTION
we previously added in the ability to show transaction names on Sentry Transactions in breadcrumbs, while removing the hyperlink for transactions that were sampled. This adds in a tooltip to explain why the transaction cannot be clicked on. 

Closes https://github.com/getsentry/sentry/issues/62800