### PR TITLE
fix(flutter-web): hide unactionable missing source context errors

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/actionableItems.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItems.spec.tsx
@@ -5,6 +5,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {ActionableItems} from 'sentry/components/events/interfaces/crashContent/exception/actionableItems';
+import {JavascriptProcessingErrors} from 'sentry/constants/eventErrors';
 import {EntryType} from 'sentry/types';
 
 describe('Actionable Items', () => {
@@ -111,6 +112,58 @@ describe('Actionable Items', () => {
 
     expect(
       await screen.findByText('Discarded unknown attribute (1)')
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Expand')).toBeInTheDocument();
+  });
+
+  it('does not render hidden flutter web errors', async () => {
+    const eventErrors = [
+      {
+        type: JavascriptProcessingErrors.JS_MISSING_SOURCES_CONTENT,
+        data: {
+          Source: "my_app/main.dart",
+        },
+      },
+      {
+        type: JavascriptProcessingErrors.JS_MISSING_SOURCES_CONTENT,
+        data: {
+          Source: "http://localhost:64053/Documents/flutter/packages/flutter/lib/src/material/ink_well.dart",
+        },
+      },
+      {
+        type: JavascriptProcessingErrors.JS_MISSING_SOURCES_CONTENT,
+        data: {
+          Source: "org-dartlang-sdk:///dart-sdk/lib/_internal/js_runtime/lib/async_patch.dart",
+        },
+      },
+      {
+        type: JavascriptProcessingErrors.JS_MISSING_SOURCES_CONTENT,
+        data: {
+          Source:
+        "org-dartlang-sdk:///dart-sdk/lib/_internal/js_runtime/lib/js_helper.dart",
+        },
+      },
+      ];
+
+    MockApiClient.addMockResponse({
+      url,
+      body: {
+        errors: eventErrors,
+      },
+      method: 'GET',
+    });
+
+    const eventWithErrors = EventFixture({
+      errors: eventErrors,
+      sdk: {
+        name: 'sentry.dart.flutter',
+      },
+    });
+
+    render(<ActionableItems {...defaultProps} event={eventWithErrors} />);
+
+    expect(
+      await screen.findByText('Missing Sources Context (1)')
     ).toBeInTheDocument();
     expect(await screen.findByText('Expand')).toBeInTheDocument();
   });

--- a/static/app/components/events/interfaces/crashContent/exception/actionableItemsUtils.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItemsUtils.tsx
@@ -128,7 +128,7 @@ export function shouldErrorBeShown(error: EventErrorData, event: Event) {
     // The Cocoa SDK sends wrong values for contexts.trace.sampled before 8.7.4
     return false;
   }
-  // Hide unactionable source context errors that happen in flutter web: https://github.com/getsentry/sentry-dart/issues/1679
+  // Hide unactionable source context errors that happen in flutter web: https://github.com/getsentry/sentry-dart/issues/1764
   if (event.sdk?.name === "sentry.dart.flutter" && error.type === JavascriptProcessingErrors.JS_MISSING_SOURCES_CONTENT) {
     const source = error.data?.Source;
     if (source.includes("org-dartlang-sdk:///dart-sdk/lib/_internal") || source.includes("flutter/packages/flutter/lib")) {

--- a/static/app/components/events/interfaces/crashContent/exception/actionableItemsUtils.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItemsUtils.tsx
@@ -128,6 +128,15 @@ export function shouldErrorBeShown(error: EventErrorData, event: Event) {
     // The Cocoa SDK sends wrong values for contexts.trace.sampled before 8.7.4
     return false;
   }
+  const errorData = error.data ?? {};
+  if (event.sdk?.name === "sentry.dart.flutter" && error.type === JavascriptProcessingErrors.JS_MISSING_SOURCES_CONTENT) {
+    if (errorData.Source.includes("org-dartlang-sdk:///dart-sdk/lib/_internal")) {
+      return false;
+    }
+    if (errorData.Source.includes("flutter/packages/flutter/lib")) {
+      return false;
+    }
+  }
   return true;
 }
 

--- a/static/app/components/events/interfaces/crashContent/exception/actionableItemsUtils.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItemsUtils.tsx
@@ -135,7 +135,7 @@ export function shouldErrorBeShown(error: EventErrorData, event: Event) {
       return false;
     }
   }
-return true;
+  return true;
 }
 
 function isDataMinified(str: string | null) {

--- a/static/app/components/events/interfaces/crashContent/exception/actionableItemsUtils.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItemsUtils.tsx
@@ -128,16 +128,14 @@ export function shouldErrorBeShown(error: EventErrorData, event: Event) {
     // The Cocoa SDK sends wrong values for contexts.trace.sampled before 8.7.4
     return false;
   }
-  const errorData = error.data ?? {};
+  // Hide unactionable source context errors that happen in flutter web: https://github.com/getsentry/sentry-dart/issues/1679
   if (event.sdk?.name === "sentry.dart.flutter" && error.type === JavascriptProcessingErrors.JS_MISSING_SOURCES_CONTENT) {
-    if (errorData.Source.includes("org-dartlang-sdk:///dart-sdk/lib/_internal")) {
-      return false;
-    }
-    if (errorData.Source.includes("flutter/packages/flutter/lib")) {
+    const source = error.data?.Source;
+    if (source.includes("org-dartlang-sdk:///dart-sdk/lib/_internal") || source.includes("flutter/packages/flutter/lib")) {
       return false;
     }
   }
-  return true;
+return true;
 }
 
 function isDataMinified(str: string | null) {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-dart/issues/1764