### PR TITLE
feat(relocation): Add relocation created analytics

### DIFF
--- a/src/sentry/analytics/events/organization_imported.py
+++ b/src/sentry/analytics/events/organization_imported.py
@@ -1,0 +1,15 @@
+from sentry import analytics
+
+
+class OrganizationImportedEvent(analytics.Event):
+    type = "organization.imported"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("owner_id"),
+        analytics.Attribute("name"),
+        analytics.Attribute("slug"),
+    )
+
+
+analytics.register(OrganizationImportedEvent)

--- a/src/sentry/analytics/events/relocation_created.py
+++ b/src/sentry/analytics/events/relocation_created.py
@@ -5,7 +5,7 @@ class RelocationCreatedEvent(analytics.Event):
     type = "relocation.created"
 
     attributes = (
-        analytics.Attribute("user_id"),
+        analytics.Attribute("creator_id"),
         analytics.Attribute("owner_id"),
         analytics.Attribute("uuid"),
     )

--- a/src/sentry/analytics/events/relocation_created.py
+++ b/src/sentry/analytics/events/relocation_created.py
@@ -1,0 +1,14 @@
+from sentry import analytics
+
+
+class RelocationCreatedEvent(analytics.Event):
+    type = "relocation.created"
+
+    attributes = (
+        analytics.Attribute("user_id"),
+        analytics.Attribute("owner_id"),
+        analytics.Attribute("uuid"),
+    )
+
+
+analytics.register(RelocationCreatedEvent)

--- a/src/sentry/analytics/events/relocation_organization_imported.py
+++ b/src/sentry/analytics/events/relocation_organization_imported.py
@@ -1,15 +1,16 @@
 from sentry import analytics
 
 
-class OrganizationImportedEvent(analytics.Event):
-    type = "organization.imported"
+class RelocationOrganizationImportedEvent(analytics.Event):
+    type = "relocation.organization_imported"
 
     attributes = (
         analytics.Attribute("organization_id"),
+        analytics.Attribute("relocation_uuid"),
         analytics.Attribute("owner_id"),
         analytics.Attribute("name"),
         analytics.Attribute("slug"),
     )
 
 
-analytics.register(OrganizationImportedEvent)
+analytics.register(RelocationOrganizationImportedEvent)

--- a/src/sentry/analytics/events/user_signup.py
+++ b/src/sentry/analytics/events/user_signup.py
@@ -12,4 +12,9 @@ class UserSignUpEvent(analytics.Event):
     )
 
 
+class RelocationUserSignUpEvent(UserSignUpEvent):
+    type = "relocation.user_signup"
+
+
 analytics.register(UserSignUpEvent)
+analytics.register(RelocationUserSignUpEvent)

--- a/src/sentry/api/endpoints/relocations/index.py
+++ b/src/sentry/api/endpoints/relocations/index.py
@@ -271,7 +271,7 @@ class RelocationIndexEndpoint(Endpoint):
         uploading_complete.delay(relocation.uuid)
         analytics.record(
             "relocation.created",
-            user_id=request.user.id,
+            creator_id=request.user.id,
             owner_id=owner.id,
             uuid=str(relocation.uuid),
         )

--- a/src/sentry/api/endpoints/relocations/index.py
+++ b/src/sentry/api/endpoints/relocations/index.py
@@ -273,6 +273,6 @@ class RelocationIndexEndpoint(Endpoint):
             "relocation.created",
             user_id=request.user.id,
             owner_id=owner.id,
-            uuid=relocation.uuid,
+            uuid=str(relocation.uuid),
         )
         return Response(serialize(relocation), status=status.HTTP_201_CREATED)

--- a/src/sentry/api/endpoints/relocations/index.py
+++ b/src/sentry/api/endpoints/relocations/index.py
@@ -12,7 +12,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import options
+from sentry import analytics, options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
@@ -269,4 +269,10 @@ class RelocationIndexEndpoint(Endpoint):
             )
 
         uploading_complete.delay(relocation.uuid)
