### PR TITLE
ref(slack): Log payload to debug message failures

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -110,7 +110,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 }
                 if features.has("organizations:slack-block-kit", event.group.project.organization):
                     # temporarily log the payload so we can debug message failures
-                    log_params["payload"] = payload
+                    log_params["payload"] = json.dumps(payload)
 
                 self.logger.info(
                     "rule.fail.slack_post",


### PR DESCRIPTION
We turned on the block kit flag yesterday and notifications were sending properly to my test organization, but failing to send in the Sentry organization (see logs [here](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Alabels.name%3D~%22sentry%22%0AjsonPayload.event%20%3D%20%22rule.fail.slack_post%22%0AjsonPayload.project_id%3D%221%22;summaryFields=:true:32:beginning;cursorTimestamp=2024-01-11T16:07:25.184081113Z;resultsSearch=invalid;startTime=2024-01-10T18:57:01.602Z;endTime=2024-01-12T01:57:01.602Z?project=internal-sentry&pli=1&rapt=AEjHL4MipYw8eZEfuNZmKz0i3ElJJ7TO9sdS0pOkVPH2UY65REszc6vaqDo-YhBXB5jIg_e2n-rELBu2rwzI9JK1mEXxJHT5OEgl4ENJ4IWPsO2jgn46l7k)). We need to know what the payload looks like to be able to debug, so we'll briefly flip the flag back on to collect data, then turn it back off and figure out what's wrong. 