### PR TITLE
ref(slack): Change 'Resolve in' to 'Resolve'

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -292,7 +292,7 @@ class SlackActionEndpoint(Endpoint):
             "blocks": [
                 {
                     "type": "section",
-                    "text": {"type": "mrkdwn", "text": "Resolve in"},
+                    "text": {"type": "mrkdwn", "text": "Resolve"},
                     "accessory": {
                         "type": "static_select",
                         "initial_option": {

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -117,7 +117,7 @@ class BaseEventTest(APITestCase):
                     {
                         "type": "section",
                         "block_id": "a6HD+",
-                        "text": {"type": "mrkdwn", "text": "Resolve in", "verbatim": False},
+                        "text": {"type": "mrkdwn", "text": "Resolve", "verbatim": False},
                         "accessory": {
                             "type": "static_select",
                             "action_id": "static_select-action",


### PR DESCRIPTION
Change the resolve modal text to "Resolve" instead of "Resolve in" since it's not grammatically correct when paired with the options - e.g. "Resolved in in the next release".

Closes #63152 