### PR TITLE
meta: Add ml & ai team as api owner option + set as ai suggested fix endpoint owner

### DIFF
--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -17,6 +17,7 @@ class ApiOwner(Enum):
     HYBRID_CLOUD = "hybrid-cloud"
     INTEGRATIONS = "product-owners-settings-integrations"
     ISSUES = "issues"
+    ML_AI = "machine-learning-ai"
     PERFORMANCE = "performance"
     TEAM_STARFISH = "team-starfish"
     PROFILING = "profiling"

--- a/src/sentry/api/endpoints/event_ai_suggested_fix.py
+++ b/src/sentry/api/endpoints/event_ai_suggested_fix.py
@@ -295,7 +295,7 @@ class EventAiSuggestedFixEndpoint(ProjectEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.ML_AI
     # go away
     private = True
     enforce_rate_limit = True


### PR DESCRIPTION
Adds machine learning team to api owner enum and set as owner of suggested fix endpoint