### PR TITLE
feat(ddm): Add the possibility to query `transaction.duration` spans

### DIFF
--- a/src/sentry/api/serializers/models/metric_spans.py
+++ b/src/sentry/api/serializers/models/metric_spans.py
@@ -19,6 +19,8 @@ class MetricSpansSerializer(Serializer):
             "transactionId": span_payload.get("transaction_id"),
             "profileId": span_payload.get("profile_id"),
             "duration": span_payload.get("duration"),
+            "segmentName": span_payload.get("segment_name"),
+            "timestamp": span_payload.get("timestamp"),
         }
 
     def serialize(self, obj, attrs, user):

--- a/src/sentry/sentry_metrics/querying/metadata/metric_spans.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metric_spans.py
@@ -240,7 +240,7 @@ def get_indexed_spans(
     projects: Sequence[Project],
 ):
     """
-    Fetches top N most recent indexed spans by building a SNQL query directly.
+    Fetches top N most recent indexed spans.
 
     The choice of not using query builders was deliberate, since we have to access columns that are not exposed via
     the query builders because they are meant to be internal.

--- a/src/sentry/sentry_metrics/querying/metadata/metric_spans.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metric_spans.py
@@ -240,7 +240,10 @@ def get_indexed_spans(
     projects: Sequence[Project],
 ):
     """
-    Fetches indexed spans using internal query builders.
+    Fetches top N most recent indexed spans by building a SNQL query directly.
+
+    The choice of not using query builders was deliberate, since we have to access columns that are not exposed via
+    the query builders because they are meant to be internal.
     """
     query = Query(
         match=Entity(EntityKey.Spans.value),
@@ -262,6 +265,7 @@ def get_indexed_spans(
         + (where or []),
         # We want to get the newest spans.
         orderby=[OrderBy(Column("timestamp"), Direction.DESC)],
+        limit=Limit(MAX_NUMBER_OF_SPANS),
     )
 
     request = Request(

--- a/src/sentry/sentry_metrics/querying/metadata/utils.py
+++ b/src/sentry/sentry_metrics/querying/metadata/utils.py
@@ -7,7 +7,9 @@ from snuba_sdk.mql.mql import parse_mql
 from sentry.sentry_metrics.querying.api import InvalidMetricsQueryError
 
 
-def transform_to_tags(conditions: Optional[ConditionGroup]) -> Optional[ConditionGroup]:
+def transform_to_tags(
+    conditions: Optional[ConditionGroup], tags_field: str = "tags"
+) -> Optional[ConditionGroup]:
     """
     Transforms all the conditions to work on tags, by wrapping each `Column` name with 'tags[x]'.
 
