### PR TITLE
feat(replays): Specify the queue the deletion task runs on

### DIFF
--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -15,6 +15,7 @@ from sentry.utils import json
 
 @instrumented_task(
     name="sentry.replays.tasks.delete_recording_segments",
+    queue="replays.delete_replay",
     default_retry_delay=5,
     max_retries=5,
     silo_mode=SiloMode.REGION,


### PR DESCRIPTION
Doing some sleight of hand with the worker queue.  We'll still publish on the replay-delete queue but process the jobs on the glob worker instead.  The dedicated replay worker will be deleted.

From Ben McKerry:

> I think if we want to move this over to a shared worker, we should keep deletions on the replays.delete_replay queue, and then I'll delete the dedicated worker & change the worker to use our shared [glob worker](https://github.com/getsentry/ops/blob/master/k8s/clusters/us/default.yaml#L819-L836) which is meant to be a catch-all for low traffic queues