### PR TITLE
feat(app-start): Add sample drawer after span selection in op table

### DIFF
--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -18,6 +18,7 @@ import {
 } from 'sentry/utils/performance/contexts/pageError';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import useRouter from 'sentry/utils/useRouter';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
@@ -29,6 +30,7 @@ import {
   MobileSortKeys,
 } from 'sentry/views/starfish/views/screens/constants';
 import {MetricsRibbon} from 'sentry/views/starfish/views/screens/screenLoadSpans/metricsRibbon';
+import {ScreenLoadSpanSamples} from 'sentry/views/starfish/views/screens/screenLoadSpans/samples';
 
 import AppStartWidgets from './widgets';
 
@@ -36,14 +38,25 @@ type Query = {
   primaryRelease: string;
   project: string;
   secondaryRelease: string;
+  spanDescription: string;
+  spanGroup: string;
+  spanOp: string;
   transaction: string;
 };
 
 function ScreenSummary() {
   const organization = useOrganization();
   const location = useLocation<Query>();
+  const router = useRouter();
 
-  const {primaryRelease, secondaryRelease, transaction: transactionName} = location.query;
+  const {
+    primaryRelease,
+    secondaryRelease,
+    transaction: transactionName,
+    spanGroup,
+    spanDescription,
+    spanOp,
+  } = location.query;
 
   const startupModule: LocationDescriptor = {
     pathname: `/organizations/${organization.slug}/starfish/appStartup/`,
@@ -213,6 +226,26 @@ function ScreenSummary() {
                   secondaryRelease={secondaryRelease}
                 />
               </ErrorBoundary>
+              {spanGroup && spanOp && (
+                <ScreenLoadSpanSamples
+                  groupId={spanGroup}
+                  transactionName={transactionName}
+                  spanDescription={spanDescription}
+                  spanOp={spanOp}
+                  onClose={() => {
+                    router.replace({
+                      pathname: router.location.pathname,
+                      query: omit(
+                        router.location.query,
+                        'spanGroup',
+                        'transactionMethod',
+                        'spanDescription',
+                        'spanOp'
+                      ),
+                    });
+                  }}
+                />
+              )}
             </Layout.Main>
           </Layout.Body>
         </PageErrorProvider>

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.spec.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.spec.tsx
@@ -96,7 +96,7 @@ describe('SpanOpSelector', function () {
 
     expect(screen.getByRole('link', {name: 'Application Init'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/starfish/appStartup/spans/?spanDescription=Application%20Init&spanGroup=7f4be68f08c0455f&transaction=foo-bar'
+      '/organizations/org-slug/starfish/appStartup/spans/?spanDescription=Application%20Init&spanGroup=7f4be68f08c0455f&spanOp=app.start.warm&transaction=foo-bar'
     );
   });
 

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -154,6 +154,7 @@ export function SpanOperationTable({
       const query = {
         ...location.query,
         transaction,
+        spanOp: row[SpanMetricsField.SPAN_OP],
         spanGroup: row[SpanMetricsField.SPAN_GROUP],
         spanDescription: row[SpanMetricsField.SPAN_DESCRIPTION],
       };

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/index.tsx
@@ -26,6 +26,7 @@ type Props = {
   transactionName: string;
   onClose?: () => void;
   spanDescription?: string;
+  spanOp?: string;
   transactionMethod?: string;
   transactionRoute?: string;
 };
@@ -37,6 +38,7 @@ export function ScreenLoadSpanSamples({
   spanDescription,
   onClose,
   transactionRoute = '/performance/summary/',
+  spanOp,
 }: Props) {
   const router = useRouter();
 
@@ -118,6 +120,7 @@ export function ScreenLoadSpanSamples({
               release={primaryRelease}
               sectionTitle={t('Release 1')}
               project={project}
+              spanOp={spanOp}
             />
           </ChartsContainerItem>
           <ChartsContainerItem key="release2">
@@ -128,6 +131,7 @@ export function ScreenLoadSpanSamples({
               release={secondaryRelease}
               sectionTitle={t('Release 2')}
               project={project}
+              spanOp={spanOp}
             />
           </ChartsContainerItem>
         </ChartsContainer>

--- a/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/samples/samplesContainer.tsx
@@ -38,6 +38,7 @@ type Props = {
   release?: string;
   sectionSubtitle?: string;
   sectionTitle?: string;
+  spanOp?: string;
   transactionMethod?: string;
 };
 
@@ -47,6 +48,7 @@ export function ScreenLoadSampleContainer({
   transactionMethod,
   release,
   project,
+  spanOp,
 }: Props) {
   const router = useRouter();
   const location = useLocation();
@@ -87,6 +89,10 @@ export function ScreenLoadSampleContainer({
 
   if (project && isCrossPlatform(project) && hasPlatformSelectFeature) {
     filters['os.name'] = platform;
+  }
+
+  if (spanOp) {
+    filters['span.op'] = spanOp;
   }
 
   const {data} = useSpanMetrics({


### PR DESCRIPTION
Opens a sample drawer after a span description is selected in the span op table for the app start page. Because the description can be for both a cold and warm start, we need to further filter by the span op

Currently uses the same as the screens drawer because there aren't any app start specific properties to raise at the span level at this time