### PR TITLE
ref(feedback): show 2 lines of message preview

### DIFF
--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -98,14 +98,19 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
             <TimeSince date={feedbackItem.firstSeen} style={{gridArea: 'time'}} />
 
             {feedbackItem.hasSeen ? null : (
-              <Row style={{gridArea: 'unread'}}>
+              <DotRow style={{gridArea: 'unread'}}>
                 <IconCircleFill size="xs" color={isOpen ? 'white' : 'purple400'} />
-              </Row>
+              </DotRow>
             )}
 
-            <Row align="flex-start" justify="flex-start" style={{gridArea: 'message'}}>
-              <TextOverflow>{feedbackItem.metadata.message}</TextOverflow>
-            </Row>
+            <PreviewRow
+              align="flex-start"
+              justify="flex-start"
+              style={{gridArea: 'message'}}
+              isOpen={isOpen}
+            >
+              <StyledTextOverflow>{feedbackItem.metadata.message}</StyledTextOverflow>
+            </PreviewRow>
 
             <BottomGrid style={{gridArea: 'bottom'}}>
               <Row justify="flex-start" gap={space(0.75)}>
@@ -197,4 +202,23 @@ const StyledProjectAvatar = styled(ProjectAvatar)`
   }
 `;
 
+const PreviewRow = styled(Row)<{isOpen: boolean}>`
+  height: 2.8em;
+  align-items: flex-start;
+  color: ${p => (p.isOpen ? p.theme.white : p.theme.gray300)};
+`;
+
+const DotRow = styled(Row)`
+  height: 2.2em;
+  align-items: flex-start;
+`;
+
+const StyledTextOverflow = styled(TextOverflow)`
+  white-space: initial;
+  height: 2.8em;
+  -webkit-line-clamp: 2;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  line-height: ${p => p.theme.text.lineHeightBody};
+`;
 export default FeedbackListItem;


### PR DESCRIPTION
- Now we're showing max 2 rows of feedback message preview. 
- Rows are fixed height, so if the message only fits on 1 line, there will be space (`1.4em` of space specifically) between the message and the short ID below. 
- The unread indicator dot aligns with the first line of the preview.
- Also updated the message preview text to be grayish (but white when it's selected w/ the purple background).


https://github.com/getsentry/sentry/assets/56095982/306b7a89-cb95-4ea8-acf4-189bfba63a2d

