### PR TITLE
chore(severity): Clean up legacy stale date code

### DIFF
--- a/tests/sentry/issues/test_issue_velocity.py
+++ b/tests/sentry/issues/test_issue_velocity.py
@@ -7,7 +7,6 @@ from django.utils import timezone
 from sentry.issues.issue_velocity import (
     DEFAULT_TTL,
     FALLBACK_TTL,
-    LEGACY_STALE_DATE_KEY,
     STALE_DATE_KEY,
     STRING_TO_DATETIME,
     THRESHOLD_KEY,
@@ -233,21 +232,6 @@ class IssueVelocityTests(TestCase, SnubaTestCase):
             threshold = get_latest_threshold(self.project)
             mock_update.assert_not_called()
             assert threshold == 0
-
-    @patch("sentry.issues.issue_velocity.calculate_threshold", return_value=2)
-    def test_legacy_date_format_compatibility(self, mock_calculation):
-        """Tests that the logic does not break if a stale date was stored with the legacy format."""
-        redis_client = get_redis_client()
-        redis_client.set(THRESHOLD_KEY.format(project_id=self.project.id), 1)
-        redis_client.set(LEGACY_STALE_DATE_KEY.format(project_id=self.project.id), 20231220)
-        threshold = get_latest_threshold(self.project)
-        assert threshold == 2
-
-        # the legacy stale date key is not updated but the current version of the stale date key is
-        assert (
-            redis_client.get(LEGACY_STALE_DATE_KEY.format(project_id=self.project.id)) == "20231220"
-        )
-        assert redis_client.get(STALE_DATE_KEY.format(project_id=self.project.id)) is not None
 
     @patch("sentry.issues.issue_velocity.calculate_threshold")
     def test_update_threshold_simple(self, mock_calculation):


### PR DESCRIPTION
Neither of the two projects that have `first-event-severity-new-escalation` enabled use the legacy stale date for storing the new escalation logic thresholds anymore ([last one logged December 23rd](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D~%22sentry%22%0AjsonPayload.event%3D%22issue_velocity.get_latest_threshold.legacy_date_format%22%0A;summaryFields=:true:32:beginning;cursorTimestamp=2023-12-23T09:42:05.188629428Z;duration=P30D?project=internal-sentry&pli=1&rapt=AEjHL4O2CQjl5LLwcsGfx-gKTjZgOiQ-FKvtIfkLItSpofcqzSdDv6zZAPBE6sZury18jYInqGDJJp9Y2QQrXpjS-buHnKx3ABBeeX6rTdg3cXMEXVftZhI)), so we can clean up the legacy code :)