### PR TITLE
feat(issues): Use stacktrace-coverage endpoint

### DIFF
--- a/static/app/components/events/interfaces/frame/context.spec.tsx
+++ b/static/app/components/events/interfaces/frame/context.spec.tsx
@@ -1,15 +1,11 @@
 import {EventFixture} from 'sentry-fixture/event';
-import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RepositoryFixture} from 'sentry-fixture/repository';
-import {RepositoryProjectPathConfigFixture} from 'sentry-fixture/repositoryProjectPathConfig';
-import {RouterContextFixture} from 'sentry-fixture/routerContextFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {Coverage, Frame, LineCoverage} from 'sentry/types';
+import {CodecovStatusCode, Coverage, Frame, LineCoverage} from 'sentry/types';
 
 import Context, {getLineCoverage} from './context';
 
@@ -17,13 +13,9 @@ describe('Frame - Context', function () {
   const org = OrganizationFixture();
   const project = ProjectFixture({});
   const event = EventFixture({projectID: project.id});
-  const integration = GitHubIntegrationFixture();
-  const repo = RepositoryFixture({integrationId: integration.id});
   const frame = {filename: '/sentry/app.py', lineNo: 233} as Frame;
-  const config = RepositoryProjectPathConfigFixture({project, repo, integration});
 
   beforeEach(function () {
-    jest.clearAllMocks();
     MockApiClient.clearMockResponses();
     ProjectsStore.loadInitialData([project]);
   });
@@ -49,41 +41,27 @@ describe('Frame - Context', function () {
     ]);
   });
 
