### PR TITLE
ref(grouping): Move background grouping code to `grouping` module

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import copy
 import ipaddress
 import logging
-import random
 import re
 import time
 import uuid
@@ -60,13 +59,16 @@ from sentry.eventtypes import EventType
 from sentry.eventtypes.transaction import TransactionEvent
 from sentry.exceptions import HashDiscarded
 from sentry.grouping.api import (
-    BackgroundGroupingConfigLoader,
     GroupingConfig,
     SecondaryGroupingConfigLoader,
     get_grouping_config_dict_for_event_data,
     get_grouping_config_dict_for_project,
 )
-from sentry.grouping.ingest import calculate_event_grouping, update_grouping_config_if_needed
+from sentry.grouping.ingest import (
+    calculate_event_grouping,
+    run_background_grouping,
+    update_grouping_config_if_needed,
+)
 from sentry.grouping.result import CalculatedHashes
 from sentry.ingest.inbound_filters import FilterStatKeys
 from sentry.issues.grouptype import GroupCategory
@@ -516,7 +518,7 @@ class EventManager:
         # either before or after the main grouping logic, depending on the option value.
         do_background_grouping_before = options.get("store.background-grouping-before")
         if do_background_grouping_before:
-            _run_background_grouping(project, job)
+            run_background_grouping(project, job)
 
         secondary_hashes = None
         migrate_off_hierarchical = False
@@ -596,7 +598,7 @@ class EventManager:
         )
 
         if not do_background_grouping_before:
-            _run_background_grouping(project, job)
+            run_background_grouping(project, job)
 
         if hashes.tree_labels:
             job["finest_tree_label"] = hashes.finest_tree_label
