### PR TITLE
ref(slack): Render resolve button instead of modal when no releases

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -237,7 +237,8 @@ def build_actions(
     def _resolve_button(use_block_kit) -> MessageAction:
         if use_block_kit:
             # TODO(CEO): handle if the issue is resolved - render a button that unresolves
-            # TODO(CEO): handle if not project.flags.has_releases in block kit - render a resolve button instead of a modal
+            if not project.flags.has_releases:
+                return MessageAction(name="status", label="Resolve", value="resolved")
             return MessageAction(
                 name="status",
                 label="Resolve",

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -248,6 +248,9 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
     @with_feature("organizations:slack-block-kit")
     def test_build_group_block(self):
         group = self.create_group(project=self.project)
+        self.project.flags.has_releases = True
+        self.project.save(update_fields=["flags"])
+
         assert SlackIssuesMessageBuilder(group).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1037,6 +1037,19 @@ class ActionsTest(TestCase):
                 "value": "resolved",
             },
         )
+        with self.feature("organizations:slack-block-kit"):
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
+            self._assert_message_actions_list(
+                res[0],
+                {
+                    "label": "Resolve",
+                    "name": "status",
+                    "type": "button",
+                    "value": "resolved",
+                },
+            )
 
     def test_resolve_unresolved_has_releases(self):
         group = self.create_group(project=self.project)
@@ -1058,6 +1071,20 @@ class ActionsTest(TestCase):
                 "value": "resolve_dialog",
             },
         )
+
+        with self.feature("organizations:slack-block-kit"):
+            res = build_actions(
+                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+            )
+            self._assert_message_actions_list(
+                res[0],
+                {
+                    "label": "Resolve",
+                    "name": "status",
+                    "type": "button",
+                    "value": "resolve_dialog",
+                },
+            )
 
     def test_assign(self):
         group = self.create_group(project=self.project)


### PR DESCRIPTION
If a project has no releases, a Slack issue alert's "Resolve" button will resolve immediately, rather than opening up a modal that has a dropdown of options relating to releases. 

It doesn't seem currently possible for this to happen - I had to comment out code that automatically created releases if you didn't provide one during event creation, but there may be customers with older projects that don't have this so I wanted to cover the case.