### PR TITLE
test: Introduce factory method for creating OrganizationIntegrations in setup

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -72,6 +72,7 @@ from sentry.models.integrations.integration_feature import (
     IntegrationFeature,
     IntegrationTypes,
 )
+from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.models.notificationaction import (
@@ -1507,11 +1508,6 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)
-    def create_provider_integration(**integration_params: Any) -> Integration:
-        return Integration.objects.create(**integration_params)
-
-    @staticmethod
-    @assume_test_silo_mode(SiloMode.CONTROL)
     def create_integration(
         organization: Organization,
         external_id: str,
@@ -1524,6 +1520,16 @@ class Factories:
         organization_integration.update(**(oi_params or {}))
 
         return integration
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CONTROL)
+    def create_provider_integration(**integration_params: Any) -> Integration:
+        return Integration.objects.create(**integration_params)
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CONTROL)
+    def create_organization_integration(**integration_params: Any) -> OrganizationIntegration:
+        return OrganizationIntegration.objects.create(**integration_params)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -12,6 +12,7 @@ from sentry.models.activity import Activity
 from sentry.models.actor import Actor, get_actor_id_for_user
 from sentry.models.grouprelease import GroupRelease
 from sentry.models.integrations.integration import Integration
+from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
@@ -443,10 +444,6 @@ class Fixtures:
 
         return integration
 
-    def create_provider_integration(self, **integration_params: Any) -> Integration:
-        """Create an integration tied to a provider but no particular organization."""
-        return Factories.create_provider_integration(**integration_params)
-
     def create_integration(
         self,
         organization: Organization,
@@ -456,6 +453,14 @@ class Fixtures:
     ) -> Integration:
         """Create an integration and add an organization."""
         return Factories.create_integration(organization, external_id, oi_params, **kwargs)
+
+    def create_provider_integration(self, **integration_params: Any) -> Integration:
+        """Create an integration tied to a provider but no particular organization."""
+        return Factories.create_provider_integration(**integration_params)
+
+    def create_organization_integration(self, **integration_params: Any) -> OrganizationIntegration:
+        """Create an OrganizationIntegration entity."""
+        return Factories.create_organization_integration(**integration_params)
 
     def create_identity(self, *args, **kwargs):
         return Factories.create_identity(*args, **kwargs)

--- a/tests/sentry/api/endpoints/test_user_organizationintegration.py
+++ b/tests/sentry/api/endpoints/test_user_organizationintegration.py
@@ -1,4 +1,3 @@
-from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 
@@ -15,7 +14,7 @@ class UserOrganizationIntegationTest(APITestCase):
     def test_simple(self):
         integration = self.create_provider_integration(provider="github")
 
-        OrganizationIntegration.objects.create(
+        self.create_organization_integration(
             organization_id=self.organization.id, integration_id=integration.id
         )
 

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -15,7 +15,6 @@ from sentry.models.authprovider import AuthProvider
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
-from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.silo import SiloMode
 from sentry.testutils.asserts import assert_mock_called_once_with_partial
 from sentry.testutils.cases import APITestCase
@@ -46,7 +45,7 @@ class StatusActionTest(APITestCase):
                     "expires_at": int(time.time()) + 86400,
                 },
             )
-            OrganizationIntegration.objects.create(
+            self.create_organization_integration(
                 organization_id=self.org.id, integration=self.integration
             )
 
@@ -290,9 +289,7 @@ class StatusActionTest(APITestCase):
                     "expires_at": int(time.time()) + 86400,
                 },
             )
