### PR TITLE
ref(grouping): Move secondary grouping functions to `grouping` module

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import copy
 import ipaddress
 import logging
 import re
-import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -66,7 +64,9 @@ from sentry.grouping.api import (
 )
 from sentry.grouping.ingest import (
     calculate_event_grouping,
+    calculate_secondary_hash,
     run_background_grouping,
+    should_run_secondary_grouping,
     update_grouping_config_if_needed,
 )
 from sentry.grouping.result import CalculatedHashes
@@ -525,12 +525,10 @@ class EventManager:
         secondary_hashes = None
         migrate_off_hierarchical = False
 
-        if _should_run_secondary_grouping(project):
+        if should_run_secondary_grouping(project):
             with metrics.timer("event_manager.secondary_grouping", tags=metric_tags):
                 secondary_grouping_config = SecondaryGroupingConfigLoader().get_config_dict(project)
-                secondary_hashes = _calculate_secondary_hash(
-                    project, job, secondary_grouping_config
-                )
+                secondary_hashes = calculate_secondary_hash(project, job, secondary_grouping_config)
 
         with metrics.timer("event_manager.load_grouping_config"):
             # At this point we want to normalize the in_app values in case the
@@ -750,16 +748,6 @@ class EventManager:
         return job["event"]
 
 
-def _should_run_secondary_grouping(project: Project) -> bool:
-    result = False
-    # These two values are basically always set
-    secondary_grouping_config = project.get_option("sentry:secondary_grouping_config")
-    secondary_grouping_expiry = project.get_option("sentry:secondary_grouping_expiry")
-    if secondary_grouping_config and (secondary_grouping_expiry or 0) >= time.time():
-        result = True
-    return result
-
-
 def _calculate_primary_hash(
     project: Project, job: Job, grouping_config: GroupingConfig
 ) -> CalculatedHashes:
