### PR TITLE
fix(issues): On hover native frame, hide filename

### DIFF
--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -333,17 +333,41 @@ function NativeFrame({
             </AddressCell>
           </GenericCellWrapper>
           <FunctionNameCell>
-            {functionName ? (
-              <AnnotatedText value={functionName.value} meta={functionName.meta} />
-            ) : (
-              `<${t('unknown')}>`
-            )}{' '}
-            {frame.filename && (
+            <Tooltip
+              title={
+                <Fragment>
+                  <FileName>
+                    {absoluteFilePaths ? frame.absPath : frame.filename}
+                    {frame.lineNo && `:${frame.lineNo}`}
+                  </FileName>
+                  <div>{frame.absPath}</div>
+                </Fragment>
+              }
+              disabled={
+                !frame.filename ||
+                !showStacktraceLinkInFrame ||
+                !(defined(frame.absPath) && frame.absPath !== frame.filename)
+              }
+              delay={tooltipDelay}
+              overlayStyle={{maxWidth: '60vw'}}
+              isHoverable
+              skipWrapper
+            >
+              <span>
+                {functionName ? (
+                  <AnnotatedText value={functionName.value} meta={functionName.meta} />
+                ) : (
+                  `<${t('unknown')}>`
+                )}{' '}
+              </span>
+            </Tooltip>
+            {frame.filename && !showStacktraceLinkInFrame && (
               <Tooltip
                 title={frame.absPath}
                 disabled={!(defined(frame.absPath) && frame.absPath !== frame.filename)}
                 delay={tooltipDelay}
                 isHoverable
+                skipWrapper
               >
                 <FileName>
                   {'('}

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -333,49 +333,57 @@ function NativeFrame({
             </AddressCell>
           </GenericCellWrapper>
           <FunctionNameCell>
-            <Tooltip
-              title={
-                <Fragment>
-                  <FileName>
-                    {absoluteFilePaths ? frame.absPath : frame.filename}
-                    {frame.lineNo && `:${frame.lineNo}`}
-                  </FileName>
-                  <div>{frame.absPath}</div>
-                </Fragment>
-              }
-              disabled={
-                !frame.filename ||
-                !showStacktraceLinkInFrame ||
-                !(defined(frame.absPath) && frame.absPath !== frame.filename)
-              }
-              delay={tooltipDelay}
-              overlayStyle={{maxWidth: '60vw'}}
-              isHoverable
-              skipWrapper
-            >
-              <span>
+            {hasStacktraceLinkInFrameFeatureFlag ? (
+              <Tooltip
+                title={
+                  <Fragment>
+                    <FileName>
+                      {absoluteFilePaths ? frame.absPath : frame.filename}
+                      {frame.lineNo && `:${frame.lineNo}`}
+                    </FileName>
+                    {defined(frame.absPath) && frame.absPath !== frame.filename && (
+                      <div>{frame.absPath}</div>
+                    )}
+                  </Fragment>
+                }
+                delay={tooltipDelay}
+                overlayStyle={{maxWidth: '65vw'}}
+                isHoverable
+                skipWrapper
+              >
+                <span>
+                  {functionName ? (
+                    <AnnotatedText value={functionName.value} meta={functionName.meta} />
+                  ) : (
+                    `<${t('unknown')}>`
+                  )}{' '}
+                </span>
+              </Tooltip>
+            ) : (
+              <Fragment>
                 {functionName ? (
                   <AnnotatedText value={functionName.value} meta={functionName.meta} />
                 ) : (
                   `<${t('unknown')}>`
                 )}{' '}
-              </span>
-            </Tooltip>
-            {frame.filename && !showStacktraceLinkInFrame && (
-              <Tooltip
-                title={frame.absPath}
-                disabled={!(defined(frame.absPath) && frame.absPath !== frame.filename)}
-                delay={tooltipDelay}
-                isHoverable
-                skipWrapper
-              >
-                <FileName>
-                  {'('}
-                  {absoluteFilePaths ? frame.absPath : frame.filename}
-                  {frame.lineNo && `:${frame.lineNo}`}
-                  {')'}
-                </FileName>
-              </Tooltip>
+                {frame.filename && (
+                  <Tooltip
+                    title={frame.absPath}
+                    disabled={
+                      !(defined(frame.absPath) && frame.absPath !== frame.filename)
+                    }
+                    delay={tooltipDelay}
+                    isHoverable
+                  >
+                    <FileName>
+                      {'('}
+                      {absoluteFilePaths ? frame.absPath : frame.filename}
+                      {frame.lineNo && `:${frame.lineNo}`}
+                      {')'}
+                    </FileName>
+                  </Tooltip>
+                )}
+              </Fragment>
             )}
           </FunctionNameCell>
           <GroupingCell>


### PR DESCRIPTION
make room for the stacktrace links by hiding the filename and putting it in the tooltip

before
![Screenshot 2024-01-09 at 2 26 27 PM](https://github.com/getsentry/sentry/assets/1400464/a32dfdcb-23ea-4a64-9d1b-d8281fb043a0)

after
![Screenshot 2024-01-09 at 2 26 45 PM](https://github.com/getsentry/sentry/assets/1400464/63314f28-9862-49ef-bf67-17bd40c5990d)


using [this issue](https://demo.sentry.io/issues/4059070900/?project=6249899&query=is%3Aunresolved+issue.category%3Aerror&referrer=issue-stream&statsPeriod=14d&stream_index=0) to test