### PR TITLE
feat(ddm): Move settings out of metrics selector

### DIFF
--- a/static/app/views/ddm/pageHeaderActions.tsx
+++ b/static/app/views/ddm/pageHeaderActions.tsx
@@ -1,9 +1,16 @@
 import {useMemo} from 'react';
 
+import {navigateTo} from 'sentry/actionCreators/navigation';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
-import {IconBookmark, IconDashboard, IconEllipsis, IconSiren} from 'sentry/icons';
+import {
+  IconBookmark,
+  IconDashboard,
+  IconEllipsis,
+  IconSettings,
+  IconSiren,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {isCustomMeasurement} from 'sentry/utils/metrics';
 import {MRIToField} from 'sentry/utils/metrics/mri';
@@ -36,8 +43,14 @@ export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Pro
         label: t('Add to Dashboard'),
         onAction: createDashboard,
       },
+      {
+        leadingItems: [<IconSettings key="icon" />],
+        key: 'metrics-settings',
+        label: t('Metrics Settings'),
+        onAction: () => navigateTo(`/settings/projects/:projectId/metrics/`, router),
+      },
     ],
-    [createDashboard]
+    [createDashboard, router]
   );
 
   const alertItems = useMemo(

--- a/static/app/views/ddm/queryBuilder.tsx
+++ b/static/app/views/ddm/queryBuilder.tsx
@@ -1,11 +1,9 @@
 import {Fragment, memo, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {navigateTo} from 'sentry/actionCreators/navigation';
-import {Button} from 'sentry/components/button';
 import {CompactSelect, SelectOption} from 'sentry/components/compactSelect';
 import Tag from 'sentry/components/tag';
-import {IconLightning, IconReleases, IconSettings} from 'sentry/icons';
+import {IconLightning, IconReleases} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {MetricMeta, MetricsOperation, MRI} from 'sentry/types';
@@ -26,7 +24,6 @@ import {useMetricsMeta} from 'sentry/utils/metrics/useMetricsMeta';
 import {useMetricsTags} from 'sentry/utils/metrics/useMetricsTags';
 import {middleEllipsis} from 'sentry/utils/middleEllipsis';
 import useKeyPress from 'sentry/utils/useKeyPress';
-import useRouter from 'sentry/utils/useRouter';
 import {MetricSearchBar} from 'sentry/views/ddm/metricSearchBar';
 
 type QueryBuilderProps = {
@@ -53,7 +50,6 @@ export const QueryBuilder = memo(function QueryBuilder({
   onChange,
 }: QueryBuilderProps) {
   const {data: meta, isLoading: isMetaLoading} = useMetricsMeta(projects);
-  const router = useRouter();
   const mriModeKeyPressed = useKeyPress('`', undefined, true);
   const [mriMode, setMriMode] = useState(powerUserMode); // power user mode that shows raw MRI instead of metrics names
 
@@ -144,34 +140,14 @@ export const QueryBuilder = memo(function QueryBuilder({
         // enable search by mri, name, unit (millisecond), type (c:), and readable type (counter)
         textValue: `${metric.mri}${getReadableMetricType(metric.type)}`,
         value: metric.mri,
-        trailingItems: mriMode
-          ? undefined
-          : ({isFocused}) => (
-              <Fragment>
-                {isFocused && isCustomMetric({mri: metric.mri}) && (
-                  <Button
-                    borderless
-                    size="zero"
-                    icon={<IconSettings />}
-                    aria-label={t('Metric Settings')}
-                    onPointerDown={() => {
-                      // not using onClick to beat the dropdown listener
-                      navigateTo(
-                        `/settings/projects/:projectId/metrics/${encodeURIComponent(
-                          metric.mri
-                        )}`,
-                        router
-                      );
-                    }}
-                  />
-                )}
-
-                <Tag tooltipText={t('Type')}>{getReadableMetricType(metric.type)}</Tag>
-                <Tag tooltipText={t('Unit')}>{metric.unit}</Tag>
-              </Fragment>
-            ),
+        trailingItems: mriMode ? undefined : (
+          <Fragment>
+            <Tag tooltipText={t('Type')}>{getReadableMetricType(metric.type)}</Tag>
+            <Tag tooltipText={t('Unit')}>{metric.unit}</Tag>
+          </Fragment>
+        ),
       })),
-    [displayedMetrics, mriMode, router]
+    [displayedMetrics, mriMode]
   );
 
   return (


### PR DESCRIPTION
This pull request moves settings out of the metrics selector (where it was often in the way) and relocates it to the top-level ellipsis menu. It will lead to the metrics index settings. For specific metric settings, you can still click on a query ellipsis and go to that query's metric settings.