### PR TITLE
ref(grouping): Move  `_calculate_primary_hash` to `grouping` module

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -63,7 +63,7 @@ from sentry.grouping.api import (
     get_grouping_config_dict_for_project,
 )
 from sentry.grouping.ingest import (
-    calculate_event_grouping,
+    calculate_primary_hash,
     calculate_secondary_hash,
     run_background_grouping,
     should_run_secondary_grouping,
@@ -550,7 +550,7 @@ class EventManager:
             op="event_manager",
             description="event_manager.save.calculate_event_grouping",
         ), metrics.timer("event_manager.calculate_event_grouping", tags=metric_tags):
-            hashes = _calculate_primary_hash(project, job, grouping_config)
+            hashes = calculate_primary_hash(project, job, grouping_config)
 
         if secondary_hashes:
             tags = {
@@ -746,17 +746,6 @@ class EventManager:
         update_grouping_config_if_needed(project)
 
         return job["event"]
-
-
-def _calculate_primary_hash(
-    project: Project, job: Job, grouping_config: GroupingConfig
-) -> CalculatedHashes:
-    """
-    Get the primary hash for the event.
-
-    This is pulled out into a separate function mostly in order to make testing easier.
-    """
-    return calculate_event_grouping(project, job["event"], grouping_config)
 
 
 @metrics.wraps("save_event.pull_out_data")

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -91,7 +91,7 @@ def _auto_update_grouping(project: Project) -> None:
         )
 
 
-def calculate_event_grouping(
+def _calculate_event_grouping(
     project: Project, event: Event, grouping_config: GroupingConfig
 ) -> CalculatedHashes:
     """
@@ -104,7 +104,7 @@ def calculate_event_grouping(
         "sdk": normalized_sdk_tag_from_event(event),
     }
 
-    with metrics.timer("save_event.calculate_event_grouping", tags=metric_tags):
+    with metrics.timer("save_event._calculate_event_grouping", tags=metric_tags):
         with metrics.timer("event_manager.normalize_stacktraces_for_grouping", tags=metric_tags):
             with sentry_sdk.start_span(op="event_manager.normalize_stacktraces_for_grouping"):
                 event.normalize_stacktraces_for_grouping(load_grouping_config(grouping_config))
@@ -166,7 +166,7 @@ def _calculate_background_grouping(
         "sdk": normalized_sdk_tag_from_event(event),
     }
     with metrics.timer("event_manager.background_grouping", tags=metric_tags):
-        return calculate_event_grouping(project, event, config)
+        return _calculate_event_grouping(project, event, config)
 
 
 def should_run_secondary_grouping(project: Project) -> bool:
@@ -195,7 +195,7 @@ def calculate_secondary_hash(
             # create a copy since `_calculate_event_grouping` modifies the event to add all sorts
             # of grouping info and we don't want the backup grouping data in there
             event_copy = copy.deepcopy(job["event"])
-            secondary_hashes = calculate_event_grouping(
+            secondary_hashes = _calculate_event_grouping(
                 project, event_copy, secondary_grouping_config
             )
     except Exception as err:
@@ -212,4 +212,4 @@ def calculate_primary_hash(
 
     This is pulled out into a separate function mostly in order to make testing easier.
     """
-    return calculate_event_grouping(project, job["event"], grouping_config)
+    return _calculate_event_grouping(project, job["event"], grouping_config)

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -202,3 +202,14 @@ def calculate_secondary_hash(
         sentry_sdk.capture_exception(err)
 
     return secondary_hashes
+
+
+def calculate_primary_hash(
+    project: Project, job: Job, grouping_config: GroupingConfig
+) -> CalculatedHashes:
+    """
+    Get the primary hash for the event.
+
+    This is pulled out into a separate function mostly in order to make testing easier.
+    """
+    return calculate_event_grouping(project, job["event"], grouping_config)

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -323,7 +323,7 @@ class EventManagerGroupingMetricsTest(TestCase):
 
         for primary_hashes, secondary_hashes, expected_tag in cases:
             with mock.patch(
-                "sentry.event_manager._calculate_primary_hash",
+                "sentry.event_manager.calculate_primary_hash",
                 return_value=CalculatedHashes(
                     hashes=primary_hashes, hierarchical_hashes=[], tree_labels=[]
                 ),

--- a/tests/sentry/grouping/test_ingest.py
+++ b/tests/sentry/grouping/test_ingest.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 from sentry.event_manager import EventManager
 from sentry.grouping.ingest import (
     _calculate_background_grouping,
-    calculate_event_grouping,
+    _calculate_event_grouping,
     calculate_secondary_hash,
 )
 from sentry.models.group import Group
@@ -144,12 +144,12 @@ class SecondaryGroupingTest(TestCase):
         secondary_grouping_config = "legacy:2019-03-12"
 
         def mock_calculate_event_grouping(project, event, grouping_config):
-            # We only want `calculate_event_grouping` to error inside of `calculate_secondary_hash`,
+            # We only want `_calculate_event_grouping` to error inside of `calculate_secondary_hash`,
             # not anywhere else it's called
             if grouping_config["id"] == secondary_grouping_config:
                 raise secondary_grouping_error
             else:
-                return calculate_event_grouping(project, event, grouping_config)
+                return _calculate_event_grouping(project, event, grouping_config)
 
         project = self.project
         project.update_option("sentry:grouping_config", "newstyle:2023-01-11")
@@ -157,7 +157,7 @@ class SecondaryGroupingTest(TestCase):
         project.update_option("sentry:secondary_grouping_expiry", time() + 3600)
 
         with patch(
-            "sentry.grouping.ingest.calculate_event_grouping",
+            "sentry.grouping.ingest._calculate_event_grouping",
             wraps=mock_calculate_event_grouping,
         ):
             manager = EventManager({"message": "foo 123"})


### PR DESCRIPTION
This moves `_calculate_primary_hash` into the `grouping` module, as part of a larger refactor. No behavior changes.