### PR TITLE
fix(hybrid-cloud): Resolve cross-silo query on serializing integration configs

### DIFF
--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, List, Sequence
 
 from django.urls import reverse
@@ -5,6 +7,7 @@ from django.urls import reverse
 from sentry.integrations.mixins import IssueBasicMixin
 from sentry.models.group import Group
 from sentry.models.user import User
+from sentry.services.hybrid_cloud.util import all_silo_function
 from sentry.shared_integrations.exceptions import ApiError, IntegrationFormError
 
 ISSUE_TYPES = (
@@ -31,8 +34,12 @@ class BitbucketIssueBasicMixin(IssueBasicMixin):
     def get_persisted_default_config_fields(self) -> Sequence[str]:
         return ["repo"]
 
-    def get_create_issue_config(self, group: Group, user: User, **kwargs) -> List[Dict[str, Any]]:
+    @all_silo_function
+    def get_create_issue_config(
+        self, group: Group | None, user: User, **kwargs
+    ) -> List[Dict[str, Any]]:
         kwargs["link_referrer"] = "bitbucket_integration"
+
         fields = super().get_create_issue_config(group, user, **kwargs)
         params = kwargs.pop("params", {})
         default_repo, repo_choices = self.get_repository_choices(group, params, **kwargs)

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -11,8 +11,9 @@ from sentry.integrations.mixins.issues import MAX_CHAR, IssueBasicMixin
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import Group
 from sentry.models.integrations.external_issue import ExternalIssue
-from sentry.models.organization import Organization
 from sentry.models.user import User
+from sentry.services.hybrid_cloud.organization.service import organization_service
+from sentry.services.hybrid_cloud.util import all_silo_function
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.utils.http import absolute_uri
 from sentry.utils.strings import truncatechars
@@ -97,6 +98,7 @@ class GitHubIssueBasic(IssueBasicMixin):
     def create_default_repo_choice(self, default_repo: str) -> tuple[str, str]:
         return default_repo, default_repo.split("/")[1]
 
+    @all_silo_function
     def get_create_issue_config(
         self, group: Group | None, user: User, **kwargs: Any
     ) -> List[Dict[str, Any]]:
@@ -119,7 +121,10 @@ class GitHubIssueBasic(IssueBasicMixin):
             org = group.organization
         else:
             fields = []
-            org = Organization.objects.get_from_cache(id=self.organization_id)
+            org_context = organization_service.get_organization_by_id(
+                id=self.organization_id, include_projects=False, include_teams=False
+            )
+            org = org_context.organization
 
         params = kwargs.pop("params", {})
         default_repo, repo_choices = self.get_repository_choices(group, params, **kwargs)

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from typing import Any, Dict, List, Mapping, Sequence
 
@@ -6,6 +8,7 @@ from django.urls import reverse
 from sentry.integrations.mixins import IssueBasicMixin
 from sentry.models.group import Group
 from sentry.models.user import User
+from sentry.services.hybrid_cloud.util import all_silo_function
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.utils.http import absolute_uri
 
@@ -45,7 +48,10 @@ class GitlabIssueBasic(IssueBasicMixin):
             return ("", "")
         return (project["id"], project["name_with_namespace"])
 
-    def get_create_issue_config(self, group: Group, user: User, **kwargs) -> List[Dict[str, Any]]:
+    @all_silo_function
+    def get_create_issue_config(
+        self, group: Group | None, user: User, **kwargs
+    ) -> List[Dict[str, Any]]:
         kwargs["link_referrer"] = "gitlab_integration"
         fields = super().get_create_issue_config(group, user, **kwargs)
         params = kwargs.pop("params", {})

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -20,12 +20,14 @@ from sentry.integrations import (
 )
 from sentry.integrations.mixins.issues import MAX_CHAR, IssueSyncMixin, ResolveSyncAction
 from sentry.issues.grouptype import GroupCategory
+from sentry.models.group import Group
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.integrations.integration_external_project import IntegrationExternalProject
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.organization.service import organization_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.services.hybrid_cloud.util import all_silo_function
 from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiHostError,
@@ -631,7 +633,8 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             )
         return meta
 
