### PR TITLE
fix(hybridcloud) Add region pinning for legacy cron ingest

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3974,6 +3974,7 @@ REGION_PINNED_URL_NAMES = {
     "sentry-api-0-prompts-activity",
     # Legacy monitor endpoints
     "sentry-api-0-monitor-ingest-check-in-index",
+    "sentry-api-0-monitor-ingest-check-in-details",
     # These paths are used by relay which is implicitly region scoped
     "sentry-api-0-relays-index",
     "sentry-api-0-relay-register-challenge",


### PR DESCRIPTION
I didn't see the error for the `/monitors/<slug>/checkins/latest/` endpoint previously but it is more visible now that we're handling larger volume of traffic.

Fixes SENTRY-2BDS