### PR TITLE
feat(replay): add session replay button in project creation flow

### DIFF
--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -14,7 +14,10 @@ import {
   platformProductAvailability,
   ProductSolution,
 } from 'sentry/components/onboarding/productSelection';
-import {performance as performancePlatforms} from 'sentry/data/platformCategories';
+import {
+  performance as performancePlatforms,
+  replayPlatforms,
+} from 'sentry/data/platformCategories';
 import {Platform} from 'sentry/data/platformPickerCategories';
 import platforms from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
@@ -167,7 +170,9 @@ export function ProjectInstallPlatform({location, params}: Props) {
 
   const issueStreamLink = `/organizations/${organization.slug}/issues/`;
   const performanceOverviewLink = `/organizations/${organization.slug}/performance/`;
+  const replayLink = `/organizations/${organization.slug}/replays/`;
   const showPerformancePrompt = performancePlatforms.includes(platform.id as PlatformKey);
+  const showReplayButton = replayPlatforms.includes(platform.id as PlatformKey);
   const isGettingStarted = window.location.href.indexOf('getting-started') > 0;
   const showDocsWithProductSelection =
     (platformProductAvailability[platform.key] ?? []).length > 0;
@@ -245,6 +250,19 @@ export function ProjectInstallPlatform({location, params}: Props) {
           >
             {t('Take me to Performance')}
           </Button>
+          {showReplayButton && (
+            <Button
+              busy={loadingProjects}
+              to={{
+                pathname: replayLink,
+                query: {
+                  project: project?.id,
+                },
+              }}
+            >
+              {t('Take me to Session Replay')}
+            </Button>
+          )}
         </StyledButtonBar>
       </div>
     </Fragment>


### PR DESCRIPTION
Adds a button "Take me to Session Replay" when a new project (both web BE & frontend) is created.

Shows up for web BE:

https://github.com/getsentry/sentry/assets/56095982/f8d1438d-a933-4399-9553-df75fa597102

Shows up for FE:

https://github.com/getsentry/sentry/assets/56095982/62914d73-9489-4502-ac54-e5a2f398c494

Closes https://github.com/getsentry/sentry/issues/61159
