### PR TITLE
fix(hybrid-cloud): Optimize organization_service RPC call for customer domain redirect urls

### DIFF
--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -29,7 +29,11 @@ NON_CUSTOMER_DOMAIN_URL_NAMES = [
 
 def resolve_redirect_url(request, org_slug, user_id=None):
     org_context = organization_service.get_organization_by_slug(
-        slug=org_slug, only_visible=False, user_id=user_id
+        slug=org_slug,
+        only_visible=False,
+        user_id=user_id,
+        include_projects=False,
+        include_teams=False,
     )
     if org_context and features.has("organizations:customer-domains", org_context.organization):
         url_base = generate_organization_url(org_context.organization.slug)


### PR DESCRIPTION
We do not need the org's projects or teams when generating a customer domain redirect URL.