### PR TITLE
fix(database): Improve spacing and layout at small screen sizes

### DIFF
--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -213,8 +213,13 @@ const PaddedContainer = styled('div')`
 
 const ChartContainer = styled('div')`
   display: grid;
-  gap: ${space(2)};
-  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  grid-template-columns: 1fr;
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    grid-template-columns: 1fr 1fr;
+    gap: ${space(2)};
+  }
 `;
 
 function AlertBanner(props) {

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -217,7 +217,6 @@ const PaddedContainer = styled('div')`
 
 const ChartContainer = styled('div')`
   display: grid;
-  gap: 0;
   grid-template-columns: 1fr;
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -180,9 +180,13 @@ export function DatabaseLandingPage() {
               </ChartContainer>
 
               <FilterOptionsContainer>
-                <ActionSelector moduleName={moduleName} value={spanAction ?? ''} />
+                <SelectorContainer>
+                  <ActionSelector moduleName={moduleName} value={spanAction ?? ''} />
+                </SelectorContainer>
 
-                <DomainSelector moduleName={moduleName} value={spanDomain ?? ''} />
+                <SelectorContainer>
+                  <DomainSelector moduleName={moduleName} value={spanDomain ?? ''} />
+                </SelectorContainer>
               </FilterOptionsContainer>
 
               <SearchBarContainer>
@@ -227,11 +231,22 @@ function AlertBanner(props) {
 }
 
 const FilterOptionsContainer = styled('div')`
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  display: flex;
+  flex-wrap: wrap;
   gap: ${space(2)};
   margin-bottom: ${space(2)};
-  max-width: 800px;
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    flex-wrap: nowrap;
+  }
+`;
+
+const SelectorContainer = styled('div')`
+  flex-basis: 100%;
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    flex-basis: auto;
+  }
 `;
 
 const SearchBarContainer = styled('div')`

--- a/static/app/views/performance/database/databaseLandingPage.tsx
+++ b/static/app/views/performance/database/databaseLandingPage.tsx
@@ -151,7 +151,9 @@ export function DatabaseLandingPage() {
               isDataAvailable={isAnyCriticalDataAvailable}
             />
           )}
+
           <FloatingFeedbackWidget />
+
           <PaddedContainer>
             <PageFilterBar condensed>
               <ProjectPageFilter />
