### PR TITLE
chore(hybrid-cloud): Resubmits reverted org query RPC cleanup commits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -484,7 +484,6 @@ module = [
     "sentry.snuba.sessions_v2",
     "sentry.snuba.spans_indexed",
     "sentry.snuba.spans_metrics",
-    "sentry.snuba.tasks",
     "sentry.stacktraces.functions",
     "sentry.tagstore.snuba.backend",
     "sentry.tagstore.types",

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Any, MutableMapping, Optional, Sequence
 
 import sentry_sdk
 from django.utils import timezone
 
 from sentry import features
 from sentry.models.environment import Environment
-from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.entity_subscription import (
     BaseEntitySubscription,
@@ -197,19 +196,16 @@ def build_query_builder(
     query: str,
     project_ids: Sequence[int],
     environment: Optional[Environment],
-    params: Optional[Mapping[str, Any]] = None,
+    params: Optional[MutableMapping[str, Any]] = None,
 ) -> QueryBuilder:
     return entity_subscription.build_query_builder(query, project_ids, environment, params)
 
 
 def _create_in_snuba(subscription: QuerySubscription) -> str:
     with sentry_sdk.start_span(op="snuba.tasks", description="create_in_snuba") as span:
-        organization_context = organization_service.get_organization_by_id(
-            id=subscription.project.organization_id
-        )
         span.set_tag(
             "uses_metrics_layer",
-            features.has("organizations:use-metrics-layer", organization_context.organization),
+            features.has("organizations:use-metrics-layer", subscription.project.organization),
         )
         span.set_tag("dataset", subscription.snuba_query.dataset)
 

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -137,6 +137,7 @@ const patterns: RegExp[] = [
   new RegExp('^auth/reactivate/$'),
   new RegExp('^auth/register/$'),
   new RegExp('^auth/close/$'),
+  new RegExp('^account/user-confirm/[^/]+/$'),
   new RegExp('^account/settings/identities/associate/[^/]+/[^/]+/[^/]+/$'),
   new RegExp('^account/settings/wizard/[^/]+/$'),
   new RegExp('^disabled-member/'),


### PR DESCRIPTION
- Revert "Revert "ref(hc): Remove unnecessary organization RPC (#62435)""
- Revert "Revert "ref(hc): Remove unnecessary get_organization_by_id (#62443)""

Reverts the revert commits for #62435 and #62443, which were likely fine but preemptively reverted due to unrelated CI issues (INC-604).


Both of these commits remove unnecessary organization query RPCs and should be safe to resubmit.

