### PR TITLE
ref(ddm): Disable DDM via env var

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3989,6 +3989,9 @@ REGION_PINNED_URL_NAMES = {
 EVENT_PROCESSING_STORE = "rc_processing_redis"
 COGS_EVENT_STORE_LABEL = "bigtable_nodestore"
 
+# Disable DDM entirely
+SENTRY_DDM_DISABLE = os.getenv("SENTRY_DDM_DISABLE", "0") in ("1", "true", "True")
+
 # Devserver configuration overrides.
 ngrok_host = os.environ.get("SENTRY_DEVSERVER_NGROK")
 if ngrok_host and SILO_MODE != "REGION":

--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -1,7 +1,6 @@
-import os
 from typing import Any, Dict, Optional, Type, Union
 
-from sentry import options
+from sentry import options, settings
 from sentry.metrics.base import MetricsBackend, Tags
 from sentry.metrics.dummy import DummyMetricsBackend
 from sentry.metrics.minimetrics import MiniMetricsMetricsBackend
@@ -9,9 +8,6 @@ from sentry.options import UnknownOption
 from sentry.utils.imports import import_string
 
 __all__ = ["CompositeExperimentalMetricsBackend"]
-
-
-DISABLED = os.getenv("SENTRY_DDM_DISABLE", "0") in ("1", "true", "True")
 
 
 class CompositeExperimentalMetricsBackend(MetricsBackend):
@@ -35,7 +31,7 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         self._minimetrics: MiniMetricsMetricsBackend = MiniMetricsMetricsBackend()
 
     def _is_denied(self, key: str) -> bool:
-        return DISABLED or key.startswith(self._deny_prefixes)
+        return settings.SENTRY_DDM_DISABLE or key.startswith(self._deny_prefixes)
 
     @staticmethod
     def _minimetrics_sample_rate() -> float:

--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict, Optional, Type, Union
 
 from sentry import options
@@ -8,6 +9,9 @@ from sentry.options import UnknownOption
 from sentry.utils.imports import import_string
 
 __all__ = ["CompositeExperimentalMetricsBackend"]
+
+
+DISABLED = os.getenv("SENTRY_DDM_DISABLE", "0") in ("1", "true", "True")
 
 
 class CompositeExperimentalMetricsBackend(MetricsBackend):
@@ -31,7 +35,7 @@ class CompositeExperimentalMetricsBackend(MetricsBackend):
         self._minimetrics: MiniMetricsMetricsBackend = MiniMetricsMetricsBackend()
 
     def _is_denied(self, key: str) -> bool:
-        return key.startswith(self._deny_prefixes)
+        return DISABLED or key.startswith(self._deny_prefixes)
 
     @staticmethod
     def _minimetrics_sample_rate() -> float:

--- a/src/sentry/metrics/composite_experimental.py
+++ b/src/sentry/metrics/composite_experimental.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, Optional, Type, Union
 
-from sentry import options, settings
+from django.conf import settings
+
+from sentry import options
 from sentry.metrics.base import MetricsBackend, Tags
 from sentry.metrics.dummy import DummyMetricsBackend
 from sentry.metrics.minimetrics import MiniMetricsMetricsBackend


### PR DESCRIPTION
Adds an environment variable `SENTRY_DDM_DISABLE`, which disables DDM for the
entire process when set to `1` or `true`. This can be used for the Sentry
indexer consumer which emits metrics in such high volume that the process cannot
keep up.

