### PR TITLE
fix(browser-starfish) don't try to render relative urls

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -174,10 +174,11 @@ function ImageContainer(props: {
   const [hasError, setHasError] = useState(false);
 
   const {fileName, size, src, showImage = true} = props;
+  const isRelativeUrl = src.startsWith('/');
 
   return (
     <div style={{width: '100%', wordWrap: 'break-word'}}>
-      {showImage && !hasError ? (
+      {showImage && !isRelativeUrl && !hasError ? (
         <div
           style={{
             width: imageWidth,


### PR DESCRIPTION
If an image src is a relative URL in the resource summary sample images, we shouldn't try to load it, as it will be relative to sentry's domain!