### PR TITLE
fix(trace): Pass datetimeSelection so we don't query 90d

### DIFF
--- a/static/app/views/performance/traceDetails/TraceDetailsRouting.tsx
+++ b/static/app/views/performance/traceDetails/TraceDetailsRouting.tsx
@@ -4,6 +4,7 @@ import {LocationDescriptorObject} from 'history';
 
 import {transactionTargetHash} from 'sentry/components/events/interfaces/spans/utils';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {Event} from 'sentry/types';
 import {TraceMetaQueryChildrenProps} from 'sentry/utils/performance/quickTrace/traceMetaQuery';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -22,6 +23,7 @@ function TraceDetailsRouting(props: Props) {
   const {metaResults, event, children} = props;
   const organization = useOrganization();
   const location = useLocation();
+  const datetimeSelection = normalizeDateTimeParams(location.query);
 
   useEffect(() => {
     const traceId = event.contexts?.trace?.trace_id ?? '';
@@ -34,19 +36,17 @@ function TraceDetailsRouting(props: Props) {
       const traceDetailsLocation: LocationDescriptorObject = getTraceDetailsUrl(
         organization,
         traceId,
-        event.title,
+        datetimeSelection,
         location.query
       );
 
       browserHistory.replace({
         pathname: traceDetailsLocation.pathname,
-        query: {
-          transaction: traceDetailsLocation.query?.transaction,
-        },
+        query: traceDetailsLocation.query,
         hash: transactionTargetHash(event.eventID) + location.hash,
       });
     }
-  }, [event, metaResults, location, organization]);
+  }, [event, metaResults, location, organization, datetimeSelection]);
 
   if (
     metaResults?.isLoading &&


### PR DESCRIPTION
- Because datetime selection wasn't being passed we'd constantly query 90d of data when we could query the daterange of the previous page instead (which usually would be less)