### PR TITLE
ref(issue-platform): Cleanup occurrence processing in tests

### DIFF
--- a/tests/sentry/api/endpoints/test_group_event_details.py
+++ b/tests/sentry/api/endpoints/test_group_event_details.py
@@ -1,7 +1,6 @@
 import uuid
 from uuid import uuid4
 
-from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.models.group import GroupStatus
 from sentry.models.release import Release
 from sentry.search.events.constants import SEMVER_ALIAS
@@ -379,14 +378,10 @@ class GroupEventDetailsHelpfulEndpointTest(
 
     def test_query_issue_platform_title(self):
         issue_title = "king of england"
-        occurrence_data = self.build_occurrence_data(project_id=self.project.id, title=issue_title)
-        occurrence, group_info = process_event_and_issue_occurrence(
-            occurrence_data,
-            event_data={
-                "event_id": occurrence_data["event_id"],
-                "project_id": occurrence_data["project_id"],
-                "level": "info",
-            },
+        occurrence, group_info = self.process_occurrence(
+            project_id=self.project.id,
+            title=issue_title,
+            event_data={"level": "info"},
         )
 
         assert group_info is not None

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -8,7 +8,6 @@ from sentry.db.models.fields.node import NodeData, NodeIntegrityFailure
 from sentry.eventstore.models import Event, GroupEvent
 from sentry.grouping.enhancer import Enhancements
 from sentry.issues.issue_occurrence import IssueOccurrence
-from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.models.environment import Environment
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
@@ -577,20 +576,15 @@ class GroupEventFromEventTest(TestCase):
 @region_silo_test
 class GroupEventOccurrenceTest(TestCase, OccurrenceTestMixin):
     def test(self):
-        occurrence_data = self.build_occurrence_data(project_id=self.project.id)
-        occurrence, group_info = process_event_and_issue_occurrence(
-            occurrence_data,
-            event_data={
-                "event_id": occurrence_data["event_id"],
-                "project_id": occurrence_data["project_id"],
-                "level": "info",
-            },
+        occurrence, group_info = self.process_occurrence(
+            project_id=self.project.id,
+            event_data={"level": "info"},
         )
         assert group_info is not None
 
         event = Event(
-            occurrence_data["project_id"],
-            occurrence_data["event_id"],
+            occurrence.project_id,
+            occurrence.event_id,
             group_info.group.id,
             data={},
             snuba_data={"occurrence_id": occurrence.id},

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -9,7 +9,6 @@ from django.db.models import ProtectedError
 from django.utils import timezone
 
 from sentry.issues.grouptype import FeedbackGroup, ProfileFileIOGroupType
-from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.models.group import Group, GroupStatus, get_group_with_redirect
 from sentry.models.groupredirect import GroupRedirect
 from sentry.models.grouprelease import GroupRelease
@@ -416,16 +415,14 @@ class GroupGetLatestEventTest(TestCase, OccurrenceTestMixin):
 
     def test_get_latest_event_occurrence(self):
         event_id = uuid.uuid4().hex
-        occurrence_data = self.build_occurrence_data(event_id=event_id, project_id=self.project.id)
-        occurrence = process_event_and_issue_occurrence(
-            occurrence_data,
-            {
-                "event_id": event_id,
+        occurrence, _ = self.process_occurrence(
+            project_id=self.project.id,
+            event_id=event_id,
+            event_data={
                 "fingerprint": ["group-1"],
-                "project_id": self.project.id,
                 "timestamp": before_now(minutes=1).isoformat(),
             },
-        )[0]
+        )
 
         group = Group.objects.first()
         group.update(type=ProfileFileIOGroupType.type_id)

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -11,7 +11,6 @@ import sentry
 from sentry.digests.backends.base import Backend
 from sentry.digests.backends.redis import RedisBackend
 from sentry.digests.notifications import event_to_record
-from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.models.projectownership import ProjectOwnership
 from sentry.models.rule import Rule
 from sentry.tasks.digests import deliver_digest
@@ -32,14 +31,10 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
             event = self.create_performance_issue()
         elif event_type == "generic":
             event_id = uuid.uuid4().hex
-            occurrence_data = self.build_occurrence_data(
-                event_id=event_id, project_id=self.project.id
-            )
-            occurrence, group_info = process_event_and_issue_occurrence(
-                occurrence_data,
-                {
-                    "event_id": event_id,
-                    "project_id": self.project.id,
+            _, group_info = self.process_occurrence(
+                event_id=event_id,
+                project_id=self.project.id,
+                event_data={
                     "timestamp": before_now(minutes=1).isoformat(),
                 },
             )

--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -1,7 +1,6 @@
 import uuid
 
 from sentry.issues.grouptype import ProfileFileIOGroupType
-from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header, with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -100,15 +99,12 @@ class GroupListTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
 
     def test_issue_platform_issue(self):
         event_id = uuid.uuid4().hex
-        occurrence_data = self.build_occurrence_data(
-            event_id=event_id, project_id=self.project.id, type=ProfileFileIOGroupType.type_id
-        )
-        occurrence, group_info = process_event_and_issue_occurrence(
-            occurrence_data,
-            {
-                "event_id": event_id,
+        _, group_info = self.process_occurrence(
+            event_id=event_id,
+            project_id=self.project.id,
+            type=ProfileFileIOGroupType.type_id,
+            event_data={
                 "fingerprint": ["group-1"],
-                "project_id": self.project.id,
                 "timestamp": before_now(minutes=1).isoformat(),
             },
         )
@@ -137,15 +133,12 @@ class GroupListTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
 
     def test_issue_platform_mixed_issue_not_title(self):
         event_id = uuid.uuid4().hex
-        occurrence_data = self.build_occurrence_data(
-            event_id=event_id, project_id=self.project.id, type=ProfileFileIOGroupType.type_id
-        )
-        occurrence, group_info = process_event_and_issue_occurrence(
-            occurrence_data,
-            {
-                "event_id": event_id,
+        _, group_info = self.process_occurrence(
+            event_id=event_id,
+            project_id=self.project.id,
+            type=ProfileFileIOGroupType.type_id,
+            event_data={
                 "fingerprint": ["group-a"],
-                "project_id": self.project.id,
                 "timestamp": before_now(minutes=1).isoformat(),
             },
         )

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -1,6 +1,5 @@
 from django.urls import reverse
 
-from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
@@ -130,11 +129,11 @@ class ProjectEventDetailsGenericTest(OccurrenceTestMixin, ProjectEventDetailsTes
         four_min_ago = iso_format(before_now(minutes=4))
 
         prev_event_id = "a" * 32
-        self.prev_event, prev_group_info = process_event_and_issue_occurrence(
-            self.build_occurrence_data(
-                event_id=prev_event_id, project_id=self.project.id, fingerprint=["group-1"]
-            ),
-            {
+        self.prev_event, _ = self.process_occurrence(
+            event_id=prev_event_id,
+            project_id=self.project.id,
+            fingerprint=["group-1"],
+            event_data={
                 "event_id": prev_event_id,
                 "project_id": self.project.id,
                 "timestamp": four_min_ago,
@@ -143,11 +142,11 @@ class ProjectEventDetailsGenericTest(OccurrenceTestMixin, ProjectEventDetailsTes
         )
 
         cur_event_id = "b" * 32
-        self.cur_event, cur_group_info = process_event_and_issue_occurrence(
-            self.build_occurrence_data(
-                event_id=cur_event_id, project_id=self.project.id, fingerprint=["group-1"]
-            ),
-            {
+        self.cur_event, cur_group_info = self.process_occurrence(
+            event_id=cur_event_id,
+            project_id=self.project.id,
+            fingerprint=["group-1"],
+            event_data={
                 "event_id": cur_event_id,
                 "project_id": self.project.id,
                 "timestamp": three_min_ago,
@@ -158,11 +157,11 @@ class ProjectEventDetailsGenericTest(OccurrenceTestMixin, ProjectEventDetailsTes
         self.cur_group = cur_group_info.group
 
         next_event_id = "c" * 32
-        self.next_event, next_group_info = process_event_and_issue_occurrence(
-            self.build_occurrence_data(
-                event_id=next_event_id, project_id=self.project.id, fingerprint=["group-1"]
-            ),
-            {
+        self.next_event, _ = self.process_occurrence(
+            event_id=next_event_id,
+            project_id=self.project.id,
+            fingerprint=["group-1"],
+            event_data={
                 "event_id": next_event_id,
                 "project_id": self.project.id,
                 "timestamp": two_min_ago,
@@ -172,18 +171,18 @@ class ProjectEventDetailsGenericTest(OccurrenceTestMixin, ProjectEventDetailsTes
         )
 
         unrelated_event_id = "d" * 32
-        process_event_and_issue_occurrence(
-            self.build_occurrence_data(
-                event_id=unrelated_event_id, project_id=self.project.id, fingerprint=["group-2"]
-            ),
-            {
+        self.process_occurrence(
+            event_id=unrelated_event_id,
+            project_id=self.project.id,
+            fingerprint=["group-2"],
+            event_data={
                 "event_id": unrelated_event_id,
                 "project_id": self.project.id,
                 "timestamp": one_min_ago,
                 "message_timestamp": one_min_ago,
                 "tags": {"environment": "production"},
             },
-        )[0]
+        )
 
     def test_generic_event_with_occurrence(self):
         url = reverse(

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -134,8 +134,6 @@ class ProjectEventDetailsGenericTest(OccurrenceTestMixin, ProjectEventDetailsTes
             project_id=self.project.id,
             fingerprint=["group-1"],
             event_data={
-                "event_id": prev_event_id,
-                "project_id": self.project.id,
                 "timestamp": four_min_ago,
                 "message_timestamp": four_min_ago,
             },
@@ -147,8 +145,6 @@ class ProjectEventDetailsGenericTest(OccurrenceTestMixin, ProjectEventDetailsTes
             project_id=self.project.id,
             fingerprint=["group-1"],
             event_data={
-                "event_id": cur_event_id,
-                "project_id": self.project.id,
                 "timestamp": three_min_ago,
                 "message_timestamp": three_min_ago,
             },
@@ -162,8 +158,6 @@ class ProjectEventDetailsGenericTest(OccurrenceTestMixin, ProjectEventDetailsTes
             project_id=self.project.id,
             fingerprint=["group-1"],
             event_data={
-                "event_id": next_event_id,
-                "project_id": self.project.id,
                 "timestamp": two_min_ago,
                 "message_timestamp": two_min_ago,
                 "tags": {"environment": "production"},
@@ -176,8 +170,6 @@ class ProjectEventDetailsGenericTest(OccurrenceTestMixin, ProjectEventDetailsTes
             project_id=self.project.id,
             fingerprint=["group-2"],
             event_data={
-                "event_id": unrelated_event_id,
-                "project_id": self.project.id,
                 "timestamp": one_min_ago,
                 "message_timestamp": one_min_ago,
                 "tags": {"environment": "production"},

--- a/tests/snuba/models/test_group.py
+++ b/tests/snuba/models/test_group.py
@@ -2,7 +2,6 @@ import uuid
 from unittest.mock import patch
 
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType, ProfileFileIOGroupType
-from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.models.group import Group
 from sentry.testutils.cases import PerformanceIssueTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -183,12 +182,11 @@ class GroupTestSnuba(TestCase, SnubaTestCase, PerformanceIssueTestCase, Occurren
 
     def test_profile_issue_helpful(self):
         event_id_1 = uuid.uuid4().hex
-        occurrence = process_event_and_issue_occurrence(
-            self.build_occurrence_data(event_id=event_id_1, project_id=self.project.id),
-            {
-                "event_id": event_id_1,
+        occurrence, _ = self.process_occurrence(
+            event_id=event_id_1,
+            project_id=self.project.id,
+            event_data={
                 "fingerprint": ["group-1"],
-                "project_id": self.project.id,
                 "timestamp": before_now(minutes=2).isoformat(),
                 "contexts": {
                     "profile": {"profile_id": uuid.uuid4().hex},
@@ -201,18 +199,17 @@ class GroupTestSnuba(TestCase, SnubaTestCase, PerformanceIssueTestCase, Occurren
                 },
                 "errors": [],
             },
-        )[0]
+        )
 
         event_id_2 = uuid.uuid4().hex
-        occurrence_2 = process_event_and_issue_occurrence(
-            self.build_occurrence_data(event_id=event_id_2, project_id=self.project.id),
-            {
-                "event_id": event_id_2,
+        occurrence_2, _ = self.process_occurrence(
+            event_id=event_id_2,
+            project_id=self.project.id,
+            event_data={
                 "fingerprint": ["group-1"],
-                "project_id": self.project.id,
                 "timestamp": before_now(minutes=1).isoformat(),
             },
-        )[0]
+        )
 
         group = Group.objects.first()
         group.update(type=ProfileFileIOGroupType.type_id)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -3685,29 +3685,15 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
             event_id_1 = uuid.uuid4().hex
             _, group_info = self.process_occurrence(
                 **{
-                    "id": uuid.uuid4().hex,
-                    "project_id": 1,
+                    "project_id": self.project.id,
                     "event_id": event_id_1,
-                    "fingerprint": ["c" * 32],
                     "issue_title": "User Feedback",
-                    "subtitle": "it was bad",
-                    "culprit": "api/123",
-                    "resource_id": "1234",
-                    "evidence_data": {"Test": 123},
-                    "evidence_display": [
-                        {"name": "hi", "value": "bye", "important": True},
-                        {"name": "what", "value": "where", "important": False},
-                    ],
                     "type": FeedbackGroup.type_id,
                     "detection_time": datetime.now().timestamp(),
                     "level": "info",
                 },
                 event_data={
-                    "event_id": event_id_1,
-                    "project_id": self.project.id,
-                    "title": "some problem",
                     "platform": "python",
-                    "tags": {"my_tag": "1"},
                     "timestamp": before_now(minutes=1).isoformat(),
                     "received": before_now(minutes=1).isoformat(),
                 },
@@ -3729,29 +3715,15 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
             event_id_1 = uuid.uuid4().hex
             _, group_info = self.process_occurrence(
                 **{
-                    "id": uuid.uuid4().hex,
-                    "project_id": 1,
+                    "project_id": self.project.id,
                     "event_id": event_id_1,
-                    "fingerprint": ["c" * 32],
                     "issue_title": "User Feedback",
-                    "subtitle": "it was bad",
-                    "culprit": "api/123",
-                    "resource_id": "1234",
-                    "evidence_data": {"Test": 123},
-                    "evidence_display": [
-                        {"name": "hi", "value": "bye", "important": True},
-                        {"name": "what", "value": "where", "important": False},
-                    ],
                     "type": FeedbackGroup.type_id,
                     "detection_time": datetime.now().timestamp(),
                     "level": "info",
                 },
                 event_data={
-                    "event_id": event_id_1,
-                    "project_id": self.project.id,
-                    "title": "some problem",
                     "platform": "python",
-                    "tags": {"my_tag": "1"},
                     "timestamp": before_now(minutes=1).isoformat(),
                     "received": before_now(minutes=1).isoformat(),
                 },

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -21,7 +21,6 @@ from sentry.issues.grouptype import (
     ProfileFileIOGroupType,
 )
 from sentry.issues.ingest import send_issue_occurrence_to_eventstream
-from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.models.environment import Environment
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
@@ -2978,9 +2977,10 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
         error_group = error_event.group
 
         profile_event_id = uuid.uuid4().hex
-        _, group_info = process_event_and_issue_occurrence(
-            self.build_occurrence_data(event_id=profile_event_id),
-            {
+        _, group_info = self.process_occurrence(
+            event_id=profile_event_id,
+            project_id=self.project.id,
+            event_data={
                 "event_id": profile_event_id,
                 "project_id": self.project.id,
                 "title": "some problem",
@@ -3409,9 +3409,10 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
         self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=timezone.utc)
 
         event_id_1 = uuid.uuid4().hex
-        _, group_info = process_event_and_issue_occurrence(
-            self.build_occurrence_data(event_id=event_id_1, issue_title="File I/O on Main Thread"),
-            {
+        _, group_info = self.process_occurrence(
+            event_id=event_id_1,
+            issue_title="File I/O on Main Thread",
+            event_data={
                 "event_id": event_id_1,
                 "project_id": self.project.id,
                 "title": "some problem",
@@ -3425,13 +3426,11 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
         self.profile_group_1 = group_info.group
 
         event_id_2 = uuid.uuid4().hex
-        _, group_info = process_event_and_issue_occurrence(
-            self.build_occurrence_data(
-                event_id=event_id_2,
-                fingerprint=["put-me-in-group-2"],
-                issue_title="File I/O on Main Thread",
-            ),
-            {
+        _, group_info = self.process_occurrence(
+            event_id=event_id_2,
+            fingerprint=["put-me-in-group-2"],
+            issue_title="File I/O on Main Thread",
+            event_data={
                 "event_id": event_id_2,
                 "project_id": self.project.id,
                 "title": "some other problem",
@@ -3445,9 +3444,10 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
         self.profile_group_2 = group_info.group
 
         event_id_3 = uuid.uuid4().hex
-        process_event_and_issue_occurrence(
-            self.build_occurrence_data(event_id=event_id_3, fingerprint=["put-me-in-group-3"]),
-            {
+        self.process_occurrence(
+            event_id=event_id_3,
+            fingerprint=["put-me-in-group-3"],
+            event_data={
                 "event_id": event_id_3,
                 "project_id": self.project.id,
                 "title": "some other problem",
@@ -3522,11 +3522,11 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
             PerformanceNPlusOneGroupType, "noise_config", new=NoiseConfig(0, timedelta(minutes=1))
         ):
             with self.feature(group_type.build_ingest_feature_name()):
-                _, group_info = process_event_and_issue_occurrence(
-                    self.build_occurrence_data(
-                        event_id=event_id, type=group_type.type_id, fingerprint=["some perf issue"]
-                    ),
-                    {
+                _, group_info = self.process_occurrence(
+                    event_id=event_id,
+                    type=group_type.type_id,
+                    fingerprint=["some perf issue"],
+                    event_data={
                         "event_id": event_id,
                         "project_id": self.project.id,
                         "title": "some problem",
@@ -3689,28 +3689,26 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
             ["organizations:issue-platform", FeedbackGroup.build_visible_feature_name()]
         ):
             event_id_1 = uuid.uuid4().hex
-            _, group_info = process_event_and_issue_occurrence(
-                self.build_occurrence_data(
-                    **{
-                        "id": uuid.uuid4().hex,
-                        "project_id": 1,
-                        "event_id": event_id_1,
-                        "fingerprint": ["c" * 32],
-                        "issue_title": "User Feedback",
-                        "subtitle": "it was bad",
-                        "culprit": "api/123",
-                        "resource_id": "1234",
-                        "evidence_data": {"Test": 123},
-                        "evidence_display": [
-                            {"name": "hi", "value": "bye", "important": True},
-                            {"name": "what", "value": "where", "important": False},
-                        ],
-                        "type": FeedbackGroup.type_id,
-                        "detection_time": datetime.now().timestamp(),
-                        "level": "info",
-                    }
-                ),
-                {
+            _, group_info = self.process_occurrence(
+                **{
+                    "id": uuid.uuid4().hex,
+                    "project_id": 1,
+                    "event_id": event_id_1,
+                    "fingerprint": ["c" * 32],
+                    "issue_title": "User Feedback",
+                    "subtitle": "it was bad",
+                    "culprit": "api/123",
+                    "resource_id": "1234",
+                    "evidence_data": {"Test": 123},
+                    "evidence_display": [
+                        {"name": "hi", "value": "bye", "important": True},
+                        {"name": "what", "value": "where", "important": False},
+                    ],
+                    "type": FeedbackGroup.type_id,
+                    "detection_time": datetime.now().timestamp(),
+                    "level": "info",
+                },
+                event_data={
                     "event_id": event_id_1,
                     "project_id": self.project.id,
                     "title": "some problem",
@@ -3735,28 +3733,26 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
             ]
         ):
             event_id_1 = uuid.uuid4().hex
-            _, group_info = process_event_and_issue_occurrence(
-                self.build_occurrence_data(
-                    **{
-                        "id": uuid.uuid4().hex,
-                        "project_id": 1,
-                        "event_id": event_id_1,
-                        "fingerprint": ["c" * 32],
-                        "issue_title": "User Feedback",
-                        "subtitle": "it was bad",
-                        "culprit": "api/123",
-                        "resource_id": "1234",
-                        "evidence_data": {"Test": 123},
-                        "evidence_display": [
-                            {"name": "hi", "value": "bye", "important": True},
-                            {"name": "what", "value": "where", "important": False},
-                        ],
-                        "type": FeedbackGroup.type_id,
-                        "detection_time": datetime.now().timestamp(),
-                        "level": "info",
-                    }
-                ),
-                {
+            _, group_info = self.process_occurrence(
+                **{
+                    "id": uuid.uuid4().hex,
+                    "project_id": 1,
+                    "event_id": event_id_1,
+                    "fingerprint": ["c" * 32],
+                    "issue_title": "User Feedback",
+                    "subtitle": "it was bad",
+                    "culprit": "api/123",
+                    "resource_id": "1234",
+                    "evidence_data": {"Test": 123},
+                    "evidence_display": [
+                        {"name": "hi", "value": "bye", "important": True},
+                        {"name": "what", "value": "where", "important": False},
+                    ],
+                    "type": FeedbackGroup.type_id,
+                    "detection_time": datetime.now().timestamp(),
+                    "level": "info",
+                },
+                event_data={
                     "event_id": event_id_1,
                     "project_id": self.project.id,
                     "title": "some problem",

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -3683,7 +3683,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
             ["organizations:issue-platform", FeedbackGroup.build_visible_feature_name()]
         ):
             event_id_1 = uuid.uuid4().hex
-            _, group_info = self.process_occurrence(
+            self.process_occurrence(
                 **{
                     "project_id": self.project.id,
                     "event_id": event_id_1,

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2981,8 +2981,6 @@ class EventsPriorityTest(TestCase, SharedSnubaMixin, OccurrenceTestMixin):
             event_id=profile_event_id,
             project_id=self.project.id,
             event_data={
-                "event_id": profile_event_id,
-                "project_id": self.project.id,
                 "title": "some problem",
                 "platform": "python",
                 "tags": {"my_tag": "1"},
@@ -3411,10 +3409,9 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
         event_id_1 = uuid.uuid4().hex
         _, group_info = self.process_occurrence(
             event_id=event_id_1,
+            project_id=self.project.id,
             issue_title="File I/O on Main Thread",
             event_data={
-                "event_id": event_id_1,
-                "project_id": self.project.id,
                 "title": "some problem",
                 "platform": "python",
                 "tags": {"my_tag": "1"},
@@ -3428,11 +3425,10 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
         event_id_2 = uuid.uuid4().hex
         _, group_info = self.process_occurrence(
             event_id=event_id_2,
+            project_id=self.project.id,
             fingerprint=["put-me-in-group-2"],
             issue_title="File I/O on Main Thread",
             event_data={
-                "event_id": event_id_2,
-                "project_id": self.project.id,
                 "title": "some other problem",
                 "platform": "python",
                 "tags": {"my_tag": "1"},
@@ -3446,10 +3442,9 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
         event_id_3 = uuid.uuid4().hex
         self.process_occurrence(
             event_id=event_id_3,
+            project_id=self.project.id,
             fingerprint=["put-me-in-group-3"],
             event_data={
-                "event_id": event_id_3,
-                "project_id": self.project.id,
                 "title": "some other problem",
                 "platform": "python",
                 "tags": {"my_tag": "2"},
@@ -3524,11 +3519,10 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
             with self.feature(group_type.build_ingest_feature_name()):
                 _, group_info = self.process_occurrence(
                     event_id=event_id,
+                    project_id=self.project.id,
                     type=group_type.type_id,
                     fingerprint=["some perf issue"],
                     event_data={
-                        "event_id": event_id,
-                        "project_id": self.project.id,
                         "title": "some problem",
                         "platform": "python",
                         "tags": {"my_tag": "2"},

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -3687,6 +3687,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
                 **{
                     "project_id": self.project.id,
                     "event_id": event_id_1,
+                    "fingerprint": ["c" * 32],
                     "issue_title": "User Feedback",
                     "type": FeedbackGroup.type_id,
                     "detection_time": datetime.now().timestamp(),
@@ -3717,6 +3718,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
                 **{
                     "project_id": self.project.id,
                     "event_id": event_id_1,
+                    "fingerprint": ["c" * 32],
                     "issue_title": "User Feedback",
                     "type": FeedbackGroup.type_id,
                     "detection_time": datetime.now().timestamp(),


### PR DESCRIPTION
Abstract away some of the occurrence creation/processing logic to provide a simpler way to create an occurrence. The basic usecase should be able to call 
`occurrence, group_info = self.process_occurrence(event_id='someid',  project_id=self.project.id)`
 and not worry about the implementations of building the occurrence with valid fields. Any additional occurrence data can be passed as kwargs, and event data as a dict. 

Fixes https://github.com/getsentry/sentry/issues/62504