### PR TITLE
feat(relocation): Add TOS acceptance after owner has been added to relocated orgs

### DIFF
--- a/src/sentry/tasks/relocation.py
+++ b/src/sentry/tasks/relocation.py
@@ -45,7 +45,7 @@ from sentry.models.user import User
 from sentry.services.hybrid_cloud.lost_password_hash import lost_password_hash_service
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.services.hybrid_cloud.user.service import user_service
-from sentry.signals import relocated
+from sentry.signals import relocated, terms_accepted
 from sentry.silo import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json
@@ -1086,6 +1086,12 @@ def postprocessing(uuid: str) -> None:
                 default_org_role=org.default_role,
                 user_id=relocation.owner_id,
                 role="owner",
+            )
+
+            terms_accepted.send_robust(
+                user_id=relocation.owner_id,
+                organization_id=org.id,
+                sender=postprocessing,
             )
         # Last, but certainly not least: trigger signals, so that interested subscribers in eg:
         # getsentry can do whatever postprocessing they need to. If even a single one fails, we fail


### PR DESCRIPTION
Relocation signup page includes a checkbox for owner to accept TOS. This adds logic to handle TOS acceptance after a relocation job has finished, since it is tied to orgs, not users. Requires https://github.com/getsentry/getsentry/pull/12608 to go in first. 