### PR TITLE
fix(browser-starfish): enable images screen shows up when viewing images

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -94,10 +94,10 @@ function SampleImagesChartPanelBody(props: {
   const hasImages = images.length > 0;
 
   useEffect(() => {
-    if (showImages && !hasImages) {
+    if (showImages && !hasImages && !isLoadingImages) {
       Sentry.captureException(new Error('No sample images found'));
     }
-  }, [showImages, hasImages]);
+  }, [showImages, hasImages, isLoadingImages]);
 
   if (isSettingsLoading || (showImages && isLoadingImages)) {
     return <LoadingIndicator />;

--- a/static/app/views/performance/browser/resources/resourceView/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceView/index.tsx
@@ -100,7 +100,7 @@ function ResourceTypeSelector({value}: {value?: string}) {
             label: (
               <span>
                 {`${t('Image')} (${IMAGE_FILE_EXTENSIONS.map(e => `.${e}`).join(', ')})`}
-                <FeatureBadge type="alpha"> </FeatureBadge>
+                <FeatureBadge type="new"> </FeatureBadge>
               </span>
             ),
           },


### PR DESCRIPTION
1. Changes alpha badge to new badge to prepare for release.
2. Ensure the sample image component remains loading while we fetch the users project settings.
3. Fix incorrect condition in 'no sample images found' Sentry error.