### PR TITLE
ref(escalating issues): Remove backend feature flag references

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -197,9 +197,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 owners = owner_details.get(group.id)
                 data.update({"owners": owners})
 
-            if "forecast" in expand and features.has(
-                "organizations:escalating-issues", group.organization
-            ):
+            if "forecast" in expand:
                 fetched_forecast = EscalatingGroupForecast.fetch(group.project_id, group.id)
                 if fetched_forecast:
                     fetched_forecast = fetched_forecast.to_dict()

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -554,10 +554,6 @@ def update_groups(
                 )
                 new_substatus = GroupSubStatus.NEW if is_new_group else GroupSubStatus.ONGOING
 
-        has_escalating_issues = len(group_list) > 0 and features.has(
-            "organizations:escalating-issues", group_list[0].organization
-        )
-
         with transaction.atomic(router.db_for_write(Group)):
             # TODO(gilbert): update() doesn't call pre_save and bypasses any substatus defaulting we have there
             #                we should centralize the logic for validating and defaulting substatus values
@@ -567,7 +563,7 @@ def update_groups(
             )
             GroupResolution.objects.filter(group__in=group_ids).delete()
             if new_status == GroupStatus.IGNORED:
-                if new_substatus == GroupSubStatus.UNTIL_ESCALATING and has_escalating_issues:
+                if new_substatus == GroupSubStatus.UNTIL_ESCALATING:
                     result["statusDetails"] = handle_archived_until_escalating(
                         group_list, acting_user, projects, sender=update_groups
                     )

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from functools import partial
 from typing import Callable, Iterable, List, Mapping, Optional, Sequence, Set, Union
 
