### PR TITLE
fix(replays): Add handling for upload errors in buffered consumer

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -63,7 +63,7 @@ def ingest_replay_recordings_buffered_options() -> List[click.Option]:
     """Return a list of ingest-replay-recordings-buffered options."""
     options = [
         click.Option(
-            ["--max-buffer-row-count", "max_buffer_row_count"],
+            ["--max-buffer-message-count", "max_buffer_message_count"],
             type=int,
             default=100,
         ),

--- a/src/sentry/replays/consumers/recording_buffered.py
+++ b/src/sentry/replays/consumers/recording_buffered.py
@@ -69,6 +69,10 @@ logger = logging.getLogger(__name__)
 RECORDINGS_CODEC = get_codec("ingest-replay-recordings")
 
 
+class BufferCommitFailed(Exception):
+    ...
+
+
 class RecordingBufferedStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
     """
     This consumer processes replay recordings, which are compressed payloads split up into
@@ -332,7 +336,7 @@ def commit_uploads(upload_events: list[UploadEvent]) -> None:
     # Raising an exception crashes the process and forces a restart from the last committed
     # offset. No rate-limiting is applied.
     if has_errors:
-        raise Exception("Could not upload one or more recordings.")
+        raise BufferCommitFailed("Could not upload one or more recordings.")
 
 
 def commit_initial_segments(initial_segment_events: list[InitialSegmentEvent]) -> None:

--- a/tests/sentry/replays/consumers/test_recording.py
+++ b/tests/sentry/replays/consumers/test_recording.py
@@ -184,7 +184,7 @@ class RecordingBufferedTestCase(RecordingTestCase):
     def processing_factory(self):
         # The options don't matter because we're calling join which commits regardless.
         return RecordingBufferedStrategyFactory(
-            max_buffer_row_count=1000,
+            max_buffer_message_count=1000,
             max_buffer_size_in_bytes=1000,
             max_buffer_time_in_seconds=1000,
         )

--- a/tests/sentry/replays/unit/test_recording_buffer.py
+++ b/tests/sentry/replays/unit/test_recording_buffer.py
@@ -4,7 +4,11 @@ from unittest.mock import patch
 import pytest
 import time_machine
 
-from sentry.replays.consumers.recording_buffered import RecordingBuffer, commit_uploads
+from sentry.replays.consumers.recording_buffered import (
+    BufferCommitFailed,
+    RecordingBuffer,
+    commit_uploads,
+)
 
 
 def test_recording_buffer_commit_default():
@@ -139,5 +143,5 @@ def test_commit_uploads_failure(_do_upload):
 
     _do_upload.side_effect = mocked
 
-    with pytest.raises(Exception):
+    with pytest.raises(BufferCommitFailed):
         commit_uploads([{}])  # type: ignore

--- a/tests/sentry/replays/unit/test_recording_buffer.py
+++ b/tests/sentry/replays/unit/test_recording_buffer.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 
 import pytest
 import time_machine
-from arroyo.processing.strategies import MessageRejected
 
 from sentry.replays.consumers.recording_buffered import RecordingBuffer, commit_uploads
 
@@ -140,5 +139,5 @@ def test_commit_uploads_failure(_do_upload):
 
     _do_upload.side_effect = mocked
 
-    with pytest.raises(MessageRejected):
+    with pytest.raises(Exception):
         commit_uploads([{}])  # type: ignore

--- a/tests/sentry/replays/unit/test_recording_buffer.py
+++ b/tests/sentry/replays/unit/test_recording_buffer.py
@@ -47,7 +47,7 @@ def test_recording_buffer_commit_default():
 
 def test_recording_buffer_commit_deadline():
     buffer = RecordingBuffer(
-        max_buffer_row_count=1_000_000,  # Never triggers commit.
+        max_buffer_message_count=1_000_000,  # Never triggers commit.
         max_buffer_size_in_bytes=1_000_000,  # Never triggers commit.
         max_buffer_time_in_seconds=5,
     )
@@ -90,7 +90,7 @@ def test_recording_buffer_commit_next_state():
     traveller = time_machine.travel(now)
     traveller.start()
     buffer = RecordingBuffer(
-        max_buffer_row_count=1_000_000,  # Never triggers commit.
+        max_buffer_message_count=1_000_000,  # Never triggers commit.
         max_buffer_size_in_bytes=1_000_000,  # Never triggers commit.
         max_buffer_time_in_seconds=5,
     )


### PR DESCRIPTION
Adds handling for errors while uploading to the service-provider.  Specifically it:

1. Captures and logs errors that occur inside the threadpool.
2. Raises an exception which resets the buffer and begins processing from the previously committed offset.

This was added to address (in a safe and reliable way) the "BadGateway" error that GCS throws.