### PR TITLE
ref(perf): Harden `useSpanMetricsSeries` data hook

### DIFF
--- a/static/app/views/performance/database/settings.ts
+++ b/static/app/views/performance/database/settings.ts
@@ -8,6 +8,7 @@ import {
   TWENTY_FOUR_HOURS,
   TWO_WEEKS,
 } from 'sentry/components/charts/utils';
+import {Aggregate} from 'sentry/views/starfish/types';
 
 export const MIN_SDK_VERSION_BY_PLATFORM: {[platform: string]: string} = {
   'sentry.python': '1.29.2',
@@ -23,7 +24,7 @@ export const MIN_SDK_VERSION_BY_PLATFORM: {[platform: string]: string} = {
 
 export const DEFAULT_INTERVAL = '10m';
 
-export const DEFAULT_DURATION_AGGREGATE = 'avg';
+export const DEFAULT_DURATION_AGGREGATE: Aggregate = 'avg';
 
 export const CHART_HEIGHT = 160;
 

--- a/static/app/views/performance/database/useAvailableDurationAggregates.tsx
+++ b/static/app/views/performance/database/useAvailableDurationAggregates.tsx
@@ -12,7 +12,9 @@ export function useAvailableDurationAggregates(): Result {
   availableAggregates.push(DEFAULT_DURATION_AGGREGATE);
 
   if (organization.features?.includes('performance-database-view-percentiles')) {
-    availableAggregates.push(...(['p50', 'p75', 'p95', 'p99'] as Aggregate[]));
+    availableAggregates.push(
+      ...['p50' as const, 'p75' as const, 'p95' as const, 'p99' as const]
+    );
   }
 
   return availableAggregates;

--- a/static/app/views/performance/database/useAvailableDurationAggregates.tsx
+++ b/static/app/views/performance/database/useAvailableDurationAggregates.tsx
@@ -12,9 +12,7 @@ export function useAvailableDurationAggregates(): Result {
   availableAggregates.push(DEFAULT_DURATION_AGGREGATE);
 
   if (organization.features?.includes('performance-database-view-percentiles')) {
-    availableAggregates.push(
-      ...['p50' as const, 'p75' as const, 'p95' as const, 'p99' as const]
-    );
+    availableAggregates.push('p50', 'p75', 'p95', 'p99');
   }
 
   return availableAggregates;

--- a/static/app/views/performance/database/useAvailableDurationAggregates.tsx
+++ b/static/app/views/performance/database/useAvailableDurationAggregates.tsx
@@ -1,19 +1,18 @@
 import useOrganization from 'sentry/utils/useOrganization';
 import {DEFAULT_DURATION_AGGREGATE} from 'sentry/views/performance/database/settings';
+import {Aggregate} from 'sentry/views/starfish/types';
 
-// TODO: Type more strictly, these should be limited to only valid aggregate
-// functions
-type Result = string[];
+type Result = Aggregate[];
 
 export function useAvailableDurationAggregates(): Result {
   const organization = useOrganization();
 
-  const availableAggregates: string[] = [];
+  const availableAggregates: Aggregate[] = [];
 
   availableAggregates.push(DEFAULT_DURATION_AGGREGATE);
 
   if (organization.features?.includes('performance-database-view-percentiles')) {
-    availableAggregates.push(...['p50', 'p75', 'p95', 'p99']);
+    availableAggregates.push(...(['p50', 'p75', 'p95', 'p99'] as Aggregate[]));
   }
 
   return availableAggregates;

--- a/static/app/views/performance/database/useSelectedDurationAggregate.tsx
+++ b/static/app/views/performance/database/useSelectedDurationAggregate.tsx
@@ -33,20 +33,26 @@ export function useSelectedDurationAggregate(): Result {
 
   const location = useLocation<Query>();
 
-  let selectedAggregate: Aggregate;
   const aggregateFromURL = decodeScalar(
     location.query.aggregate,
     previouslySelectedAggregate
   );
 
-  // `availableAggregates` is typed `as const` so I have to cast to unknown to allow comparison to string
-  if ((availableAggregates as unknown as string[]).includes(aggregateFromURL)) {
-    selectedAggregate = aggregateFromURL as Aggregate;
-  } else {
-    selectedAggregate = DEFAULT_DURATION_AGGREGATE;
-  }
+  const selectedAggregate = isAnAvailableAggregate(aggregateFromURL, availableAggregates)
+    ? aggregateFromURL
+    : DEFAULT_DURATION_AGGREGATE;
 
   return [selectedAggregate, setSelectedAggregate];
+}
+
+function isAnAvailableAggregate(
+  maybeAggregate: string,
+  availableAggregates: Aggregate[]
+): maybeAggregate is Aggregate {
+  // Manually widen `availableAggregates` to allow the comparison to string
+  return (availableAggregates as unknown as string[]).includes(
+    maybeAggregate as Aggregate
+  );
 }
 
 const KEY = 'performance-database-default-aggregation-function';

--- a/static/app/views/performance/database/useSelectedDurationAggregate.tsx
+++ b/static/app/views/performance/database/useSelectedDurationAggregate.tsx
@@ -5,14 +5,13 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import {DEFAULT_DURATION_AGGREGATE} from 'sentry/views/performance/database/settings';
 import {useAvailableDurationAggregates} from 'sentry/views/performance/database/useAvailableDurationAggregates';
+import {Aggregate} from 'sentry/views/starfish/types';
 
 type Query = {
   aggregate: string;
 };
 
-// TODO: Type more strictly, these should be limited to only valid aggregate
-// functions
-type Result = [string, (string) => void];
+type Result = [Aggregate, (string) => void];
 
 export function useSelectedDurationAggregate(): Result {
   const [previouslySelectedAggregate, setPreviouslySelectedAggregate] =
@@ -34,12 +33,16 @@ export function useSelectedDurationAggregate(): Result {
 
   const location = useLocation<Query>();
 
-  let selectedAggregate = decodeScalar(
+  let selectedAggregate: Aggregate;
+  const aggregateFromURL = decodeScalar(
     location.query.aggregate,
     previouslySelectedAggregate
   );
 
-  if (!availableAggregates.includes(selectedAggregate)) {
+  // `availableAggregates` is typed `as const` so I have to cast to unknown to allow comparison to string
+  if ((availableAggregates as unknown as string[]).includes(aggregateFromURL)) {
+    selectedAggregate = aggregateFromURL as Aggregate;
+  } else {
     selectedAggregate = DEFAULT_DURATION_AGGREGATE;
   }
 

--- a/static/app/views/starfish/queries/useSpanMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.tsx
@@ -60,9 +60,6 @@ function getEventView(
 ) {
   const query = MutableSearch.fromQueryObject(filters);
 
-  // TODO: This condition should be enforced everywhere
-  // query.addFilterValue('has', 'span.description');
-
   const eventView = EventView.fromNewQueryWithLocation(
     {
       name: '',

--- a/static/app/views/starfish/queries/useSpanMetrics.tsx
+++ b/static/app/views/starfish/queries/useSpanMetrics.tsx
@@ -1,10 +1,9 @@
-import {Location} from 'history';
-
+import {PageFilters} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
+import usePageFilters from 'sentry/utils/usePageFilters';
 import {
   MetricsProperty,
   MetricsResponse,
@@ -26,9 +25,9 @@ export const useSpanMetrics = <Fields extends MetricsProperty[]>(
 ) => {
   const {fields = [], filters = {}, sorts = [], limit, cursor, referrer} = options;
 
-  const location = useLocation();
+  const pageFilters = usePageFilters();
 
-  const eventView = getEventView(filters, fields, sorts, location);
+  const eventView = getEventView(filters, fields, sorts, pageFilters.selection);
 
   const enabled = Object.values(filters).every(value => Boolean(value));
 
@@ -56,11 +55,11 @@ function getEventView(
   filters: SpanMetricsQueryFilters = {},
   fields: string[] = [],
   sorts: Sort[] = [],
-  location: Location
+  pageFilters: PageFilters
 ) {
   const query = MutableSearch.fromQueryObject(filters);
 
-  const eventView = EventView.fromNewQueryWithLocation(
+  const eventView = EventView.fromNewQueryWithPageFilters(
     {
       name: '',
       query: query.formatString(),
@@ -68,7 +67,7 @@ function getEventView(
       dataset: DiscoverDatasets.SPANS_METRICS,
       version: 2,
     },
-    location
+    pageFilters
   );
 
   if (sorts.length > 0) {

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.spec.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.spec.tsx
@@ -78,7 +78,7 @@ describe('useSpanMetricsSeries', () => {
             release: '0.0.1',
             'resource.render_blocking_status': 'blocking' as const,
           },
-          yAxis: ['spm()' as const],
+          yAxis: ['spm()'] as MetricsProperty[],
         },
       }
     );

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.spec.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.spec.tsx
@@ -9,6 +9,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {useSpanMetricsSeries} from 'sentry/views/starfish/queries/useSpanMetricsSeries';
+import {MetricsProperty} from 'sentry/views/starfish/types';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
@@ -77,7 +78,7 @@ describe('useSpanMetricsSeries', () => {
             release: '0.0.1',
             'resource.render_blocking_status': 'blocking' as const,
           },
-          yAxis: ['spm()'],
+          yAxis: ['spm()' as const],
         },
       }
     );
@@ -125,7 +126,7 @@ describe('useSpanMetricsSeries', () => {
       {
         wrapper: Wrapper,
         initialProps: {
-          yAxis: ['avg(span.self_time)', 'spm()'],
+          yAxis: ['avg(span.self_time)', 'spm()'] as MetricsProperty[],
         },
       }
     );
@@ -136,13 +137,13 @@ describe('useSpanMetricsSeries', () => {
         method: 'GET',
         query: expect.objectContaining({
           interval: '30m',
-          yAxis: ['avg(span.self_time)', 'spm()'],
+          yAxis: ['avg(span.self_time)', 'spm()'] as MetricsProperty[],
         }),
       })
     );
 
     rerender({
-      yAxis: ['p95(span.self_time)', 'spm()'],
+      yAxis: ['p95(span.self_time)', 'spm()'] as MetricsProperty[],
     });
 
     expect(eventsRequest).toHaveBeenLastCalledWith(
@@ -151,7 +152,7 @@ describe('useSpanMetricsSeries', () => {
         method: 'GET',
         query: expect.objectContaining({
           interval: '1h',
-          yAxis: ['p95(span.self_time)', 'spm()'],
+          yAxis: ['p95(span.self_time)', 'spm()'] as MetricsProperty[],
         }),
       })
     );

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -11,24 +11,23 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {getIntervalForMetricFunction} from 'sentry/views/performance/database/getIntervalForMetricFunction';
 import {DEFAULT_INTERVAL} from 'sentry/views/performance/database/settings';
-import {SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
-import {useSpansQuery} from 'sentry/views/starfish/utils/useSpansQuery';
+import {MetricsProperty, SpanMetricsQueryFilters} from 'sentry/views/starfish/types';
+import {useWrappedDiscoverTimeseriesQuery} from 'sentry/views/starfish/utils/useSpansQuery';
 
-export type SpanMetrics = {
+interface SpanMetricTimeseriesRow {
+  [key: string]: number;
   interval: number;
-  'p95(span.self_time)': number;
-  'spm()': number;
-  'sum(span.self_time)': number;
-  'time_spent_percentage()': number;
-};
-
-interface UseSpanMetricsSeriesOptions {
-  filters?: SpanMetricsQueryFilters;
-  referrer?: string;
-  yAxis?: string[];
 }
 
-export const useSpanMetricsSeries = (options: UseSpanMetricsSeriesOptions) => {
+interface UseSpanMetricsSeriesOptions<Fields> {
+  filters?: SpanMetricsQueryFilters;
+  referrer?: string;
+  yAxis?: Fields;
+}
+
+export const useSpanMetricsSeries = <Fields extends MetricsProperty[]>(
+  options: UseSpanMetricsSeriesOptions<Fields> = {}
+) => {
   const {filters = {}, yAxis = [], referrer = 'span-metrics-series'} = options;
 
   const pageFilters = usePageFilters();
@@ -37,7 +36,7 @@ export const useSpanMetricsSeries = (options: UseSpanMetricsSeriesOptions) => {
 
   const enabled = Object.values(filters).every(value => Boolean(value));
 
-  const result = useSpansQuery<SpanMetrics[]>({
+  const result = useWrappedDiscoverTimeseriesQuery<SpanMetricTimeseriesRow[]>({
     eventView,
     initialData: [],
     referrer,
@@ -50,14 +49,14 @@ export const useSpanMetricsSeries = (options: UseSpanMetricsSeriesOptions) => {
         seriesName,
         data: (result?.data ?? []).map(datum => ({
           value: datum[seriesName],
-          name: datum.interval,
+          name: datum?.interval,
         })),
       };
 
       return series;
     }),
     'seriesName'
-  );
+  ) as Record<Fields[number], Series>;
 
   return {...result, data: parsedData};
 };

--- a/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
+++ b/static/app/views/starfish/queries/useSpanMetricsSeries.tsx
@@ -69,9 +69,6 @@ function getEventView(
 ) {
   const query = MutableSearch.fromQueryObject(filters);
 
-  // TODO: This condition should be enforced everywhere
-  // query.addFilterValue('has', 'span.description');
-
   // Pick the highest possible interval for the given yAxis selection. Find the ideal interval for each function, then choose the largest one. This results in the lowest granularity, but best performance.
   const interval = sortBy(
     yAxis.map(yAxisFunctionName => {

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -63,7 +63,7 @@ export type SpanMetricsQueryFilters = {
 
 export type SpanStringArrayFields = 'span.domain';
 
-export const COUNTER_AGGREGATES = ['avg', 'min', 'max', 'p100'] as const;
+export const COUNTER_AGGREGATES = ['sum', 'avg', 'min', 'max', 'p100'] as const;
 export const DISTRIBUTION_AGGREGATES = ['p50', 'p75', 'p95', 'p99'] as const;
 
 export const AGGREGATES = [...COUNTER_AGGREGATES, ...DISTRIBUTION_AGGREGATES] as const;

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -81,9 +81,7 @@ export const SPAN_FUNCTIONS = [
 export type SpanFunctions = (typeof SPAN_FUNCTIONS)[number];
 
 export type MetricsResponse = {
-  [Property in SpanNumberFields as `avg(${Property})`]: number;
-} & {
-  [Property in SpanNumberFields as `sum(${Property})`]: number;
+  [Property in SpanNumberFields as `${Aggregate}(${Property})`]: number;
 } & {
   [Property in SpanFunctions as `${Property}()`]: number;
 } & {

--- a/static/app/views/starfish/utils/useSpansQuery.tsx
+++ b/static/app/views/starfish/utils/useSpansQuery.tsx
@@ -63,7 +63,7 @@ export function useSpansQuery<T = any[]>({
   throw new Error('eventView argument must be defined when Starfish useDiscover is true');
 }
 
-function useWrappedDiscoverTimeseriesQuery<T>({
+export function useWrappedDiscoverTimeseriesQuery<T>({
   eventView,
   enabled,
   initialData,


### PR DESCRIPTION
`useSpanMetricsSeries` now matches `useSpanMetrics`:

- strict typing! Only genuine metrics fields are allowed in `yAxis`
- generic return type now takes `yAxis` into account
- same logic under-the-hood

**e.g.,**

Here's TypeScript's auto-complete being helpful:

<img width="629" alt="Screenshot 2024-01-15 at 5 53 23 PM" src="https://github.com/getsentry/sentry/assets/989898/49f3678f-d768-46c8-88ff-59132eead31a">

## Changes

- Remove pointless comment
- `useLocation` --> `usePageFilters`
- Add strict `Aggregate` typing
- Add sum an an allow aggregate function
- Use interpolated types to declare all aggregates
- Add strict typing to `useSpanMetricsSeries`
