### PR TITLE
ref(staff): Move local sso check and change error codes

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -245,11 +245,13 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
                     if not Authenticator.objects.filter(
                         user_id=request.user.id, type=U2fInterface.type
                     ).exists():
-                        return Response({"detail": "no_u2f"}, status=status.HTTP_403_FORBIDDEN)
+                        return Response(
+                            {"detail": {"code": "no_u2f"}}, status=status.HTTP_403_FORBIDDEN
+                        )
             authenticated = self._validate_superuser(validator, request, verify_authenticator)
 
         if not authenticated:
-            return Response({"detail": "ignore"}, status=status.HTTP_403_FORBIDDEN)
+            return Response({"detail": {"code": "ignore"}}, status=status.HTTP_403_FORBIDDEN)
 
         try:
             # Must use the httprequest object instead of request

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -35,6 +35,8 @@ DISABLE_SU_FORM_U2F_CHECK_FOR_LOCAL = getattr(
     settings, "DISABLE_SU_FORM_U2F_CHECK_FOR_LOCAL", False
 )
 
+MISSING_AUTH_ERROR_MESSAGE = "Missing password or U2F"
+
 
 @control_silo_endpoint
 class BaseAuthIndexEndpoint(Endpoint):
@@ -141,7 +143,7 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
 
         """
         if not validator.is_valid():
-            raise NotAuthenticated(detail="Missing password or U2F")
+            raise NotAuthenticated(detail=MISSING_AUTH_ERROR_MESSAGE)
 
         authenticated = (
             self._verify_user_via_inputs(validator, request)
@@ -219,7 +221,7 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
 
         if not (request.user.is_superuser and request.data.get("isSuperuserModal")):
             if not validator.is_valid():
-                raise NotAuthenticated(detail="Missing password or U2F")
+                raise NotAuthenticated(detail=MISSING_AUTH_ERROR_MESSAGE)
 
             authenticated = self._verify_user_via_inputs(validator, request)
         else:

--- a/src/sentry/api/validators/auth.py
+++ b/src/sentry/api/validators/auth.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+MISSING_PASSWORD_OR_U2F_CODE = "no_password_or_u2f"
+
 
 class AuthVerifyValidator(serializers.Serializer):
     password = serializers.CharField(required=False, trim_whitespace=False)
@@ -13,5 +15,6 @@ class AuthVerifyValidator(serializers.Serializer):
         if "challenge" in data and "response" in data:
             return data
         raise serializers.ValidationError(
-            "You must provide `password` or `challenge` and `response`."
+            detail="You must provide `password` or `challenge` and `response`.",
+            code=MISSING_PASSWORD_OR_U2F_CODE,
         )

--- a/src/sentry/auth/staff.py
+++ b/src/sentry/auth/staff.py
@@ -41,8 +41,6 @@ ALLOWED_IPS = frozenset(getattr(settings, "STAFF_ALLOWED_IPS", settings.INTERNAL
 
 STAFF_ORG_ID = getattr(settings, "STAFF_ORG_ID", None)
 
-DISABLE_SSO_CHECK_FOR_LOCAL_DEV = getattr(settings, "DISABLE_SSO_CHECK_FOR_LOCAL_DEV", False)
-
 UNSET = object()
 
 
@@ -90,9 +88,7 @@ class Staff(ElevatedMode):
         # _admin should have always completed SSO to gain status.
         # We expect ORG_ID to always be set in production.
         if STAFF_ORG_ID and not has_completed_sso(self.request, STAFF_ORG_ID):
-            # Allow staff session on dev env for non sso flow
-            if not DISABLE_SSO_CHECK_FOR_LOCAL_DEV:
-                return False, InactiveReason.INCOMPLETE_SSO
+            return False, InactiveReason.INCOMPLETE_SSO
 
         # if there's no IPs configured, we allow assume its the same as *
         if not allowed_ips:

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -66,8 +66,6 @@ UNSET = object()
 
 ENABLE_SU_UPON_LOGIN_FOR_LOCAL_DEV = getattr(settings, "ENABLE_SU_UPON_LOGIN_FOR_LOCAL_DEV", False)
 
-DISABLE_SSO_CHECK_FOR_LOCAL_DEV = getattr(settings, "DISABLE_SSO_CHECK_FOR_LOCAL_DEV", False)
-
 
 def is_active_superuser(request):
     if is_system_auth(getattr(request, "auth", None)):
@@ -154,9 +152,8 @@ class Superuser(ElevatedMode):
         # if we've bound superuser to an organization they must
         # have completed SSO to gain status
         if self.org_id and not has_completed_sso(self.request, self.org_id):
-            # Allow superuser session on dev env for non sso flow
-            if not DISABLE_SSO_CHECK_FOR_LOCAL_DEV:
-                return False, InactiveReason.INCOMPLETE_SSO
+            return False, InactiveReason.INCOMPLETE_SSO
+
         # if there's no IPs configured, we allow assume its the same as *
         if not allowed_ips:
             return True, InactiveReason.NONE

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -29,6 +29,8 @@ _LOGIN_URL: Optional[str] = None
 
 MFA_SESSION_KEY = "mfa"
 
+DISABLE_SSO_CHECK_FOR_LOCAL_DEV = getattr(settings, "DISABLE_SSO_CHECK_FOR_LOCAL_DEV", False)
+
 
 def _sso_expiry_from_env(seconds: Optional[str]) -> timedelta:
     if seconds is None:
@@ -63,7 +65,6 @@ class SsoSession:
     def from_django_session_value(
         cls, organization_id: int, session_value: Mapping[str, Any]
     ) -> SsoSession:
-
         return cls(
             organization_id,
             datetime.fromtimestamp(session_value[cls.SSO_LOGIN_TIMESTAMP], tz=timezone.utc),
@@ -235,6 +236,9 @@ def has_completed_sso(request: HttpRequest, organization_id: int) -> bool:
     """
     look for the org id under the sso session key, and check that the timestamp isn't past our expiry limit
     """
+    if DISABLE_SSO_CHECK_FOR_LOCAL_DEV:
+        return True
+
     sso_session_in_request = request.session.get(
         SsoSession.django_session_key(organization_id), None
     )

--- a/static/app/components/superuserAccessForm.tsx
+++ b/static/app/components/superuserAccessForm.tsx
@@ -105,7 +105,7 @@ class SuperuserAccessForm extends Component<Props, State> {
   handleError = err => {
     let errorType = '';
     if (err.status === 403) {
-      if (err.responseJSON.detail === 'no_u2f') {
+      if (err.responseJSON.detail.code === 'no_u2f') {
         errorType = ErrorCodes.NO_AUTHENTICATOR;
       } else {
         errorType = ErrorCodes.INVALID_PASSWORD;

--- a/static/app/components/superuserAccessForm.tsx
+++ b/static/app/components/superuserAccessForm.tsx
@@ -111,13 +111,13 @@ class SuperuserAccessForm extends Component<Props, State> {
         errorType = ErrorCodes.INVALID_PASSWORD;
       }
     } else if (err.status === 401) {
-      if (err.responseJSON.detail === 'Missing password or U2F') {
+      errorType = ErrorCodes.INVALID_SSO_SESSION;
+    } else if (err.status === 400) {
+      if (err.responseJSON.detail.code === 'missing_password_or_u2f') {
         errorType = ErrorCodes.MISSING_PASSWORD_OR_U2F;
       } else {
-        errorType = ErrorCodes.INVALID_SSO_SESSION;
+        errorType = ErrorCodes.INVALID_ACCESS_CATEGORY;
       }
-    } else if (err.status === 400) {
-      errorType = ErrorCodes.INVALID_ACCESS_CATEGORY;
     } else if (err === ErrorCodes.NO_AUTHENTICATOR) {
       errorType = ErrorCodes.NO_AUTHENTICATOR;
     } else {

--- a/static/app/components/superuserAccessForm.tsx
+++ b/static/app/components/superuserAccessForm.tsx
@@ -105,13 +105,17 @@ class SuperuserAccessForm extends Component<Props, State> {
   handleError = err => {
     let errorType = '';
     if (err.status === 403) {
-      if (err.responseJSON.detail.code === 'no_u2f') {
+      if (err.responseJSON.detail === 'no_u2f') {
         errorType = ErrorCodes.NO_AUTHENTICATOR;
       } else {
         errorType = ErrorCodes.INVALID_PASSWORD;
       }
     } else if (err.status === 401) {
-      errorType = ErrorCodes.INVALID_SSO_SESSION;
+      if (err.responseJSON.detail === 'Missing password or U2F') {
+        errorType = ErrorCodes.MISSING_PASSWORD_OR_U2F;
+      } else {
+        errorType = ErrorCodes.INVALID_SSO_SESSION;
+      }
     } else if (err.status === 400) {
       errorType = ErrorCodes.INVALID_ACCESS_CATEGORY;
     } else if (err === ErrorCodes.NO_AUTHENTICATOR) {

--- a/static/app/constants/superuserAccessErrors.tsx
+++ b/static/app/constants/superuserAccessErrors.tsx
@@ -4,6 +4,7 @@ export enum ErrorCodes {
   INVALID_PASSWORD = 'Incorrect password',
   INVALID_SSO_SESSION = 'Your SSO Session has expired, please reauthenticate',
   INVALID_ACCESS_CATEGORY = 'Please fill out the access category and reason correctly',
+  MISSING_PASSWORD_OR_U2F = 'Missing password or U2F challenge/response',
   NO_AUTHENTICATOR = 'Please add a U2F authenticator to your account',
   UNKNOWN_ERROR = 'An error occurred, please try again',
 }

--- a/tests/sentry/api/endpoints/test_auth_index.py
+++ b/tests/sentry/api/endpoints/test_auth_index.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 
 from django.test import override_settings
 
-from sentry.api.endpoints.auth_index import MISSING_AUTH_ERROR_MESSAGE
+from sentry.api.validators.auth import MISSING_PASSWORD_OR_U2F_CODE
 from sentry.auth.superuser import COOKIE_NAME, Superuser
 from sentry.models.authenticator import Authenticator
 from sentry.models.authidentity import AuthIdentity
@@ -112,8 +112,8 @@ class AuthVerifyEndpointTest(APITestCase):
         user = self.create_user("foo@example.com")
         self.login_as(user)
         response = self.client.put(self.path, data={})
-        assert response.status_code == 401
-        assert response.data["detail"] == MISSING_AUTH_ERROR_MESSAGE
+        assert response.status_code == 400
+        assert response.data["detail"]["code"] == MISSING_PASSWORD_OR_U2F_CODE
 
     @mock.patch("sentry.api.endpoints.auth_index.metrics")
     @mock.patch("sentry.auth.authenticators.U2fInterface.is_available", return_value=True)
@@ -329,8 +329,8 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
                     "superuserReason": "for testing",
                 },
             )
-            assert response.status_code == 401
-            assert response.data["detail"] == MISSING_AUTH_ERROR_MESSAGE
+            assert response.status_code == 400
+            assert response.data["detail"]["code"] == MISSING_PASSWORD_OR_U2F_CODE
 
     @with_feature("organizations:u2f-superuser-form")
     @mock.patch("sentry.auth.authenticators.U2fInterface.is_available", return_value=True)
@@ -417,8 +417,8 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
                     "isSuperuserModal": True,
                 },
             )
-            assert response.status_code == 401
-            assert response.data["detail"] == MISSING_AUTH_ERROR_MESSAGE
+            assert response.status_code == 400
+            assert response.data["detail"]["code"] == MISSING_PASSWORD_OR_U2F_CODE
 
     # su form is disabled by overriding local dev setting which skip checks
     @mock.patch("sentry.api.endpoints.auth_index.DISABLE_SSO_CHECK_FOR_LOCAL_DEV", True)
@@ -455,8 +455,8 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
                     "isSuperuserModal": True,
                 },
             )
-            assert response.status_code == 401
-            assert response.data["detail"] == MISSING_AUTH_ERROR_MESSAGE
+            assert response.status_code == 400
+            assert response.data["detail"]["code"] == MISSING_PASSWORD_OR_U2F_CODE
 
     @override_settings(SENTRY_SELF_HOSTED=True)
     @with_feature("organizations:u2f-superuser-form")
@@ -491,8 +491,8 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
                     "isSuperuserModal": True,
                 },
             )
-            assert response.status_code == 401
-            assert response.data["detail"] == MISSING_AUTH_ERROR_MESSAGE
+            assert response.status_code == 400
+            assert response.data["detail"]["code"] == MISSING_PASSWORD_OR_U2F_CODE
 
     @with_feature("organizations:u2f-superuser-form")
     def test_superuser_no_sso_with_referrer(self):

--- a/tests/sentry/api/endpoints/test_auth_index.py
+++ b/tests/sentry/api/endpoints/test_auth_index.py
@@ -4,6 +4,7 @@ from urllib.parse import urlencode
 
 from django.test import override_settings
 
+from sentry.api.endpoints.auth_index import MISSING_AUTH_ERROR_MESSAGE
 from sentry.auth.superuser import COOKIE_NAME, Superuser
 from sentry.models.authenticator import Authenticator
 from sentry.models.authidentity import AuthIdentity
@@ -112,7 +113,7 @@ class AuthVerifyEndpointTest(APITestCase):
         self.login_as(user)
         response = self.client.put(self.path, data={})
         assert response.status_code == 401
-        assert response.data["detail"] == "Missing password or U2F"
+        assert response.data["detail"] == MISSING_AUTH_ERROR_MESSAGE
 
     @mock.patch("sentry.api.endpoints.auth_index.metrics")
     @mock.patch("sentry.auth.authenticators.U2fInterface.is_available", return_value=True)
@@ -329,7 +330,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
                 },
             )
             assert response.status_code == 401
-            assert response.data["detail"] == "Missing password or U2F"
+            assert response.data["detail"] == MISSING_AUTH_ERROR_MESSAGE
 
     @with_feature("organizations:u2f-superuser-form")
     @mock.patch("sentry.auth.authenticators.U2fInterface.is_available", return_value=True)
@@ -417,7 +418,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
                 },
             )
             assert response.status_code == 401
-            assert response.data["detail"] == "Missing password or U2F"
+            assert response.data["detail"] == MISSING_AUTH_ERROR_MESSAGE
 
     # su form is disabled by overriding local dev setting which skip checks
     @mock.patch("sentry.api.endpoints.auth_index.DISABLE_SSO_CHECK_FOR_LOCAL_DEV", True)
@@ -455,7 +456,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
                 },
             )
             assert response.status_code == 401
-            assert response.data["detail"] == "Missing password or U2F"
+            assert response.data["detail"] == MISSING_AUTH_ERROR_MESSAGE
 
     @override_settings(SENTRY_SELF_HOSTED=True)
     @with_feature("organizations:u2f-superuser-form")
@@ -491,7 +492,7 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
                 },
             )
             assert response.status_code == 401
-            assert response.data["detail"] == "Missing password or U2F"
+            assert response.data["detail"] == MISSING_AUTH_ERROR_MESSAGE
 
     @with_feature("organizations:u2f-superuser-form")
     def test_superuser_no_sso_with_referrer(self):


### PR DESCRIPTION
This PR does two things:
1. Move `DISABLE_SSO_CHECK_FOR_LOCAL_DEV` into `has_completed_sso` and handle the respective changes
2. Fixes the returned error from the `auth_index` endpoint.
    - Formats existing errors as `{"detail": err_message}` instead of `{"detail": {"code": err_message}}`
    - Fixes not validating a missing password or U2F challenger response and unknown error. We now actually use the `AuthVerifyValidator.is_valid`  check and raise an error respectively