### PR TITLE
chore(replays): remove frontend feature flags references for new zero state UI

### DIFF
--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -49,8 +49,7 @@ function EventReplayContent({
   }
 
   const platform = group?.project.platform ?? 'other';
-  const newOnboarding = organization.features.includes('session-replay-new-zero-state');
-  if (newOnboarding && !replayId && replayBackendPlatforms.includes(platform)) {
+  if (!replayId && replayBackendPlatforms.includes(platform)) {
     // if backend project, show new onboarding panel
     return (
       <ErrorBoundary mini>

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -190,10 +190,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     defaultTab
   );
 
-  const newOnboarding = organization.features.includes('session-replay-new-zero-state');
-
   const showJsFrameworkInstructions =
-    newOnboarding &&
     currentProject.platform &&
     replayBackendPlatforms.includes(currentProject.platform) &&
     setupMode() === 'npm';
@@ -205,7 +202,6 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
       .includes(currentProject.platform);
 
   const showRadioButtons =
-    newOnboarding &&
     currentProject.platform &&
     replayJsLoaderInstructionsPlatformList.includes(currentProject.platform);
 
@@ -222,11 +218,12 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     ? platforms.find(p => p.id === currentProject.platform) ?? otherPlatform
     : otherPlatform;
 
+  // For old onboarding
   const docKeys = useMemo(() => {
-    return currentPlatform && !newOnboarding ? generateDocKeys(currentPlatform.id) : [];
-  }, [currentPlatform, newOnboarding]);
+    return currentPlatform ? generateDocKeys(currentPlatform.id) : [];
+  }, [currentPlatform]);
 
-  // Old onboarding docs
+  // Old onboarding docs, fallback if new docs fail for some reasond
   const {docContents, isLoading, hasOnboardingContents} = useOnboardingDocs({
     project: currentProject,
     docKeys,
@@ -301,8 +298,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
           onChange={setSetupMode}
         />
       ) : (
-        newDocs?.platformOptions &&
-        newOnboarding && (
+        newDocs?.platformOptions && (
           <PlatformSelect>
             {tct("I'm using [platformSelect]", {
               platformSelect: (
@@ -350,11 +346,8 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     );
   }
 
-  if (
-    !currentPlatform ||
-    (!newOnboarding && !hasOnboardingContents) ||
-    (newOnboarding && !newDocs)
-  ) {
+  // No platform or no docs (new nor old)
+  if (!currentPlatform || (!newDocs && !hasOnboardingContents)) {
     return (
       <Fragment>
         <div>
@@ -379,7 +372,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
   return (
     <Fragment>
       {radioButtons}
-      {newOnboarding && newDocs ? (
+      {newDocs ? (
         <ReplayOnboardingLayout
           docsConfig={newDocs}
           dsn={dsn}

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -223,7 +223,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     return currentPlatform ? generateDocKeys(currentPlatform.id) : [];
   }, [currentPlatform]);
 
-  // Old onboarding docs, fallback if new docs fail for some reasond
+  // Old onboarding docs, fallback if new docs fail for some reason
   const {docContents, isLoading, hasOnboardingContents} = useOnboardingDocs({
     project: currentProject,
     docKeys,


### PR DESCRIPTION
- remove references to the feature flag `organizations:session-replay-new-zero-state` in the frontend (applies to issue details page for the CTA, as well as our new onboarding sidebar)
- default docs are now the new onboarding docs
- however, if the new onboarding docs fail, we'll still fallback to the old docs (so none of those are deleted yet, and the code still renders them if needed)
- added comments for clarity with regards to new vs old docs

BE changes to be merged after: https://github.com/getsentry/sentry/pull/63288
relates to https://github.com/getsentry/sentry/issues/63290