### PR TITLE
ref(sdk-crashes): Extract store event fixture 

### DIFF
--- a/tests/sentry/utils/sdk_crashes/conftest.py
+++ b/tests/sentry/utils/sdk_crashes/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture
+def store_event(default_project, factories):
+    def inner(data):
+        return factories.store_event(data=data, project_id=default_project.id)
+
+    return inner

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -18,14 +18,6 @@ from sentry.utils.sdk_crashes.sdk_crash_detection_config import SDKCrashDetectio
 sdk_configs = [SDKCrashDetectionConfig(sdk_name=SdkName.Cocoa, project_id=1234, sample_rate=1.0)]
 
 
-@pytest.fixture
-def store_event(default_project, factories):
-    def inner(data):
-        return factories.store_event(data=data, project_id=default_project.id)
-
-    return inner
-
-
 class BaseSDKCrashDetectionMixin(BaseTestCase, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def create_event(self, data, project_id, assert_no_errors=True):


### PR DESCRIPTION
Move store event fixture to conftest.py so that it can be reused.