### PR TITLE
fix(default-overview): Add count sort to Errors by Country widget

### DIFF
--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -216,7 +216,7 @@ _PREBUILT_DASHBOARDS: list[dict[str, Any]] = [
                         "fields": ["geo.country_code", "geo.region", "count()"],
                         "aggregates": ["count()"],
                         "columns": ["geo.country_code", "geo.region"],
-                        "orderby": "",
+                        "orderby": "-count()",
                     }
                 ],
             },
@@ -232,7 +232,7 @@ _PREBUILT_DASHBOARDS: list[dict[str, Any]] = [
                         "fields": ["browser.name", "count()"],
                         "aggregates": ["count()"],
                         "columns": ["browser.name"],
-                        "orderby": "-count",
+                        "orderby": "-count()",
                     }
                 ],
             },


### PR DESCRIPTION
The Errors by Country widget should be sorted by count.

Also updates another sort to be in the function format for consistency.