### PR TITLE
fix(browser-starfish): disable perf settings when no access

### DIFF
--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -828,6 +828,30 @@ class ProjectPerformance extends DeprecatedAsyncView<Props, State> {
       <Fragment>
         <SettingsPageHeader title={t('Performance')} />
         <PermissionAlert project={project} />
+        <Access access={requiredScopes} project={project}>
+          {({hasAccess}) => (
+            <Feature features="organizations:starfish-browser-resource-module-image-view">
+              <Form
+                initialData={this.state.general}
+                saveOnBlur
+                apiEndpoint={`/projects/${organization.slug}/${project.slug}/performance/configure/`}
+              >
+                <JsonForm
+                  disabled={!hasAccess}
+                  fields={[
+                    {
+                      name: 'enable_images',
+                      type: 'boolean',
+                      label: t('Images'),
+                      help: t('Enables images from real data to be displayed'),
+                    },
+                  ]}
+                  title={t('General')}
+                />
+              </Form>
+            </Feature>
+          )}
+        </Access>
 
         <Form
           saveOnBlur


### PR DESCRIPTION
Currently any user can flip the image setting toggle and if they don't have access it will just fail.
With this change, we are now disabling the toggle completely when the user has no access (just as the other settings in this page)
![image](https://github.com/getsentry/sentry/assets/44422760/d81e9336-713e-4720-bed8-718467c8bdd3)
