### PR TITLE
fix(discord): Fix 400 error from bad user id request

### DIFF
--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 # to avoid a circular import
 import logging
-from urllib.parse import urlencode
 
 from sentry import options
 from sentry.integrations.client import ApiClient
 from sentry.integrations.discord.message_builder.base.base import DiscordMessageBuilder
-from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 
 logger = logging.getLogger("sentry.integrations.discord")
 
@@ -28,10 +26,6 @@ CHANNEL_URL = "/channels/{channel_id}"
 # https://discord.com/developers/docs/resources/channel#create-message
 MESSAGE_URL = "/channels/{channel_id}/messages"
 
-TOKEN_URL = "/oauth2/token"
-
-USER_URL = "/users/@me"
-
 
 class DiscordClient(ApiClient):
     integration_name: str = "discord"
@@ -40,8 +34,6 @@ class DiscordClient(ApiClient):
     def __init__(self):
         super().__init__()
         self.application_id = options.get("discord.application-id")
-        self.CLIENT_ID = options.get("discord.application-id")
-        self.CLIENT_SECRET = options.get("discord.client-secret")
         self.bot_token = options.get("discord.bot-token")
 
     def prepare_auth_header(self) -> dict[str, str]:
@@ -64,50 +56,6 @@ class DiscordClient(ApiClient):
     def get_guild_name(self, guild_id: str) -> str:
         response = self.get(GUILD_URL.format(guild_id=guild_id), headers=self.prepare_auth_header())
         return response["name"]  # type: ignore
-
-    def get_user_id(self, access_token: str):
-        headers = {"Authorization": f"Bearer {access_token}"}
-        try:
-            response = self.get(
-                USER_URL,
-                headers=headers,
-            )
-            user_id = response.get("id")
-            if user_id is None:
-                logger.error("discord.install.no_user_id_in_response")
-                raise IntegrationError("Could not retrieve Discord user information.")
-            return user_id
-        except Exception as e:
-            logger.exception(
-                "discord.install.failed_to_get_user_id",
-                extra={"error": str(e)},
-            )
-            raise IntegrationError("Could not retrieve Discord user information.")
-
-    def get_access_token(self, code: str, url: str):
-        data = {
-            "client_id": self.CLIENT_ID,
-            "client_secret": self.CLIENT_SECRET,
-            "grant_type": "authorization_code",
-            "code": code,
-            "redirect_uri": url,
-            "scope": "identify guilds guilds.members.read",
-        }
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-        try:
-            response = self.post(TOKEN_URL, json=False, data=urlencode(data), headers=headers)
-            access_token = response.get("access_token")
-            if access_token is None:
-                logger.error("discord.install.failed_to_get_access_token")
-                raise IntegrationError("Failed to complete Discord OAuth2 flow.")
-            return access_token
-        except ApiError as e:
-            logger.exception(
-                "discord.install.failed_to_complete_oauth2_flow", extra={"error": str(e)}
-            )
-            raise IntegrationError("Failed to complete Discord OAuth2 flow.")
 
     def leave_guild(self, guild_id: str) -> None:
         """

--- a/src/sentry/integrations/discord/client.py
+++ b/src/sentry/integrations/discord/client.py
@@ -6,6 +6,7 @@ import logging
 from sentry import options
 from sentry.integrations.client import ApiClient
 from sentry.integrations.discord.message_builder.base.base import DiscordMessageBuilder
+from src.sentry.shared_integrations.exceptions import IntegrationError
 
 logger = logging.getLogger("sentry.integrations.discord")
 
@@ -26,6 +27,10 @@ CHANNEL_URL = "/channels/{channel_id}"
 # https://discord.com/developers/docs/resources/channel#create-message
 MESSAGE_URL = "/channels/{channel_id}/messages"
 
+TOKEN_URL = "/oauth2/token"
+
+USER_URL = "/users/@me"
+
 
 class DiscordClient(ApiClient):
     integration_name: str = "discord"
@@ -34,6 +39,8 @@ class DiscordClient(ApiClient):
     def __init__(self):
         super().__init__()
         self.application_id = options.get("discord.application-id")
+        self.CLIENT_ID = options.get("discord.application-id")
+        self.CLIENT_SECRET = options.get("discord.client-secret")
         self.bot_token = options.get("discord.bot-token")
 
     def prepare_auth_header(self) -> dict[str, str]:
@@ -56,6 +63,47 @@ class DiscordClient(ApiClient):
     def get_guild_name(self, guild_id: str) -> str:
         response = self.get(GUILD_URL.format(guild_id=guild_id), headers=self.prepare_auth_header())
         return response["name"]  # type: ignore
+
+    def get_user_id(self, access_token: str):
+        headers = {"Authorization": f"Bearer {access_token}"}
+        try:
+            response = self.get(
+                USER_URL,
+                headers=headers,
+            )
+            user_id = response.get("id")
+            if user_id is None:
+                logger.error("discord.install.no_user_id_in_response")
+                raise IntegrationError("Could not retrieve Discord user information.")
+            return user_id
+        except Exception as e:
+            logger.exception(
+                "discord.install.failed_to_get_user_id",
+                extra={"error": str(e)},
+            )
+            raise IntegrationError("Could not retrieve Discord user information.")
+
+    def get_access_token(self, code: str, url: str):
+        data = {
+            "client_id": self.CLIENT_ID,
+            "client_secret": self.CLIENT_SECRET,
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": url,
+            "scope": "identify guilds guilds.members.read",
+        }
+        try:
+            response = self.post(TOKEN_URL, data=data, json=False)
+            access_token = response.get("access_token")
+            if access_token is None:
+                logger.error("discord.install.failed_to_get_access_token")
+                raise IntegrationError("Failed to complete Discord OAuth2 flow.")
+            return access_token
+        except Exception as e:
+            logger.exception(
+                "discord.install.failed_to_complete_oauth2_flow", extra={"error": str(e)}
+            )
+            raise IntegrationError("Failed to complete Discord OAuth2 flow.")
 
     def leave_guild(self, guild_id: str) -> None:
         """

