### PR TITLE
feat(sdk-crashes): Add org allowlist for RN

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1774,6 +1774,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# The allowlist of org IDs that the react-native crash detection is enabled for.
+register(
+    "issues.sdk_crash_detection.react-native.organization_allowlist",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 register(
     "issues.sdk_crash_detection.react-native.sample_rate",
     default=0.0,

--- a/src/sentry/utils/sdk_crashes/build_sdk_crash_detection_configs.py
+++ b/src/sentry/utils/sdk_crashes/build_sdk_crash_detection_configs.py
@@ -7,12 +7,15 @@ from sentry.utils.sdk_crashes.sdk_crash_detection_config import SDKCrashDetectio
 
 
 def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
-    configs = [_build_config(SdkName.Cocoa), _build_config(SdkName.ReactNative)]
+    configs = [
+        _build_config(SdkName.Cocoa, False),
+        _build_config(SdkName.ReactNative, True),
+    ]
 
     return [config for config in configs if config is not None]
 
 
-def _build_config(sdk_name: SdkName) -> Optional[SDKCrashDetectionConfig]:
+def _build_config(sdk_name: SdkName, has_allowlist: bool) -> Optional[SDKCrashDetectionConfig]:
     options_prefix = f"issues.sdk_crash_detection.{sdk_name.value}"
 
     project_id = options.get(f"{options_prefix}.project_id")
@@ -24,6 +27,13 @@ def _build_config(sdk_name: SdkName) -> Optional[SDKCrashDetectionConfig]:
     if not sample_rate:
         return None
 
+    organization_allowlist: Optional[list[int]] = None
+    if has_allowlist:
+        organization_allowlist = options.get(f"{options_prefix}.organization_allowlist")
+
     return SDKCrashDetectionConfig(
-        sdk_name=sdk_name, project_id=project_id, sample_rate=sample_rate
+        sdk_name=sdk_name,
+        project_id=project_id,
+        sample_rate=sample_rate,
+        organization_allowlist=organization_allowlist,
     )

--- a/src/sentry/utils/sdk_crashes/build_sdk_crash_detection_configs.py
+++ b/src/sentry/utils/sdk_crashes/build_sdk_crash_detection_configs.py
@@ -8,8 +8,8 @@ from sentry.utils.sdk_crashes.sdk_crash_detection_config import SDKCrashDetectio
 
 def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
     configs = [
-        _build_config(SdkName.Cocoa, False),
-        _build_config(SdkName.ReactNative, True),
+        _build_config(sdk_name=SdkName.Cocoa, has_allowlist=False),
+        _build_config(sdk_name=SdkName.ReactNative, has_allowlist=True),
     ]
 
     return [config for config in configs if config is not None]

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -91,6 +91,13 @@ class SDKCrashDetection:
 
         sample_rate = config[0]["sample_rate"]
         project_id = config[0]["project_id"]
+        organization_allowlist = config[0].get("organization_allowlist", None)
+
+        if (
+            organization_allowlist is not None
+            and event.project.organization_id not in organization_allowlist
+        ):
+            return None
 
         context = get_path(event.data, "contexts", "sdk_crash_detection")
         if context is not None:

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -1,4 +1,5 @@
 from enum import Enum, unique
+from typing import Optional
 
 from typing_extensions import TypedDict
 
@@ -18,3 +19,5 @@ class SDKCrashDetectionConfig(TypedDict):
     project_id: int
     """The percentage of events to sample. 0.0 = 0%, 0.5 = 50% 1.0 = 100%."""
     sample_rate: float
+    """The organization allowlist to detect crashes for. If None, all organizations are allowed."""
+    organization_allowlist: Optional[list[int]]

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1812,6 +1812,9 @@ class SDKCrashMonitoringTestMixin(BasePostProgressGroupMixin):
         {
             "issues.sdk_crash_detection.cocoa.project_id": 1234,
             "issues.sdk_crash_detection.cocoa.sample_rate": 1.0,
+            "issues.sdk_crash_detection.react-native.project_id": 12345,
+            "issues.sdk_crash_detection.react-native.sample_rate": 1.0,
+            "issues.sdk_crash_detection.react-native.organization_allowlist": [1],
         }
     )
     def test_sdk_crash_monitoring_is_called(self, mock_sdk_crash_detection):
@@ -1832,7 +1835,18 @@ class SDKCrashMonitoringTestMixin(BasePostProgressGroupMixin):
         args = mock_sdk_crash_detection.detect_sdk_crash.call_args[-1]
         assert args["event"].project.id == event.project.id
         assert args["configs"] == [
-            {"sdk_name": SdkName.Cocoa, "project_id": 1234, "sample_rate": 1.0}
+            {
+                "sdk_name": SdkName.Cocoa,
+                "project_id": 1234,
+                "sample_rate": 1.0,
+                "organization_allowlist": None,
+            },
+            {
+                "sdk_name": SdkName.ReactNative,
+                "project_id": 12345,
+                "sample_rate": 1.0,
+                "organization_allowlist": [1],
+            },
         ]
 
     @with_feature("organizations:sdk-crash-detection")

--- a/tests/sentry/utils/sdk_crashes/test_build_sdk_crash_detection_configs.py
+++ b/tests/sentry/utils/sdk_crashes/test_build_sdk_crash_detection_configs.py
@@ -11,14 +11,22 @@ from sentry.utils.sdk_crashes.sdk_crash_detection_config import SDKCrashDetectio
         "issues.sdk_crash_detection.cocoa.sample_rate": 0.1,
         "issues.sdk_crash_detection.react-native.project_id": 2,
         "issues.sdk_crash_detection.react-native.sample_rate": 0.2,
+        "issues.sdk_crash_detection.react-native.organization_allowlist": [1],
     }
 )
 def test_build_sdk_crash_detection_configs():
     configs = build_sdk_crash_detection_configs()
 
     assert configs == [
-        SDKCrashDetectionConfig(sdk_name=SdkName.Cocoa, project_id=1, sample_rate=0.1),
-        SDKCrashDetectionConfig(sdk_name=SdkName.ReactNative, project_id=2, sample_rate=0.2),
+        SDKCrashDetectionConfig(
+            sdk_name=SdkName.Cocoa,
+            project_id=1,
+            sample_rate=0.1,
+            organization_allowlist=None,
+        ),
+        SDKCrashDetectionConfig(
+            sdk_name=SdkName.ReactNative, project_id=2, sample_rate=0.2, organization_allowlist=[1]
+        ),
     ]
 
 
