### PR TITLE
feat(app-start): Add span operation table

### DIFF
--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -22,6 +22,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {EventSamples} from 'sentry/views/starfish/views/appStartup/screenSummary/eventSamples';
+import {SpanOperationTable} from 'sentry/views/starfish/views/appStartup/screenSummary/spanOperationTable';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {
   MobileCursors,
@@ -117,6 +118,13 @@ function ScreenSummary() {
                     </div>
                   </ErrorBoundary>
                 </EventSamplesContainer>
+                <ErrorBoundary mini>
+                  <SpanOperationTable
+                    transaction={transactionName}
+                    primaryRelease={primaryRelease}
+                    secondaryRelease={secondaryRelease}
+                  />
+                </ErrorBoundary>
               </PageFiltersContainer>
             </Layout.Main>
           </Layout.Body>

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.spec.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.spec.tsx
@@ -1,0 +1,80 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {SpanOpSelector} from 'sentry/views/starfish/views/appStartup/screenSummary/spanOpSelector';
+
+jest.mock('sentry/utils/usePageFilters');
+
+describe('SpanOpSelector', function () {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+
+  jest.mocked(usePageFilters).mockReturnValue({
+    isReady: true,
+    desyncedFilters: new Set(),
+    pinnedFilters: new Set(),
+    shouldPersist: true,
+    selection: {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+      environments: [],
+      projects: [parseInt(project.id, 10)],
+    },
+  });
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/events/`,
+    body: {
+      meta: {
+        fields: {
+          'span.op': 'string',
+          'count()': 'integer',
+        },
+      },
+      data: [
+        {
+          'span.op': 'app.start.cold',
+          'count()': 1,
+        },
+        {
+          'span.op': 'app.start.warm',
+          'count()': 2,
+        },
+        {
+          'span.op': 'contentprovider.load',
+          'count()': 3,
+        },
+      ],
+    },
+  });
+
+  it('lists all span operations that are stored', async function () {
+    render(
+      <SpanOpSelector
+        primaryRelease="release1"
+        secondaryRelease="release2"
+        transaction="foo-bar"
+      />
+    );
+
+    expect(await screen.findByText('All')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('All'));
+
+    // These options appear because the events request says we have spans stored
+    expect(
+      await screen.findByRole('option', {name: 'app.start.cold'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'app.start.warm'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', {name: 'contentprovider.load'})
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOpSelector.tsx
@@ -1,0 +1,96 @@
+import {browserHistory} from 'react-router';
+import styled from '@emotion/styled';
+
+import {CompactSelect} from 'sentry/components/compactSelect';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {NewQuery} from 'sentry/types';
+import EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
+import {STARTUP_SPANS} from 'sentry/views/starfish/views/appStartup/screenSummary/spanOperationTable';
+import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
+import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
+
+type Props = {
+  primaryRelease?: string;
+  secondaryRelease?: string;
+  transaction?: string;
+};
+
+export function SpanOpSelector({transaction, primaryRelease, secondaryRelease}: Props) {
+  const location = useLocation();
+  const {selection} = usePageFilters();
+
+  const value = decodeScalar(location.query[SpanMetricsField.SPAN_OP]) ?? '';
+
+  const searchQuery = new MutableSearch([
+    'transaction.op:ui.load',
+    `transaction:${transaction}`,
+    `span.op:[${[...STARTUP_SPANS].join(',')}]`,
+    'has:span.description',
+    '!span.description:"Cold Start"',
+    '!span.description:"Warm Start"',
+  ]);
+  const queryStringPrimary = appendReleaseFilters(
+    searchQuery,
+    primaryRelease,
+    secondaryRelease
+  );
+
+  const newQuery: NewQuery = {
+    name: '',
+    fields: [SpanMetricsField.SPAN_OP, 'count()'],
+    query: queryStringPrimary,
+    dataset: DiscoverDatasets.SPANS_METRICS,
+    version: 2,
+    projects: selection.projects,
+  };
+
+  const eventView = EventView.fromNewQueryWithLocation(newQuery, location);
+  const {data} = useTableQuery({
+    eventView,
+    enabled: true,
+    limit: 25,
+    referrer: 'api.starfish.get-span-operations',
+  });
+
+  const options = [
+    {value: '', label: t('All')},
+    ...(data?.data ?? [])
+      .filter(datum => Boolean(datum[SpanMetricsField.SPAN_OP]))
+      .map(datum => {
+        return {
+          value: datum[SpanMetricsField.SPAN_OP],
+          label: datum[SpanMetricsField.SPAN_OP],
+        };
+      }),
+  ];
+
+  return (
+    <StyledCompactSelect
+      triggerProps={{prefix: t('Operation'), size: 'xs'}}
+      value={value}
+      options={options ?? []}
+      onChange={newValue => {
+        browserHistory.push({
+          ...location,
+          query: {
+            ...location.query,
+            [SpanMetricsField.SPAN_OP]: newValue.value,
+            [MobileCursors.SPANS_TABLE]: undefined,
+          },
+        });
+      }}
+    />
+  );
+}
+
+const StyledCompactSelect = styled(CompactSelect)`
+  margin-bottom: ${space(1)};
+`;

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.spec.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.spec.tsx
@@ -85,7 +85,7 @@ describe('SpanOpSelector', function () {
     expect(screen.getByRole('link', {name: 'Duration (release1)'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Duration (release2)'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Total Count'})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Time Spent'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Total Time Spent'})).toBeInTheDocument();
 
     expect(await screen.findByRole('cell', {name: 'app.start.warm'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: 'Application Init'})).toBeInTheDocument();

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.spec.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.spec.tsx
@@ -1,0 +1,155 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {SpanOperationTable} from 'sentry/views/starfish/views/appStartup/screenSummary/spanOperationTable';
+
+jest.mock('sentry/utils/usePageFilters');
+jest.mock('sentry/utils/useLocation');
+
+describe('SpanOpSelector', function () {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture();
+  let mockEventsRequest;
+
+  jest.mocked(usePageFilters).mockReturnValue({
+    isReady: true,
+    desyncedFilters: new Set(),
+    pinnedFilters: new Set(),
+    shouldPersist: true,
+    selection: {
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+      environments: [],
+      projects: [parseInt(project.id, 10)],
+    },
+  });
+
+  jest.mocked(useLocation).mockReturnValue(LocationFixture());
+
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+
+    mockEventsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        meta: {
+          fields: {
+            'project.id': 'integer',
+            'span.op': 'string',
+            'span.description': 'string',
+            'span.group': 'string',
+            'avg_if(span.self_time,release,release1)': 'duration',
+            'time_spent_percentage()': 'percentage',
+            'count()': 'integer',
+            'avg_if(span.self_time,release,release2)': 'duration',
+            'sum(span.self_time)': 'duration',
+          },
+        },
+        data: [
+          {
+            'project.id': parseInt(project.id, 10),
+            'span.op': 'app.start.warm',
+            'span.description': 'Application Init',
+            'span.group': '7f4be68f08c0455f',
+            'avg_if(span.self_time,release,release1)': 22.549867,
+            'time_spent_percentage()': 0.003017625053431528,
+            'count()': 14,
+            'avg_if(span.self_time,release,release2)': 12504.931908384617,
+            'sum(span.self_time)': 162586.66467600001,
+          },
+        ],
+      },
+    });
+  });
+
+  it('renders data properly', async function () {
+    render(
+      <SpanOperationTable
+        transaction="foo-bar"
+        primaryRelease="release1"
+        secondaryRelease="release2"
+      />
+    );
+
+    expect(await screen.findByRole('link', {name: 'Operation'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Span Description'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Duration (release1)'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Duration (release2)'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Total Count'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Time Spent'})).toBeInTheDocument();
+
+    expect(await screen.findByRole('cell', {name: 'app.start.warm'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'Application Init'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '22.55ms'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '12.50s'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '14'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: '2.71min'})).toBeInTheDocument();
+
+    expect(screen.getByRole('link', {name: 'Application Init'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/starfish/appStartup/spans/?spanDescription=Application%20Init&spanGroup=7f4be68f08c0455f&transaction=foo-bar'
+    );
+  });
+
+  it('modifies the request to events when a span operation is selected', async function () {
+    // Mock useLocation to simulate the span op query param
+    jest.mocked(useLocation).mockReturnValue(
+      LocationFixture({
+        query: {
+          'span.op': 'app.start.cold',
+        },
+      })
+    );
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        meta: {
+          fields: {
+            'span.op': 'string',
+            'count()': 'integer',
+          },
+        },
+        data: [
+          {
+            'span.op': 'app.start.cold',
+            'count()': 1,
+          },
+        ],
+      },
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options?.query?.referrer === 'api.starfish.get-span-operations';
+        },
+      ],
+    });
+
+    render(
+      <SpanOperationTable
+        transaction="foo-bar"
+        primaryRelease="release1"
+        secondaryRelease="release2"
+      />
+    );
+
+    await waitFor(function () {
+      expect(mockEventsRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: expect.stringContaining('span.op:app.start.cold'),
+          }),
+        })
+      );
+    });
+  });
+});

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -147,8 +147,9 @@ export function SpanOperationTable({
     if (column.key === SPAN_DESCRIPTION) {
       const label = row[SpanMetricsField.SPAN_DESCRIPTION];
 
+      // TODO(nar), change out URL when moving tabs
       const pathname = normalizeUrl(
-        `/organizations/${organization.slug}/starfish/appStartup/spans/` // todo, change out URL
+        `/organizations/${organization.slug}/starfish/appStartup/spans/`
       );
       const query = {
         ...location.query,
@@ -185,7 +186,6 @@ export function SpanOperationTable({
       width: column.width,
     };
 
-    // TODO: This could probably be simplified
     function generateSortLink() {
       if (!tableMeta) {
         return undefined;

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -136,7 +136,7 @@ export function SpanOperationTable({
       'Duration (%s)',
       truncatedSecondary
     ),
-    ['time_spent_percentage()']: t('Time Spent'),
+    ['time_spent_percentage()']: t('Total Time Spent'),
   };
 
   function renderBodyCell(column, row): React.ReactNode {

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -32,9 +32,9 @@ import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
+import {SpanOpSelector} from 'sentry/views/starfish/views/appStartup/screenSummary/spanOpSelector';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
-import {SpanOpSelector} from 'sentry/views/starfish/views/screens/screenLoadSpans/spanOpSelector';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
 const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, PROJECT_ID} =
@@ -45,6 +45,16 @@ type Props = {
   secondaryRelease?: string;
   transaction?: string;
 };
+
+const IOS_STARTUP_SPANS = ['app.start.cold', 'app.start.warm'];
+const ANDROID_STARTUP_SPANS = [
+  'app.start.cold',
+  'app.start.warm',
+  'contentprovider.load',
+  'application.load',
+  'activity.load',
+];
+export const STARTUP_SPANS = new Set([...IOS_STARTUP_SPANS, ...ANDROID_STARTUP_SPANS]);
 
 export function SpanOperationTable({
   transaction,
@@ -69,7 +79,7 @@ export function SpanOperationTable({
     '!span.description:"Warm Start"',
     ...(spanOp
       ? [`${SpanMetricsField.SPAN_OP}:${spanOp}`]
-      : ['span.op:[app.start.cold,app.start.warm]']), // TODO: Add the android-specific span ops
+      : [`span.op:[${[...STARTUP_SPANS].join(',')}]`]),
   ]);
   const queryStringPrimary = appendReleaseFilters(
     searchQuery,
@@ -110,7 +120,7 @@ export function SpanOperationTable({
   const {data, isLoading, pageLinks} = useTableQuery({
     eventView,
     enabled: true,
-    referrer: 'potato',
+    referrer: 'api.starfish.mobile-spartup-span-table',
     cursor,
   });
 

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -1,0 +1,254 @@
+import {Fragment} from 'react';
+import {browserHistory} from 'react-router';
+import * as qs from 'query-string';
+
+import {getInterval} from 'sentry/components/charts/utils';
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  GridColumnHeader,
+} from 'sentry/components/gridEditable';
+import SortLink from 'sentry/components/gridEditable/sortLink';
+import Link from 'sentry/components/links/link';
+import Pagination, {CursorHandler} from 'sentry/components/pagination';
+import {t} from 'sentry/locale';
+import {NewQuery} from 'sentry/types';
+import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
+import EventView, {
+  fromSorts,
+  isFieldSortable,
+  MetaType,
+} from 'sentry/utils/discover/eventView';
+import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {fieldAlignment, Sort} from 'sentry/utils/discover/fields';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
+import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
+import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
+import {MobileCursors} from 'sentry/views/starfish/views/screens/constants';
+import {SpanOpSelector} from 'sentry/views/starfish/views/screens/screenLoadSpans/spanOpSelector';
+import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
+
+const {SPAN_SELF_TIME, SPAN_DESCRIPTION, SPAN_GROUP, SPAN_OP, PROJECT_ID} =
+  SpanMetricsField;
+
+type Props = {
+  primaryRelease?: string;
+  secondaryRelease?: string;
+  transaction?: string;
+};
+
+export function SpanOperationTable({
+  transaction,
+  primaryRelease,
+  secondaryRelease,
+}: Props) {
+  const location = useLocation();
+  const {selection} = usePageFilters();
+  const organization = useOrganization();
+  const cursor = decodeScalar(location.query?.[MobileCursors.SPANS_TABLE]);
+
+  const spanOp = decodeScalar(location.query[SpanMetricsField.SPAN_OP]) ?? '';
+  const truncatedPrimary = formatVersionAndCenterTruncate(primaryRelease ?? '', 15);
+  const truncatedSecondary = formatVersionAndCenterTruncate(secondaryRelease ?? '', 15);
+
+  const searchQuery = new MutableSearch([
+    'transaction.op:ui.load',
+    `transaction:${transaction}`,
+    'has:span.description',
+    // Exclude root level spans because they're comprised of nested operations
+    '!span.description:"Cold Start"',
+    '!span.description:"Warm Start"',
+    ...(spanOp
+      ? [`${SpanMetricsField.SPAN_OP}:${spanOp}`]
+      : ['span.op:[app.start.cold,app.start.warm]']), // TODO: Add the android-specific span ops
+  ]);
+  const queryStringPrimary = appendReleaseFilters(
+    searchQuery,
+    primaryRelease,
+    secondaryRelease
+  );
+
+  const sort = fromSorts(
+    decodeScalar(location.query[QueryParameterNames.SPANS_SORT])
+  )[0] ?? {
+    kind: 'desc',
+    field: 'time_spent_percentage()',
+  };
+
+  const newQuery: NewQuery = {
+    name: '',
+    fields: [
+      PROJECT_ID,
+      SPAN_OP,
+      SPAN_GROUP,
+      SPAN_DESCRIPTION,
+      `avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`,
+      `avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`,
+      'count()',
+      'time_spent_percentage()',
+      `sum(${SPAN_SELF_TIME})`,
+    ],
+    query: queryStringPrimary,
+    dataset: DiscoverDatasets.SPANS_METRICS,
+    version: 2,
+    projects: selection.projects,
+    interval: getInterval(selection.datetime, STARFISH_CHART_INTERVAL_FIDELITY),
+  };
+
+  const eventView = EventView.fromNewQueryWithLocation(newQuery, location);
+  eventView.sorts = [sort];
+
+  const {data, isLoading, pageLinks} = useTableQuery({
+    eventView,
+    enabled: true,
+    referrer: 'potato',
+    cursor,
+  });
+
+  const columnNameMap = {
+    [SPAN_OP]: t('Operation'),
+    [SPAN_DESCRIPTION]: t('Span Description'),
+    'count()': t('Total Count'),
+    [`avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`]: t(
+      'Duration (%s)',
+      truncatedPrimary
+    ),
+    [`avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`]: t(
+      'Duration (%s)',
+      truncatedSecondary
+    ),
+    ['time_spent_percentage()']: t('Time Spent'),
+  };
+
+  function renderBodyCell(column, row): React.ReactNode {
+    if (!data?.meta || !data?.meta.fields) {
+      return row[column.key];
+    }
+
+    if (column.key === SPAN_DESCRIPTION) {
+      const label = row[SpanMetricsField.SPAN_DESCRIPTION];
+
+      const pathname = normalizeUrl(
+        `/organizations/${organization.slug}/starfish/appStartup/spans/` // todo, change out URL
+      );
+      const query = {
+        ...location.query,
+        transaction,
+        spanGroup: row[SpanMetricsField.SPAN_GROUP],
+        spanDescription: row[SpanMetricsField.SPAN_DESCRIPTION],
+      };
+
+      return (
+        <Link to={`${pathname}?${qs.stringify(query)}`}>
+          <OverflowEllipsisTextContainer>{label}</OverflowEllipsisTextContainer>
+        </Link>
+      );
+    }
+
+    const renderer = getFieldRenderer(column.key, data?.meta.fields, false);
+    const rendered = renderer(row, {
+      location,
+      organization,
+      unit: data?.meta.units?.[column.key],
+    });
+    return rendered;
+  }
+
+  function renderHeadCell(
+    column: GridColumnHeader,
+    tableMeta?: MetaType
+  ): React.ReactNode {
+    const fieldType = tableMeta?.fields?.[column.key];
+
+    const alignment = fieldAlignment(column.key as string, fieldType);
+    const field = {
+      field: column.key as string,
+      width: column.width,
+    };
+
+    // TODO: This could probably be simplified
+    function generateSortLink() {
+      if (!tableMeta) {
+        return undefined;
+      }
+
+      let newSortDirection: Sort['kind'] = 'desc';
+      if (sort?.field === column.key) {
+        if (sort.kind === 'desc') {
+          newSortDirection = 'asc';
+        }
+      }
+
+      function getNewSort() {
+        return `${newSortDirection === 'desc' ? '-' : ''}${column.key}`;
+      }
+
+      return {
+        ...location,
+        query: {...location.query, [QueryParameterNames.SPANS_SORT]: getNewSort()},
+      };
+    }
+
+    const canSort = isFieldSortable(field, tableMeta?.fields, true);
+
+    const sortLink = (
+      <SortLink
+        align={alignment}
+        title={column.name}
+        direction={sort?.field === column.key ? sort.kind : undefined}
+        canSort={canSort}
+        generateSortLink={generateSortLink}
+      />
+    );
+    return sortLink;
+  }
+
+  const columnSortBy = eventView.getSorts();
+
+  const handleCursor: CursorHandler = (newCursor, pathname, query) => {
+    browserHistory.push({
+      pathname,
+      query: {...query, [MobileCursors.SPANS_TABLE]: newCursor},
+    });
+  };
+
+  return (
+    <Fragment>
+      <SpanOpSelector
+        primaryRelease={primaryRelease}
+        transaction={transaction}
+        secondaryRelease={secondaryRelease}
+      />
+      <GridEditable
+        isLoading={isLoading}
+        data={data?.data as TableDataRow[]}
+        columnOrder={[
+          String(SPAN_OP),
+          String(SPAN_DESCRIPTION),
+          `avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`,
+          `avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`,
+          'count()',
+          'time_spent_percentage()',
+        ].map(col => {
+          return {key: col, name: columnNameMap[col] ?? col, width: COL_WIDTH_UNDEFINED};
+        })}
+        columnSortBy={columnSortBy}
+        location={location}
+        grid={{
+          renderHeadCell: column => renderHeadCell(column, data?.meta),
+          renderBodyCell,
+        }}
+      />
+      <Pagination pageLinks={pageLinks} onCursor={handleCursor} />
+    </Fragment>
+  );
+}


### PR DESCRIPTION
Add a span operation table at the bottom of the app start page. This addition is strictly only for the table and does not yet include the side drawer functionality when clicking the span description.

<img width="1460" alt="Screenshot 2024-01-09 at 11 49 05 AM" src="https://github.com/getsentry/sentry/assets/22846452/c689cc79-6262-4843-89b3-f143dba9887f">