@@ -791,34 +793,6 @@ def _calculate_secondary_hash(
         sentry_sdk.capture_exception()
 
     return secondary_hashes
-
-
-def _calculate_background_grouping(
-    project: Project, event: Event, config: GroupingConfig
-) -> CalculatedHashes:
-    metric_tags: MutableTags = {
-        "grouping_config": config["id"],
-        "platform": event.platform or "unknown",
-        "sdk": normalized_sdk_tag_from_event(event),
-    }
-    with metrics.timer("event_manager.background_grouping", tags=metric_tags):
-        return calculate_event_grouping(project, event, config)
-
-
-def _run_background_grouping(project: Project, job: Job) -> None:
-    """Optionally run a fraction of events with a third grouping config
-    This can be helpful to measure its performance impact.
-    This does not affect actual grouping.
-    """
-    try:
-        sample_rate = options.get("store.background-grouping-sample-rate")
-        if sample_rate and random.random() <= sample_rate:
-            config = BackgroundGroupingConfigLoader().get_config_dict(project)
-            if config["id"]:
-                copied_event = copy.deepcopy(job["event"])
-                _calculate_background_grouping(project, copied_event, config)
-    except Exception:
-        sentry_sdk.capture_exception()
 
 
 @metrics.wraps("save_event.pull_out_data")

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -153,8 +153,8 @@ def run_background_grouping(project: Project, job: Job) -> None:
             if config["id"]:
                 copied_event = copy.deepcopy(job["event"])
                 _calculate_background_grouping(project, copied_event, config)
-    except Exception:
-        sentry_sdk.capture_exception()
+    except Exception as err:
+        sentry_sdk.capture_exception(err)
 
 
 def _calculate_background_grouping(

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import copy
+import random
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, MutableMapping
 
 import sentry_sdk
 from django.conf import settings
 from django.core.cache import cache
 
+from sentry import options
 from sentry.grouping.api import (
+    BackgroundGroupingConfigLoader,
     GroupingConfig,
     GroupingConfigNotFound,
     apply_server_fingerprinting,
@@ -26,6 +30,8 @@ from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
 
 if TYPE_CHECKING:
     from sentry.eventstore.models import Event
+
+Job = MutableMapping[str, Any]
 
 
 def update_grouping_config_if_needed(project: Project) -> None:
@@ -133,3 +139,31 @@ def calculate_event_grouping(
 
         hashes.write_to_event(event.data)
         return hashes
+
+
+def run_background_grouping(project: Project, job: Job) -> None:
+    """Optionally run a fraction of events with a third grouping config
+    This can be helpful to measure its performance impact.
+    This does not affect actual grouping.
+    """
+    try:
+        sample_rate = options.get("store.background-grouping-sample-rate")
+        if sample_rate and random.random() <= sample_rate:
+            config = BackgroundGroupingConfigLoader().get_config_dict(project)
+            if config["id"]:
+                copied_event = copy.deepcopy(job["event"])
+                _calculate_background_grouping(project, copied_event, config)
+    except Exception:
+        sentry_sdk.capture_exception()
+
+
+def _calculate_background_grouping(
+    project: Project, event: Event, config: GroupingConfig
+) -> CalculatedHashes:
+    metric_tags: MutableTags = {
+        "grouping_config": config["id"],
+        "platform": event.platform or "unknown",
+        "sdk": normalized_sdk_tag_from_event(event),
+    }
+    with metrics.timer("event_manager.background_grouping", tags=metric_tags):
+        return calculate_event_grouping(project, event, config)

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -212,7 +212,7 @@ class EventManagerGroupingTest(TestCase):
         event3 = save_event(4)
         assert event3.group_id == event2.group_id
 
-    @mock.patch("sentry.event_manager._calculate_background_grouping")
+    @mock.patch("sentry.grouping.ingest._calculate_background_grouping")
     def test_applies_background_grouping(self, mock_calc_grouping):
         timestamp = time() - 300
         manager = EventManager(
@@ -233,7 +233,7 @@ class EventManagerGroupingTest(TestCase):
 
         assert mock_calc_grouping.call_count == 1
 
-    @mock.patch("sentry.event_manager._calculate_background_grouping")
+    @mock.patch("sentry.grouping.ingest._calculate_background_grouping")
     def test_background_grouping_sample_rate(self, mock_calc_grouping):
         timestamp = time() - 300
         manager = EventManager(

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -212,50 +212,6 @@ class EventManagerGroupingTest(TestCase):
         event3 = save_event(4)
         assert event3.group_id == event2.group_id
 
-    @mock.patch("sentry.grouping.ingest._calculate_background_grouping")
-    def test_applies_background_grouping(self, mock_calc_grouping):
-        timestamp = time() - 300
-        manager = EventManager(
-            make_event(message="foo 123", event_id="a" * 32, timestamp=timestamp)
-        )
-        manager.normalize()
-        manager.save(self.project.id)
-
-        assert mock_calc_grouping.call_count == 0
-
-        with self.options(
-            {
-                "store.background-grouping-config-id": "mobile:2021-02-12",
-                "store.background-grouping-sample-rate": 1.0,
-            }
-        ):
-            manager.save(self.project.id)
-
-        assert mock_calc_grouping.call_count == 1
-
-    @mock.patch("sentry.grouping.ingest._calculate_background_grouping")
-    def test_background_grouping_sample_rate(self, mock_calc_grouping):
-        timestamp = time() - 300
-        manager = EventManager(
-            make_event(message="foo 123", event_id="a" * 32, timestamp=timestamp)
-        )
-        manager.normalize()
-        manager.save(self.project.id)
-
-        assert mock_calc_grouping.call_count == 0
-
-        with self.options(
-            {
-                "store.background-grouping-config-id": "mobile:2021-02-12",
-                "store.background-grouping-sample-rate": 0.0,
-            }
-        ):
-            manager.save(self.project.id)
-
-        manager.save(self.project.id)
-
-        assert mock_calc_grouping.call_count == 0
-
     def test_puts_events_with_matching_fingerprints_in_same_group(self):
         ts = time() - 200
         manager = EventManager(

--- a/tests/sentry/grouping/test_ingest.py
+++ b/tests/sentry/grouping/test_ingest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from sentry.event_manager import EventManager
+from sentry.grouping.ingest import _calculate_background_grouping
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
@@ -12,7 +13,10 @@ pytestmark = [requires_snuba]
 
 @region_silo_test
 class BackgroundGroupingTest(TestCase):
-    @patch("sentry.grouping.ingest._calculate_background_grouping")
+    @patch(
+        "sentry.grouping.ingest._calculate_background_grouping",
+        wraps=_calculate_background_grouping,
+    )
     def test_applies_background_grouping(self, mock_calc_background_grouping: MagicMock) -> None:
         manager = EventManager({"message": "foo 123"})
         manager.normalize()

--- a/tests/sentry/grouping/test_ingest.py
+++ b/tests/sentry/grouping/test_ingest.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from sentry.event_manager import EventManager
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+from sentry.testutils.skips import requires_snuba
+
+pytestmark = [requires_snuba]
+
+
+@region_silo_test
+class BackgroundGroupingTest(TestCase):
+    @patch("sentry.grouping.ingest._calculate_background_grouping")
+    def test_applies_background_grouping(self, mock_calc_background_grouping: MagicMock) -> None:
+        manager = EventManager({"message": "foo 123"})
+        manager.normalize()
+        manager.save(self.project.id)
+
+        assert mock_calc_background_grouping.call_count == 0
+
+        with self.options(
+            {
+                "store.background-grouping-config-id": "mobile:2021-02-12",
+                "store.background-grouping-sample-rate": 1.0,
+            }
+        ):
+            manager.save(self.project.id)
+
+        assert mock_calc_background_grouping.call_count == 1
+
+    @patch("sentry.grouping.ingest._calculate_background_grouping")
+    def test_background_grouping_can_be_disabled_via_sample_rate(
+        self, mock_calc_background_grouping: MagicMock
+    ) -> None:
+        manager = EventManager({"message": "foo 123"})
+        manager.normalize()
+        manager.save(self.project.id)
+
+        assert mock_calc_background_grouping.call_count == 0
+
+        with self.options(
+            {
+                "store.background-grouping-config-id": "mobile:2021-02-12",
+                "store.background-grouping-sample-rate": 0.0,
+            }
+        ):
+            manager.save(self.project.id)
+
+        manager.save(self.project.id)
+
+        assert mock_calc_background_grouping.call_count == 0


### PR DESCRIPTION
This moves the code handling background grouping (and the associated tests) into the `grouping` module, as part of a larger refactor. 

No other code changes made, though I did add a missing test and modify an existing one to spy on rather than mock `_calculate_background_grouping`, both in order to placate codecov.