+        analytics.record(
+            "relocation.created",
+            user_id=request.user.id,
+            owner_id=owner.id,
+            uuid=relocation.uuid,
+        )
         return Response(serialize(relocation), status=status.HTTP_201_CREATED)

--- a/src/sentry/api/endpoints/relocations/retry.py
+++ b/src/sentry/api/endpoints/relocations/retry.py
@@ -7,6 +7,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
@@ -118,4 +119,10 @@ class RelocationRetryEndpoint(Endpoint):
             )
 
         uploading_complete.delay(new_relocation.uuid)
+        analytics.record(
+            "relocation.created",
+            creator_id=request.user.id,
+            owner_id=owner.id,
+            uuid=str(relocation.uuid),
+        )
         return Response(serialize(new_relocation), status=status.HTTP_201_CREATED)

--- a/src/sentry/api/endpoints/relocations/retry.py
+++ b/src/sentry/api/endpoints/relocations/retry.py
@@ -123,6 +123,6 @@ class RelocationRetryEndpoint(Endpoint):
             "relocation.created",
             creator_id=request.user.id,
             owner_id=owner.id,
-            uuid=str(relocation.uuid),
+            uuid=str(new_relocation.uuid),
         )
         return Response(serialize(new_relocation), status=status.HTTP_201_CREATED)

--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -16,6 +16,7 @@ from django.db import router, transaction
 from google.cloud.devtools.cloudbuild_v1 import Build
 from google.cloud.devtools.cloudbuild_v1 import CloudBuildClient as CloudBuildClient
 
+from sentry import analytics
 from sentry.api.serializers.rest_framework.base import camel_to_snake_case, convert_dict_key_case
 from sentry.backup.dependencies import NormalizedModelName, get_model
 from sentry.backup.exports import export_in_config_scope, export_in_user_scope
@@ -1084,6 +1085,13 @@ def postprocessing(uuid: str) -> None:
                 default_org_role=org.default_role,
                 user_id=relocation.owner_id,
                 role="owner",
+            )
+
+            analytics.record(
+                organization_id=org.id,
+                slug=org.slug,
+                name=org.name,
+                owner_id=relocation.owner_id,
             )
 
         # Last, but certainly not least: trigger signals, so that interested subscribers in eg:

--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -1088,9 +1088,9 @@ def postprocessing(uuid: str) -> None:
             )
 
             analytics.record(
+                "organization.imported",
                 organization_id=org.id,
                 slug=org.slug,
-                name=org.name,
                 owner_id=relocation.owner_id,
             )
 

--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -1087,7 +1087,6 @@ def postprocessing(uuid: str) -> None:
                 user_id=relocation.owner_id,
                 role="owner",
             )
-
         # Last, but certainly not least: trigger signals, so that interested subscribers in eg:
         # getsentry can do whatever postprocessing they need to. If even a single one fails, we fail
         # the entire task.

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -315,7 +315,7 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            user_id=int(response.data["creatorId"]),
+            creator_id=int(response.data["creatorId"]),
             owner_id=int(response.data["ownerId"]),
             uuid=response.data["uuid"],
         )
@@ -365,7 +365,7 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            user_id=int(response.data["creatorId"]),
+            creator_id=int(response.data["creatorId"]),
             owner_id=int(response.data["ownerId"]),
             uuid=response.data["uuid"],
         )
@@ -414,7 +414,7 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            user_id=int(response.data["creatorId"]),
+            creator_id=int(response.data["creatorId"]),
             owner_id=int(response.data["ownerId"]),
             uuid=response.data["uuid"],
         )
@@ -474,7 +474,7 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            user_id=int(response.data["creatorId"]),
+            creator_id=int(response.data["creatorId"]),
             owner_id=int(response.data["ownerId"]),
             uuid=response.data["uuid"],
         )
@@ -589,7 +589,7 @@ class PostRelocationsTest(APITestCase):
             assert analytics_record_mock.call_count == 1
             analytics_record_mock.assert_called_with(
                 "relocation.created",
-                user_id=int(response.data["creatorId"]),
+                creator_id=int(response.data["creatorId"]),
                 owner_id=int(response.data["ownerId"]),
                 uuid=response.data["uuid"],
             )
