### PR TITLE
convert project > projectSlug on BE

### DIFF
--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -58,7 +58,7 @@ class ReleaseThresholdStatusIndexSerializer(serializers.Serializer):
         child=serializers.CharField(),
         help_text=("Provide a list of environment names to filter your results by"),
     )
-    project = serializers.ListField(
+    projectSlug = serializers.ListField(
         required=False,
         allow_empty=True,
         child=serializers.CharField(),
@@ -145,7 +145,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint, Envi
             return Response(serializer.errors, status=400)
 
         environments_list = serializer.validated_data.get("environment")
-        project_slug_list = serializer.validated_data.get("project")
+        project_slug_list = serializer.validated_data.get("projectSlug")
         releases_list = serializer.validated_data.get("release")
 
         # ========================================================================

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -383,7 +383,7 @@ class ReleaseThresholdStatusTest(APITestCase):
         now = str(datetime.now())
         yesterday = str(datetime.now() - timedelta(hours=24))
         response = self.get_success_response(
-            self.organization.slug, start=yesterday, end=now, project=[self.project2.slug]
+            self.organization.slug, start=yesterday, end=now, projectSlug=[self.project2.slug]
         )
 
         assert len(response.data.keys()) == 1


### PR DESCRIPTION
Update the release threshold status API to expect `projectSlug` rather than `project`

Affects: https://github.com/getsentry/sentry/pull/63260
