### PR TITLE
fix(ddm): Default orderBy without field

### DIFF
--- a/static/app/utils/metrics/index.spec.tsx
+++ b/static/app/utils/metrics/index.spec.tsx
@@ -176,6 +176,36 @@ describe('getMetricsApiRequestQuery', () => {
       per_page: 10,
     });
   });
+
+  it('does not add a default orderBy if there is no field', () => {
+    const metric = {
+      field: '',
+      query: 'error',
+      groupBy: [],
+    };
+    const filters = {
+      projects: [1],
+      environments: ['production'],
+      datetime: {start: '2023-01-01', end: '2023-01-02', period: null, utc: true},
+    };
+    const overrides = {};
+
+    const result = getMetricsApiRequestQuery(metric, filters, overrides);
+
+    expect(result).toEqual({
+      start: '2023-01-01T00:00:00.000Z',
+      end: '2023-01-02T00:00:00.000Z',
+      query: 'error',
+      project: [1],
+      environment: ['production'],
+      field: '',
+      useCase: 'custom',
+      interval: '5m',
+      groupBy: [],
+      allowPrivate: true,
+      per_page: 10,
+    });
+  });
 });
 
 describe('getDDMInterval', () => {

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -254,7 +254,7 @@ export function getMetricsApiRequestQuery(
     useCase,
     interval,
     groupBy,
-    orderBy: hasGroupBy && !orderBy ? `-${field}` : orderBy,
+    orderBy: hasGroupBy && !orderBy && field ? `-${field}` : orderBy,
     allowPrivate: true, // TODO(ddm): reconsider before widening audience
     // Max result groups for compatibility with old metrics layer
     // TODO(telemetry-experience): remove once everyone is on new metrics layer


### PR DESCRIPTION
Do not send a default orderBy if no field is given.