### PR TITLE
fix(settings): fix routing for plugin settings on reload

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -534,6 +534,11 @@ urlpatterns += [
                     name="sentry-customer-domain-organization-settings",
                 ),
                 re_path(
+                    r"^plugins/",
+                    react_page_view,
+                    name="sentry-customer-domain-plugins-settings",
+                ),
+                re_path(
                     r"^projects/",
                     react_page_view,
                     name="sentry-customer-domain-projects-settings",


### PR DESCRIPTION
Fixes this bug happening on page reload:

https://github.com/getsentry/sentry/assets/1127549/a7d5f707-a77f-4831-8fab-b72f2f748251
