### PR TITLE
chore: Redeploy #62799

### DIFF
--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -363,11 +363,9 @@ def assume_test_silo_mode(desired_silo: SiloMode, can_be_monolith: bool = True) 
             region_dir = get_test_env_directory()
             with region_dir.swap_to_default_region():
                 yield
-        elif desired_silo == SiloMode.MONOLITH:
+        else:
             with override_settings(SENTRY_REGION=None):
                 yield
-        else:
-            yield
 
 
 @contextmanager


### PR DESCRIPTION
Redeploy #62799, which was reverted due to a unit test regression. The regression was caused by https://github.com/getsentry/getsentry/pull/12563 being merged concurrently, and was fixed by https://github.com/getsentry/getsentry/pull/12586.