### PR TITLE
ref(slack): Allow for some more billing attachments

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -628,7 +628,12 @@ class SlackActionEndpoint(Endpoint):
         action_option = self.get_action_option(slack_request=slack_request)
 
         # If a user is just clicking a button link we return a 200
-        if action_option in ("sentry_docs_link_clicked", "grace_period_warning"):
+        if action_option in (
+            "sentry_docs_link_clicked",
+            "grace_period_warning",
+            "integration_disabled_slack",
+            "trial_end_warning",
+        ):
             return self.respond()
 
         if action_option in UNFURL_ACTION_OPTIONS:


### PR DESCRIPTION
Allow for a couple more billing attachment links to be clicked with a 200 response - this must be merged prior to https://github.com/getsentry/getsentry/pull/12516 and https://github.com/getsentry/getsentry/pull/12521 being merged. 