@@ -28,13 +36,16 @@ def test_build_sdk_crash_detection_configs():
         "issues.sdk_crash_detection.cocoa.sample_rate": None,
         "issues.sdk_crash_detection.react-native.project_id": 2,
         "issues.sdk_crash_detection.react-native.sample_rate": 0.2,
+        "issues.sdk_crash_detection.react-native.organization_allowlist": [1],
     }
 )
 def test_build_sdk_crash_detection_configs_only_react_native():
     configs = build_sdk_crash_detection_configs()
 
     assert configs == [
-        SDKCrashDetectionConfig(sdk_name=SdkName.ReactNative, project_id=2, sample_rate=0.2),
+        SDKCrashDetectionConfig(
+            sdk_name=SdkName.ReactNative, project_id=2, sample_rate=0.2, organization_allowlist=[1]
+        ),
     ]
 
 
@@ -44,13 +55,16 @@ def test_build_sdk_crash_detection_configs_only_react_native():
         "issues.sdk_crash_detection.cocoa.sample_rate": None,
         "issues.sdk_crash_detection.react-native.project_id": 2,
         "issues.sdk_crash_detection.react-native.sample_rate": 0.2,
+        "issues.sdk_crash_detection.react-native.organization_allowlist": [1],
     }
 )
 def test_build_sdk_crash_detection_configs_no_sample_rate():
     configs = build_sdk_crash_detection_configs()
 
     assert configs == [
-        SDKCrashDetectionConfig(sdk_name=SdkName.ReactNative, project_id=2, sample_rate=0.2),
+        SDKCrashDetectionConfig(
+            sdk_name=SdkName.ReactNative, project_id=2, sample_rate=0.2, organization_allowlist=[1]
+        ),
     ]
 
 
@@ -60,6 +74,7 @@ def test_build_sdk_crash_detection_configs_no_sample_rate():
         "issues.sdk_crash_detection.cocoa.sample_rate": None,
         "issues.sdk_crash_detection.react-native.project_id": None,
         "issues.sdk_crash_detection.react-native.sample_rate": None,
+        "issues.sdk_crash_detection.react-native.organization_allowlist": [],
     }
 )
 def test_build_sdk_crash_detection_configs_no_configs():

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -15,7 +15,11 @@ from sentry.utils.safe import get_path, set_path
 from sentry.utils.sdk_crashes.sdk_crash_detection import sdk_crash_detection
 from sentry.utils.sdk_crashes.sdk_crash_detection_config import SDKCrashDetectionConfig, SdkName
 
-sdk_configs = [SDKCrashDetectionConfig(sdk_name=SdkName.Cocoa, project_id=1234, sample_rate=1.0)]
+sdk_configs = [
+    SDKCrashDetectionConfig(
+        sdk_name=SdkName.Cocoa, project_id=1234, sample_rate=1.0, organization_allowlist=None
+    )
+]
 
 
 class BaseSDKCrashDetectionMixin(BaseTestCase, metaclass=abc.ABCMeta):
@@ -114,7 +118,10 @@ class SDKCrashReportTestMixin(BaseSDKCrashDetectionMixin, SnubaTestCase):
 
         configs = [
             SDKCrashDetectionConfig(
-                sdk_name=SdkName.Cocoa, project_id=cocoa_sdk_crashes_project.id, sample_rate=1.0
+                sdk_name=SdkName.Cocoa,
+                project_id=cocoa_sdk_crashes_project.id,
+                sample_rate=1.0,
+                organization_allowlist=None,
             )
         ]
         sdk_crash_event = sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)
@@ -185,8 +192,12 @@ def test_multiple_configs_first_one_picked(mock_sdk_crash_reporter, store_event)
     event = store_event(data=get_crash_event())
 
     configs = [
-        SDKCrashDetectionConfig(sdk_name=SdkName.Cocoa, project_id=1234, sample_rate=1.0),
-        SDKCrashDetectionConfig(sdk_name=SdkName.Cocoa, project_id=12345, sample_rate=1.0),
+        SDKCrashDetectionConfig(
+            sdk_name=SdkName.Cocoa, project_id=1234, sample_rate=1.0, organization_allowlist=None
+        ),
+        SDKCrashDetectionConfig(
+            sdk_name=SdkName.Cocoa, project_id=12345, sample_rate=1.0, organization_allowlist=None
+        ),
     ]
 
     sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)


### PR DESCRIPTION
Add an optional organization allowlist for React-Native to specify which organizations
the SDK crash detection is enabled per SDK configuration.