### PR TITLE
fix(issues): Remove "toggle context" tooltip in stacktrace

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -16,7 +16,6 @@ import {
 import {getThreadById} from 'sentry/components/events/interfaces/utils';
 import StrictClick from 'sentry/components/strictClick';
 import Tag from 'sentry/components/tag';
-import {SLOW_TOOLTIP_DELAY} from 'sentry/constants';
 import {IconChevron, IconFix, IconRefresh} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import DebugMetaStore from 'sentry/stores/debugMetaStore';
@@ -221,7 +220,6 @@ export class DeprecatedLine extends Component<Props, State> {
       return null;
     }
 
-    const {isHoverPreviewed} = this.props;
     const {isExpanded} = this.state;
 
     return (
@@ -229,8 +227,7 @@ export class DeprecatedLine extends Component<Props, State> {
         className="btn-toggle"
         data-test-id={`toggle-button-${isExpanded ? 'expanded' : 'collapsed'}`}
         size="zero"
-        title={t('Toggle Context')}
-        tooltipProps={isHoverPreviewed ? {delay: SLOW_TOOLTIP_DELAY} : undefined}
+        aria-label={t('Toggle Context')}
         onClick={this.toggleContext}
       >
         <IconChevron direction={isExpanded ? 'up' : 'down'} legacySize="8px" />

--- a/static/app/components/events/interfaces/frame/line/expander.tsx
+++ b/static/app/components/events/interfaces/frame/line/expander.tsx
@@ -24,7 +24,7 @@ function Expander({isExpandable, isHoverPreviewed, isExpanded, onToggleContext}:
     <StyledButton
       className="btn-toggle"
       size="zero"
-      title={t('Toggle Context')}
+      aria-label={t('Toggle Context')}
       tooltipProps={isHoverPreviewed ? {delay: SLOW_TOOLTIP_DELAY} : undefined}
       onClick={onToggleContext}
     >

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -407,7 +407,6 @@ function NativeFrame({
             {expandable && (
               <ToggleButton
                 size="zero"
-                title={t('Toggle Context')}
                 aria-label={t('Toggle Context')}
                 tooltipProps={isHoverPreviewed ? {delay: SLOW_TOOLTIP_DELAY} : undefined}
                 icon={


### PR DESCRIPTION
Still has an aria label.

This one
![image](https://github.com/getsentry/sentry/assets/1400464/68890365-c884-4c43-a429-58722cb415c6)
