### PR TITLE
Encode grouping Enhancements using zstd

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -9,12 +9,13 @@ from typing import Any, Sequence
 
 import msgpack
 import sentry_sdk
+import zstandard
 from django.core.cache import cache
 from parsimonious.exceptions import ParseError
 from parsimonious.grammar import Grammar
 from parsimonious.nodes import NodeVisitor
 
-from sentry import projectoptions
+from sentry import options, projectoptions
 from sentry.grouping.component import GroupingComponent
 from sentry.stacktraces.functions import set_in_app
 from sentry.utils import metrics
@@ -112,7 +113,6 @@ class StacktraceState:
 
 
 class Enhancements:
-
     # NOTE: You must add a version to ``VERSIONS`` any time attributes are added
     # to this class, s.t. no enhancements lacking these attributes are loaded
     # from cache.
@@ -181,7 +181,6 @@ class Enhancements:
         stacktrace_state = StacktraceState()
         # Apply direct frame actions and update the stack state alongside
         for rule in self._updater_rules:
-
             for idx, action in rule.get_matching_frame_actions(
                 match_frames, platform, exception_data, in_memory_cache
             ):
@@ -256,6 +255,13 @@ class Enhancements:
             rv["rules"] = [x.as_dict() for x in self.rules]
         return rv
 
+    def iter_rules(self):
+        for base in self.bases:
+            base = ENHANCEMENT_BASES.get(base)
+            if base:
+                yield from base.iter_rules()
+        yield from self.rules
+
     def _to_config_structure(self):
         return [
             self.version,
@@ -264,18 +270,14 @@ class Enhancements:
         ]
 
     def dumps(self):
-        return (
-            base64.urlsafe_b64encode(zlib.compress(msgpack.dumps(self._to_config_structure())))
-            .decode("ascii")
-            .strip("=")
-        )
+        encoded = msgpack.dumps(self._to_config_structure())
 
-    def iter_rules(self):
-        for base in self.bases:
-            base = ENHANCEMENT_BASES.get(base)
-            if base:
-                yield from base.iter_rules()
-        yield from self.rules
+        if options.get("enhancers.use-zstd"):
+            compressed = zstandard.compress(encoded)
+        else:
+            compressed = zlib.compress(encoded)
+
+        return base64.urlsafe_b64encode(compressed).decode("ascii").strip("=")
 
     @classmethod
     def _from_config_structure(cls, data):
@@ -294,9 +296,14 @@ class Enhancements:
             data = data.encode("ascii", "ignore")
         padded = data + b"=" * (4 - (len(data) % 4))
         try:
-            return cls._from_config_structure(
-                msgpack.loads(zlib.decompress(base64.urlsafe_b64decode(padded)), raw=False)
-            )
+            compressed = base64.urlsafe_b64decode(padded)
+
+            if compressed.startswith(b"\x28\xb5\x2f\xfd"):
+                encoded = zstandard.decompress(compressed)
+            else:
+                encoded = zlib.decompress(compressed)
+
+            return cls._from_config_structure(msgpack.loads(encoded, raw=False))
         except (LookupError, AttributeError, TypeError, ValueError) as e:
             raise ValueError("invalid stack trace rule config: %s" % e)
 

--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -272,7 +272,13 @@ class Enhancements:
     def dumps(self):
         encoded = msgpack.dumps(self._to_config_structure())
 
-        if options.get("enhancers.use-zstd"):
+        try:
+            # I don’t want to put DB access into all of the tests ;-)
+            use_zstd = options.get("enhancers.use-zstd")
+        except Exception:
+            use_zstd = False
+
+        if use_zstd:
             compressed = zstandard.compress(encoded)
         else:
             compressed = zlib.compress(encoded)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -834,6 +834,9 @@ register(
 # Whether to use `zstd` instead of `zlib` for the attachment cache.
 register("attachment-cache.use-zstd", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# Whether to use `zstd` instead of `zlib` for encoded grouping enhancers.
+register("enhancers.use-zstd", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # Set of projects that will always store `EventAttachment` blobs directly.
 register("eventattachments.store-blobs.projects", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Percentage sample rate for `EventAttachment`s that should use direct blob storage.

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -57,12 +57,15 @@ family:native                                   max-frames=3
     assert isinstance(dumped, str)
 
     with override_options({"enhancers.use-zstd": True}):
-        dumped = enhancement.dumps()
-        assert Enhancements.loads(dumped).dumps() == dumped
+        dumped_zstd = enhancement.dumps()
+
+        assert dumped_zstd is not dumped
+        assert Enhancements.loads(dumped_zstd).dumps() == dumped_zstd
         assert (
-            Enhancements.loads(dumped)._to_config_structure() == enhancement._to_config_structure()
+            Enhancements.loads(dumped_zstd)._to_config_structure()
+            == enhancement._to_config_structure()
         )
-        assert isinstance(dumped, str)
+        assert isinstance(dumped_zstd, str)
 
 
 def test_parsing_errors():

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -8,13 +8,15 @@ from sentry.grouping.component import GroupingComponent
 from sentry.grouping.enhancer import Enhancements
 from sentry.grouping.enhancer.exceptions import InvalidEnhancerConfig
 from sentry.grouping.enhancer.matchers import create_match_frame
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.pytest.fixtures import django_db_all
 
 
 def dump_obj(obj):
     if not isinstance(getattr(obj, "__dict__", None), dict):
         return obj
     rv: dict[str, Any] = {}
-    for (key, value) in obj.__dict__.items():
+    for key, value in obj.__dict__.items():
         if key.startswith("_"):
             continue
         elif isinstance(value, list):
@@ -27,6 +29,7 @@ def dump_obj(obj):
 
 
 @pytest.mark.parametrize("version", [1, 2])
+@django_db_all
 def test_basic_parsing(insta_snapshot, version):
     enhancement = Enhancements.from_config_string(
         """
@@ -46,11 +49,20 @@ family:native                                   max-frames=3
     )
     enhancement.version = version
 
-    dumped = enhancement.dumps()
     insta_snapshot(dump_obj(enhancement))
+
+    dumped = enhancement.dumps()
     assert Enhancements.loads(dumped).dumps() == dumped
     assert Enhancements.loads(dumped)._to_config_structure() == enhancement._to_config_structure()
     assert isinstance(dumped, str)
+
+    with override_options({"enhancers.use-zstd": True}):
+        dumped = enhancement.dumps()
+        assert Enhancements.loads(dumped).dumps() == dumped
+        assert (
+            Enhancements.loads(dumped)._to_config_structure() == enhancement._to_config_structure()
+        )
+        assert isinstance(dumped, str)
 
 
 def test_parsing_errors():


### PR DESCRIPTION
Using zstd for the attachments cache yielded surprisingly positive results, and in local tests zstd is also 50% faster for Enhancements compression.