### PR TITLE
fix(open-pr-comments): get matching function name

### DIFF
--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -399,8 +399,10 @@ class TestGetCommentIssues(CreateEventTestCase):
 
         top_5_issues = get_top_5_issues_by_count_for_file([self.project], ["baz.py"], ["world"])
         top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
+        function_names = [issue["function_name"] for issue in top_5_issues]
         assert group_id != self.group_id
         assert top_5_issue_ids == [self.group_id, group_id]
+        assert function_names == ["world", "world"]
 
     def test_not_within_frame_limit(self):
         function_names = ["world"] + ["a" for _ in range(STACKFRAME_COUNT)]


### PR DESCRIPTION
Followup to #62763

We are currently always returning the function name of the top frame of the stacktrace, even though it is a possible that an issue is returned in which the filename+function name matches at some other frame (up to 6 frames deep atm).

We use a `multiIf` to fix this https://clickhouse.com/docs/en/sql-reference/functions/conditional-functions#multiif
If the first frame of the stacktrace matches in filename + function, then we return the function name of the first frame. If the second frame matches in filename + function, then we return the function name of the second frame... etc... Otherwise, just return the function name of the first frame.