### PR TITLE
Correctly handle 0-sized attachments

### DIFF
--- a/src/sentry/api/serializers/models/eventattachment.py
+++ b/src/sentry/api/serializers/models/eventattachment.py
@@ -17,7 +17,7 @@ class EventAttachmentSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         file = attrs.get("file")
         content_type = obj.content_type or get_mimetype(file)
-        size = obj.size or file.size
+        size = obj.size if obj.size is not None else file.size
         sha1 = obj.sha1 or file.checksum
         headers = {"Content-Type": content_type}
 

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -1,6 +1,7 @@
 import mimetypes
 import random
 from dataclasses import dataclass
+from hashlib import sha1
 from io import BytesIO
 from typing import IO, Optional
 
@@ -124,6 +125,9 @@ class EventAttachment(Model):
         return rv
 
     def getfile(self) -> IO:
+        if self.size == 0:
+            return BytesIO(b"")
+
         if self.blob_path:
             if self.blob_path.startswith("eventattachments/v1/"):
                 storage = get_storage()
@@ -142,8 +146,12 @@ class EventAttachment(Model):
     def putfile(cls, project_id: int, attachment: CachedAttachment) -> PutfileResult:
         from sentry.models.files import File, FileBlob
 
-        blob = BytesIO(attachment.data)
         content_type = normalize_content_type(attachment.content_type, attachment.name)
+
+        if len(attachment.data) == 0:
+            return PutfileResult(content_type=content_type, size=0, sha1=sha1().hexdigest())
+
+        blob = BytesIO(attachment.data)
 
         store_blobs = project_id in options.get("eventattachments.store-blobs.projects") or (
             random.random() < options.get("eventattachments.store-blobs.sample-rate")

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -475,13 +475,17 @@ def test_individual_attachments(
         assert not attachments
     else:
         (attachment,) = attachments
-        file = File.objects.get(id=attachment.file_id)
-        assert file.type == chunks[1]
-        assert file.headers == {"Content-Type": chunks[2]}
+        assert attachment.name == "foo.txt"
         assert attachment.group_id == group_id
-        file_contents = file.getfile()
+        assert attachment.content_type == chunks[2]
+
+        if attachment.file_id:
+            file = File.objects.get(id=attachment.file_id)
+            assert file.type == chunks[1]
+            assert file.headers == {"Content-Type": chunks[2]}
+
+        file_contents = attachment.getfile()
         assert file_contents.read() == b"".join(chunks[0])
-        assert file_contents.name == "foo.txt"
 
 
 @django_db_all


### PR DESCRIPTION
This primarily fixes an error in the Serializer with `File`-less attachments which would erroneously fall back to the `File` because of boolean coercion.

In this process also optimize this case a bit better to just early-return in case of a zero-sized attachment and do not save anything at all.

Fixes SENTRY-2D7Z