-from sentry import features
 from sentry.api.event_search import (
     AggregateFilter,
     ParenExpression,
@@ -303,11 +302,6 @@ def convert_query_values(
             if isinstance(search_filter, (ParenExpression, str)):
                 continue
             if search_filter.key.name == "substatus":
-                if not features.has("organizations:escalating-issues", org):
-                    raise InvalidSearchQuery(
-                        "The substatus filter is not supported for this organization"
-                    )
-
                 converted = convert_search_filter(search_filter, org)
                 new_value = converted.value.raw_value
                 status = GROUP_SUBSTATUS_TO_STATUS_MAP.get(

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1529,8 +1529,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:dynamic-sampling": False,
     # Enables data secrecy mode
     "organizations:enterprise-data-secrecy": False,
-    # Enable archive/escalating issue workflow
-    "organizations:escalating-issues": True,
     # Enable archive/escalating issue workflow in MS Teams
     "organizations:escalating-issues-msteams": False,
     # Enable archive/escalating issue workflow features in v2

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -101,7 +101,6 @@ default_manager.add("organizations:ds-sliding-window", OrganizationFeature, Feat
 default_manager.add("organizations:enterprise-data-secrecy", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:escalating-issues-msteams", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:escalating-issues-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:escalating-issues", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:escalating-metrics-backend", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:gitlab-disable-on-broken", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:group-chunk-load-errors", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -62,9 +62,7 @@ def build_assigned_text(identity: RpcIdentity, assignee: str) -> str | None:
     return f"*Issue assigned to {assignee_text} by <@{identity.external_id}>*"
 
 
-def build_action_text(
-    identity: RpcIdentity, action: MessageAction, has_escalating: bool = False
-) -> str | None:
+def build_action_text(identity: RpcIdentity, action: MessageAction) -> str | None:
     if action.name == "assign":
         selected_options = action.selected_options or []
         if not len(selected_options):
@@ -74,7 +72,7 @@ def build_action_text(
 
     # Resolve actions have additional 'parameters' after ':'
     status = STATUSES.get((action.value or "").split(":", 1)[0])
-    status = "archived" if status == "ignored" and has_escalating else status
+    status = "archived" if status == "ignored" else status
     # Action has no valid action text, ignore
     if not status:
         return None
@@ -181,18 +179,14 @@ def get_group_assignees(group: Group) -> Sequence[Mapping[str, Any]]:
     return option_groups
 
 
-def get_action_text(
-    text: str, actions: Sequence[Any], identity: RpcIdentity, has_escalating: bool = False
-) -> str:
+def get_action_text(text: str, actions: Sequence[Any], identity: RpcIdentity) -> str:
     return (
         text
         + "\n"
         + "\n".join(
             [
                 action_text
-                for action_text in [
-                    build_action_text(identity, action, has_escalating) for action in actions
-                ]
+                for action_text in [build_action_text(identity, action) for action in actions]
                 if action_text
             ]
         )
@@ -208,11 +202,10 @@ def build_actions(
     identity: RpcIdentity | None = None,
 ) -> tuple[Sequence[MessageAction], str, str]:
     """Having actions means a button will be shown on the Slack message e.g. ignore, resolve, assign."""
-    has_escalating = features.has("organizations:escalating-issues", project.organization)
     use_block_kit = features.has("organizations:slack-block-kit", project.organization)
 
     if actions and identity:
-        text = get_action_text(text, actions, identity, has_escalating)
+        text = get_action_text(text, actions, identity)
         return [], text, "_actioned_issue"
 
     status = group.get_status()
@@ -224,14 +217,14 @@ def build_actions(
         if status == GroupStatus.IGNORED:
             return MessageAction(
                 name="status",
-                label="Mark as Ongoing" if has_escalating else "Stop Ignoring",
+                label="Mark as Ongoing",
                 value="unresolved:ongoing",
             )
 
         return MessageAction(
             name="status",
-            label="Archive" if has_escalating else "Ignore",
-            value="ignored:until_escalating" if has_escalating else "ignored:forever",
+            label="Archive",
+            value="ignored:until_escalating",
         )
 
     def _resolve_button(use_block_kit) -> MessageAction:

--- a/src/sentry/issues/update_inbox.py
+++ b/src/sentry/issues/update_inbox.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from sentry import features
 from sentry.issues.ongoing import bulk_transition_group_to_ongoing
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupinbox import (
@@ -37,9 +36,6 @@ def update_inbox(
         for group in group_list:
             add_group_to_inbox(group, GroupInboxReason.MANUAL)
     elif not in_inbox:
-        has_escalating = features.has(
-            "organizations:escalating-issues", group_list[0].project.organization, actor=acting_user
-        )
         for group in group_list:
             # Remove from inbox first to insert the mark reviewed activity
             remove_group_from_inbox(
@@ -48,11 +44,7 @@ def update_inbox(
                 user=acting_user,
                 referrer=http_referrer,
             )
-            if (
-                has_escalating
-                and group.substatus != GroupSubStatus.ONGOING
-                and group.status == GroupStatus.UNRESOLVED
-            ):
+            if group.substatus != GroupSubStatus.ONGOING and group.status == GroupStatus.UNRESOLVED:
                 bulk_transition_group_to_ongoing(
                     group.status,
                     group.substatus,

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -180,7 +180,7 @@ class AlertRuleNotification(ProjectNotification):
             "has_alert_integration": has_alert_integration(self.project),
             "issue_type": self.group.issue_type.description,
             "subtitle": self.event.title,
-            "has_issue_states": features.has("organizations:escalating-issues", self.organization),
+            "has_issue_states": True,
         }
 
         # if the organization has enabled enhanced privacy controls we don't send

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -180,7 +180,6 @@ class AlertRuleNotification(ProjectNotification):
             "has_alert_integration": has_alert_integration(self.project),
             "issue_type": self.group.issue_type.description,
             "subtitle": self.event.title,
-            "has_issue_states": True,
         }
 
         # if the organization has enabled enhanced privacy controls we don't send

--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -58,8 +58,7 @@ def send_issue_resolved_webhook(organization_id, project, group, user, resolutio
 def send_issue_ignored_webhook(project, user, group_list, **kwargs):
     for issue in group_list:
         send_workflow_webhooks(project.organization, issue, user, "issue.ignored")
-        if features.has("organizations:escalating-issues", project.organization):
-            send_workflow_webhooks(project.organization, issue, user, "issue.archived")
+        send_workflow_webhooks(project.organization, issue, user, "issue.archived")
 
 
 @comment_created.connect(weak=False)

--- a/src/sentry/tasks/clear_expired_snoozes.py
+++ b/src/sentry/tasks/clear_expired_snoozes.py
@@ -1,6 +1,5 @@
 from django.utils import timezone
 
-from sentry import features
 from sentry.issues.escalating import manage_issue_states
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupinbox import GroupInboxReason
@@ -32,10 +31,7 @@ def clear_expired_snoozes():
     GroupSnooze.objects.filter(id__in=group_snooze_ids).delete()
 
     for group in ignored_groups:
-        if features.has("organizations:escalating-issues", group.organization):
-            manage_issue_states(group, GroupInboxReason.ESCALATING)
-        else:
-            manage_issue_states(group, GroupInboxReason.UNIGNORED)
+        manage_issue_states(group, GroupInboxReason.ESCALATING)
 
         issue_unignored.send_robust(
             project=group.project,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -910,7 +910,6 @@ def process_snoozes(job: PostProcessJob) -> None:
     # Check if group is escalating
     if (
         not should_use_new_escalation_logic
-        and features.has("organizations:escalating-issues", group.organization)
         and group.status == GroupStatus.IGNORED
         and group.substatus == GroupSubStatus.UNTIL_ESCALATING
     ):
@@ -962,10 +961,7 @@ def process_snoozes(job: PostProcessJob) -> None:
                 "user_window": snooze.user_window,
             }
 
-            if features.has("organizations:escalating-issues", group.organization):
-                manage_issue_states(group, GroupInboxReason.ESCALATING, event, snooze_details)
-            else:
-                manage_issue_states(group, GroupInboxReason.UNIGNORED, event, snooze_details)
+            manage_issue_states(group, GroupInboxReason.ESCALATING, event, snooze_details)
 
             snooze.delete()
 

--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -64,7 +64,7 @@
 <div class="container">
   <div class="inner">
     <h2 {% if notification_reason %}style="margin-bottom: 4px"{% else %}style="margin-bottom: 15px"{% endif %}>
-        {% if has_issue_states and group_header %}
+        {% if group_header %}
         {{ group_header }}
         {% else %}
         New alert from <a href="{{group.project.get_absolute_url}}">{{ project_label }}</a>
@@ -95,11 +95,6 @@
             <th colspan="2">Issue</th>
         </tr>
         <tr>
-          {% if not has_issue_states %}
-          <td class="error-level">
-              <span class="level level-{{ group.get_level_display }}">{{ group.get_level_display }}</span>
-          </td>
-          {% endif %}
           <td class="event-detail">
             <div class="issue">
               {% with type=event.get_event_type metadata=event.get_event_metadata transaction=event.transaction %}
@@ -174,7 +169,6 @@
         {% endif %}
       </div>
 
-      {% if has_issue_states %}
       <div class="interface">
         <table>
           <colgroup>
@@ -198,7 +192,6 @@
           </tbody>
         </table>
       </div>
-      {% endif %}
 
 
       {% if commits %}

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -417,7 +417,6 @@ class ActivityMailDebugView(View):
         )
 
 
-has_issue_states = True
 replay_id = "9188182919744ea987d8e4e58f4a6dec"
 
 
@@ -458,7 +457,6 @@ def alert(request):
             "culprit": random.choice(["sentry.tasks.culprit.culprit", None]),
             "subtitle": random.choice(["subtitles are cool", None]),
             "issue_type": group.issue_type.description,
-            "has_issue_states": has_issue_states,
             "replay_id": replay_id,
             "issue_replays_url": get_issue_replay_link(group, "?referrer=alert_email"),
         },

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -248,7 +248,6 @@ class UpdateGroupsTest(TestCase):
         assert not GroupInbox.objects.filter(group=group).exists()
         assert send_robust.called
 
-    @with_feature("organizations:escalating-issues")
     @patch("sentry.signals.issue_ignored.send_robust")
     def test_ignore_with_substatus_archived_until_escalating(self, send_robust: Mock) -> None:
         group = self.create_group()

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -74,7 +74,6 @@ class OrganizationSerializerTest(TestCase):
             "discover-basic",
             "discover-query",
             "derive-code-mappings",
-            "escalating-issues",
             "event-attachments",
             "integrations-alert-rule",
             "integrations-chat-unfurl",

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -26,7 +26,6 @@ from sentry.issues.grouptype import GroupCategory, get_group_types_by_category
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES, GroupStatus
 from sentry.search.utils import get_teams_for_users
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.testutils.silo import region_silo_test
 from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus
 
@@ -233,7 +232,6 @@ class ConvertStatusValueTest(TestCase):
             )
 
 
-@apply_feature_flag_on_cls("organizations:escalating-issues")
 class ConvertSubStatusValueTest(TestCase):
     def test_valid(self):
         for substatus_string, substatus_val in SUBSTATUS_UPDATE_CHOICES.items():

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -230,25 +230,24 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             link_to_event=True,
         )
 
-        with self.feature("organizations:escalating-issues"):
-            test_message = build_test_message(
-                teams={self.team},
-                users={self.user},
-                timestamp=group.last_seen,
-                group=group,
-            )
-            test_message["actions"] = [
-                action
-                if action["text"] != "Ignore"
-                else {
-                    "name": "status",
-                    "text": "Archive",
-                    "type": "button",
-                    "value": "ignored:until_escalating",
-                }
-                for action in test_message["actions"]
-            ]
-            assert SlackIssuesMessageBuilder(group).build() == test_message
+        test_message = build_test_message(
+            teams={self.team},
+            users={self.user},
+            timestamp=group.last_seen,
+            group=group,
+        )
+        test_message["actions"] = [
+            action
+            if action["text"] != "Ignore"
+            else {
+                "name": "status",
+                "text": "Archive",
+                "type": "button",
+                "value": "ignored:until_escalating",
+            }
+            for action in test_message["actions"]
+        ]
+        assert SlackIssuesMessageBuilder(group).build() == test_message
 
     @with_feature("organizations:slack-block-kit")
     def test_build_group_block(self):
@@ -285,23 +284,22 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             link_to_event=True,
         )
 
-        with self.feature("organizations:escalating-issues"):
-            test_message = build_test_message_blocks(
-                teams={self.team},
-                users={self.user},
-                timestamp=group.last_seen,
-                group=group,
-            )
+        test_message = build_test_message_blocks(
+            teams={self.team},
+            users={self.user},
+            timestamp=group.last_seen,
+            group=group,
+        )
 
-            for section in test_message["blocks"]:
-                if section["type"] == "actions":
-                    for element in section["elements"]:
-                        if "ignore" in element["action_id"]:
-                            element["action_id"] = "ignored:until_escalating"
-                            element["value"] = "ignored:until_escalating"
-                            element["text"]["text"] = "Archive"
+        for section in test_message["blocks"]:
+            if section["type"] == "actions":
+                for element in section["elements"]:
+                    if "ignore" in element["action_id"]:
+                        element["action_id"] = "ignored:until_escalating"
+                        element["value"] = "ignored:until_escalating"
+                        element["text"]["text"] = "Archive"
 
-            assert SlackIssuesMessageBuilder(group).build() == test_message
+        assert SlackIssuesMessageBuilder(group).build() == test_message
 
     @patch(
         "sentry.integrations.slack.message_builder.issues.get_option_groups",
@@ -907,10 +905,9 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.IGNORED
         group.save()
 
-        with self.feature({"organizations:escalating-issues": True}):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
 
         expected = {
             "label": "Mark as Ongoing",
@@ -922,9 +919,7 @@ class ActionsTest(TestCase):
             res[0],
             expected,
         )
-        with self.feature("organizations:escalating-issues"), self.feature(
-            "organizations:slack-block-kit"
-        ):
+        with self.feature("organizations:slack-block-kit"):
             res = build_actions(
                 group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
             )
@@ -966,10 +961,9 @@ class ActionsTest(TestCase):
         group.status = GroupStatus.UNRESOLVED
         group.save()
 
-        with self.feature({"organizations:escalating-issues": True}):
-            res = build_actions(
-                group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
-            )
+        res = build_actions(
+            group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
+        )
         expected = {
             "label": "Archive",
             "name": "status",
@@ -980,9 +974,7 @@ class ActionsTest(TestCase):
             res[0],
             expected,
         )
-        with self.feature("organizations:slack-block-kit"), self.feature(
-            "organizations:escalating-issues"
-        ):
+        with self.feature("organizations:slack-block-kit"):
             res = build_actions(
                 group, self.project, "test txt", "red", [MessageAction(name="TEST")], None
             )

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -16,6 +16,7 @@ from sentry.integrations.utils.code_mapping import (
     should_include,
     stacktrace_buckets,
 )
+from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -16,7 +16,6 @@ from sentry.integrations.utils.code_mapping import (
     should_include,
     stacktrace_buckets,
 )
-from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase

--- a/tests/sentry/issues/test_escalating.py
+++ b/tests/sentry/issues/test_escalating.py
@@ -278,49 +278,44 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
     @freeze_time(TIME_YESTERDAY)
     def test_is_escalating_issue(self) -> None:
         """Test when an archived until escalating issue starts escalating"""
-        with self.feature("organizations:escalating-issues"):
-            # The group had 6 events in the last hour
-            event = self._create_events_for_group(count=6)
-            assert event.group is not None
-            archived_group = event.group
-            self.archive_until_escalating(archived_group)
+        # The group had 6 events in the last hour
+        event = self._create_events_for_group(count=6)
+        assert event.group is not None
+        archived_group = event.group
+        self.archive_until_escalating(archived_group)
 
-            # The escalating forecast for today is 5, thus, it should escalate
-            forecast_values = [5] + [6] * 13
-            self.save_mock_escalating_group_forecast(
-                group=archived_group, forecast_values=forecast_values, date_added=datetime.now()
-            )
-            assert is_escalating(archived_group) == (True, 5)
+        # The escalating forecast for today is 5, thus, it should escalate
+        forecast_values = [5] + [6] * 13
+        self.save_mock_escalating_group_forecast(
+            group=archived_group, forecast_values=forecast_values, date_added=datetime.now()
+        )
+        assert is_escalating(archived_group) == (True, 5)
 
-            # Test cache
-            assert (
-                cache.get(f"hourly-group-count:{archived_group.project.id}:{archived_group.id}")
-                == 6
-            )
+        # Test cache
+        assert cache.get(f"hourly-group-count:{archived_group.project.id}:{archived_group.id}") == 6
 
     @freeze_time(TIME_YESTERDAY)
     def test_not_escalating_issue(self) -> None:
         """Test when an archived until escalating issue is not escalating"""
-        with self.feature("organizations:escalating-issues"):
-            # Group 1 had 4 events yesterday
-            self._create_events_for_group(count=4, hours_ago=24)
-            # Group 2 had 5 events today
-            event = self._create_events_for_group(count=5, group="group-escalating")
-            assert event.group is not None
-            group = event.group
-            self.archive_until_escalating(group)
+        # Group 1 had 4 events yesterday
+        self._create_events_for_group(count=4, hours_ago=24)
+        # Group 2 had 5 events today
+        event = self._create_events_for_group(count=5, group="group-escalating")
+        assert event.group is not None
+        group = event.group
+        self.archive_until_escalating(group)
 
-            # The escalating forecast for today is 6 (since date_added was one day ago)
-            forecast_values = [5] + [6] * 13
-            self.save_mock_escalating_group_forecast(
-                group=group,
-                forecast_values=forecast_values,
-                date_added=datetime.now() - timedelta(days=1),
-            )
-            assert is_escalating(group) == (False, None)
-            assert group.substatus == GroupSubStatus.UNTIL_ESCALATING
-            assert group.status == GroupStatus.IGNORED
-            assert not GroupInbox.objects.filter(group=group).exists()
+        # The escalating forecast for today is 6 (since date_added was one day ago)
+        forecast_values = [5] + [6] * 13
+        self.save_mock_escalating_group_forecast(
+            group=group,
+            forecast_values=forecast_values,
+            date_added=datetime.now() - timedelta(days=1),
+        )
+        assert is_escalating(group) == (False, None)
+        assert group.substatus == GroupSubStatus.UNTIL_ESCALATING
+        assert group.status == GroupStatus.IGNORED
+        assert not GroupInbox.objects.filter(group=group).exists()
 
     @freeze_time(TIME_YESTERDAY.replace(minute=12, second=40, microsecond=0))
     def test_hourly_count_query(self) -> None:
@@ -338,9 +333,7 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
         Test that when an archived until escalating issue does not have a forecast that is in range,
         the last forecast is used as a fallback and an error is reported
         """
-        with self.feature("organizations:escalating-issues") and patch(
-            "sentry.issues.escalating_group_forecast.logger"
-        ) as logger:
+        with patch("sentry.issues.escalating_group_forecast.logger") as logger:
             event = self._create_events_for_group(count=2)
             assert event.group is not None
             archived_group = event.group
@@ -362,24 +355,20 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
         Test when an archived until escalating issue starts escalating after exactly 2 weeks.
         This can happen when the previous nodestore forecast hasn't expired yet.
         """
-        with self.feature("organizations:escalating-issues"):
-            # The group had 6 events in the last hour
-            event = self._create_events_for_group(count=6)
-            assert event.group is not None
-            archived_group = event.group
-            self.archive_until_escalating(archived_group)
+        # The group had 6 events in the last hour
+        event = self._create_events_for_group(count=6)
+        assert event.group is not None
+        archived_group = event.group
+        self.archive_until_escalating(archived_group)
 
-            # The escalating forecast for today is 5, thus, it should escalate
-            forecast_values = [5] * 14
-            self.save_mock_escalating_group_forecast(
-                group=archived_group,
-                forecast_values=forecast_values,
-                date_added=TIME_YESTERDAY - timedelta(days=14),
-            )
-            assert is_escalating(archived_group) == (True, 5)
+        # The escalating forecast for today is 5, thus, it should escalate
+        forecast_values = [5] * 14
+        self.save_mock_escalating_group_forecast(
+            group=archived_group,
+            forecast_values=forecast_values,
+            date_added=TIME_YESTERDAY - timedelta(days=14),
+        )
+        assert is_escalating(archived_group) == (True, 5)
 
-            # Test cache
-            assert (
-                cache.get(f"hourly-group-count:{archived_group.project.id}:{archived_group.id}")
-                == 6
-            )
+        # Test cache
+        assert cache.get(f"hourly-group-count:{archived_group.project.id}:{archived_group.id}") == 6

--- a/tests/sentry/issues/test_ignored.py
+++ b/tests/sentry/issues/test_ignored.py
@@ -6,7 +6,6 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.groupinbox import GroupInbox, GroupInboxReason, add_group_to_inbox
 from sentry.models.groupsnooze import GroupSnooze
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.testutils.skips import requires_snuba
 from sentry.types.group import GroupSubStatus
 from tests.sentry.issues.test_utils import get_mock_groups_past_counts_response
@@ -58,7 +57,6 @@ class HandleIgnoredTest(TestCase):
         assert Group.objects.get(id=self.group.id).substatus == GroupSubStatus.UNTIL_CONDITION_MET
 
 
-@apply_feature_flag_on_cls("organizations:escalating-issues")
 class HandleArchiveUntilEscalating(TestCase):
     @patch("sentry.issues.forecasts.query_groups_past_counts", return_value={})
     @patch("sentry.issues.forecasts.generate_and_save_missing_forecasts.delay")

--- a/tests/sentry/issues/test_update_inbox.py
+++ b/tests/sentry/issues/test_update_inbox.py
@@ -3,7 +3,6 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
 from sentry.models.groupinbox import GroupInbox, GroupInboxReason, add_group_to_inbox
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import with_feature
 from sentry.types.group import GroupSubStatus
 
 
@@ -27,7 +26,6 @@ class MarkReviewedTest(TestCase):
         )
         assert not GroupInbox.objects.filter(group=self.group).exists()
 
-    @with_feature("organizations:escalating-issues")
     def test_mark_escalating_reviewed(self) -> None:
         self.group.update(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ESCALATING)
         update_inbox(

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -45,7 +45,6 @@ from sentry.replays.testutils import mock_replay
 from sentry.services.hybrid_cloud.actor import RpcActor
 from sentry.silo import SiloMode
 from sentry.testutils.cases import PerformanceIssueTestCase, ReplaysSnubaTestCase, TestCase
-from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_snuba
@@ -1235,7 +1234,6 @@ class MailAdapterNotifyIssueOwnersTest(BaseMailAdapterTest):
                 [],
             )
 
-    @with_feature("organizations:escalating-issues")
     def test_group_substatus_header(self):
         event = self.store_event(
             data={"message": "Hello world", "level": "error"}, project_id=self.project.id

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -318,9 +318,7 @@ class TestIssueWorkflowNotificationsSentryFunctions(APITestCase):
 
     def test_notify_after_issue_archived(self, delay):
 
-        with Feature(
-            {"organizations:sentry-functions": True, "organizations:escalating-issues": True}
-        ):
+        with Feature({"organizations:sentry-functions": True}):
             self.update_issue({"status": "ignored"})
             sub_data = {}
             with assume_test_silo_mode(SiloMode.CONTROL):

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -10,13 +10,11 @@ from sentry.tasks.auto_ongoing_issues import (
     schedule_auto_transition_to_ongoing,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import apply_feature_flag_on_cls
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
 
 
-@apply_feature_flag_on_cls("organizations:escalating-issues")
 class ScheduleAutoNewOngoingIssuesTest(TestCase):
     @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
@@ -269,7 +267,6 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
         )
 
 
-@apply_feature_flag_on_cls("organizations:escalating-issues")
 class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
     @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")
@@ -373,7 +370,6 @@ class ScheduleAutoRegressedOngoingIssuesTest(TestCase):
         )
 
 
-@apply_feature_flag_on_cls("organizations:escalating-issues")
 class ScheduleAutoEscalatingOngoingIssuesTest(TestCase):
     @freeze_time("2023-07-12 18:40:00Z")
     @mock.patch("sentry.tasks.auto_ongoing_issues.backend")

--- a/tests/sentry/tasks/test_clear_expired_snoozes.py
+++ b/tests/sentry/tasks/test_clear_expired_snoozes.py
@@ -8,7 +8,6 @@ from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
 from sentry.models.groupsnooze import GroupSnooze
 from sentry.tasks.clear_expired_snoozes import clear_expired_snoozes
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import with_feature
 from sentry.types.group import GroupSubStatus
 
 
@@ -50,7 +49,6 @@ class ClearExpiredSnoozesTest(TestCase):
 
         assert send_robust.called
 
-    @with_feature("organizations:escalating-issues")
     @patch("sentry.signals.issue_unignored.send_robust")
     def test_simple_with_escalating_issues(self, send_robust):
         group1 = self.create_group(status=GroupStatus.IGNORED)

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1555,7 +1555,6 @@ class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
 
 
 class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
-    @with_feature("organizations:escalating-issues")
     @patch("sentry.signals.issue_escalating.send_robust")
     @patch("sentry.signals.issue_unignored.send_robust")
     @patch("sentry.rules.processor.RuleProcessor")
@@ -1636,7 +1635,6 @@ class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
 
 
 class SnoozeTestMixin(BasePostProgressGroupMixin):
-    @with_feature("organizations:escalating-issues")
     @patch("sentry.signals.issue_escalating.send_robust")
     @patch("sentry.signals.issue_unignored.send_robust")
     @patch("sentry.rules.processor.RuleProcessor")
@@ -1759,7 +1757,6 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
         assert group.status == GroupStatus.UNRESOLVED
         assert group.substatus == GroupSubStatus.NEW
 
-    @with_feature("organizations:escalating-issues")
     @patch("sentry.issues.escalating.is_escalating", return_value=(True, 0))
     def test_forecast_in_activity(self, mock_is_escalating):
         """
@@ -1786,7 +1783,6 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
         ).exists()
 
     @with_feature("projects:first-event-severity-new-escalation")
-    @with_feature("organizations:escalating-issues")
     @patch("sentry.issues.escalating.is_escalating")
     def test_skip_escalation_logic_for_new_groups(self, mock_is_escalating):
         """

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -9,7 +9,6 @@ from sentry.models.groupinbox import GroupInboxReason, add_group_to_inbox, remov
 from sentry.models.groupowner import GROUP_OWNER_TYPE, GroupOwner, GroupOwnerType
 from sentry.models.release import Release
 from sentry.testutils.cases import APITestCase, SnubaTestCase
-from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 
@@ -188,22 +187,21 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         assert response.data["owners"][0]["type"] == GROUP_OWNER_TYPE[GroupOwnerType.SUSPECT_COMMIT]
 
     def test_group_expand_forecasts(self):
-        with Feature("organizations:escalating-issues"):
-            self.login_as(user=self.user)
-            event = self.store_event(
-                data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
-                project_id=self.project.id,
-            )
-            group = event.group
-            generate_and_save_forecasts([group])
+        self.login_as(user=self.user)
+        event = self.store_event(
+            data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
+            project_id=self.project.id,
+        )
+        group = event.group
+        generate_and_save_forecasts([group])
 
-            url = f"/api/0/issues/{group.id}/?expand=forecast"
+        url = f"/api/0/issues/{group.id}/?expand=forecast"
 
-            response = self.client.get(url, format="json")
-            assert response.status_code == 200, response.content
-            assert response.data["forecast"] is not None
-            assert response.data["forecast"]["data"] is not None
-            assert response.data["forecast"]["date_added"] is not None
+        response = self.client.get(url, format="json")
+        assert response.status_code == 200, response.content
+        assert response.data["forecast"] is not None
+        assert response.data["forecast"]["data"] is not None
+        assert response.data["forecast"]["date_added"] is not None
 
     def test_assigned_to_unknown(self):
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -48,7 +48,7 @@ from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
-from sentry.testutils.helpers.features import Feature, with_feature
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
@@ -1664,7 +1664,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.data[0]["inbox"]["reason"] == GroupInboxReason.UNIGNORED.value
         assert response.data[0]["inbox"]["reason_details"] == snooze_details
 
-    @with_feature("organizations:escalating-issues")
     def test_inbox_fields_issue_states(self):
         event = self.store_event(
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},
@@ -2084,25 +2083,22 @@ class GroupListTest(APITestCase, SnubaTestCase):
             query="is:unresolved",
         )
 
-        with Feature("organizations:escalating-issues"):
-            response1 = get_query_response(
-                query="is:ongoing"
-            )  # (status=unresolved, substatus=(ongoing))
-            response2 = get_query_response(
-                query="is:unresolved"
-            )  # (status=unresolved, substatus=*)
-            response3 = get_query_response(
-                query="is:unresolved is:ongoing !is:regressed"
-            )  # (status=unresolved, substatus=(ongoing, !regressed))
-            response4 = get_query_response(
-                query="is:unresolved is:ongoing !is:ignored"
-            )  # (status=unresolved, substatus=(ongoing, !ignored))
-            response5 = get_query_response(
-                query="!is:regressed is:unresolved"
-            )  # (status=unresolved, substatus=(!regressed))
-            response6 = get_query_response(
-                query="!is:until_escalating"
-            )  # (status=(!unresolved), substatus=(!until_escalating))
+        response1 = get_query_response(
+            query="is:ongoing"
+        )  # (status=unresolved, substatus=(ongoing))
+        response2 = get_query_response(query="is:unresolved")  # (status=unresolved, substatus=*)
+        response3 = get_query_response(
+            query="is:unresolved is:ongoing !is:regressed"
+        )  # (status=unresolved, substatus=(ongoing, !regressed))
+        response4 = get_query_response(
+            query="is:unresolved is:ongoing !is:ignored"
+        )  # (status=unresolved, substatus=(ongoing, !ignored))
+        response5 = get_query_response(
+            query="!is:regressed is:unresolved"
+        )  # (status=unresolved, substatus=(!regressed))
+        response6 = get_query_response(
+            query="!is:until_escalating"
+        )  # (status=(!unresolved), substatus=(!until_escalating))
 
         assert (
             response0.status_code
@@ -2137,17 +2133,16 @@ class GroupListTest(APITestCase, SnubaTestCase):
             self.get_response, sort_by="date", limit=10, expand="inbox", collapse="stats"
         )
 
-        with Feature("organizations:escalating-issues"):
-            response1 = get_query_response(query="is:escalating")
-            response2 = get_query_response(query="is:new")
-            response3 = get_query_response(query="is:regressed")
-            response4 = get_query_response(query="is:forever")
-            response5 = get_query_response(query="is:until_condition_met")
-            response6 = get_query_response(query="is:until_escalating")
-            response7 = get_query_response(query="is:resolved")
-            response8 = get_query_response(query="is:ignored")
-            response9 = get_query_response(query="is:muted")
-            response10 = get_query_response(query="!is:unresolved")
+        response1 = get_query_response(query="is:escalating")
+        response2 = get_query_response(query="is:new")
+        response3 = get_query_response(query="is:regressed")
+        response4 = get_query_response(query="is:forever")
+        response5 = get_query_response(query="is:until_condition_met")
+        response6 = get_query_response(query="is:until_escalating")
+        response7 = get_query_response(query="is:resolved")
+        response8 = get_query_response(query="is:ignored")
+        response9 = get_query_response(query="is:muted")
+        response10 = get_query_response(query="!is:unresolved")
 
         assert (
             response1.status_code

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -445,9 +445,8 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         self.run_test_query("status:[resolved, muted]", [self.group2, group_3], [self.group1])
 
     def test_substatus(self):
-        with Feature("organizations:escalating-issues"):
-            results = self.make_query(search_filter_query="is:ongoing")
-            assert set(results) == {self.group1}
+        results = self.make_query(search_filter_query="is:ongoing")
+        assert set(results) == {self.group1}
 
     def test_category(self):
         results = self.make_query(search_filter_query="issue.category:error")


### PR DESCRIPTION
Backend component of https://github.com/getsentry/sentry/pull/62967 to remove the `escalating-issues` feature flag, must be merged last (after the FE one and https://github.com/getsentry/getsentry/pull/12572 and https://github.com/getsentry/getsentry/pull/12575). 