### PR TITLE
ref(crons): Change copy for status toggle

### DIFF
--- a/static/app/views/monitors/components/statusToggleButton.tsx
+++ b/static/app/views/monitors/components/statusToggleButton.tsx
@@ -25,7 +25,7 @@ function SimpleStatusToggle({
   const Icon = isDisabled ? IconPlay : IconPause;
 
   const label = isDisabled
-    ? t('Reactive this monitor')
+    ? t('Enable this monitor')
     : t('Disable this monitor and discard incoming check-ins');
 
   return (


### PR DESCRIPTION

<img width="1270" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/279f29cf-5f4a-4aec-825e-bf9d088fe12f">


Correct typo, but also just change to `Enable` to more closely reflect the `Disable` language in the opposite toggle case