### PR TITLE
fix: remove lodash/flatmap usages

### DIFF
--- a/static/app/actionCreators/formSearch.tsx
+++ b/static/app/actionCreators/formSearch.tsx
@@ -1,4 +1,3 @@
-import flatMap from 'lodash/flatMap';
 import flatten from 'lodash/flatten';
 
 import {Field, JsonFormObject} from 'sentry/components/forms/types';
@@ -26,7 +25,7 @@ const createSearchMap = ({
   // If `formGroups` is defined, then return a flattened list of fields in all formGroups
   // Otherwise `fields` is a map of fieldName -> fieldObject -- create a list of fields
   const listOfFields = formGroups
-    ? flatMap(formGroups, formGroup => formGroup.fields)
+    ? formGroups.flatMap(formGroup => formGroup.fields)
     : Object.keys(fields).map(fieldName => fields[fieldName]);
 
   return listOfFields.map(field => ({

--- a/static/app/components/dropdownAutoComplete/autoCompleteFilter.tsx
+++ b/static/app/components/dropdownAutoComplete/autoCompleteFilter.tsx
@@ -1,5 +1,3 @@
-import flatMap from 'lodash/flatMap';
-
 import type {Item, ItemsAfterFilter, ItemsBeforeFilter} from './types';
 
 type Items = ItemsBeforeFilter;
@@ -49,7 +47,7 @@ function autoCompleteFilter(
 
   if (hasRootGroup(items)) {
     // if the first item has children, we assume it is a group
-    return flatMap(filterGroupedItems(items, inputValue), item => {
+    return filterGroupedItems(items, inputValue).flatMap(item => {
       const groupItems = item.items.map(groupedItem => ({
         ...groupedItem,
         index: itemCount++,

--- a/static/app/components/events/suspectCommits.tsx
+++ b/static/app/components/events/suspectCommits.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
-import flatMap from 'lodash/flatMap';
 import uniqBy from 'lodash/uniqBy';
 
 import type {CommitRowProps} from 'sentry/components/commitRow';
@@ -34,7 +33,7 @@ export function SuspectCommits({group, eventId, project, commitRow: CommitRow}: 
 
   function getUniqueCommitsWithAuthors() {
     // Get a list of commits with author information attached
-    const commitsWithAuthors = flatMap(committers, ({commits, author}) =>
+    const commitsWithAuthors = committers.flatMap(({commits, author}) =>
       commits.map(commit => ({
         ...commit,
         author,

--- a/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
@@ -1,6 +1,5 @@
 import {Component, Fragment} from 'react';
 import find from 'lodash/find';
-import flatMap from 'lodash/flatMap';
 
 import SelectField from 'sentry/components/forms/fields/selectField';
 import FormContext from 'sentry/components/forms/formContext';
@@ -100,8 +99,7 @@ function findResource(r: PermissionResource) {
  *
  */
 function permissionStateToList(permissions: Permissions) {
-  return flatMap(
-    Object.entries(permissions),
+  return Object.entries(permissions).flatMap(
     ([r, p]) => findResource(r as PermissionResource)?.choices?.[p]?.scopes
   );
 }


### PR DESCRIPTION
Removes `lodash/flatmap` and replaces it with `Array.prototype.flatMap`

Ref: https://github.com/getsentry/frontend-tsc/issues/55