@@ -699,7 +699,7 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            user_id=int(response.data["creatorId"]),
+            creator_id=int(response.data["creatorId"]),
             owner_id=int(response.data["ownerId"]),
             uuid=response.data["uuid"],
         )
@@ -976,7 +976,7 @@ class PostRelocationsTest(APITestCase):
         assert analytics_record_mock.call_count == 1
         analytics_record_mock.assert_called_with(
             "relocation.created",
-            user_id=int(initial_response.data["creatorId"]),
+            creator_id=int(initial_response.data["creatorId"]),
             owner_id=int(initial_response.data["ownerId"]),
             uuid=initial_response.data["uuid"],
         )
@@ -1045,13 +1045,13 @@ class PostRelocationsTest(APITestCase):
             [
                 call(
                     "relocation.created",
-                    user_id=int(initial_response.data["creatorId"]),
+                    creator_id=int(initial_response.data["creatorId"]),
                     owner_id=int(initial_response.data["ownerId"]),
                     uuid=initial_response.data["uuid"],
                 ),
                 call(
                     "relocation.created",
-                    user_id=int(throttled_response.data["creatorId"]),
+                    creator_id=int(throttled_response.data["creatorId"]),
                     owner_id=int(throttled_response.data["ownerId"]),
                     uuid=throttled_response.data["uuid"],
                 ),
@@ -1124,13 +1124,13 @@ class PostRelocationsTest(APITestCase):
             [
                 call(
                     "relocation.created",
-                    user_id=int(initial_response.data["creatorId"]),
+                    creator_id=int(initial_response.data["creatorId"]),
                     owner_id=int(initial_response.data["ownerId"]),
                     uuid=initial_response.data["uuid"],
                 ),
                 call(
                     "relocation.created",
-                    user_id=int(unthrottled_response.data["creatorId"]),
+                    creator_id=int(unthrottled_response.data["creatorId"]),
                     owner_id=int(unthrottled_response.data["ownerId"]),
                     uuid=unthrottled_response.data["uuid"],
                 ),
@@ -1206,13 +1206,13 @@ class PostRelocationsTest(APITestCase):
             [
                 call(
                     "relocation.created",
-                    user_id=int(initial_response.data["creatorId"]),
+                    creator_id=int(initial_response.data["creatorId"]),
                     owner_id=int(initial_response.data["ownerId"]),
                     uuid=initial_response.data["uuid"],
                 ),
                 call(
                     "relocation.created",
-                    user_id=int(unthrottled_response.data["creatorId"]),
+                    creator_id=int(unthrottled_response.data["creatorId"]),
                     owner_id=int(unthrottled_response.data["ownerId"]),
                     uuid=unthrottled_response.data["uuid"],
                 ),

--- a/tests/sentry/api/endpoints/relocations/test_index.py
+++ b/tests/sentry/api/endpoints/relocations/test_index.py
@@ -2,7 +2,7 @@ import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Tuple
-from unittest.mock import patch
+from unittest.mock import Mock, call, patch
 from uuid import UUID
 
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -232,6 +232,7 @@ class GetRelocationsTest(APITestCase):
 
 
 @region_silo_test
+@patch("sentry.analytics.record")
 class PostRelocationsTest(APITestCase):
     endpoint = "sentry-api-0-relocations-index"
 
@@ -257,7 +258,11 @@ class PostRelocationsTest(APITestCase):
         return (tmp_priv_key_path, tmp_pub_key_path)
 
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_good_simple(self, uploading_complete_mock):
+    def test_good_simple(
+        self,
+        uploading_complete_mock: Mock,
+        analytics_record_mock: Mock,
+    ):
         self.login_as(user=self.owner, superuser=False)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
@@ -307,8 +312,20 @@ class PostRelocationsTest(APITestCase):
 
         assert uploading_complete_mock.call_count == 1
 
+        assert analytics_record_mock.call_count == 1
+        analytics_record_mock.assert_called_with(
+            "relocation.created",
+            user_id=int(response.data["creatorId"]),
+            owner_id=int(response.data["ownerId"]),
+            uuid=response.data["uuid"],
+        )
+
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_good_with_valid_autopause_option(self, uploading_complete_mock):
+    def test_good_with_valid_autopause_option(
+        self,
+        uploading_complete_mock: Mock,
+        analytics_record_mock: Mock,
+    ):
         self.login_as(user=self.owner, superuser=False)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -345,8 +362,20 @@ class PostRelocationsTest(APITestCase):
 
         assert uploading_complete_mock.call_count == 1
 
+        assert analytics_record_mock.call_count == 1
+        analytics_record_mock.assert_called_with(
+            "relocation.created",
+            user_id=int(response.data["creatorId"]),
+            owner_id=int(response.data["ownerId"]),
+            uuid=response.data["uuid"],
+        )
+
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_good_with_invalid_autopause_option(self, uploading_complete_mock):
+    def test_good_with_invalid_autopause_option(
+        self,
+        uploading_complete_mock: Mock,
+        analytics_record_mock: Mock,
+    ):
         self.login_as(user=self.owner, superuser=False)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -382,9 +411,18 @@ class PostRelocationsTest(APITestCase):
         assert response.data["scheduledPauseAtStep"] is None
 
         assert uploading_complete_mock.call_count == 1
+        assert analytics_record_mock.call_count == 1
+        analytics_record_mock.assert_called_with(
+            "relocation.created",
+            user_id=int(response.data["creatorId"]),
+            owner_id=int(response.data["ownerId"]),
+            uuid=response.data["uuid"],
+        )
 
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_good_with_superuser_when_feature_disabled(self, uploading_complete_mock):
+    def test_good_with_superuser_when_feature_disabled(
+        self, uploading_complete_mock: Mock, analytics_record_mock: Mock
+    ):
         self.login_as(user=self.superuser, superuser=True)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
@@ -433,7 +471,15 @@ class PostRelocationsTest(APITestCase):
 
         assert uploading_complete_mock.call_count == 1
 
-    def test_bad_without_superuser_when_feature_disabled(self):
+        assert analytics_record_mock.call_count == 1
+        analytics_record_mock.assert_called_with(
+            "relocation.created",
+            user_id=int(response.data["creatorId"]),
+            owner_id=int(response.data["ownerId"]),
+            uuid=response.data["uuid"],
+        )
+
+    def test_bad_without_superuser_when_feature_disabled(self, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
@@ -460,7 +506,9 @@ class PostRelocationsTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_FEATURE_DISABLED
 
-    def test_bad_expired_superuser_when_feature_disabled(self):
+        assert analytics_record_mock.call_count == 0
+
+    def test_bad_expired_superuser_when_feature_disabled(self, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
@@ -487,6 +535,8 @@ class PostRelocationsTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_FEATURE_DISABLED
 
+        assert analytics_record_mock.call_count == 0
+
     # pytest parametrize does not work in TestCase subclasses, so hack around this
     for org_slugs, expected in [
         ("testing,foo,", ["testing", "foo"]),
@@ -497,7 +547,11 @@ class PostRelocationsTest(APITestCase):
 
         @patch("sentry.tasks.relocation.uploading_complete.delay")
         def test_good_valid_org_slugs(
-            self, uploading_complete_mock, org_slugs=org_slugs, expected=expected
+            self,
+            uploading_complete_mock: Mock,
+            analytics_record_mock: Mock,
+            org_slugs=org_slugs,
+            expected=expected,
         ):
             self.login_as(user=self.owner, superuser=False)
             relocation_count = Relocation.objects.count()
@@ -532,6 +586,14 @@ class PostRelocationsTest(APITestCase):
             assert Relocation.objects.get(owner_id=self.owner.id).want_org_slugs == expected
             assert uploading_complete_mock.call_count == 1
 
+            assert analytics_record_mock.call_count == 1
+            analytics_record_mock.assert_called_with(
+                "relocation.created",
+                user_id=int(response.data["creatorId"]),
+                owner_id=int(response.data["ownerId"]),
+                uuid=response.data["uuid"],
+            )
+
     for org_slugs, invalid_org_slug in [
         (",,", ""),
         ("testing,,foo", ""),
@@ -541,7 +603,11 @@ class PostRelocationsTest(APITestCase):
 
         @patch("sentry.tasks.relocation.uploading_complete.delay")
         def test_bad_invalid_org_slugs(
-            self, uploading_complete_mock, org_slugs=org_slugs, invalid_org_slug=invalid_org_slug
+            self,
+            analytics_record_mock: Mock,
+            uploading_complete_mock: Mock,
+            org_slugs=org_slugs,
+            invalid_org_slug=invalid_org_slug,
         ):
             self.login_as(user=self.owner, superuser=False)
             relocation_count = Relocation.objects.count()
@@ -579,7 +645,9 @@ class PostRelocationsTest(APITestCase):
             assert RelocationFile.objects.count() == relocation_file_count
             assert uploading_complete_mock.call_count == 0
 
-    def test_good_relocation_for_same_owner_already_completed(self):
+            assert analytics_record_mock.call_count == 0
+
+    def test_good_relocation_for_same_owner_already_completed(self, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
         Relocation.objects.create(
             creator_id=self.superuser.id,
@@ -628,7 +696,15 @@ class PostRelocationsTest(APITestCase):
         assert Relocation.objects.count() == relocation_count + 1
         assert RelocationFile.objects.count() == relocation_file_count + 1
 
-    def test_bad_missing_file(self):
+        assert analytics_record_mock.call_count == 1
+        analytics_record_mock.assert_called_with(
+            "relocation.created",
+            user_id=int(response.data["creatorId"]),
+            owner_id=int(response.data["ownerId"]),
+            uuid=response.data["uuid"],
+        )
+
+    def test_bad_missing_file(self, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
@@ -651,7 +727,9 @@ class PostRelocationsTest(APITestCase):
         assert response.data.get("file") is not None
         assert response.data.get("file")[0].code == "required"
 
-    def test_bad_missing_orgs(self):
+        analytics_record_mock.assert_not_called()
+
+    def test_bad_missing_orgs(self, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
@@ -682,7 +760,9 @@ class PostRelocationsTest(APITestCase):
         assert response.data.get("orgs") is not None
         assert response.data.get("orgs")[0].code == "required"
 
-    def test_bad_missing_owner(self):
+        analytics_record_mock.assert_not_called()
+
+    def test_bad_missing_owner(self, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
@@ -713,7 +793,9 @@ class PostRelocationsTest(APITestCase):
         assert response.data.get("owner") is not None
         assert response.data.get("owner")[0].code == "required"
 
-    def test_bad_nonexistent_owner(self):
+        analytics_record_mock.assert_not_called()
+
+    def test_bad_nonexistent_owner(self, analytics_record_mock: Mock):
         self.login_as(user=self.superuser, superuser=True)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
@@ -747,7 +829,9 @@ class PostRelocationsTest(APITestCase):
             owner_username="doesnotexist"
         )
 
-    def test_bad_owner_not_self(self):
+        analytics_record_mock.assert_not_called()
+
+    def test_bad_owner_not_self(self, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
         with tempfile.TemporaryDirectory() as tmp_dir:
             (_, tmp_pub_key_path) = self.tmp_keys(tmp_dir)
@@ -779,12 +863,16 @@ class PostRelocationsTest(APITestCase):
         assert response.data.get("detail") is not None
         assert response.data.get("detail") == ERR_INVALID_OWNER.substitute(creator_username="owner")
 
+        analytics_record_mock.assert_not_called()
+
     for stat in [
         Relocation.Status.IN_PROGRESS,
         Relocation.Status.PAUSE,
     ]:
 
-        def test_bad_relocation_for_same_owner_already_active(self, stat=stat):
+        def test_bad_relocation_for_same_owner_already_active(
+            self, analytics_record_mock: Mock, stat=stat
+        ):
             self.login_as(user=self.owner, superuser=False)
             Relocation.objects.create(
                 creator_id=self.superuser.id,
@@ -822,7 +910,9 @@ class PostRelocationsTest(APITestCase):
 
             assert response.status_code == status.HTTP_409_CONFLICT
 
-    def test_bad_throttle_if_daily_limit_reached(self):
+            analytics_record_mock.assert_not_called()
+
+    def test_bad_throttle_if_daily_limit_reached(self, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
@@ -883,7 +973,15 @@ class PostRelocationsTest(APITestCase):
         assert Relocation.objects.count() == relocation_count + 1
         assert RelocationFile.objects.count() == relocation_file_count + 1
 
-    def test_good_no_throttle_for_superuser(self):
+        assert analytics_record_mock.call_count == 1
+        analytics_record_mock.assert_called_with(
+            "relocation.created",
+            user_id=int(initial_response.data["creatorId"]),
+            owner_id=int(initial_response.data["ownerId"]),
+            uuid=initial_response.data["uuid"],
+        )
+
+    def test_good_no_throttle_for_superuser(self, analytics_record_mock: Mock):
         self.login_as(user=self.superuser, superuser=True)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
@@ -942,7 +1040,25 @@ class PostRelocationsTest(APITestCase):
         assert Relocation.objects.count() == relocation_count + 2
         assert RelocationFile.objects.count() == relocation_file_count + 2
 
-    def test_good_no_throttle_different_bucket_relocations(self):
+        assert analytics_record_mock.call_count == 2
+        analytics_record_mock.assert_has_calls(
+            [
+                call(
+                    "relocation.created",
+                    user_id=int(initial_response.data["creatorId"]),
+                    owner_id=int(initial_response.data["ownerId"]),
+                    uuid=initial_response.data["uuid"],
+                ),
+                call(
+                    "relocation.created",
+                    user_id=int(throttled_response.data["creatorId"]),
+                    owner_id=int(throttled_response.data["ownerId"]),
+                    uuid=throttled_response.data["uuid"],
+                ),
+            ]
+        )
+
+    def test_good_no_throttle_different_bucket_relocations(self, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
@@ -1003,7 +1119,25 @@ class PostRelocationsTest(APITestCase):
         assert Relocation.objects.count() == relocation_count + 2
         assert RelocationFile.objects.count() == relocation_file_count + 2
 
-    def test_good_no_throttle_relocation_over_multiple_days(self):
+        assert analytics_record_mock.call_count == 2
+        analytics_record_mock.assert_has_calls(
+            [
+                call(
+                    "relocation.created",
+                    user_id=int(initial_response.data["creatorId"]),
+                    owner_id=int(initial_response.data["ownerId"]),
+                    uuid=initial_response.data["uuid"],
+                ),
+                call(
+                    "relocation.created",
+                    user_id=int(unthrottled_response.data["creatorId"]),
+                    owner_id=int(unthrottled_response.data["ownerId"]),
+                    uuid=unthrottled_response.data["uuid"],
+                ),
+            ]
+        )
+
+    def test_good_no_throttle_relocation_over_multiple_days(self, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
@@ -1066,7 +1200,26 @@ class PostRelocationsTest(APITestCase):
         assert Relocation.objects.count() == relocation_count + 2
         assert RelocationFile.objects.count() == relocation_file_count + 2
 
-    def test_bad_no_auth(self):
+        assert analytics_record_mock.call_count == 2
+
+        analytics_record_mock.assert_has_calls(
+            [
+                call(
+                    "relocation.created",
+                    user_id=int(initial_response.data["creatorId"]),
+                    owner_id=int(initial_response.data["ownerId"]),
+                    uuid=initial_response.data["uuid"],
+                ),
+                call(
+                    "relocation.created",
+                    user_id=int(unthrottled_response.data["creatorId"]),
+                    owner_id=int(unthrottled_response.data["ownerId"]),
+                    uuid=unthrottled_response.data["uuid"],
+                ),
+            ]
+        )
+
+    def test_bad_no_auth(self, analytics_record_mock: Mock):
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
 
@@ -1096,3 +1249,5 @@ class PostRelocationsTest(APITestCase):
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert Relocation.objects.count() == relocation_count
         assert RelocationFile.objects.count() == relocation_file_count
+
+        analytics_record_mock.assert_not_called()

--- a/tests/sentry/api/endpoints/relocations/test_retry.py
+++ b/tests/sentry/api/endpoints/relocations/test_retry.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from functools import lru_cache
 from io import BytesIO
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from uuid import uuid4
 
 from rest_framework import status
@@ -42,6 +42,7 @@ def get_test_tarball() -> BytesIO:
 
 
 @region_silo_test
+@patch("sentry.analytics.record")
 class RetryRelocationTest(APITestCase):
     endpoint = "sentry-api-0-relocations-retry"
 
@@ -85,7 +86,7 @@ class RetryRelocationTest(APITestCase):
         )
 
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_good_simple(self, uploading_complete_mock):
+    def test_good_simple(self, uploading_complete_mock: Mock, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
@@ -124,8 +125,17 @@ class RetryRelocationTest(APITestCase):
 
         assert uploading_complete_mock.call_count == 1
 
+        analytics_record_mock.assert_called_with(
+            "relocation.created",
+            creator_id=int(response.data["creatorId"]),
+            owner_id=int(response.data["ownerId"]),
+            uuid=response.data["uuid"],
+        )
+
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_good_with_superuser_when_feature_disabled(self, uploading_complete_mock):
+    def test_good_with_superuser_when_feature_disabled(
+        self, uploading_complete_mock: Mock, analytics_record_mock: Mock
+    ):
         self.login_as(user=self.superuser, superuser=True)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
@@ -154,8 +164,17 @@ class RetryRelocationTest(APITestCase):
 
         assert uploading_complete_mock.call_count == 1
 
+        analytics_record_mock.assert_called_with(
+            "relocation.created",
+            creator_id=int(response.data["creatorId"]),
+            owner_id=int(response.data["ownerId"]),
+            uuid=response.data["uuid"],
+        )
+
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_bad_without_superuser_when_feature_disabled(self, uploading_complete_mock):
+    def test_bad_without_superuser_when_feature_disabled(
+        self, uploading_complete_mock: Mock, analytics_record_mock: Mock
+    ):
         self.login_as(user=self.owner, superuser=False)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
@@ -179,7 +198,9 @@ class RetryRelocationTest(APITestCase):
         assert uploading_complete_mock.call_count == 0
 
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_bad_expired_superuser_when_feature_disabled(self, uploading_complete_mock):
+    def test_bad_expired_superuser_when_feature_disabled(
+        self, uploading_complete_mock: Mock, analytics_record_mock: Mock
+    ):
         self.login_as(user=self.owner, superuser=True)
         relocation_count = Relocation.objects.count()
         relocation_file_count = RelocationFile.objects.count()
@@ -201,9 +222,12 @@ class RetryRelocationTest(APITestCase):
         assert File.objects.count() == file_count
 
         assert uploading_complete_mock.call_count == 0
+        analytics_record_mock.assert_not_called()
 
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_bad_relocation_not_found(self, uploading_complete_mock):
+    def test_bad_relocation_not_found(
+        self, uploading_complete_mock: Mock, analytics_record_mock: Mock
+    ):
         self.login_as(user=self.owner, superuser=False)
 
         with self.options({"relocation.enabled": True, "relocation.daily-limit.small": 2}):
@@ -212,9 +236,12 @@ class RetryRelocationTest(APITestCase):
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
         assert uploading_complete_mock.call_count == 0
+        analytics_record_mock.assert_not_called()
 
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_bad_relocation_file_not_found(self, uploading_complete_mock):
+    def test_bad_relocation_file_not_found(
+        self, uploading_complete_mock: Mock, analytics_record_mock: Mock
+    ):
         self.login_as(user=self.owner, superuser=False)
         RelocationFile.objects.all().delete()
 
@@ -225,9 +252,10 @@ class RetryRelocationTest(APITestCase):
         assert response.data.get("detail") == ERR_FILE_NO_LONGER_EXISTS
 
         assert uploading_complete_mock.call_count == 0
+        analytics_record_mock.assert_not_called()
 
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_bad_file_not_found(self, uploading_complete_mock):
+    def test_bad_file_not_found(self, uploading_complete_mock: Mock, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
         File.objects.all().delete()
 
@@ -240,7 +268,7 @@ class RetryRelocationTest(APITestCase):
         assert uploading_complete_mock.call_count == 0
 
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_bad_owner_not_found(self, uploading_complete_mock):
+    def test_bad_owner_not_found(self, uploading_complete_mock: Mock, analytics_record_mock: Mock):
         self.login_as(user=self.superuser, superuser=True)
         with assume_test_silo_mode(SiloMode.CONTROL):
             User.objects.filter(id=self.owner.id).delete()
@@ -252,9 +280,10 @@ class RetryRelocationTest(APITestCase):
         assert response.data.get("detail") == ERR_OWNER_NO_LONGER_EXISTS
 
         assert uploading_complete_mock.call_count == 0
+        analytics_record_mock.assert_not_called()
 
     @patch("sentry.tasks.relocation.uploading_complete.delay")
-    def test_bad_throttled(self, uploading_complete_mock):
+    def test_bad_throttled(self, uploading_complete_mock: Mock, analytics_record_mock: Mock):
         self.login_as(user=self.owner, superuser=False)
 
         with self.options({"relocation.enabled": True, "relocation.daily-limit.small": 1}):
@@ -264,6 +293,7 @@ class RetryRelocationTest(APITestCase):
         assert response.data.get("detail") == ERR_THROTTLED_RELOCATION
 
         assert uploading_complete_mock.call_count == 0
+        analytics_record_mock.assert_not_called()
 
     for stat in [
         Relocation.Status.IN_PROGRESS,
@@ -271,7 +301,9 @@ class RetryRelocationTest(APITestCase):
     ]:
 
         @patch("sentry.tasks.relocation.uploading_complete.delay")
-        def test_bad_relocation_still_ongoing(self, uploading_complete_mock, stat=stat):
+        def test_bad_relocation_still_ongoing(
+            self, uploading_complete_mock: Mock, analytics_record_mock: Mock, stat=stat
+        ):
             self.login_as(user=self.owner, superuser=False)
             self.relocation.status = stat.value
             self.relocation.latest_notified = Relocation.EmailKind.STARTED.value
@@ -288,6 +320,7 @@ class RetryRelocationTest(APITestCase):
             )
 
             assert uploading_complete_mock.call_count == 0
+            analytics_record_mock.assert_not_called()
 
     for stat in [
         Relocation.Status.IN_PROGRESS,
@@ -295,7 +328,9 @@ class RetryRelocationTest(APITestCase):
     ]:
 
         @patch("sentry.tasks.relocation.uploading_complete.delay")
-        def test_bad_owner_has_another_active_relocation(self, uploading_complete_mock, stat=stat):
+        def test_bad_owner_has_another_active_relocation(
+            self, uploading_complete_mock: Mock, analytics_record_mock: Mock, stat=stat
+        ):
             self.login_as(user=self.owner, superuser=False)
             Relocation.objects.create(
                 date_added=TEST_DATE_ADDED,
@@ -321,3 +356,4 @@ class RetryRelocationTest(APITestCase):
             assert response.data.get("detail") == ERR_DUPLICATE_RELOCATION
 
             assert uploading_complete_mock.call_count == 0
+            analytics_record_mock.assert_not_called()

--- a/tests/sentry/tasks/test_relocation.py
+++ b/tests/sentry/tasks/test_relocation.py
@@ -1794,13 +1794,8 @@ class PostprocessingTest(RelocationTaskTestCase):
         assert relocation.latest_notified != Relocation.EmailKind.FAILED.value
         assert not relocation.failure_reason
 
-        analytics_record_mock.assert_called_with(
-            "relocation.organization_imported",
-            organization_id=self.imported_org_id,
-            relocation_uuid=str(relocation.uuid),
-            slug=self.imported_org_slug,
-            owner_id=self.owner.id,
-        )
+        # Technically this should be called, but since we're mocking out the `send_robust` function, it won't
+        analytics_record_mock.assert_not_called()
 
     def test_fail_if_no_attempts_left(
         self,


### PR DESCRIPTION
Adds a couple of analytics that will be helpful in the context of relocations.

1. Orgs that are created during the relocation process
2. Relocations that are kicked off