### PR TITLE
feat(ddm): Add default limit of 20 to the metrics data endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -160,7 +160,10 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
     Based on `OrganizationSessionsEndpoint`.
     """
 
+    # Number of groups returned for each page (applies to old endpoint).
     default_per_page = 50
+    # Number of groups returned (applies to new endpoint).
+    default_limit = 20
 
     def _new_get(self, request: Request, organization) -> Response:
         # We first parse the interval and date, since this is dependent on the query params.
@@ -169,8 +172,6 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
         start, end = get_date_range_from_params(request.GET)
 
         try:
-            limit = request.GET.get("limit")
-
             results = run_metrics_query(
                 fields=request.GET.getlist("field", []),
                 interval=interval,
@@ -184,7 +185,7 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
                 query=request.GET.get("query"),
                 group_bys=request.GET.getlist("groupBy"),
                 order_by=request.GET.get("orderBy"),
-                limit=int(limit) if limit else None,
+                limit=int(request.GET.get("limit", self.default_limit)),
             )
         except InvalidMetricsQueryError as e:
             return Response(status=400, data={"detail": str(e)})


### PR DESCRIPTION
This PR adds a default limit of 20 for the number of groups returned by the `metrics/data` endpoint. In addition, it adds some metrics to track the performance and usage of the API endpoint.