### PR TITLE
fix(spans): remove lodash/map usages

### DIFF
--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
-import map from 'lodash/map';
 import omit from 'lodash/omit';
 
 import {Alert} from 'sentry/components/alert';
@@ -536,7 +535,7 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
                   header. You may have to enable this collection manually.
                 </TextTr>
               )}
-              {map(sizeKeys, (value, key) => (
+              {Object.entries(sizeKeys).map(([key, value]) => (
                 <Row title={key} key={key}>
                   <Fragment>
                     <FileSize bytes={value} />
@@ -544,7 +543,7 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
                   </Fragment>
                 </Row>
               ))}
-              {map(nonSizeKeys, (value, key) =>
+              {Object.entries(nonSizeKeys).map(([key, value]) =>
                 !isHiddenDataKey(key) ? (
                   <Row title={key} key={key}>
                     {maybeStringify(value)}

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
-import map from 'lodash/map';
 import omit from 'lodash/omit';
 
 import {Alert} from 'sentry/components/alert';
@@ -559,7 +558,7 @@ function SpanDetail(props: Props) {
                   header. You may have to enable this collection manually.
                 </TextTr>
               )}
-              {map(sizeKeys, (value, key) => (
+              {Object.entries(sizeKeys).map(([key, value]) => (
                 <Row title={key} key={key}>
                   <Fragment>
                     <FileSize bytes={value} />
@@ -567,7 +566,7 @@ function SpanDetail(props: Props) {
                   </Fragment>
                 </Row>
               ))}
-              {map(nonSizeKeys, (value, key) =>
+              {Object.entries(nonSizeKeys).map(([key, value]) =>
                 !isHiddenDataKey(key) ? (
                   <Row title={key} key={key}>
                     {maybeStringify(value)}


### PR DESCRIPTION
Replaces `lodash/map` with `Object.entries(val).map()`

Ref: https://github.com/getsentry/frontend-tsc/issues/55