### PR TITLE
chore(issue-platform): Strengthen typing for payload types

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -266,7 +266,7 @@ def _process_message(
         sampled=True,
     ) as txn:
         try:
-            # Assume messaged without a payload type are of type OCCURRENCE
+            # Messages without payload_type default to an OCCURRENCE payload
             payload_type = message.get("payload_type", PayloadType.OCCURRENCE.value)
             if payload_type == PayloadType.STATUS_CHANGE.value:
                 group = process_status_change_message(message, txn)

--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -47,12 +47,11 @@ _occurrence_producer = SingletonProducer(
 
 
 def produce_occurrence_to_kafka(
-    payload_type: PayloadType | None = PayloadType.OCCURRENCE,
+    payload_type: PayloadType = PayloadType.OCCURRENCE,
     occurrence: IssueOccurrence | None = None,
     status_change: StatusChangeMessage | None = None,
     event_data: Optional[Dict[str, Any]] = None,
 ) -> None:
-    payload_data = None
     if payload_type == PayloadType.OCCURRENCE:
         payload_data = _prepare_occurrence_message(occurrence, event_data)
     elif payload_type == PayloadType.STATUS_CHANGE:

--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -22,6 +22,13 @@ logger = logging.getLogger(__name__)
 
 
 class PayloadType(ValueEqualityEnum):
+    """
+    Defines the type of payload that is being sent to Kafka.
+
+    Messages without PayloadTypes default to OCCURRENCE.
+    When adding new types, existing tests must pass without modifying the payload_type or the payload for backwards compatibility.
+    """
+
     OCCURRENCE = "occurrence"
     STATUS_CHANGE = "status_change"
 

--- a/tests/sentry/issues/test_producer.py
+++ b/tests/sentry/issues/test_producer.py
@@ -54,6 +54,25 @@ class TestProduceOccurrenceToKafka(TestCase, OccurrenceTestMixin):
         assert stored_occurrence
         assert occurrence.event_id == stored_occurrence.event_id
 
+    def test_without_payload_type(self) -> None:
+        # Ensure the occurrence is processes without a payload_type too.
+        occurrence = self.build_occurrence(project_id=self.project.id)
+        produce_occurrence_to_kafka(
+            occurrence=occurrence,
+            event_data={
+                "event_id": occurrence.event_id,
+                "project_id": self.project.id,
+                "title": "some problem",
+                "platform": "python",
+                "tags": {"my_tag": "2"},
+                "timestamp": before_now(minutes=1).isoformat(),
+                "received": before_now(minutes=1).isoformat(),
+            },
+        )
+        stored_occurrence = IssueOccurrence.fetch(occurrence.id, occurrence.project_id)
+        assert stored_occurrence
+        assert occurrence.event_id == stored_occurrence.event_id
+
     def test_with_only_occurrence(self) -> None:
         event = self.store_event(data=load_data("transaction"), project_id=self.project.id)
         occurrence = self.build_occurrence(event_id=event.event_id, project_id=self.project.id)


### PR DESCRIPTION
Previous work in this space should ensure dev requests go through the same Kafka processing as production. Adding a few comments to call out compatibility concerns if we extend the PayloadType class.

Fixes https://github.com/getsentry/sentry/issues/62509