-  it("doesn't query stacktrace link if the flag is off", function () {
+  it("doesn't query stacktrace coverage if the flag is off", function () {
     const mock = MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
-      body: {
-        config,
-        sourceUrl: null,
-        integrations: [integration],
-      },
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-coverage/`,
+      body: {status: CodecovStatusCode.NO_COVERAGE_DATA},
     });
-    render(
-      <Context
-        frame={frame}
-        event={event}
-        organization={org}
-        registers={{}}
-        components={[]}
-      />,
-      {
-        context: RouterContextFixture([{organization: org}]),
-        organization: org,
-      }
-    );
+    render(<Context frame={frame} event={event} registers={{}} components={[]} />, {
+      organization: org,
+    });
 
     expect(mock).not.toHaveBeenCalled();
   });
 
   describe('syntax highlighting', function () {
     it('renders code correctly when context lines end in newline characters', function () {
+      const organization = {
+        ...org,
+        codecovAccess: true,
+      };
       MockApiClient.addMockResponse({
-        url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
-        body: {
-          config,
-          sourceUrl: null,
-          integrations: [integration],
-        },
+        url: `/projects/${org.slug}/${project.slug}/stacktrace-coverage/`,
+        body: {status: CodecovStatusCode.NO_COVERAGE_DATA},
       });
 
       const testFrame: Frame = {
@@ -102,10 +80,10 @@ describe('Frame - Context', function () {
           hasContextSource
           frame={testFrame}
           event={event}
-          organization={org}
           registers={{}}
           components={[]}
-        />
+        />,
+        {organization}
       );
 
       expect(screen.getAllByTestId('context-line')).toHaveLength(3);

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -18,7 +18,6 @@ import {
   Coverage,
   Frame,
   LineCoverage,
-  Organization,
   SentryAppComponent,
   SentryAppSchemaStacktraceLink,
 } from 'sentry/types';
@@ -26,8 +25,8 @@ import {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 import {getFileExtension} from 'sentry/utils/fileExtension';
 import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import withOrganization from 'sentry/utils/withOrganization';
 
 import {parseAssembly} from '../utils';
 
@@ -51,7 +50,6 @@ type Props = {
   hasContextVars?: boolean;
   isExpanded?: boolean;
   isFirst?: boolean;
-  organization?: Organization;
   registersMeta?: Record<any, any>;
 };
 
@@ -81,11 +79,11 @@ function Context({
   components,
   frame,
   event,
-  organization,
   className,
   frameMeta,
   registersMeta,
 }: Props) {
+  const organization = useOrganization({allowNull: true});
   const {user} = useLegacyStore(ConfigStore);
   const hasInFrameFeature = hasStacktraceLinkInFrameFeature(organization, user);
 
@@ -239,7 +237,7 @@ function Context({
   );
 }
 
-export default withOrganization(Context);
+export default Context;
 
 const StyledClippedBox = styled(ClippedBox)`
   padding: 0;

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -6,6 +6,7 @@ import ClippedBox from 'sentry/components/clippedBox';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import {StacktraceLink} from 'sentry/components/events/interfaces/frame/stacktraceLink';
 import {usePrismTokensSourceContext} from 'sentry/components/events/interfaces/frame/usePrismTokensSourceContext';
+import {useStacktraceCoverage} from 'sentry/components/events/interfaces/frame/useStacktraceCoverage';
 import {hasStacktraceLinkInFrameFeature} from 'sentry/components/events/interfaces/frame/utils';
 import {IconFlag} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -35,7 +36,6 @@ import ContextLineNumber from './contextLineNumber';
 import {FrameRegisters} from './frameRegisters';
 import {FrameVariables} from './frameVariables';
 import {OpenInContextLine} from './openInContextLine';
-import useStacktraceLink from './useStacktraceLink';
 
 type Props = {
   components: SentryAppComponent<SentryAppSchemaStacktraceLink>[];
@@ -99,7 +99,7 @@ function Context({
     [projects, event]
   );
 
-  const {data, isLoading} = useStacktraceLink(
+  const {data: coverage, isLoading: isLoadingCoverage} = useStacktraceCoverage(
     {
       event,
       frame,
@@ -124,11 +124,11 @@ function Context({
     : frame?.context?.filter(l => l[0] === activeLineNumber);
 
   const hasCoverageData =
-    !isLoading && data?.codecov?.status === CodecovStatusCode.COVERAGE_EXISTS;
+    !isLoadingCoverage && coverage?.status === CodecovStatusCode.COVERAGE_EXISTS;
 
   const [lineCoverage = [], hasCoverage] =
-    hasCoverageData && data!.codecov?.lineCoverage && !!activeLineNumber! && contextLines
-      ? getLineCoverage(contextLines, data!.codecov?.lineCoverage)
+    hasCoverageData && coverage?.lineCoverage && !!activeLineNumber! && contextLines
+      ? getLineCoverage(contextLines, coverage.lineCoverage)
       : [];
 
   useRouteAnalyticsParams(

--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -215,6 +215,7 @@ describe('StacktraceLink', function () {
     const organization = {
       ...org,
       codecovAccess: true,
+      features: ['codecov-integration'],
     };
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
@@ -222,11 +223,14 @@ describe('StacktraceLink', function () {
         config,
         sourceUrl: 'https://github.com/username/path/to/file.py',
         integrations: [integration],
-        codecov: {
-          status: CodecovStatusCode.COVERAGE_EXISTS,
-          lineCoverage: [[233, 0]],
-          coverageUrl: 'https://app.codecov.io/gh/path/to/file.py',
-        },
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-coverage/`,
+      body: {
+        status: CodecovStatusCode.COVERAGE_EXISTS,
+        lineCoverage: [[233, 0]],
+        coverageUrl: 'https://app.codecov.io/gh/path/to/file.py',
       },
     });
     render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
@@ -252,6 +256,7 @@ describe('StacktraceLink', function () {
     const organization = {
       ...org,
       codecovAccess: true,
+      features: ['codecov-integration'],
     };
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
@@ -259,8 +264,11 @@ describe('StacktraceLink', function () {
         config,
         sourceUrl: 'https://github.com/username/path/to/file.py',
         integrations: [integration],
-        codecov: {status: CodecovStatusCode.NO_COVERAGE_DATA},
       },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-coverage/`,
+      body: {status: CodecovStatusCode.NO_COVERAGE_DATA},
     });
     render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
       context: RouterContextFixture(),
@@ -289,6 +297,10 @@ describe('StacktraceLink', function () {
         sourceUrl: 'https://github.com/username/path/to/file.py',
         integrations: [integration],
       },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-coverage/`,
+      body: {},
     });
     render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
       context: RouterContextFixture(),

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -10,6 +10,7 @@ import {
   usePromptsCheck,
 } from 'sentry/actionCreators/prompts';
 import {Button} from 'sentry/components/button';
+import {useStacktraceCoverage} from 'sentry/components/events/interfaces/frame/useStacktraceCoverage';
 import {
   hasFileExtension,
   hasStacktraceLinkInFrameFeature,
@@ -124,9 +125,9 @@ function StacktraceLinkSetup({
 
 function shouldShowCodecovFeatures(
   organization: Organization,
-  match: StacktraceLinkResult
+  match: StacktraceLinkResult,
+  codecovStatus: CodecovStatusCode
 ) {
-  const codecovStatus = match.codecov?.status;
   const validStatus = codecovStatus && codecovStatus !== CodecovStatusCode.NO_INTEGRATION;
 
   return (
@@ -267,8 +268,20 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
       projectSlug: project?.slug,
     },
     {
-      staleTime: Infinity,
       enabled: isQueryEnabled, // The query will not run until `isQueryEnabled` is true
+    }
+  );
+  const coverageEnabled =
+    isQueryEnabled && organization.features.includes('codecov-integration');
+  const {data: coverage, isLoading: isLoadingCoverage} = useStacktraceCoverage(
+    {
+      event,
+      frame,
+      orgSlug: organization.slug,
+      projectSlug: project?.slug,
+    },
+    {
+      enabled: coverageEnabled,
     }
   );
 
@@ -397,10 +410,13 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
             ? null
             : t('Open this line in %s', match.config.provider.name)}
         </OpenInLink>
-        {shouldShowCodecovFeatures(organization, match) ? (
+        {coverageEnabled && isLoadingCoverage ? (
+          <Placeholder height="14px" width="14px" />
+        ) : coverage &&
+          shouldShowCodecovFeatures(organization, match, coverage.status) ? (
           <CodecovLink
-            coverageUrl={`${match.codecov?.coverageUrl}#L${frame.lineNo}`}
-            status={match.codecov?.status}
+            coverageUrl={`${coverage.coverageUrl}#L${frame.lineNo}`}
+            status={coverage.status}
             organization={organization}
             event={event}
             hasInFrameFeature={hasInFrameFeature}
@@ -438,10 +454,13 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
           <StyledIconWrapper>{getIntegrationIcon('github', 'sm')}</StyledIconWrapper>
           {hasInFrameFeature ? t('GitHub') : t('Open this line in GitHub')}
         </OpenInLink>
-        {shouldShowCodecovFeatures(organization, match) ? (
+        {coverageEnabled && isLoadingCoverage ? (
+          <Placeholder height="14px" width="14px" />
+        ) : coverage &&
+          shouldShowCodecovFeatures(organization, match, coverage.status) ? (
           <CodecovLink
             coverageUrl={`${frame.sourceLink}`}
-            status={match.codecov?.status}
+            status={coverage.status}
             organization={organization}
             event={event}
             hasInFrameFeature={hasInFrameFeature}

--- a/static/app/components/events/interfaces/frame/useStacktraceCoverage.tsx
+++ b/static/app/components/events/interfaces/frame/useStacktraceCoverage.tsx
@@ -1,0 +1,34 @@
+import {buildStacktraceLinkQuery} from 'sentry/components/events/interfaces/frame/useStacktraceLink';
+import type {CodecovResponse, Event, Frame} from 'sentry/types';
+import {ApiQueryKey, useApiQuery, UseApiQueryOptions} from 'sentry/utils/queryClient';
+
+interface UseStacktraceCoverageProps {
+  event: Partial<Pick<Event, 'platform' | 'release' | 'sdk' | 'groupID'>>;
+  frame: Partial<
+    Pick<Frame, 'absPath' | 'filename' | 'function' | 'module' | 'package' | 'lineNo'>
+  >;
+  orgSlug: string;
+  projectSlug: string | undefined;
+}
+
+const stacktraceLinkQueryKey = (
+  orgSlug: string,
+  projectSlug: string | undefined,
+  query: any
+): ApiQueryKey => [`/projects/${orgSlug}/${projectSlug}/stacktrace-coverage/`, {query}];
+
+export function useStacktraceCoverage(
+  {event, frame, orgSlug, projectSlug}: UseStacktraceCoverageProps,
+  options: Partial<UseApiQueryOptions<CodecovResponse>> = {}
+) {
+  const query = buildStacktraceLinkQuery(event, frame);
+  return useApiQuery<CodecovResponse>(
+    stacktraceLinkQueryKey(orgSlug, projectSlug, query),
+    {
+      staleTime: Infinity,
+      retry: false,
+      refetchOnWindowFocus: false,
+      ...options,
+    }
+  );
+}

--- a/static/app/components/events/interfaces/frame/useStacktraceCoverage.tsx
+++ b/static/app/components/events/interfaces/frame/useStacktraceCoverage.tsx
@@ -11,10 +11,10 @@ interface UseStacktraceCoverageProps {
   projectSlug: string | undefined;
 }
 
-const stacktraceLinkQueryKey = (
+const stacktraceCoverageQueryKey = (
   orgSlug: string,
   projectSlug: string | undefined,
-  query: any
+  query: ReturnType<typeof buildStacktraceLinkQuery>
 ): ApiQueryKey => [`/projects/${orgSlug}/${projectSlug}/stacktrace-coverage/`, {query}];
 
 export function useStacktraceCoverage(
@@ -23,11 +23,10 @@ export function useStacktraceCoverage(
 ) {
   const query = buildStacktraceLinkQuery(event, frame);
   return useApiQuery<CodecovResponse>(
-    stacktraceLinkQueryKey(orgSlug, projectSlug, query),
+    stacktraceCoverageQueryKey(orgSlug, projectSlug, query),
     {
       staleTime: Infinity,
       retry: false,
-      refetchOnWindowFocus: false,
       ...options,
     }
   );

--- a/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
@@ -10,20 +10,32 @@ interface UseStacktraceLinkProps {
   projectSlug: string | undefined;
 }
 
+interface StacktraceLinkQuery {
+  file: string;
+  lineNo: number;
+  platform: string;
+  absPath?: string;
+  commitId?: string;
+  groupId?: string;
+  module?: string;
+  package?: string;
+  sdkName?: string;
+}
+
 export function buildStacktraceLinkQuery(
   event: UseStacktraceLinkProps['event'],
   frame: UseStacktraceLinkProps['frame']
-) {
+): StacktraceLinkQuery {
   const query = {
-    file: frame.filename,
-    platform: event.platform,
+    file: frame.filename!,
+    platform: event.platform!,
+    lineNo: frame.lineNo!,
+    groupId: event.groupID,
     commitId: event.release?.lastCommit?.id,
     ...(event.sdk?.name && {sdkName: event.sdk.name}),
     ...(frame.absPath && {absPath: frame.absPath}),
     ...(frame.module && {module: frame.module}),
     ...(frame.package && {package: frame.package}),
-    lineNo: frame.lineNo,
-    groupId: event.groupID,
   };
   return query;
 }
@@ -31,7 +43,7 @@ export function buildStacktraceLinkQuery(
 const stacktraceLinkQueryKey = (
   orgSlug: string,
   projectSlug: string | undefined,
-  query: any
+  query: StacktraceLinkQuery
 ): ApiQueryKey => [`/projects/${orgSlug}/${projectSlug}/stacktrace-link/`, {query}];
 
 function useStacktraceLink(
@@ -44,7 +56,6 @@ function useStacktraceLink(
     {
       staleTime: Infinity,
       retry: false,
-      refetchOnWindowFocus: false,
       ...options,
     }
   );

--- a/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
@@ -10,15 +10,9 @@ interface UseStacktraceLinkProps {
   projectSlug: string | undefined;
 }
 
-const stacktraceLinkQueryKey = (
-  orgSlug: string,
-  projectSlug: string | undefined,
-  query: any
-): ApiQueryKey => [`/projects/${orgSlug}/${projectSlug}/stacktrace-link/`, {query}];
-
-function useStacktraceLink(
-  {event, frame, orgSlug, projectSlug}: UseStacktraceLinkProps,
-  options: Partial<UseApiQueryOptions<StacktraceLinkResult>> = {}
+export function buildStacktraceLinkQuery(
+  event: UseStacktraceLinkProps['event'],
+  frame: UseStacktraceLinkProps['frame']
 ) {
   const query = {
     file: frame.filename,
@@ -31,7 +25,20 @@ function useStacktraceLink(
     lineNo: frame.lineNo,
     groupId: event.groupID,
   };
+  return query;
+}
 
+const stacktraceLinkQueryKey = (
+  orgSlug: string,
+  projectSlug: string | undefined,
+  query: any
+): ApiQueryKey => [`/projects/${orgSlug}/${projectSlug}/stacktrace-link/`, {query}];
+
+function useStacktraceLink(
+  {event, frame, orgSlug, projectSlug}: UseStacktraceLinkProps,
+  options: Partial<UseApiQueryOptions<StacktraceLinkResult>> = {}
+) {
+  const query = buildStacktraceLinkQuery(event, frame);
   return useApiQuery<StacktraceLinkResult>(
     stacktraceLinkQueryKey(orgSlug, projectSlug, query),
     {

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -181,14 +181,13 @@ export interface CodecovResponse {
   lineCoverage?: LineCoverage[];
 }
 
-export type StacktraceLinkResult = {
+export interface StacktraceLinkResult {
   integrations: Integration[];
   attemptedUrl?: string;
-  codecov?: CodecovResponse;
   config?: RepositoryProjectPathConfigWithIntegration;
   error?: StacktraceErrorMessage;
   sourceUrl?: string;
-};
+}
 
 export type StacktraceErrorMessage =
   | 'file_not_found'


### PR DESCRIPTION
Uses the new stacktrace-coverage endpoint added in https://github.com/getsentry/sentry/pull/63163 to display coverage inside the stacktrace link and the frame context