### PR TITLE
modify API response to request projectSlug list

### DIFF
--- a/static/app/views/releases/detail/overview/sidebar/thresholdStatuses.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/thresholdStatuses.tsx
@@ -38,7 +38,7 @@ function ThresholdStatuses({project, release, organization, selectedEnvs}: Props
       start: start.toISOString(),
       end: end.toISOString(),
       release: [releaseVersion],
-      project: [project.slug],
+      projectSlug: [project.slug],
     };
     if (selectedEnvs.length) {
       query.environment = selectedEnvs;

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -199,7 +199,7 @@ class ReleasesList extends DeprecatedAsyncView<Props, State> {
       release: releaseVersions,
     };
     if (selection.projects.length) {
-      query.project = this.getSelectedProjectSlugs();
+      query.projectSlug = this.getSelectedProjectSlugs();
     }
     if (selection.environments.length) {
       query.environment = selection.environments;

--- a/static/app/views/releases/utils/types.tsx
+++ b/static/app/views/releases/utils/types.tsx
@@ -11,7 +11,7 @@ export type ThresholdStatusesQuery = Omit<ThresholdQuery, 'project'> & {
   end: string;
   release: string[]; // list of release versions
   start: string;
-  project?: string[]; // list of project slugs
+  projectSlug?: string[]; // list of project slugs
 };
 
 export type ThresholdStatus = Threshold & {


### PR DESCRIPTION
Currently all of our organization APIs expect the list of projects to be queried as `projectSlug` rather than just `project`

Ideally we'd consolidate on `project` being the customer facing project slug - however for the sake of consistency, we should keep this uniform until we do a sweep and update all apis

Requires: https://github.com/getsentry/sentry/pull/63260