### PR TITLE
fix(hybrid-cloud): Remove silo limit from Slack post_message task

### DIFF
--- a/src/sentry/tasks/integrations/slack/post_message.py
+++ b/src/sentry/tasks/integrations/slack/post_message.py
@@ -5,7 +5,6 @@ from typing import Any, Mapping
 
 from sentry.integrations.slack.client import SlackClient
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo import SiloMode
 from sentry.tasks.base import instrumented_task
 
 logger = logging.getLogger("sentry.integrations.slack.tasks")
@@ -16,7 +15,6 @@ logger = logging.getLogger("sentry.integrations.slack.tasks")
     name="sentry.integrations.slack.post_message",
     queue="integrations",
     max_retries=0,
-    silo_mode=SiloMode.REGION,
 )
 def post_message(
     integration_id: int,


### PR DESCRIPTION
Fixes [SENTRY-2E0C](https://sentry.sentry.io/issues/4875976165)

The Slack `post_message` task doesn't need to be either a region nor a control silo exclusive task. The reason being is that the `SlackClient` can make API requests from either the control or region silo since it extends `IntegrationProxyClient`.  

See: https://github.com/getsentry/sentry/blob/bff620f402dc106a98594f2f6cd3ecfc3f76ff35/src/sentry/integrations/slack/client.py#L22



