### PR TITLE
fix(slack): assign issue properly with typeahead dropdown

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -62,12 +62,16 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         }
 
     @staticmethod
-    def get_external_select_action(action):
-        return {
+    def get_external_select_action(action, initial_option):
+        action = {
             "type": "external_select",
             "placeholder": {"type": "plain_text", "text": action.label, "emoji": True},
             "action_id": action.name,
         }
+        if initial_option:
+            action["initial_option"] = initial_option
+
+        return action
 
     @staticmethod
     def get_button_action(action):

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -9,6 +9,7 @@ from sentry.integrations.message_builder import (
     build_attachment_text,
     build_attachment_title,
     build_footer,
+    format_actor_option,
     format_actor_options,
     get_color,
     get_timestamp,
@@ -427,7 +428,12 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             ):
                 actions.append(self.get_button_action(action))
             elif action.name == "assign":
-                actions.append(self.get_external_select_action(action))
+                assignee = self.group.get_assignee()
+                actions.append(
+                    self.get_external_select_action(
+                        action, format_actor_option(assignee, True) if assignee else None
+                    )
+                )
 
         if actions:
             action_block = {"type": "actions", "elements": [action for action in actions]}

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -581,7 +581,7 @@ class SlackActionEndpoint(Endpoint):
             if action_data[0].get("action_id"):
                 action_list = []
                 for action_data in action_data:
-                    if action_data.get("type") == "static_select":
+                    if action_data.get("type") == "external_select":
                         action = BlockKitMessageAction(
                             name=action_data["action_id"],
                             label=action_data["selected_option"]["text"]["text"],

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -90,7 +90,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
 
     def get_assign_status_action(self, type, text, id):
         return {
-            "type": "static_select",
+            "type": "external_select",
             "action_id": "assign",
             "block_id": "qBjgd",
             "selected_option": {


### PR DESCRIPTION
The typeahead-supported assignment dropdown didn't actually assign the user/team. This fixes that. Also, preloads with assignee if there is an automatically assigned one.


https://github.com/getsentry/sentry/assets/45607721/a6e36154-1ce1-4cca-9448-00a5d63ab6b9

