### PR TITLE
feat(ddm): Optimize for single query experience

### DIFF
--- a/static/app/views/ddm/context.tsx
+++ b/static/app/views/ddm/context.tsx
@@ -40,6 +40,7 @@ interface DDMContextValue {
   selectedWidgetIndex: number;
   setDefaultQuery: (query: Record<string, any> | null) => void;
   setSelectedWidgetIndex: (index: number) => void;
+  showQuerySymbols: boolean;
   updateWidget: (index: number, data: Partial<MetricWidgetQueryParams>) => void;
   widgets: MetricWidgetQueryParams[];
 }
@@ -57,6 +58,7 @@ export const DDMContext = createContext<DDMContextValue>({
   selectedWidgetIndex: 0,
   setDefaultQuery: () => {},
   setSelectedWidgetIndex: () => {},
+  showQuerySymbols: false,
   updateWidget: () => {},
   widgets: [],
 });
@@ -295,6 +297,7 @@ export function DDMContextProvider({children}: {children: React.ReactNode}) {
       removeFocusArea: handleRemoveFocusArea,
       setDefaultQuery,
       isDefaultQuery,
+      showQuerySymbols: widgets.length > 1,
     }),
     [
       handleAddWidget,

--- a/static/app/views/ddm/pageHeaderActions.tsx
+++ b/static/app/views/ddm/pageHeaderActions.tsx
@@ -56,7 +56,7 @@ export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Pro
         onAction: () => navigateTo(`/settings/projects/:projectId/metrics/`, router),
       },
       {
-        leadingItems: [<IconAdd key="icon" />],
+        leadingItems: [<IconAdd isCircled key="icon" />],
         key: 'add-query',
         label: t('Add Query'),
         disabled: hasEmptyWidget,

--- a/static/app/views/ddm/pageHeaderActions.tsx
+++ b/static/app/views/ddm/pageHeaderActions.tsx
@@ -1,10 +1,12 @@
 import {useMemo} from 'react';
+import * as Sentry from '@sentry/react';
 
 import {navigateTo} from 'sentry/actionCreators/navigation';
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {
+  IconAdd,
   IconBookmark,
   IconDashboard,
   IconEllipsis,
@@ -12,6 +14,7 @@ import {
   IconSiren,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {isCustomMeasurement} from 'sentry/utils/metrics';
 import {MRIToField} from 'sentry/utils/metrics/mri';
 import {middleEllipsis} from 'sentry/utils/middleEllipsis';
@@ -33,7 +36,10 @@ export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Pro
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const createDashboard = useCreateDashboard();
-  const {isDefaultQuery, setDefaultQuery, widgets} = useDDMContext();
+  const {addWidget, isDefaultQuery, setDefaultQuery, widgets, showQuerySymbols} =
+    useDDMContext();
+
+  const hasEmptyWidget = widgets.length === 0 || widgets.some(widget => !widget.mri);
 
   const items = useMemo(
     () => [
@@ -49,8 +55,21 @@ export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Pro
         label: t('Metrics Settings'),
         onAction: () => navigateTo(`/settings/projects/:projectId/metrics/`, router),
       },
+      {
+        leadingItems: [<IconAdd key="icon" />],
+        key: 'add-query',
+        label: t('Add Query'),
+        disabled: hasEmptyWidget,
+        onAction: () => {
+          trackAnalytics('ddm.widget.add', {
+            organization,
+          });
+          Sentry.metrics.increment('ddm.widget.add');
+          addWidget();
+        },
+      },
     ],
-    [createDashboard, router]
+    [addWidget, createDashboard, hasEmptyWidget, organization, router]
   );
 
   const alertItems = useMemo(
@@ -66,7 +85,9 @@ export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Pro
           op: widget.op,
         });
         return {
-          leadingItems: [<QuerySymbol key="icon" index={index} />],
+          leadingItems: showQuerySymbols
+            ? [<QuerySymbol key="icon" index={index} />]
+            : [],
           key: `add-alert-${index}`,
           label: widget.mri
             ? middleEllipsis(MRIToField(widget.mri, widget.op!), 60, /\.|-|_/)
@@ -83,6 +104,7 @@ export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Pro
       selection.datetime,
       selection.environments,
       selection.projects,
+      showQuerySymbols,
       widgets,
     ]
   );
