### PR TITLE
fix(integrations) Fix error on invalid select option data

### DIFF
--- a/src/sentry/mediators/external_requests/select_requester.py
+++ b/src/sentry/mediators/external_requests/select_requester.py
@@ -77,7 +77,6 @@ class SelectRequester(Mediator):
                 },
             )
             response = {}
-
         if not self._validate_response(response):
             raise APIError()
 
@@ -94,6 +93,9 @@ class SelectRequester(Mediator):
         choices = []
 
         for option in resp:
+            if not ("value" in option and "label" in option):
+                raise APIError("Missing `value` or `label` in option data")
+
             choices.append([option["value"], option["label"]])
             if option.get("default"):
                 response["defaultValue"] = option["value"]

--- a/tests/sentry/mediators/external_requests/test_select_requester.py
+++ b/tests/sentry/mediators/external_requests/test_select_requester.py
@@ -58,9 +58,32 @@ class TestSelectRequester(TestCase):
         assert requests[0]["event_type"] == "select_options.requested"
 
     @responses.activate
-    def test_invalid_response_format(self):
+    def test_invalid_response_missing_label(self):
         # missing 'label'
         invalid_format = {"value": "12345"}
+        responses.add(
+            method=responses.GET,
+            url=f"https://example.com/get-issues?installationId={self.install.uuid}&projectSlug={self.project.slug}",
+            json=invalid_format,
+            status=200,
+            content_type="application/json",
+        )
+
+        with pytest.raises(APIError):
+            SelectRequester.run(
+                install=self.install,
+                project_slug=self.project.slug,
+                group=self.group,
+                uri="/get-issues",
+                fields={},
+            )
+
+    @responses.activate
+    def test_invalid_response_missing_value(self):
+        # missing 'label' and 'value'
+        invalid_format = [
+            {"project": "ACME", "webUrl": "foo"},
+        ]
         responses.add(
             method=responses.GET,
             url=f"https://example.com/get-issues?installationId={self.install.uuid}&projectSlug={self.project.slug}",


### PR DESCRIPTION
We expect all options to have `label` and `value` defined. Sometimes folks build integrations that don't comply to these requirements and we encounter `KeyError`.

Fixes SENTRY-2DGC
