### PR TITLE
feat(issues): Display stacktrace links as icons

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -144,11 +144,9 @@ describe('StacktraceLink', function () {
     render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
       context: RouterContextFixture(),
     });
-    expect(await screen.findByRole('link')).toHaveAttribute(
-      'href',
-      'https://something.io#L233'
-    );
-    expect(screen.getByText('Open this line in GitHub')).toBeInTheDocument();
+    const link = await screen.findByRole('link', {name: 'Open this line in GitHub'});
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://something.io#L233');
   });
 
   it('displays fix modal on error', async function () {
@@ -233,12 +231,14 @@ describe('StacktraceLink', function () {
       organization,
     });
 
-    expect(await screen.findByText('Open in Codecov')).toHaveAttribute(
+    const link = await screen.findByRole('link', {name: 'Open in Codecov'});
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
       'href',
       'https://app.codecov.io/gh/path/to/file.py#L233'
     );
 
-    await userEvent.click(await screen.findByText('Open in Codecov'));
+    await userEvent.click(link);
     expect(analyticsSpy).toHaveBeenCalledWith(
       'integrations.stacktrace_codecov_link_clicked',
       expect.anything()
@@ -317,11 +317,12 @@ describe('StacktraceLink', function () {
         context: RouterContextFixture(),
       }
     );
-    expect(await screen.findByRole('link')).toHaveAttribute(
+    const link = await screen.findByRole('link', {name: 'Open this line in GitHub'});
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
       'href',
       'https://www.github.com/username/path/to/file.py#L100'
     );
-    expect(screen.getByText('Open this line in GitHub')).toBeInTheDocument();
   });
 
   it('renders the link using sourceUrl instead of sourceLink if it exists for a .NET project', async function () {
@@ -348,11 +349,12 @@ describe('StacktraceLink', function () {
         context: RouterContextFixture(),
       }
     );
-    expect(await screen.findByRole('link')).toHaveAttribute(
+    const link = await screen.findByRole('link', {name: 'Open this line in GitHub'});
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
       'href',
       'https://www.github.com/url/from/code/mapping#L1'
     );
-    expect(screen.getByText('Open this line in GitHub')).toBeInTheDocument();
   });
 
   it('hides stacktrace link if there is no source link for .NET projects', async function () {
@@ -400,7 +402,9 @@ describe('StacktraceLink', function () {
       'https://something.io#L233'
     );
 
-    expect(await screen.getByText('GitHub')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {name: 'Open this line in GitHub'})
+    ).toBeInTheDocument();
 
     jest.useRealTimers();
   });

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -15,6 +15,7 @@ import HookOrDefault from 'sentry/components/hookOrDefault';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import Placeholder from 'sentry/components/placeholder';
+import {Tooltip} from 'sentry/components/tooltip';
 import {IconClose, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -173,8 +174,14 @@ function CodecovLink({
 
   return (
     <OpenInLink href={coverageUrl} openInNewTab onClick={onOpenCodecovLink}>
-      <StyledIconWrapper>{getIntegrationIcon('codecov', 'sm')}</StyledIconWrapper>
-      {hasStacktraceLinkFeatureFlag ? t('Codecov') : t('Open in Codecov')}
+      <Tooltip
+        title={t('Open in Codecov')}
+        disabled={!hasStacktraceLinkFeatureFlag}
+        skipWrapper
+      >
+        <StyledIconWrapper>{getIntegrationIcon('codecov', 'sm')}</StyledIconWrapper>
+      </Tooltip>
+      {hasStacktraceLinkFeatureFlag ? null : t('Open in Codecov')}
     </OpenInLink>
   );
 }
@@ -290,7 +297,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
       <StacktraceLinkWrapper>
         <Placeholder
           height={hasStacktraceLinkFeatureFlag ? '14px' : '24px'}
-          width={hasStacktraceLinkFeatureFlag ? '171px' : '120px'}
+          width={hasStacktraceLinkFeatureFlag ? '40px' : '120px'}
         />
       </StacktraceLinkWrapper>
     );
@@ -309,11 +316,17 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
           )}
           openInNewTab
         >
-          <StyledIconWrapper>
-            {getIntegrationIcon(match.config.provider.key, 'sm')}
-          </StyledIconWrapper>
+          <Tooltip
+            disabled={!hasStacktraceLinkFeatureFlag}
+            title={t('Open this line in %s', match.config.provider.name)}
+            skipWrapper
+          >
+            <StyledIconWrapper>
+              {getIntegrationIcon(match.config.provider.key, 'sm')}
+            </StyledIconWrapper>
+          </Tooltip>
           {hasStacktraceLinkFeatureFlag
-            ? match.config.provider.name
+            ? null
             : t('Open this line in %s', match.config.provider.name)}
         </OpenInLink>
         {shouldShowCodecovFeatures(organization, match) ? (

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -173,7 +173,12 @@ function CodecovLink({
     organization?.features?.includes('issue-details-stacktrace-link-in-frame') ?? false;
 
   return (
-    <OpenInLink href={coverageUrl} openInNewTab onClick={onOpenCodecovLink}>
+    <OpenInLink
+      href={coverageUrl}
+      openInNewTab
+      onClick={onOpenCodecovLink}
+      aria-label={hasStacktraceLinkFeatureFlag ? t('Open in Codecov') : undefined}
+    >
       <Tooltip
         title={t('Open in Codecov')}
         disabled={!hasStacktraceLinkFeatureFlag}
@@ -315,6 +320,11 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
             frame.lineNo
           )}
           openInNewTab
+          aria-label={
+            hasStacktraceLinkFeatureFlag
+              ? t('Open this line in %s', match.config.provider.name)
+              : undefined
+          }
         >
           <Tooltip
             disabled={!hasStacktraceLinkFeatureFlag}


### PR DESCRIPTION
these screenshots don't really illustrate the motivation for making them smaller, but the text gets very cramped

before
![image](https://github.com/getsentry/sentry/assets/1400464/c37731fb-1a4f-4039-85ab-310ddebed7c6)


after
![image](https://github.com/getsentry/sentry/assets/1400464/27c8036d-c978-4d6c-ac97-cbdf070a1d55)
