### PR TITLE
feat(queryset): Add opt-in ability to send a `post_update` signal when using `queryset.update`

### DIFF
--- a/src/sentry/db/models/manager/base_query_set.py
+++ b/src/sentry/db/models/manager/base_query_set.py
@@ -23,7 +23,7 @@ class BaseQuerySet(QuerySet, abc.ABC):
         return qs
 
     def _clone(self) -> "BaseQuerySet":
-        qs = super()._clone()
+        qs = super()._clone()  # type: ignore[misc]
         qs._send_post_update_signal = self._send_post_update_signal
         return qs
 

--- a/src/sentry/db/models/manager/base_query_set.py
+++ b/src/sentry/db/models/manager/base_query_set.py
@@ -4,12 +4,42 @@ from typing import Any
 from django.db import router
 from django.db.models import QuerySet
 
+from sentry.signals import post_update
+
 
 class BaseQuerySet(QuerySet, abc.ABC):
-    # XXX(dcramer): we prefer values_list, but we can't disable values as Django uses it
-    # internally
-    # def values(self, *args, **kwargs):
-    #     raise NotImplementedError('Use ``values_list`` instead [performance].')
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._send_post_update_signal = False
+
+    def enable_post_update_signal(self, enable: bool) -> "BaseQuerySet":
+        """
+        Enables sending a `post_update` signal after this queryset runs an update command. Note that this is less
+        efficient than just running the update. To get the list of group ids affected, we first run the query to
+        fetch the rows we want to update, then run the update using those ids.
+        """
+        qs = self.all()
+        qs._send_post_update_signal = enable
+        return qs
+
+    def _clone(self) -> "BaseQuerySet":
+        qs = super()._clone()
+        qs._send_post_update_signal = self._send_post_update_signal
+        return qs
+
+    def update(self, **kwargs: Any) -> int:
+        if self._send_post_update_signal:
+            ids = list(self.values_list("id", flat=True))
+            updated = (
+                self.model.objects.filter(id__in=ids)
+                .enable_post_update_signal(False)
+                .update(**kwargs)
+            )
+            updated_fields = list(kwargs.keys())
+            post_update.send(sender=self.model, updated_fields=updated_fields, model_ids=ids)
+            return updated
+        else:
+            return super().update(**kwargs)
 
     def using_replica(self) -> "BaseQuerySet":
         """

--- a/src/sentry/db/models/manager/base_query_set.py
+++ b/src/sentry/db/models/manager/base_query_set.py
@@ -69,7 +69,8 @@ class BaseQuerySet(QuerySet, abc.ABC):
 
     def update(self, **kwargs: Any) -> int:
         if self._with_post_update_signal:
-            ids = [result[0] for result in self.update_with_returning(["id"], **kwargs)]
+            pk = self.model._meta.pk.name
+            ids = [result[0] for result in self.update_with_returning([pk], **kwargs)]
             updated_fields = list(kwargs.keys())
             post_update.send(sender=self.model, updated_fields=updated_fields, model_ids=ids)
             return len(ids)

--- a/src/sentry/db/models/manager/base_query_set.py
+++ b/src/sentry/db/models/manager/base_query_set.py
@@ -32,12 +32,12 @@ class BaseQuerySet(QuerySet, abc.ABC):
         """
         Copied and modified from `Queryset.update()` to support `RETURNING <returned_fields>`
         """
-        self._not_support_combined_queries("update")
+        self._not_support_combined_queries("update")  # type: ignore[attr-defined]
         if self.query.is_sliced:
             raise TypeError("Cannot update a query once a slice has been taken.")
         self._for_write = True
         query = self.query.chain(sql.UpdateQuery)
-        query.add_update_values(kwargs)
+        query.add_update_values(kwargs)  # type: ignore[attr-defined]
 
         # Inline annotations in order_by(), if possible.
         new_order_by = []
@@ -65,7 +65,7 @@ class BaseQuerySet(QuerySet, abc.ABC):
         self._result_cache = None
         return result_ids
 
-    update_with_returning.alters_data = True
+    update_with_returning.alters_data = True  # type: ignore[attr-defined]
 
     def update(self, **kwargs: Any) -> int:
         if self._with_post_update_signal:

--- a/src/sentry/db/models/paranoia.py
+++ b/src/sentry/db/models/paranoia.py
@@ -1,15 +1,14 @@
 from typing import ClassVar
 
 from django.db import models
-from django.db.models.query import QuerySet
 from django.utils import timezone
 from typing_extensions import Self
 
-from sentry.db.models import BaseManager, BaseModel, sane_repr
+from sentry.db.models import BaseManager, BaseModel, BaseQuerySet, sane_repr
 from sentry.db.models.manager import M
 
 
-class ParanoidQuerySet(QuerySet):
+class ParanoidQuerySet(BaseQuerySet):
     """
     Prevents objects from being hard-deleted. Instead, sets the
     ``date_deleted``, effectively soft-deleting the object.

