### PR TITLE
fix(similar-issues): Fix merge count

### DIFF
--- a/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/index.spec.tsx
@@ -118,4 +118,27 @@ describe('Issues Similar View', function () {
       '/organizations/org-slug/issues/321/similar/'
     );
   });
+
+  it('correctly shows merge count', async function () {
+    render(
+      <GroupSimilarIssues
+        project={project}
+        params={{orgId: 'org-slug', groupId: 'group-id'}}
+        location={router.location}
+        router={router}
+        routeParams={router.params}
+        routes={router.routes}
+        route={{}}
+      />,
+      {context: routerContext}
+    );
+    renderGlobalModal();
+
+    await userEvent.click(await screen.findByTestId('similar-item-row'));
+    expect(screen.getByText('Merge (1)')).toBeInTheDocument();
+
+    // Correctly show "Merge (0)" when the item is un-clicked
+    await userEvent.click(await screen.findByTestId('similar-item-row'));
+    expect(screen.getByText('Merge (0)')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
@@ -28,6 +28,7 @@ class SimilarToolbar extends Component<Props, State> {
 
   onGroupChange = ({mergeList}) => {
     if (!mergeList?.length) {
+      this.setState({mergeCount: 0});
       return;
     }
 


### PR DESCRIPTION
Set mergeCount to 0 when mergeList is empty.
This happens when item(s) were selected and then all items were un-selected

fixes https://github.com/getsentry/sentry/issues/62591