### PR TITLE
fix(hybridcloud) Handle integration/orgintegration missing

### DIFF
--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING, List, Mapping, Type, cast
 
 from django.http import HttpRequest
 from django.http.response import HttpResponseBase
+from rest_framework import status
+from rest_framework.response import Response
 
+from sentry.models.integrations.integration import Integration
+from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.utils import metrics
 
 if TYPE_CHECKING:
@@ -131,7 +135,15 @@ class IntegrationClassification(BaseClassification):
             request=request,
             response_handler=self.response_handler,
         )
-        response = parser.get_response()
+        try:
+            response = parser.get_response()
+        except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
+            metrics.incr(
+                f"hybrid_cloud.integration_control.integration.{parser.provider}",
+                tags={"url_name": parser.match.url_name, "status_code": 404},
+            )
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
         metrics.incr(
             f"hybrid_cloud.integration_control.integration.{parser.provider}",
             tags={"url_name": parser.match.url_name, "status_code": response.status_code},

--- a/tests/sentry/middleware/integrations/test_integration_control.py
+++ b/tests/sentry/middleware/integrations/test_integration_control.py
@@ -128,6 +128,11 @@ class IntegrationControlMiddlewareTest(TestCase):
         assert result != response
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
+    def test_handles_missing_integration(self):
+        response = self.middleware(self.factory.post("/extensions/jira/issue-updated/"))
+        assert response.status_code == 404
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
     @patch.object(PluginRequestParser, "get_response")
     def test_returns_parser_get_response_plugin(self, mock_parser_get_response):
         result = HttpResponse(status=204)


### PR DESCRIPTION
When handling integration webhooks we need to handle requests coming in for organizations that no longer exist without increasing our error rates.

Fixes HC-1055
Fixes SENTRY-2DH1
Fixes SENTRY-2DH2
