### PR TITLE
fix(browser-starfish) resource module reads project.id before fetched

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -118,7 +118,7 @@ function ResourceSummary() {
             />
           </HeaderContainer>
           {isImage && (
-            <SampleImages groupId={groupId} projectId={data[0]['project.id']} />
+            <SampleImages groupId={groupId} projectId={data?.[0]?.['project.id']} />
           )}
           <ResourceSummaryCharts groupId={groupId} />
           <ResourceSummaryTable />

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -28,7 +28,7 @@ const imageHeight = '180px';
 function SampleImages({groupId, projectId}: Props) {
   const [showImages, setShowImages] = useState(false);
   const {data: settings} = usePerformanceGeneralProjectSettings(projectId);
-  const isImagesEnabled = !settings?.enable_images ?? false;
+  const isImagesEnabled = settings?.enable_images ?? false;
 
   const {data: imageResources, isLoading: isLoadingImages} = useIndexedResourcesQuery({
     queryConditions: [`${SPAN_GROUP}:${groupId}`],

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -19,7 +19,7 @@ import {usePerformanceGeneralProjectSettings} from 'sentry/views/performance/uti
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
 
-type Props = {groupId: string; projectId: number};
+type Props = {groupId: string; projectId?: number};
 
 const {SPAN_GROUP, SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH} = SpanIndexedField;
 const imageWidth = '200px';
@@ -28,7 +28,7 @@ const imageHeight = '180px';
 function SampleImages({groupId, projectId}: Props) {
   const [showImages, setShowImages] = useState(false);
   const {data: settings} = usePerformanceGeneralProjectSettings(projectId);
-  const isImagesEnabled = settings?.enable_images ?? false;
+  const isImagesEnabled = !settings?.enable_images ?? false;
 
   const {data: imageResources, isLoading: isLoadingImages} = useIndexedResourcesQuery({
     queryConditions: [`${SPAN_GROUP}:${groupId}`],

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -662,11 +662,11 @@ export function getSelectedTransaction(
   return transactions.length > 0 ? transactions[0] : undefined;
 }
 
-export function usePerformanceGeneralProjectSettings(projectId: number) {
+export function usePerformanceGeneralProjectSettings(projectId?: number) {
   const api = useApi();
   const organization = useOrganization();
   const {projects} = useProjects();
-  const stringProjectId = projectId.toString();
+  const stringProjectId = projectId?.toString();
   const project = projects.find(p => p.id === stringProjectId);
 
   return useQuery(['settings', 'general', projectId], {


### PR DESCRIPTION
Fixes JAVASCRIPT-2QKK

Simple cannot read property of undefined error, as a result of trying to read the response before it comes back.