### PR TITLE
feat(stacktrace-links): Add groupId to stacktracelink query

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -69,6 +69,7 @@ describe('StacktraceLink', function () {
           file: frame.filename,
           platform,
           lineNo: frame.lineNo,
+          groupId: event.groupID,
         },
       })
     );

--- a/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
@@ -2,7 +2,7 @@ import type {Event, Frame, StacktraceLinkResult} from 'sentry/types';
 import {ApiQueryKey, useApiQuery, UseApiQueryOptions} from 'sentry/utils/queryClient';
 
 interface UseStacktraceLinkProps {
-  event: Partial<Pick<Event, 'platform' | 'release' | 'sdk'>>;
+  event: Partial<Pick<Event, 'platform' | 'release' | 'sdk' | 'groupID'>>;
   frame: Partial<
     Pick<Frame, 'absPath' | 'filename' | 'function' | 'module' | 'package' | 'lineNo'>
   >;
@@ -29,6 +29,7 @@ function useStacktraceLink(
     ...(frame.module && {module: frame.module}),
     ...(frame.package && {package: frame.package}),
     lineNo: frame.lineNo,
+    groupId: event.groupID,
   };
 
   return useApiQuery<StacktraceLinkResult>(


### PR DESCRIPTION
## Objective:

Frontend PR for the broader analytics around Stacktrace Link backend optimizations.

Related Backend PR: https://github.com/getsentry/sentry/pull/62812

Should be merged first.

Related Issue: https://github.com/getsentry/sentry/issues/62708