### PR TITLE
feat(app-start): Add duration to span metrics map

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -295,6 +295,8 @@ SPAN_METRICS_MAP = {
     "http.response_content_length": "d:spans/http.response_content_length@byte",
     "http.decoded_response_content_length": "d:spans/http.decoded_response_content_length@byte",
     "http.response_transfer_size": "d:spans/http.response_transfer_size@byte",
+    # Duration is only collected for specific app start spans
+    "duration": "d:spans/duration@millisecond",
 }
 SELF_TIME_LIGHT = "d:spans/exclusive_time_light@millisecond"
 # 50 to match the size of tables in the UI + 1 for pagination reasons


### PR DESCRIPTION
Add duration to the span metrics map. It was reintroduced in https://github.com/getsentry/relay/pull/2906 for root app start spans because they have nested spans, making self time incompatible with the use case to show start time metrics.

The use case for this is to allow for `duration` in the `avg_if` function for span metrics