@@ -101,16 +123,27 @@ export function PageHeaderActions({showCustomMetricButton, addCustomMetric}: Pro
       >
         {isDefaultQuery ? t('Remove Default') : t('Save as default')}
       </Button>
-      <DropdownMenu
-        items={alertItems}
-        triggerLabel={t('Create Alert')}
-        triggerProps={{
-          size: 'sm',
-          showChevron: false,
-          icon: <IconSiren direction="down" size="xs" />,
-        }}
-        position="bottom-end"
-      />
+      {alertItems.length === 1 ? (
+        <Button
+          size="sm"
+          icon={<IconSiren />}
+          disabled={!alertItems[0].onAction}
+          onClick={alertItems[0].onAction}
+        >
+          {t('Create Alert')}
+        </Button>
+      ) : (
+        <DropdownMenu
+          items={alertItems}
+          triggerLabel={t('Create Alert')}
+          triggerProps={{
+            size: 'sm',
+            showChevron: false,
+            icon: <IconSiren direction="down" size="sm" />,
+          }}
+          position="bottom-end"
+        />
+      )}
       <DropdownMenu
         items={items}
         triggerProps={{

--- a/static/app/views/ddm/querySymbol.tsx
+++ b/static/app/views/ddm/querySymbol.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {space} from 'sentry/styles/space';
+import {useDDMContext} from 'sentry/views/ddm/context';
 
 const indexToChar = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
@@ -33,6 +34,10 @@ export function QuerySymbol({
   index,
   ...props
 }: React.ComponentProps<typeof Symbol> & {index: number}) {
+  const {showQuerySymbols} = useDDMContext();
+  if (!showQuerySymbols) {
+    return null;
+  }
   return (
     <Symbol {...props}>
       <span>{getQuerySymbol(index)}</span>

--- a/static/app/views/ddm/scratchpad.tsx
+++ b/static/app/views/ddm/scratchpad.tsx
@@ -19,6 +19,7 @@ export function MetricScratchpad() {
     focusArea,
     addFocusArea,
     removeFocusArea,
+    showQuerySymbols,
   } = useDDMContext();
   const {selection} = usePageFilters();
 
@@ -53,6 +54,7 @@ export function MetricScratchpad() {
           environments={selection.environments}
           addFocusArea={addFocusArea}
           removeFocusArea={removeFocusArea}
+          showQuerySymbols={showQuerySymbols}
           focusArea={focusArea}
         />
       ))}

--- a/static/app/views/ddm/widget.tsx
+++ b/static/app/views/ddm/widget.tsx
@@ -49,6 +49,7 @@ type MetricWidgetProps = {
   isSelected?: boolean;
   onSelect?: (index: number) => void;
   removeFocusArea?: () => void;
+  showQuerySymbols?: boolean;
 };
 
 export const MetricWidget = memo(
@@ -64,6 +65,7 @@ export const MetricWidget = memo(
     hasSiblings = false,
     addFocusArea,
     removeFocusArea,
+    showQuerySymbols,
     focusArea = null,
   }: MetricWidgetProps) => {
     const handleChange = useCallback(
@@ -120,7 +122,7 @@ export const MetricWidget = memo(
       >
         <PanelBody>
           <MetricWidgetHeader>
-            <QuerySymbol index={index} />
+            {showQuerySymbols && <QuerySymbol index={index} />}
             <WidgetTitle>
               <StyledTooltip
                 title={widgetTitle}


### PR DESCRIPTION
Hide query symbols when there is only one.
Move `Add query` into page actions dropdown.
Let `Create Alert` be a simple button if there is only one query.

https://github.com/getsentry/sentry/assets/7033940/ee33e930-83c7-41ca-989e-b8069b098cc2

- closes https://github.com/getsentry/sentry/issues/63102