### PR TITLE
ref(hybrid-cloud): Removes unnecessary queries to team and project in org RPC calls

### DIFF
--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -328,7 +328,9 @@ class GitlabWebhookEndpoint(Endpoint, GitlabWebhookMixin):
             return HttpResponse(status=400, reason=extra["reason"])
 
         for install in installs:
-            org_context = organization_service.get_organization_by_id(id=install.organization_id)
+            org_context = organization_service.get_organization_by_id(
+                id=install.organization_id, include_teams=False, include_projects=False
+            )
             if org_context:
                 organization = org_context.organization
                 handler()(integration, organization, event)

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -208,7 +208,9 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 "Unable to communicate with the Jira instance. You may need to reinstall the addon."
             )
 
-        context = organization_service.get_organization_by_id(id=self.organization_id)
+        context = organization_service.get_organization_by_id(
+            id=self.organization_id, include_projects=False, include_teams=False
+        )
         organization = context.organization
 
         has_issue_sync = features.has("organizations:integrations-issue-sync", organization)
@@ -513,7 +515,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 group.organization
                 if group
                 else organization_service.get_organization_by_id(
-                    id=self.organization_id
+                    id=self.organization_id, include_projects=False, include_teams=False
                 ).organization
             )
             fkwargs["url"] = self.search_url(organization.slug)

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -365,7 +365,9 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
                 "Unable to communicate with the Jira instance. You may need to reinstall the addon."
             )
 
-        context = organization_service.get_organization_by_id(id=self.organization_id)
+        context = organization_service.get_organization_by_id(
+            id=self.organization_id, include_teams=False, include_projects=False
+        )
         organization = context.organization
 
         has_issue_sync = features.has("organizations:integrations-issue-sync", organization)
@@ -623,7 +625,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
                 group.organization
                 if group
                 else organization_service.get_organization_by_id(
-                    id=self.organization_id
+                    id=self.organization_id, include_teams=False, include_projects=False
                 ).organization
             )
             fkwargs["url"] = self.search_url(organization.slug)


### PR DESCRIPTION
Removes Team and Project queries from `organization_service.get_organization_by_id` calls that don't appear to actually use these properties.