### PR TITLE
ref(starfish): Extract `MutableQuery` creation logic from data hooks

### DIFF
--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -6,6 +6,8 @@ describe('utils/tokenizeSearch', function () {
       [{transaction: '/index'}, 'transaction:/index'],
       [{transaction: '/index', has: 'span.domain'}, 'transaction:/index has:span.domain'],
       [{transaction: '/index', 'span.domain': undefined}, 'transaction:/index'],
+      [{'span.domain': '*hello*'}, 'span.domain:"\\*hello\\*"'],
+      [{'span.description': '*hello*'}, 'span.description:*hello*'],
     ])('converts %s to search string', (query, result) => {
       expect(MutableSearch.fromQueryObject(query).formatString()).toEqual(result);
     });

--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -1,6 +1,15 @@
 import {MutableSearch, TokenType} from 'sentry/utils/tokenizeSearch';
 
 describe('utils/tokenizeSearch', function () {
+  describe('MutableSearch.fromObject', function () {
+    it.each([[{transaction: '/index'}, 'transaction:/index']])(
+      'converts %s to search string',
+      (params, result) => {
+        expect(MutableSearch.fromObject(params).formatString()).toEqual(result);
+      }
+    );
+  });
+
   describe('new MutableSearch()', function () {
     const cases = [
       {

--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -8,6 +8,7 @@ describe('utils/tokenizeSearch', function () {
       [{transaction: '/index', 'span.domain': undefined}, 'transaction:/index'],
       [{'span.domain': '*hello*'}, 'span.domain:"\\*hello\\*"'],
       [{'span.description': '*hello*'}, 'span.description:*hello*'],
+      [{transaction: '(empty)'}, '!has:transaction'],
     ])('converts %s to search string', (query, result) => {
       expect(MutableSearch.fromQueryObject(query).formatString()).toEqual(result);
     });

--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -2,12 +2,13 @@ import {MutableSearch, TokenType} from 'sentry/utils/tokenizeSearch';
 
 describe('utils/tokenizeSearch', function () {
   describe('MutableSearch.fromQueryObject', function () {
-    it.each([[{transaction: '/index'}, 'transaction:/index']])(
-      'converts %s to search string',
-      (query, result) => {
-        expect(MutableSearch.fromQueryObject(query).formatString()).toEqual(result);
-      }
-    );
+    it.each([
+      [{transaction: '/index'}, 'transaction:/index'],
+      [{transaction: '/index', has: 'span.domain'}, 'transaction:/index has:span.domain'],
+      [{transaction: '/index', 'span.domain': undefined}, 'transaction:/index'],
+    ])('converts %s to search string', (query, result) => {
+      expect(MutableSearch.fromQueryObject(query).formatString()).toEqual(result);
+    });
   });
 
   describe('new MutableSearch()', function () {

--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -1,11 +1,11 @@
 import {MutableSearch, TokenType} from 'sentry/utils/tokenizeSearch';
 
 describe('utils/tokenizeSearch', function () {
-  describe('MutableSearch.fromObject', function () {
+  describe('MutableSearch.fromQueryObject', function () {
     it.each([[{transaction: '/index'}, 'transaction:/index']])(
       'converts %s to search string',
-      (params, result) => {
-        expect(MutableSearch.fromObject(params).formatString()).toEqual(result);
+      (query, result) => {
+        expect(MutableSearch.fromQueryObject(query).formatString()).toEqual(result);
       }
     );
   });

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -36,6 +36,10 @@ function isParen(token: Token, character: '(' | ')') {
 export class MutableSearch {
   tokens: Token[];
 
+  static fromObject(params: {[key: string]: string | number}): MutableSearch {
+    return new MutableSearch([`transaction:${params?.transaction}`]);
+  }
+
   /**
    * Creates a MutableSearch from a string query
    */

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -1,6 +1,7 @@
 import {escapeDoubleQuotes} from 'sentry/utils';
 
 const ALLOWED_WILDCARD_FIELDS = ['span.description'];
+export const EMPTY_OPTION_VALUE = '(empty)' as const;
 
 export enum TokenType {
   OPERATOR,
@@ -55,7 +56,15 @@ export class MutableSearch {
         return;
       }
 
-      query.addFilterValue(key, value.toString(), !ALLOWED_WILDCARD_FIELDS.includes(key));
+      if (value === EMPTY_OPTION_VALUE) {
+        query.addFilterValue('!has', key);
+      } else {
+        query.addFilterValue(
+          key,
+          value.toString(),
+          !ALLOWED_WILDCARD_FIELDS.includes(key)
+        );
+      }
     });
 
     return query;

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -36,7 +36,14 @@ function isParen(token: Token, character: '(' | ')') {
 export class MutableSearch {
   tokens: Token[];
 
-  static fromObject(params: {[key: string]: string | number}): MutableSearch {
+  /**
+   * Creates a `MutableSearch` from a key-value mapping of field:value.
+   * This construct doesn't support conditions like `OR` and `AND` or
+   * parentheses, so it's only useful for simple queries.
+   * @param params
+   * @returns {MutableSearch}
+   */
+  static fromQueryObject(params: {[key: string]: string | number}): MutableSearch {
     return new MutableSearch([`transaction:${params?.transaction}`]);
   }
 

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -1,5 +1,7 @@
 import {escapeDoubleQuotes} from 'sentry/utils';
 
+const ALLOWED_WILDCARD_FIELDS = ['span.description'];
+
 export enum TokenType {
   OPERATOR,
   FILTER,
@@ -53,7 +55,7 @@ export class MutableSearch {
         return;
       }
 
-      query.addFilterValue(key, value.toString());
+      query.addFilterValue(key, value.toString(), !ALLOWED_WILDCARD_FIELDS.includes(key));
     });
 
     return query;

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -43,8 +43,20 @@ export class MutableSearch {
    * @param params
    * @returns {MutableSearch}
    */
-  static fromQueryObject(params: {[key: string]: string | number}): MutableSearch {
-    return new MutableSearch([`transaction:${params?.transaction}`]);
+  static fromQueryObject(params: {
+    [key: string]: string | number | undefined;
+  }): MutableSearch {
+    const query = new MutableSearch('');
+
+    Object.entries(params).forEach(([key, value]) => {
+      if (!value) {
+        return;
+      }
+
+      query.addFilterValue(key, value.toString());
+    });
+
+    return query;
   }
 
   /**

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -1,6 +1,7 @@
 import {useDiscoverQuery} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {EMPTY_OPTION_VALUE} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
@@ -14,7 +15,6 @@ import {
 } from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {ValidSort} from 'sentry/views/performance/browser/resources/utils/useResourceSort';
 import {SpanFunction, SpanMetricsField} from 'sentry/views/starfish/types';
-import {EMPTY_OPTION_VALUE} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
 const {
   SPAN_DOMAIN,

--- a/static/app/views/starfish/queries/useSpanMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.tsx
@@ -11,7 +11,6 @@ import {
   SpanMetricsQueryFilters,
 } from 'sentry/views/starfish/types';
 import {useWrappedDiscoverQuery} from 'sentry/views/starfish/utils/useSpansQuery';
-import {EMPTY_OPTION_VALUE} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
 interface UseSpanMetricsOptions<Fields> {
   cursor?: string;
@@ -59,19 +58,7 @@ function getEventView(
   sorts: Sort[] = [],
   location: Location
 ) {
-  const query = new MutableSearch('');
-
-  Object.entries(filters).forEach(([key, value]) => {
-    if (!value) {
-      return;
-    }
-
-    if (value === EMPTY_OPTION_VALUE) {
-      query.addFilterValue('!has', key);
-    }
-
-    query.addFilterValue(key, value, !ALLOWED_WILDCARD_FIELDS.includes(key));
-  });
+  const query = MutableSearch.fromQueryObject(filters);
 
   // TODO: This condition should be enforced everywhere
   // query.addFilterValue('has', 'span.description');
@@ -93,5 +80,3 @@ function getEventView(
 
   return eventView;
 }
-
-const ALLOWED_WILDCARD_FIELDS = ['span.description'];

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -13,7 +13,6 @@ import {getIntervalForMetricFunction} from 'sentry/views/performance/database/ge
 import {DEFAULT_INTERVAL} from 'sentry/views/performance/database/settings';
 import {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
-import {EMPTY_OPTION_VALUE} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
 export type SpanMetrics = {
   interval: number;
@@ -68,19 +67,7 @@ function getEventView(
   pageFilters: PageFilters,
   yAxis: string[]
 ) {
-  const query = new MutableSearch('');
-
-  Object.entries(filters).forEach(([key, value]) => {
-    if (!value) {
-      return;
-    }
-
-    if (value === EMPTY_OPTION_VALUE) {
-      query.addFilterValue('!has', key);
-    }
-
-    query.addFilterValue(key, value, !ALLOWED_WILDCARD_FIELDS.includes(key));
-  });
+  const query = MutableSearch.fromQueryObject(filters);
 
   // TODO: This condition should be enforced everywhere
   // query.addFilterValue('has', 'span.description');
@@ -114,5 +101,3 @@ function getEventView(
     pageFilters
   );
 }
-
-const ALLOWED_WILDCARD_FIELDS = ['span.description'];

--- a/static/app/views/starfish/utils/buildEventViewQuery.tsx
+++ b/static/app/views/starfish/utils/buildEventViewQuery.tsx
@@ -1,8 +1,8 @@
 import {Location} from 'history';
 
 import {defined} from 'sentry/utils';
+import {EMPTY_OPTION_VALUE} from 'sentry/utils/tokenizeSearch';
 import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
-import {EMPTY_OPTION_VALUE} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 import {NULL_SPAN_CATEGORY} from 'sentry/views/starfish/views/webServiceView/spanGroupBreakdownContainer';
 
 const {SPAN_DESCRIPTION, SPAN_OP, SPAN_DOMAIN, SPAN_ACTION, SPAN_MODULE} =

--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -7,15 +7,13 @@ import SelectControl from 'sentry/components/forms/controls/selectControl';
 import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {EMPTY_OPTION_VALUE} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQuery';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
-import {
-  EMPTY_OPTION_VALUE,
-  EmptyContainer,
-} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
+import {EmptyContainer} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
 const {SPAN_ACTION} = SpanMetricsField;
 

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -11,15 +11,13 @@ import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import {EMPTY_OPTION_VALUE} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQuery';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
-import {
-  EMPTY_OPTION_VALUE,
-  EmptyContainer,
-} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
+import {EmptyContainer} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
 type Props = {
   additionalQuery?: string[];

--- a/static/app/views/starfish/views/spans/selectors/emptyOption.tsx
+++ b/static/app/views/starfish/views/spans/selectors/emptyOption.tsx
@@ -2,8 +2,6 @@ import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
 
-export const EMPTY_OPTION_VALUE = '(empty)';
-
 export const EmptyContainer = styled('span')`
   color: ${p => p.theme.gray300};
 `;

--- a/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/spanOperationSelector.tsx
@@ -6,14 +6,12 @@ import SelectControl from 'sentry/components/forms/controls/selectControl';
 import {t} from 'sentry/locale';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {EMPTY_OPTION_VALUE} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {buildEventViewQuery} from 'sentry/views/starfish/utils/buildEventViewQuery';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
-import {
-  DefaultEmptyOption,
-  EMPTY_OPTION_VALUE,
-} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
+import {DefaultEmptyOption} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 
 const {SPAN_OP} = SpanMetricsField;
 

--- a/static/app/views/starfish/views/spans/spanTimeCharts.tsx
+++ b/static/app/views/starfish/views/spans/spanTimeCharts.tsx
@@ -8,6 +8,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import {RateUnits} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {formatRate} from 'sentry/utils/formatters';
+import {EMPTY_OPTION_VALUE} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {AVG_COLOR, ERRORS_COLOR, THROUGHPUT_COLOR} from 'sentry/views/starfish/colours';
 import Chart, {useSynchronizeCharts} from 'sentry/views/starfish/components/chart';
@@ -16,7 +17,6 @@ import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 import {useErrorRateQuery as useErrorCountQuery} from 'sentry/views/starfish/views/spans/queries';
-import {EMPTY_OPTION_VALUE} from 'sentry/views/starfish/views/spans/selectors/emptyOption';
 import {
   DataTitles,
   getDurationChartTitle,


### PR DESCRIPTION
Adds a new static method to `MutableQuery` to create a query from a simple object. Very useful in Starfish code, to create a `MutableQuery` from filters that are passed-in.
