### PR TITLE
feat(system): Add new_issue count health check for release threshold

### DIFF
--- a/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
+++ b/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
@@ -37,6 +37,9 @@ def update_new_issues_count_healthy_for_thresholds(
         else:
             q = q.union(annotation, all=True)
 
+    if q is None:
+        return
+
     # Execute the query to retrieve the unique_key and count columns that hold the data we need
     # Each resultant threshold should be a dictionary with the 2 columns
     results = q.values(NEW_ISSUES_UNIQUE_KEY_COLUMN, NEW_ISSUES_COUNT_COLUMN)

--- a/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
+++ b/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
@@ -7,7 +7,7 @@ from sentry.models.group import Group
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.release_threshold.constants import TriggerType
 
-logger = getLogger("sentry.releases.servicer")
+logger = getLogger("sentry.release_threshold.health_checks.is_new_issues_count_healthy")
 
 
 def is_new_issues_count_healthy(release_threshold: EnrichedThreshold) -> bool:

--- a/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
+++ b/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
@@ -3,41 +3,35 @@ from __future__ import annotations
 from datetime import datetime
 from logging import getLogger
 
-from sentry import search
-from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
+from sentry.models.group import Group
+from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.release_threshold import ReleaseThreshold
 from sentry.models.release_threshold.constants import TriggerType
-from sentry.search.events.constants import RELEASE_ALIAS
 
 default_logger = getLogger("sentry.releases.servicer")
 
 
-def get_new_issue_count_is_healthy(
+def is_new_issues_count_healthy(
     project: Project,
     release: Release,
     release_threshold: ReleaseThreshold,
     start: datetime,
     end: datetime,
 ) -> bool:
-    query_kwargs = {
-        "projects": [project],
-        "date_from": start,
-        "date_to": end,
-        "count_hits": True,
-        "limit": 1,  # we don't need the returned objects, just the total count
-        "search_filters": [
-            SearchFilter(
-                key=(SearchKey(RELEASE_ALIAS)), operator="=", value=SearchValue(release.version)
-            )
-        ],
-    }
-    if release_threshold.environment:
-        query_kwargs["environments"] = [release_threshold.environment]
-
     try:
-        result = search.query(**query_kwargs)  # type: ignore
+        if release_threshold.environment:
+            new_issues = GroupEnvironment.objects.filter(
+                first_release=release,
+                environment=release_threshold.environment,
+                group__project=project,
+                first_seen__range=(start, end),
+            ).count()
+        else:
+            new_issues = Group.objects.filter(
+                project=project, first_release=release, first_seen__range=(start, end)
+            ).count()
     except Exception:
         default_logger.exception(
             "There was an error trying to grab new issue count",
@@ -45,15 +39,11 @@ def get_new_issue_count_is_healthy(
                 "project": project.id,
                 "release": release.id,
                 "release_threshold": release_threshold.id,
-                "query_kwargs": query_kwargs,
+                "start": start,
+                "end": end,
             },
         )
         return False
-
-    new_issues = result.hits
-    # If no issues where found for the specified query, then no issues exist
-    if new_issues is None:
-        new_issues = 0
 
     baseline_value = release_threshold.value
     if release_threshold.trigger_type == TriggerType.OVER:

--- a/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
+++ b/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional
 from uuid import uuid4
 
 from django.db.models import CharField, Count, QuerySet, Value
@@ -22,7 +22,7 @@ def update_new_issues_count_healthy_for_thresholds(
     Each release threshold is considered to be a unique threshold to determine its own health.
     """
     queries = {}
-    q = None
+    q: Optional[QuerySet] = None
     # Loop through each enriched_threshold and get the query that we need to aggregate
     for ethreshold in release_thresholds:
         # Ignore any incorrect thresholds that might have slipped in

--- a/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
+++ b/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime
+from logging import getLogger
+
+from sentry import search
+from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
+from sentry.models.project import Project
+from sentry.models.release import Release
+from sentry.models.release_threshold import ReleaseThreshold
+from sentry.models.release_threshold.constants import TriggerType
+from sentry.search.events.constants import RELEASE_ALIAS
+
+default_logger = getLogger("sentry.releases.servicer")
+
+
+def get_new_issue_count_is_healthy(
+    project: Project,
+    release: Release,
+    release_threshold: ReleaseThreshold,
+    start: datetime,
+    end: datetime,
+) -> bool:
+    query_kwargs = {
+        "projects": [project],
+        "date_from": start,
+        "date_to": end,
+        "count_hits": True,
+        "limit": 1,  # we don't need the returned objects, just the total count
+        "search_filters": [
+            SearchFilter(
+                key=(SearchKey(RELEASE_ALIAS)), operator="=", value=SearchValue(release.version)
+            )
+        ],
+    }
+    if release_threshold.environment:
+        query_kwargs["environments"] = [release_threshold.environment]
+
+    try:
+        result = search.query(**query_kwargs)  # type: ignore
+    except Exception:
+        default_logger.exception(
+            "There was an error trying to grab new issue count",
+            extra={
+                "project": project.id,
+                "release": release.id,
+                "release_threshold": release_threshold.id,
+                "query_kwargs": query_kwargs,
+            },
+        )
+        return False
+
+    new_issues = result.hits
+    # If no issues where found for the specified query, then no issues exist
+    if new_issues is None:
+        new_issues = 0
+
+    baseline_value = release_threshold.value
+    if release_threshold.trigger_type == TriggerType.OVER:
+        # If new issues is under/equal the threshold value, then it is healthy
+        return new_issues <= baseline_value
+    # Else, if new issues is over/equal the threshold value, then it is healthy
+    return new_issues >= baseline_value

--- a/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
+++ b/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
@@ -1,46 +1,93 @@
 from __future__ import annotations
 
-from logging import getLogger
+from typing import List
+from uuid import uuid4
+
+from django.db.models import CharField, Count, QuerySet, Value
 
 from sentry.api.endpoints.release_thresholds.types import EnrichedThreshold
 from sentry.models.group import Group
-from sentry.models.groupenvironment import GroupEnvironment
-from sentry.models.release_threshold.constants import TriggerType
+from sentry.models.release_threshold.constants import ReleaseThresholdType, TriggerType
 
-logger = getLogger("sentry.release_threshold.health_checks.is_new_issues_count_healthy")
+NEW_ISSUES_COUNT_COLUMN = "count"
+NEW_ISSUES_UNIQUE_KEY_COLUMN = "unique_key"
 
 
-def is_new_issues_count_healthy(release_threshold: EnrichedThreshold) -> bool:
+def update_new_issues_count_healthy_for_thresholds(
+    release_thresholds: List[EnrichedThreshold],
+) -> None:
+    """
+    Updates the release thresholds is_healthy for the given iterable.
+    This function leverages bulk querying to update the values of the release thresholds.
+    Each release threshold is considered to be a unique threshold to determine its own health.
+    """
+    queries = {}
+    q = None
+    # Loop through each enriched_threshold and get the query that we need to aggregate
+    for ethreshold in release_thresholds:
+        # Ignore any incorrect thresholds that might have slipped in
+        if ethreshold["threshold_type"] != ReleaseThresholdType.NEW_ISSUE_COUNT_STR:
+            continue
+
+        unique_id = str(uuid4())
+        queries[unique_id] = ethreshold
+        annotation = get_is_new_issues_count_healthy_query(ethreshold, unique_id)
+        if q is None:
+            q = annotation
+        else:
+            q = q.union(annotation, all=True)
+
+    # Execute the query to retrieve the unique_key and count columns that hold the data we need
+    # Each resultant threshold should be a dictionary with the 2 columns
+    results = q.values(NEW_ISSUES_UNIQUE_KEY_COLUMN, NEW_ISSUES_COUNT_COLUMN)
+
+    # Update the enriched_thresholds with the results
+    for result in results:
+        unique_key = result[
+            NEW_ISSUES_UNIQUE_KEY_COLUMN
+        ]  # Get the unique key from the result dictionary
+        value = result[NEW_ISSUES_COUNT_COLUMN]  # Get the count value
+        ethreshold = queries[unique_key]
+        is_healthy = is_new_issues_count_healthy(enriched_threshold=ethreshold, new_issues=value)
+
+        ethreshold.update({"is_healthy": is_healthy})
+
+
+def get_is_new_issues_count_healthy_query(
+    release_threshold: EnrichedThreshold, unique_key: str
+) -> QuerySet:
+    """
+    Return a queryset that contains the count of new issues for this specific release threshold.
+    It will group by the unique key.
+    The expectation is for the caller to only have to use the `unique_key` and `count` fields.
+    The reason for this function is to help bulk query the results to the datastore and prevent N+1 queries.
+    """
     release_id = release_threshold["release_id"]
     project_id = release_threshold["project_id"]
     time_range = (release_threshold["start"], release_threshold["end"])
-    try:
-        if release_threshold["environment"]:
-            new_issues = GroupEnvironment.objects.filter(
-                first_release__id=release_id,
-                environment__id=release_threshold["environment"]["id"],
-                group__project__id=project_id,
-                first_seen__range=time_range,
-            ).count()
-        else:
-            new_issues = Group.objects.filter(
-                project__id=project_id, first_release__id=release_id, first_seen__range=time_range
-            ).count()
-    except Exception:
-        logger.exception(
-            "There was an error trying to grab new issue count",
-            extra={
-                "project": project_id,
-                "release": release_id,
-                "release_threshold": release_threshold["key"],
-                "start": time_range[0],
-                "end": time_range[1],
-            },
-        )
-        return False
 
-    baseline_value = release_threshold["value"]
-    if release_threshold["trigger_type"] == TriggerType.OVER_STR:
+    query = Group.objects.filter(
+        project__id=project_id, first_release__id=release_id, first_seen__range=time_range
+    )
+
+    if release_threshold["environment"]:
+        query = query.filter(
+            groupenvironment__environment__id=release_threshold["environment"]["id"],
+        )
+
+    # Annotate the queryset with the count and a unique key
+    # The unique key is used to group all the rows together for the full count.
+    query = (
+        query.annotate(unique_key=Value(unique_key, output_field=CharField()))
+        .values(NEW_ISSUES_UNIQUE_KEY_COLUMN)
+        .annotate(count=Count("*"))
+    )
+    return query
+
+
+def is_new_issues_count_healthy(enriched_threshold: EnrichedThreshold, new_issues: int) -> bool:
+    baseline_value = enriched_threshold["value"]
+    if enriched_threshold["trigger_type"] == TriggerType.OVER_STR:
         # If new issues is under/equal the threshold value, then it is healthy
         return new_issues <= baseline_value
     # Else, if new issues is over/equal the threshold value, then it is healthy

--- a/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
+++ b/src/sentry/api/endpoints/release_thresholds/health_checks/is_new_issues_count_healthy.py
@@ -1,52 +1,46 @@
 from __future__ import annotations
 
-from datetime import datetime
 from logging import getLogger
 
+from sentry.api.endpoints.release_thresholds.types import EnrichedThreshold
 from sentry.models.group import Group
 from sentry.models.groupenvironment import GroupEnvironment
-from sentry.models.project import Project
-from sentry.models.release import Release
-from sentry.models.release_threshold import ReleaseThreshold
 from sentry.models.release_threshold.constants import TriggerType
 
-default_logger = getLogger("sentry.releases.servicer")
+logger = getLogger("sentry.releases.servicer")
 
 
-def is_new_issues_count_healthy(
-    project: Project,
-    release: Release,
-    release_threshold: ReleaseThreshold,
-    start: datetime,
-    end: datetime,
-) -> bool:
+def is_new_issues_count_healthy(release_threshold: EnrichedThreshold) -> bool:
+    release_id = release_threshold["release_id"]
+    project_id = release_threshold["project_id"]
+    time_range = (release_threshold["start"], release_threshold["end"])
     try:
-        if release_threshold.environment:
+        if release_threshold["environment"]:
             new_issues = GroupEnvironment.objects.filter(
-                first_release=release,
-                environment=release_threshold.environment,
-                group__project=project,
-                first_seen__range=(start, end),
+                first_release__id=release_id,
+                environment__id=release_threshold["environment"]["id"],
+                group__project__id=project_id,
+                first_seen__range=time_range,
             ).count()
         else:
             new_issues = Group.objects.filter(
-                project=project, first_release=release, first_seen__range=(start, end)
+                project__id=project_id, first_release__id=release_id, first_seen__range=time_range
             ).count()
     except Exception:
-        default_logger.exception(
+        logger.exception(
             "There was an error trying to grab new issue count",
             extra={
-                "project": project.id,
-                "release": release.id,
-                "release_threshold": release_threshold.id,
-                "start": start,
-                "end": end,
+                "project": project_id,
+                "release": release_id,
+                "release_threshold": release_threshold["key"],
+                "start": time_range[0],
+                "end": time_range[1],
             },
         )
         return False
 
-    baseline_value = release_threshold.value
-    if release_threshold.trigger_type == TriggerType.OVER:
+    baseline_value = release_threshold["value"]
+    if release_threshold["trigger_type"] == TriggerType.OVER_STR:
         # If new issues is under/equal the threshold value, then it is healthy
         return new_issues <= baseline_value
     # Else, if new issues is over/equal the threshold value, then it is healthy

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -19,7 +19,7 @@ from sentry.api.endpoints.release_thresholds.health_checks.is_error_count_health
     is_error_count_healthy,
 )
 from sentry.api.endpoints.release_thresholds.health_checks.is_new_issues_count_healthy import (
-    is_new_issues_count_healthy,
+    update_new_issues_count_healthy_for_thresholds,
 )
 from sentry.api.endpoints.release_thresholds.utils import (
     get_errors_counts_timeseries_by_project_and_release,
@@ -343,9 +343,8 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
                     )  # so we can fill all thresholds under the same key
             elif threshold_type == ReleaseThresholdType.NEW_ISSUE_COUNT:
                 metrics.incr("release.threshold_health_status.check.new_issue_count")
+                update_new_issues_count_healthy_for_thresholds(category_thresholds)
                 for ethreshold in category_thresholds:
-                    is_healthy = is_new_issues_count_healthy(ethreshold)
-                    ethreshold.update({"is_healthy": is_healthy})
                     release_threshold_health[ethreshold["key"]].append(
                         ethreshold
                     )  # so we can fill all thresholds under the same key

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -19,7 +19,7 @@ from sentry.api.endpoints.release_thresholds.health_checks.is_error_count_health
     is_error_count_healthy,
 )
 from sentry.api.endpoints.release_thresholds.health_checks.is_new_issues_count_healthy import (
-    get_new_issue_count_is_healthy,
+    is_new_issues_count_healthy,
 )
 from sentry.api.endpoints.release_thresholds.utils import (
     get_errors_counts_timeseries_by_project_and_release,
@@ -275,7 +275,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
                     threshold_end = threshold_start + timedelta(seconds=threshold.window_in_seconds)
                     is_healthy: bool = False
                     if threshold.threshold_type == ReleaseThresholdType.NEW_ISSUE_COUNT:
-                        is_healthy = get_new_issue_count_is_healthy(
+                        is_healthy = is_new_issues_count_healthy(
                             project=project,
                             release=release,
                             release_threshold=threshold,

--- a/src/sentry/api/endpoints/release_thresholds/types.py
+++ b/src/sentry/api/endpoints/release_thresholds/types.py
@@ -21,3 +21,4 @@ class EnrichedThreshold(SerializedThreshold):
     project_id: int
     start: datetime
     metric_value: int | None
+    release_id: int

--- a/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_error_count_healthy.py
+++ b/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_error_count_healthy.py
@@ -89,6 +89,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,  # error counts _not_ be over threshold value
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=current_threshold_healthy, timeseries=timeseries
@@ -112,6 +113,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 1,  # error counts equal to threshold limit value
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_at_limit_healthy, timeseries=timeseries
@@ -135,6 +137,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 2,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=past_threshold_healthy, timeseries=timeseries
@@ -158,6 +161,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_under_unhealthy, timeseries=timeseries
@@ -181,6 +185,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_unfinished, timeseries=timeseries
@@ -265,6 +270,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_healthy, timeseries=timeseries
@@ -288,6 +294,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 1,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_unhealthy, timeseries=timeseries
@@ -373,6 +380,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_healthy, timeseries=timeseries
@@ -396,6 +404,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 1,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_unhealthy, timeseries=timeseries
@@ -480,6 +489,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 2,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_healthy, timeseries=timeseries
@@ -503,6 +513,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 1,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_unhealthy, timeseries=timeseries
@@ -567,6 +578,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,  # error counts _not_ be over threshold value
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=current_threshold_healthy, timeseries=timeseries
@@ -590,6 +602,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 1,  # error counts equal to threshold limit value
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_at_limit_healthy, timeseries=timeseries
@@ -613,6 +626,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 2,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=past_threshold_healthy, timeseries=timeseries
@@ -636,6 +650,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_under_unhealthy, timeseries=timeseries
@@ -659,6 +674,7 @@ class ErrorCountThresholdCheckTest(TestCase):
             "value": 4,
             "window_in_seconds": 60,  # NOTE: window_in_seconds only used to determine start/end. Not utilized in validation method
             "metric_value": None,
+            "release_id": self.release1.id,
         }
         is_healthy, metric_count = is_error_count_healthy(
             ethreshold=threshold_unfinished, timeseries=timeseries

--- a/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
+++ b/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import List
 from uuid import uuid4
 
 from sentry.api.endpoints.release_thresholds.health_checks.is_new_issues_count_healthy import (
@@ -426,5 +427,5 @@ class TestUpdateNewIssuesCountHealthyForThresholds(TestCase):
         assert wrong_threshold["is_healthy"] is False
 
     def test_returns_early_when_no_annotations_are_found(self) -> None:
-        list_of_thresholds = []
+        list_of_thresholds: List[EnrichedThreshold] = []
         update_new_issues_count_healthy_for_thresholds(list_of_thresholds)

--- a/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
+++ b/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
@@ -1,0 +1,139 @@
+from datetime import timedelta
+from uuid import uuid4
+
+from sentry.api.endpoints.release_thresholds.health_checks.is_new_issues_count_healthy import (
+    get_new_issue_count_is_healthy,
+)
+from sentry.models.environment import Environment
+from sentry.models.release import Release
+from sentry.models.release_threshold.constants import ReleaseThresholdType
+from sentry.models.release_threshold.release_threshold import ReleaseThreshold
+from sentry.models.releaseenvironment import ReleaseEnvironment
+from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
+from sentry.testutils.cases import SnubaTestCase, TestCase
+from sentry.testutils.helpers.datetime import iso_format
+
+
+class TestGetNewIssueCountIsHealthy(TestCase, SnubaTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.project1 = self.create_project(name="foo", organization=self.organization)
+        self.project2 = self.create_project(name="bar", organization=self.organization)
+
+        self.canary_environment = Environment.objects.create(
+            organization_id=self.organization.id, name="canary"
+        )
+        self.production_environment = Environment.objects.create(
+            organization_id=self.organization.id, name="production"
+        )
+
+        # release created for proj1, and proj2
+        self.release1 = Release.objects.create(version="v1", organization=self.organization)
+        # add_project get_or_creates a ReleaseProject
+        self.release1.add_project(self.project1)
+        self.release1.add_project(self.project2)
+
+        # release created for proj1
+        self.release2 = Release.objects.create(version="v2", organization=self.organization)
+        self.release2.add_project(self.project1)
+
+        # Attaches the release to a particular environment
+        # project superfluous/deprecated in ReleaseEnvironment
+        # release1 canary
+        ReleaseEnvironment.objects.create(
+            organization_id=self.organization.id,
+            release_id=self.release1.id,
+            environment_id=self.canary_environment.id,
+        )
+        # Release Project Environments are required to query releases by project
+        # Even though both environment & project are here, this seems to just attach a release to a project
+        # You can have multiple ReleaseProjectEnvironment's per release (this attaches multiple projects to the release&env)
+        # release1 project1 canary
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release1.id,
+            project_id=self.project1.id,
+            environment_id=self.canary_environment.id,
+        )
+        # release1 project2 canary
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release1.id,
+            project_id=self.project2.id,
+            environment_id=self.canary_environment.id,
+        )
+
+        # release2 prod
+        ReleaseEnvironment.objects.create(
+            organization_id=self.organization.id,
+            release_id=self.release2.id,
+            environment_id=self.production_environment.id,
+        )
+        # release2 project1 prod
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release2.id,
+            project_id=self.project1.id,
+            environment_id=self.production_environment.id,
+        )
+
+        self.new_issue_count_release_threshold = ReleaseThreshold.objects.create(
+            threshold_type=ReleaseThresholdType.NEW_ISSUE_COUNT,
+            trigger_type=1,
+            value=2,
+            window_in_seconds=100,
+            project=self.project1,
+            environment=self.canary_environment,
+        )
+        self._create_new_issues_for_release_threshold()
+
+    def _create_new_issues_for_release_threshold(self) -> None:
+        self.new_issue_time = self.new_issue_count_release_threshold.date_added + timedelta(
+            seconds=10
+        )
+        for _ in range(2):
+            self.store_event(
+                project_id=self.new_issue_count_release_threshold.project.id,
+                data={
+                    "fingerprint": [str(uuid4())],
+                    "timestamp": iso_format(self.new_issue_time),
+                    "user": {"id": self.user.id, "email": self.user.email},
+                    "release": self.release1.version,
+                    "environment": self.canary_environment.name,
+                },
+            )
+
+    def test_returns_true(self) -> None:
+        start_time = self.new_issue_time - timedelta(seconds=10)
+        end_time = self.new_issue_time + timedelta(seconds=10)
+        is_healthy = get_new_issue_count_is_healthy(
+            project=self.project1,
+            release=self.release1,
+            release_threshold=self.new_issue_count_release_threshold,
+            start=start_time,
+            end=end_time,
+        )
+        assert is_healthy is True
+
+    def test_returns_false(self) -> None:
+        # Get a time range when no issues are there
+        start_time = self.new_issue_time + timedelta(hours=1)
+        end_time = self.new_issue_time + timedelta(hours=2)
+        is_healthy = get_new_issue_count_is_healthy(
+            project=self.project1,
+            release=self.release1,
+            release_threshold=self.new_issue_count_release_threshold,
+            start=start_time,
+            end=end_time,
+        )
+        assert is_healthy is False
+
+    def test_returns_false_when_no_issues_found(self) -> None:
+        start_time = self.new_issue_time - timedelta(seconds=10)
+        end_time = self.new_issue_time + timedelta(seconds=10)
+        is_healthy = get_new_issue_count_is_healthy(
+            project=self.project2,
+            release=self.release1,
+            release_threshold=self.new_issue_count_release_threshold,
+            start=start_time,
+            end=end_time,
+        )
+        assert is_healthy is False

--- a/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
+++ b/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
@@ -191,6 +191,7 @@ class TestGetNewIssueCountIsHealthy(TestCase):
                 "end": end_time,
                 "project_id": self.project1.id,
                 "release_id": self.release1.id,
+                "key": "key",
             }
         )
         del enriched_threshold["environment"]["id"]

--- a/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
+++ b/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
@@ -424,3 +424,7 @@ class TestUpdateNewIssuesCountHealthyForThresholds(TestCase):
         update_new_issues_count_healthy_for_thresholds(list_of_thresholds)
         assert enriched_threshold["is_healthy"] is True
         assert wrong_threshold["is_healthy"] is False
+
+    def test_returns_early_when_no_annotations_are_found(self) -> None:
+        list_of_thresholds = []
+        update_new_issues_count_healthy_for_thresholds(list_of_thresholds)

--- a/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
+++ b/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
@@ -1,22 +1,27 @@
-from datetime import timedelta
-from unittest import mock
+from datetime import datetime, timedelta
+from uuid import uuid4
 
 from sentry.api.endpoints.release_thresholds.health_checks.is_new_issues_count_healthy import (
+    NEW_ISSUES_COUNT_COLUMN,
+    NEW_ISSUES_UNIQUE_KEY_COLUMN,
+    get_is_new_issues_count_healthy_query,
     is_new_issues_count_healthy,
+    update_new_issues_count_healthy_for_thresholds,
 )
+from sentry.api.endpoints.release_thresholds.types import EnrichedThreshold
 from sentry.api.serializers import serialize
 from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.release import Release
-from sentry.models.release_threshold.constants import ReleaseThresholdType
+from sentry.models.release_threshold.constants import ReleaseThresholdType, TriggerType
 from sentry.models.release_threshold.release_threshold import ReleaseThreshold
 from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.testutils.cases import TestCase
 
 
-class TestGetNewIssueCountIsHealthy(TestCase):
+class TestGetNewIssueCountIsHealthyQuery(TestCase):
     def setUp(self):
         super().setUp()
 
@@ -101,6 +106,8 @@ class TestGetNewIssueCountIsHealthy(TestCase):
         for _ in range(2):
             grouped_issue = Group.objects.create(
                 project=self.project1,
+                first_release=self.release1,
+                first_seen=self.new_issue_time,
             )
             GroupEnvironment.objects.create(
                 group=grouped_issue,
@@ -113,7 +120,7 @@ class TestGetNewIssueCountIsHealthy(TestCase):
                 project=self.project2, first_release=self.release1, first_seen=self.new_issue_time
             )
 
-    def test_returns_true_when_is_healthy(self) -> None:
+    def test_returns_correct_count(self) -> None:
         enriched_threshold = serialize(self.new_issue_count_release_threshold)
         start_time = self.new_issue_time - timedelta(seconds=10)
         end_time = self.new_issue_time + timedelta(seconds=10)
@@ -126,10 +133,17 @@ class TestGetNewIssueCountIsHealthy(TestCase):
             }
         )
 
-        is_healthy = is_new_issues_count_healthy(enriched_threshold)
-        assert is_healthy is True
+        unique_key = str(uuid4())
+        query = get_is_new_issues_count_healthy_query(enriched_threshold, unique_key)
 
-    def test_returns_false_when_is_not_healthy(self) -> None:
+        values = query.values(NEW_ISSUES_UNIQUE_KEY_COLUMN, NEW_ISSUES_COUNT_COLUMN)
+        assert len(values) == 1
+
+        result = values[0]
+        expected_result = {NEW_ISSUES_UNIQUE_KEY_COLUMN: unique_key, NEW_ISSUES_COUNT_COLUMN: 2}
+        assert expected_result == result
+
+    def test_returns_no_count_when_out_of_range(self) -> None:
         enriched_threshold = serialize(self.new_issue_count_release_threshold)
         # Get a time range when no issues are there
         start_time = self.new_issue_time + timedelta(hours=1)
@@ -143,10 +157,16 @@ class TestGetNewIssueCountIsHealthy(TestCase):
             }
         )
 
-        is_healthy = is_new_issues_count_healthy(enriched_threshold)
-        assert is_healthy is False
+        unique_key = str(uuid4())
+        query = get_is_new_issues_count_healthy_query(enriched_threshold, unique_key)
+        values = query.values(NEW_ISSUES_UNIQUE_KEY_COLUMN, NEW_ISSUES_COUNT_COLUMN)
+        assert len(values) == 1
 
-    def test_returns_false_when_no_issues_exist(self) -> None:
+        result = values[0]
+        expected_result = {NEW_ISSUES_UNIQUE_KEY_COLUMN: unique_key, NEW_ISSUES_COUNT_COLUMN: 0}
+        assert expected_result == result
+
+    def test_returns_no_count_when_no_issues_exist(self) -> None:
         enriched_threshold = serialize(self.new_issue_count_release_threshold)
         start_time = self.new_issue_time - timedelta(seconds=10)
         end_time = self.new_issue_time + timedelta(seconds=10)
@@ -159,8 +179,14 @@ class TestGetNewIssueCountIsHealthy(TestCase):
             }
         )
 
-        is_healthy = is_new_issues_count_healthy(enriched_threshold)
-        assert is_healthy is False
+        unique_key = str(uuid4())
+        query = get_is_new_issues_count_healthy_query(enriched_threshold, unique_key)
+        values = query.values(NEW_ISSUES_UNIQUE_KEY_COLUMN, NEW_ISSUES_COUNT_COLUMN)
+        assert len(values) == 1
+
+        result = values[0]
+        expected_result = {NEW_ISSUES_UNIQUE_KEY_COLUMN: unique_key, NEW_ISSUES_COUNT_COLUMN: 0}
+        assert expected_result == result
 
     def test_when_release_threshold_does_not_have_env(self) -> None:
         enriched_threshold = serialize(self.new_issue_count_release_threshold_without_env)
@@ -175,13 +201,176 @@ class TestGetNewIssueCountIsHealthy(TestCase):
             }
         )
 
-        is_healthy = is_new_issues_count_healthy(enriched_threshold)
-        assert is_healthy is True
+        unique_key = str(uuid4())
+        query = get_is_new_issues_count_healthy_query(enriched_threshold, unique_key)
+        values = query.values(NEW_ISSUES_UNIQUE_KEY_COLUMN, NEW_ISSUES_COUNT_COLUMN)
+        assert len(values) == 1
 
-    @mock.patch(
-        "sentry.api.endpoints.release_thresholds.health_checks.is_new_issues_count_healthy.logger"
-    )
-    def test_returns_false_when_error_in_query(self, logger) -> None:
+        result = values[0]
+        expected_result = {NEW_ISSUES_UNIQUE_KEY_COLUMN: unique_key, NEW_ISSUES_COUNT_COLUMN: 2}
+        assert expected_result == result
+
+
+class TestIsNewIssuesCountHealthy(TestCase):
+    def test_trigger_type_over(self) -> None:
+        t = datetime.now()
+        # Most garbage values are used except for value and trigger type
+        enriched_threshold = EnrichedThreshold(
+            value=2,
+            trigger_type=TriggerType.OVER_STR,
+            date=t,
+            end=t,
+            environment=None,
+            is_healthy=False,
+            key="key",
+            metric_value=None,
+            project={},
+            project_id=0,
+            project_slug="",
+            release_id=0,
+            release="",
+            start=t,
+            threshold_type=0,
+            window_in_seconds=0,
+        )
+
+        # Check edge case for below
+        assert is_new_issues_count_healthy(enriched_threshold, 0) is True
+        # Check edge case for exact value
+        assert is_new_issues_count_healthy(enriched_threshold, 2) is True
+        # Check value for above
+        assert is_new_issues_count_healthy(enriched_threshold, 3) is False
+
+    def test_trigger_type_under(self) -> None:
+        t = datetime.now()
+        # Most garbage values are used except for value and trigger type
+        enriched_threshold = EnrichedThreshold(
+            value=2,
+            trigger_type=TriggerType.UNDER_STR,
+            date=t,
+            end=t,
+            environment=None,
+            is_healthy=False,
+            key="key",
+            metric_value=None,
+            project={},
+            project_id=0,
+            project_slug="",
+            release_id=0,
+            release="",
+            start=t,
+            threshold_type=0,
+            window_in_seconds=0,
+        )
+
+        # Check edge case for below
+        assert is_new_issues_count_healthy(enriched_threshold, 0) is False
+        # Check edge case for exact value
+        assert is_new_issues_count_healthy(enriched_threshold, 2) is True
+        # Check value for above
+        assert is_new_issues_count_healthy(enriched_threshold, 3) is True
+
+
+class TestUpdateNewIssuesCountHealthyForThresholds(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.project1 = self.create_project(name="foo", organization=self.organization)
+        self.project2 = self.create_project(name="bar", organization=self.organization)
+
+        self.canary_environment = Environment.objects.create(
+            organization_id=self.organization.id, name="canary"
+        )
+        self.production_environment = Environment.objects.create(
+            organization_id=self.organization.id, name="production"
+        )
+
+        # release created for proj1, and proj2
+        self.release1 = Release.objects.create(version="v1", organization=self.organization)
+        # add_project get_or_creates a ReleaseProject
+        self.release1.add_project(self.project1)
+        self.release1.add_project(self.project2)
+
+        # release created for proj1
+        self.release2 = Release.objects.create(version="v2", organization=self.organization)
+        self.release2.add_project(self.project1)
+
+        # Attaches the release to a particular environment
+        # project superfluous/deprecated in ReleaseEnvironment
+        # release1 canary
+        ReleaseEnvironment.objects.create(
+            organization_id=self.organization.id,
+            release_id=self.release1.id,
+            environment_id=self.canary_environment.id,
+        )
+        # Release Project Environments are required to query releases by project
+        # Even though both environment & project are here, this seems to just attach a release to a project
+        # You can have multiple ReleaseProjectEnvironment's per release (this attaches multiple projects to the release&env)
+        # release1 project1 canary
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release1.id,
+            project_id=self.project1.id,
+            environment_id=self.canary_environment.id,
+        )
+        # release1 project2 canary
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release1.id,
+            project_id=self.project2.id,
+            environment_id=self.canary_environment.id,
+        )
+
+        # release2 prod
+        ReleaseEnvironment.objects.create(
+            organization_id=self.organization.id,
+            release_id=self.release2.id,
+            environment_id=self.production_environment.id,
+        )
+        # release2 project1 prod
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release2.id,
+            project_id=self.project1.id,
+            environment_id=self.production_environment.id,
+        )
+
+        self.new_issue_count_release_threshold = ReleaseThreshold.objects.create(
+            threshold_type=ReleaseThresholdType.NEW_ISSUE_COUNT,
+            trigger_type=1,
+            value=2,
+            window_in_seconds=100,
+            project=self.project1,
+            environment=self.canary_environment,
+        )
+        self.new_issue_count_release_threshold_without_env = ReleaseThreshold.objects.create(
+            threshold_type=ReleaseThresholdType.NEW_ISSUE_COUNT,
+            trigger_type=1,
+            value=1,
+            window_in_seconds=100,
+            project=self.project2,
+        )
+        self._create_new_issues_for_release_threshold()
+
+    def _create_new_issues_for_release_threshold(self) -> None:
+        self.new_issue_time = self.new_issue_count_release_threshold.date_added + timedelta(
+            seconds=10
+        )
+        for _ in range(2):
+            grouped_issue = Group.objects.create(
+                project=self.project1,
+                first_release=self.release1,
+                first_seen=self.new_issue_time,
+            )
+            GroupEnvironment.objects.create(
+                group=grouped_issue,
+                environment=self.canary_environment,
+                first_release=self.release1,
+                first_seen=self.new_issue_time,
+            )
+
+            Group.objects.create(
+                project=self.project2, first_release=self.release1, first_seen=self.new_issue_time
+            )
+
+    def test_updates_list_in_place(self) -> None:
         enriched_threshold = serialize(self.new_issue_count_release_threshold)
         start_time = self.new_issue_time - timedelta(seconds=10)
         end_time = self.new_issue_time + timedelta(seconds=10)
@@ -191,10 +380,47 @@ class TestGetNewIssueCountIsHealthy(TestCase):
                 "end": end_time,
                 "project_id": self.project1.id,
                 "release_id": self.release1.id,
-                "key": "key",
             }
         )
-        del enriched_threshold["environment"]["id"]
-        is_healthy = is_new_issues_count_healthy(enriched_threshold)
-        assert is_healthy is False
-        assert logger.exception.call_count == 1
+
+        list_of_thresholds = [enriched_threshold]
+        update_new_issues_count_healthy_for_thresholds(list_of_thresholds)
+        assert enriched_threshold["is_healthy"] is True
+
+    def test_ignores_wrong_thresholds(self) -> None:
+        enriched_threshold = serialize(self.new_issue_count_release_threshold)
+        start_time = self.new_issue_time - timedelta(seconds=10)
+        end_time = self.new_issue_time + timedelta(seconds=10)
+        enriched_threshold.update(
+            {
+                "start": start_time,
+                "end": end_time,
+                "project_id": self.project1.id,
+                "release_id": self.release1.id,
+            }
+        )
+
+        t = datetime.now()
+        wrong_threshold = EnrichedThreshold(
+            value=2,
+            trigger_type=TriggerType.UNDER_STR,
+            date=t,
+            end=t,
+            environment=None,
+            is_healthy=False,
+            key="key",
+            metric_value=None,
+            project={},
+            project_id=0,
+            project_slug="",
+            release_id=0,
+            release="",
+            start=t,
+            threshold_type=6,
+            window_in_seconds=0,
+        )
+
+        list_of_thresholds = [enriched_threshold, wrong_threshold]
+        update_new_issues_count_healthy_for_thresholds(list_of_thresholds)
+        assert enriched_threshold["is_healthy"] is True
+        assert wrong_threshold["is_healthy"] is False

--- a/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
+++ b/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from sentry.api.endpoints.release_thresholds.health_checks.is_new_issues_count_healthy import (
     is_new_issues_count_healthy,
 )
+from sentry.api.serializers import serialize
 from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.groupenvironment import GroupEnvironment
@@ -112,50 +113,66 @@ class TestGetNewIssueCountIsHealthy(TestCase):
             )
 
     def test_returns_true_when_is_healthy(self) -> None:
+        enriched_threshold = serialize(self.new_issue_count_release_threshold)
         start_time = self.new_issue_time - timedelta(seconds=10)
         end_time = self.new_issue_time + timedelta(seconds=10)
-        is_healthy = is_new_issues_count_healthy(
-            project=self.project1,
-            release=self.release1,
-            release_threshold=self.new_issue_count_release_threshold,
-            start=start_time,
-            end=end_time,
+        enriched_threshold.update(
+            {
+                "start": start_time,
+                "end": end_time,
+                "project_id": self.project1.id,
+                "release_id": self.release1.id,
+            }
         )
+
+        is_healthy = is_new_issues_count_healthy(enriched_threshold)
         assert is_healthy is True
 
     def test_returns_false_when_is_not_healthy(self) -> None:
+        enriched_threshold = serialize(self.new_issue_count_release_threshold)
         # Get a time range when no issues are there
         start_time = self.new_issue_time + timedelta(hours=1)
         end_time = self.new_issue_time + timedelta(hours=2)
-        is_healthy = is_new_issues_count_healthy(
-            project=self.project1,
-            release=self.release1,
-            release_threshold=self.new_issue_count_release_threshold,
-            start=start_time,
-            end=end_time,
+        enriched_threshold.update(
+            {
+                "start": start_time,
+                "end": end_time,
+                "project_id": self.project1.id,
+                "release_id": self.release1.id,
+            }
         )
+
+        is_healthy = is_new_issues_count_healthy(enriched_threshold)
         assert is_healthy is False
 
     def test_returns_false_when_no_issues_exist(self) -> None:
+        enriched_threshold = serialize(self.new_issue_count_release_threshold)
         start_time = self.new_issue_time - timedelta(seconds=10)
         end_time = self.new_issue_time + timedelta(seconds=10)
-        is_healthy = is_new_issues_count_healthy(
-            project=self.project1,
-            release=self.release2,
-            release_threshold=self.new_issue_count_release_threshold,
-            start=start_time,
-            end=end_time,
+        enriched_threshold.update(
+            {
+                "start": start_time,
+                "end": end_time,
+                "project_id": self.project1.id,
+                "release_id": self.release2.id,
+            }
         )
+
+        is_healthy = is_new_issues_count_healthy(enriched_threshold)
         assert is_healthy is False
 
     def test_when_release_threshold_does_not_have_env(self) -> None:
+        enriched_threshold = serialize(self.new_issue_count_release_threshold_without_env)
         start_time = self.new_issue_time - timedelta(seconds=10)
         end_time = self.new_issue_time + timedelta(seconds=10)
-        is_healthy = is_new_issues_count_healthy(
-            project=self.project2,
-            release=self.release1,
-            release_threshold=self.new_issue_count_release_threshold_without_env,
-            start=start_time,
-            end=end_time,
+        enriched_threshold.update(
+            {
+                "start": start_time,
+                "end": end_time,
+                "project_id": self.project2.id,
+                "release_id": self.release1.id,
+            }
         )
+
+        is_healthy = is_new_issues_count_healthy(enriched_threshold)
         assert is_healthy is True

--- a/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
+++ b/tests/sentry/api/endpoints/release_thresholds/health_checks/test_is_new_issues_count_healthy.py
@@ -182,14 +182,14 @@ class TestGetNewIssueCountIsHealthy(TestCase):
         "sentry.api.endpoints.release_thresholds.health_checks.is_new_issues_count_healthy.logger"
     )
     def test_returns_false_when_error_in_query(self, logger) -> None:
-        enriched_threshold = serialize(self.new_issue_count_release_threshold_without_env)
+        enriched_threshold = serialize(self.new_issue_count_release_threshold)
         start_time = self.new_issue_time - timedelta(seconds=10)
         end_time = self.new_issue_time + timedelta(seconds=10)
         enriched_threshold.update(
             {
                 "start": start_time,
                 "end": end_time,
-                "project_id": self.project2.id,
+                "project_id": self.project1.id,
                 "release_id": self.release1.id,
             }
         )

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -136,6 +136,8 @@ class ReleaseThresholdStatusTest(APITestCase):
         for _ in range(2):
             grouped_issue = Group.objects.create(
                 project=self.project1,
+                first_release=self.release1,
+                first_seen=new_issue_time,
             )
             GroupEnvironment.objects.create(
                 group=grouped_issue,

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from uuid import uuid4
 
 from sentry.models.deploy import Deploy
 from sentry.models.environment import Environment
@@ -135,26 +136,17 @@ class ReleaseThresholdStatusTest(APITestCase, SnubaTestCase):
         time_to_use = iso_format(
             self.new_issue_count_release_threshold.date_added + timedelta(seconds=10)
         )
-        self.store_event(
-            project_id=self.new_issue_count_release_threshold.project.id,
-            data={
-                "fingerprint": ["group-1"],
-                "timestamp": time_to_use,
-                "user": {"id": self.user.id, "email": self.user.email},
-                "release": self.release1.version,
-                "environment": self.canary_environment.name,
-            },
-        )
-        self.store_event(
-            project_id=self.new_issue_count_release_threshold.project.id,
-            data={
-                "fingerprint": ["group-1"],
-                "timestamp": time_to_use,
-                "user": {"id": self.user.id, "email": self.user.email},
-                "release": self.release1.version,
-                "environment": self.canary_environment.name,
-            },
-        )
+        for i in range(2):
+            self.store_event(
+                project_id=self.new_issue_count_release_threshold.project.id,
+                data={
+                    "fingerprint": [str(uuid4())],
+                    "timestamp": time_to_use,
+                    "user": {"id": self.user.id, "email": self.user.email},
+                    "release": self.release1.version,
+                    "environment": self.canary_environment.name,
+                },
+            )
 
     def test_get_success(self):
         """


### PR DESCRIPTION
Add logic to determine is_healthy for release thresholds. Uses `Group` Django model to aggregate the data, and uses bulk query to avoid N+1 queries.

Resolves: https://github.com/getsentry/team-enterprise/issues/18