### PR TITLE
feat(browser-starfish): add metrics to track resource image loads

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -176,6 +176,19 @@ function ImageContainer(props: {
   const {fileName, size, src, showImage = true} = props;
   const isRelativeUrl = src.startsWith('/');
 
+  const handleError = () => {
+    setHasError(true);
+    Sentry.metrics.increment('performance.resource.image_load', 1, {
+      tags: {status: 'error'},
+    });
+  };
+
+  const handleLoad = () => {
+    Sentry.metrics.increment('performance.resource.image_load', 1, {
+      tags: {status: 'success'},
+    });
+  };
+
   return (
     <div style={{width: '100%', wordWrap: 'break-word'}}>
       {showImage && !isRelativeUrl && !hasError ? (
@@ -186,7 +199,8 @@ function ImageContainer(props: {
           }}
         >
           <img
-            onError={() => setHasError(true)}
+            onError={handleError}
+            onLoad={handleLoad}
             src={src}
             style={{
               width: '100%',


### PR DESCRIPTION
Adds a metric to track whether or not an image on the sample image view has successfully loaded or error out (due to it being private for example).