### PR TITLE
brew: tap no longer necessary

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -22,7 +22,5 @@ brew 'watchman'
 # If it's installed in the early steps of the setup process, it just leads to confusion.
 # brew 'direnv'
 
-tap 'homebrew/cask'
-
 # required for acceptance testing
 cask 'chromedriver'


### PR DESCRIPTION
brew now fatals with this, so removed

```
Tapping homebrew/cask
Error: Tapping homebrew/cask is no longer typically necessary.
Add --force if you are sure you need it done.
Tapping homebrew/cask has failed!
Installing chromedriver
Homebrew Bundle failed!
```