### PR TITLE
Centralize opening a `ProguardMapper`

### DIFF
--- a/src/sentry/lang/java/plugin.py
+++ b/src/sentry/lang/java/plugin.py
@@ -1,7 +1,7 @@
 import sentry_sdk
-from symbolic.proguard import ProguardMapper
 
 from sentry.lang.java.processing import deobfuscate_exception_value
+from sentry.lang.java.proguard import open_proguard_mapper
 from sentry.lang.java.utils import (
     deobfuscate_view_hierarchy,
     get_jvm_images,
@@ -45,12 +45,11 @@ class JavaStacktraceProcessor(StacktraceProcessor):
             if dif_path is None:
                 error_type = EventError.PROGUARD_MISSING_MAPPING
             else:
-                with sentry_sdk.start_span(op="proguard.open"):
-                    view = ProguardMapper.open(dif_path)
-                    if not view.has_line_info:
-                        error_type = EventError.PROGUARD_MISSING_LINENO
-                    else:
-                        self.mapping_views.append(view)
+                view = open_proguard_mapper(dif_path)
+                if not view.has_line_info:
+                    error_type = EventError.PROGUARD_MISSING_LINENO
+                else:
+                    self.mapping_views.append(view)
 
             if error_type is None:
                 continue

--- a/src/sentry/lang/java/proguard.py
+++ b/src/sentry/lang/java/proguard.py
@@ -1,0 +1,7 @@
+import sentry_sdk
+from symbolic.proguard import ProguardMapper
+
+
+def open_proguard_mapper(*args, **kwargs):
+    with sentry_sdk.start_span(op="proguard.open"):
+        return ProguardMapper.open(*args, **kwargs)

--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -4,10 +4,10 @@ import os
 from typing import Any
 
 import sentry_sdk
-from symbolic.proguard import ProguardMapper
 
 from sentry.attachments import CachedAttachment, attachment_cache
 from sentry.ingest.consumer.processors import CACHE_TIMEOUT
+from sentry.lang.java.proguard import open_proguard_mapper
 from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.project import Project
 from sentry.utils import json
@@ -61,8 +61,7 @@ def get_proguard_mapper(uuid: str, project: Project):
             sentry_sdk.capture_exception(exc)
             return
 
-    with sentry_sdk.start_span(op="proguard.open"):
-        mapper = ProguardMapper.open(debug_file_path)
+    mapper = open_proguard_mapper(debug_file_path)
 
     if not mapper.has_line_info:
         return

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -9,10 +9,10 @@ from typing import Any, List, Mapping, MutableMapping, Optional, Tuple
 import msgpack
 import sentry_sdk
 from django.conf import settings
-from symbolic.proguard import ProguardMapper
 
 from sentry import options, quotas
 from sentry.constants import DataCategory
+from sentry.lang.java.proguard import open_proguard_mapper
 from sentry.lang.javascript.processing import _handles_frame as is_valid_javascript_frame
 from sentry.lang.native.processing import _merge_image
 from sentry.lang.native.symbolicator import Symbolicator, SymbolicatorTaskKind
@@ -529,7 +529,6 @@ def _process_symbolicator_results(
 def _process_symbolicator_results_for_sample(
     profile: Profile, stacktraces: List[Any], frames_sent: set[int], platform: str
 ) -> None:
-
     if platform == "rust":
 
         def truncate_stack_needed(frames: List[dict[str, Any]], stack: List[Any]) -> List[Any]:
@@ -724,10 +723,9 @@ def _deobfuscate(profile: Profile, project: Project) -> None:
         if debug_file_path is None:
             return
 
-    with sentry_sdk.start_span(op="proguard.open"):
-        mapper = ProguardMapper.open(debug_file_path)
-        if not mapper.has_line_info:
-            return
+    mapper = open_proguard_mapper(debug_file_path)
+    if not mapper.has_line_info:
+        return
 
     with sentry_sdk.start_span(op="proguard.remap"):
         for method in profile["profile"]["methods"]:
@@ -806,10 +804,9 @@ def _deobfuscate_v2(profile: Profile, project: Project) -> None:
         if debug_file_path is None:
             return
 
-    with sentry_sdk.start_span(op="proguard.open"):
-        mapper = ProguardMapper.open(debug_file_path, initialize_param_mapping=True)
-        if not mapper.has_line_info:
-            return
+    mapper = open_proguard_mapper(debug_file_path, initialize_param_mapping=True)
+    if not mapper.has_line_info:
+        return
 
     with sentry_sdk.start_span(op="proguard.remap"):
         for method in profile["profile"]["methods"]:

--- a/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
+++ b/src/sentry/utils/performance_issues/detectors/io_main_thread_detector.py
@@ -5,7 +5,6 @@ import os
 from collections import defaultdict
 
 import sentry_sdk
-from symbolic.proguard import ProguardMapper
 
 from sentry import features, options
 from sentry.issues.grouptype import (
@@ -13,6 +12,7 @@ from sentry.issues.grouptype import (
     PerformanceFileIOMainThreadGroupType,
 )
 from sentry.issues.issue_occurrence import IssueEvidence
+from sentry.lang.java.proguard import open_proguard_mapper
 from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -139,8 +139,7 @@ class FileIOMainThreadDetector(BaseIOMainThreadDetector):
                         if debug_file_path is None:
                             return
 
-                    with sentry_sdk.start_span(op="proguard.open"):
-                        mapper = ProguardMapper.open(debug_file_path)
+                    mapper = open_proguard_mapper(debug_file_path)
                     if not mapper.has_line_info:
                         return
                     self.mapper = mapper

--- a/tests/sentry/profiles/test_java.py
+++ b/tests/sentry/profiles/test_java.py
@@ -1,6 +1,6 @@
 import pytest
-from symbolic.proguard import ProguardMapper
 
+from sentry.lang.java.proguard import open_proguard_mapper
 from sentry.profiles.java import deobfuscate_signature, format_signature
 
 PROGUARD_SOURCE = b"""\
@@ -23,7 +23,7 @@ def mapper(tmp_path):
     mapping_file_path = str(tmp_path.joinpath("mapping_file"))
     with open(mapping_file_path, "wb") as f:
         f.write(PROGUARD_SOURCE)
-    mapper = ProguardMapper.open(mapping_file_path)
+    mapper = open_proguard_mapper(mapping_file_path)
     assert mapper.has_line_info
     return mapper
 


### PR DESCRIPTION
We are working on moving this from using the `symbolic` bindings to a different solution. So lets move this to a central place first :-)