### PR TITLE
fix(issue-details): Move location of new issues experience button

### DIFF
--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -369,9 +369,6 @@ export function Actions(props: Props) {
   });
   return (
     <ActionWrapper>
-      {organization.features.includes('issue-details-new-experience-toggle') ? (
-        <NewIssueExperienceButton />
-      ) : null}
       <DropdownMenu
         triggerProps={{
           'aria-label': t('More Actions'),
@@ -472,6 +469,9 @@ export function Actions(props: Props) {
           },
         ]}
       />
+      {organization.features.includes('issue-details-new-experience-toggle') ? (
+        <NewIssueExperienceButton />
+      ) : null}
       <SubscribeAction
         className="hidden-xs"
         disabled={disabled}


### PR DESCRIPTION
Moves it to the right of the overflow menu:

![CleanShot 2024-01-12 at 12 19 21](https://github.com/getsentry/sentry/assets/10888943/e46c35dc-54b5-4771-97d8-3b723071b9d9)
