### PR TITLE
fix(ui) Don't show system health banners in sentry.io v2

### DIFF
--- a/static/app/components/modals/commandPalette.spec.tsx
+++ b/static/app/components/modals/commandPalette.spec.tsx
@@ -69,13 +69,6 @@ function renderMockRequests() {
   });
 
   MockApiClient.addMockResponse({
-    url: '/internal/health/',
-    body: {
-      problems: [],
-    },
-  });
-
-  MockApiClient.addMockResponse({
     url: '/assistant/',
     body: [],
   });

--- a/static/app/components/modals/helpSearchModal.spec.tsx
+++ b/static/app/components/modals/helpSearchModal.spec.tsx
@@ -42,13 +42,6 @@ describe('Docs Search Modal', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: '/internal/health/',
-      body: {
-        problems: [],
-      },
-    });
-
-    MockApiClient.addMockResponse({
       url: '/assistant/',
       body: [],
     });

--- a/static/app/components/modals/sudoModal.spec.tsx
+++ b/static/app/components/modals/sudoModal.spec.tsx
@@ -22,12 +22,6 @@ describe('Sudo Modal', function () {
 
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: '/internal/health/',
-      body: {
-        problems: [],
-      },
-    });
-    MockApiClient.addMockResponse({
       url: '/assistant/',
       body: [],
     });

--- a/static/app/views/app/index.spec.tsx
+++ b/static/app/views/app/index.spec.tsx
@@ -21,13 +21,6 @@ describe('App', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: '/internal/health/',
-      body: {
-        problems: [],
-      },
-    });
-
-    MockApiClient.addMockResponse({
       url: '/assistant/',
       body: [],
     });
@@ -146,5 +139,29 @@ describe('App', function () {
     expect(sentryUrl).toEqual('https://sentry.io');
     expect(window.location.replace).toHaveBeenCalledWith('https://sentry.io');
     expect(window.location.replace).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds health issues to alertstore', async function () {
+    const getMock = MockApiClient.addMockResponse({
+      url: '/internal/health/',
+      body: {
+        healthy: false,
+        problems: [
+          {id: 'abc123', message: 'Celery workers have not checked in', severity: 'critical'},
+        ],
+      },
+    });
+    const restore = ConfigStore.get('isSelfHosted');
+    ConfigStore.set('isSelfHosted', true);
+
+    render(
+      <App {...routerProps}>
+        <div>placeholder content</div>
+      </App>
+    );
+    ConfigStore.config.isSelfHosted = restore;
+
+    expect(getMock).toHaveBeenCalled();
+    expect(await screen.findByText(/Celery workers have not checked in/)).toBeInTheDocument();
   });
 });

--- a/static/app/views/app/index.spec.tsx
+++ b/static/app/views/app/index.spec.tsx
@@ -100,6 +100,13 @@ describe('App', function () {
     ConfigStore.set('needsUpgrade', true);
     ConfigStore.set('isSelfHosted', true);
 
+    MockApiClient.addMockResponse({
+      url: '/internal/health/',
+      body: {
+        problems: [],
+      },
+    });
+
     render(
       <App {...routerProps}>
         <div>placeholder content</div>

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -88,6 +88,10 @@ function App({children, params}: Props) {
    * Creates Alerts for any internal health problems
    */
   const checkInternalHealth = useCallback(async () => {
+    // For saas deployments we have more robust ways of checking application health.
+    if (!config.isSelfHosted) {
+      return;
+    }
     let data: any = null;
 
     try {
@@ -102,7 +106,7 @@ function App({children, params}: Props) {
 
       AlertStore.addAlert({id, message, type, url, opaque: true});
     });
-  }, [api]);
+  }, [api, config.isSelfHosted]);
 
   const {sentryUrl} = ConfigStore.get('links');
   const {orgId} = params;

--- a/static/app/views/settings/components/settingsLayout.spec.tsx
+++ b/static/app/views/settings/components/settingsLayout.spec.tsx
@@ -12,12 +12,6 @@ describe('SettingsLayout', function () {
   beforeEach(function () {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: '/internal/health/',
-      body: {
-        problems: [],
-      },
-    });
-    MockApiClient.addMockResponse({
       url: '/organizations/',
       body: [OrganizationFixture()],
     });

--- a/static/app/views/settings/project/projectTeams.spec.tsx
+++ b/static/app/views/settings/project/projectTeams.spec.tsx
@@ -282,10 +282,6 @@ describe('ProjectTeams', function () {
 
   it('creates a new team adds it to current project using the "create team modal" in dropdown', async function () {
     MockApiClient.addMockResponse({
-      url: '/internal/health/',
-      body: {},
-    });
-    MockApiClient.addMockResponse({
       url: '/assistant/',
       body: {},
     });


### PR DESCRIPTION
Mulligan on #62879 which caused tests to fail post merge because of semantic conflicts with other changes to self-hosted installation.