### PR TITLE
fix(group-attributes): Fix syncing status for issues when archiving

### DIFF
--- a/src/sentry/issues/status_change.py
+++ b/src/sentry/issues/status_change.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections import defaultdict, namedtuple
 from typing import Any, Dict, Sequence
 
+from django.db.models.signals import post_save
+
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import record_group_history_from_activity_type
@@ -116,5 +118,12 @@ def handle_status_update(
             kick_off_status_syncs.apply_async(
                 kwargs={"project_id": group.project_id, "group_id": group.id}
             )
+
+        post_save.send(
+            sender=Group,
+            instance=group,
+            created=False,
+            update_fields=["status", "substatus"],
+        )
 
     return ActivityInfo(activity_type, activity_data)

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -16,7 +16,7 @@ from sentry.api.helpers.group_index.validators import ValidationError
 from sentry.api.issue_search import parse_search_query
 from sentry.models.activity import Activity
 from sentry.models.actor import ActorTuple
-from sentry.models.group import GroupStatus
+from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupbookmark import GroupBookmark
 from sentry.models.groupinbox import GroupInbox, GroupInboxReason, add_group_to_inbox
@@ -134,7 +134,8 @@ class UpdateGroupsTest(TestCase):
         assert send_robust.called
 
     @patch("sentry.signals.issue_ignored.send_robust")
-    def test_ignoring_group_archived_forever(self, send_robust: Mock) -> None:
+    @patch("sentry.issues.status_change.post_save")
+    def test_ignoring_group_archived_forever(self, post_save: Mock, send_robust: Mock) -> None:
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.NEW)
 
@@ -153,6 +154,12 @@ class UpdateGroupsTest(TestCase):
         assert group.status == GroupStatus.IGNORED
         assert group.substatus == GroupSubStatus.FOREVER
         assert send_robust.called
+        post_save.send.assert_called_with(
+            sender=Group,
+            instance=group,
+            created=False,
+            update_fields=["status", "substatus"],
+        )
         assert not GroupInbox.objects.filter(group=group).exists()
 
     @patch("sentry.signals.issue_ignored.send_robust")


### PR DESCRIPTION
This properly fires the post save signal when archive an issue, which will fix syncing issues we have with things not being ignored properly.