--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import Any
 from urllib.parse import urlencode
 
-import requests
 from django.utils.translation import gettext_lazy as _
 
 from sentry import options
@@ -21,7 +20,7 @@ from sentry.integrations.discord.client import DiscordClient
 from sentry.models.integrations.integration import Integration
 from sentry.pipeline.views.base import PipelineView
 from sentry.services.hybrid_cloud.organization.model import RpcOrganizationSummary
-from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
 
 from .utils import logger
@@ -233,38 +232,9 @@ class DiscordIntegrationProvider(IntegrationProvider):
         integration.
 
         """
-        form_data = f"client_id={self.application_id}&client_secret={self.client_secret}&grant_type=authorization_code&code={auth_code}&redirect_uri={url}"
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-
-        try:
-            response = self.client.post(
-                "https://discord.com/api/v10/oauth2/token",
-                json=False,
-                data=form_data,
-                headers=headers,
-            )
-            token = response["access_token"]  # type: ignore
-
-        except ApiError as e:
-            logger.error("discord.install.failed_to_complete_oauth2_flow", extra={"error": str(e)})
-            raise IntegrationError("Failed to complete Discord OAuth2 flow.")
-        except KeyError:
-            logger.error("discord.install.failed_to_extract_oauth2_access_token")
-            raise IntegrationError("Failed to complete Discord OAuth2 flow.")
-
-        headers = {"Authorization": f"Bearer {token}"}
-        # Can't use self.client.get because that will overwrite our header
-        # with our bot's authorization
-        response = requests.get(f"{self.client.base_url}/users/@me", headers=headers)
-        if response.status_code == 200:
-            return response.json()["id"]
-
-        logger.error(
-            "discord.install.failed_to_get_discord_user_id", extra={"code": response.status_code}
-        )
-        raise IntegrationError("Could not retrieve Discord user information.")
+        access_token = self.client.get_access_token(auth_code, url)
+        user_id = self.client.get_user_id(access_token)
+        return user_id
 
     def get_params_for_oauth(
         self,

--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import Any
 from urllib.parse import urlencode
 
+import requests
 from django.utils.translation import gettext_lazy as _
 
 from sentry import options
@@ -20,7 +21,7 @@ from sentry.integrations.discord.client import DiscordClient
 from sentry.models.integrations.integration import Integration
 from sentry.pipeline.views.base import PipelineView
 from sentry.services.hybrid_cloud.organization.model import RpcOrganizationSummary
-from sentry.shared_integrations.exceptions import ApiError
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.utils.http import absolute_uri
 
 from .utils import logger
@@ -236,9 +237,38 @@ class DiscordIntegrationProvider(IntegrationProvider):
         integration.
 
         """
