### PR TITLE
ref(logging): Log dates in ISO format

### DIFF
--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -124,10 +124,10 @@ def schedule_auto_transition_issues_new_to_ongoing(
 
     logger_extra = {
         "first_seen_lte": first_seen_lte,
-        "first_seen_lte_datetime": first_seen_lte_datetime,
+        "first_seen_lte_datetime": first_seen_lte_datetime.isoformat(),
     }
     if base_queryset:
-        logger_extra["issue_first_seen"] = base_queryset[0].first_seen
+        logger_extra["issue_first_seen"] = base_queryset[0].first_seen.isoformat()
     logger.info(
         "auto_transition_issues_new_to_ongoing started",
         extra=logger_extra,

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -261,8 +261,10 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
             "auto_transition_issues_new_to_ongoing started",
             extra={
                 "first_seen_lte": 1688582400,
-                "first_seen_lte_datetime": datetime(2023, 7, 5, 18, 40, tzinfo=timezone.utc),
-                "issue_first_seen": datetime(2023, 7, 5, 17, 40, tzinfo=timezone.utc),
+                "first_seen_lte_datetime": datetime(
+                    2023, 7, 5, 18, 40, tzinfo=timezone.utc
+                ).isoformat(),
+                "issue_first_seen": datetime(2023, 7, 5, 17, 40, tzinfo=timezone.utc).isoformat(),
             },
         )
 


### PR DESCRIPTION
this log hasn't been logging correctly for at least a month, and I believe it's because datetimes aren't JSON serializable. 