### PR TITLE
feat(replay): Add "canvas supported" notice in replayer

### DIFF
--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -59,5 +59,5 @@ export function CanvasSupportNotice() {
 }
 
 const StyledAlert = styled(Alert)`
-  margin-bottom: ${space(1)};;
+  margin-bottom: ${space(1)};
 `;

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -6,6 +6,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -58,7 +59,5 @@ export function CanvasSupportNotice() {
 }
 
 const StyledAlert = styled(Alert)`
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  margin-bottom: 0;
+  margin-bottom: ${space(1)};;
 `;

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -6,6 +6,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -49,7 +50,7 @@ export function CanvasSupportNotice() {
       }
     >
       {tct(
-        'Recording canvas in Replay is now supported, learn how to set it up [link:here].',
+        'We now support Canvas in SDK Version 7.94.0. Learn more [link:here].',
         {
           link: (
             <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
@@ -61,7 +62,5 @@ export function CanvasSupportNotice() {
 }
 
 const StyledAlert = styled(Alert)`
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  margin-bottom: 0;
+  margin-bottom: ${space(1)};
 `;

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -35,25 +35,28 @@ export function CanvasSupportNotice() {
   }
 
   return (
-  <StyledAlert
-          type="info"
-          showIcon
-          trailingItems={
-            <Button
-              aria-label={t('Dismiss banner')}
-              icon={<IconClose />}
-              onClick={dismiss}
-              size="zero"
-              borderless
-            />
-          }
-        >
-          {tct('Recording canvas in Replay is now supported, learn how to set it up [link:here].', {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
-            ),
-          })}
-        </StyledAlert>
+    <StyledAlert
+      type="info"
+      showIcon
+      trailingItems={
+        <Button
+          aria-label={t('Dismiss banner')}
+          icon={<IconClose />}
+          onClick={dismiss}
+          size="zero"
+          borderless
+        />
+      }
+    >
+      {tct(
+        'Recording canvas in Replay is now supported, learn how to set it up [link:here].',
+        {
+          link: (
+            <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
+          ),
+        }
+      )}
+    </StyledAlert>
   );
 }
 

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -1,0 +1,64 @@
+import styled from '@emotion/styled';
+
+import Alert from 'sentry/components/alert';
+import {Button} from 'sentry/components/button';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {IconClose} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import useDismissAlert from 'sentry/utils/useDismissAlert';
+import useOrganization from 'sentry/utils/useOrganization';
+
+const LOCAL_STORAGE_KEY = 'replay-canvas-supported';
+
+/**
+ * Displays a notice about canvas support if a <canvas> element is detected in the replay, but not recorded
+ */
+export function CanvasSupportNotice() {
+  const organization = useOrganization();
+  const {dismiss, isDismissed} = useDismissAlert({key: LOCAL_STORAGE_KEY});
+  const {isFetching, replay} = useReplayContext();
+
+  // No need for notice if they are not feature flagged into the replayer
+  if (!organization.features.includes('session-replay-enable-canvas-replayer')) {
+    return null;
+  }
+
+  // User has dismissed this alert already, do not show
+  if (isDismissed || isFetching) {
+    return null;
+  }
+
+  // Did not detect any canvas elements in the replay, do not show alert
+  if (!replay?.hasCanvasElementInReplay()) {
+    return null;
+  }
+
+  return (
+  <StyledAlert
+          type="info"
+          showIcon
+          trailingItems={
+            <Button
+              aria-label={t('Dismiss banner')}
+              icon={<IconClose />}
+              onClick={dismiss}
+              size="zero"
+              borderless
+            />
+          }
+        >
+          {tct('Recording canvas in Replay is now supported, learn how to set it up [link:here].', {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
+            ),
+          })}
+        </StyledAlert>
+  );
+}
+
+const StyledAlert = styled(Alert)`
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  margin-bottom: 0;
+`;

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -6,7 +6,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -59,5 +58,7 @@ export function CanvasSupportNotice() {
 }
 
 const StyledAlert = styled(Alert)`
-  margin-bottom: ${space(1)};
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  margin-bottom: 0;
 `;

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -49,14 +49,11 @@ export function CanvasSupportNotice() {
         />
       }
     >
-      {tct(
-        'We now support Canvas in SDK Version 7.94.0. Learn more [link:here].',
-        {
-          link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
-          ),
-        }
-      )}
+      {tct('We now support Canvas in SDK Version 7.94.0. Learn more [link:here].', {
+        link: (
+          <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
+        ),
+      })}
     </StyledAlert>
   );
 }

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -31,8 +31,7 @@ export function CanvasSupportNotice() {
   }
 
   // If we're already recording canvas, or no canvas elements detected, then do not show alert
