### PR TITLE
fix(group-attributes): Fix post save syncing for group attributes

### DIFF
--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -49,7 +49,12 @@ def update(instance: Model, using: str | None = None, **kwargs: Any) -> int:
     for k, v in kwargs.items():
         setattr(instance, k, _handle_value(instance, v))
     if affected == 1:
-        post_save.send(sender=instance.__class__, instance=instance, created=False)
+        post_save.send(
+            sender=instance.__class__,
+            instance=instance,
+            created=False,
+            update_fields=list(kwargs.keys()),
+        )
         return affected
     elif affected == 0:
         return affected

--- a/src/sentry/issues/attributes.py
+++ b/src/sentry/issues/attributes.py
@@ -200,18 +200,21 @@ def post_save_log_group_attributes_changed(instance, sender, created, *args, **k
             _log_group_attributes_changed(Operation.CREATED, "group", None)
             send_snapshot_values(None, instance, False)
         else:
-            if "update_fields" in kwargs:
-                update_fields = kwargs["update_fields"]
+            update_fields = kwargs.get("update_fields", set())
+            if not update_fields:
                 # we have no guarantees update_fields is used everywhere save() is called
                 # we'll need to assume any of the attributes are updated in that case
+                attributes_updated = {"all"}
+            else:
                 attributes_updated = {"status", "substatus", "num_comments"}.intersection(
                     update_fields or ()
                 )
-                if attributes_updated:
-                    _log_group_attributes_changed(
-                        Operation.UPDATED, "group", "-".join(sorted(attributes_updated))
-                    )
-                    send_snapshot_values(None, instance, False)
+            if attributes_updated:
+                _log_group_attributes_changed(
+                    Operation.UPDATED, "group", "-".join(sorted(attributes_updated))
+                )
+                send_snapshot_values(None, instance, False)
+
     except Exception:
         logger.exception("failed to log group attributes after group post_save")
 


### PR DESCRIPTION
Currently, we only sync group attributes when `update_fields` is explicitly passed to `.save()`. It makes sense to filter on this when available, but if not passed we have to assume that the fields we care about might have been updated, otherwise we can get out of sync. This will help make sure that we keep `Group` in postgres in sync with the group attributes table in snuba.
