### PR TITLE
style(ui): fix page banner line height

### DIFF
--- a/static/app/components/alerts/pageBanner.tsx
+++ b/static/app/components/alerts/pageBanner.tsx
@@ -112,7 +112,7 @@ const TextContainer = styled('div')`
 const SubText = styled('div')`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
-  line-height: ${p => p.theme.fontSizeMedium};
+  line-height: ${p => p.theme.text.lineHeightBody};
 `;
 
 const TypeText = styled(SubText)`


### PR DESCRIPTION
See https://sentry.sentry.io/stories/?name=app/styles/typography.stories.tsx

What it looked like before:
<img width="794" alt="SCR-20240111-kzfe" src="https://github.com/getsentry/sentry/assets/56095982/e0d25074-7713-4a5c-8695-964c7ded5b4b">
