### PR TITLE
chore(staff): Activate staff middleware

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -346,6 +346,7 @@ MIDDLEWARE: tuple[str, ...] = (
     "sentry.middleware.customer_domain.CustomerDomainMiddleware",
     "sentry.middleware.sudo.SudoMiddleware",
     "sentry.middleware.superuser.SuperuserMiddleware",
+    "sentry.middleware.staff.StaffMiddleware",
     "sentry.middleware.locale.SentryLocaleMiddleware",
     "sentry.middleware.ratelimit.RatelimitMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",


### PR DESCRIPTION
Starting to test this locally, so activating the middleware. This will attach the staff object to all requests, although it doesn't do anything as long as you don't include checks for staff (which we currently don't do in prod).

Closes https://github.com/getsentry/team-enterprise/issues/6