### PR TITLE
chore(stats-detectors): Lower threshold for EMA detection

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -174,7 +174,7 @@ class EndpointRegressionDetector(RegressionDetector):
             min_data_points=18,
             moving_avg_short_factory=lambda: ExponentialMovingAverage(2 / 21),
             moving_avg_long_factory=lambda: ExponentialMovingAverage(2 / 41),
-            threshold=0.2,
+            threshold=0.15,
         )
 
     @classmethod
@@ -216,7 +216,7 @@ class FunctionRegressionDetector(RegressionDetector):
             min_data_points=18,
             moving_avg_short_factory=lambda: ExponentialMovingAverage(2 / 21),
             moving_avg_long_factory=lambda: ExponentialMovingAverage(2 / 41),
-            threshold=0.2,
+            threshold=0.15,
         )
 
     @classmethod


### PR DESCRIPTION
It's actually quite hard for something to match the threshold of 0.2 during EMA detection. Lower it to 0.15 to capture more regressions. The next stage will continue to filter them.