### PR TITLE
feat(browser-starfish): make sure images should up when all reesource types are selected

### DIFF
--- a/static/app/views/performance/browser/resources/index.spec.tsx
+++ b/static/app/views/performance/browser/resources/index.spec.tsx
@@ -86,7 +86,7 @@ describe('ResourcesLandingPage', function () {
         ],
         "per_page": 100,
         "project": [],
-        "query": "!span.description:"browser-extension://*" ( span.op:resource.script OR file_extension:css OR file_extension:[woff,woff2,ttf,otf,eot] ) ",
+        "query": "!span.description:"browser-extension://*" ( span.op:resource.script OR file_extension:css OR file_extension:[woff,woff2,ttf,otf,eot] OR file_extension:[jpg,jpeg,png,gif,svg,webp,apng,avif] OR span.op:resource.img ) ",
         "referrer": "api.performance.browser.resources.main-table",
         "sort": "-time_spent_percentage()",
         "statsPeriod": "10d",

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -19,6 +19,7 @@ import SampleImages from 'sentry/views/performance/browser/resources/resourceSum
 import {FilterOptionsContainer} from 'sentry/views/performance/browser/resources/resourceView';
 import {IMAGE_FILE_EXTENSIONS} from 'sentry/views/performance/browser/resources/shared/constants';
 import RenderBlockingSelector from 'sentry/views/performance/browser/resources/shared/renderBlockingSelector';
+import {ResourceSpanOps} from 'sentry/views/performance/browser/resources/shared/types';
 import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {ModulePageProviders} from 'sentry/views/performance/database/modulePageProviders';
 import {useSpanMetrics} from 'sentry/views/starfish/queries/useSpanMetrics';
@@ -32,6 +33,7 @@ const {
   HTTP_RESPONSE_CONTENT_LENGTH,
   HTTP_RESPONSE_TRANSFER_SIZE,
   RESOURCE_RENDER_BLOCKING_STATUS,
+  SPAN_OP,
 } = SpanMetricsField;
 
 function ResourceSummary() {
@@ -52,15 +54,17 @@ function ResourceSummary() {
       `avg(${HTTP_RESPONSE_TRANSFER_SIZE})`,
       `sum(${SPAN_SELF_TIME})`,
       'spm()',
+      SPAN_OP,
       SPAN_DESCRIPTION,
       'time_spent_percentage()',
       'project.id',
     ],
   });
   const spanMetrics = data[0] ?? {};
