### PR TITLE
fix: remove lodash/find usages

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
@@ -1,11 +1,10 @@
 import {Component, Fragment} from 'react';
-import find from 'lodash/find';
 
 import SelectField from 'sentry/components/forms/fields/selectField';
 import FormContext from 'sentry/components/forms/formContext';
 import {SENTRY_APP_PERMISSIONS} from 'sentry/constants';
 import {t} from 'sentry/locale';
-import {PermissionResource, Permissions, PermissionValue} from 'sentry/types/index';
+import {PermissionResource, Permissions, PermissionValue} from 'sentry/types';
 
 /**
  * Custom form element that presents API scopes in a resource-centric way. Meaning
@@ -88,7 +87,7 @@ type State = {
 };
 
 function findResource(r: PermissionResource) {
-  return find(SENTRY_APP_PERMISSIONS, ['resource', r]);
+  return SENTRY_APP_PERMISSIONS.find(permissions => permissions.resource === r);
 }
 
 /**


### PR DESCRIPTION
Replaces `lodash.find` with `Array.prototype.find` method.

Ref: https://github.com/getsentry/frontend-tsc/issues/55