### PR TITLE
fix(hybrid-cloud): Enables citext extension in region/control dbs before import

### DIFF
--- a/bin/split-silo-database
+++ b/bin/split-silo-database
@@ -44,6 +44,19 @@ def split_database(tables: List[str], source: str, destination: str, reset: bool
         exec_run(postgres, ["dropdb", "-U", "postgres", "--if-exists", destination])
         exec_run(postgres, ["createdb", "-U", "postgres", destination])
 
+    citext_command = [
+        "psql",
+        "-U",
+        "postgres",
+        destination,
+        "-c",
+        "'CREATE EXTENSION IF NOT EXISTS citext'",
+    ]
+
+    if verbose:
+        click.echo(f">> RUNNING: {' '.join(citext_command)}")
+    exec_run(postgres, citext_command)
+
     # Use the dump file to build control silo tables.
     click.echo(f">> Building {destination} database from dump file")
     import_command = ["psql", "-U", "postgres", destination, "<", f"/tmp/{destination}-tables.sql"]


### PR DESCRIPTION
Fixes an issue with bin/split-silo-database not enabling the citext extension before attempting to create tables that use it.
