### PR TITLE
fix: remove lodash/isNil usages

### DIFF
--- a/static/app/actionCreators/group.tsx
+++ b/static/app/actionCreators/group.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/react';
-import isNil from 'lodash/isNil';
 
 import {Tag} from 'sentry/actionCreators/events';
 import {Client, RequestCallbacks, RequestOptions} from 'sentry/api';
@@ -242,7 +241,7 @@ export function paramsToQueryArgs(params: ParamsType): QueryArgs {
     : {}; // all items
 
   // only include environment if it is not null/undefined
-  if (params.query && !isNil(params.environment)) {
+  if (params.query && params.environment !== null && params.environment !== undefined) {
     p.environment = params.environment;
   }
 
@@ -254,7 +253,7 @@ export function paramsToQueryArgs(params: ParamsType): QueryArgs {
   // only include date filters if they are not null/undefined
   if (params.query) {
     ['start', 'end', 'period', 'utc'].forEach(prop => {
-      if (!isNil(params[prop])) {
+      if (params[prop] !== null && params[prop] !== undefined) {
         p[prop === 'period' ? 'statsPeriod' : prop] = params[prop];
       }
     });

--- a/static/app/components/events/interfaces/analyzeFrames.tsx
+++ b/static/app/components/events/interfaces/analyzeFrames.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import isNil from 'lodash/isNil';
 
 import {
   getMappedThreadState,
@@ -150,7 +149,7 @@ const CULPRIT_FRAMES: SuspectFrame[] = [
 ];
 
 function satisfiesModuleCondition(frame: Frame, suspect: SuspectFrame) {
-  if (isNil(suspect.module)) {
+  if (suspect.module === null || suspect.module === undefined) {
     return true;
   }
   const matchFuction = suspect.module;
@@ -160,10 +159,14 @@ function satisfiesModuleCondition(frame: Frame, suspect: SuspectFrame) {
 }
 
 function satisfiesFunctionCondition(frame: Frame, suspect: SuspectFrame) {
-  if (isNil(suspect.functions) || suspect.functions.length === 0) {
+  if (
+    suspect.functions === undefined ||
+    suspect.functions === null ||
+    suspect.functions.length === 0
+  ) {
     return true;
   }
-  if (isNil(frame.function)) {
+  if (frame.function === null || frame.function === undefined) {
     return false;
   }
   for (let index = 0; index < suspect.functions.length; index++) {
@@ -183,12 +186,12 @@ function satisfiesOffendingThreadCondition(
   threadState: string | undefined | null,
   offendingThreadStates?: ThreadStates[]
 ) {
-  if (isNil(offendingThreadStates) || offendingThreadStates.length === 0) {
+  if (offendingThreadStates === undefined || offendingThreadStates.length === 0) {
     return true;
   }
   const mappedState = getMappedThreadState(threadState);
 
-  if (isNil(mappedState)) {
+  if (mappedState === undefined) {
     return false;
   }
   return offendingThreadStates.includes(mappedState);
@@ -201,13 +204,13 @@ export function analyzeFramesForRootCause(event: Event): {
   const exception = event.entries.find(entry => entry.type === EntryType.EXCEPTION) as
     | EntryException
     | undefined;
-  if (isNil(exception)) {
+  if (exception === undefined) {
     return null;
   }
 
   const exceptionFrames = exception.data.values?.[0]?.stacktrace?.frames;
 
-  if (isNil(exceptionFrames)) {
+  if (exceptionFrames === undefined) {
     return null;
   }
 

--- a/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
@@ -1,7 +1,6 @@
 import {css, Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import forOwn from 'lodash/forOwn';
-import isNil from 'lodash/isNil';
 
 import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import {Hovercard} from 'sentry/components/hovercard';
@@ -58,7 +57,7 @@ export function Mechanism({data: mechanism, meta: mechanismMeta}: Props) {
     </Pill>,
   ];
 
-  if (!isNil(handled)) {
+  if (handled !== null && handled !== undefined) {
     pills.push(<Pill key="handled" name="handled" value={handled} />);
   }
 
@@ -79,7 +78,8 @@ export function Mechanism({data: mechanism, meta: mechanismMeta}: Props) {
   if (signal) {
     const code = signal.code_name || `${t('code')} ${signal.code}`;
     const name = signal.name || signal.number;
-    const value = isNil(signal.code) ? name : `${name} (${code})`;
+    const value =
+      signal.code === null || signal.code === undefined ? name : `${name} (${code})`;
     pills.push(<Pill key="signal" name="signal" value={value} />);
   }
 

--- a/static/app/components/events/interfaces/performance/anrRootCause.tsx
+++ b/static/app/components/events/interfaces/performance/anrRootCause.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useContext, useEffect} from 'react';
 import styled from '@emotion/styled';
-import isNil from 'lodash/isNil';
 
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {analyzeFramesForRootCause} from 'sentry/components/events/interfaces/analyzeFrames';
@@ -36,7 +35,7 @@ export function AnrRootCause({event, organization}: Props) {
   const anrCulprit = analyzeFramesForRootCause(event);
 
   useEffect(() => {
-    if (isNil(anrCulprit?.culprit)) {
+    if (!anrCulprit || anrCulprit.culprit === null || anrCulprit.culprit === undefined) {
       return;
     }
 
@@ -45,7 +44,7 @@ export function AnrRootCause({event, organization}: Props) {
       group: event?.groupID,
       culprit: typeof anrCulprit?.culprit === 'string' ? anrCulprit?.culprit : 'lock',
     });
-  }, [anrCulprit?.culprit, organization, event?.groupID]);
+  }, [anrCulprit, organization, event?.groupID]);
 
   const noPerfIssueOnTrace =
     !quickTrace ||
@@ -64,7 +63,7 @@ export function AnrRootCause({event, organization}: Props) {
   );
 
   const helpText =
-    isNil(potentialAnrRootCause) || potentialAnrRootCause.length === 0
+    !potentialAnrRootCause || potentialAnrRootCause.length === 0
       ? t(
           'Suspect Root Cause identifies common patterns that may be contributing to this ANR'
         )

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
-import isNil from 'lodash/isNil';
 
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {getLockReason} from 'sentry/components/events/interfaces/threads/threadSelector/lockReason';
@@ -65,7 +64,7 @@ function getIntendedStackView(
 }
 
 export function getThreadStateIcon(state: ThreadStates | undefined) {
-  if (isNil(state)) {
+  if (state === null || state === undefined) {
     return null;
   }
   switch (state) {
@@ -137,7 +136,7 @@ export function Threads({
       heldLocks,
     } = activeThread ?? {};
 
-    if (isNil(id) || !name) {
+    if (id === null || id === undefined || !name) {
       return null;
     }
 
@@ -146,7 +145,7 @@ export function Threads({
 
     return (
       <Pills>
-        {!isNil(id) && <Pill name={t('id')} value={String(id)} />}
+        <Pill name={t('id')} value={id} />
         {!!name?.trim() && <Pill name={t('name')} value={name} />}
         {current !== undefined && <Pill name={t('was active')} value={current} />}
         {crashed !== undefined && (
@@ -154,7 +153,7 @@ export function Threads({
             {crashed ? t('yes') : t('no')}
           </Pill>
         )}
-        {!isNil(threadStateDisplay) && (
+        {threadStateDisplay !== undefined && (
           <Pill name={t('state')} value={threadStateDisplay} />
         )}
         {defined(lockReason) && <Pill name={t('lock reason')} value={lockReason} />}
@@ -232,7 +231,7 @@ export function Threads({
   const threadStateDisplay = getMappedThreadState(activeThread?.state);
 
   const {id: activeThreadId, name: activeThreadName} = activeThread ?? {};
-  const hideThreadTags = isNil(activeThreadId) || !activeThreadName;
+  const hideThreadTags = activeThreadId === undefined || !activeThreadName;
 
   return (
     <Fragment>

--- a/static/app/components/events/interfaces/threads/threadSelector/selectedOption.tsx
+++ b/static/app/components/events/interfaces/threads/threadSelector/selectedOption.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import isNil from 'lodash/isNil';
 
 import {ThreadStates} from 'sentry/components/events/interfaces/threads/threadSelector/threadStates';
 import TextOverflow from 'sentry/components/textOverflow';
@@ -19,7 +18,7 @@ type ThreadInfo = {
 };
 
 function getThreadLabel(details: ThreadInfo, name?: string | null) {
-  if (!isNil(name) && name) {
+  if (name?.length) {
     return name;
   }
   return details?.label || `<${t('unknown')}>`;

--- a/static/app/views/issueList/utils/useSelectedSavedSearch.tsx
+++ b/static/app/views/issueList/utils/useSelectedSavedSearch.tsx
@@ -1,5 +1,4 @@
 import {useMemo} from 'react';
-import isNil from 'lodash/isNil';
 
 import {t} from 'sentry/locale';
 import {SavedSearch} from 'sentry/types';
@@ -27,7 +26,8 @@ export const useSelectedSavedSearch = (): SavedSearch | null => {
   // If there's no direct saved search being requested (via URL route)
   // *AND* there's no query in URL, then check if there is pinned search
   const selectedSavedSearch =
-    !selectedSearchId && isNil(location.query.query)
+    !selectedSearchId &&
+    (location.query.query === null || location.query.query === undefined)
       ? savedSearches?.find(search => search.isPinned)
       : savedSearches?.find(({id}) => id === selectedSearchId);
 


### PR DESCRIPTION
Removes `lodash.isNil` and replaces is with `val === null && val === undefined` because Sentry Eslint configuration does not allow `val == null` checks. More discussion on this is available at https://github.com/getsentry/eslint-config-sentry/pull/193

Ref: https://github.com/getsentry/frontend-tsc/issues/55