### PR TITLE
introduce releases-v2-internal flag for internal testing

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1823,6 +1823,7 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # True if Relay should drop raw session payloads after extracting metrics from them.
     "organizations:release-health-drop-sessions": False,
     # Enable new release UI
+    "organizations:releases-v2-internal": False,
     "organizations:releases-v2": False,
     "organizations:releases-v2-st": False,
     "organizations:releases-v2-banner": False,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1823,10 +1823,10 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # True if Relay should drop raw session payloads after extracting metrics from them.
     "organizations:release-health-drop-sessions": False,
     # Enable new release UI
-    "organizations:releases-v2-internal": False,
     "organizations:releases-v2": False,
-    "organizations:releases-v2-st": False,
     "organizations:releases-v2-banner": False,
+    "organizations:releases-v2-internal": False,
+    "organizations:releases-v2-st": False,
     # Enable version 2 of reprocessing (completely distinct from v1)
     "organizations:reprocessing-v2": False,
     # Enable team member role provisioning through scim

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -234,6 +234,7 @@ default_manager.add("organizations:release-health-drop-sessions", OrganizationFe
 default_manager.add("organizations:releases-v2-banner", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:releases-v2-st", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:releases-v2", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:releases-v2-internal", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:reprocessing-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:required-email-verification", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sandbox-kill-switch", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -366,6 +366,7 @@ class ReleaseOverview extends DeprecatedAsyncView<Props> {
     const {organization, selection, location, api} = this.props;
     const {start, end, period, utc} = this.pageDateTime;
     const hasV2ReleaseUIEnabled =
+      organization.features.includes('releases-v2-internal') ||
       organization.features.includes('releases-v2') ||
       organization.features.includes('releases-v2-st');
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -90,6 +90,7 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
   shouldReload = true;
   shouldRenderBadRequests = true;
   hasV2ReleaseUIEnabled =
+    this.props.organization.features.includes('releases-v2-internal') ||
     this.props.organization.features.includes('releases-v2') ||
     this.props.organization.features.includes('releases-v2-st');
 

--- a/static/app/views/releases/thresholdsList/index.tsx
+++ b/static/app/views/releases/thresholdsList/index.tsx
@@ -40,6 +40,7 @@ function ReleaseThresholdList({}: Props) {
   const organization = useOrganization();
   useEffect(() => {
     const hasV2ReleaseUIEnabled =
+      organization.features.includes('releases-v2-internal') ||
       organization.features.includes('releases-v2') ||
       organization.features.includes('releases-v2-st');
     if (!hasV2ReleaseUIEnabled) {

--- a/static/app/views/releases/thresholdsList/thresholdGroupRows.tsx
+++ b/static/app/views/releases/thresholdsList/thresholdGroupRows.tsx
@@ -16,7 +16,7 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {
-  CRASH_FREE_SESSION_RATE_STR as _CRASH_FREE_SESSION_RATE_STR,
+  CRASH_FREE_SESSION_RATE_STR,
   CRASH_FREE_USER_RATE_STR as _CRASH_FREE_USER_RATE_STR,
   FAILURE_RATE_STR as _FAILURE_RATE_STR,
   NEW_ISSUE_COUNT_STR as _NEW_ISSUE_COUNT_STR,
@@ -80,6 +80,27 @@ export function ThresholdGroupRows({
     }
     return new Set([...initial, ...Object.keys(editingThresholds)]);
   }, [initialThreshold, editingThresholds]);
+
+  const thresholdTypeList = useMemo(() => {
+    const isInternal = organization.features?.includes('releases-v2-internal');
+    const list = [
+      {
+        value: TOTAL_ERROR_COUNT_STR,
+        textValue: 'Errors',
+        label: 'Error Count',
+      },
+    ];
+    if (isInternal) {
+      list.push(
+        {
+          value: CRASH_FREE_SESSION_RATE_STR,
+          textValue: 'Crash Free Sessions',
+          label: 'Crash Free Sessions',
+        },
+      );
+    }
+    return list;
+  }, [organization]);
 
   const initializeNewThreshold = (
     environmentName: string | undefined = undefined,
@@ -311,18 +332,7 @@ export function ThresholdGroupRows({
                         selectedOption.value
                       )
                     }
-                    options={[
-                      {
-                        value: TOTAL_ERROR_COUNT_STR,
-                        textValue: 'Errors',
-                        label: 'Error Count',
-                      },
-                      // {
-                      //   value: CRASH_FREE_SESSION_RATE_STR,
-                      //   textValue: 'Crash Free Sessions',
-                      //   label: 'Crash Free Sessions',
-                      // },
-                    ]}
+                    options={thresholdTypeList}
                   />
                   {threshold.trigger_type === 'over' ? (
                     <Button

--- a/static/app/views/releases/utils/useFetchThresholdsListData.tsx
+++ b/static/app/views/releases/utils/useFetchThresholdsListData.tsx
@@ -34,7 +34,9 @@ export default function useFetchThresholdsListData({
     {
       staleTime: 0,
       enabled:
-        (organization.features?.includes('releases-v2') ||
+        (
+          organization.features?.includes('releases-v2-internal') ||
+          organization.features?.includes('releases-v2') ||
           organization.features?.includes('releases-v2-st')) ??
         false,
     }


### PR DESCRIPTION
Allows us to hide new threshold types behind an internal flag rather than the beta flag