### PR TITLE
ref(ts): Prefer actionCreator for org updates

### DIFF
--- a/static/app/actionCreators/onboardingTasks.spec.tsx
+++ b/static/app/actionCreators/onboardingTasks.spec.tsx
@@ -3,15 +3,17 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
 
 import {updateOnboardingTask} from 'sentry/actionCreators/onboardingTasks';
+import {updateOrganization} from 'sentry/actionCreators/organizations';
 import ConfigStore from 'sentry/stores/configStore';
-import OrganizationStore from 'sentry/stores/organizationStore';
 import {OnboardingTaskKey} from 'sentry/types';
+
+jest.mock('sentry/actionCreators/organizations', () => ({
+  updateOrganization: jest.fn(),
+}));
 
 describe('actionCreators/onboardingTasks', function () {
   const api = new MockApiClient();
   const user = ConfigStore.get('user');
-
-  jest.spyOn(OrganizationStore, 'onUpdate');
 
   describe('updateOnboardingTask', function () {
     it('Adds the task to the organization when task does not exists', async function () {
@@ -37,7 +39,7 @@ describe('actionCreators/onboardingTasks', function () {
 
       expect(mockUpdate).toHaveBeenCalled();
 
-      expect(OrganizationStore.onUpdate).toHaveBeenCalledWith({
+      expect(updateOrganization).toHaveBeenCalledWith({
         onboardingTasks: [{...testTask, user}],
       });
     });
@@ -68,7 +70,7 @@ describe('actionCreators/onboardingTasks', function () {
 
       // NOTE: user is not passed as it is already associated to the existing
       // onboarding task.
-      expect(OrganizationStore.onUpdate).toHaveBeenCalledWith({
+      expect(updateOrganization).toHaveBeenCalledWith({
         onboardingTasks: [testTask],
       });
     });
@@ -93,7 +95,7 @@ describe('actionCreators/onboardingTasks', function () {
       await tick();
 
       expect(mockUpdate).not.toHaveBeenCalled();
-      expect(OrganizationStore.onUpdate).toHaveBeenCalledWith({
+      expect(updateOrganization).toHaveBeenCalledWith({
         onboardingTasks: [{...testTask, user}],
       });
     });

--- a/static/app/actionCreators/onboardingTasks.tsx
+++ b/static/app/actionCreators/onboardingTasks.tsx
@@ -1,7 +1,8 @@
 import type {Client} from 'sentry/api';
 import ConfigStore from 'sentry/stores/configStore';
-import OrganizationStore from 'sentry/stores/organizationStore';
 import type {OnboardingTask, OnboardingTaskStatus, Organization} from 'sentry/types';
+
+import {updateOrganization} from './organizations';
 
 interface UpdatedTask extends Partial<Pick<OnboardingTask, 'status' | 'data'>> {
   task: OnboardingTask['task'];
@@ -41,5 +42,5 @@ export function updateOnboardingTask(
       )
     : [...organization.onboardingTasks, {...updatedTask, user} as OnboardingTaskStatus];
 
-  OrganizationStore.onUpdate({onboardingTasks});
+  updateOrganization({onboardingTasks});
 }


### PR DESCRIPTION
This was one of the only insatnces of `OrganizationStore.onUpdate`
outside of the action creator abstraction.