### PR TITLE
feat(feedback): add replay banner CTA

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -19,6 +19,7 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types';
 import type {FeedbackIssue} from 'sentry/utils/feedback/types';
 import useReplayCountForFeedbacks from 'sentry/utils/replayCount/useReplayCountForFeedbacks';
+import {useHaveSelectedProjectsSentAnyReplayEvents} from 'sentry/utils/replays/hooks/useReplayOnboarding';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props {
@@ -35,6 +36,8 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
   const url = eventData?.tags.find(tag => tag.key === 'url');
   const replayId = eventData?.contexts?.feedback?.replay_id;
   const crashReportId = eventData?.contexts?.feedback?.associated_event_id;
+
+  const {hasSentOneReplay} = useHaveSelectedProjectsSentAnyReplayEvents();
 
   return (
     <Fragment>
@@ -82,7 +85,7 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
               />
             </ErrorBoundary>
           </Section>
-        ) : (
+        ) : hasSentOneReplay ? null : (
           <Section icon={<IconPlay size="xs" />} title={t('Linked Replay')}>
             <ReplayInlineCTAPanel />
           </Section>

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -7,6 +7,7 @@ import FeedbackActivitySection from 'sentry/components/feedback/feedbackItem/fee
 import FeedbackItemHeader from 'sentry/components/feedback/feedbackItem/feedbackItemHeader';
 import Section from 'sentry/components/feedback/feedbackItem/feedbackItemSection';
 import FeedbackViewers from 'sentry/components/feedback/feedbackItem/feedbackViewers';
+import ReplayInlineCTAPanel from 'sentry/components/feedback/feedbackItem/replayInlineCTAPanel';
 import ReplaySection from 'sentry/components/feedback/feedbackItem/replaySection';
 import TagsSection from 'sentry/components/feedback/feedbackItem/tagsSection';
 import PanelItem from 'sentry/components/panels/panelItem';
@@ -71,7 +72,7 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
           </Section>
         )}
 
-        {hasReplayId && replayId && (
+        {hasReplayId && replayId ? (
           <Section icon={<IconPlay size="xs" />} title={t('Linked Replay')}>
             <ErrorBoundary mini>
               <ReplaySection
@@ -80,6 +81,10 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
                 replayId={replayId}
               />
             </ErrorBoundary>
+          </Section>
+        ) : (
+          <Section icon={<IconPlay size="xs" />} title={t('Linked Replay')}>
+            <ReplayInlineCTAPanel />
           </Section>
         )}
 

--- a/static/app/components/feedback/feedbackItem/replayInlineCTAPanel.tsx
+++ b/static/app/components/feedback/feedbackItem/replayInlineCTAPanel.tsx
@@ -33,13 +33,9 @@ export default function ReplayInlineCTAPanel() {
           </Button>
         </ButtonBar>
       }
-      description={
-        <DescriptionText>
-          {t(
-            "Don't fully understand the feedback message? Install Session Replay to see what the user was doing leading up to the feedback submission."
-          )}
-        </DescriptionText>
-      }
+      description={t(
+        "Don't fully understand the feedback message? Install Session Replay to see what the user was doing leading up to the feedback submission."
+      )}
       heading={t('Set Up Session Replay')}
       icon={<IconBroadcast size="sm" color="purple300" />}
       image={replaysInlineOnboarding}
@@ -51,8 +47,4 @@ export default function ReplayInlineCTAPanel() {
 const PurpleText = styled('span')`
   color: ${p => p.theme.purple300};
   font-weight: bold;
-`;
-
-const DescriptionText = styled('span')`
-  line-height: 1.5em;
 `;

--- a/static/app/components/feedback/feedbackItem/replayInlineCTAPanel.tsx
+++ b/static/app/components/feedback/feedbackItem/replayInlineCTAPanel.tsx
@@ -1,0 +1,59 @@
+import styled from '@emotion/styled';
+
+import replaysInlineOnboarding from 'sentry-images/spot/replay-onboarding-backend.svg';
+
+import PageBanner from 'sentry/components/alerts/pageBanner';
+import {Button} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import HookOrDefault from 'sentry/components/hookOrDefault';
+import {IconBroadcast} from 'sentry/icons/iconBroadcast';
+import {t} from 'sentry/locale';
+import {useReplayOnboardingSidebarPanel} from 'sentry/utils/replays/hooks/useReplayOnboarding';
+
+const OnboardingCTAButton = HookOrDefault({
+  hookName: 'component:replay-onboarding-cta-button',
+  defaultComponent: null,
+});
+
+export default function ReplayInlineCTAPanel() {
+  const {activateSidebar} = useReplayOnboardingSidebarPanel();
+
+  return (
+    <PageBanner
+      button={
+        <ButtonBar gap={1}>
+          <OnboardingCTAButton />
+          <Button
+            priority="primary"
+            analyticsEventName="Clicked Replay Onboarding Backend CTA Button in Issue Details"
+            analyticsEventKey="issue_details.replay-onboarding-backend-cta-button-clicked"
+            analyticsParams={{button: 'Set Up Now'}}
+            onClick={activateSidebar}
+          >
+            {t('Set Up Now')}
+          </Button>
+        </ButtonBar>
+      }
+      description={
+        <DescriptionText>
+          {t(
+            "Don't fully understand the feedback message? Install Session Replay to see what the user was doing leading up to the feedback submission."
+          )}
+        </DescriptionText>
+      }
+      heading={t('Set Up Session Replay')}
+      icon={<IconBroadcast size="sm" color="purple300" />}
+      image={replaysInlineOnboarding}
+      title={<PurpleText>{t('Session Replay')}</PurpleText>}
+    />
+  );
+}
+
+const PurpleText = styled('span')`
+  color: ${p => p.theme.purple300};
+  font-weight: bold;
+`;
+
+const DescriptionText = styled('span')`
+  line-height: 1.5em;
+`;

--- a/static/app/components/feedback/feedbackItem/replayInlineCTAPanel.tsx
+++ b/static/app/components/feedback/feedbackItem/replayInlineCTAPanel.tsx
@@ -25,9 +25,8 @@ export default function ReplayInlineCTAPanel() {
           <OnboardingCTAButton />
           <Button
             priority="primary"
-            analyticsEventName="Clicked Replay Onboarding Backend CTA Button in Issue Details"
-            analyticsEventKey="issue_details.replay-onboarding-backend-cta-button-clicked"
-            analyticsParams={{button: 'Set Up Now'}}
+            analyticsEventName="Clicked Replay Onboarding CTA Button in User Feedback"
+            analyticsEventKey="feedback.replay-onboarding-cta-button-clicked"
             onClick={activateSidebar}
           >
             {t('Set Up Now')}


### PR DESCRIPTION
If the selected project(s) don't have replay set up yet, then we'll show this set up CTA.
<img width="825" alt="SCR-20240111-kspo" src="https://github.com/getsentry/sentry/assets/56095982/cffeccf7-3462-46dc-b393-9976568a8c49">

- It opens up the same fly-out sidebar that's also used on the Replay Index & Issue Details CTA.
- On prod it will also have the "view sample" button that opens up the modal with the Arcade.
- If the projects have replay set up but there isn't a replay available for that feedback, we won't show the CTA.

Closes https://github.com/getsentry/sentry/issues/62975