### PR TITLE
fix(webvitals): Updates webVitalsDetalPanel to render content when possible even on loading state to reduce layout shifting

### DIFF
--- a/static/app/views/performance/browser/webVitals/components/webVitalDescription.tsx
+++ b/static/app/views/performance/browser/webVitals/components/webVitalDescription.tsx
@@ -26,9 +26,9 @@ import {vitalSupportedBrowsers} from 'sentry/views/performance/vitalDetail/utils
 import PerformanceScoreRingWithTooltips from './performanceScoreRingWithTooltips';
 
 type Props = {
-  score: number;
-  value: string;
   webVital: WebVitals;
+  score?: number;
+  value?: string;
 };
 
 const WEB_VITAL_FULL_NAME_MAP = {
@@ -68,7 +68,7 @@ export function WebVitalDetailHeader({score, value, webVital}: Props) {
   const theme = useTheme();
   const colors = theme.charts.getColorPalette(3);
   const dotColor = colors[['lcp', 'fcp', 'fid', 'cls', 'ttfb'].indexOf(webVital)];
-  const status = scoreToStatus(score);
+  const status = score !== undefined ? scoreToStatus(score) : undefined;
 
   return (
     <Header>
@@ -76,13 +76,15 @@ export function WebVitalDetailHeader({score, value, webVital}: Props) {
         <WebVitalName>{`${WEB_VITAL_FULL_NAME_MAP[webVital]} (P75)`}</WebVitalName>
         <Value>
           <Dot color={dotColor} />
-          {value}
+          {value ?? ' \u2014 '}
         </Value>
       </span>
-      <ScoreBadge status={status}>
-        <StatusText>{STATUS_TEXT[status]}</StatusText>
-        <StatusScore>{score}</StatusScore>
-      </ScoreBadge>
+      {status && score && (
+        <ScoreBadge status={status}>
+          <StatusText>{STATUS_TEXT[status]}</StatusText>
+          <StatusScore>{score}</StatusScore>
+        </ScoreBadge>
+      )}
     </Header>
   );
 }

--- a/static/app/views/performance/browser/webVitals/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/pageOverviewWebVitalsDetailPanel.tsx
@@ -267,23 +267,21 @@ export function PageOverviewWebVitalsDetailPanel({
   };
 
   const webVitalScore = projectScore[`${webVital}Score`];
+  const webVitalValue = projectData?.data[0][`p75(measurements.${webVital})`] as
+    | number
+    | undefined;
 
   return (
     <PageErrorProvider>
       <DetailPanel detailKey={webVital ?? undefined} onClose={onClose}>
-        {webVital && projectData && webVitalScore !== undefined && (
+        {webVital && (
           <WebVitalDetailHeader
             value={
-              webVital !== 'cls'
-                ? getDuration(
-                    (projectData?.data[0][`p75(measurements.${webVital})`] as number) /
-                      1000,
-                    2,
-                    true
-                  )
-                : (
-                    projectData?.data[0][`p75(measurements.${webVital})`] as number
-                  )?.toFixed(2)
+              webVitalValue !== undefined
+                ? webVital !== 'cls'
+                  ? getDuration(webVitalValue / 1000, 2, true)
+                  : (webVitalValue as number)?.toFixed(2)
+                : undefined
             }
             webVital={webVital}
             score={webVitalScore}

--- a/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.spec.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.spec.tsx
@@ -1,0 +1,74 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
+
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import usePageFilters from 'sentry/utils/usePageFilters';
+import {WebVitalsDetailPanel} from 'sentry/views/performance/browser/webVitals/webVitalsDetailPanel';
+
+jest.mock('sentry/utils/useLocation');
+jest.mock('sentry/utils/usePageFilters');
+jest.mock('sentry/utils/useOrganization');
+
+describe('WebVitalsDetailPanel', function () {
+  const organization = OrganizationFixture();
+  let eventsMock, eventsStatsMock;
+
+  beforeEach(function () {
+    jest.mocked(useLocation).mockReturnValue({
+      pathname: '',
+      search: '',
+      query: {},
+      hash: '',
+      state: undefined,
+      action: 'PUSH',
+      key: '',
+    });
+    jest.mocked(usePageFilters).mockReturnValue({
+      isReady: true,
+      desyncedFilters: new Set(),
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: {
+        datetime: {
+          period: '10d',
+          start: null,
+          end: null,
+          utc: false,
+        },
+        environments: [],
+        projects: [],
+      },
+    });
+    jest.mocked(useOrganization).mockReturnValue(organization);
+
+    eventsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [],
+      },
+    });
+    eventsStatsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      body: {},
+    });
+  });
+
+  afterEach(function () {
+    jest.resetAllMocks();
+  });
+
+  it('renders correctly with empty results', async () => {
+    render(<WebVitalsDetailPanel onClose={() => undefined} webVital="lcp" />);
+    await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
+    // Once for project web vitals and once for samples
+    expect(eventsMock).toHaveBeenCalledTimes(2);
+    expect(eventsStatsMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Largest Contentful Paint (P75)')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Largest Contentful Paint \(LCP\) measures the render/)
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
+++ b/static/app/views/performance/browser/webVitals/webVitalsDetailPanel.tsx
@@ -236,23 +236,21 @@ export function WebVitalsDetailPanel({
   };
 
   const webVitalScore = projectScore[`${webVital}Score`];
+  const webVitalValue = projectData?.data?.[0]?.[mapWebVitalToColumn(webVital)] as
+    | number
+    | undefined;
 
   return (
     <PageErrorProvider>
       <DetailPanel detailKey={detailKey ?? undefined} onClose={onClose}>
-        {webVital && webVitalScore !== undefined && (
+        {webVital && (
           <WebVitalDescription
             value={
-              webVital !== 'cls'
-                ? getDuration(
-                    (projectData?.data?.[0]?.[mapWebVitalToColumn(webVital)] as number) /
-                      1000,
-                    2,
-                    true
-                  )
-                : (
-                    projectData?.data?.[0]?.[mapWebVitalToColumn(webVital)] as number
-                  )?.toFixed(2)
+              webVitalValue !== undefined
+                ? webVital !== 'cls'
+                  ? getDuration(webVitalValue / 1000, 2, true)
+                  : webVitalValue?.toFixed(2)
+                : undefined
             }
             webVital={webVital}
             score={webVitalScore}


### PR DESCRIPTION
Certain elements like webvital descriptions were being render controlled by loading state even when not necessary. Also adds a basic test.