### PR TITLE
fix(browser-starfish): non-extension images not showing up when images selected

### DIFF
--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -167,7 +167,9 @@ export const getResourceTypeFilter = (
   let resourceFilter: string[] = [`${SPAN_OP}:resource.*`];
 
   if (selectedSpanOp) {
-    resourceFilter = SPAN_OP_FILTER[selectedSpanOp] || [`${SPAN_OP}:${selectedSpanOp}`];
+    resourceFilter = SPAN_OP_FILTER[selectedSpanOp].join(' OR ') || [
+      `${SPAN_OP}:${selectedSpanOp}`,
+    ];
   } else if (defaultResourceTypes) {
     resourceFilter = [
       defaultResourceTypes.map(type => SPAN_OP_FILTER[type].join(' OR ')).join(' OR '),

--- a/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useResourcesQuery.ts
@@ -167,7 +167,7 @@ export const getResourceTypeFilter = (
   let resourceFilter: string[] = [`${SPAN_OP}:resource.*`];
 
   if (selectedSpanOp) {
-    resourceFilter = SPAN_OP_FILTER[selectedSpanOp].join(' OR ') || [
+    resourceFilter = [SPAN_OP_FILTER[selectedSpanOp].join(' OR ')] || [
       `${SPAN_OP}:${selectedSpanOp}`,
     ];
   } else if (defaultResourceTypes) {


### PR DESCRIPTION
There was a missing `OR` in the query, that caused any span that didn't have an extension but had the resource.img span.op to only appear when `all` resources types are selected but not when images are selected

It was my understanding that having a space is the same as an OR condition, but it appears to differ within parentheses as the two queries yield different results.

Old query
<img width="746" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/b3df387c-f993-4c13-84f7-0ad9d0399e60">

new query
<img width="727" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/79baaa91-3da6-4530-8584-ded0bf9e98fa">
