### PR TITLE
fix(replays): Add new condition class and update test suite to send new-style snuba payloads

### DIFF
--- a/src/sentry/replays/testutils.py
+++ b/src/sentry/replays/testutils.py
@@ -130,6 +130,8 @@ def mock_replay(
 ) -> dict[str, Any]:
     tags = kwargs.pop("tags", {})
     tags.update({"transaction": kwargs.pop("title", "Title")})
+    tags = [[key, value] for key, value in tags.items()]
+
     return {
         "type": "replay_event",
         "start_time": sec(timestamp),
@@ -146,7 +148,7 @@ def mock_replay(
                         "segment_id": kwargs.pop("segment_id", 0),
                         "tags": tags,
                         "urls": kwargs.pop("urls", []),
-                        "is_archived": kwargs.pop("is_archived", None),
+                        "is_archived": kwargs.pop("is_archived", False),
                         "error_ids": kwargs.pop(
                             "error_ids", ["a3a62ef6-ac86-415b-83c2-416fc2f76db1"]
                         ),
@@ -237,8 +239,8 @@ def mock_replay_click(
                                 "testid": kwargs.pop("testid", ""),
                                 "aria_label": kwargs.pop("aria_label", ""),
                                 "title": kwargs.pop("title", ""),
-                                "is_dead": kwargs.pop("is_dead", 0),
-                                "is_rage": kwargs.pop("is_rage", 0),
+                                "is_dead": int(kwargs.pop("is_dead", 0)),
+                                "is_rage": int(kwargs.pop("is_rage", 0)),
                                 "event_hash": str(uuid.uuid4()),
                                 "timestamp": sec(timestamp),
                             }

--- a/src/sentry/replays/testutils.py
+++ b/src/sentry/replays/testutils.py
@@ -124,7 +124,7 @@ def mock_expected_response(
 
 def mock_replay(
     timestamp: datetime.datetime,
-    project_id: str,
+    project_id: int,
     replay_id: str,
     **kwargs: Any,
 ) -> dict[str, Any]:
@@ -148,7 +148,7 @@ def mock_replay(
                         "segment_id": kwargs.pop("segment_id", 0),
                         "tags": tags,
                         "urls": kwargs.pop("urls", []),
-                        "is_archived": kwargs.pop("is_archived", False),
+                        "is_archived": kwargs.pop("is_archived", None),
                         "error_ids": kwargs.pop(
                             "error_ids", ["a3a62ef6-ac86-415b-83c2-416fc2f76db1"]
                         ),

--- a/src/sentry/replays/usecases/query/configs/scalar.py
+++ b/src/sentry/replays/usecases/query/configs/scalar.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 from typing import Sequence, Union
 
 from sentry.api.event_search import ParenExpression, SearchFilter
-from sentry.replays.lib.new_query.conditions import IPv4Scalar, StringArray, StringScalar, UUIDArray
+from sentry.replays.lib.new_query.conditions import (
+    IPv4Scalar,
+    NonEmptyStringScalar,
+    StringArray,
+    StringScalar,
+    UUIDArray,
+)
 from sentry.replays.lib.new_query.fields import FieldProtocol, StringColumnField, UUIDColumnField
 from sentry.replays.lib.new_query.parsers import parse_str, parse_uuid
 from sentry.replays.lib.selector.parse import parse_selector
@@ -23,21 +29,21 @@ def string_field(column_name: str) -> StringColumnField:
 
 # Static Search Config
 static_search_config: dict[str, FieldProtocol] = {
-    "browser.name": StringColumnField("browser_name", parse_str, StringScalar),
-    "browser.version": StringColumnField("browser_version", parse_str, StringScalar),
-    "device.brand": StringColumnField("device_brand", parse_str, StringScalar),
-    "device.family": StringColumnField("device_family", parse_str, StringScalar),
-    "device.model": StringColumnField("device_model", parse_str, StringScalar),
-    "device.name": StringColumnField("device_name", parse_str, StringScalar),
-    "dist": StringColumnField("dist", parse_str, StringScalar),
-    "environment": StringColumnField("environment", parse_str, StringScalar),
+    "browser.name": StringColumnField("browser_name", parse_str, NonEmptyStringScalar),
+    "browser.version": StringColumnField("browser_version", parse_str, NonEmptyStringScalar),
+    "device.brand": StringColumnField("device_brand", parse_str, NonEmptyStringScalar),
+    "device.family": StringColumnField("device_family", parse_str, NonEmptyStringScalar),
+    "device.model": StringColumnField("device_model", parse_str, NonEmptyStringScalar),
+    "device.name": StringColumnField("device_name", parse_str, NonEmptyStringScalar),
+    "dist": StringColumnField("dist", parse_str, NonEmptyStringScalar),
+    "environment": StringColumnField("environment", parse_str, NonEmptyStringScalar),
     "id": StringColumnField("replay_id", lambda x: str(parse_uuid(x)), StringScalar),
-    "os.name": StringColumnField("os_name", parse_str, StringScalar),
-    "os.version": StringColumnField("os_version", parse_str, StringScalar),
-    "platform": StringColumnField("platform", parse_str, StringScalar),
-    "releases": StringColumnField("release", parse_str, StringScalar),
-    "sdk.name": StringColumnField("sdk_name", parse_str, StringScalar),
-    "sdk.version": StringColumnField("sdk_version", parse_str, StringScalar),
+    "os.name": StringColumnField("os_name", parse_str, NonEmptyStringScalar),
+    "os.version": StringColumnField("os_version", parse_str, NonEmptyStringScalar),
+    "platform": StringColumnField("platform", parse_str, NonEmptyStringScalar),
+    "releases": StringColumnField("release", parse_str, NonEmptyStringScalar),
+    "sdk.name": StringColumnField("sdk_name", parse_str, NonEmptyStringScalar),
+    "sdk.version": StringColumnField("sdk_version", parse_str, NonEmptyStringScalar),
 }
 # Aliases
 static_search_config["release"] = static_search_config["releases"]
@@ -53,10 +59,10 @@ varying_search_config: dict[str, FieldProtocol] = {
     "error_ids": ComputedField(parse_uuid, ErrorIdsArray),
     "trace_ids": UUIDColumnField("trace_ids", parse_uuid, UUIDArray),
     "urls": StringColumnField("urls", parse_str, StringArray),
-    "user.email": StringColumnField("user_email", parse_str, StringScalar),
-    "user.id": StringColumnField("user_id", parse_str, StringScalar),
+    "user.email": StringColumnField("user_email", parse_str, NonEmptyStringScalar),
+    "user.id": StringColumnField("user_id", parse_str, NonEmptyStringScalar),
     "user.ip_address": StringColumnField("ip_address_v4", parse_str, IPv4Scalar),
-    "user.username": StringColumnField("user_name", parse_str, StringScalar),
+    "user.username": StringColumnField("user_name", parse_str, NonEmptyStringScalar),
 }
 
 # Aliases

--- a/tests/sentry/replays/test_project_replay_recording_segment_details.py
+++ b/tests/sentry/replays/test_project_replay_recording_segment_details.py
@@ -101,7 +101,7 @@ class StorageReplayRecordingSegmentDetailsTestCase(EnvironmentBase, ReplaysSnuba
         self.store_replays(
             mock_replay(
                 datetime.datetime.now() - datetime.timedelta(seconds=22),
-                str(metadata.project_id),
+                metadata.project_id,
                 metadata.replay_id,
                 segment_id=metadata.segment_id,
                 retention_days=metadata.retention_days,


### PR DESCRIPTION
Only one change affecting running code.  I've added `NonEmptyStringScalar` to the scalar query config.  The reason being negation queries (e.g. platform != "javascript") would match the empty string and return the row.  This isn't a problem in the aggregate config.  To fix this we explicitly filter out `""` in negation queries.

This is a problem with or without the new processor.  It just happens to be the case that the new processor demonstrated it.

**Test-suite only changes:**

- Produces `tags` as `list[list[str]]`.
- Explicitly send `click_is_dead` and `click_is_rage` as integers (matches the messages we produce in production).
- Provide project-id as an integer.

