### PR TITLE
ref(dashboards): rename `isEditing` prop

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -228,7 +228,7 @@ function AddToDashboardModal({
               >
                 <WidgetCard
                   organization={organization}
-                  isEditing={false}
+                  isEditingDashboard={false}
                   widgetLimitReached={false}
                   selection={
                     selectedDashboard

--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -128,7 +128,7 @@ describe('Dashboards > Dashboard', () => {
         router={initialData.router}
         location={initialData.router.location}
         widgetLimitReached={false}
-        isEditing={false}
+        isEditingDashboard={false}
       />,
       {context: initialData.routerContext}
     );
@@ -143,7 +143,7 @@ describe('Dashboards > Dashboard', () => {
         paramDashboardId="1"
         dashboard={mockDashboard}
         organization={initialData.organization}
-        isEditing={false}
+        isEditingDashboard={false}
         onUpdate={() => undefined}
         handleUpdateWidgetList={() => undefined}
         handleAddCustomWidget={mockHandleAddCustomWidget}
@@ -167,7 +167,7 @@ describe('Dashboards > Dashboard', () => {
         paramDashboardId="1"
         dashboard={mockDashboard}
         organization={initialData.organization}
-        isEditing={false}
+        isEditingDashboard={false}
         onUpdate={() => undefined}
         handleUpdateWidgetList={() => undefined}
         handleAddCustomWidget={mockHandleAddCustomWidget}
@@ -187,7 +187,7 @@ describe('Dashboards > Dashboard', () => {
         paramDashboardId="1"
         dashboard={mockDashboard}
         organization={initialData.organization}
-        isEditing={false}
+        isEditingDashboard={false}
         onUpdate={() => undefined}
         handleUpdateWidgetList={() => undefined}
         handleAddCustomWidget={mockHandleAddCustomWidget}
@@ -210,7 +210,7 @@ describe('Dashboards > Dashboard', () => {
         paramDashboardId="1"
         dashboard={mockDashboard}
         organization={initialData.organization}
-        isEditing={false}
+        isEditingDashboard={false}
         onUpdate={() => undefined}
         handleUpdateWidgetList={() => undefined}
         handleAddCustomWidget={mockHandleAddCustomWidget}
@@ -238,7 +238,7 @@ describe('Dashboards > Dashboard', () => {
               paramDashboardId="1"
               dashboard={dashboard}
               organization={mockedOrg}
-              isEditing={false}
+              isEditingDashboard={false}
               onUpdate={() => undefined}
               handleUpdateWidgetList={() => undefined}
               handleAddCustomWidget={() => undefined}
@@ -290,7 +290,7 @@ describe('Dashboards > Dashboard', () => {
               paramDashboardId="1"
               dashboard={dashboard}
               organization={mockedOrg}
-              isEditing
+              isEditingDashboard
               onUpdate={newWidgets => {
                 widgets.splice(0, widgets.length, ...newWidgets);
               }}

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -71,7 +71,7 @@ type Props = {
   dashboard: DashboardDetails;
   handleAddCustomWidget: (widget: Widget) => void;
   handleUpdateWidgetList: (widgets: Widget[]) => void;
-  isEditing: boolean;
+  isEditingDashboard: boolean;
   location: Location;
   /**
    * Fired when widgets are added/removed/sorted.
@@ -239,7 +239,7 @@ class Dashboard extends Component<Props, State> {
   };
 
   handleUpdateComplete = (prevWidget: Widget) => (nextWidget: Widget) => {
-    const {isEditing, onUpdate, handleUpdateWidgetList} = this.props;
+    const {isEditingDashboard, onUpdate, handleUpdateWidgetList} = this.props;
 
     let nextList = [...this.props.dashboard.widgets];
     const updateIndex = nextList.indexOf(prevWidget);
@@ -260,26 +260,26 @@ class Dashboard extends Component<Props, State> {
     }
 
     onUpdate(nextList);
-    if (!isEditing) {
+    if (!isEditingDashboard) {
       handleUpdateWidgetList(nextList);
     }
   };
 
   handleDeleteWidget = (widgetToDelete: Widget) => () => {
-    const {dashboard, onUpdate, isEditing, handleUpdateWidgetList} = this.props;
+    const {dashboard, onUpdate, isEditingDashboard, handleUpdateWidgetList} = this.props;
 
     let nextList = dashboard.widgets.filter(widget => widget !== widgetToDelete);
     nextList = generateWidgetsAfterCompaction(nextList);
 
     onUpdate(nextList);
 
-    if (!isEditing) {
+    if (!isEditingDashboard) {
       handleUpdateWidgetList(nextList);
     }
   };
 
   handleDuplicateWidget = (widget: Widget, index: number) => () => {
-    const {dashboard, onUpdate, isEditing, handleUpdateWidgetList} = this.props;
+    const {dashboard, onUpdate, isEditingDashboard, handleUpdateWidgetList} = this.props;
 
     const widgetCopy = cloneDeep(
       assignTempId({...widget, id: undefined, tempId: undefined})
@@ -290,7 +290,7 @@ class Dashboard extends Component<Props, State> {
     nextList = generateWidgetsAfterCompaction(nextList);
 
     onUpdate(nextList);
-    if (!isEditing) {
+    if (!isEditingDashboard) {
       handleUpdateWidgetList(nextList);
     }
   };
@@ -335,11 +335,11 @@ class Dashboard extends Component<Props, State> {
 
   renderWidget(widget: Widget, index: number) {
     const {isMobile, windowWidth} = this.state;
-    const {isEditing, widgetLimitReached, isPreview, dashboard, location} = this.props;
+    const {isEditingDashboard, widgetLimitReached, isPreview, dashboard, location} = this.props;
 
     const widgetProps = {
       widget,
-      isEditing,
+      isEditingDashboard,
       widgetLimitReached,
       onDelete: this.handleDeleteWidget(widget),
       onEdit: this.handleEditWidget(index),
@@ -463,7 +463,7 @@ class Dashboard extends Component<Props, State> {
 
   render() {
     const {layouts, isMobile} = this.state;
-    const {isEditing, dashboard, widgetLimitReached, organization} = this.props;
+    const {isEditingDashboard, dashboard, widgetLimitReached, organization} = this.props;
     let {widgets} = dashboard;
     // Filter out any issue/release widgets if the user does not have the feature flag
     widgets = widgets.filter(({widgetType}) => {
@@ -476,7 +476,7 @@ class Dashboard extends Component<Props, State> {
     const columnDepths = calculateColumnDepths(layouts[DESKTOP]);
     const widgetsWithLayout = assignDefaultLayout(widgets, columnDepths);
 
-    const canModifyLayout = !isMobile && isEditing;
+    const canModifyLayout = !isMobile && isEditingDashboard;
 
     return (
       <GridLayout
@@ -505,7 +505,7 @@ class Dashboard extends Component<Props, State> {
         isBounded
       >
         {widgetsWithLayout.map((widget, index) => this.renderWidget(widget, index))}
-        {(isEditing || hasDDMExperimentalFeature(organization)) &&
+        {(isEditingDashboard || hasDDMExperimentalFeature(organization)) &&
           !widgetLimitReached && (
             <AddWidgetWrapper
               key={ADD_WIDGET_BUTTON_DRAG_ID}

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -234,7 +234,7 @@ class DashboardDetail extends Component<Props, State> {
     return DashboardState.PREVIEW === dashboardState;
   }
 
-  get isEditing() {
+  get isEditingDashboard() {
     const {dashboardState} = this.state;
     return [
       DashboardState.EDIT,
@@ -443,7 +443,7 @@ class DashboardDetail extends Component<Props, State> {
       modifiedDashboard: newModifiedDashboard,
       widgetLimitReached: widgets.length >= MAX_WIDGETS,
     });
-    if (this.isEditing || this.isPreview) {
+    if (this.isEditingDashboard || this.isPreview) {
       return;
     }
     updateDashboard(api, organization.slug, newModifiedDashboard).then(
@@ -636,7 +636,9 @@ class DashboardDetail extends Component<Props, State> {
     return isValidElement(children)
       ? cloneElement<any>(children, {
           dashboard: modifiedDashboard ?? dashboard,
-          onSave: this.isEditing ? this.onUpdateWidget : this.handleUpdateWidgetList,
+          onSave: this.isEditingDashboard
+            ? this.onUpdateWidget
+            : this.handleUpdateWidgetList,
         })
       : children;
   }
@@ -667,7 +669,7 @@ class DashboardDetail extends Component<Props, State> {
                     <DashboardTitle
                       dashboard={modifiedDashboard ?? dashboard}
                       onUpdate={this.setModifiedDashboard}
-                      isEditing={this.isEditing}
+                      isEditingDashboard={this.isEditingDashboard}
                     />
                   </Layout.Title>
                   <Controls
@@ -687,7 +689,7 @@ class DashboardDetail extends Component<Props, State> {
                   filters={{}} // Default Dashboards don't have filters set
                   location={location}
                   hasUnsavedChanges={false}
-                  isEditing={false}
+                  isEditingDashboard={false}
                   isPreview={false}
                   onDashboardFilterChange={this.handleChangeFilter}
                 />
@@ -709,7 +711,7 @@ class DashboardDetail extends Component<Props, State> {
                           paramDashboardId={dashboardId}
                           dashboard={modifiedDashboard ?? dashboard}
                           organization={organization}
-                          isEditing={this.isEditing}
+                          isEditingDashboard={this.isEditingDashboard}
                           widgetLimitReached={widgetLimitReached}
                           onUpdate={this.onUpdateWidget}
                           handleUpdateWidgetList={this.handleUpdateWidgetList}
@@ -805,7 +807,7 @@ class DashboardDetail extends Component<Props, State> {
                         <DashboardTitle
                           dashboard={modifiedDashboard ?? dashboard}
                           onUpdate={this.setModifiedDashboard}
-                          isEditing={this.isEditing}
+                          isEditingDashboard={this.isEditingDashboard}
                         />
                       </Layout.Title>
                     </Layout.HeaderContent>
@@ -855,9 +857,9 @@ class DashboardDetail extends Component<Props, State> {
                                 filters={(modifiedDashboard ?? dashboard).filters}
                                 location={location}
                                 hasUnsavedChanges={hasUnsavedFilters}
-                                isEditing={
+                                isEditingDashboard={
                                   dashboardState !== DashboardState.CREATE &&
-                                  this.isEditing
+                                  this.isEditingDashboard
                                 }
                                 isPreview={this.isPreview}
                                 onDashboardFilterChange={this.handleChangeFilter}
@@ -912,7 +914,7 @@ class DashboardDetail extends Component<Props, State> {
                                   paramDashboardId={dashboardId}
                                   dashboard={modifiedDashboard ?? dashboard}
                                   organization={organization}
-                                  isEditing={this.isEditing}
+                                  isEditingDashboard={this.isEditingDashboard}
                                   widgetLimitReached={widgetLimitReached}
                                   onUpdate={this.onUpdateWidget}
                                   handleUpdateWidgetList={this.handleUpdateWidgetList}

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -23,7 +23,7 @@ import {DashboardFilterKeys, DashboardFilters} from './types';
 type FiltersBarProps = {
   filters: DashboardFilters;
   hasUnsavedChanges: boolean;
-  isEditing: boolean;
+  isEditingDashboard: boolean;
   isPreview: boolean;
   location: Location;
   onDashboardFilterChange: (activeFilters: DashboardFilters) => void;
@@ -34,7 +34,7 @@ type FiltersBarProps = {
 export default function FiltersBar({
   filters,
   hasUnsavedChanges,
-  isEditing,
+  isEditingDashboard,
   isPreview,
   location,
   onCancel,
@@ -52,9 +52,9 @@ export default function FiltersBar({
   return (
     <Wrapper>
       <PageFilterBar condensed>
-        <ProjectPageFilter disabled={isEditing} />
-        <EnvironmentPageFilter disabled={isEditing} />
-        <DatePageFilter disabled={isEditing} />
+        <ProjectPageFilter disabled={isEditingDashboard} />
+        <EnvironmentPageFilter disabled={isEditingDashboard} />
+        <DatePageFilter disabled={isEditingDashboard} />
       </PageFilterBar>
       <Fragment>
         <FilterButtons>
@@ -62,11 +62,11 @@ export default function FiltersBar({
             <ReleasesSelectControl
               handleChangeFilter={onDashboardFilterChange}
               selectedReleases={selectedReleases}
-              isDisabled={isEditing}
+              isDisabled={isEditingDashboard}
             />
           </ReleasesProvider>
         </FilterButtons>
-        {hasUnsavedChanges && !isEditing && !isPreview && (
+        {hasUnsavedChanges && !isEditingDashboard && !isPreview && (
           <FilterButtons>
             <Button priority="primary" onClick={onSave}>
               {t('Save')}

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -10,7 +10,7 @@ const TABLE_ITEM_LIMIT = 20;
 
 type Props = {
   index: string;
-  isEditing: boolean;
+  isEditingDashboard: boolean;
   onDelete: () => void;
   onDuplicate: () => void;
   onEdit: () => void;
@@ -25,7 +25,7 @@ type Props = {
 function SortableWidget(props: Props) {
   const {
     widget,
-    isEditing,
+    isEditingDashboard,
     widgetLimitReached,
     onDelete,
     onEdit,
@@ -39,7 +39,7 @@ function SortableWidget(props: Props) {
 
   const widgetProps: ComponentProps<typeof WidgetCard> = {
     widget,
-    isEditing,
+    isEditingDashboard,
     widgetLimitReached,
     onDelete,
     onEdit,

--- a/static/app/views/dashboards/title.tsx
+++ b/static/app/views/dashboards/title.tsx
@@ -7,18 +7,18 @@ import {DashboardDetails} from './types';
 
 type Props = {
   dashboard: DashboardDetails | null;
-  isEditing: boolean;
+  isEditingDashboard: boolean;
   onUpdate: (dashboard: DashboardDetails) => void;
 };
 
-function DashboardTitle({dashboard, isEditing, onUpdate}: Props) {
+function DashboardTitle({dashboard, isEditingDashboard, onUpdate}: Props) {
   return (
     <Fragment>
       {!dashboard ? (
         t('Dashboards')
       ) : (
         <EditableText
-          isDisabled={!isEditing}
+          isDisabled={!isEditingDashboard}
           value={dashboard.title}
           onChange={newTitle => onUpdate({...dashboard, title: newTitle})}
           errorMessage={t('Please set a title for this dashboard')}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/visualizationStep.tsx
@@ -114,7 +114,7 @@ export function VisualizationStep({
           selection={pageFilters}
           widget={debouncedWidget}
           dashboardFilters={getDashboardFiltersFromURL(location) ?? dashboardFilters}
-          isEditing={false}
+          isEditingDashboard={false}
           widgetLimitReached={false}
           renderErrorMessage={errorMessage =>
             typeof errorMessage === 'string' && (

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -102,7 +102,7 @@ describe('Dashboards > WidgetCard', function () {
         organization={organization}
         widget={multipleQueryWidget}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -129,7 +129,7 @@ describe('Dashboards > WidgetCard', function () {
         organization={organization}
         widget={{...multipleQueryWidget, queries: [multipleQueryWidget.queries[0]]}}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -154,7 +154,7 @@ describe('Dashboards > WidgetCard', function () {
         organization={organization}
         widget={multipleQueryWidget}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -188,7 +188,7 @@ describe('Dashboards > WidgetCard', function () {
           ],
         }}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -224,7 +224,7 @@ describe('Dashboards > WidgetCard', function () {
           ],
         }}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -261,7 +261,7 @@ describe('Dashboards > WidgetCard', function () {
           ],
         }}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -291,7 +291,7 @@ describe('Dashboards > WidgetCard', function () {
           queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
         }}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={mock}
@@ -319,7 +319,7 @@ describe('Dashboards > WidgetCard', function () {
           queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
         }}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={mock}
@@ -347,7 +347,7 @@ describe('Dashboards > WidgetCard', function () {
           queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
         }}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={mock}
         onDuplicate={() => undefined}
@@ -375,7 +375,7 @@ describe('Dashboards > WidgetCard', function () {
           queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
         }}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={mock}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -410,7 +410,7 @@ describe('Dashboards > WidgetCard', function () {
           queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
         }}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={mock}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -445,7 +445,7 @@ describe('Dashboards > WidgetCard', function () {
           queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
         }}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={mock}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -491,7 +491,7 @@ describe('Dashboards > WidgetCard', function () {
         organization={organization}
         widget={tableWidget}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -524,7 +524,7 @@ describe('Dashboards > WidgetCard', function () {
         organization={organization}
         widget={widget}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -552,7 +552,7 @@ describe('Dashboards > WidgetCard', function () {
         organization={organization}
         widget={widget}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -592,7 +592,7 @@ describe('Dashboards > WidgetCard', function () {
           queries: [{...multipleQueryWidget.queries[0]}],
         }}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -663,7 +663,7 @@ describe('Dashboards > WidgetCard', function () {
           ],
         }}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -759,7 +759,7 @@ describe('Dashboards > WidgetCard', function () {
           ],
         }}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -789,7 +789,7 @@ describe('Dashboards > WidgetCard', function () {
         }}
         widget={multipleQueryWidget}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -60,7 +60,7 @@ type DraggableProps = Pick<ReturnType<typeof useSortable>, 'attributes' | 'liste
 
 type Props = WithRouterProps & {
   api: Client;
-  isEditing: boolean;
+  isEditingDashboard: boolean;
   location: Location;
   organization: Organization;
   selection: PageFilters;
@@ -113,11 +113,11 @@ class WidgetCard extends Component<Props, State> {
       onDuplicate,
       draggableProps,
       hideToolbar,
-      isEditing,
+      isEditingDashboard,
       isMobile,
     } = this.props;
 
-    if (!isEditing) {
+    if (!isEditingDashboard) {
       return null;
     }
 
@@ -174,7 +174,7 @@ class WidgetCard extends Component<Props, State> {
       onEdit,
       onDuplicate,
       onDelete,
-      isEditing,
+      isEditingDashboard,
       router,
       location,
       index,
@@ -183,7 +183,7 @@ class WidgetCard extends Component<Props, State> {
     const {seriesData, tableData, pageLinks, totalIssuesCount, seriesResultsType} =
       this.state;
 
-    if (isEditing) {
+    if (isEditingDashboard) {
       return null;
     }
 

--- a/static/app/views/dashboards/widgetCard/issueWidgetCard.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/issueWidgetCard.spec.tsx
@@ -85,7 +85,7 @@ describe('Dashboards > IssueWidgetCard', function () {
         organization={organization}
         widget={widget}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -115,7 +115,7 @@ describe('Dashboards > IssueWidgetCard', function () {
         organization={organization}
         widget={widget}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}
@@ -144,7 +144,7 @@ describe('Dashboards > IssueWidgetCard', function () {
         organization={organization}
         widget={widget}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={mock}
@@ -168,7 +168,7 @@ describe('Dashboards > IssueWidgetCard', function () {
         organization={organization}
         widget={widget}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={mock}
@@ -200,7 +200,7 @@ describe('Dashboards > IssueWidgetCard', function () {
           ],
         }}
         selection={selection}
-        isEditing={false}
+        isEditingDashboard={false}
         onDelete={() => undefined}
         onEdit={() => undefined}
         onDuplicate={() => undefined}


### PR DESCRIPTION
renames `isEditing` to `isEditingDashboard` in order to differentiate from props requeired for widget editing that will be introduced in
-  #62785 