### PR TITLE
fix(ui): Consistent spacing on discover

### DIFF
--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -700,7 +700,7 @@ export class Results extends Component<Props, State> {
 }
 
 const StyledPageFilterBar = styled(PageFilterBar)`
-  margin-bottom: ${space(1)};
+  margin-bottom: ${space(2)};
 `;
 
 const StyledSearchBar = styled(SearchBar)`


### PR DESCRIPTION
Before

<img alt="clipboard.png" width="344" src="https://i.imgur.com/cqCyazX.png" />

After

<img width="183" alt="image" src="https://github.com/getsentry/sentry/assets/1421724/84d6c503-0cfa-4165-ad0e-af7a4b9f35bc">
