### PR TITLE
fix(dashboards): hide inline edit behind feature flag

### DIFF
--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -341,7 +341,10 @@ class Dashboard extends Component<Props, State> {
 
     const widget = this.props.dashboard.widgets[index];
 
-    if (widget.widgetType === WidgetType.METRICS) {
+    if (
+      widget.widgetType === WidgetType.METRICS &&
+      hasDDMExperimentalFeature(organization)
+    ) {
       this.handleStartEditMetricWidget(index);
       return;
     }


### PR DESCRIPTION
Inline edit feature is currently experimental and should be behind `organizations:ddm-experimental`