### PR TITLE
fix(superuser): Skip superuser sso and password validation locally

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -141,7 +141,8 @@ class AuthIndexEndpoint(BaseAuthIndexEndpoint):
         SSO and if they do not, we redirect them back to the SSO login.
 
         """
-        validator.is_valid(raise_exception=True)
+        # Disable exception for missing password or u2f code if we're running locally
+        validator.is_valid(raise_exception=not DISABLE_SSO_CHECK_FOR_LOCAL_DEV)
 
         authenticated = (
             self._verify_user_via_inputs(validator, request)


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/63047, I changed it to return 400 on missing password/U2F, but this check needs to be skipped for local devserver.

Also ref tests to use a fixture to override a feature flag