### PR TITLE
fix(integrations): pass query parameters when changing subdomain

### DIFF
--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -129,7 +129,8 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
     const customerDomain = ConfigStore.get('customerDomain');
     // redirect to the org if it's different than the org being selected
     if (customerDomain?.subdomain && orgSlug !== customerDomain?.subdomain) {
-      window.location.assign(generateOrgSlugUrl(orgSlug));
+      const urlWithQuery = generateOrgSlugUrl(orgSlug) + this.props.location.search;
+      window.location.assign(urlWithQuery);
       return;
     }
 


### PR DESCRIPTION
We need to maintain query parameters when we change the subdomain