### PR TITLE
feat(ddm): Add more fields to the metric spans endpoint

### DIFF
--- a/src/sentry/api/serializers/models/metric_spans.py
+++ b/src/sentry/api/serializers/models/metric_spans.py
@@ -14,12 +14,14 @@ class MetricSpansSerializer(Serializer):
     def _serialize_span_payload(self, span_payload):
         return {
             "projectId": span_payload.get("project_id"),
-            "spanId": span_payload.get("span_id"),
-            "traceId": span_payload.get("trace_id"),
             "transactionId": span_payload.get("transaction_id"),
+            "traceId": span_payload.get("trace_id"),
+            "spanId": span_payload.get("span_id"),
             "profileId": span_payload.get("profile_id"),
-            "duration": span_payload.get("duration"),
             "segmentName": span_payload.get("segment_name"),
+            "op": span_payload.get("op"),
+            "description": span_payload.get("description"),
+            "duration": span_payload.get("duration"),
             "timestamp": span_payload.get("timestamp"),
         }
 

--- a/src/sentry/sentry_metrics/querying/metadata/metric_spans.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metric_spans.py
@@ -57,12 +57,14 @@ SENTRY_TAG_TO_COLUMN_NAME = {
 @dataclass(frozen=True)
 class Span:
     project_id: int
-    span_id: str
-    trace_id: str
     transaction_id: Optional[str]
+    trace_id: str
+    span_id: str
     profile_id: Optional[str]
-    duration: int
     segment_name: str
+    op: str
+    description: str
+    duration: int
     timestamp: datetime
 
 
@@ -323,12 +325,14 @@ def get_indexed_spans(
         match=Entity(EntityKey.Spans.value),
         select=[
             Column("project_id"),
-            Column("span_id"),
-            Column("trace_id"),
             Column("transaction_id"),
+            Column("trace_id"),
+            Column("span_id"),
             Column("profile_id"),
-            Column("duration"),
             Column("segment_name"),
+            Column("op"),
+            Column("description"),
+            Column("duration"),
             Column("timestamp"),
         ],
         where=[
@@ -354,12 +358,14 @@ def get_indexed_spans(
     return [
         Span(
             project_id=value["project_id"],
-            span_id=value["span_id"],
-            trace_id=value["trace_id"],
             transaction_id=value["transaction_id"],
+            trace_id=value["trace_id"],
+            span_id=value["span_id"],
             profile_id=value["profile_id"],
-            duration=value["duration"],
             segment_name=value["segment_name"],
+            op=value["op"],
+            description=value["description"],
+            duration=value["duration"],
             timestamp=value["timestamp"],
         )
         for value in data


### PR DESCRIPTION
This PR adds new fields to the ddm meta endpoint for `metricSpans`.

_Because of OCD, the fields of all classes and queries have been ordered according to the database columns order._