### PR TITLE
fix(browser-starfish): fix resource edge case with duplicate same groups

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/index.tsx
@@ -40,6 +40,7 @@ function ResourceSummary() {
   const organization = useOrganization();
   const {groupId} = useParams();
   const filters = useResourceModuleFilters();
+  const selectedSpanOp = filters[SPAN_OP];
   const {
     query: {transaction},
   } = useLocation();
@@ -60,11 +61,18 @@ function ResourceSummary() {
       'project.id',
     ],
   });
-  const spanMetrics = data[0] ?? {};
+  const spanMetrics = selectedSpanOp
+    ? data.find(item => item[SPAN_OP] === selectedSpanOp) ?? {}
+    : data[0] ?? {};
+
+  const uniqueSpanOps = new Set(data.map(item => item[SPAN_OP]));
+
   const isImage =
+    filters[SPAN_OP] === ResourceSpanOps.IMAGE ||
     IMAGE_FILE_EXTENSIONS.includes(
       spanMetrics[SpanMetricsField.SPAN_DESCRIPTION]?.split('.').pop() || ''
-    ) || spanMetrics[SPAN_OP] === ResourceSpanOps.IMAGE;
+    ) ||
+    (uniqueSpanOps.size === 1 && spanMetrics[SPAN_OP] === ResourceSpanOps.IMAGE);
   return (
     <ModulePageProviders
       title={[t('Performance'), t('Resources'), t('Resource Summary')].join(' — ')}

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -17,6 +17,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import ResourceSize from 'sentry/views/performance/browser/resources/shared/resourceSize';
 import {useIndexedResourcesQuery} from 'sentry/views/performance/browser/resources/utils/useIndexedResourceQuery';
+import {useResourceModuleFilters} from 'sentry/views/performance/browser/resources/utils/useResourceFilters';
 import {usePerformanceGeneralProjectSettings} from 'sentry/views/performance/utils';
 import ChartPanel from 'sentry/views/starfish/components/chartPanel';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
@@ -25,19 +26,24 @@ type Props = {groupId: string; projectId?: number};
 
 export const LOCAL_STORAGE_SHOW_LINKS = 'performance-resources-images-showLinks';
 
-const {SPAN_GROUP, SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH} = SpanIndexedField;
+const {SPAN_GROUP, SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH, SPAN_OP} =
+  SpanIndexedField;
 const imageWidth = '200px';
 const imageHeight = '180px';
 
 function SampleImages({groupId, projectId}: Props) {
   const [showLinks, setShowLinks] = useLocalStorageState(LOCAL_STORAGE_SHOW_LINKS, false);
+  const filters = useResourceModuleFilters();
   const [showImages, setShowImages] = useState(showLinks);
   const {data: settings, isLoading: isSettingsLoading} =
     usePerformanceGeneralProjectSettings(projectId);
   const isImagesEnabled = settings?.enable_images ?? false;
 
   const {data: imageResources, isLoading: isLoadingImages} = useIndexedResourcesQuery({
-    queryConditions: [`${SPAN_GROUP}:${groupId}`],
+    queryConditions: [
+      `${SPAN_GROUP}:${groupId}`,
+      ...(filters[SPAN_OP] ? [`${SPAN_OP}:${filters[SPAN_OP]}`] : []),
+    ],
     sorts: [{field: `measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`, kind: 'desc'}],
     limit: 100,
     referrer: 'api.performance.resources.sample-images',

--- a/static/app/views/performance/browser/resources/resourceView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceView/resourceTable.tsx
@@ -129,6 +129,7 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
           <SpanDescriptionCell
             moduleName={ModuleName.HTTP}
             projectId={row[PROJECT_ID]}
+            spanOp={row[SPAN_OP]}
             description={row[SPAN_DESCRIPTION]}
             group={row[SPAN_GROUP]}
           />

--- a/static/app/views/starfish/components/spanDescriptionLink.tsx
+++ b/static/app/views/starfish/components/spanDescriptionLink.tsx
@@ -5,8 +5,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
+import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {extractRoute} from 'sentry/views/starfish/utils/extractRoute';
 import {useRoutingContext} from 'sentry/views/starfish/utils/routingContext';
+
+const {SPAN_OP} = SpanMetricsField;
 
 interface Props {
   description: React.ReactNode;
@@ -14,6 +17,7 @@ interface Props {
   endpoint?: string;
   endpointMethod?: string;
   group?: string;
+  spanOp?: string;
 }
 
 export function SpanDescriptionLink({
@@ -21,6 +25,7 @@ export function SpanDescriptionLink({
   projectId,
   endpoint,
   endpointMethod,
+  spanOp,
   description,
 }: Props) {
   const location = useLocation();
@@ -32,6 +37,7 @@ export function SpanDescriptionLink({
     project: projectId,
     endpoint,
     endpointMethod,
+    ...(spanOp ? {[SPAN_OP]: spanOp} : {}),
   };
 
   return (

--- a/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
+++ b/static/app/views/starfish/components/tableCells/spanDescriptionCell.tsx
@@ -6,10 +6,12 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {FullSpanDescription} from 'sentry/views/starfish/components/fullSpanDescription';
 import {SpanDescriptionLink} from 'sentry/views/starfish/components/spanDescriptionLink';
-import {ModuleName} from 'sentry/views/starfish/types';
+import {ModuleName, SpanMetricsField} from 'sentry/views/starfish/types';
 import {SQLishFormatter} from 'sentry/views/starfish/utils/sqlish/SQLishFormatter';
 
 const formatter = new SQLishFormatter();
+
+const {SPAN_OP} = SpanMetricsField;
 
 interface Props {
   description: string;
@@ -18,12 +20,14 @@ interface Props {
   endpoint?: string;
   endpointMethod?: string;
   group?: string;
+  spanOp?: string;
 }
 
 export function SpanDescriptionCell({
   description: rawDescription,
   group,
   moduleName,
+  spanOp,
   endpoint,
   endpointMethod,
   projectId,
@@ -45,6 +49,7 @@ export function SpanDescriptionCell({
       group={group}
       projectId={projectId}
       endpoint={endpoint}
+      spanOp={spanOp}
       endpointMethod={endpointMethod}
       description={formatterDescription}
     />
@@ -81,6 +86,7 @@ export function SpanDescriptionCell({
                 group={group}
                 shortDescription={rawDescription}
                 language="http"
+                filters={spanOp ? {[SPAN_OP]: spanOp} : undefined}
               />
             </Fragment>
           }


### PR DESCRIPTION
There is an edge case here where we can have the same span group, but two different span ops, one is an image, and one is a script.
<img width="573" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/0f840ec6-79b7-44ee-802a-60b2844bc7e1">

This causes a bunch of problems that are addressed in this PR.
1. Fetching the example url from the img version, can return the script version instead
<img width="543" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/d0c1e5ee-64b0-43f6-aab6-7911085c32ab">

2. We try to load the sample images even if you click on the script version of that span group
<img width="1057" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/bef29d65-a4a5-41e3-8d9c-45be1c5196a6">

3. We might try to load the script version in the sample images

4. We might use the wrong info in the resourceInfo view
<img width="919" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/ee34e4e5-dc96-499d-b0be-a419201d3cf8">

5. A few other things