-            OrganizationIntegration.objects.create(
-                organization_id=org2.id, integration=integration2
-            )
+            self.create_organization_integration(organization_id=org2.id, integration=integration2)
 
             idp2 = IdentityProvider.objects.create(type="msteams", external_id="54rum4n", config={})
             Identity.objects.create(

--- a/tests/sentry/integrations/msteams/test_link_identity.py
+++ b/tests/sentry/integrations/msteams/test_link_identity.py
@@ -5,7 +5,6 @@ import responses
 
 from sentry.integrations.msteams.link_identity import build_linking_url
 from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
-from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
@@ -34,7 +33,7 @@ class MsTeamsIntegrationLinkIdentityTest(TestCase):
                 "expires_at": int(time.time()) + 86400,
             },
         )
-        OrganizationIntegration.objects.create(
+        self.create_organization_integration(
             organization_id=self.org.id, integration=self.integration
         )
 

--- a/tests/sentry/integrations/msteams/test_message_builder.py
+++ b/tests/sentry/integrations/msteams/test_message_builder.py
@@ -45,7 +45,6 @@ from sentry.integrations.msteams.card_builder.notifications import (
 )
 from sentry.models.group import GroupStatus
 from sentry.models.groupassignee import GroupAssignee
-from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.organization import Organization
 from sentry.models.rule import Rule
 from sentry.testutils.cases import TestCase
@@ -105,7 +104,7 @@ class MSTeamsMessageBuilderTest(TestCase):
             external_id="f3ll0wsh1p",
             metadata={},
         )
-        OrganizationIntegration.objects.create(
+        self.create_organization_integration(
             organization_id=self.org.id, integration=self.integration
         )
 

--- a/tests/sentry/integrations/msteams/test_unlink_identity.py
+++ b/tests/sentry/integrations/msteams/test_unlink_identity.py
@@ -4,7 +4,6 @@ import responses
 
 from sentry.integrations.msteams.unlink_identity import build_unlinking_url
 from sentry.models.identity import Identity, IdentityProvider, IdentityStatus
-from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.signing import unsign
@@ -31,7 +30,7 @@ class MsTeamsIntegrationUnlinkIdentityTest(TestCase):
                 "expires_at": int(time.time()) + 86400,
             },
         )
