### PR TITLE
fix(ddm-dashboard): Empty string limit

### DIFF
--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -26,9 +26,9 @@ export type ParsedMRI = {
 
 export type MetricsApiRequestMetric = {
   field: string;
-  query: string;
   groupBy?: string[];
   orderBy?: string;
+  query?: string;
 };
 
 export type MetricsApiRequestQuery = MetricsApiRequestMetric & {

--- a/static/app/views/dashboards/datasetConfig/metrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/metrics.tsx
@@ -393,13 +393,13 @@ function getMetricRequest(
   const requestData = getMetricsApiRequestQuery(
     {
       field: query.aggregates[0],
-      query: query.conditions,
-      groupBy: query.columns,
-      orderBy: query.orderby,
+      query: query.conditions || undefined,
+      groupBy: query.columns || undefined,
+      orderBy: query.orderby || undefined,
     },
     pageFilters,
     {
-      limit,
+      limit: limit || undefined,
       useNewMetricsLayer,
       fidelity: displayType === DisplayType.BAR ? 'low' : 'high',
     }


### PR DESCRIPTION
#### Problem
For some reason we end up with empty string values for limit, orderBy
and query in dashboard if they are not set in the widget builder. In
case of `limit` this poses a problem for the metrics data endpoint.

#### Solution
Don't send falsy values to the BE for those 3 keys.