### PR TITLE
fix(hybridcloud) Adopt organization scoped prompts-activity

### DIFF
--- a/static/app/actionCreators/prompts.tsx
+++ b/static/app/actionCreators/prompts.tsx
@@ -7,8 +7,11 @@ type PromptsUpdateParams = {
    * The prompt feature name
    */
   feature: string;
-  organization: OrganizationSummary;
   status: 'snoozed' | 'dismissed';
+  // TODO(mark) Remove optional once getsentry is updated.
+  organization?: OrganizationSummary,
+  // Deprecated.
+  organizationId?: string,
   /**
    * The numeric project ID as a string
    */
@@ -19,18 +22,19 @@ type PromptsUpdateParams = {
  * Update the status of a prompt
  */
 export function promptsUpdate(api: Client, params: PromptsUpdateParams) {
-  return api.requestPromise(
-    `/organizations/${params.organization.slug}/prompts-activity/`,
-    {
-      method: 'PUT',
-      data: {
-        organization_id: params.organization.id,
-        project_id: params.projectId,
-        feature: params.feature,
-        status: params.status,
-      },
-    }
-  );
+  const organizationId = params.organization ? params.organization.id : params.organizationId;
+  const url = params.organization
+    ? `/organizations/${params.organization.slug}/prompts-activity/`
+    : '/prompts-activity/';
+  return api.requestPromise(url, {
+    method: 'PUT',
+    data: {
+      organization_id: organizationId,
+      project_id: params.projectId,
+      feature: params.feature,
+      status: params.status,
+    },
+  });
 }
 
 type PromptCheckParams = {
@@ -38,7 +42,10 @@ type PromptCheckParams = {
    * The prompt feature name
    */
   feature: string;
-  organization: OrganizationSummary;
+  // TODO(mark) Remove optional once getsentry change has landed.
+  organization?: OrganizationSummary,
+  // Deprecated To be removed once all usage has organization
+  organizationId?: string;
   /**
    * The numeric project ID as a string
    */
@@ -66,18 +73,19 @@ export async function promptsCheck(
   api: Client,
   params: PromptCheckParams
 ): Promise<PromptData> {
+  const organizationId = params.organization ? params.organization.id : params.organizationId;
   const query = {
     feature: params.feature,
-    organization_id: params.organization.id,
+    organization_id: organizationId,
     ...(params.projectId === undefined ? {} : {project_id: params.projectId}),
   };
+  const url = params.organization
+    ? `/organizations/${params.organization.slug}/prompts-activity/`
+    : '/prompts-activity/';
 
-  const response: PromptResponse = await api.requestPromise(
-    `/organizations/${params.organization.slug}/prompts-activity/`,
-    {
-      query,
-    }
-  );
+  const response: PromptResponse = await api.requestPromise(url, {
+    query,
+  });
 
   if (response?.data) {
     return {
@@ -92,21 +100,29 @@ export async function promptsCheck(
 export const makePromptsCheckQueryKey = ({
   feature,
   organization,
+  organizationId,
   projectId,
-}: PromptCheckParams): ApiQueryKey => [
-  `/organizations/${organization.slug}/prompts-activity/`,
-  {query: {feature, organization_id: organization.id, project_id: projectId}},
-];
+}: PromptCheckParams): ApiQueryKey => {
+  const orgId = organization ? organization.id : organizationId;
+  const url = organization
+    ? `/organizations/${organization.slug}/prompts-activity/`
+    : '/prompts-activity/';
+
+  return [
+    url,
+    {query: {feature, organization_id: orgId, project_id: projectId}},
+  ];
+};
 
 /**
  * @param organizationId org numerical id, not the slug
  */
 export function usePromptsCheck(
-  {feature, organization, projectId}: PromptCheckParams,
+  {feature, organization, organizationId, projectId}: PromptCheckParams,
   options: Partial<UseApiQueryOptions<PromptResponse>> = {}
 ) {
   return useApiQuery<PromptResponse>(
-    makePromptsCheckQueryKey({feature, organization, projectId}),
+    makePromptsCheckQueryKey({feature, organization, organizationId, projectId}),
     {
       staleTime: 120000,
       ...options,
@@ -120,20 +136,21 @@ export function usePromptsCheck(
 export async function batchedPromptsCheck<T extends readonly string[]>(
   api: Client,
   features: T,
-  params: {organization: OrganizationSummary; projectId?: string}
+  params: {organization?: OrganizationSummary; organizationId?: string; projectId?: string}
 ): Promise<{[key in T[number]]: PromptData}> {
+  const orgId = params.organization ? params.organization.id : params.organizationId;
   const query = {
     feature: features,
-    organization_id: params.organization.id,
+    organization_id: orgId,
     ...(params.projectId === undefined ? {} : {project_id: params.projectId}),
   };
+  const url = params.organization
+    ? `/organizations/${params.organization.slug}/prompts-activity/`
+    : '/prompts-activity/';
 
-  const response: PromptResponse = await api.requestPromise(
-    `/organizations/${params.organization.slug}/prompts-activity/`,
-    {
-      query,
-    }
-  );
+  const response: PromptResponse = await api.requestPromise(url, {
+    query,
+  });
   const responseFeatures = response?.features;
 
   const result: {[key in T[number]]?: PromptData} = {};

--- a/static/app/actionCreators/prompts.tsx
+++ b/static/app/actionCreators/prompts.tsx
@@ -7,7 +7,7 @@ type PromptsUpdateParams = {
    * The prompt feature name
    */
   feature: string;
-  organization: OrganizationSummary,
+  organization: OrganizationSummary;
   status: 'snoozed' | 'dismissed';
   /**
    * The numeric project ID as a string
@@ -19,15 +19,18 @@ type PromptsUpdateParams = {
  * Update the status of a prompt
  */
 export function promptsUpdate(api: Client, params: PromptsUpdateParams) {
-  return api.requestPromise(`/organizations/${params.organization.slug}/prompts-activity/`, {
-    method: 'PUT',
-    data: {
-      organization_id: params.organization.id,
-      project_id: params.projectId,
-      feature: params.feature,
-      status: params.status,
-    },
-  });
+  return api.requestPromise(
+    `/organizations/${params.organization.slug}/prompts-activity/`,
+    {
+      method: 'PUT',
+      data: {
+        organization_id: params.organization.id,
+        project_id: params.projectId,
+        feature: params.feature,
+        status: params.status,
+      },
+    }
+  );
 }
 
 type PromptCheckParams = {
@@ -35,7 +38,7 @@ type PromptCheckParams = {
    * The prompt feature name
    */
   feature: string;
-  organization: OrganizationSummary,
+  organization: OrganizationSummary;
   /**
    * The numeric project ID as a string
    */
@@ -69,9 +72,12 @@ export async function promptsCheck(
     ...(params.projectId === undefined ? {} : {project_id: params.projectId}),
   };
 
-  const response: PromptResponse = await api.requestPromise(`/organizations/${params.organization.slug}/prompts-activity/`, {
-    query,
-  });
+  const response: PromptResponse = await api.requestPromise(
+    `/organizations/${params.organization.slug}/prompts-activity/`,
+    {
+      query,
+    }
+  );
 
   if (response?.data) {
     return {
@@ -122,9 +128,12 @@ export async function batchedPromptsCheck<T extends readonly string[]>(
     ...(params.projectId === undefined ? {} : {project_id: params.projectId}),
   };
 
-  const response: PromptResponse = await api.requestPromise(`/organizations/${params.organization.slug}/prompts-activity/`, {
-    query,
-  });
+  const response: PromptResponse = await api.requestPromise(
+    `/organizations/${params.organization.slug}/prompts-activity/`,
+    {
+      query,
+    }
+  );
   const responseFeatures = response?.features;
 
   const result: {[key in T[number]]?: PromptData} = {};

--- a/static/app/actionCreators/prompts.tsx
+++ b/static/app/actionCreators/prompts.tsx
@@ -9,9 +9,9 @@ type PromptsUpdateParams = {
   feature: string;
   status: 'snoozed' | 'dismissed';
   // TODO(mark) Remove optional once getsentry is updated.
-  organization?: OrganizationSummary,
+  organization?: OrganizationSummary;
   // Deprecated.
-  organizationId?: string,
+  organizationId?: string;
   /**
    * The numeric project ID as a string
    */
@@ -22,7 +22,9 @@ type PromptsUpdateParams = {
  * Update the status of a prompt
  */
 export function promptsUpdate(api: Client, params: PromptsUpdateParams) {
-  const organizationId = params.organization ? params.organization.id : params.organizationId;
+  const organizationId = params.organization
+    ? params.organization.id
+    : params.organizationId;
   const url = params.organization
     ? `/organizations/${params.organization.slug}/prompts-activity/`
     : '/prompts-activity/';
@@ -43,7 +45,7 @@ type PromptCheckParams = {
    */
   feature: string;
   // TODO(mark) Remove optional once getsentry change has landed.
-  organization?: OrganizationSummary,
+  organization?: OrganizationSummary;
   // Deprecated To be removed once all usage has organization
   organizationId?: string;
   /**
@@ -73,7 +75,9 @@ export async function promptsCheck(
   api: Client,
   params: PromptCheckParams
 ): Promise<PromptData> {
-  const organizationId = params.organization ? params.organization.id : params.organizationId;
+  const organizationId = params.organization
+    ? params.organization.id
+    : params.organizationId;
   const query = {
     feature: params.feature,
     organization_id: organizationId,
@@ -108,10 +112,7 @@ export const makePromptsCheckQueryKey = ({
     ? `/organizations/${organization.slug}/prompts-activity/`
     : '/prompts-activity/';
 
-  return [
-    url,
-    {query: {feature, organization_id: orgId, project_id: projectId}},
-  ];
+  return [url, {query: {feature, organization_id: orgId, project_id: projectId}}];
 };
 
 /**
@@ -136,7 +137,11 @@ export function usePromptsCheck(
 export async function batchedPromptsCheck<T extends readonly string[]>(
   api: Client,
   features: T,
-  params: {organization?: OrganizationSummary; organizationId?: string; projectId?: string}
+  params: {
+    organization?: OrganizationSummary;
+    organizationId?: string;
+    projectId?: string;
+  }
 ): Promise<{[key in T[number]]: PromptData}> {
   const orgId = params.organization ? params.organization.id : params.organizationId;
   const query = {

--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -27,7 +27,7 @@ describe('Exception Content', function () {
   beforeEach(function () {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: `/prompts-activity/`,
+      url: `/organizations/${organization.slug}/prompts-activity/`,
     });
     MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/stacktrace-link/`,
@@ -232,7 +232,7 @@ describe('Exception Content', function () {
         snoozed_ts: undefined,
       };
       MockApiClient.addMockResponse({
-        url: '/prompts-activity/',
+        url: `/organizations/${organization.slug}/prompts-activity/`,
         body: promptResponse,
       });
       MockApiClient.addMockResponse({

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
@@ -56,7 +56,7 @@ describe('StackTrace', function () {
       snoozed_ts: undefined,
     };
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: promptResponse,
     });
     MockApiClient.addMockResponse({

--- a/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/nativeContent.spec.tsx
@@ -56,7 +56,7 @@ describe('Native StackTrace', function () {
       snoozed_ts: undefined,
     };
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: promptResponse,
     });
     MockApiClient.addMockResponse({

--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -42,7 +42,7 @@ describe('StacktraceLink', function () {
     MockApiClient.clearMockResponses();
     promptActivity = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/prompts-activity/',
+      url: `/organizations/${org.slug}/prompts-activity/`,
       body: {},
     });
     ProjectsStore.loadInitialData([project]);
@@ -77,7 +77,7 @@ describe('StacktraceLink', function () {
     );
     expect(promptActivity).toHaveBeenCalledTimes(1);
     expect(promptActivity).toHaveBeenCalledWith(
-      '/prompts-activity/',
+      `/organizations/${org.slug}/prompts-activity/`,
       expect.objectContaining({
         query: {
           feature: 'stacktrace_link',
@@ -95,7 +95,7 @@ describe('StacktraceLink', function () {
     });
     const dismissPrompt = MockApiClient.addMockResponse({
       method: 'PUT',
-      url: `/prompts-activity/`,
+      url: `/organizations/${org.slug}/prompts-activity/`,
       body: {},
     });
     const {container} = render(<StacktraceLink frame={frame} event={event} line="" />, {
@@ -114,7 +114,7 @@ describe('StacktraceLink', function () {
     });
 
     expect(dismissPrompt).toHaveBeenCalledWith(
-      `/prompts-activity/`,
+      `/organizations/${org.slug}/prompts-activity/`,
       expect.objectContaining({
         data: {
           feature: 'stacktrace_link',

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -78,7 +78,7 @@ function StacktraceLinkSetup({
 
   const dismissPrompt = () => {
     promptsUpdate(api, {
-      organizationId: organization.id,
+      organization,
       projectId: project?.id,
       feature: 'stacktrace_link',
       status: 'dismissed',
@@ -89,8 +89,8 @@ function StacktraceLinkSetup({
     setApiQueryData<PromptResponse>(
       queryClient,
       makePromptsCheckQueryKey({
+        organization,
         feature: 'stacktrace_link',
-        organizationId: organization.id,
         projectId: project?.id,
       }),
       () => {
@@ -227,8 +227,8 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
   );
 
   const prompt = usePromptsCheck({
+    organization,
     feature: 'stacktrace_link',
-    organizationId: organization.id,
     projectId: project?.id,
   });
   const isPromptDismissed =

--- a/static/app/components/events/interfaces/threads.spec.tsx
+++ b/static/app/components/events/interfaces/threads.spec.tsx
@@ -27,7 +27,7 @@ describe('Threads', function () {
       snoozed_ts: undefined,
     };
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: promptResponse,
     });
     MockApiClient.addMockResponse({

--- a/static/app/components/globalSdkUpdateAlert.spec.tsx
+++ b/static/app/components/globalSdkUpdateAlert.spec.tsx
@@ -67,14 +67,15 @@ describe('GlobalSDKUpdateAlert', () => {
       dismissed_ts: undefined,
       snoozed_ts: undefined,
     };
+    const organization = OrganizationFixture();
 
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: promptResponse,
     });
 
     const {rerender} = render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
-      organization: OrganizationFixture(),
+      organization,
     });
 
     expect(
@@ -98,9 +99,10 @@ describe('GlobalSDKUpdateAlert', () => {
       dismissed_ts: undefined,
       snoozed_ts: undefined,
     };
+    const organization = OrganizationFixture();
 
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: {data: promptResponse},
     });
 
@@ -123,14 +125,15 @@ describe('GlobalSDKUpdateAlert', () => {
         .unix(),
       snoozed_ts: undefined,
     };
+    const organization = OrganizationFixture();
 
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: {data: promptResponse},
     });
 
     render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
-      organization: OrganizationFixture(),
+      organization,
     });
 
     await waitFor(() =>
@@ -150,14 +153,15 @@ describe('GlobalSDKUpdateAlert', () => {
         .subtract(DEFAULT_SNOOZE_PROMPT_DAYS + 1, 'days')
         .unix(),
     };
+    const organization = OrganizationFixture();
 
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: {data: promptResponse},
     });
 
     render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
-      organization: OrganizationFixture(),
+      organization,
     });
 
     expect(
@@ -175,14 +179,15 @@ describe('GlobalSDKUpdateAlert', () => {
         .subtract(DEFAULT_SNOOZE_PROMPT_DAYS - 2, 'days')
         .unix(),
     };
+    const organization = OrganizationFixture();
 
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: {data: promptResponse},
     });
 
     render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
-      organization: OrganizationFixture(),
+      organization,
     });
 
     await waitFor(() =>
@@ -202,14 +207,15 @@ describe('GlobalSDKUpdateAlert', () => {
       dismissed_ts: undefined,
       snoozed_ts: undefined,
     };
+    const organization = OrganizationFixture();
 
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: promptResponse,
     });
 
     render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
-      organization: OrganizationFixture(),
+      organization,
     });
 
     expect(
@@ -224,25 +230,26 @@ describe('GlobalSDKUpdateAlert', () => {
       dismissed_ts: undefined,
       snoozed_ts: undefined,
     };
+    const organization = OrganizationFixture();
 
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: {data: promptResponse},
     });
 
     const promptsActivityMock = MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       method: 'PUT',
     });
 
     render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
-      organization: OrganizationFixture(),
+      organization,
     });
 
     await userEvent.click(await screen.findByRole('button', {name: 'Remind me later'}));
 
     expect(promptsActivityMock).toHaveBeenCalledWith(
-      '/prompts-activity/',
+      `/organizations/${organization.slug}/prompts-activity/`,
       expect.objectContaining({
         data: expect.objectContaining({
           feature: 'sdk_updates',

--- a/static/app/components/globalSdkUpdateAlert.tsx
+++ b/static/app/components/globalSdkUpdateAlert.tsx
@@ -33,7 +33,7 @@ function InnerGlobalSdkUpdateAlert(
 
   const handleSnoozePrompt = useCallback(() => {
     promptsUpdate(api, {
-      organizationId: organization.id,
+      organization,
       feature: 'sdk_updates',
       status: 'snoozed',
     });
@@ -53,7 +53,7 @@ function InnerGlobalSdkUpdateAlert(
     let isUnmounted = false;
 
     promptsCheck(api, {
-      organizationId: organization.id,
+      organization,
       feature: 'sdk_updates',
     }).then(prompt => {
       if (isUnmounted) {

--- a/static/app/views/alerts/list/incidents/index.spec.tsx
+++ b/static/app/views/alerts/list/incidents/index.spec.tsx
@@ -106,11 +106,11 @@ describe('IncidentsList', () => {
       body: [],
     });
     const promptsMock = MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {data: {dismissed_ts: null}},
     });
     const promptsUpdateMock = MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       method: 'PUT',
     });
 
@@ -133,7 +133,7 @@ describe('IncidentsList', () => {
       body: [],
     });
     const promptsMock = MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {data: {dismissed_ts: Math.floor(Date.now() / 1000)}},
     });
 
@@ -157,7 +157,7 @@ describe('IncidentsList', () => {
       body: [{id: 1}],
     });
     const promptsMock = MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {data: {dismissed_ts: Math.floor(Date.now() / 1000)}},
     });
 

--- a/static/app/views/alerts/list/incidents/index.tsx
+++ b/static/app/views/alerts/list/incidents/index.tsx
@@ -110,7 +110,7 @@ class IncidentsList extends DeprecatedAsyncComponent<
 
     // Check if they have already seen the prompt for the alert stream
     const prompt = await promptsCheck(this.api, {
-      organizationId: organization.id,
+      organization,
       feature: 'alert_stream',
     });
 
@@ -120,8 +120,8 @@ class IncidentsList extends DeprecatedAsyncComponent<
       // Prompt has not been seen, mark the prompt as seen immediately so they
       // don't see it again
       promptsUpdate(this.api, {
+        organization,
         feature: 'alert_stream',
-        organizationId: organization.id,
         status: 'dismissed',
       });
     }

--- a/static/app/views/alerts/rules/metric/details/errorMigrationWarning.spec.tsx
+++ b/static/app/views/alerts/rules/metric/details/errorMigrationWarning.spec.tsx
@@ -24,7 +24,7 @@ describe('ErrorMigrationWarning', () => {
       query: '',
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: {},
     });
     render(<ErrorMigrationWarning project={project} rule={rule} />, {
@@ -44,11 +44,11 @@ describe('ErrorMigrationWarning', () => {
       query: '',
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: {},
     });
     const dismissMock = MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       method: 'PUT',
       body: {},
     });
@@ -71,7 +71,7 @@ describe('ErrorMigrationWarning', () => {
       dateCreated: '2024-01-01T00:00:00Z',
     });
     const promptApi = MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: {},
     });
     const {container} = render(<ErrorMigrationWarning project={project} rule={rule} />, {

--- a/static/app/views/alerts/rules/metric/details/errorMigrationWarning.tsx
+++ b/static/app/views/alerts/rules/metric/details/errorMigrationWarning.tsx
@@ -50,8 +50,8 @@ export function ErrorMigrationWarning({project, rule}: ErrorMigrationWarningProp
   const isCreatedAfterMigration = rule && createdOrModifiedAfterMigration(rule);
   const prompt = usePromptsCheck(
     {
+      organization,
       feature: METRIC_ALERT_IGNORE_ARCHIVED_ISSUES,
-      organizationId: organization.id,
       projectId: project?.id,
     },
     {staleTime: Infinity, enabled: showErrorMigrationWarning && !isCreatedAfterMigration}
@@ -76,7 +76,7 @@ export function ErrorMigrationWarning({project, rule}: ErrorMigrationWarningProp
 
   const dismissPrompt = () => {
     promptsUpdate(api, {
-      organizationId: organization.id,
+      organization,
       projectId: project?.id,
       feature: METRIC_ALERT_IGNORE_ARCHIVED_ISSUES,
       status: 'dismissed',
@@ -86,8 +86,8 @@ export function ErrorMigrationWarning({project, rule}: ErrorMigrationWarningProp
     setApiQueryData<PromptResponse>(
       queryClient,
       makePromptsCheckQueryKey({
+        organization,
         feature: METRIC_ALERT_IGNORE_ARCHIVED_ISSUES,
-        organizationId: organization.id,
         projectId: project?.id,
       }),
       () => {

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -72,7 +72,7 @@ describe('Dashboards > Detail', function () {
         body: [],
       });
       MockApiClient.addMockResponse({
-        url: '/prompts-activity/',
+        url: '/organizations/org-slug/prompts-activity/',
         body: {},
       });
       MockApiClient.addMockResponse({
@@ -353,7 +353,7 @@ describe('Dashboards > Detail', function () {
         body: [],
       });
       MockApiClient.addMockResponse({
-        url: '/prompts-activity/',
+        url: '/organizations/org-slug/prompts-activity/',
         body: {},
       });
     });

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -220,7 +220,7 @@ const mockGroupApis = (
   });
 
   MockApiClient.addMockResponse({
-    url: '/prompts-activity/',
+    url: `/organizations/${organization.slug}/prompts-activity/`,
     body: undefined,
   });
 

--- a/static/app/views/issueDetails/groupSidebar.spec.tsx
+++ b/static/app/views/issueDetails/groupSidebar.spec.tsx
@@ -64,7 +64,7 @@ describe('GroupSidebar', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/prompts-activity/`,
+      url: `/organizations/${organization.slug}/prompts-activity/`,
       body: {},
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/issueDetails/quickTrace/usePromptCheck.tsx
+++ b/static/app/views/issueDetails/quickTrace/usePromptCheck.tsx
@@ -18,7 +18,7 @@ function usePromptCheck({feature, organization, projectId}: Opts) {
 
   useEffect(() => {
     promptsCheck(api, {
-      organizationId: organization.id,
+      organization,
       projectId,
       feature,
     }).then(data => {
@@ -29,7 +29,7 @@ function usePromptCheck({feature, organization, projectId}: Opts) {
   const snoozePrompt = useCallback(async () => {
     const data = {
       projectId,
-      organizationId: organization.id,
+      organization,
       feature,
       status: 'snoozed' as const,
     };

--- a/static/app/views/performance/content.spec.tsx
+++ b/static/app/views/performance/content.spec.tsx
@@ -131,7 +131,7 @@ describe('Performance > Content', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -75,7 +75,7 @@ describe('Performance > Landing > Index', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/performance/landing/metricsDataSwitcher.spec.tsx
+++ b/static/app/views/performance/landing/metricsDataSwitcher.spec.tsx
@@ -66,7 +66,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/performance/transactionEvents.spec.tsx
+++ b/static/app/views/performance/transactionEvents.spec.tsx
@@ -47,7 +47,7 @@ describe('Performance > TransactionSummary', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
 

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/index.spec.tsx
@@ -27,7 +27,7 @@ describe('AnomaliesTab', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -65,7 +65,7 @@ describe('Performance Transaction Events Content', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -106,7 +106,7 @@ describe('Performance GridEditable Table', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.spec.tsx
@@ -73,7 +73,7 @@ describe('Transaction Summary Content', function () {
   beforeEach(function () {
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -143,7 +143,7 @@ describe('Performance > TransactionSummary', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/index.spec.tsx
@@ -44,7 +44,7 @@ describe('Performance > Transaction Spans', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.spec.tsx
@@ -131,7 +131,7 @@ describe('Performance > Transaction Tags', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/performance/transactionSummary/transactionVitals/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/index.spec.tsx
@@ -170,7 +170,7 @@ describe('Performance > Web Vitals', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
 

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -184,7 +184,7 @@ describe('Performance > Trends', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
     MockApiClient.addMockResponse({

--- a/static/app/views/projectDetail/index.spec.tsx
+++ b/static/app/views/projectDetail/index.spec.tsx
@@ -22,7 +22,7 @@ describe('ProjectDetail', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       body: {},
     });
   });

--- a/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.spec.tsx
@@ -27,7 +27,7 @@ describe('inviteBanner', function () {
       body: [missingMembers],
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       method: 'GET',
       body: {
         dismissed_ts: undefined,
@@ -200,7 +200,7 @@ describe('inviteBanner', function () {
         .unix(),
     };
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${org.slug}/prompts-activity/`,
       method: 'GET',
       body: {data: promptResponse},
     });
@@ -234,7 +234,7 @@ describe('inviteBanner', function () {
         .unix(),
     };
     const mockPrompt = MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: `/organizations/${org.slug}/prompts-activity/`,
       method: 'GET',
       body: {data: promptResponse},
     });

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -60,7 +60,7 @@ export function InviteBanner({
     });
     setShowBanner(false);
     await promptsUpdate(api, {
-      organizationId: organization.id,
+      organization,
       feature: promptsFeature,
       status: 'snoozed',
     });
@@ -100,7 +100,7 @@ export function InviteBanner({
     }
     fetchMissingMembers();
     promptsCheck(api, {
-      organizationId: organization.id,
+      organization,
       feature: promptsFeature,
     }).then(prompt => {
       setShowBanner(!promptIsDismissed(prompt));

--- a/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.spec.tsx
@@ -171,7 +171,7 @@ describe('OrganizationMembersList', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       method: 'GET',
       body: {
         dismissed_ts: undefined,

--- a/static/app/views/settings/organizationMembers/organizationMembersWrapper.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersWrapper.spec.tsx
@@ -105,7 +105,7 @@ describe('OrganizationMembersWrapper', function () {
       body: [member],
     });
     MockApiClient.addMockResponse({
-      url: '/prompts-activity/',
+      url: '/organizations/org-slug/prompts-activity/',
       method: 'GET',
       body: {},
     });


### PR DESCRIPTION
Using the organization scoped endpoint will ensure that any requests that do go to control silo in the future can be routed to the correct region.

Refs HC-1066