### PR TITLE
feat(profiling): use the profiling.flamegraph.profile-set.size option to set query limit

### DIFF
--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional
 
 from snuba_sdk import Column, Condition, Entity, Function, Limit, Op, Query, Request
 
+from sentry import options
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.types import ParamsType
 from sentry.snuba import functions
@@ -23,7 +24,7 @@ def query_profiles_data(
         params=params,
         query=query,
         selected_columns=selected_columns,
-        limit=200,
+        limit=int(options.get("profiling.flamegraph.profile-set.size")),
     )
 
     builder.add_conditions(

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -24,7 +24,7 @@ def query_profiles_data(
         params=params,
         query=query,
         selected_columns=selected_columns,
-        limit=int(options.get("profiling.flamegraph.profile-set.size")),
+        limit=options.get("profiling.flamegraph.profile-set.size"),
     )
 
     builder.add_conditions(


### PR DESCRIPTION
Use the profiling.flamegraph.profile-set.size option to set the max number of profiles fetched for the flamegraph aggregation instead of hardcoding the value in the code

