### PR TITLE
fix(stacktrace): Remove mapping which classified the .h extension as apple

### DIFF
--- a/static/app/utils/fileExtension.tsx
+++ b/static/app/utils/fileExtension.tsx
@@ -13,7 +13,6 @@ const FILE_EXTENSION_TO_PLATFORM = {
   rs: 'rust',
   rlib: 'rust',
   swift: 'swift',
-  h: 'apple',
   m: 'apple',
   mm: 'apple',
   M: 'apple',


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/62728

Another option is that we could assign `.h` files to `native` and display a "C" icon. I think that would be okay too since it's either c, c++, or obj-c. But removing the option entirely will default to other file extensions or the event platform which I think is a bit safer.