@@ -170,16 +172,19 @@ export function DatabaseLandingPage() {
                   series={throughputData['spm()']}
                   isLoading={isThroughputDataLoading}
                 />
+
                 <DurationChart
                   series={durationData[`${selectedAggregate}(span.self_time)`]}
                   isLoading={isDurationDataLoading}
                 />
               </ChartContainer>
+
               <FilterOptionsContainer>
                 <ActionSelector moduleName={moduleName} value={spanAction ?? ''} />
 
                 <DomainSelector moduleName={moduleName} value={spanDomain ?? ''} />
               </FilterOptionsContainer>
+
               <SearchBarContainer>
                 <SearchBar
                   query={spanDescription}

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -142,8 +142,9 @@ function SpanSummaryPage({params}: Props) {
       </Layout.Header>
 
       <Layout.Body>
-        <FloatingFeedbackWidget />
         <Layout.Main fullWidth>
+          <FloatingFeedbackWidget />
+
           <HeaderContainer>
             <PaddedContainer>
               <PageFilterBar condensed>
@@ -169,6 +170,7 @@ function SpanSummaryPage({params}: Props) {
               series={throughputData['spm()']}
               isLoading={isThroughputDataLoading}
             />
+
             <DurationChart
               series={
                 durationData[`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`]

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -210,8 +210,13 @@ const PaddedContainer = styled('div')`
 
 const ChartContainer = styled('div')`
   display: grid;
-  gap: ${space(2)};
-  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  grid-template-columns: 1fr;
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    grid-template-columns: 1fr 1fr;
+    gap: ${space(2)};
+  }
 `;
 
 const HeaderContainer = styled('div')`

--- a/static/app/views/performance/database/databaseSpanSummaryPage.tsx
+++ b/static/app/views/performance/database/databaseSpanSummaryPage.tsx
@@ -29,7 +29,6 @@ import {
 } from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {useModuleSort} from 'sentry/views/starfish/views/spans/useModuleSort';
-import {Block, BlockContainer} from 'sentry/views/starfish/views/spanSummaryPage/block';
 import {SampleList} from 'sentry/views/starfish/views/spanSummaryPage/sampleList';
 import {SpanMetricsRibbon} from 'sentry/views/starfish/views/spanSummaryPage/spanMetricsRibbon';
 import {SpanTransactionsTable} from 'sentry/views/starfish/views/spanSummaryPage/spanTransactionsTable';
@@ -165,23 +164,18 @@ function SpanSummaryPage({params}: Props) {
             </DescriptionContainer>
           )}
 
-          <BlockContainer>
-            <Block>
-              <ThroughputChart
-                series={throughputData['spm()']}
-                isLoading={isThroughputDataLoading}
-              />
-            </Block>
-
-            <Block>
-              <DurationChart
-                series={
-                  durationData[`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`]
-                }
-                isLoading={isDurationDataLoading}
-              />
-            </Block>
-          </BlockContainer>
+          <ChartContainer>
+            <ThroughputChart
+              series={throughputData['spm()']}
+              isLoading={isThroughputDataLoading}
+            />
+            <DurationChart
+              series={
+                durationData[`${selectedAggregate}(${SpanMetricsField.SPAN_SELF_TIME})`]
+              }
+              isLoading={isDurationDataLoading}
+            />
+          </ChartContainer>
 
           {span && (
             <SpanTransactionsTable
@@ -210,6 +204,12 @@ const DEFAULT_SORT: Sort = {
 
 const PaddedContainer = styled('div')`
   margin-bottom: ${space(2)};
+`;
+
+const ChartContainer = styled('div')`
+  display: grid;
+  gap: ${space(2)};
+  grid-template-columns: 1fr 1fr;
 `;
 
 const HeaderContainer = styled('div')`

--- a/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
+++ b/static/app/views/starfish/views/spanSummaryPage/spanTransactionsTable.tsx
@@ -11,7 +11,6 @@ import GridEditable, {
 } from 'sentry/components/gridEditable';
 import Link from 'sentry/components/links/link';
 import Pagination, {CursorHandler} from 'sentry/components/pagination';
-import Truncate from 'sentry/components/truncate';
 import {t} from 'sentry/locale';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {Sort} from 'sentry/utils/discover/fields';
@@ -25,6 +24,7 @@ import {
   renderHeadCell,
   SORTABLE_FIELDS,
 } from 'sentry/views/starfish/components/tableCells/renderHeadCell';
+import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 import {
   SpanTransactionMetrics,
   useSpanTransactionMetrics,
@@ -114,17 +114,19 @@ export function SpanTransactionsTable({span, endpoint, endpointMethod, sort}: Pr
       }
 
       return (
-        <Link
-          to={`${pathname}?${qs.stringify(query)}`}
-          onClick={() => {
-            router.replace({
-              pathname,
-              query,
-            });
-          }}
-        >
-          <Truncate value={label} maxLength={75} />
-        </Link>
+        <OverflowEllipsisTextContainer>
+          <Link
+            to={`${pathname}?${qs.stringify(query)}`}
+            onClick={() => {
+              router.replace({
+                pathname,
+                query,
+              });
+            }}
+          >
+            {label}
+          </Link>
+        </OverflowEllipsisTextContainer>
       );
     }
 

--- a/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/actionSelector.tsx
@@ -79,9 +79,17 @@ export function ActionSelector({
           },
         });
       }}
+      styles={{
+        control: provided => ({
+          ...provided,
+          minWidth: MIN_WIDTH,
+        }),
+      }}
     />
   );
 }
+
+const MIN_WIDTH = 230;
 
 const HTTP_ACTION_OPTIONS = [
   {value: '', label: 'All'},

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -153,9 +153,17 @@ export function DomainSelector({
         });
       }}
       noOptionsMessage={() => t('No results')}
+      styles={{
+        control: provided => ({
+          ...provided,
+          minWidth: MIN_WIDTH,
+        }),
+      }}
     />
   );
 }
+
+const MIN_WIDTH = 300;
 
 const LIMIT = 100;
 


### PR DESCRIPTION
A grab-bag of fixes to the layout. Highlights:

- spacing between elements is now the same on the Queries page and the Query Summary page
- chart widgets take up the entire width of the screen on small screens
- domain/action selectors take full width at small sizes
- better truncation for transaction names

I didn't bother with fixing the metrics ribbon and the samples panel yet, but I will soon!

<img width="491" alt="Screenshot 2024-01-15 at 2 43 24 PM" src="https://github.com/getsentry/sentry/assets/989898/92ad87a6-0aee-446f-875a-3b2be00b8ba5">