### PR TITLE
fix(browser-starfish): capture sample images exception in useffect

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -71,7 +71,7 @@ function SampleImagesChartPanelBody(props: {
 
   useEffect(() => {
     if (showImages && !isImagesEnabled) {
-      Sentry.captureException(new Error('No sample images missing'));
+      Sentry.captureException(new Error('No sample images found'));
     }
   }, [showImages, isImagesEnabled]);
 

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, useState} from 'react';
+import {CSSProperties, useEffect, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -69,6 +69,12 @@ function SampleImagesChartPanelBody(props: {
 }) {
   const {onClickShowLinks, images, isLoadingImages, showImages, isImagesEnabled} = props;
 
+  useEffect(() => {
+    if (showImages && !isImagesEnabled) {
+      Sentry.captureException(new Error('No sample images missing'));
+    }
+  }, [showImages, isImagesEnabled]);
+
   const hasImages = images.length > 0;
 
   if (!showImages) {
@@ -78,7 +84,6 @@ function SampleImagesChartPanelBody(props: {
     return <LoadingIndicator />;
   }
   if (showImages && !hasImages) {
-    Sentry.captureException(new Error('No sample images missing'));
     return (
       <EmptyStateWarning>
         <p>{t('No images detected')}</p>


### PR DESCRIPTION
Fix from https://github.com/getsentry/sentry/pull/62957/files/4abfa30f25d18b8be8e652aaee73aa393e33d8d2#r1448063376

Puts the capture exception in a useEffect, as the captureException because it is a sideEffect of the render.