-  const isImage = IMAGE_FILE_EXTENSIONS.includes(
-    spanMetrics[SpanMetricsField.SPAN_DESCRIPTION]?.split('.').pop() || ''
-  );
+  const isImage =
+    IMAGE_FILE_EXTENSIONS.includes(
+      spanMetrics[SpanMetricsField.SPAN_DESCRIPTION]?.split('.').pop() || ''
+    ) || spanMetrics[SPAN_OP] === ResourceSpanOps.IMAGE;
   return (
     <ModulePageProviders
       title={[t('Performance'), t('Resources'), t('Resource Summary')].join(' — ')}

--- a/static/app/views/performance/browser/resources/resourceView/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceView/index.tsx
@@ -37,9 +37,10 @@ const {
 } = BrowserStarfishFields;
 
 export const DEFAULT_RESOURCE_TYPES = [
-  'resource.script',
-  'resource.css',
-  'resource.font',
+  ResourceSpanOps.SCRIPT,
+  ResourceSpanOps.CSS,
+  ResourceSpanOps.FONT,
+  ResourceSpanOps.IMAGE,
 ];
 
 type Option = {

--- a/static/app/views/performance/browser/resources/resourceView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceView/resourceTable.tsx
@@ -2,7 +2,6 @@ import {Fragment, useEffect} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
-import {PLATFORM_TO_ICON} from 'platformicons/build/platformIcon';
 
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
@@ -10,13 +9,18 @@ import GridEditable, {
   GridColumnOrder,
 } from 'sentry/components/gridEditable';
 import Pagination, {CursorHandler} from 'sentry/components/pagination';
+import {IconImage} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {PageAlert, usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {RESOURCE_THROUGHPUT_UNIT} from 'sentry/views/performance/browser/resources';
-import {FONT_FILE_EXTENSIONS} from 'sentry/views/performance/browser/resources/shared/constants';
+import {
+  FONT_FILE_EXTENSIONS,
+  IMAGE_FILE_EXTENSIONS,
+} from 'sentry/views/performance/browser/resources/shared/constants';
+import {ResourceSpanOps} from 'sentry/views/performance/browser/resources/shared/types';
 import {ValidSort} from 'sentry/views/performance/browser/resources/utils/useResourceSort';
 import {useResourcesQuery} from 'sentry/views/performance/browser/resources/utils/useResourcesQuery';
 import {DurationCell} from 'sentry/views/starfish/components/tableCells/durationCell';
@@ -115,28 +119,13 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
 
   const renderBodyCell = (col: Column, row: Row) => {
     const {key} = col;
-    const getIcon = (
-      spanOp: string,
-      fileExtension: string
-    ): keyof typeof PLATFORM_TO_ICON | 'unknown' => {
-      if (spanOp === 'resource.script') {
-        return 'javascript';
-      }
-      if (fileExtension === 'css') {
-        return 'css';
-      }
-      if (FONT_FILE_EXTENSIONS.includes(fileExtension)) {
-        return 'font';
-      }
-      return 'unknown';
-    };
 
     if (key === SPAN_DESCRIPTION) {
       const fileExtension = row[SPAN_DESCRIPTION].split('.').pop() || '';
 
       return (
         <DescriptionWrapper>
-          <PlatformIcon platform={getIcon(row[SPAN_OP], fileExtension) || 'unknown'} />
+          <ResourceIcon fileExtension={fileExtension} spanOp={row[SPAN_OP]} />
           <SpanDescriptionCell
             moduleName={ModuleName.HTTP}
             projectId={row[PROJECT_ID]}
@@ -210,6 +199,24 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
       <Pagination pageLinks={pageLinks} onCursor={handleCursor} />
     </Fragment>
   );
+}
+
+function ResourceIcon(props: {fileExtension: string; spanOp: string}) {
+  const {spanOp, fileExtension} = props;
+
+  if (spanOp === ResourceSpanOps.SCRIPT) {
+    return <PlatformIcon platform="javascript" />;
+  }
+  if (fileExtension === 'css') {
+    return <PlatformIcon platform="css" />;
+  }
+  if (FONT_FILE_EXTENSIONS.includes(fileExtension)) {
+    return <PlatformIcon platform="font" />;
+  }
+  if (spanOp === ResourceSpanOps.IMAGE || IMAGE_FILE_EXTENSIONS.includes(fileExtension)) {
+    return <IconImage color="black" legacySize="20px" />;
+  }
+  return <PlatformIcon platform="unknown" />;
 }
 
 export default ResourceTable;

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -165,11 +165,12 @@ export const getResourceTypeFilter = (
   defaultResourceTypes: string[] | undefined
 ) => {
   let resourceFilter: string[] = [`${SPAN_OP}:resource.*`];
+
   if (selectedSpanOp) {
     resourceFilter = SPAN_OP_FILTER[selectedSpanOp] || [`${SPAN_OP}:${selectedSpanOp}`];
   } else if (defaultResourceTypes) {
     resourceFilter = [
-      defaultResourceTypes.map(type => SPAN_OP_FILTER[type]).join(' OR '),
+      defaultResourceTypes.map(type => SPAN_OP_FILTER[type].join(' OR ')).join(' OR '),
     ];
   }
   return ['(', ...resourceFilter, ')'];

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -925,7 +925,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
           per_page: QUERY_LIMIT_PARAM,
           project: ['-42'],
           query:
-            '!span.description:browser-extension://* resource.render_blocking_status:blocking ( span.op:resource.script OR file_extension:css OR file_extension:[woff,woff2,ttf,otf,eot] ) transaction.op:pageload',
+            '!span.description:browser-extension://* resource.render_blocking_status:blocking ( span.op:resource.script OR file_extension:css OR file_extension:[woff,woff2,ttf,otf,eot] OR file_extension:[jpg,jpeg,png,gif,svg,webp,apng,avif] OR span.op:resource.img ) transaction.op:pageload',
           sort: '-time_spent_percentage()',
           statsPeriod: '7d',
         }),


### PR DESCRIPTION
1. Ensures images are properly queried for when 'All' resource types are selected
<img width="269" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/d4f6afc3-347c-4f71-9207-bb42375947f6">


2. Adds image icon to resource list
<img width="359" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/5ecdcc25-2945-4728-9669-04b440b7e719">

3. Ensure sample view is displayed when an image resource has the resource image span op but no file extension.