-    def get_create_issue_config(self, group, user, **kwargs):
+    @all_silo_function
+    def get_create_issue_config(self, group: Group | None, user: RpcUser, **kwargs):
         """
         We use the `group` to get three things: organization_slug, project
         defaults, and default title and description. In the case where we're

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -25,6 +25,7 @@ from sentry.integrations import (
 )
 from sentry.integrations.jira_server.utils.choice import build_user_choice
 from sentry.integrations.mixins import IssueSyncMixin, ResolveSyncAction
+from sentry.models.group import Group
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.models.integrations.integration_external_project import IntegrationExternalProject
 from sentry.pipeline import PipelineView
@@ -32,6 +33,7 @@ from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.organization.service import organization_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.services.hybrid_cloud.util import all_silo_function
 from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiHostError,
@@ -686,7 +688,8 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
             raise IntegrationError(no_projects_error_message)
         return jira_projects
 
-    def get_create_issue_config(self, group, user, **kwargs):
+    @all_silo_function
+    def get_create_issue_config(self, group: Group | None, user: RpcUser, **kwargs):
         """
         We use the `group` to get three things: organization_slug, project
         defaults, and default title and description. In the case where we're

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -17,6 +17,7 @@ from sentry.notifications.utils import get_notification_group_title
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user_option import get_option_from_list, user_option_service
+from sentry.services.hybrid_cloud.util import all_silo_function
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.tasks.integrations import sync_status_inbound as sync_status_inbound_task
 from sentry.utils.http import absolute_uri
@@ -100,7 +101,10 @@ class IssueBasicMixin:
             output.extend(["", "```", body, "```"])
         return "\n".join(output)
 
-    def get_create_issue_config(self, group: Group, user: User, **kwargs) -> List[Dict[str, Any]]:
+    @all_silo_function
+    def get_create_issue_config(
+        self, group: Group | None, user: User, **kwargs
+    ) -> List[Dict[str, Any]]:
         """
         These fields are used to render a form for the user,
         and are then passed in the format of:
@@ -110,6 +114,9 @@ class IssueBasicMixin:
         to `create_issue`, which handles creation of the issue
         in Jira, VSTS, GitHub, etc
         """
+        if not group:
+            return []
+
         event = group.get_latest_event()
 
         return [

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -10,6 +10,7 @@ from sentry.models.activity import Activity
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.services.hybrid_cloud.user.service import user_service
+from sentry.services.hybrid_cloud.util import all_silo_function
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
 
 if TYPE_CHECKING:
@@ -107,6 +108,7 @@ class VstsIssueSync(IssueSyncMixin):
     def get_create_issue_config_no_group(self, project: str) -> Sequence[Mapping[str, Any]]:
         return self.get_create_issue_config(None, None, project=project)
 
+    @all_silo_function
     def get_create_issue_config(
         self, group: Optional["Group"], user: Optional[RpcUser], **kwargs: Any
     ) -> Sequence[Mapping[str, Any]]:

--- a/src/sentry/services/hybrid_cloud/util.py
+++ b/src/sentry/services/hybrid_cloud/util.py
@@ -6,7 +6,7 @@ from sentry.utils.env import in_test_environment
 
 def flags_to_bits(*flag_values: bool) -> int:
     bits = 0
-    for (index, value) in enumerate(flag_values):
+    for index, value in enumerate(flag_values):
         if value:
             bits |= 1 << index
     return bits
@@ -36,3 +36,4 @@ class FunctionSiloLimit(SiloLimit):
 
 region_silo_function = FunctionSiloLimit(SiloMode.REGION)
 control_silo_function = FunctionSiloLimit(SiloMode.CONTROL)
+all_silo_function = FunctionSiloLimit(SiloMode.REGION, SiloMode.CONTROL)

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -1,4 +1,6 @@
+import datetime
 from functools import cached_property
+from typing import cast
 from unittest.mock import patch
 
 import responses
@@ -10,16 +12,82 @@ from sentry.integrations.github.integration import GitHubIntegration
 from sentry.integrations.github.issues import GitHubIssueBasic
 from sentry.models.integrations.external_issue import ExternalIssue
 from sentry.services.hybrid_cloud.integration import integration_service
-from sentry.silo import SiloMode
 from sentry.silo.util import PROXY_BASE_URL_HEADER, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import IntegratedApiTestCase, PerformanceIssueTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
-from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.testutils.silo import all_silo_test, region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
 
 pytestmark = [requires_snuba]
+
+
+@all_silo_test
+class GitHubIssueBasicAllSiloTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        ten_days = datetime.datetime.utcnow() + datetime.timedelta(days=10)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="github_external_id",
+            name="getsentry",
+            metadata={
+                "access_token": "some-token",
+                "expires_at": ten_days.strftime("%Y-%m-%dT%H:%M:%S"),
+            },
+        )
+        install = self.integration.get_installation(self.organization.id)
+        self.install = cast(GitHubIntegration, install)
+
+    @fixture(autouse=True)
+    def stub_get_jwt(self):
+        with patch.object(client, "get_jwt", return_value="jwt_token_1"):
+            yield
+
+    @responses.activate
+    def test_get_create_issue_config_without_group(self):
+        responses.add(
+            responses.GET,
+            "https://api.github.com/installation/repositories",
+            json={
+                "total_count": 2,
+                "repositories": [
+                    {"full_name": "getsentry/sentry", "name": "sentry"},
+                    {"full_name": "getsentry/other", "name": "other", "archived": True},
+                ],
+            },
+        )
+        responses.add(
+            responses.GET,
+            "https://api.github.com/repos/getsentry/sentry/assignees",
+            json=[{"login": "leeandher"}],
+        )
+
+        responses.add(
+            responses.GET,
+            "https://api.github.com/repos/getsentry/sentry/labels",
+            json=[
+                {"name": "bug"},
+                {"name": "not-bug"},
+            ],
+        )
+
+        install = self.install
+        config = install.get_create_issue_config(None, self.user, params={})
+        [repo_field, assignee_field, label_field] = config
+        assert repo_field["name"] == "repo"
+        assert repo_field["type"] == "select"
+        assert repo_field["label"] == "GitHub Repository"
+        assert assignee_field["name"] == "assignee"
+        assert assignee_field["type"] == "select"
+        assert assignee_field["label"] == "Assignee"
+        assert label_field["name"] == "labels"
+        assert label_field["type"] == "select"
+        assert label_field["label"] == "Labels"
 
 
 @region_silo_test
