### PR TITLE
feat(metrics_extraction): Drop old spec version

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1685,8 +1685,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:on-demand-metrics-prefill": False,
     # Display on demand metrics related UI elements
     "organizations:on-demand-metrics-ui": False,
-    # Query on demand metrics with the new environment logic
-    "organizations:on-demand-query-with-new-env-logic": False,
     # Enable the SDK selection feature in the onboarding
     "organizations:onboarding-sdk-selection": False,
     # Enable the setting of org roles for team

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -161,7 +161,6 @@ default_manager.add("organizations:on-demand-metrics-extraction-experimental", O
 default_manager.add("organizations:on-demand-metrics-extraction-widgets", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:on-demand-metrics-extraction", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:on-demand-metrics-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:on-demand-query-with-new-env-logic", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:onboarding-sdk-selection", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:onboarding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)  # Only enabled in sentry.io to enable onboarding flows.
 default_manager.add("organizations:org-roles-for-teams", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -153,6 +153,9 @@ class MetricsQueryBuilder(QueryBuilder):
                     "Must include on demand metrics type when querying on demand"
                 )
 
+            # Instead of calling OnDemandMetricSpec without a spec_version (defaulting to the least),
+            # we keep this logic here to make future spec versions easier to roll out since it will
+            # save us to look where to add this logic again
             spec_version = OnDemandMetricSpecVersioning.get_query_spec_version(self.organization_id)
             return OnDemandMetricSpec(
                 field=field,

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -146,12 +146,8 @@ def test_get_metric_extraction_config_with_double_write_env_alert(
         config = get_metric_extraction_config(default_project)
 
         assert config
-        # We expect two specs since we collect both
-        # Once we do not run two versions we will need to change this test
-        assert len(config["metrics"]) == 2
-        # The old way of generating the config has no parentheses, thus if we have lower binding in the original
-        # expression, we will prioritize our filter.
-        assert config["metrics"][1] == {
+        assert len(config["metrics"]) == 1
+        assert config["metrics"][0] == {
             "category": "transaction",
             "condition": {
                 "inner": [
@@ -169,27 +165,6 @@ def test_get_metric_extraction_config_with_double_write_env_alert(
             "field": None,
             "mri": "c:transactions/on_demand@none",
             "tags": [{"key": "query_hash", "value": "ca87c609"}],
-        }
-        # The new way parenthesizes correctly the environment expression, making the original expression resolve first
-        # and then AND with the injected environment.
-        assert config["metrics"][0] == {
-            "category": "transaction",
-            "condition": {
-                "inner": [
-                    {
-                        "inner": [
-                            {"name": "event.environment", "op": "eq", "value": "development"},
-                            {"name": "event.tags.device.platform", "op": "eq", "value": "android"},
-                        ],
-                        "op": "and",
-                    },
-                    {"name": "event.tags.device.platform", "op": "eq", "value": "ios"},
-                ],
-                "op": "or",
-            },
-            "field": None,
-            "mri": "c:transactions/on_demand@none",
-            "tags": [{"key": "query_hash", "value": "47bc817d"}],
         }
 
 
@@ -245,7 +220,7 @@ def test_get_metric_extraction_config_multiple_alerts_above_max_limit(
 
         out, _ = capfd.readouterr()
         assert out.splitlines()[0].split(": ")[1:3] == [
-            "Spec version 0",
+            "Spec version 1",
             "Too many (2) on demand metric alerts for project bar",
         ]
 
@@ -495,7 +470,7 @@ def test_get_metric_extraction_config_multiple_widgets_above_max_limit(
 
         out, _ = capfd.readouterr()
         assert out.splitlines()[0].split(": ")[1:3] == [
-            "Spec version 0",
+            "Spec version 1",
             "Too many (2) on demand metric widgets for project bar",
         ]
 


### PR DESCRIPTION
Now that we have migrated all alerts from not including the environment we can drop the old version.