### PR TITLE
fix(issues): Display stacktracelink for native frames w/o lineNo

### DIFF
--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -148,8 +148,7 @@ function NativeFrame({
   const [isHovering, setHovering] = useState(false);
 
   const contextLine = (frame?.context || []).find(l => l[0] === frame.lineNo);
-  const hasStacktraceLink =
-    frame.inApp && !!frame.filename && frame.lineNo && (isHovering || expanded);
+  const hasStacktraceLink = frame.inApp && !!frame.filename && (isHovering || expanded);
   const hasStacktraceLinkInFrameFeatureFlag =
     organization?.features?.includes('issue-details-stacktrace-link-in-frame') ?? false;
   const showStacktraceLinkInFrame =

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -234,6 +234,9 @@ export const getIntegrationSourceUrl = (
     case 'github':
     case 'github_enterprise':
     default:
+      if (lineNo === null) {
+        return sourceUrl;
+      }
       return `${sourceUrl}#L${lineNo}`;
   }
 };


### PR DESCRIPTION
example issue https://demo.sentry.io/issues/4059070900/?project=6249899&query=is%3Aunresolved+issue.category%3Aerror&referrer=issue-stream&statsPeriod=14d&stream_index=0

![image](https://github.com/getsentry/sentry/assets/1400464/1f78c8d0-36f6-411f-9068-cb8f44bb7187)
