### PR TITLE
ref: prevent test_push_event from reaching out to public github

### DIFF
--- a/fixtures/github.py
+++ b/fixtures/github.py
@@ -2176,6 +2176,44 @@ PULL_REQUEST_CLOSED_EVENT_EXAMPLE = b"""{
   }
 }"""
 
+# https://api.github.com/users/baxterthehacker
+API_GITHUB_COM_USERS_BAXTERTHEHACKER = """\
+{
+  "login": "baxterthehacker",
+  "id": 6752317,
+  "node_id": "MDQ6VXNlcjY3NTIzMTc=",
+  "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=4",
+  "gravatar_id": "",
+  "url": "https://api.github.com/users/baxterthehacker",
+  "html_url": "https://github.com/baxterthehacker",
+  "followers_url": "https://api.github.com/users/baxterthehacker/followers",
+  "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
+  "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
+  "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
+  "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
+  "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
+  "repos_url": "https://api.github.com/users/baxterthehacker/repos",
+  "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
+  "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
+  "type": "User",
+  "site_admin": false,
+  "name": null,
+  "company": null,
+  "blog": "",
+  "location": null,
+  "email": null,
+  "hireable": null,
+  "bio": null,
+  "twitter_username": null,
+  "public_repos": 6,
+  "public_gists": 0,
+  "followers": 9,
+  "following": 1,
+  "created_at": "2014-02-21T22:24:28Z",
+  "updated_at": "2023-12-22T12:36:56Z"
+}
+"""
+
 # Example taken from github with additional example commit added https://docs.github.com/en/rest/commits/commits#compare-two-commits
 COMPARE_COMMITS_EXAMPLE_WITH_INTERMEDIATE = """{
   "url": "https://api.github.com/repos/octocat/Hello-World/compare/master...topic",


### PR DESCRIPTION
otherwise this fails with:

```
tests/sentry_plugins/github/endpoints/test_push_event.py:115: in test_user_email
    assert commit.author.email == "alberto@sentry.io"
E   AssertionError: assert 'baxterthehac...ly.github.com' == 'alberto@sentry.io'
E     - alberto@sentry.io
E     + baxterthehacker@users.noreply.github.com
```

cc @dashed 

<!-- Describe your PR here. -->