@@ -769,32 +757,6 @@ def _calculate_primary_hash(
     This is pulled out into a separate function mostly in order to make testing easier.
     """
     return calculate_event_grouping(project, job["event"], grouping_config)
-
-
-def _calculate_secondary_hash(
-    project: Project, job: Job, secondary_grouping_config: GroupingConfig
-) -> None | CalculatedHashes:
-    """Calculate secondary hash for event using a fallback grouping config for a period of time.
-    This happens when we upgrade all projects that have not opted-out to automatic upgrades plus
-    when the customer changes the grouping config.
-    This causes extra load in save_event processing.
-    """
-    secondary_hashes = None
-    try:
-        with sentry_sdk.start_span(
-            op="event_manager",
-            description="event_manager.save.secondary_calculate_event_grouping",
-        ):
-            # create a copy since `calculate_event_grouping` modifies the event to add all sorts
-            # of grouping info and we don't want the backup grouping data in there
-            event_copy = copy.deepcopy(job["event"])
-            secondary_hashes = calculate_event_grouping(
-                project, event_copy, secondary_grouping_config
-            )
-    except Exception:
-        sentry_sdk.capture_exception()
-
-    return secondary_hashes
 
 
 @metrics.wraps("save_event.pull_out_data")

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -198,7 +198,7 @@ def calculate_secondary_hash(
             secondary_hashes = calculate_event_grouping(
                 project, event_copy, secondary_grouping_config
             )
-    except Exception:
-        sentry_sdk.capture_exception()
+    except Exception as err:
+        sentry_sdk.capture_exception(err)
 
     return secondary_hashes

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -354,7 +354,7 @@ class EventManagerGroupingMetricsTest(TestCase):
         assert hashes_calculated_calls[1].kwargs["amount"] == 2
 
     @mock.patch("sentry.event_manager.metrics.incr")
-    @mock.patch("sentry.event_manager._should_run_secondary_grouping", return_value=True)
+    @mock.patch("sentry.event_manager.should_run_secondary_grouping", return_value=True)
     def test_records_hash_comparison(self, _, mock_metrics_incr: MagicMock):
         project = self.project
         project.update_option("sentry:grouping_config", "newstyle:2023-01-11")
@@ -377,7 +377,7 @@ class EventManagerGroupingMetricsTest(TestCase):
                 ),
             ):
                 with mock.patch(
-                    "sentry.event_manager._calculate_secondary_hash",
+                    "sentry.event_manager.calculate_secondary_hash",
                     return_value=CalculatedHashes(
                         hashes=secondary_hashes, hierarchical_hashes=[], tree_labels=[]
                     ),

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -37,54 +37,6 @@ def get_relevant_metrics_calls(mock_fn: MagicMock, key: str) -> list[mock._Call]
 
 @region_silo_test
 class EventManagerGroupingTest(TestCase):
-    def test_applies_secondary_grouping(self):
-        project = self.project
-        project.update_option("sentry:grouping_config", "legacy:2019-03-12")
-        project.update_option("sentry:secondary_grouping_expiry", 0)
-
-        timestamp = time() - 300
-        manager = EventManager(
-            make_event(message="foo 123", event_id="a" * 32, timestamp=timestamp)
-        )
-        manager.normalize()
-        event = manager.save(project.id)
-
-        project.update_option("sentry:grouping_config", "newstyle:2023-01-11")
-        project.update_option("sentry:secondary_grouping_config", "legacy:2019-03-12")
-        project.update_option("sentry:secondary_grouping_expiry", time() + (24 * 90 * 3600))
-
-        # Switching to newstyle grouping changes hashes as 123 will be removed
-        manager = EventManager(
-            make_event(message="foo 123", event_id="b" * 32, timestamp=timestamp + 2.0)
-        )
-        manager.normalize()
-
-        with self.tasks():
-            event2 = manager.save(project.id)
-
-        # make sure that events did get into same group because of fallback grouping, not because of hashes which come from primary grouping only
-        assert not set(event.get_hashes().hashes) & set(event2.get_hashes().hashes)
-        assert event.group_id == event2.group_id
-
-        group = Group.objects.get(id=event.group_id)
-
-        assert group.times_seen == 2
-        assert group.last_seen == event2.datetime
-        assert group.message == event2.message
-        assert group.data.get("type") == "default"
-        assert group.data.get("metadata").get("title") == "foo 123"
-
-        # After expiry, new events are still assigned to the same group:
-        project.update_option("sentry:secondary_grouping_expiry", 0)
-        manager = EventManager(
-            make_event(message="foo 123", event_id="c" * 32, timestamp=timestamp + 4.0)
-        )
-        manager.normalize()
-
-        with self.tasks():
-            event3 = manager.save(project.id)
-        assert event3.group_id == event2.group_id
-
     def test_applies_secondary_grouping_hierarchical(self):
         project = self.project
         project.update_option("sentry:grouping_config", "legacy:2019-03-12")

--- a/tests/sentry/grouping/test_ingest.py
+++ b/tests/sentry/grouping/test_ingest.py
@@ -90,29 +90,25 @@ class SecondaryGroupingTest(TestCase):
     def test_applies_secondary_grouping(self):
         project = self.project
         project.update_option("sentry:grouping_config", "legacy:2019-03-12")
-        project.update_option("sentry:secondary_grouping_expiry", 0)
 
-        timestamp = time() - 300
-        manager = EventManager(
-            make_event(message="foo 123", event_id="a" * 32, timestamp=timestamp)
-        )
+        timestamp = time()
+        manager = EventManager({"message": "foo 123", "timestamp": timestamp})
         manager.normalize()
         event = manager.save(project.id)
 
         project.update_option("sentry:grouping_config", "newstyle:2023-01-11")
         project.update_option("sentry:secondary_grouping_config", "legacy:2019-03-12")
-        project.update_option("sentry:secondary_grouping_expiry", time() + (24 * 90 * 3600))
+        project.update_option("sentry:secondary_grouping_expiry", timestamp + 3600)
 
-        # Switching to newstyle grouping changes hashes as 123 will be removed
-        manager = EventManager(
-            make_event(message="foo 123", event_id="b" * 32, timestamp=timestamp + 2.0)
-        )
+        # Switching to newstyle grouping changes the hash because now '123' will be parametrized
+        manager = EventManager({"message": "foo 123", "timestamp": timestamp + 2.0})
         manager.normalize()
-
+        # We need `self.tasks` here because updating group metadata normally happens async
         with self.tasks():
             event2 = manager.save(project.id)
 
-        # make sure that events did get into same group because of fallback grouping, not because of hashes which come from primary grouping only
+        # Make sure that events did get into same group because of fallback grouping, not because of
+        # hashes which come from primary grouping only
         assert not set(event.get_hashes().hashes) & set(event2.get_hashes().hashes)
         assert event.group_id == event2.group_id
 
@@ -124,11 +120,9 @@ class SecondaryGroupingTest(TestCase):
         assert group.data.get("type") == "default"
         assert group.data.get("metadata").get("title") == "foo 123"
 
-        # After expiry, new events are still assigned to the same group:
+        # After expiry, new events are still assigned to the same group
         project.update_option("sentry:secondary_grouping_expiry", 0)
-        manager = EventManager(
-            make_event(message="foo 123", event_id="c" * 32, timestamp=timestamp + 4.0)
-        )
+        manager = EventManager({"message": "foo 123"})
         manager.normalize()
 
         with self.tasks():

--- a/tests/sentry/grouping/test_ingest.py
+++ b/tests/sentry/grouping/test_ingest.py
@@ -4,7 +4,11 @@ from time import time
 from unittest.mock import MagicMock, patch
 
 from sentry.event_manager import EventManager
-from sentry.grouping.ingest import _calculate_background_grouping
+from sentry.grouping.ingest import (
+    _calculate_background_grouping,
+    calculate_event_grouping,
+    calculate_secondary_hash,
+)
 from sentry.models.group import Group
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
@@ -128,3 +132,39 @@ class SecondaryGroupingTest(TestCase):
         with self.tasks():
             event3 = manager.save(project.id)
         assert event3.group_id == event2.group_id
+
+    @patch("sentry_sdk.capture_exception")
+    @patch("sentry.event_manager.calculate_secondary_hash", wraps=calculate_secondary_hash)
+    def test_handles_errors_with_secondary_grouping(
+        self,
+        mock_calculate_secondary_hash: MagicMock,
+        mock_capture_exception: MagicMock,
+    ) -> None:
+        secondary_grouping_error = Exception("nope")
+        secondary_grouping_config = "legacy:2019-03-12"
+
+        def mock_calculate_event_grouping(project, event, grouping_config):
+            # We only want `calculate_event_grouping` to error inside of `calculate_secondary_hash`,
+            # not anywhere else it's called
+            if grouping_config["id"] == secondary_grouping_config:
+                raise secondary_grouping_error
+            else:
+                return calculate_event_grouping(project, event, grouping_config)
+
+        project = self.project
+        project.update_option("sentry:grouping_config", "newstyle:2023-01-11")
+        project.update_option("sentry:secondary_grouping_config", secondary_grouping_config)
+        project.update_option("sentry:secondary_grouping_expiry", time() + 3600)
+
+        with patch(
+            "sentry.grouping.ingest.calculate_event_grouping",
+            wraps=mock_calculate_event_grouping,
+        ):
+            manager = EventManager({"message": "foo 123"})
+            manager.normalize()
+            event = manager.save(self.project.id)
+
+            assert mock_calculate_secondary_hash.call_count == 1
+            mock_capture_exception.assert_called_with(secondary_grouping_error)
+            # This proves the secondary grouping crash didn't crash the overall grouping process
+            assert event.group

--- a/tests/sentry/grouping/test_ingest.py
+++ b/tests/sentry/grouping/test_ingest.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from time import time
 from unittest.mock import MagicMock, patch
 
 from sentry.event_manager import EventManager
 from sentry.grouping.ingest import _calculate_background_grouping
+from sentry.models.group import Group
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
@@ -81,3 +83,54 @@ class BackgroundGroupingTest(TestCase):
         manager.save(self.project.id)
 
         assert mock_calc_background_grouping.call_count == 0
+
+
+@region_silo_test
+class SecondaryGroupingTest(TestCase):
+    def test_applies_secondary_grouping(self):
+        project = self.project
+        project.update_option("sentry:grouping_config", "legacy:2019-03-12")
+        project.update_option("sentry:secondary_grouping_expiry", 0)
+
+        timestamp = time() - 300
+        manager = EventManager(
+            make_event(message="foo 123", event_id="a" * 32, timestamp=timestamp)
+        )
+        manager.normalize()
+        event = manager.save(project.id)
+
+        project.update_option("sentry:grouping_config", "newstyle:2023-01-11")
+        project.update_option("sentry:secondary_grouping_config", "legacy:2019-03-12")
+        project.update_option("sentry:secondary_grouping_expiry", time() + (24 * 90 * 3600))
+
+        # Switching to newstyle grouping changes hashes as 123 will be removed
+        manager = EventManager(
+            make_event(message="foo 123", event_id="b" * 32, timestamp=timestamp + 2.0)
+        )
+        manager.normalize()
+
+        with self.tasks():
+            event2 = manager.save(project.id)
+
+        # make sure that events did get into same group because of fallback grouping, not because of hashes which come from primary grouping only
+        assert not set(event.get_hashes().hashes) & set(event2.get_hashes().hashes)
+        assert event.group_id == event2.group_id
+
+        group = Group.objects.get(id=event.group_id)
+
+        assert group.times_seen == 2
+        assert group.last_seen == event2.datetime
+        assert group.message == event2.message
+        assert group.data.get("type") == "default"
+        assert group.data.get("metadata").get("title") == "foo 123"
+
+        # After expiry, new events are still assigned to the same group:
+        project.update_option("sentry:secondary_grouping_expiry", 0)
+        manager = EventManager(
+            make_event(message="foo 123", event_id="c" * 32, timestamp=timestamp + 4.0)
+        )
+        manager.normalize()
+
+        with self.tasks():
+            event3 = manager.save(project.id)
+        assert event3.group_id == event2.group_id


### PR DESCRIPTION
This moves the functions which calculate an event's secondary hash to the `grouping` module, as part of a larger refactor. It also adds a missing test, for error handling when calculating secondary hashes. No behavior changes.