### PR TITLE
chore(requests): Make request test utils available in getsentry

### DIFF
--- a/src/sentry/testutils/requests.py
+++ b/src/sentry/testutils/requests.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import functools
+from typing import Callable, Optional, Tuple
+
+from django.contrib.auth.models import AnonymousUser, User
+from django.core.cache import cache
+from django.http import HttpRequest
+
+from sentry.app import env
+from sentry.middleware.auth import AuthenticationMiddleware
+from sentry.middleware.placeholder import placeholder_get_response
+from sentry.testutils.factories import Factories
+from sentry.utils.auth import login
+
+RequestFactory = Callable[[], Optional[Tuple[HttpRequest, User]]]
+
+
+def request_factory(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwds) -> Tuple[HttpRequest, User] | None:
+        result = f(*args, **kwds)
+        if result is not None:
+            request, user = result
+            if not user.is_anonymous:
+                login(request, user)
+                AuthenticationMiddleware(placeholder_get_response).process_request(request)
+            else:
+                request.user = user
+                request.auth = None
+            env.request = request
+            cache.clear()
+        else:
+            env.clear()
+        return result
+
+    return wrapper
+
+
+@request_factory
+def make_request() -> tuple[HttpRequest, AnonymousUser]:
+    request = HttpRequest()
+    request.method = "GET"
+    request.META["REMOTE_ADDR"] = "127.0.0.1"
+    request.META["SERVER_NAME"] = "testserver"
+    request.META["SERVER_PORT"] = 80
+    request.session = Factories.create_session()
+    return request, AnonymousUser()
+
+
+@request_factory
+def make_user_request(org=None) -> Tuple[HttpRequest, User]:
+    request, _ = make_request()
+    user = Factories.create_user()
+    org = org or Factories.create_organization()
+    Factories.create_member(organization=org, user=user)
+    teams = [Factories.create_team(org, members=[user]) for i in range(2)]
+    [Factories.create_project(org, teams=teams) for i in range(2)]
+    return request, user
+
+
+@request_factory
+def make_user_request_from_org(org=None):
+    org = org or Factories.create_organization()
+    request, user = make_user_request(org)
+    request.session["activeorg"] = org.slug
+    return request, user

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -1,19 +1,12 @@
 from __future__ import annotations
 
-import functools
-from typing import Callable, Optional, Tuple
-
 import pytest
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser, User
 from django.core.cache import cache
-from django.http import HttpRequest
 from django.test import override_settings
 
 from sentry import options
 from sentry.app import env
-from sentry.middleware.auth import AuthenticationMiddleware
-from sentry.middleware.placeholder import placeholder_get_response
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organization import Organization
@@ -23,63 +16,16 @@ from sentry.silo import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.region import get_test_env_directory
+from sentry.testutils.requests import (
+    RequestFactory,
+    make_request,
+    make_user_request,
+    make_user_request_from_org,
+    request_factory,
+)
 from sentry.testutils.silo import control_silo_test, create_test_regions
 from sentry.types import region
-from sentry.utils.auth import login
 from sentry.web.client_config import get_client_config
-
-RequestFactory = Callable[[], Optional[Tuple[HttpRequest, User]]]
-
-
-def request_factory(f):
-    @functools.wraps(f)
-    def wrapper(*args, **kwds) -> Tuple[HttpRequest, User] | None:
-        result = f(*args, **kwds)
-        if result is not None:
-            request, user = result
-            if not user.is_anonymous:
-                login(request, user)
-                AuthenticationMiddleware(placeholder_get_response).process_request(request)
-            else:
-                request.user = user
-                request.auth = None
-            env.request = request
-            cache.clear()
-        else:
-            env.clear()
-        return result
-
-    return wrapper
-
-
-@request_factory
-def make_request() -> tuple[HttpRequest, AnonymousUser]:
-    request = HttpRequest()
-    request.method = "GET"
-    request.META["REMOTE_ADDR"] = "127.0.0.1"
-    request.META["SERVER_NAME"] = "testserver"
-    request.META["SERVER_PORT"] = 80
-    request.session = Factories.create_session()
-    return request, AnonymousUser()
-
-
-@request_factory
-def make_user_request(org=None) -> Tuple[HttpRequest, User]:
-    request, _ = make_request()
-    user = Factories.create_user()
-    org = org or Factories.create_organization()
-    Factories.create_member(organization=org, user=user)
-    teams = [Factories.create_team(org, members=[user]) for i in range(2)]
-    [Factories.create_project(org, teams=teams) for i in range(2)]
-    return request, user
-
-
-@request_factory
-def make_user_request_from_org(org=None):
-    org = org or Factories.create_organization()
-    request, user = make_user_request(org)
-    request.session["activeorg"] = org.slug
-    return request, user
 
 
 @request_factory


### PR DESCRIPTION
Sharing these utils to reuse them in client config tests on getsentry