### PR TITLE
fix(inbound-filters): Fix test for default inbound filters

### DIFF
--- a/src/sentry/api/helpers/default_inbound_filters.py
+++ b/src/sentry/api/helpers/default_inbound_filters.py
@@ -5,7 +5,6 @@ from sentry.ingest import inbound_filters
 
 # Turns on certain inbound filters by default for project.
 def set_default_inbound_filters(project):
-    state: Dict[str, Union[bool, List[str]]] = {}
     filters = [
         "browser-extensions",
         "legacy-browsers",
@@ -14,6 +13,7 @@ def set_default_inbound_filters(project):
     ]
 
     for filter_id in filters:
+        state: Dict[str, Union[bool, List[str]]] = {}
         if filter_id == "legacy-browsers":
             state["subfilters"] = [
                 "ie_pre_9",

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -183,6 +183,16 @@ class TeamProjectsCreateTest(APITestCase):
         }
 
         assert javascript_filter_states["browser-extensions"]
-        assert javascript_filter_states["legacy-browsers"]
+        assert set(javascript_filter_states["legacy-browsers"]) == {
+            "ie_pre_9",
+            "ie9",
+            "ie10",
+            "ie11",
+            "safari_pre_6",
+            "opera_pre_15",
+            "opera_mini_pre_8",
+            "android_pre_4",
+            "edge_pre_79",
+        }
         assert javascript_filter_states["web-crawlers"]
         assert javascript_filter_states["filtered-transaction"]


### PR DESCRIPTION
this pr fixes a mistake in the default inbound filters code, which wasn't resetting the state. It didn't have any impact on the result of the function, but still best to fix it and the test.