### PR TITLE
fix(hybridcloud) Add region pin to legacy monitor checkins

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3963,6 +3963,8 @@ REGION_PINNED_URL_NAMES = {
     # These paths have organization scoped aliases
     "sentry-api-0-builtin-symbol-sources",
     "sentry-api-0-grouping-configs",
+    # Legacy monitor endpoints
+    "sentry-api-0-monitor-ingest-check-in-index",
     # These paths are used by relay which is implicitly region scoped
     "sentry-api-0-relays-index",
     "sentry-api-0-relay-register-challenge",


### PR DESCRIPTION
We're still getting a significant amount of traffic to the legacy monitor checkin URL. Add this endpoint to the list of endpoints that are only forwarded to the US.

Fixes HC-1065