--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -45,7 +45,13 @@ def update(instance: Model, using: str | None = None, **kwargs: Any) -> int:
         if getattr(field, "auto_now", False) and field.name not in kwargs:
             kwargs[field.name] = field.pre_save(instance, False)
 
-    affected = instance.__class__._base_manager.using(using).filter(pk=instance.pk).update(**kwargs)
+    affected = (
+        instance.__class__.objects.using(using)
+        .filter(pk=instance.pk)
+        # Disable the post update query signal since we're going to send a more specific `post_save` signal here.
+        .enable_post_update_signal(False)
+        .update(**kwargs)
+    )
     for k, v in kwargs.items():
         setattr(instance, k, _handle_value(instance, v))
     if affected == 1:

--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -49,7 +49,7 @@ def update(instance: Model, using: str | None = None, **kwargs: Any) -> int:
         instance.__class__.objects.using(using)
         .filter(pk=instance.pk)
         # Disable the post update query signal since we're going to send a more specific `post_save` signal here.
-        .enable_post_update_signal(False)
+        .with_post_update_signal(False)
         .update(**kwargs)
     )
     for k, v in kwargs.items():

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -21,7 +21,7 @@ from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 from snuba_sdk import Column, Condition, Op
 
-from sentry import eventstore, eventtypes, tagstore
+from sentry import eventstore, eventtypes, options, tagstore
 from sentry.backup.scopes import RelocationScope
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS, MAX_CULPRIT_LENGTH
 from sentry.db.models import (
@@ -298,6 +298,13 @@ def get_recommended_event_for_environments(
 
 class GroupManager(BaseManager["Group"]):
     use_for_related_fields = True
+
+    def get_queryset(self):
+        return (
+            super()
+            .get_queryset()
+            .enable_post_update_signal(options.get("groups.enable-post-update-signal"))
+        )
 
     def by_qualified_short_id(self, organization_id: int, short_id: str):
         return self.by_qualified_short_id_bulk(organization_id, [short_id])[0]

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -303,7 +303,7 @@ class GroupManager(BaseManager["Group"]):
         return (
             super()
             .get_queryset()
-            .enable_post_update_signal(options.get("groups.enable-post-update-signal"))
+            .with_post_update_signal(options.get("groups.enable-post-update-signal"))
         )
 
     def by_qualified_short_id(self, organization_id: int, short_id: str):

--- a/src/sentry/new_migrations/monkey/__init__.py
+++ b/src/sentry/new_migrations/monkey/__init__.py
@@ -6,15 +6,18 @@ from sentry.new_migrations.monkey.fields import deconstruct
 
 LAST_VERIFIED_DJANGO_VERSION = (4, 2)
 CHECK_MESSAGE = """Looks like you're trying to upgrade Django! Since we monkeypatch
-the Django migration library in several places, please verify that we have the latest
-code, and that the monkeypatching still works as expected. Currently the main things
-to check are:
+Django in several places, please verify that we have the latest code, and that the
+monkeypatching still works as expected. Currently the main things to check are:
  - `django.db.migrations.executor.MigrationExecutor`. The `is_dangerous` flag should
    continue to work here when we set `MIGRATION_SKIP_DANGEROUS=1` as an environment
    variable. Confirm that the structure of the class hasn't drastically changed.
-- `django.db.migrations.writer.MIGRATION_TEMPLATE`. Verify that the template hasn't
+ - `django.db.migrations.writer.MIGRATION_TEMPLATE`. Verify that the template hasn't
   significantly changed. Details on what we've changed are in a comment on
   `sentry.migrations.monkey.writer.SENTRY_MIGRATION_TEMPLATE`
+ - `sentry.db.models.manager.base_query_set.BaseQuerySet.update_with_returning`. This
+    is copied and modified from `Queryset.update()` to add `RETURNING <fields>` to
+    the update query. Verify that the `update` code hasn't significantly changed,
+    and if it has update as needed.
 
 When you're happy that these changes are good to go, update
 `LAST_VERIFIED_DJANGO_VERSION` to the version of Django you're upgrading to. If the

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1989,3 +1989,10 @@ register(
     type=Bool,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Enable sending a post update signal after we update groups using a queryset update
+register(
+    "groups.enable-post-update-signal",
+    default=False,
+    flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -198,5 +198,7 @@ relocated = BetterSignal()  # ["relocation_uuid"]
 relocation_link_promo_code = BetterSignal()  # ["relocation_uuid", "promo_code"]
 relocation_redeem_promo_code = BetterSignal()  # ["user_id", "relocation_uuid", "orgs"]
 
+# Fired after an update is performed on a `PostUpdateQuerySet`. Separate to a `.update` call on a model.
+post_update = BetterSignal()  # [sender: Model, update_fields: list[str], model_ids: list[int]]
 # After `sentry upgrade` has completed.  Better than post_migrate because it won't run in tests.
 post_upgrade = BetterSignal()  # []

--- a/tests/sentry/db/models/manager/test_base_query_set.py
+++ b/tests/sentry/db/models/manager/test_base_query_set.py
@@ -1,0 +1,69 @@
+from contextlib import contextmanager
+from unittest import mock
+
+from sentry.models.group import Group
+from sentry.signals import post_update
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import override_options
+
+
+@contextmanager
+def catch_signal(signal):
+    handler = mock.Mock()
+    signal.connect(handler)
+    yield handler
+    signal.disconnect(handler)
+
+
+class TestSendPostUpdateSignal(TestCase):
+    def test_not_triggered(self):
+        with catch_signal(post_update) as handler:
+            self.group.message = "hi"
+            self.group.save()
+
+        assert not handler.called
+
+        with catch_signal(post_update) as handler:
+            self.group.update(message="hi")
+
+        assert not handler.called
+
+        with catch_signal(post_update) as handler, override_options(
+            {"groups.enable-post-update-signal": False}
+        ):
+            Group.objects.filter(id=self.group.id).update(message="hi")
+
+        assert not handler.called
+
+        with catch_signal(post_update) as handler, override_options(
+            {"groups.enable-post-update-signal": True}
+        ):
+            Group.objects.filter(id=self.group.id).enable_post_update_signal(False).update(
+                message="hi"
+            )
+
+        assert not handler.called
+
+    def test_enable(self):
+        qs = Group.objects.all()
+        assert not qs._send_post_update_signal
+        new_qs = qs.enable_post_update_signal(True)
+        # Make sure we don't modify the previous queryset
+        assert not qs._send_post_update_signal
+        assert new_qs._send_post_update_signal
+
+    def test_triggered(self):
+        message = "hi"
+        with catch_signal(post_update) as handler, override_options(
+            {"groups.enable-post-update-signal": True}
+        ):
+            Group.objects.filter(id=self.group.id).update(message=message)
+
+        self.group.refresh_from_db()
+        assert self.group.message == message
+        handler.assert_called_once_with(
+            signal=post_update,
+            sender=Group,
+            updated_fields=["message"],
+            model_ids=[self.group.id],
+        )

--- a/tests/sentry/db/models/manager/test_base_query_set.py
+++ b/tests/sentry/db/models/manager/test_base_query_set.py
@@ -17,13 +17,17 @@ def catch_signal(signal):
 
 class TestSendPostUpdateSignal(TestCase):
     def test_not_triggered(self):
-        with catch_signal(post_update) as handler:
+        with catch_signal(post_update) as handler, override_options(
+            {"groups.enable-post-update-signal": True}
+        ):
             self.group.message = "hi"
             self.group.save()
 
         assert not handler.called
 
-        with catch_signal(post_update) as handler:
+        with catch_signal(post_update) as handler, override_options(
+            {"groups.enable-post-update-signal": True}
+        ):
             self.group.update(message="hi")
 
         assert not handler.called

--- a/tests/sentry/db/models/manager/test_base_query_set.py
+++ b/tests/sentry/db/models/manager/test_base_query_set.py
@@ -62,7 +62,7 @@ class TestSendPostUpdateSignal(TestCase):
         ):
             assert (
                 Group.objects.filter(id=self.group.id)
-                .enable_post_update_signal(False)
+                .with_post_update_signal(False)
                 .update(message="hi")
                 == 1
             )
@@ -71,11 +71,11 @@ class TestSendPostUpdateSignal(TestCase):
 
     def test_enable(self):
         qs = Group.objects.all()
-        assert not qs._send_post_update_signal
-        new_qs = qs.enable_post_update_signal(True)
+        assert not qs._with_post_update_signal
+        new_qs = qs.with_post_update_signal(True)
         # Make sure we don't modify the previous queryset
-        assert not qs._send_post_update_signal
-        assert new_qs._send_post_update_signal
+        assert not qs._with_post_update_signal
+        assert new_qs._with_post_update_signal
 
     def test_triggered(self):
         message = "hi"

--- a/tests/sentry/db/models/manager/test_base_query_set.py
+++ b/tests/sentry/db/models/manager/test_base_query_set.py
@@ -15,6 +15,24 @@ def catch_signal(signal):
     signal.disconnect(handler)
 
 
+class TestUpdateWithReturning(TestCase):
+    def test(self):
+        group_2 = self.create_group()
+        ids = [self.group.id, group_2.id]
+        returned = Group.objects.filter(id__in=ids).update_with_returning(
+            returned_fields=["id"], message="hi"
+        )
+        assert {r[0] for r in returned} == set(ids)
+        returned = Group.objects.filter(id=self.group.id).update_with_returning(
+            returned_fields=["id"], message="hi"
+        )
+        assert [r[0] for r in returned] == [self.group.id]
+        returned = Group.objects.filter(id__in=ids).update_with_returning(
+            returned_fields=["id", "message"], message="hi"
+        )
+        assert {r for r in returned} == {(id_, "hi") for id_ in ids}
+
+
 class TestSendPostUpdateSignal(TestCase):
     def test_not_triggered(self):
         with catch_signal(post_update) as handler, override_options(
@@ -35,15 +53,18 @@ class TestSendPostUpdateSignal(TestCase):
         with catch_signal(post_update) as handler, override_options(
             {"groups.enable-post-update-signal": False}
         ):
-            Group.objects.filter(id=self.group.id).update(message="hi")
+            assert Group.objects.filter(id=self.group.id).update(message="hi") == 1
 
         assert not handler.called
 
         with catch_signal(post_update) as handler, override_options(
             {"groups.enable-post-update-signal": True}
         ):
-            Group.objects.filter(id=self.group.id).enable_post_update_signal(False).update(
-                message="hi"
+            assert (
+                Group.objects.filter(id=self.group.id)
+                .enable_post_update_signal(False)
+                .update(message="hi")
+                == 1
             )
 
         assert not handler.called
@@ -61,7 +82,7 @@ class TestSendPostUpdateSignal(TestCase):
         with catch_signal(post_update) as handler, override_options(
             {"groups.enable-post-update-signal": True}
         ):
-            Group.objects.filter(id=self.group.id).update(message=message)
+            assert Group.objects.filter(id=self.group.id).update(message=message) == 1
 
         self.group.refresh_from_db()
         assert self.group.message == message


### PR DESCRIPTION
Currently, when calling `<queryset>`.update no signals are fired, since we don't know which rows are updated. This pr adds the ability for a queryset to opt-in to sending a `post_update` signal. To achieve this, we use the Postgres `RETURNING <fields>` functionality. Django doesn't support this currently, so I've copied and modified the existing update code from Django.

Will follow this up with adding the option to places where we're manually firing a post save signal for groups.
