### PR TITLE
chore(ddm): remove addWidgets functionality

### DIFF
--- a/static/app/views/ddm/context.tsx
+++ b/static/app/views/ddm/context.tsx
@@ -30,7 +30,6 @@ import {useStructuralSharing} from 'sentry/views/ddm/useStructuralSharing';
 interface DDMContextValue {
   addFocusArea: (area: FocusArea) => void;
   addWidget: () => void;
-  addWidgets: (widgets: Partial<MetricWidgetQueryParams>[]) => void;
   duplicateWidget: (index: number) => void;
   focusArea: FocusArea | null;
   isDefaultQuery: boolean;
@@ -48,7 +47,6 @@ interface DDMContextValue {
 export const DDMContext = createContext<DDMContextValue>({
   addFocusArea: () => {},
   addWidget: () => {},
-  addWidgets: () => {},
   duplicateWidget: () => {},
   focusArea: null,
   isDefaultQuery: false,
@@ -136,16 +134,6 @@ export function useMetricWidgets() {
     setWidgets(currentWidgets => [...currentWidgets, emptyWidget]);
   }, [setWidgets]);
 
-  const addWidgets = useCallback(
-    (newWidgets: Partial<MetricWidgetQueryParams>[]) => {
-      const widgetsCopy = [...widgets].filter(widget => !!widget.mri);
-      widgetsCopy.push(...newWidgets.map(widget => ({...emptyWidget, ...widget})));
-
-      setWidgets(widgetsCopy);
-    },
-    [widgets, setWidgets]
-  );
-
   const removeWidget = useCallback(
     (index: number) => {
       setWidgets(currentWidgets => {
@@ -172,7 +160,7 @@ export function useMetricWidgets() {
     widgets,
     updateWidget,
     addWidget,
-    addWidgets,
+
     removeWidget,
     duplicateWidget,
   };
@@ -210,7 +198,7 @@ export function DDMContextProvider({children}: {children: React.ReactNode}) {
   const {setDefaultQuery, isDefaultQuery} = useDefaultQuery();
 
   const [selectedWidgetIndex, setSelectedWidgetIndex] = useState(0);
-  const {widgets, updateWidget, addWidget, addWidgets, removeWidget, duplicateWidget} =
+  const {widgets, updateWidget, addWidget, removeWidget, duplicateWidget} =
     useMetricWidgets();
   const [focusArea, setFocusArea] = useState<FocusArea | null>(null);
 
@@ -282,7 +270,6 @@ export function DDMContextProvider({children}: {children: React.ReactNode}) {
   const contextValue = useMemo<DDMContextValue>(
     () => ({
       addWidget: handleAddWidget,
-      addWidgets,
       selectedWidgetIndex:
         selectedWidgetIndex > widgets.length - 1 ? 0 : selectedWidgetIndex,
       setSelectedWidgetIndex,
@@ -300,7 +287,6 @@ export function DDMContextProvider({children}: {children: React.ReactNode}) {
     }),
     [
       handleAddWidget,
-      addWidgets,
       selectedWidgetIndex,
       widgets,
       handleUpdateWidget,

--- a/static/app/views/ddm/dashboardImportModal.tsx
+++ b/static/app/views/ddm/dashboardImportModal.tsx
@@ -43,7 +43,7 @@ type FormState = {
 };
 
 function DashboardImportModal({Header, Body, Footer}: ModalRenderProps) {
-  const {metricsMeta, addWidgets} = useDDMContext();
+  const {metricsMeta} = useDDMContext();
   const [formState, setFormState] = useState<FormState>({
     step: 'initial',
     dashboard: '',
@@ -65,12 +65,6 @@ function DashboardImportModal({Header, Body, Footer}: ModalRenderProps) {
       }));
     }
   }, [formState.isValid, formState.dashboard, metricsMeta]);
-
-  const handleSetWidgets = useCallback(() => {
-    if (formState.importResult) {
-      addWidgets(formState.importResult.widgets);
-    }
-  }, [addWidgets, formState.importResult]);
 
   return (
     <Fragment>
@@ -133,9 +127,7 @@ function DashboardImportModal({Header, Body, Footer}: ModalRenderProps) {
           <Button
             priority="primary"
             disabled={!formState.isValid}
-            onClick={
-              formState.step === 'initial' ? handleImportDashboard : handleSetWidgets
-            }
+            onClick={handleImportDashboard}
           >
             {formState.step === 'initial' ? t('Import') : t('Add Widgets')}
           </Button>


### PR DESCRIPTION
Since Import Dashboard functionality will be moved to dashboards in #62820 the `addWidgets` function is not needed anymore in `DDMContext`