### PR TITLE
nit(staff): Remove middleware override from tests

### DIFF
--- a/tests/sentry/middleware/test_staff.py
+++ b/tests/sentry/middleware/test_staff.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from django.conf import settings
 from django.test import override_settings
 from django.urls import re_path
 from rest_framework.permissions import AllowAny
@@ -26,14 +25,6 @@ urlpatterns = [
 ]
 
 
-def provision_middleware():
-    middleware = list(settings.MIDDLEWARE)
-    if "sentry.middleware.staff.StaffMiddleware" not in middleware:
-        index = middleware.index("sentry.middleware.superuser.SuperuserMiddleware")
-        middleware.insert(index + 1, "sentry.middleware.staff.StaffMiddleware")
-    return middleware
-
-
 @override_settings(
     ROOT_URLCONF=__name__,
     SENTRY_SELF_HOSTED=False,
@@ -45,22 +36,19 @@ class End2EndTest(APITestCase):
 
     def setUp(self):
         super().setUp()
-        self.middleware = provision_middleware()
 
     def test_as_superuser(self):
         self.login_as(self.create_user(is_staff=True), staff=True)
 
-        with override_settings(MIDDLEWARE=tuple(self.middleware)):
-            response = self.get_success_response(status=200)
-            # cookie name defaults to staff because imported
-            # cookie name is not set when testing
-            assert "staff" in response.cookies
+        response = self.get_success_response(status=200)
+        # cookie name defaults to staff because imported
+        # cookie name is not set when testing
+        assert "staff" in response.cookies
 
     def test_not_superuser(self):
         self.login_as(self.create_user(is_staff=False))
 
-        with override_settings(MIDDLEWARE=tuple(self.middleware)):
-            response = self.get_success_response(status=200)
-            # cookie name defaults to staff because imported
-            # cookie name is not set when testing
-            assert "staff" not in response.cookies
+        response = self.get_success_response(status=200)
+        # cookie name defaults to staff because imported
+        # cookie name is not set when testing
+        assert "staff" not in response.cookies


### PR DESCRIPTION
Now that staff middleware is active, we don't need to manually insert it in the tests anymore