-        access_token = self.client.get_access_token(auth_code, url)
-        user_id = self.client.get_user_id(access_token)
-        return user_id
+        form_data = f"client_id={self.application_id}&client_secret={self.client_secret}&grant_type=authorization_code&code={auth_code}&redirect_uri={url}"
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        try:
+            response = self.client.post(
+                "https://discord.com/api/v10/oauth2/token",
+                json=False,
+                data=form_data,
+                headers=headers,
+            )
+            token = response["access_token"]  # type: ignore
+
+        except ApiError as e:
+            logger.error("discord.install.failed_to_complete_oauth2_flow", extra={"error": str(e)})
+            raise IntegrationError("Failed to complete Discord OAuth2 flow.")
+        except KeyError:
+            logger.error("discord.install.failed_to_extract_oauth2_access_token")
+            raise IntegrationError("Failed to complete Discord OAuth2 flow.")
+
+        headers = {"Authorization": f"Bearer {token}"}
+        # Can't use self.client.get because that will overwrite our header
+        # with our bot's authorization
+        response = requests.get(f"{self.client.base_url}/users/@me", headers=headers)
+        if response.status_code == 200:
+            return response.json()["id"]
+
+        logger.error(
+            "discord.install.failed_to_get_discord_user_id", extra={"code": response.status_code}
+        )
+        raise IntegrationError("Could not retrieve Discord user information.")
 
     def get_params_for_oauth(
         self,

--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -172,11 +172,12 @@ class DiscordIntegrationProvider(IntegrationProvider):
         else:
             use_configure = False
         url = self.configure_url if use_configure else self.setup_url
-        try:
-            auth_code = str(state.get("code"))
+
+        auth_code = str(state.get("code"))
+        if auth_code:
             discord_user_id = self._get_discord_user_id(auth_code, url)
-        except ApiError as e:
-            raise ApiError(str(e))
+        else:
+            raise IntegrationError("Missing code from state.")
 
         return {
             "name": guild_name,

--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -171,7 +171,11 @@ class DiscordIntegrationProvider(IntegrationProvider):
         else:
             use_configure = False
         url = self.configure_url if use_configure else self.setup_url
-        discord_user_id = self._get_discord_user_id(str(state.get("code")), url)
+        try:
+            auth_code = str(state.get("code"))
+            discord_user_id = self._get_discord_user_id(auth_code, url)
+        except ApiError as e:
+            raise ApiError(str(e))
 
         return {
             "name": guild_name,

--- a/tests/sentry/integrations/discord/test_integration.py
+++ b/tests/sentry/integrations/discord/test_integration.py
@@ -260,6 +260,23 @@ class DiscordIntegrationTest(IntegrationTestCase):
         assert result["name"] == guild_name
 
     @responses.activate
+    def test_build_integration_no_code_in_state(self):
+        provider = self.provider()
+        guild_id = "guild_id"
+        guild_name = "guild_name"
+        responses.add(
+            responses.GET,
+            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=guild_id)}",
+            match=[header_matcher({"Authorization": f"Bot {self.bot_token}"})],
+            json={
+                "id": guild_id,
+                "name": guild_name,
+            },
+        )
+        with pytest.raises(IntegrationError):
+            provider.build_integration({"guild_id": "guild_id", "code": ""})
+
+    @responses.activate
     def test_get_guild_name_failure(self):
         provider = self.provider()
         user_id = "user1234"
@@ -392,20 +409,3 @@ class DiscordIntegrationTest(IntegrationTestCase):
         )
         with pytest.raises(ApiError):
             provider.post_install(integration=self.integration, organization=self.organization)
-
-    @responses.activate
-    def test_no_code_in_state(self):
-        provider = self.provider()
-        guild_id = "guild_id"
-        guild_name = "guild_name"
-        responses.add(
-            responses.GET,
-            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=guild_id)}",
-            match=[header_matcher({"Authorization": f"Bot {self.bot_token}"})],
-            json={
-                "id": guild_id,
-                "name": guild_name,
-            },
-        )
-        with pytest.raises(IntegrationError):
-            provider.build_integration({"guild_id": guild_id})

--- a/tests/sentry/integrations/discord/test_integration.py
+++ b/tests/sentry/integrations/discord/test_integration.py
@@ -392,3 +392,20 @@ class DiscordIntegrationTest(IntegrationTestCase):
         )
         with pytest.raises(ApiError):
             provider.post_install(integration=self.integration, organization=self.organization)
+
+    @responses.activate
+    def test_no_code_in_state(self):
+        provider = self.provider()
+        guild_id = "guild_id"
+        guild_name = "guild_name"
+        responses.add(
+            responses.GET,
+            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=guild_id)}",
+            match=[header_matcher({"Authorization": f"Bot {self.bot_token}"})],
+            json={
+                "id": guild_id,
+                "name": guild_name,
+            },
+        )
+        with pytest.raises(IntegrationError):
+            provider.build_integration({"guild_id": guild_id})


### PR DESCRIPTION
Fixing `400 Client Error: Bad Request for url: https://discord.com/api/v10/oauth2/token`.
If the state is missing the code, the request for the token will be malformed.

Adds a try/except to catch before we try to get the user id.