### PR TITLE
chore(hybrid-cloud): Merge min/max aggregate for scheduling outbox batches

### DIFF
--- a/src/sentry/tasks/deliver_from_outbox.py
+++ b/src/sentry/tasks/deliver_from_outbox.py
@@ -67,8 +67,10 @@ def schedule_batch(
         for outbox_name in settings.SENTRY_OUTBOX_MODELS[silo_mode.name]:
             outbox_model: Type[OutboxBase] = OutboxBase.from_outbox_name(outbox_name)
 
-            lo = outbox_model.objects.all().aggregate(Min("id"))["id__min"] or 0
-            hi = outbox_model.objects.all().aggregate(Max("id"))["id__max"] or -1
+            aggregates = outbox_model.objects.all().aggregate(Min("id"), Max("id"))
+
+            lo = aggregates["id__min"] or 0
+            hi = aggregates["id__max"] or -1
             if hi < lo:
                 continue
 


### PR DESCRIPTION
Fixes https://sentry-st.sentry.io/issues/4744469729/.

We've been getting several performance issue notifications for this query on the test region. I'm merging them together as per the Django docs for `aggregate()`: https://docs.djangoproject.com/en/3.2/topics/db/aggregation/#generating-aggregates-over-a-queryset