### PR TITLE
feat(ds): Only show Get Samples if org is dynamically sampled

### DIFF
--- a/static/app/components/dynamicSampling/investigationRule.tsx
+++ b/static/app/components/dynamicSampling/investigationRule.tsx
@@ -300,6 +300,11 @@ function InvestigationRuleCreationInternal(props: PropsInternal) {
 
 export function InvestigationRuleCreation(props: Props) {
   const organization = useOrganization();
+
+  if (!organization.isDynamicallySampled) {
+    return null;
+  }
+
   return (
     <Feature features="investigation-bias">
       <InvestigationRuleCreationInternal {...props} organization={organization} />


### PR DESCRIPTION
To avoid confusion, we want to show the investigation bias button only if the org is dynamically sampled.