-  // @ts-expect-error TODO Update SDK
-  if (replay?.getSDKOptions().shouldRecordCanvas || !replay?.hasCanvasElementInReplay()) {
+  if (replay?.getSDKOptions()?.shouldRecordCanvas || !replay?.hasCanvasElementInReplay()) {
     return null;
   }
 

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -55,7 +55,7 @@ export function CanvasSupportNotice() {
       {tct(
         'This replay contains a [code:canvas] element. Support for recording [code:canvas] data was added in SDK version 7.94.1. [link:Learn more].',
         {
-          canvas: <code />,
+          code: <code />,
           link: (
             <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
           ),

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -30,8 +30,8 @@ export function CanvasSupportNotice() {
     return null;
   }
 
-  // Did not detect any canvas elements in the replay, do not show alert
-  if (!replay?.hasCanvasElementInReplay()) {
+  // If we're already recording canvas, or no canvas elements detected, then do not show alert
+  if (this.getSDKOptions().shouldRecordCanvas || !replay?.hasCanvasElementInReplay()) {
     return null;
   }
 
@@ -49,7 +49,8 @@ export function CanvasSupportNotice() {
         />
       }
     >
-      {tct('We now support Canvas in SDK Version 7.94.0. Learn more [link:here].', {
+      {tct('This replay contains a [code:canvas] element. Support for recording [code:canvas] data was added in SDK version 7.94.0. [link:Learn more].', {
+        canvas: <code>,
         link: (
           <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
         ),

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -53,7 +53,7 @@ export function CanvasSupportNotice() {
       }
     >
       {tct(
-        'This replay contains a [code:canvas] element. Support for recording [code:canvas] data was added in SDK version 7.94.1. [link:Learn more].',
+        'This replay contains a [code:canvas] element. Support for recording [code:canvas] data was added in SDK version 7.98.0. [link:Learn more].',
         {
           code: <code />,
           link: (

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -51,7 +51,7 @@ export function CanvasSupportNotice() {
       }
     >
       {tct(
-        'This replay contains a [code:canvas] element. Support for recording [code:canvas] data was added in SDK version 7.94.0. [link:Learn more].',
+        'This replay contains a [code:canvas] element. Support for recording [code:canvas] data was added in SDK version 7.94.1. [link:Learn more].',
         {
           canvas: <code />,
           link: (

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -50,12 +50,15 @@ export function CanvasSupportNotice() {
         />
       }
     >
-      {tct('This replay contains a [code:canvas] element. Support for recording [code:canvas] data was added in SDK version 7.94.0. [link:Learn more].', {
-        canvas: <code />,
-        link: (
-          <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
-        ),
-      })}
+      {tct(
+        'This replay contains a [code:canvas] element. Support for recording [code:canvas] data was added in SDK version 7.94.0. [link:Learn more].',
+        {
+          canvas: <code />,
+          link: (
+            <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
+          ),
+        }
+      )}
     </StyledAlert>
   );
 }

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -31,7 +31,8 @@ export function CanvasSupportNotice() {
   }
 
   // If we're already recording canvas, or no canvas elements detected, then do not show alert
-  if (this.getSDKOptions().shouldRecordCanvas || !replay?.hasCanvasElementInReplay()) {
+  // @ts-expect-error TODO Update SDK
+  if (replay?.getSDKOptions().shouldRecordCanvas || !replay?.hasCanvasElementInReplay()) {
     return null;
   }
 
@@ -50,7 +51,7 @@ export function CanvasSupportNotice() {
       }
     >
       {tct('This replay contains a [code:canvas] element. Support for recording [code:canvas] data was added in SDK version 7.94.0. [link:Learn more].', {
-        canvas: <code>,
+        canvas: <code />,
         link: (
           <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
         ),

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -31,7 +31,10 @@ export function CanvasSupportNotice() {
   }
 
   // If we're already recording canvas, or no canvas elements detected, then do not show alert
-  if (replay?.getSDKOptions()?.shouldRecordCanvas || !replay?.hasCanvasElementInReplay()) {
+  if (
+    replay?.getSDKOptions()?.shouldRecordCanvas ||
+    !replay?.hasCanvasElementInReplay()
+  ) {
     return null;
   }
 

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -46,10 +46,12 @@ function ReplayView({toggleFullscreen}: Props) {
           {!isFetching && replay?.hasProcessingErrors() ? (
             <ReplayProcessingError processingErrors={replay.processingErrors()} />
           ) : (
-            <Panel>
+            <div>
               <CanvasSupportNotice />
-              <ReplayPlayer />
-            </Panel>
+              <Panel>
+                <ReplayPlayer />
+              </Panel>
+            </div>
           )}
         </PlayerContainer>
         {isFullscreen && isSidebarOpen ? (

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -46,10 +46,12 @@ function ReplayView({toggleFullscreen}: Props) {
           {!isFetching && replay?.hasProcessingErrors() ? (
             <ReplayProcessingError processingErrors={replay.processingErrors()} />
           ) : (
-            <Panel>
+            <FluidHeight>
               <CanvasSupportNotice />
-              <ReplayPlayer />
-            </Panel>
+              <Panel>
+                <ReplayPlayer />
+              </Panel>
+            </FluidHeight>
           )}
         </PlayerContainer>
         {isFullscreen && isSidebarOpen ? (

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -15,6 +15,8 @@ import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
 import BrowserOSIcons from 'sentry/views/replays/detail/browserOSIcons';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 
+import {CanvasSupportNotice} from './canvasSupportNotice';
+
 type Props = {
   toggleFullscreen: () => void;
 };
@@ -45,6 +47,7 @@ function ReplayView({toggleFullscreen}: Props) {
             <ReplayProcessingError processingErrors={replay.processingErrors()} />
           ) : (
             <Panel>
+              <CanvasSupportNotice />
               <ReplayPlayer />
             </Panel>
           )}

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -46,10 +46,10 @@ function ReplayView({toggleFullscreen}: Props) {
           {!isFetching && replay?.hasProcessingErrors() ? (
             <ReplayProcessingError processingErrors={replay.processingErrors()} />
           ) : (
-              <Panel>
-                <CanvasSupportNotice />
-                <ReplayPlayer />
-              </Panel>
+            <Panel>
+              <CanvasSupportNotice />
+              <ReplayPlayer />
+            </Panel>
           )}
         </PlayerContainer>
         {isFullscreen && isSidebarOpen ? (

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -46,12 +46,10 @@ function ReplayView({toggleFullscreen}: Props) {
           {!isFetching && replay?.hasProcessingErrors() ? (
             <ReplayProcessingError processingErrors={replay.processingErrors()} />
           ) : (
-            <div>
-              <CanvasSupportNotice />
               <Panel>
+                <CanvasSupportNotice />
                 <ReplayPlayer />
               </Panel>
-            </div>
           )}
         </PlayerContainer>
         {isFullscreen && isSidebarOpen ? (

--- a/static/app/utils/replays/replayReader.spec.tsx
+++ b/static/app/utils/replays/replayReader.spec.tsx
@@ -319,14 +319,11 @@ describe('ReplayReader', () => {
     });
     const attachments = [firstDiv];
 
-    const replay = ReplayReader.factory(
-      {
-        attachments,
-        errors: [],
-        replayRecord,
-      },
-      {}
-    );
+    const replay = ReplayReader.factory({
+      attachments,
+      errors: [],
+      replayRecord,
+    });
 
     expect(replay?.hasCanvasElementInReplay()).toBe(true);
   });
@@ -356,14 +353,11 @@ describe('ReplayReader', () => {
       },
     ];
 
-    const replay = ReplayReader.factory(
-      {
-        attachments,
-        errors: [],
-        replayRecord,
-      },
-      {}
-    );
+    const replay = ReplayReader.factory({
+      attachments,
+      errors: [],
+      replayRecord,
+    });
 
     expect(replay?.hasCanvasElementInReplay()).toBe(true);
   });

--- a/static/app/utils/replays/replayReader.spec.tsx
+++ b/static/app/utils/replays/replayReader.spec.tsx
@@ -1,4 +1,4 @@
-import {EventType} from '@sentry-internal/rrweb';
+import {EventType, IncrementalSource} from '@sentry-internal/rrweb';
 import {
   ReplayClickEventFixture,
   ReplayConsoleEventFixture,
@@ -14,7 +14,7 @@ import {
   ReplaySpanFrameEventFixture,
 } from 'sentry-fixture/replay/replayFrameEvents';
 import {ReplayRequestFrameFixture} from 'sentry-fixture/replay/replaySpanFrameData';
-import {RRWebFullSnapshotFrameEventFixture} from 'sentry-fixture/replay/rrweb';
+import {RRWebDOMFrameFixture, RRWebFullSnapshotFrameEventFixture} from 'sentry-fixture/replay/rrweb';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
 import {BreadcrumbType} from 'sentry/types/breadcrumbs';
@@ -296,5 +296,67 @@ describe('ReplayReader', () => {
 
       expect(replay?.isNetworkDetailsSetup()).toBe(expected);
     });
+  });
+
+  it('detects canvas element from full snapshot', () => {
+    const timestamp = new Date('2023-12-25T00:02:00');
+
+    const firstDiv = RRWebFullSnapshotFrameEventFixture({timestamp, childNodes: [
+      RRWebDOMFrameFixture({
+        tagName: 'div',
+        childNodes: [
+          RRWebDOMFrameFixture({
+            tagName: 'canvas',
+          })
+        ]
+      })
+    ]});
+    const attachments = [
+      firstDiv,
+    ];
+
+    const replay = ReplayReader.factory(
+      {
+        attachments,
+        errors: [],
+        replayRecord,
+      },
+      {}
+    );
+
+    expect(replay?.hasCanvasElementInReplay()).toBe(true);
+  });
+
+  it('detects canvas element from dom mutations', () => {
+    const timestamp = new Date('2023-12-25T00:02:00');
+
+    const snapshot = RRWebFullSnapshotFrameEventFixture({timestamp});
+    const attachments = [
+      snapshot,
+      {
+        type: EventType.IncrementalSnapshot,
+        timestamp,
+        data: {
+          source: IncrementalSource.Mutation,
+          adds: [{node: RRWebDOMFrameFixture({
+            tagName: 'canvas',
+          })}],
+          removes: [],
+          texts: [],
+          attributes: [],
+        }
+      }
+    ];
+
+    const replay = ReplayReader.factory(
+      {
+        attachments,
+        errors: [],
+        replayRecord,
+      },
+      {}
+    );
+
+    expect(replay?.hasCanvasElementInReplay()).toBe(true);
   });
 });

--- a/static/app/utils/replays/replayReader.spec.tsx
+++ b/static/app/utils/replays/replayReader.spec.tsx
@@ -14,7 +14,10 @@ import {
   ReplaySpanFrameEventFixture,
 } from 'sentry-fixture/replay/replayFrameEvents';
 import {ReplayRequestFrameFixture} from 'sentry-fixture/replay/replaySpanFrameData';
-import {RRWebDOMFrameFixture, RRWebFullSnapshotFrameEventFixture} from 'sentry-fixture/replay/rrweb';
+import {
+  RRWebDOMFrameFixture,
+  RRWebFullSnapshotFrameEventFixture,
+} from 'sentry-fixture/replay/rrweb';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
 import {BreadcrumbType} from 'sentry/types/breadcrumbs';
@@ -301,19 +304,20 @@ describe('ReplayReader', () => {
   it('detects canvas element from full snapshot', () => {
     const timestamp = new Date('2023-12-25T00:02:00');
 
-    const firstDiv = RRWebFullSnapshotFrameEventFixture({timestamp, childNodes: [
-      RRWebDOMFrameFixture({
-        tagName: 'div',
-        childNodes: [
-          RRWebDOMFrameFixture({
-            tagName: 'canvas',
-          })
-        ]
-      })
-    ]});
-    const attachments = [
-      firstDiv,
-    ];
+    const firstDiv = RRWebFullSnapshotFrameEventFixture({
+      timestamp,
+      childNodes: [
+        RRWebDOMFrameFixture({
+          tagName: 'div',
+          childNodes: [
+            RRWebDOMFrameFixture({
+              tagName: 'canvas',
+            }),
+          ],
+        }),
+      ],
+    });
+    const attachments = [firstDiv];
 
     const replay = ReplayReader.factory(
       {
@@ -338,14 +342,18 @@ describe('ReplayReader', () => {
         timestamp,
         data: {
           source: IncrementalSource.Mutation,
-          adds: [{node: RRWebDOMFrameFixture({
-            tagName: 'canvas',
-          })}],
+          adds: [
+            {
+              node: RRWebDOMFrameFixture({
+                tagName: 'canvas',
+              }),
+            },
+          ],
           removes: [],
           texts: [],
           attributes: [],
-        }
-      }
+        },
+      },
     ];
 
     const replay = ReplayReader.factory(

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -348,7 +348,6 @@ export default class ReplayReader {
   });
 }
 
-
 function findCanvas(event: RecordingFrame) {
   if (event.type === EventType.FullSnapshot) {
     return findCanvasInSnapshot(event);
@@ -362,16 +361,21 @@ function findCanvas(event: RecordingFrame) {
 }
 
 function findCanvasInMutation(event: incrementalSnapshotEvent) {
-  if (event.data.source !== IncrementalSource.Mutation){
+  if (event.data.source !== IncrementalSource.Mutation) {
     return false;
   }
 
-  return event.data.adds.find((add) => add.node && add.node.type === 2 && add.node.tagName === 'canvas');
+  return event.data.adds.find(
+    add => add.node && add.node.type === 2 && add.node.tagName === 'canvas'
+  );
 }
 
-
 function findCanvasInChildNodes(nodes: serializedNodeWithId[]) {
-  return nodes.find(node => node.type === 2 && (node.tagName === 'canvas' || findCanvasInChildNodes(node.childNodes || [])));
+  return nodes.find(
+    node =>
+      node.type === 2 &&
+      (node.tagName === 'canvas' || findCanvasInChildNodes(node.childNodes || []))
+  );
 }
 
 function findCanvasInSnapshot(event: fullSnapshotEvent) {

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -318,14 +318,6 @@ export default class ReplayReader {
    * application. Needed to inform them that we now support canvas in replays.
    */
   hasCanvasElementInReplay = memoize(() => {
-    const sdkOptions = this.getSDKOptions();
-    // @ts-expect-error TODO: Update SDK
-    if (sdkOptions?.shouldRecordCanvas) {
-      // Return false to ignore this condition, as they are already using the
-      // new canvas integration
-      return false;
-    }
-
     return Boolean(this._sortedRRWebEvents.filter(findCanvas).length);
   });
 

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -320,7 +320,7 @@ export default class ReplayReader {
   hasCanvasElementInReplay = memoize(() => {
     const sdkOptions = this.getSDKOptions();
     // @ts-expect-error TODO: Update SDK
-    if (sdkOptions?.canvas) {
+    if (sdkOptions?.shouldRecordCanvas) {
       // Return false to ignore this condition, as they are already using the
       // new canvas integration
       return false;

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -20,9 +20,11 @@ import {replayTimestamps} from 'sentry/utils/replays/replayDataUtils';
 import type {
   BreadcrumbFrame,
   ErrorFrame,
+  fullSnapshotEvent,
   MemoryFrame,
   OptionFrame,
   RecordingFrame,
+  serializedNodeWithId,
   SlowClickFrame,
   SpanFrame,
 } from 'sentry/utils/replays/types';
@@ -311,6 +313,21 @@ export default class ReplayReader {
 
   getSDKOptions = () => this._optionFrame;
 
+  /**
+   * Checks the replay to see if user has any canvas elements in their
+   * application. Needed to inform them that we now support canvas in replays.
+   */
+  hasCanvasElementInReplay = memoize(() => {
+    const sdkOptions = this.getSDKOptions();
+    if (sdkOptions?.canvas) {
+      // Return false to ignore this condition, as they are already using the
+      // new canvas integration
+      return false;
+    }
+
+    return Boolean(this._sortedRRWebEvents.filter(findCanvas).length);
+  });
+
   isNetworkDetailsSetup = memoize(() => {
     const sdkOptions = this.getSDKOptions();
     if (sdkOptions) {
@@ -329,4 +346,38 @@ export default class ReplayReader {
         Object.keys(frame?.data?.response?.headers ?? {}).length
     );
   });
+}
+
+
+function findCanvas(event: RecordingFrame) {
+  if (event.type === EventType.FullSnapshot) {
+    return findCanvasInSnapshot(event);
+  }
+
+  if (event.type === EventType.IncrementalSnapshot) {
+    return findCanvasInMutation(event);
+  }
+
+  return false;
+}
+
+function findCanvasInMutation(event: incrementalSnapshotEvent) {
+  if (event.data.source !== IncrementalSource.Mutation){
+    return false;
+  }
+
+  return event.data.adds.find((add) => add.node && add.node.type === 2 && add.node.tagName === 'canvas');
+}
+
+
+function findCanvasInChildNodes(nodes: serializedNodeWithId[]) {
+  return nodes.find(node => node.type === 2 && (node.tagName === 'canvas' || findCanvasInChildNodes(node.childNodes || [])));
+}
+
+function findCanvasInSnapshot(event: fullSnapshotEvent) {
+  if (event.data.node.type !== 0) {
+    return false;
+  }
+
+  return findCanvasInChildNodes(event.data.node.childNodes);
 }

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -319,6 +319,7 @@ export default class ReplayReader {
    */
   hasCanvasElementInReplay = memoize(() => {
     const sdkOptions = this.getSDKOptions();
+    // @ts-expect-error TODO: Update SDK
     if (sdkOptions?.canvas) {
       // Return false to ignore this condition, as they are already using the
       // new canvas integration


### PR DESCRIPTION
This adds a notice to the replayer if a canvas element is detected inside of the replay, informing the user how to use the new canvas recording integration.

<img width="765" alt="Screenshot 2024-01-17 at 12 24 38 PM" src="https://github.com/getsentry/sentry/assets/55311782/146ef8dd-459c-4d6a-93ad-15ab71969033">

Closes https://github.com/getsentry/sentry/issues/61524