-        OrganizationIntegration.objects.create(
+        self.create_organization_integration(
             organization_id=self.org.id, integration=self.integration
         )
 

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -829,7 +829,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         # add a second organization
         org = self.create_organization(owner=self.user)
         with assume_test_silo_mode(SiloMode.CONTROL):
-            OrganizationIntegration.objects.create(
+            self.create_organization_integration(
                 organization_id=org.id, integration=self.integration
             )
 
@@ -912,7 +912,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         # add a second organization
         org = self.create_organization(owner=self.user)
         with assume_test_silo_mode(SiloMode.CONTROL):
-            OrganizationIntegration.objects.create(
+            self.create_organization_integration(
                 organization_id=org.id, integration=self.integration
             )
 

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -3,7 +3,6 @@ import responses
 from sentry.integrations.slack.views.link_identity import build_linking_url
 from sentry.integrations.slack.views.unlink_identity import build_unlinking_url
 from sentry.models.identity import Identity, IdentityStatus
-from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import add_identity, install_slack
 from sentry.testutils.silo import control_silo_test
@@ -107,7 +106,7 @@ class SlackIntegrationUnlinkIdentityTest(SlackIntegrationLinkIdentityTestBase):
     @responses.activate
     def test_user_with_multiple_organizations(self):
         # Create a second organization where the user is _not_ a member.
-        OrganizationIntegration.objects.create(
+        self.create_organization_integration(
             organization_id=self.create_organization(name="Another Org").id,
             integration=self.integration,
         )

--- a/tests/sentry/integrations/slack/test_link_team.py
+++ b/tests/sentry/integrations/slack/test_link_team.py
@@ -9,7 +9,6 @@ from rest_framework import status
 from sentry.integrations.slack.views.link_team import build_team_linking_url
 from sentry.integrations.slack.views.unlink_team import build_team_unlinking_url
 from sentry.models.integrations.external_actor import ExternalActor
-from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.models.organization import Organization
 from sentry.models.team import Team
@@ -219,7 +218,7 @@ class SlackIntegrationLinkTeamTest(SlackIntegrationLinkTeamTestBase):
         organization2 = self.create_organization(owner=self.user)
         team2 = self.create_team(organization=organization2, members=[self.user])
         with assume_test_silo_mode(SiloMode.CONTROL):
-            OrganizationIntegration.objects.create(
+            self.create_organization_integration(
                 organization_id=organization2.id, integration=self.integration
             )
 
@@ -375,7 +374,7 @@ class SlackIntegrationUnlinkTeamTest(SlackIntegrationLinkTeamTestBase):
         organization2 = self.create_organization(owner=self.user)
         team2 = self.create_team(organization=organization2, members=[self.user])
         with assume_test_silo_mode(SiloMode.CONTROL):
-            OrganizationIntegration.objects.create(
+            self.create_organization_integration(
                 organization_id=organization2.id, integration=self.integration
             )
         self.link_team(team2)

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -339,7 +339,7 @@ class SlackNotifyActionTest(RuleTestCase):
 
     def test_disabled_org_integration(self):
         org = self.create_organization(owner=self.user)
-        OrganizationIntegration.objects.create(organization_id=org.id, integration=self.integration)
+        self.create_organization_integration(organization_id=org.id, integration=self.integration)
         OrganizationIntegration.objects.get(
             integration=self.integration, organization_id=self.event.project.organization.id
         ).update(status=ObjectStatus.DISABLED)
@@ -415,7 +415,7 @@ class SlackNotifyActionTest(RuleTestCase):
     @responses.activate
     def test_multiple_integrations(self):
         org = self.create_organization(owner=self.user)
-        OrganizationIntegration.objects.create(organization_id=org.id, integration=self.integration)
+        self.create_organization_integration(organization_id=org.id, integration=self.integration)
 
         event = self.get_event()
 

--- a/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
+++ b/tests/sentry/integrations/slack/webhooks/commands/test_link_team.py
@@ -8,7 +8,6 @@ from sentry.integrations.slack.webhooks.command import (
     LINK_USER_FIRST_MESSAGE,
     TEAM_NOT_LINKED_MESSAGE,
 )
-from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.silo import SiloMode
 from sentry.testutils.helpers import get_response_text, link_user
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
@@ -183,7 +182,7 @@ class SlackCommandsUnlinkTeamTest(SlackCommandsLinkTeamTestBase):
         organization2 = self.create_organization(owner=self.user)
         team2 = self.create_team(organization=organization2, members=[self.user])
         with assume_test_silo_mode(SiloMode.CONTROL):
-            OrganizationIntegration.objects.create(
+            self.create_organization_integration(
                 organization_id=organization2.id, integration=self.integration
             )
         self.link_team(team2)

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -269,7 +269,7 @@ class FinishPipelineTestCase(IntegrationTestCase):
             external_id=self.external_id,
             metadata={"url": "https://example.com"},
         )
-        OrganizationIntegration.objects.create(
+        self.create_organization_integration(
             organization_id=self.organization.id,
             integration=integration,
             default_auth_id=old_identity_id,

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -15,7 +15,6 @@ from fixtures.vercel import (
     SIGNATURE_NEW,
 )
 from sentry import VERSION
-from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.models.integrations.sentry_app_installation_for_provider import (
     SentryAppInstallationForProvider,
@@ -78,7 +77,7 @@ class VercelReleasesTest(APITestCase):
             metadata={"access_token": "my_token"},
         )
 
-        self.org_integration = OrganizationIntegration.objects.create(
+        self.org_integration = self.create_organization_integration(
             organization_id=self.organization.id,
             integration=self.integration,
             config={


### PR DESCRIPTION
Introduce `create_organization_integration` as a test case factory method. Globally find and replace instances of `OrganizationIntegration.objects.create` so that they are wrapped in `assume_test_silo_mode(SiloMode.CONTROL)`.