### PR TITLE
fix(browser-starfish): determine if resource is image from file extension

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -17,8 +17,8 @@ import ResourceSummaryCharts from 'sentry/views/performance/browser/resources/re
 import ResourceSummaryTable from 'sentry/views/performance/browser/resources/resourceSummaryPage/resourceSummaryTable';
 import SampleImages from 'sentry/views/performance/browser/resources/resourceSummaryPage/sampleImages';
 import {FilterOptionsContainer} from 'sentry/views/performance/browser/resources/resourceView';
+import {IMAGE_FILE_EXTENSIONS} from 'sentry/views/performance/browser/resources/shared/constants';
 import RenderBlockingSelector from 'sentry/views/performance/browser/resources/shared/renderBlockingSelector';
-import {ResourceSpanOps} from 'sentry/views/performance/browser/resources/shared/types';
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
@@ -32,7 +32,6 @@ const {
   HTTP_RESPONSE_CONTENT_LENGTH,
   HTTP_RESPONSE_TRANSFER_SIZE,
   RESOURCE_RENDER_BLOCKING_STATUS,
-  SPAN_OP,
 } = SpanMetricsField;
 
 function ResourceSummary() {
@@ -59,8 +58,9 @@ function ResourceSummary() {
     ],
   });
   const spanMetrics = data[0] ?? {};
-  const isImage = filters[SPAN_OP] === ResourceSpanOps.IMAGE;
-
+  const isImage = IMAGE_FILE_EXTENSIONS.includes(
+    spanMetrics[SpanMetricsField.SPAN_DESCRIPTION]?.split('.').pop() || ''
+  );
   return (
     <ModulePageProviders
       title={[t('Performance'), t('Resources'), t('Resource Summary')].join(' — ')}


### PR DESCRIPTION
Rather then relying on the span op query param, we're now grabbing the file extension to determine whether or not a span is a image. This is to prevent an issue where you navigate to the resource summary page without the query param.

Unfortunately this introduces some CLS at page load, but there are some methods to help avoid it in a future PR.