### PR TITLE
fix(hybridcloud) Don't render HTML for region domains 

### DIFF
--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -84,6 +84,7 @@ class CustomerDomainMiddleware:
         ):
             return self.get_response(request)
         subdomain = request.subdomain
+        # This is where the request is going wrong as we're relying on lastorg from here on.
         if subdomain is None or subdomain_is_region(request):
             return self.get_response(request)
 

--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -84,7 +84,6 @@ class CustomerDomainMiddleware:
         ):
             return self.get_response(request)
         subdomain = request.subdomain
-        # This is where the request is going wrong as we're relying on lastorg from here on.
         if subdomain is None or subdomain_is_region(request):
             return self.get_response(request)
 

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -31,7 +31,7 @@ def absolute_uri(url: str | None = None, url_prefix: str | None = None) -> str:
     return urljoin(url_prefix.rstrip("/") + "/", url.lstrip("/"))
 
 
-def query_string(request: Request) -> str:
+def query_string(request: HttpRequest) -> str:
     qs = request.META.get("QUERY_STRING") or ""
     if qs:
         qs = f"?{qs}"

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import logging
 from fnmatch import fnmatch
 
 import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
 from django.middleware.csrf import get_token as get_csrf_token
 from django.urls import resolve
 from rest_framework.request import Request
@@ -12,6 +14,8 @@ from rest_framework.request import Request
 from sentry import features, options
 from sentry.api.utils import customer_domain_path, generate_organization_url
 from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.services.hybrid_cloud.user.model import RpcUser
+from sentry.types.region import subdomain_is_region
 from sentry.utils.http import is_using_customer_domain, query_string
 from sentry.web.frontend.base import BaseView, ControlSiloOrganizationView
 from sentry.web.helpers import render_to_response
@@ -27,7 +31,7 @@ NON_CUSTOMER_DOMAIN_URL_NAMES = [
 ]
 
 
-def resolve_redirect_url(request, org_slug, user_id=None):
+def resolve_redirect_url(request: HttpRequest | Request, org_slug: str, user_id=None):
     org_context = organization_service.get_organization_by_slug(
         slug=org_slug, only_visible=False, user_id=user_id
     )
@@ -37,6 +41,19 @@ def resolve_redirect_url(request, org_slug, user_id=None):
         qs = query_string(request)
         return f"{url_base}{path}{qs}"
     return None
+
+
+def resolve_activeorg_redirect_url(request: HttpRequest | Request) -> str | None:
+    user: AnonymousUser | RpcUser | None = getattr(request, "user", None)
+    if not user or isinstance(user, AnonymousUser):
+        return
+    session = request.session
+    if not session:
+        return
+    last_active_org = session.get("activeorg", None)
+    if not last_active_org:
+        return
+    return resolve_redirect_url(request=request, org_slug=last_active_org, user_id=user.id)
 
 
 class ReactMixin:
@@ -79,6 +96,21 @@ class ReactMixin:
             )
             return HttpResponseRedirect(redirect_url)
 
+        # We don't allow HTML pages to be served from region domains.
+        if request.subdomain and subdomain_is_region(request):
+            redirect_url = resolve_activeorg_redirect_url(request)
+            if redirect_url:
+                logger.info(
+                    "react_page.redirect.regiondomain",
+                    extra={"path": request.path, "location": redirect_url},
+                )
+                return HttpResponseRedirect(redirect_url)
+            else:
+                raise Http404()
+
+        # If a request doesn't have a subdomain, but is expected to be
+        # on a customer domain, and the route parameters include an organization slug
+        # redirect to that organization domain.
         if request.subdomain is None and not url_is_non_customer_domain:
             matched_url = resolve(request.path)
             if "organization_slug" in matched_url.kwargs:
@@ -93,20 +125,13 @@ class ReactMixin:
                     )
                     return HttpResponseRedirect(redirect_url)
             else:
-                user = getattr(request, "user", None) or None
-                if user is not None and not isinstance(user, AnonymousUser):
-                    session = getattr(request, "session", None)
-                    last_active_org = (session.get("activeorg", None) or None) if session else None
-                    if last_active_org:
-                        redirect_url = resolve_redirect_url(
-                            request=request, org_slug=last_active_org, user_id=user.id
-                        )
-                        if redirect_url:
-                            logger.info(
-                                "react_page.redirect.activeorg",
-                                extra={"path": request.path, "location": redirect_url},
-                            )
-                            return HttpResponseRedirect(redirect_url)
+                redirect_url = resolve_activeorg_redirect_url(request)
+                if redirect_url:
+                    logger.info(
+                        "react_page.redirect.activeorg",
+                        extra={"path": request.path, "location": redirect_url},
+                    )
+                    return HttpResponseRedirect(redirect_url)
 
         response = render_to_response("sentry/base-react.html", context=context, request=request)
 


### PR DESCRIPTION
Accessing region domains directly shouldn't render an HTML page. Instead it should redirect to the customers' lastactive org or render a 404.

In the future, HTML pages will only come from Control silo instances.

Fixes HC-960