### PR TITLE
tests(metrics_extraction): Change default value for OnDemandMetricSpec

### DIFF
--- a/src/sentry/snuba/metrics/extraction.py
+++ b/src/sentry/snuba/metrics/extraction.py
@@ -1042,7 +1042,7 @@ class OnDemandMetricSpec:
         environment: Optional[str] = None,
         groupbys: Optional[Sequence[str]] = None,
         spec_type: MetricSpecType = MetricSpecType.SIMPLE_QUERY,
-        use_updated_env_logic: bool = True,
+        use_updated_env_logic: bool = False,
     ):
         self.field = field
         self.query = query

--- a/tests/sentry/snuba/test_extraction.py
+++ b/tests/sentry/snuba/test_extraction.py
@@ -292,10 +292,16 @@ def test_spec_context_mapping() -> None:
 
 def test_spec_query_or_precedence_with_environment() -> None:
     spec_1 = OnDemandMetricSpec(
-        "count()", "(transaction.duration:>1s OR http.status_code:200)", "dev"
+        "count()",
+        "(transaction.duration:>1s OR http.status_code:200)",
+        "dev",
+        use_updated_env_logic=True,
     )
     spec_2 = OnDemandMetricSpec(
-        "count()", "transaction.duration:>1s OR http.status_code:200", "dev"
+        "count()",
+        "transaction.duration:>1s OR http.status_code:200",
+        "dev",
+        use_updated_env_logic=True,
     )
 
     assert spec_1._metric_type == "c"
@@ -324,6 +330,7 @@ def test_spec_count_if_query_with_environment() -> None:
         "count_if(transaction.duration,equals,300)",
         "(http.method:GET AND endpoint:/hello)",
         "production",
+        use_updated_env_logic=True,
     )
 
     assert spec._metric_type == "c"
@@ -350,6 +357,7 @@ def test_spec_complex_query_with_environment() -> None:
         "count()",
         "transaction.duration:>1s AND http.status_code:200 OR os.browser:Chrome",
         "staging",
+        use_updated_env_logic=True,
     )
 
     assert spec._metric_type == "c"


### PR DESCRIPTION
When instantiating OnDemandMetricSpec we should not have use_updated_env_logic to be True by default.