### PR TITLE
chore(hybrid-cloud): Hide installation wizard for non-self-hosted

### DIFF
--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -159,12 +159,12 @@ function App({children, params}: Props) {
     ConfigStore.set('user', {...config.user, flags});
   }
 
-  const needsUpgrade = config.user?.isSuperuser && config.needsUpgrade;
+  const displayInstallWizard = config.user?.isSuperuser && config.needsUpgrade && config.isSelfHosted;
   const newsletterConsentPrompt = config.user?.flags?.newsletter_consent_prompt;
   const partnershipAgreementPrompt = config.partnershipAgreementPrompt;
 
   function renderBody() {
-    if (needsUpgrade) {
+    if (displayInstallWizard) {
       return (
         <Suspense fallback={null}>
           <InstallWizard onConfigured={clearUpgrade} />;


### PR DESCRIPTION
The installation wizard should never be shown in SaaS as we do not want any superusers to unintentionally change the option values.

This pull request hides the install wizard in frontend whenever `isSelfHosted` is false.. 