### PR TITLE
fix: remove lodash/first usages

### DIFF
--- a/static/app/components/stories/matrix.tsx
+++ b/static/app/components/stories/matrix.tsx
@@ -1,6 +1,5 @@
 import {type ElementType, isValidElement} from 'react';
 import styled from '@emotion/styled';
-import first from 'lodash/first';
 
 import JSXProperty from 'sentry/components/stories/jsxProperty';
 import SizingWindow, {
@@ -29,7 +28,7 @@ export default function Matrix<P extends RenderProps>({
 }: Props<P>) {
   const defaultValues = Object.fromEntries(
     Object.entries(propMatrix).map(([key, values]) => {
-      return [key, first(values as any)];
+      return [key, (values as any[]).at(0)];
     })
   );
 

--- a/static/app/utils/api/useAggregatedQueryKeys.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.tsx
@@ -1,5 +1,4 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import first from 'lodash/first';
 import uniq from 'lodash/uniq';
 
 import {ApiResult} from 'sentry/api';
@@ -81,7 +80,7 @@ export default function useAggregatedQueryKeys<AggregatableQueryKey, Data>({
   const queryClient = useQueryClient();
   const cache = queryClient.getQueryCache();
 
-  const key = first(getQueryKey([]));
+  const key = getQueryKey([]).at(0);
 
   // The query keys that this instance cares about
   const prevQueryKeys = useRef<AggregatableQueryKey[]>([]);


### PR DESCRIPTION
Replaces `lodash/first` with `Array.prototype.at(0)`

Ref: https://github.com/getsentry/frontend-tsc/issues/55