### PR TITLE
feat(ddm): Add spans summary to the ddm/meta endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_ddm.py
+++ b/src/sentry/api/endpoints/organization_ddm.py
@@ -14,7 +14,7 @@ from sentry.api.serializers.models.metric_spans import MetricSpansSerializer
 from sentry.api.utils import get_date_range_from_params
 from sentry.exceptions import InvalidParams
 from sentry.sentry_metrics.querying.metadata.code_locations import get_code_locations
-from sentry.sentry_metrics.querying.metadata.metric_spans import get_spans_of_metric
+from sentry.sentry_metrics.querying.metadata.metric_spans import get_correlations_of_metric
 
 
 class MetaType(Enum):
@@ -83,7 +83,7 @@ class OrganizationDDMMetaEndpoint(OrganizationEndpoint):
 
                 query = request.GET.get("query")
 
-                data = get_spans_of_metric(
+                data = get_correlations_of_metric(
                     metric_mri=metric_mris[0],
                     query=query,
                     start=start,

--- a/src/sentry/api/serializers/models/metric_spans.py
+++ b/src/sentry/api/serializers/models/metric_spans.py
@@ -6,23 +6,31 @@ class MetricSpansSerializer(Serializer):
         Serializer.__init__(self, *args, **kwargs)
 
     def _compute_attrs(self, item):
-        return [span.__dict__ for span in item.spans]
+        return [segment.__dict__ for segment in item.segments]
 
     def get_attrs(self, item_list, user):
         return {item: self._compute_attrs(item) for item in item_list}
 
-    def _serialize_span_payload(self, span_payload):
+    def _serialize_spans_summary_payload(self, spans_summary):
+        return [
+            {"spanOp": span_summary.span_op, "spanDuration": span_summary.span_duration}
+            for span_summary in spans_summary
+        ]
+
+    def _serialize_segment_payload(self, segment_payload):
         return {
-            "projectId": span_payload.get("project_id"),
-            "transactionId": span_payload.get("transaction_id"),
-            "traceId": span_payload.get("trace_id"),
-            "profileId": span_payload.get("profile_id"),
-            "segmentName": span_payload.get("segment_name"),
-            "spansNumber": span_payload.get("spans_number"),
-            "spansSummary": span_payload.get("spansSummary"),
-            "duration": span_payload.get("duration"),
-            "timestamp": span_payload.get("timestamp"),
+            "projectId": segment_payload.get("project_id"),
+            "transactionId": segment_payload.get("segment_id"),
+            "traceId": segment_payload.get("trace_id"),
+            "profileId": segment_payload.get("profile_id"),
+            "segmentName": segment_payload.get("segment_name"),
+            "spansNumber": segment_payload.get("spans_number"),
+            "spansSummary": self._serialize_spans_summary_payload(
+                segment_payload.get("spans_summary", [])
+            ),
+            "duration": segment_payload.get("duration"),
+            "timestamp": segment_payload.get("timestamp"),
         }
 
     def serialize(self, obj, attrs, user):
-        return [self._serialize_span_payload(span) for span in attrs]
+        return [self._serialize_segment_payload(span) for span in attrs]

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -4,6 +4,7 @@ import hashlib
 import importlib.metadata
 import inspect
 import os.path
+import random
 import re
 import time
 from contextlib import contextmanager
@@ -1391,37 +1392,86 @@ class SnubaTestCase(BaseTestCase):
 
 
 class BaseSpansTestCase(SnubaTestCase):
-    def store_span(
+
+    def _random_span_id(self):
+        random_number = random.randint(0, 100)
+        return hex(random_number)
+
+    def store_segment(
         self,
         project_id: int,
-        span_id: str = "98230207e6e4a6ad",
-        trace_id: str = "b2565c0df13c4c00a654d2209e06e4bd",
-        transaction_id: Optional[str] = None,
+        trace_id: str,
+        transaction_id: str,
+        span_id: Optional[str] = None,
         profile_id: Optional[str] = None,
-        transaction: str = None,
-        is_segment: bool = False,
-        duration_ms: int = 10,
+        transaction: Optional[str] = None,
+        duration: int = 10,
         tags: Optional[Mapping[str, Any]] = None,
         measurements: Optional[Mapping[str, Union[int, float]]] = None,
         timestamp: Optional[datetime] = None,
-        store_only_summary: bool = False,
-        store_metrics_summary: Optional[Mapping[str, Sequence[Mapping[str, Any]]]] = None,
-        store_transaction_and_span: bool = False,
     ):
+        if span_id is None:
+            span_id = self._random_span_id()
         if timestamp is None:
             timestamp = datetime.now(tz=timezone.utc)
 
         payload = {
-            "duration_ms": int(duration_ms),
-            "exclusive_time_ms": 5,
-            "is_segment": is_segment,
             "project_id": project_id,
-            "received": datetime.now(tz=timezone.utc).timestamp(),
-            "retention_days": 90,
-            "sentry_tags": {"transaction": transaction or "/hello"},
             "span_id": span_id,
-            "start_timestamp_ms": int(timestamp.timestamp() * 1000),
             "trace_id": trace_id,
+            "duration_ms": int(duration),
+            "exclusive_time_ms": 5,
+            "is_segment": True,
+            "received": datetime.now(tz=timezone.utc).timestamp(),
+            "start_timestamp_ms": int(timestamp.timestamp() * 1000),
+            "sentry_tags": {"transaction": transaction or "/hello"},
+            "retention_days": 90,
+        }
+
+        if tags:
+            payload["tags"] = tags
+        if transaction_id:
+            payload["event_id"] = transaction_id
+        if profile_id:
+            payload["profile_id"] = profile_id
+        if measurements:
+            payload["measurements"] = {
+                measurement: {"value": value} for measurement, value in measurements.items()
+            }
+
+        self._snuba_insert(payload, "spans")
+
+    def store_span(
+        self,
+        project_id: int,
+        trace_id: str,
+        transaction_id: str,
+        span_id: Optional[str] = None,
+        profile_id: Optional[str] = None,
+        transaction: Optional[str] = None,
+        op: Optional[str] = None,
+        duration: int = 10,
+        tags: Optional[Mapping[str, Any]] = None,
+        timestamp: Optional[datetime] = None,
+        store_only_summary: bool = False,
+        store_metrics_summary: Optional[Mapping[str, Sequence[Mapping[str, Any]]]] = None,
+    ):
+        if span_id is None:
+            span_id = self._random_span_id()
+        if timestamp is None:
+            timestamp = datetime.now(tz=timezone.utc)
+
+        payload = {
+            "project_id": project_id,
+            "span_id": span_id,
+            "trace_id": trace_id,
+            "duration_ms": int(duration),
+            "exclusive_time_ms": 5,
+            "is_segment": False,
+            "received": datetime.now(tz=timezone.utc).timestamp(),
+            "start_timestamp_ms": int(timestamp.timestamp() * 1000),
+            "sentry_tags": {"transaction": transaction or "/hello", "op": op or "http"},
+            "retention_days": 90,
         }
 
         if tags:
@@ -1432,22 +1482,11 @@ class BaseSpansTestCase(SnubaTestCase):
             payload["profile_id"] = profile_id
         if store_metrics_summary:
             payload["_metrics_summary"] = store_metrics_summary
-        if measurements:
-            payload["measurements"] = {
-                measurement: {"value": value} for measurement, value in measurements.items()
-            }
 
         # We want to give the caller the possibility to store only a summary since the database does not deduplicate
         # on the span_id which makes the assumptions of a unique span_id in the database invalid.
         if not store_only_summary:
-            if store_transaction_and_span:
-                # To simplify the testing, the span duration is half the duration of the transaction.
-                for is_segment, duration in ((True, duration_ms), (False, duration_ms / 2)):
-                    self._snuba_insert(
-                        {**payload, "is_segment": is_segment, "duration_ms": int(duration)}, "spans"
-                    )
-            else:
-                self._snuba_insert(payload, "spans")
+            self._snuba_insert(payload, "spans")
 
         if "_metrics_summary" in payload:
             self._snuba_insert(payload, "metrics_summaries")

--- a/tests/sentry/api/endpoints/test_organization_ddm_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_ddm_meta.py
@@ -335,13 +335,23 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
         transaction_id = uuid.uuid4().hex
         trace_id = uuid.uuid4().hex
         span_id = "98230207e6e4a6ad"
+
+        self.store_segment(
+            project_id=self.project.id,
+            timestamp=before_now(minutes=5),
+            trace_id=trace_id,
+            transaction_id=transaction_id,
+            span_id=uuid.uuid4().hex,
+            duration=10,
+        )
         self.store_span(
             project_id=self.project.id,
             timestamp=before_now(minutes=5),
             trace_id=trace_id,
             transaction_id=transaction_id,
             span_id=span_id,
-            store_transaction_and_span=True,
+            op="db",
+            duration=5,
             store_metrics_summary={
                 mri: [
                     {
@@ -374,6 +384,7 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
     def test_get_metric_spans_with_bounds(self):
         mri = "g:custom/page_load@millisecond"
 
+        trace_id = uuid.uuid4().hex
         transaction_id_1 = uuid.uuid4().hex
         span_id_1 = "98230207e6e4a6ad"
         transaction_id_2 = uuid.uuid4().hex
@@ -385,12 +396,22 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
                 (transaction_id_2, span_id_2, 120.0, 200.0),
             )
         ):
+            self.store_segment(
+                project_id=self.project.id,
+                timestamp=before_now(minutes=5 + i),
+                trace_id=trace_id,
+                transaction_id=transaction_id,
+                span_id=uuid.uuid4().hex,
+                duration=10,
+            )
             self.store_span(
                 project_id=self.project.id,
                 timestamp=before_now(minutes=5 + i),
+                trace_id=trace_id,
                 transaction_id=transaction_id,
                 span_id=span_id,
-                store_transaction_and_span=True,
+                op="db",
+                duration=5,
                 store_metrics_summary={
                     mri: [
                         {
@@ -636,7 +657,7 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
                 timestamp=before_now(minutes=5 - index),
                 span_id=span_id,
                 is_segment=True,
-                duration_ms=100,
+                duration=100,
                 transaction=transaction,
                 tags={"device": device},
             )
@@ -693,7 +714,7 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             timestamp=before_now(minutes=5),
             span_id=span_id,
             is_segment=True,
-            duration_ms=100,
+            duration=100,
             transaction=transaction,
         )
 


### PR DESCRIPTION
This PR implements the support for returning `spansSummary` for each transaction. In addition, some drive-by improvements include:
* Reworking the test suite `store_*` methods.
* Renaming `spans` to `correlations` to be more generic.