### PR TITLE
fix(dev-env): Pull x86 image for snuba

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2933,6 +2933,7 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
             },
             "only_if": "snuba" in settings.SENTRY_EVENTSTREAM
             or "kafka" in settings.SENTRY_EVENTSTREAM,
+            "platform": "linux/x86_64",
         }
     ),
     "bigtable": lambda settings, options: (

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2933,7 +2933,10 @@ SENTRY_DEVSERVICES: dict[str, Callable[[Any, Any], dict[str, Any]]] = {
             },
             "only_if": "snuba" in settings.SENTRY_EVENTSTREAM
             or "kafka" in settings.SENTRY_EVENTSTREAM,
-            "platform": "linux/x86_64",
+            # we don't build linux/arm64 snuba images anymore
+            # apple silicon users should have working emulation under colima 0.6.2
+            # or docker desktop
+            "platform": "linux/amd64",
         }
     ),
     "bigtable": lambda settings, options: (

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -131,7 +131,10 @@ def retryable_pull(
     # See https://github.com/docker/docker-py/issues/2101 for more information
     while True:
         try:
-            client.images.pull(image, platform=platform)
+            if platform:
+                client.images.pull(image, platform=platform)
+            else:
+                client.images.pull(image)
         except APIError:
             if current_attempt + 1 >= max_attempts:
                 raise


### PR DESCRIPTION
This was trying to pull the ARM image which has not been built since getsentry/snuba#5365. To pull the x86 image, we have to explicitly specify the platform otherwise it'll try to pull the latest ARM image which doesn't exist and silently continues using the previously pulled ARM image.