### PR TITLE
fix(onboarding-docs): Text block spacing

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -281,6 +281,13 @@ const Description = styled('div')`
   code {
     color: ${p => p.theme.pink400};
   }
+
+  && > p,
+  && > h4,
+  && > h5,
+  && > h6 {
+    margin-bottom: ${space(1)};
+  }
 `;
 
 const AdditionalInfo = styled(Description)``;


### PR DESCRIPTION
Some platform docs have multiple html elements (paragraphs & headings) in description blocks.
These were missing spacing in-between.

e.g. unreal

before:
<img width="1175" alt="Screenshot 2024-01-12 at 10 42 39" src="https://github.com/getsentry/sentry/assets/7033940/a0db2a4f-6b07-4b06-a7f3-f389c994dc64">

after:
<img width="1175" alt="Screenshot 2024-01-12 at 10 42 25" src="https://github.com/getsentry/sentry/assets/7033940/c06fc791-f217-4e09-bf84-e4aae0e26fa0">

