### PR TITLE
feat(system): Add new issue count threshold

### DIFF
--- a/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
+++ b/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
@@ -7,7 +7,7 @@ from sentry.models.group import Group
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.release_threshold.constants import TriggerType
 
-logger = getLogger("sentry.releases.servicer")
+logger = getLogger("sentry.release_threshold.health_checks.is_new_issues_count_healthy")
 
 
 def is_new_issues_count_healthy(release_threshold: EnrichedThreshold) -> bool:

--- a/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
+++ b/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
@@ -3,41 +3,35 @@ from __future__ import annotations
 from datetime import datetime
 from logging import getLogger
 
-from sentry import search
-from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
+from sentry.models.group import Group
+from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.release_threshold import ReleaseThreshold
 from sentry.models.release_threshold.constants import TriggerType
-from sentry.search.events.constants import RELEASE_ALIAS
 
 default_logger = getLogger("sentry.releases.servicer")
 
 
-def get_new_issue_count_is_healthy(
+def is_new_issues_count_healthy(
     project: Project,
     release: Release,
     release_threshold: ReleaseThreshold,
     start: datetime,
     end: datetime,
 ) -> bool:
-    query_kwargs = {
-        "projects": [project],
-        "date_from": start,
-        "date_to": end,
-        "count_hits": True,
-        "limit": 1,  # we don't need the returned objects, just the total count
-        "search_filters": [
-            SearchFilter(
-                key=(SearchKey(RELEASE_ALIAS)), operator="=", value=SearchValue(release.version)
-            )
-        ],
-    }
-    if release_threshold.environment:
-        query_kwargs["environments"] = [release_threshold.environment]
-
     try:
-        result = search.query(**query_kwargs)  # type: ignore
+        if release_threshold.environment:
+            new_issues = GroupEnvironment.objects.filter(
+                first_release=release,
+                environment=release_threshold.environment,
+                group__project=project,
+                first_seen__range=(start, end),
+            ).count()
+        else:
+            new_issues = Group.objects.filter(
+                project=project, first_release=release, first_seen__range=(start, end)
+            ).count()
     except Exception:
         default_logger.exception(
             "There was an error trying to grab new issue count",
@@ -45,15 +39,11 @@ def get_new_issue_count_is_healthy(
                 "project": project.id,
                 "release": release.id,
                 "release_threshold": release_threshold.id,
-                "query_kwargs": query_kwargs,
+                "start": start,
+                "end": end,
             },
         )
         return False
-
-    new_issues = result.hits
-    # If no issues where found for the specified query, then no issues exist
-    if new_issues is None:
-        new_issues = 0
 
     baseline_value = release_threshold.value
     if release_threshold.trigger_type == TriggerType.OVER:

--- a/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
+++ b/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime
+from logging import getLogger
+
+from sentry import search
+from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
+from sentry.models.project import Project
+from sentry.models.release import Release
+from sentry.models.release_threshold import ReleaseThreshold
+from sentry.models.release_threshold.constants import TriggerType
+from sentry.search.events.constants import RELEASE_ALIAS
+
+default_logger = getLogger("sentry.releases.servicer")
+
+
+def get_new_issue_count_is_healthy(
+    project: Project,
+    release: Release,
+    release_threshold: ReleaseThreshold,
+    start: datetime,
+    end: datetime,
+) -> bool:
+    query_kwargs = {
+        "projects": [project],
+        "date_from": start,
+        "date_to": end,
+        "count_hits": True,
+        "limit": 1,  # we don't need the returned objects, just the total count
+        "search_filters": [
+            SearchFilter(
+                key=(SearchKey(RELEASE_ALIAS)), operator="=", value=SearchValue(release.version)
+            )
+        ],
+    }
+    if release_threshold.environment:
+        query_kwargs["environments"] = [release_threshold.environment]
+
+    try:
+        result = search.query(**query_kwargs)  # type: ignore
+    except Exception:
+        default_logger.exception(
+            "There was an error trying to grab new issue count",
+            extra={
+                "project": project.id,
+                "release": release.id,
+                "release_threshold": release_threshold.id,
+                "query_kwargs": query_kwargs,
+            },
+        )
+        return False
+
+    new_issues = result.hits
+    # If no issues where found for the specified query, then no issues exist
+    if new_issues is None:
+        new_issues = 0
+
+    baseline_value = release_threshold.value
+    if release_threshold.trigger_type == TriggerType.OVER:
+        # If new issues is under/equal the threshold value, then it is healthy
+        return new_issues <= baseline_value
+    # Else, if new issues is over/equal the threshold value, then it is healthy
+    return new_issues >= baseline_value

--- a/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
+++ b/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
@@ -1,52 +1,46 @@
 from __future__ import annotations
 
-from datetime import datetime
 from logging import getLogger
 
+from sentry.api.endpoints.release_thresholds.types import EnrichedThreshold
 from sentry.models.group import Group
 from sentry.models.groupenvironment import GroupEnvironment
-from sentry.models.project import Project
-from sentry.models.release import Release
-from sentry.models.release_threshold import ReleaseThreshold
 from sentry.models.release_threshold.constants import TriggerType
 
-default_logger = getLogger("sentry.releases.servicer")
+logger = getLogger("sentry.releases.servicer")
 
 
-def is_new_issues_count_healthy(
-    project: Project,
-    release: Release,
-    release_threshold: ReleaseThreshold,
-    start: datetime,
-    end: datetime,
-) -> bool:
+def is_new_issues_count_healthy(release_threshold: EnrichedThreshold) -> bool:
+    release_id = release_threshold["release_id"]
+    project_id = release_threshold["project_id"]
+    time_range = (release_threshold["start"], release_threshold["end"])
     try:
-        if release_threshold.environment:
+        if release_threshold["environment"]:
             new_issues = GroupEnvironment.objects.filter(
-                first_release=release,
-                environment=release_threshold.environment,
-                group__project=project,
-                first_seen__range=(start, end),
+                first_release__id=release_id,
+                environment__id=release_threshold["environment"]["id"],
+                group__project__id=project_id,
+                first_seen__range=time_range,
             ).count()
         else:
             new_issues = Group.objects.filter(
-                project=project, first_release=release, first_seen__range=(start, end)
+                project__id=project_id, first_release__id=release_id, first_seen__range=time_range
             ).count()
     except Exception:
-        default_logger.exception(
+        logger.exception(
             "There was an error trying to grab new issue count",
             extra={
-                "project": project.id,
-                "release": release.id,
-                "release_threshold": release_threshold.id,
-                "start": start,
-                "end": end,
+                "project": project_id,
+                "release": release_id,
+                "release_threshold": release_threshold["key"],
+                "start": time_range[0],
+                "end": time_range[1],
             },
         )
         return False
 
-    baseline_value = release_threshold.value
-    if release_threshold.trigger_type == TriggerType.OVER:
+    baseline_value = release_threshold["value"]
+    if release_threshold["trigger_type"] == TriggerType.OVER_STR:
         # If new issues is under/equal the threshold value, then it is healthy
         return new_issues <= baseline_value
     # Else, if new issues is over/equal the threshold value, then it is healthy

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -19,7 +19,7 @@ from sentry.api.endpoints.release_thresholds.health_checks.is_error_count_health
     is_error_count_healthy,
 )
 from sentry.api.endpoints.release_thresholds.health_checks.is_new_issues_count_healthy import (
-    get_new_issue_count_is_healthy,
+    is_new_issues_count_healthy,
 )
 from sentry.api.endpoints.release_thresholds.utils import (
     get_errors_counts_timeseries_by_project_and_release,
@@ -275,7 +275,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
                     threshold_end = threshold_start + timedelta(seconds=threshold.window_in_seconds)
                     is_healthy: bool = False
                     if threshold.threshold_type == ReleaseThresholdType.NEW_ISSUE_COUNT:
-                        is_healthy = get_new_issue_count_is_healthy(
+                        is_healthy = is_new_issues_count_healthy(
                             project=project,
                             release=release,
                             release_threshold=threshold,

--- a/src/sentry/api/endpoints/release_thresholds/types.py
+++ b/src/sentry/api/endpoints/release_thresholds/types.py
@@ -21,3 +21,4 @@ class EnrichedThreshold(SerializedThreshold):
     project_id: int
     start: datetime
     metric_value: int | None
+    release_id: int

--- a/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_error_count_healthy.py
+++ b/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_error_count_healthy.py
@@ -89,6 +89,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,  # error counts _not_ be over threshold value
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=current_threshold_healthy, timeseries=timeseries
@@ -112,6 +113,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 1,  # error counts equal to threshold limit value
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_at_limit_healthy, timeseries=timeseries
@@ -135,6 +137,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 2,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=past_threshold_healthy, timeseries=timeseries
@@ -158,6 +161,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_under_unhealthy, timeseries=timeseries
@@ -181,6 +185,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_unfinished, timeseries=timeseries
@@ -265,6 +270,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_healthy, timeseries=timeseries
@@ -288,6 +294,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 1,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_unhealthy, timeseries=timeseries
@@ -373,6 +380,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_healthy, timeseries=timeseries
@@ -396,6 +404,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 1,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_unhealthy, timeseries=timeseries
@@ -480,6 +489,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 2,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_healthy, timeseries=timeseries
@@ -503,6 +513,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 1,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_unhealthy, timeseries=timeseries
@@ -567,6 +578,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,  # error counts _not_ be over threshold value
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=current_threshold_healthy, timeseries=timeseries
@@ -590,6 +602,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 1,  # error counts equal to threshold limit value
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_at_limit_healthy, timeseries=timeseries
@@ -613,6 +626,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 2,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=past_threshold_healthy, timeseries=timeseries
@@ -636,6 +650,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_under_unhealthy, timeseries=timeseries
@@ -659,6 +674,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_unfinished, timeseries=timeseries

--- a/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
+++ b/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
@@ -1,0 +1,139 @@
+from datetime import timedelta
+from uuid import uuid4
+
+from sentry.api.endpoints.release_thresholds.health_checks.is_new_issues_count_healthy import (
+    get_new_issue_count_is_healthy,
+)
+from sentry.models.environment import Environment
+from sentry.models.release import Release
+from sentry.models.release_threshold.constants import ReleaseThresholdType
+from sentry.models.release_threshold.release_threshold import ReleaseThreshold
+from sentry.models.releaseenvironment import ReleaseEnvironment
+from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
+from sentry.testutils.cases import SnubaTestCase, TestCase
+from sentry.testutils.helpers.datetime import iso_format
+
+
+class TestGetNewIssueCountIsHealthy(TestCase, SnubaTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.project1 = self.create_project(name="foo", organization=self.organization)
+        self.project2 = self.create_project(name="bar", organization=self.organization)
+
+        self.canary_environment = Environment.objects.create(
+            organization_id=self.organization.id, name="canary"
+        )
+        self.production_environment = Environment.objects.create(
+            organization_id=self.organization.id, name="production"
+        )
+
+        # release created for proj1, and proj2
+        self.release1 = Release.objects.create(version="v1", organization=self.organization)
+        # add_project get_or_creates a ReleaseProject
+        self.release1.add_project(self.project1)
+        self.release1.add_project(self.project2)
+
+        # release created for proj1
+        self.release2 = Release.objects.create(version="v2", organization=self.organization)
+        self.release2.add_project(self.project1)
+
+        # Attaches the release to a particular environment
+        # project superfluous/deprecated in ReleaseEnvironment
+        # release1 canary
+        ReleaseEnvironment.objects.create(
+            organization_id=self.organization.id,
+            release_id=self.release1.id,
+            environment_id=self.canary_environment.id,
+        )
+        # Release Project Environments are required to query releases by project
+        # Even though both environment & project are here, this seems to just attach a release to a project
+        # You can have multiple ReleaseProjectEnvironment's per release (this attaches multiple projects to the release&env)
+        # release1 project1 canary
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release1.id,
+            project_id=self.project1.id,
+            environment_id=self.canary_environment.id,
+        )
+        # release1 project2 canary
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release1.id,
+            project_id=self.project2.id,
+            environment_id=self.canary_environment.id,
+        )
+
+        # release2 prod
+        ReleaseEnvironment.objects.create(
+            organization_id=self.organization.id,
+            release_id=self.release2.id,
+            environment_id=self.production_environment.id,
+        )
+        # release2 project1 prod
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release2.id,
+            project_id=self.project1.id,
+            environment_id=self.production_environment.id,
+        )
+
+        self.new_issue_count_release_threshold = ReleaseThreshold.objects.create(
+            threshold_type=ReleaseThresholdType.NEW_ISSUE_COUNT,
+            trigger_type=1,
+            value=2,
+            window_in_seconds=100,
+            project=self.project1,
+            environment=self.canary_environment,
+        )
+        self._create_new_issues_for_release_threshold()
+
+    def _create_new_issues_for_release_threshold(self) -> None:
+        self.new_issue_time = self.new_issue_count_release_threshold.date_added + timedelta(
+            seconds=10
+        )
+        for _ in range(2):
+            self.store_event(
+                project_id=self.new_issue_count_release_threshold.project.id,
+                data={
+                    "fingerprint": [str(uuid4())],
+                    "timestamp": iso_format(self.new_issue_time),
+                    "user": {"id": self.user.id, "email": self.user.email},
+                    "release": self.release1.version,
+                    "environment": self.canary_environment.name,
+                },
+            )
+
+    def test_returns_true(self) -> None:
+        start_time = self.new_issue_time - timedelta(seconds=10)
+        end_time = self.new_issue_time + timedelta(seconds=10)
+        is_healthy = get_new_issue_count_is_healthy(
+            project=self.project1,
+            release=self.release1,
+            release_threshold=self.new_issue_count_release_threshold,
+            start=start_time,
+            end=end_time,
+        )
+        assert is_healthy is True
+
+    def test_returns_false(self) -> None:
+        # Get a time range when no issues are there
+        start_time = self.new_issue_time + timedelta(hours=1)
+        end_time = self.new_issue_time + timedelta(hours=2)
+        is_healthy = get_new_issue_count_is_healthy(
+            project=self.project1,
+            release=self.release1,
+            release_threshold=self.new_issue_count_release_threshold,
+            start=start_time,
+            end=end_time,
+        )
+        assert is_healthy is False
+
+    def test_returns_false_when_no_issues_found(self) -> None:
+        start_time = self.new_issue_time - timedelta(seconds=10)
+        end_time = self.new_issue_time + timedelta(seconds=10)
+        is_healthy = get_new_issue_count_is_healthy(
+            project=self.project2,
+            release=self.release1,
+            release_threshold=self.new_issue_count_release_threshold,
+            start=start_time,
+            end=end_time,
+        )
+        assert is_healthy is False

--- a/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
+++ b/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from sentry.api.endpoints.release_thresholds.health_checks.is_new_issues_count_healthy import (
     is_new_issues_count_healthy,
 )
+from sentry.api.serializers import serialize
 from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.groupenvironment import GroupEnvironment
@@ -112,50 +113,66 @@ class TestGetNewIssueCountIsHealthy(TestCase):
             )
 
     def test_returns_true_when_is_healthy(self) -> None:
+        enriched_threshold = serialize(self.new_issue_count_release_threshold)
         start_time = self.new_issue_time - timedelta(seconds=10)
         end_time = self.new_issue_time + timedelta(seconds=10)
-        is_healthy = is_new_issues_count_healthy(
-            project=self.project1,
-            release=self.release1,
-            release_threshold=self.new_issue_count_release_threshold,
-            start=start_time,
-            end=end_time,
+        enriched_threshold.update(
+            {
+                "start": start_time,
+                "end": end_time,
+                "project_id": self.project1.id,
+                "release_id": self.release1.id,
+            }
         )
+
+        is_healthy = is_new_issues_count_healthy(enriched_threshold)
         assert is_healthy is True
 
     def test_returns_false_when_is_not_healthy(self) -> None:
+        enriched_threshold = serialize(self.new_issue_count_release_threshold)
         # Get a time range when no issues are there
         start_time = self.new_issue_time + timedelta(hours=1)
         end_time = self.new_issue_time + timedelta(hours=2)
-        is_healthy = is_new_issues_count_healthy(
-            project=self.project1,
-            release=self.release1,
-            release_threshold=self.new_issue_count_release_threshold,
-            start=start_time,
-            end=end_time,
+        enriched_threshold.update(
+            {
+                "start": start_time,
+                "end": end_time,
+                "project_id": self.project1.id,
+                "release_id": self.release1.id,
+            }
         )
+
+        is_healthy = is_new_issues_count_healthy(enriched_threshold)
         assert is_healthy is False
 
     def test_returns_false_when_no_issues_exist(self) -> None:
+        enriched_threshold = serialize(self.new_issue_count_release_threshold)
         start_time = self.new_issue_time - timedelta(seconds=10)
         end_time = self.new_issue_time + timedelta(seconds=10)
-        is_healthy = is_new_issues_count_healthy(
-            project=self.project1,
-            release=self.release2,
-            release_threshold=self.new_issue_count_release_threshold,
-            start=start_time,
-            end=end_time,
+        enriched_threshold.update(
+            {
+                "start": start_time,
+                "end": end_time,
+                "project_id": self.project1.id,
+                "release_id": self.release2.id,
+            }
         )
+
+        is_healthy = is_new_issues_count_healthy(enriched_threshold)
         assert is_healthy is False
 
     def test_when_release_threshold_does_not_have_env(self) -> None:
+        enriched_threshold = serialize(self.new_issue_count_release_threshold_without_env)
         start_time = self.new_issue_time - timedelta(seconds=10)
         end_time = self.new_issue_time + timedelta(seconds=10)
-        is_healthy = is_new_issues_count_healthy(
-            project=self.project2,
-            release=self.release1,
-            release_threshold=self.new_issue_count_release_threshold_without_env,
-            start=start_time,
-            end=end_time,
+        enriched_threshold.update(
+            {
+                "start": start_time,
+                "end": end_time,
+                "project_id": self.project2.id,
+                "release_id": self.release1.id,
+            }
         )
+
+        is_healthy = is_new_issues_count_healthy(enriched_threshold)
         assert is_healthy is True

--- a/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
+++ b/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
@@ -182,14 +182,14 @@ class TestGetNewIssueCountIsHealthy(TestCase):
         "sentry.api.endpoints.release_thresholds.health_checks.is_new_issues_count_healthy.logger"
     )
     def test_returns_false_when_error_in_query(self, logger) -> None:
-        enriched_threshold = serialize(self.new_issue_count_release_threshold_without_env)
+        enriched_threshold = serialize(self.new_issue_count_release_threshold)
         start_time = self.new_issue_time - timedelta(seconds=10)
         end_time = self.new_issue_time + timedelta(seconds=10)
         enriched_threshold.update(
             {
                 "start": start_time,
                 "end": end_time,
-                "project_id": self.project2.id,
+                "project_id": self.project1.id,
                 "release_id": self.release1.id,
             }
         )

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from uuid import uuid4
 
 from sentry.models.deploy import Deploy
 from sentry.models.environment import Environment
@@ -135,26 +136,17 @@ class ReleaseThresholdStatusTest(APITestCase, SnubaTestCase):
         time_to_use = iso_format(
             self.new_issue_count_release_threshold.date_added + timedelta(seconds=10)
         )
-        self.store_event(
-            project_id=self.new_issue_count_release_threshold.project.id,
-            data={
-                "fingerprint": ["group-1"],
-                "timestamp": time_to_use,
-                "user": {"id": self.user.id, "email": self.user.email},
-                "release": self.release1.version,
-                "environment": self.canary_environment.name,
-            },
-        )
-        self.store_event(
-            project_id=self.new_issue_count_release_threshold.project.id,
-            data={
-                "fingerprint": ["group-1"],
-                "timestamp": time_to_use,
-                "user": {"id": self.user.id, "email": self.user.email},
-                "release": self.release1.version,
-                "environment": self.canary_environment.name,
-            },
-        )
+        for i in range(2):
+            self.store_event(
+                project_id=self.new_issue_count_release_threshold.project.id,
+                data={
+                    "fingerprint": [str(uuid4())],
+                    "timestamp": time_to_use,
+                    "user": {"id": self.user.id, "email": self.user.email},
+                    "release": self.release1.version,
+                    "environment": self.canary_environment.name,
+                },
+            )
 
     def test_get_success(self):
         """


### PR DESCRIPTION
Add logic to count how "new issue" count threshold is considered healthy or not. The logic is to check Snuba for issue counts with a specific environment, project, and release within the threshold time frame.

Some open ended questions I had:
> For the new_issues release threshold, what do we constitute as a "new issue"? Only if it's unresolved, or if it's simply _new_ to that _release_, or if it's a brand new issue never seen before on that project? What if the window, we had 5 issues, but they all resolved themselves automatically (maybe it was due to some timeouts and the dependent service was still booting up, etc)

For now it is advised to include resolved issues. "New Issues" counts as any issue that is new to the release.

Resolves: https://github.com/getsentry/team-enterprise/issues/18