@@ -28,7 +30,7 @@ def transform_to_tags(conditions: Optional[ConditionGroup]) -> Optional[Conditio
         elif isinstance(condition, Condition) and isinstance(condition.lhs, Column):
             # We assume that all incoming conditions are on tags, since we do not allow filtering by project in the
             # query filters.
-            tag_column = f"tags[{condition.lhs.name}]"
+            tag_column = f"{tags_field}[{condition.lhs.name}]"
             transformed_conditions.append(
                 Condition(lhs=Column(name=tag_column), op=condition.op, rhs=condition.rhs)
             )
@@ -52,4 +54,4 @@ def get_snuba_conditions_from_query(query: str) -> Optional[ConditionGroup]:
         # For now, we reuse data from `api` but we will soon lift out common components from that file.
         raise InvalidMetricsQueryError("The supplied query is not valid")
 
-    return transform_to_tags(parsed_phantom_query.filters)
+    return parsed_phantom_query.filters

--- a/src/sentry/sentry_metrics/querying/metadata/utils.py
+++ b/src/sentry/sentry_metrics/querying/metadata/utils.py
@@ -1,17 +1,17 @@
-from typing import Optional
+from typing import Mapping, Optional
 
 from snuba_sdk import Column, Condition, Timeseries
-from snuba_sdk.conditions import BooleanCondition, ConditionGroup
+from snuba_sdk.conditions import BooleanCondition, BooleanOp, ConditionGroup
 from snuba_sdk.mql.mql import parse_mql
 
 from sentry.sentry_metrics.querying.api import InvalidMetricsQueryError
 
 
 def transform_to_tags(
-    conditions: Optional[ConditionGroup], tags_field: str = "tags"
+    conditions: Optional[ConditionGroup], check_sentry_tags: bool = False
 ) -> Optional[ConditionGroup]:
     """
-    Transforms all the conditions to work on tags, by wrapping each `Column` name with 'tags[x]'.
+    Transforms all the conditions to work on tags, by wrapping each `Column` name with 'tags[x]' and `sentry_tags[x]`.
 
     This function assumes that the query of a metric only refers to tags, since it can't be inferred that it's not
     referring to tags by just looking at the string. The values that are not tags, are specific to the data layer.
@@ -24,15 +24,72 @@ def transform_to_tags(
         if isinstance(condition, BooleanCondition):
             transformed_conditions.append(
                 BooleanCondition(
-                    op=condition.op, conditions=transform_to_tags(condition.conditions)
+                    op=condition.op,
+                    conditions=transform_to_tags(condition.conditions, check_sentry_tags),
                 )
             )
         elif isinstance(condition, Condition) and isinstance(condition.lhs, Column):
             # We assume that all incoming conditions are on tags, since we do not allow filtering by project in the
             # query filters.
-            tag_column = f"{tags_field}[{condition.lhs.name}]"
+            tag_column = f"tags[{condition.lhs.name}]"
+            sentry_tag_column = f"sentry_tags[{condition.lhs.name}]"
+
+            if check_sentry_tags:
+                tag_column = f"tags[{condition.lhs.name}]"
+                # We might have tags across multiple nested structures such as `tags` and `sentry_tags` for this reason
+                # we want to emit a condition that spans both.
+                transformed_conditions.append(
+                    BooleanCondition(
+                        op=BooleanOp.OR,
+                        conditions=[
+                            Condition(
+                                lhs=Column(name=tag_column), op=condition.op, rhs=condition.rhs
+                            ),
+                            Condition(
+                                lhs=Column(name=sentry_tag_column),
+                                op=condition.op,
+                                rhs=condition.rhs,
+                            ),
+                        ],
+                    )
+                )
+            else:
+                transformed_conditions.append(
+                    Condition(lhs=Column(name=tag_column), op=condition.op, rhs=condition.rhs)
+                )
+
+    return transformed_conditions
+
+
+def transform_conditions_with(
+    conditions: Optional[ConditionGroup], mappings: Optional[Mapping[str, str]] = None
+) -> Optional[ConditionGroup]:
+    """
+    Maps all the `Column`(s) whose `key` matches one of the supplied mappings. If found, replaces it with the mapped
+    value.
+    """
+    if conditions is None:
+        return None
+
+    if not mappings:
+        return conditions
+
+    transformed_conditions = []
+    for condition in conditions:
+        if isinstance(condition, BooleanCondition):
             transformed_conditions.append(
-                Condition(lhs=Column(name=tag_column), op=condition.op, rhs=condition.rhs)
+                BooleanCondition(
+                    op=condition.op,
+                    conditions=transform_conditions_with(condition.conditions, mappings),
+                )
+            )
+        elif isinstance(condition, Condition) and isinstance(condition.lhs, Column):
+            new_value = condition.lhs.name
+            if (mapped_value := mappings.get(condition.lhs.key)) is not None:
+                new_value = mapped_value
+
+            transformed_conditions.append(
+                Condition(lhs=Column(name=new_value), op=condition.op, rhs=condition.rhs)
             )
 
     return transformed_conditions

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1401,15 +1401,15 @@ class BaseSpansTestCase(SnubaTestCase):
         metrics_summary: Optional[Mapping[str, Sequence[Mapping[str, Any]]]] = None,
         timestamp: datetime = None,
         tags: Mapping[str, Any] = None,
-        sentry_tags: Mapping[str, Any] = None,
         store_only_summary: bool = False,
         is_segment: int = 0,
         duration_ms: int = 10,
+        transaction: str = None,
     ):
         payload = {
             "start_timestamp_ms": int(timestamp.timestamp() * 1000),
             "exclusive_time_ms": 5,
-            "duration_ms": 10,
+            "duration_ms": duration_ms,
             "project_id": project_id,
             "span_id": span_id,
             "trace_id": trace_id,
@@ -1418,6 +1418,9 @@ class BaseSpansTestCase(SnubaTestCase):
             "tags": tags,
             "is_segment": is_segment,
         }
+
+        sentry_tags = {"transaction": transaction or "/hello"}
+
         if sentry_tags:
             payload["sentry_tags"] = sentry_tags
         if metrics_summary:

--- a/tests/sentry/api/endpoints/test_organization_ddm_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_ddm_meta.py
@@ -639,8 +639,54 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             statsPeriod="1d",
             metricSpans="true",
         )
-
         metric_spans = response.data["metricSpans"]
         assert len(metric_spans) == 1
+        assert metric_spans[0]["spanId"] == data[1][0]
+        assert metric_spans[0]["segmentName"] == data[1][1]
+
+        response = self.get_success_response(
+            self.organization.slug,
+            metric=[mri],
+            query="transaction:/api/users AND (device:OnePlus OR device:iPhone)",
+            min="50",
+            max="150",
+            project=[self.project.id],
+            statsPeriod="1d",
+            metricSpans="true",
+        )
+        metric_spans = response.data["metricSpans"]
+        assert len(metric_spans) == 2
+        assert metric_spans[0]["spanId"] == data[0][0]
+        assert metric_spans[0]["segmentName"] == data[0][1]
+        assert metric_spans[0]["spanId"] == data[1][0]
+        assert metric_spans[0]["segmentName"] == data[1][1]
+
+        response = self.get_success_response(
+            self.organization.slug,
+            metric=[mri],
+            query="transaction:/api/users AND device:iPhone AND device:OnePlus",
+            min="50",
+            max="150",
+            project=[self.project.id],
+            statsPeriod="1d",
+            metricSpans="true",
+        )
+        metric_spans = response.data["metricSpans"]
+        assert len(metric_spans) == 0
+
+        response = self.get_success_response(
+            self.organization.slug,
+            metric=[mri],
+            query="",
+            min="50",
+            max="150",
+            project=[self.project.id],
+            statsPeriod="1d",
+            metricSpans="true",
+        )
+        metric_spans = response.data["metricSpans"]
+        assert len(metric_spans) == 2
+        assert metric_spans[0]["spanId"] == data[0][0]
+        assert metric_spans[0]["segmentName"] == data[0][1]
         assert metric_spans[0]["spanId"] == data[1][0]
         assert metric_spans[0]["segmentName"] == data[1][1]

--- a/tests/sentry/api/endpoints/test_organization_ddm_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_ddm_meta.py
@@ -485,46 +485,26 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
     def test_get_metric_spans_with_multiple_spans(self):
         mri = "g:custom/page_load@millisecond"
 
-        span_id_1 = "98230207e6e4a6ad"
-        self.store_span(
-            project_id=self.project.id,
-            timestamp=before_now(minutes=5),
-            span_id=span_id_1,
-            metrics_summary={
-                mri: [
-                    {
-                        "min": 10.0,
-                        "max": 100.0,
-                        "sum": 110.0,
-                        "count": 2,
-                        "tags": {
-                            "transaction": "/hello",
-                        },
-                    }
-                ]
-            },
-        )
-
-        span_id_2 = "10220507e6f4e6ad"
-        self.store_span(
-            project_id=self.project.id,
-            # We mark the second span as "older".
-            timestamp=before_now(minutes=10),
-            span_id=span_id_2,
-            metrics_summary={
-                mri: [
-                    {
-                        "min": 10.0,
-                        "max": 100.0,
-                        "sum": 110.0,
-                        "count": 2,
-                        "tags": {
-                            "transaction": "/world",
-                        },
-                    }
-                ]
-            },
-        )
+        data = [("98230207e6e4a6ad", "/hello"), ("10220507e6f4e6ad", "/world")]
+        for index, (span_id, transaction) in enumerate(data):
+            self.store_span(
+                project_id=self.project.id,
+                timestamp=before_now(minutes=5 - index),
+                span_id=span_id,
+                metrics_summary={
+                    mri: [
+                        {
+                            "min": 10.0,
+                            "max": 100.0,
+                            "sum": 110.0,
+                            "count": 2,
+                            "tags": {
+                                "transaction": transaction,
+                            },
+                        }
+                    ]
+                },
+            )
 
         response = self.get_success_response(
             self.organization.slug,
@@ -537,8 +517,8 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
         metric_spans = response.data["metricSpans"]
         assert len(metric_spans) == 2
         # We expect the first span to be the newest.
-        assert metric_spans[0]["spanId"] == span_id_1
-        assert metric_spans[1]["spanId"] == span_id_2
+        assert metric_spans[0]["spanId"] == data[1][0]
+        assert metric_spans[1]["spanId"] == data[0][0]
 
     @patch("sentry.sentry_metrics.querying.metadata.metric_spans.MAX_NUMBER_OF_SPANS", 1)
     def test_get_metric_spans_with_limit_exceeded(self):
@@ -616,12 +596,12 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
 
         data = [
             ("98230207e6e4a6ad", "/api/users", "iPhone"),
-            ("98230207e6e4a6ad", "/api/users", "OnePlus"),
+            ("96b41c8d77b591ab", "/api/users", "OnePlus"),
         ]
-        for span_id, transaction, device in data:
+        for index, (span_id, transaction, device) in enumerate(data):
             self.store_span(
                 project_id=self.project.id,
-                timestamp=before_now(minutes=5),
+                timestamp=before_now(minutes=5 - index),
                 span_id=span_id,
                 is_segment=1,
                 duration_ms=100,
@@ -633,8 +613,6 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             self.organization.slug,
             metric=[mri],
             query="transaction:/api/users AND device:OnePlus",
-            min="50",
-            max="150",
             project=[self.project.id],
             statsPeriod="1d",
             metricSpans="true",
@@ -648,25 +626,21 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             self.organization.slug,
             metric=[mri],
             query="transaction:/api/users AND (device:OnePlus OR device:iPhone)",
-            min="50",
-            max="150",
             project=[self.project.id],
             statsPeriod="1d",
             metricSpans="true",
         )
         metric_spans = response.data["metricSpans"]
         assert len(metric_spans) == 2
-        assert metric_spans[0]["spanId"] == data[0][0]
-        assert metric_spans[0]["segmentName"] == data[0][1]
         assert metric_spans[0]["spanId"] == data[1][0]
         assert metric_spans[0]["segmentName"] == data[1][1]
+        assert metric_spans[1]["spanId"] == data[0][0]
+        assert metric_spans[1]["segmentName"] == data[0][1]
 
         response = self.get_success_response(
             self.organization.slug,
             metric=[mri],
             query="transaction:/api/users AND device:iPhone AND device:OnePlus",
-            min="50",
-            max="150",
             project=[self.project.id],
             statsPeriod="1d",
             metricSpans="true",
@@ -674,19 +648,46 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
         metric_spans = response.data["metricSpans"]
         assert len(metric_spans) == 0
 
-        response = self.get_success_response(
-            self.organization.slug,
-            metric=[mri],
-            query="",
-            min="50",
-            max="150",
-            project=[self.project.id],
-            statsPeriod="1d",
-            metricSpans="true",
+    def test_get_metric_spans_with_transaction_duration_with_bounds(self):
+        mri = TransactionMRI.DURATION.value
+
+        span_id = "98230207e6e4a6ad"
+        transaction = "/api/users"
+        self.store_span(
+            project_id=self.project.id,
+            timestamp=before_now(minutes=5),
+            span_id=span_id,
+            is_segment=1,
+            duration_ms=100,
+            transaction=transaction,
         )
-        metric_spans = response.data["metricSpans"]
-        assert len(metric_spans) == 2
-        assert metric_spans[0]["spanId"] == data[0][0]
-        assert metric_spans[0]["segmentName"] == data[0][1]
-        assert metric_spans[0]["spanId"] == data[1][0]
-        assert metric_spans[0]["segmentName"] == data[1][1]
+
+        for min_val, max_val, expected_span_ids in (
+            (10.0, 100.0, [span_id]),
+            (90.0, 150.0, [span_id]),
+            (10.0, 50.0, []),
+            (None, 90, []),
+            (None, 100, [span_id]),
+            (110, None, []),
+            (100, None, [span_id]),
+            (None, None, [span_id]),
+        ):
+            extra_params = {}
+            if min_val:
+                extra_params["min"] = min_val
+            if max_val:
+                extra_params["max"] = max_val
+
+            response = self.get_success_response(
+                self.organization.slug,
+                metric=[mri],
+                project=[self.project.id],
+                statsPeriod="1d",
+                metricSpans="true",
+                **extra_params,
+            )
+
+            metric_spans = response.data["metricSpans"]
+            assert len(metric_spans) == len(cast(Sequence[str], expected_span_ids))
+            for i, expected_span_id in enumerate(cast(Sequence[str], expected_span_ids)):
+                assert metric_spans[i]["spanId"] == expected_span_id

--- a/tests/sentry/api/endpoints/test_organization_ddm_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_ddm_meta.py
@@ -611,17 +611,18 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             status_code=500,
         )
 
-    @pytest.mark.skip(reason="transaction.duration is currently not supported")
     def test_get_metric_spans_with_transaction_duration(self):
         mri = TransactionMRI.DURATION.value
 
         span_id = "98230207e6e4a6ad"
+        transaction = "/api/users"
         self.store_span(
             project_id=self.project.id,
             timestamp=before_now(minutes=5),
             span_id=span_id,
             is_segment=1,
             duration_ms=100,
+            transaction=transaction,
         )
 
         response = self.get_success_response(
@@ -637,3 +638,4 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
         metric_spans = response.data["metricSpans"]
         assert len(metric_spans) == 1
         assert metric_spans[0]["spanId"] == span_id
+        assert metric_spans[0]["segmentName"] == transaction


### PR DESCRIPTION
This PR adds the support for querying `transaction.duration` correlated spans. In addition, it adds the `segmentName` and `timestamp` in the API response.

Closes https://github.com/getsentry/sentry/issues/62251