### PR TITLE
feat(crons): Remove beta tag once ga flag is flipped

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -399,7 +399,8 @@ function Sidebar({organization}: Props) {
         label={t('Crons')}
         to={`/organizations/${organization.slug}/crons/`}
         id="crons"
-        isBeta
+        // TODO(davidenwang): Remove isBeta completely after GA Jan 11th
+        isBeta={organization.features.includes('crons-disable-new-projects')}
       />
     </Feature>
   );


### PR DESCRIPTION
Once this flag is flipped off, we can remove the beta tag off crons as we will allow new orgs/projects to make monitors