### PR TITLE
feat(grouping): Add support for SDK matcher in custom fingerprints

### DIFF
--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-exception-type-and-sdk-mismatch.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-exception-type-and-sdk-mismatch.json
@@ -1,0 +1,36 @@
+{
+  "_fingerprinting_rules": [
+    {
+      "matchers": [
+        ["sdk", "sentry.javascript.nextjs"],
+        ["type", "ChunkLoadError"]
+      ],
+      "fingerprint": ["chunkloaderror"]
+    }
+  ],
+  "fingerprint": ["my-route", "{{ default }}"],
+  "exception": {
+    "values": [
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "main",
+              "abs_path": "foo/bar.tsx",
+              "module": "foo.bar",
+              "filename": "bar.tsx",
+              "lineno": 13,
+              "in_app": false
+            }
+          ]
+        },
+        "type": "ChunkLoadError",
+        "value": "ChunkLoadError something something..."
+      }
+    ]
+  },
+  "platform": "javascript",
+  "sdk": {
+    "name": "sentry.javascript.ember"
+  }
+}

--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-exception-type-and-sdk-mismatch.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-exception-type-and-sdk-mismatch.json
@@ -2,10 +2,11 @@
   "_fingerprinting_rules": [
     {
       "matchers": [
-        ["sdk", "sentry.javascript.nextjs"],
-        ["type", "ChunkLoadError"]
+        ["sdk", "sentry.java"],
+        ["type", "DatabaseUnavailable"]
       ],
-      "fingerprint": ["chunkloaderror"]
+      "fingerprint": ["database-unavailable"],
+      "__test_description": "Shows that the custom fingerprinting rule is not applied when type matches, but SDK does not"
     }
   ],
   "fingerprint": ["my-route", "{{ default }}"],
@@ -16,21 +17,22 @@
           "frames": [
             {
               "function": "main",
-              "abs_path": "foo/bar.tsx",
-              "module": "foo.bar",
-              "filename": "bar.tsx",
+              "abs_path": "Application.java",
+              "module": "io.sentry.example.Application",
+              "filename": "Application.java",
               "lineno": 13,
               "in_app": false
             }
           ]
         },
-        "type": "ChunkLoadError",
-        "value": "ChunkLoadError something something..."
+        "type": "DatabaseUnavailable",
+        "value": "For some reason the database went away"
       }
     ]
   },
-  "platform": "javascript",
+  "platform": "java",
   "sdk": {
-    "name": "sentry.javascript.ember"
+    "name": "sentry.native.android",
+    "version": "1.2.3"
   }
 }

--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-exception-type-and-sdk.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-exception-type-and-sdk.json
@@ -2,10 +2,11 @@
   "_fingerprinting_rules": [
     {
       "matchers": [
-        ["sdk", "sentry.javascript.nextjs"],
-        ["type", "ChunkLoadError"]
+        ["sdk", "sentry.java"],
+        ["type", "DatabaseUnavailable"]
       ],
-      "fingerprint": ["chunkloaderror"]
+      "fingerprint": ["database-unavailable"],
+      "__test_description": "Shows that the custom fingerprinting rule is applied when both SDK and type match"
     }
   ],
   "fingerprint": ["my-route", "{{ default }}"],
@@ -16,21 +17,22 @@
           "frames": [
             {
               "function": "main",
-              "abs_path": "foo/bar.tsx",
-              "module": "foo.bar",
-              "filename": "bar.tsx",
+              "abs_path": "Application.java",
+              "module": "io.sentry.example.Application",
+              "filename": "Application.java",
               "lineno": 13,
               "in_app": false
             }
           ]
         },
-        "type": "ChunkLoadError",
-        "value": "ChunkLoadError something something..."
+        "type": "DatabaseUnavailable",
+        "value": "For some reason the database went away"
       }
     ]
   },
-  "platform": "javascript",
+  "platform": "java",
   "sdk": {
-    "name": "sentry.javascript.nextjs"
+    "name": "sentry.java",
+    "version": "1.7.30"
   }
 }

--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-exception-type-and-sdk.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-exception-type-and-sdk.json
@@ -1,0 +1,36 @@
+{
+  "_fingerprinting_rules": [
+    {
+      "matchers": [
+        ["sdk", "sentry.javascript.nextjs"],
+        ["type", "ChunkLoadError"]
+      ],
+      "fingerprint": ["chunkloaderror"]
+    }
+  ],
+  "fingerprint": ["my-route", "{{ default }}"],
+  "exception": {
+    "values": [
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "main",
+              "abs_path": "foo/bar.tsx",
+              "module": "foo.bar",
+              "filename": "bar.tsx",
+              "lineno": 13,
+              "in_app": false
+            }
+          ]
+        },
+        "type": "ChunkLoadError",
+        "value": "ChunkLoadError something something..."
+      }
+    ]
+  },
+  "platform": "javascript",
+  "sdk": {
+    "name": "sentry.javascript.nextjs"
+  }
+}

--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-on-sdk.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-on-sdk.json
@@ -1,0 +1,14 @@
+{
+  "_fingerprinting_rules": [
+    {
+      "matchers": [["sdk", "sentry.javascript.nextjs"]],
+      "fingerprint": ["sdk-nextjs"]
+    }
+  ],
+  "logentry": {
+    "formatted": "Es Dee Kay"
+  },
+  "sdk": {
+    "name": "sentry.javascript.nextjs"
+  }
+}

