### PR TITLE
ref(profiling): bump upper limit for profiles fetched for flamegraph generation to 200

### DIFF
--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -23,7 +23,7 @@ def query_profiles_data(
         params=params,
         query=query,
         selected_columns=selected_columns,
-        limit=100,
+        limit=200,
     )
 
     builder.add_conditions(


### PR DESCRIPTION
This is only bumped for the main flaemgraph displayed in the profiling dashboard

Depends on https://github.com/getsentry/vroom/pull/388
