### PR TITLE
ref(core): Add organization_id to Project's __repr__

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -300,7 +300,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
         db_table = "sentry_project"
         unique_together = (("organization", "slug"),)
 
-    __repr__ = sane_repr("team_id", "name", "slug", "organization")
+    __repr__ = sane_repr("team_id", "name", "slug", "organization_id")
 
     _rename_fields_on_pending_delete = frozenset(["slug"])
 

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -300,7 +300,7 @@ class Project(Model, PendingDeletionMixin, OptionMixin, SnowflakeIdMixin):
         db_table = "sentry_project"
         unique_together = (("organization", "slug"),)
 
-    __repr__ = sane_repr("team_id", "name", "slug")
+    __repr__ = sane_repr("team_id", "name", "slug", "organization")
 
     _rename_fields_on_pending_delete = frozenset(["slug"])
 


### PR DESCRIPTION
Add  `organization_id` to the string representation of the `Project` model.

```python
>>> Project('foo', organization=Organization('bar'))
<Project at 0x122f066b0: id='foo', team_id=None, name='', slug=None, organization_id='bar'> 
```