### PR TITLE
ref(crons): Change 'next' to 'create' in monitor forms

### DIFF
--- a/static/app/views/monitors/components/monitorCreateForm.tsx
+++ b/static/app/views/monitors/components/monitorCreateForm.tsx
@@ -93,7 +93,7 @@ export default function MonitorCreateForm() {
         'config.schedule_type': DEFAULT_SCHEDULE_CONFIG.scheduleType,
       }}
       onSubmitSuccess={onCreateMonitor}
-      submitLabel={t('Next')}
+      submitLabel={t('Create')}
     >
       <FieldContainer>
         <MultiColumnInput columns="250px 1fr">

--- a/static/app/views/monitors/create.tsx
+++ b/static/app/views/monitors/create.tsx
@@ -63,7 +63,7 @@ function CreateMonitor() {
             apiMethod="POST"
             apiEndpoint={`/organizations/${orgSlug}/monitors/`}
             onSubmitSuccess={onSubmitSuccess}
-            submitLabel={t('Next')}
+            submitLabel={t('Create')}
           />
         </Layout.Main>
       </Layout.Body>


### PR DESCRIPTION
Convey more clearly to the user that this operation will create and consume quota