@@ -31,12 +99,14 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
     def setUp(self):
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.model = self.create_provider_integration(
-                provider="github", external_id="github_external_id", name="getsentry"
-            )
-            self.model.add_organization(self.organization, self.user)
-        self.integration = GitHubIntegration(self.model, self.organization.id)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="github_external_id",
+            name="getsentry",
+        )
+        install = self.integration.get_installation(self.organization.id)
+        self.install = cast(GitHubIntegration, install)
         self.min_ago = iso_format(before_now(minutes=1))
         self.repo = "getsentry/sentry"
 
@@ -48,7 +118,8 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
     def _check_proxying(self) -> None:
         assert len(responses.calls) == 1
         request = responses.calls[0].request
-        assert request.headers[PROXY_OI_HEADER] == str(self.integration.org_integration.id)
+        assert self.install.org_integration is not None
+        assert request.headers[PROXY_OI_HEADER] == str(self.install.org_integration.id)
         assert request.headers[PROXY_BASE_URL_HEADER] == "https://api.github.com"
         assert PROXY_SIGNATURE_HEADER in request.headers
 
@@ -60,7 +131,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             json=[{"login": "MeredithAnya"}],
         )
 
-        assert self.integration.get_allowed_assignees(self.repo) == (
+        assert self.install.get_allowed_assignees(self.repo) == (
             ("", "Unassigned"),
             ("MeredithAnya", "MeredithAnya"),
         )
@@ -99,7 +170,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         repo = "getsentry/sentry"
 
         # results should be sorted alphabetically
-        assert self.integration.get_repo_labels(repo) == (
+        assert self.install.get_repo_labels(repo) == (
             ("1", "1"),
             ("2", "2"),
             ("10", "10"),
@@ -138,7 +209,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             "description": "This is the description",
         }
 
-        assert self.integration.create_issue(form_data) == {
+        assert self.install.create_issue(form_data) == {
             "key": 321,
             "description": "This is the description",
             "title": "hello",
@@ -218,7 +289,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             "https://api.github.com/repos/getsentry/sentry/issues",
             json=[{"number": 321, "title": "hello", "body": "This is the description"}],
         )
-        assert self.integration.get_repo_issues(self.repo) == ((321, "#321 hello"),)
+        assert self.install.get_repo_issues(self.repo) == ((321, "#321 hello"),)
 
         if self.should_call_api_without_proxying():
             assert len(responses.calls) == 2
@@ -248,7 +319,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
 
         data = {"repo": "getsentry/sentry", "externalIssue": issue_id, "comment": "hello"}
 
-        assert self.integration.get_issue(issue_id, data=data) == {
+        assert self.install.get_issue(issue_id, data=data) == {
             "key": issue_id,
             "description": "This is the description",
             "title": "hello",
@@ -296,7 +367,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             },
         )
 
-        resp = self.integration.get_create_issue_config(group=event.group, user=self.user)
+        resp = self.install.get_create_issue_config(group=event.group, user=self.user)
         assert resp[0]["choices"] == [("getsentry/sentry", "sentry")]
 
         responses.add(
@@ -312,14 +383,14 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
 
         # create an issue
         data = {"params": {"repo": "getsentry/hello"}}
-        resp = self.integration.get_create_issue_config(group=event.group, user=self.user, **data)
+        resp = self.install.get_create_issue_config(group=event.group, user=self.user, **data)
         assert resp[0]["choices"] == [
             ("getsentry/hello", "hello"),
             ("getsentry/sentry", "sentry"),
         ]
         # link an issue
         data = {"params": {"repo": "getsentry/hello"}}
-        resp = self.integration.get_link_issue_config(group=event.group, **data)
+        resp = self.install.get_link_issue_config(group=event.group, **data)
         assert resp[0]["choices"] == [
             ("getsentry/hello", "hello"),
             ("getsentry/sentry", "sentry"),
@@ -335,10 +406,12 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
 
         data = {"comment": "hello"}
         external_issue = ExternalIssue.objects.create(
-            organization_id=self.organization.id, integration_id=self.model.id, key="hello#321"
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            key="hello#321",
         )
 
-        self.integration.after_link_issue(external_issue, data=data)
+        self.install.after_link_issue(external_issue, data=data)
 
         request = responses.calls[0].request
         assert request.headers["Authorization"] == b"Bearer jwt_token_1"
@@ -364,12 +437,12 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         assert event.group is not None
         group = event.group
         integration_service.update_organization_integration(
-            org_integration_id=self.integration.org_integration.id,
+            org_integration_id=self.install.org_integration.id,
             config={
                 "project_issue_defaults": {str(group.project_id): {"repo": "getsentry/sentry"}}
             },
         )
-        fields = self.integration.get_link_issue_config(group)
+        fields = self.install.get_link_issue_config(group)
         for field in fields:
             if field["name"] == "repo":
                 repo_field = field
@@ -402,12 +475,12 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         assert event.group is not None
         group = event.group
         integration_service.update_organization_integration(
-            org_integration_id=self.integration.org_integration.id,
+            org_integration_id=self.install.org_integration.id,
             config={
                 "project_issue_defaults": {str(group.project_id): {"repo": "getsentry/sentry"}}
             },
         )
-        fields = self.integration.get_create_issue_config(group, self.user)
+        fields = self.install.get_create_issue_config(group, self.user)
         for field in fields:
             if field["name"] == "repo":
                 repo_field = field
@@ -424,7 +497,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         event = self.store_event(
             data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
         )
-        fields = self.integration.get_link_issue_config(event.group)
+        fields = self.install.get_link_issue_config(event.group)
         repo_field = [field for field in fields if field["name"] == "repo"][0]
         assert repo_field["default"] == ""
         assert repo_field["choices"] == []
@@ -439,7 +512,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         event = self.store_event(
             data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
         )
-        fields = self.integration.get_create_issue_config(event.group, self.user)
+        fields = self.install.get_create_issue_config(event.group, self.user)
         repo_field = [field for field in fields if field["name"] == "repo"][0]
         assignee_field = [field for field in fields if field["name"] == "assignee"][0]
 

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -304,7 +304,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
 
     @responses.activate
     def test_link_issue(self):
-        issue_id = 321
+        issue_id = "321"
 
         responses.add(
             responses.GET,
@@ -390,6 +390,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         ]
         # link an issue
         data = {"params": {"repo": "getsentry/hello"}}
+        assert event.group is not None
         resp = self.install.get_link_issue_config(group=event.group, **data)
         assert resp[0]["choices"] == [
             ("getsentry/hello", "hello"),
@@ -436,6 +437,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         )
         assert event.group is not None
         group = event.group
+        assert self.install.org_integration is not None
         integration_service.update_organization_integration(
             org_integration_id=self.install.org_integration.id,
             config={
@@ -474,6 +476,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         )
         assert event.group is not None
         group = event.group
+        assert self.install.org_integration is not None
         integration_service.update_organization_integration(
             org_integration_id=self.install.org_integration.id,
             config={
@@ -497,6 +500,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         event = self.store_event(
             data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
         )
+        assert event.group is not None
         fields = self.install.get_link_issue_config(event.group)
         repo_field = [field for field in fields if field["name"] == "repo"][0]
         assert repo_field["default"] == ""


### PR DESCRIPTION
Fixes [SENTRY-2E3X](https://sentry.sentry.io/issues/4881491711/)

And types a few more instances that this could break on. I might try to refactor and test the other integrations so we know this won't happen on other integrations, since the events in prod only apply to GitHub