### PR TITLE
fix(replays): add all project access to meta events call

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -2,6 +2,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {Client} from 'sentry/api';
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import parseLinkHeader, {ParsedHeader} from 'sentry/utils/parseLinkHeader';
 import {mapResponseToReplayRecord} from 'sentry/utils/replays/replayDataUtils';
 import RequestError from 'sentry/utils/requestError/requestError';
@@ -253,6 +254,7 @@ async function fetchReplayErrors(
       query: `replayId:[${replayId}]`,
       per_page: limit,
       cursor,
+      project: ALL_ACCESS_PROJECTS,
     },
   });
 }


### PR DESCRIPTION
we should pass the all project access flag, as on orgs with open membership users are able to see replays of projects they are not a member of, and in those cases right now error links do not work on replay details.

This PR fixes by adding the `project: ALL_ACCESS_PROJECTS,` query param to the replay events meta query.