### PR TITLE
fix(replay): Use start of replay for hydration error (if within 2000ms)

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -28,6 +28,8 @@ interface Props extends ModalRenderProps {
   rightTimestamp: number;
 }
 
+const MAX_CLAMP_TO_START = 2000;
+
 export default function ReplayComparisonModal({
   Body,
   Header,
@@ -42,6 +44,12 @@ export default function ReplayComparisonModal({
 
   const [leftBody, setLeftBody] = useState(null);
   const [rightBody, setRightBody] = useState(null);
+  let startOffset = leftTimestamp - 1;
+  // If the error occurs close to the start of the replay, clamp the start offset to 1
+  // to help compare with the html provided by the server, This helps with some errors on localhost.
+  if (startOffset < MAX_CLAMP_TO_START) {
+    startOffset = 1;
+  }
 
   return (
     <OrganizationContext.Provider value={organization}>
@@ -97,12 +105,12 @@ export default function ReplayComparisonModal({
             <ReplayContextProvider
               isFetching={fetching}
               replay={replay}
-              initialTimeOffsetMs={{offsetMs: leftTimestamp - 1}}
+              initialTimeOffsetMs={{offsetMs: startOffset}}
             >
               <ComparisonSideWrapper id="leftSide">
                 <ReplaySide
                   selector="#leftSide iframe"
-                  expectedTime={leftTimestamp - 1}
+                  expectedTime={startOffset}
                   onLoad={setLeftBody}
                 />
               </ComparisonSideWrapper>


### PR DESCRIPTION
If a hydration error is close to the start of a replay, use the start as the comparison offset. This helps with localhost errors that may happen later in the replay.

so for this replay https://sentry.dev.getsentry.net:7999/replays/c83c488b699046419aae46274f7d56ac/?project=4506355199770625&query=is%3Aunresolved&referrer=%2Fissues%2F%3AgroupId%2Freplays%2F&statsPeriod=30d&yAxis=count%28%29
the left offset was 1648ms and now it will be 1ms because its within the first 2000ms 

