### PR TITLE
feat(hybridcloud) Add metric for proxy duration

### DIFF
--- a/src/sentry/hybridcloud/apigateway/apigateway.py
+++ b/src/sentry/hybridcloud/apigateway/apigateway.py
@@ -52,9 +52,12 @@ def proxy_request_if_needed(
     if not silo_modes or current_silo_mode in silo_modes:
         return None
 
+    url_name = "unknown"
+    if request.resolver_match:
+        url_name = request.resolver_match.url_name or url_name
+
     if "organization_slug" in view_kwargs:
         org_slug = view_kwargs["organization_slug"]
-        url_name = request.resolver_match.url_name if request.resolver_match else "unknown"
 
         metrics.incr(
             "apigateway.proxy_request",
@@ -63,7 +66,7 @@ def proxy_request_if_needed(
                 "kind": "orgslug",
             },
         )
-        return proxy_request(request, org_slug)
+        return proxy_request(request, org_slug, url_name)
 
     if (
         "uuid" in view_kwargs
@@ -74,11 +77,11 @@ def proxy_request_if_needed(
         metrics.incr(
             "apigateway.proxy_request",
             tags={
-                "url_name": request.resolver_match.url_name,
+                "url_name": url_name,
                 "kind": "sentryapp-installation",
             },
         )
-        return proxy_sentryappinstallation_request(request, install_uuid)
+        return proxy_sentryappinstallation_request(request, install_uuid, url_name)
 
     if (
         "sentry_app_slug" in view_kwargs
@@ -89,11 +92,11 @@ def proxy_request_if_needed(
         metrics.incr(
             "apigateway.proxy_request",
             tags={
-                "url_name": request.resolver_match.url_name,
+                "url_name": url_name,
                 "kind": "sentryapp",
             },
         )
-        return proxy_sentryapp_request(request, app_slug)
+        return proxy_sentryapp_request(request, app_slug, url_name)
 
     if (
         request.resolver_match
@@ -103,10 +106,10 @@ def proxy_request_if_needed(
         metrics.incr(
             "apigateway.proxy_request",
             tags={
-                "url_name": request.resolver_match.url_name,
+                "url_name": url_name,
                 "kind": "regionpin",
             },
         )
 
-        return proxy_region_request(request, region)
+        return proxy_region_request(request, region, url_name)
     return None

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -16,13 +16,15 @@ from sentry.testutils.helpers.response import close_streaming_response
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
 
+url_name = "sentry-api-0-projets"
+
 
 @control_silo_test(regions=[ApiGatewayTestCase.REGION], include_monolith_run=True)
 class ProxyTestCase(ApiGatewayTestCase):
     @responses.activate
     def test_simple(self):
         request = RequestFactory().get("http://sentry.io/get")
-        resp = proxy_request(request, self.organization.slug)
+        resp = proxy_request(request, self.organization.slug, url_name)
         resp_json = json.loads(close_streaming_response(resp))
         assert resp.status_code == 200
         assert resp_json["proxy"]
@@ -32,7 +34,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert resp[PROXY_DIRECT_LOCATION_HEADER] == "http://us.internal.sentry.io/get"
 
         request = RequestFactory().get("http://sentry.io/error")
-        resp = proxy_request(request, self.organization.slug)
+        resp = proxy_request(request, self.organization.slug, url_name)
         resp_json = json.loads(close_streaming_response(resp))
         assert resp.status_code == 400
         assert resp_json["proxy"]
@@ -48,7 +50,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         query_param_str = urlencode(query_param_dict, doseq=True)
         request = RequestFactory().get(f"http://sentry.io/echo?{query_param_str}")
 
-        resp = proxy_request(request, self.organization.slug)
+        resp = proxy_request(request, self.organization.slug, url_name)
         resp_json = json.loads(close_streaming_response(resp))
 
         assert resp.status_code == 200
@@ -59,7 +61,7 @@ class ProxyTestCase(ApiGatewayTestCase):
     @responses.activate
     def test_bad_org(self):
         request = RequestFactory().get("http://sentry.io/get")
-        resp = proxy_request(request, "doesnotexist")
+        resp = proxy_request(request, "doesnotexist", url_name)
         assert resp.status_code == 404
 
     @responses.activate
@@ -74,7 +76,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         request = RequestFactory().post(
             "http://sentry.io/post", data=request_body, content_type="application/json"
         )
-        resp = proxy_request(request, self.organization.slug)
+        resp = proxy_request(request, self.organization.slug, url_name)
         resp_json = json.loads(close_streaming_response(resp))
 
         assert resp.status_code == 200
@@ -94,7 +96,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         request = RequestFactory().put(
             "http://sentry.io/put", data=request_body, content_type="application/json"
         )
-        resp = proxy_request(request, self.organization.slug)
+        resp = proxy_request(request, self.organization.slug, url_name)
         resp_json = json.loads(close_streaming_response(resp))
 
         assert resp.status_code == 200
@@ -114,7 +116,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         request = RequestFactory().patch(
             "http://sentry.io/patch", data=request_body, content_type="application/json"
         )
-        resp = proxy_request(request, self.organization.slug)
+        resp = proxy_request(request, self.organization.slug, url_name)
         resp_json = json.loads(close_streaming_response(resp))
 
         assert resp.status_code == 200
@@ -134,7 +136,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         request = RequestFactory().head(
             "http://sentry.io/head", data=request_body, content_type="application/json"
         )
-        resp = proxy_request(request, self.organization.slug)
+        resp = proxy_request(request, self.organization.slug, url_name)
         resp_json = json.loads(close_streaming_response(resp))
 
         assert resp.status_code == 200
@@ -154,7 +156,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         request = RequestFactory().delete(
             "http://sentry.io/delete", data=request_body, content_type="application/json"
         )
-        resp = proxy_request(request, self.organization.slug)
+        resp = proxy_request(request, self.organization.slug, url_name)
         resp_json = json.loads(close_streaming_response(resp))
 
         assert resp.status_code == 200
@@ -179,7 +181,7 @@ class ProxyTestCase(ApiGatewayTestCase):
         request = RequestFactory().post(
             "http://sentry.io/post", data=request_body, format="multipart"
         )
-        resp = proxy_request(request, self.organization.slug)
+        resp = proxy_request(request, self.organization.slug, url_name)
         resp_json = json.loads(close_streaming_response(resp))
 
         assert resp.status_code == 200
@@ -201,7 +203,7 @@ class ProxyTestCase(ApiGatewayTestCase):
             data=request_body,
             content_type="application/x-www-form-urlencoded",
         )
-        resp = proxy_request(request, self.organization.slug)
+        resp = proxy_request(request, self.organization.slug, url_name)
         resp_json = json.loads(close_streaming_response(resp))
 
         assert resp.status_code == 200
@@ -229,5 +231,5 @@ class ProxyTestCase(ApiGatewayTestCase):
             },
         )
 
-        resp = proxy_request(request, self.organization.slug)
+        resp = proxy_request(request, self.organization.slug, url_name)
         assert not any([header in resp for header in INVALID_OUTBOUND_HEADERS])


### PR DESCRIPTION
To better understand the latency of the apigateway, I would like to know how much time is spent by the other host.