### PR TITLE
feat(tos): Change `terms_accepted` signature

### DIFF
--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -178,7 +178,7 @@ comment_created = BetterSignal()  # ["project", "user", "group", "activity_data"
 comment_updated = BetterSignal()  # ["project", "user", "group", "activity_data"]
 comment_deleted = BetterSignal()  # ["project", "user", "group", "activity_data"]
 
-terms_accepted = BetterSignal()  # ["organization", "organization_id", "user", "ip_address"]
+terms_accepted = BetterSignal()  # ["organization_id", "user", "ip_address"]
 team_created = (
     BetterSignal()
 )  # ["organization", "user", "team", "team_id", "organization_id", "user_id"]


### PR DESCRIPTION
This merely changes the comment describing the available parameters, since those are passed in dynamically. There is only one consumer in this repository, which already omits the removed parameter. All other consumers are in getsentry, and have already been updated.