--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-on-sdk.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-on-sdk.json
@@ -2,7 +2,8 @@
   "_fingerprinting_rules": [
     {
       "matchers": [["sdk", "sentry.javascript.nextjs"]],
-      "fingerprint": ["sdk-nextjs"]
+      "fingerprint": ["sdk-nextjs"],
+      "__test_description": "Shows that the custom fingerprinting rule is applied when SDK is nextjs"
     }
   ],
   "logentry": {

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
@@ -1,22 +1,23 @@
 ---
-created: '2024-01-10T00:09:15.538545Z'
+created: '2024-01-10T17:07:19.615751Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
+# Shows that the custom fingerprinting rule is applied when both SDK and type match
 ---
 config:
   rules:
   - attributes: {}
     fingerprint:
-    - chunkloaderror
+    - database-unavailable
     matchers:
     - - sdk
-      - sentry.javascript.nextjs
+      - sentry.java
     - - type
-      - ChunkLoadError
+      - DatabaseUnavailable
   version: 1
 fingerprint:
-- chunkloaderror
-title: 'ChunkLoadError: ChunkLoadError something something...'
+- database-unavailable
+title: 'DatabaseUnavailable: For some reason the database went away'
 variants:
   app:
     component:
@@ -27,10 +28,10 @@ variants:
     client_values:
     - my-route
     - '{{ default }}'
-    matched_rule: sdk:"sentry.javascript.nextjs" type:"ChunkLoadError" -> "chunkloaderror"
+    matched_rule: sdk:"sentry.java" type:"DatabaseUnavailable" -> "database-unavailable"
     type: custom-fingerprint
     values:
-    - chunkloaderror
+    - database-unavailable
   system:
     component:
       contributes: false

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk.pysnap
@@ -1,0 +1,38 @@
+---
+created: '2024-01-10T00:09:15.538545Z'
+creator: sentry
+source: tests/sentry/grouping/test_fingerprinting.py
+---
+config:
+  rules:
+  - attributes: {}
+    fingerprint:
+    - chunkloaderror
+    matchers:
+    - - sdk
+      - sentry.javascript.nextjs
+    - - type
+      - ChunkLoadError
+  version: 1
+fingerprint:
+- chunkloaderror
+title: 'ChunkLoadError: ChunkLoadError something something...'
+variants:
+  app:
+    component:
+      contributes: false
+      hint: custom fingerprint takes precedence
+    type: component
+  custom-fingerprint:
+    client_values:
+    - my-route
+    - '{{ default }}'
+    matched_rule: sdk:"sentry.javascript.nextjs" type:"ChunkLoadError" -> "chunkloaderror"
+    type: custom-fingerprint
+    values:
+    - chunkloaderror
+  system:
+    component:
+      contributes: false
+      hint: custom fingerprint takes precedence
+    type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
@@ -1,0 +1,37 @@
+---
+created: '2024-01-10T00:12:11.862148Z'
+creator: sentry
+source: tests/sentry/grouping/test_fingerprinting.py
+---
+config:
+  rules:
+  - attributes: {}
+    fingerprint:
+    - chunkloaderror
+    matchers:
+    - - sdk
+      - sentry.javascript.nextjs
+    - - type
+      - ChunkLoadError
+  version: 1
+fingerprint:
+- my-route
+- '{{ default }}'
+title: 'ChunkLoadError: ChunkLoadError something something...'
+variants:
+  app:
+    component:
+      contributes: false
+      hint: exception of system takes precedence
+    type: salted-component
+    values:
+    - my-route
+    - '{{ default }}'
+  system:
+    component:
+      contributes: true
+      hint: null
+    type: salted-component
+    values:
+    - my-route
+    - '{{ default }}'

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_sdk_mismatch.pysnap
@@ -1,23 +1,24 @@
 ---
-created: '2024-01-10T00:12:11.862148Z'
+created: '2024-01-10T17:07:19.931277Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
+# Shows that the custom fingerprinting rule is not applied when type matches, but SDK does not
 ---
 config:
   rules:
   - attributes: {}
     fingerprint:
-    - chunkloaderror
+    - database-unavailable
     matchers:
     - - sdk
-      - sentry.javascript.nextjs
+      - sentry.java
     - - type
-      - ChunkLoadError
+      - DatabaseUnavailable
   version: 1
 fingerprint:
 - my-route
 - '{{ default }}'
-title: 'ChunkLoadError: ChunkLoadError something something...'
+title: 'DatabaseUnavailable: For some reason the database went away'
 variants:
   app:
     component:

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
@@ -1,0 +1,28 @@
+---
+created: '2024-01-09T23:55:15.059223Z'
+creator: sentry
+source: tests/sentry/grouping/test_fingerprinting.py
+---
+config:
+  rules:
+  - attributes: {}
+    fingerprint:
+    - sdk-nextjs
+    matchers:
+    - - sdk
+      - sentry.javascript.nextjs
+  version: 1
+fingerprint:
+- sdk-nextjs
+title: Es Dee Kay
+variants:
+  custom-fingerprint:
+    matched_rule: sdk:"sentry.javascript.nextjs" -> "sdk-nextjs"
+    type: custom-fingerprint
+    values:
+    - sdk-nextjs
+  default:
+    component:
+      contributes: false
+      hint: custom fingerprint takes precedence
+    type: component

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_sdk.pysnap
@@ -2,6 +2,7 @@
 created: '2024-01-09T23:55:15.059223Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
+# Shows that the custom fingerprinting rule is applied when SDK is nextj
 ---
 config:
   rules:


### PR DESCRIPTION
Allows using `sdk` as [a matcher in fingerprinting rules](https://docs.sentry.io/product/data-management-settings/event-grouping/fingerprint-rules/#matchers). 

Expects a _normalized_ SDK name
https://github.com/getsentry/sentry/blob/fe7320639f7e496b11245f9a3963194417293015/src/sentry/utils/tag_normalization.py#L10-L44.
