### PR TITLE
ref(slack): Add support for mentions

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1892,6 +1892,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:spike-protection-decay-heuristic": False,
     # Enable Slack messages using Block Kit
     "organizations:slack-block-kit": False,
+    # Enable new Slack message formatting
+    "organizations:slack-formatting-update": False,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -263,6 +263,7 @@ default_manager.add("organizations:session-replay-ui", OrganizationFeature, Feat
 default_manager.add("organizations:session-replay-weekly-email", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-block-kit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
+default_manager.add("organizations:slack-formatting-update", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-overage-notifications", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:source-maps-debugger-blue-thunder-edition", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sourcemaps-bundle-flat-file-indexing", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -22,7 +22,7 @@ from sentry.utils import json, metrics
 class SlackNotifyServiceAction(IntegrationEventAction):
     id = "sentry.integrations.slack.notify_action.SlackNotifyServiceAction"
     form_cls = SlackNotifyServiceForm
-    label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"
+    label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification. Add user and/or user group mentions: {mentions}."
     prompt = "Send a Slack notification"
     provider = "slack"
     integration_key = "workspace"
@@ -37,6 +37,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             "channel": {"type": "string", "placeholder": "e.g., #critical, Jane Schmidt"},
             "channel_id": {"type": "string", "placeholder": "e.g., CA2FRA079 or UA1J9RTE1"},
             "tags": {"type": "string", "placeholder": "e.g., environment,user,my_tag"},
+            "mentions": {"type": "string", "placeholder": "e.g. @colleen, @on-call-team"},
         }
 
     def after(
@@ -44,6 +45,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     ) -> Generator[CallbackFuture, None, None]:
         channel = self.get_option("channel_id")
         tags = set(self.get_tags_list())
+        mentions = self.get_option("mentions", "")
 
         i = self.get_integration()
         if not i:
@@ -65,6 +67,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     tags=tags,
                     rules=rules,
                     notification_uuid=notification_uuid,
+                    mentions=mentions,
                 )
                 if additional_attachment:
                     for block in additional_attachment:

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -41,7 +41,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         if features.has("organizations:slack-formatting-update", self.project.organization):
             self.form_fields["mentions"] = {
                 "type": "string",
-                "placeholder": "e.g. @colleen, @on-call-team",
+                "placeholder": "e.g. @jane, @on-call-team",
             }
 
     def after(

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -22,7 +22,7 @@ from sentry.utils import json, metrics
 class SlackNotifyServiceAction(IntegrationEventAction):
     id = "sentry.integrations.slack.notify_action.SlackNotifyServiceAction"
     form_cls = SlackNotifyServiceForm
-    label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification. Add user and/or user group mentions: {mentions}."
+    label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags}  and mentions {mentions} in notification."
     prompt = "Send a Slack notification"
     provider = "slack"
     integration_key = "workspace"
@@ -135,6 +135,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             channel=self.get_option("channel"),
             channel_id=self.get_option("channel_id"),
             tags="[{}]".format(", ".join(tags)),
+            mentions=self.get_option("mentions", ""),
         )
 
     def get_tags_list(self) -> Sequence[str]:

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -136,7 +136,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         tags = self.get_tags_list()
 
         if features.has("organizations:slack-formatting-update", self.project.organization):
-            self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and mentions {mentions} in notification"
             return self.label.format(
                 workspace=self.get_integration_name(),
                 channel=self.get_option("channel"),
@@ -145,7 +144,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 mentions=self.get_option("mentions", ""),
             )
 
-        self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"
         return self.label.format(
             workspace=self.get_integration_name(),
             channel=self.get_option("channel"),

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -23,12 +23,15 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     id = "sentry.integrations.slack.notify_action.SlackNotifyServiceAction"
     form_cls = SlackNotifyServiceForm
     prompt = "Send a Slack notification"
-    label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"
     provider = "slack"
     integration_key = "workspace"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        # XXX(CEO): when removing the feature flag, put `label` back up as a class var
+        self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"  # type: ignore
+        if features.has("organizations:slack-formatting-update", self.project.organization):
+            self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and mentions {mentions} in notification"  # type: ignore
         self.form_fields = {
             "workspace": {
                 "type": "choice",
@@ -134,7 +137,6 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         tags = self.get_tags_list()
 
         if features.has("organizations:slack-formatting-update", self.project.organization):
-            self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and mentions {mentions} in notification"
             return self.label.format(
                 workspace=self.get_integration_name(),
                 channel=self.get_option("channel"),

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -29,7 +29,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"
-        if features.has("organizations:slack-block-kit", self.project.organization):
+        if features.has("organizations:slack-formatting-update", self.project.organization):
             self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and mentions {mentions} in notification"
         self.form_fields = {
             "workspace": {
@@ -40,7 +40,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             "channel_id": {"type": "string", "placeholder": "e.g., CA2FRA079 or UA1J9RTE1"},
             "tags": {"type": "string", "placeholder": "e.g., environment,user,my_tag"},
         }
-        if features.has("organizations:slack-block-kit", self.project.organization):
+        if features.has("organizations:slack-formatting-update", self.project.organization):
             self.form_fields["mentions"] = {
                 "type": "string",
                 "placeholder": "e.g. @colleen, @on-call-team",
@@ -135,7 +135,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     def render_label(self) -> str:
         tags = self.get_tags_list()
 
-        if features.has("organizations:slack-block-kit", self.project.organization):
+        if features.has("organizations:slack-formatting-update", self.project.organization):
             self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and mentions {mentions} in notification"
             return self.label.format(
                 workspace=self.get_integration_name(),

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -23,14 +23,12 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     id = "sentry.integrations.slack.notify_action.SlackNotifyServiceAction"
     form_cls = SlackNotifyServiceForm
     prompt = "Send a Slack notification"
+    label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"
     provider = "slack"
     integration_key = "workspace"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"
-        if features.has("organizations:slack-formatting-update", self.project.organization):
-            self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and mentions {mentions} in notification"
         self.form_fields = {
             "workspace": {
                 "type": "choice",
@@ -136,6 +134,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         tags = self.get_tags_list()
 
         if features.has("organizations:slack-formatting-update", self.project.organization):
+            self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and mentions {mentions} in notification"
             return self.label.format(
                 workspace=self.get_integration_name(),
                 channel=self.get_option("channel"),

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -45,7 +45,6 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
             title = tag["title"]
             value = tag["value"]
             fields.append({"type": "mrkdwn", "text": f"*{title}:*\n{value}"})
-
         return {"type": "section", "fields": fields}
 
     @staticmethod

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -408,7 +408,10 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             blocks.append(self.get_tags_block(tags))
 
         # add mentions
-        if self.mentions:
+        if (
+            features.has("organizations:slack-formatting-update", self.group.project.organization)
+            and self.mentions
+        ):
             mentions_text = f"Mentions: {self.mentions}"
             blocks.append(self.get_markdown_block(mentions_text))
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -299,6 +299,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         recipient: RpcActor | None = None,
         is_unfurl: bool = False,
         skip_fallback: bool = False,
+        mentions: str | None = None,
     ) -> None:
         super().__init__()
         self.group = group
@@ -313,6 +314,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self.recipient = recipient
         self.is_unfurl = is_unfurl
         self.skip_fallback = skip_fallback
+        self.mentions = mentions
 
     @property
     def escape_text(self) -> bool:
@@ -406,6 +408,11 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if tags:
             blocks.append(self.get_tags_block(tags))
 
+        # add mentions
+        if self.mentions:
+            mentions_text = f"Mentions: {self.mentions}"
+            blocks.append(self.get_markdown_block(mentions_text))
+
         # build footer block
         timestamp = None
         if not self.issue_details:
@@ -452,6 +459,7 @@ def build_group_attachment(
     issue_details: bool = False,
     is_unfurl: bool = False,
     notification_uuid: str | None = None,
+    mentions: str | None = None,
 ) -> Union[SlackBlock, SlackAttachment]:
 
     return SlackIssuesMessageBuilder(
@@ -464,4 +472,5 @@ def build_group_attachment(
         link_to_event,
         issue_details,
         is_unfurl=is_unfurl,
+        mentions=mentions,
     ).build(notification_uuid=notification_uuid)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -386,7 +386,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             )
 
         # build up the blocks for newer issue alert formatting #
-
         tags = get_tags(event_for_tags, self.tags)
         # build title block
         title_link = get_title_link(

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -284,28 +284,30 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             event=event,
         )
         # add mentions to message
-        assert SlackIssuesMessageBuilder(
-            group, event, mentions=mentions
-        ).build() == build_test_message_blocks(
-            teams={self.team},
-            users={self.user},
-            timestamp=group.last_seen,
-            group=group,
-            mentions=mentions,
-            event=event,
-        )
+        with self.feature("organizations:slack-formatting-update"):
+            assert SlackIssuesMessageBuilder(
+                group, event, mentions=mentions
+            ).build() == build_test_message_blocks(
+                teams={self.team},
+                users={self.user},
+                timestamp=group.last_seen,
+                group=group,
+                mentions=mentions,
+                event=event,
+            )
         # add tags and mentions to message
-        assert SlackIssuesMessageBuilder(
-            group, event, tags={"level"}, mentions=mentions
-        ).build() == build_test_message_blocks(
-            teams={self.team},
-            users={self.user},
-            timestamp=group.last_seen,
-            group=group,
-            tags=tags,
-            mentions=mentions,
-            event=event,
-        )
+        with self.feature("organizations:slack-formatting-update"):
+            assert SlackIssuesMessageBuilder(
+                group, event, tags={"level"}, mentions=mentions
+            ).build() == build_test_message_blocks(
+                teams={self.team},
+                users={self.user},
+                timestamp=group.last_seen,
+                group=group,
+                tags=tags,
+                mentions=mentions,
+                event=event,
+            )
 
         assert SlackIssuesMessageBuilder(
             group, event.for_group(group)

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -76,7 +76,7 @@ class SlackNotifyActionTest(RuleTestCase):
             == "Send a notification to the Awesome Team Slack workspace to #my-channel (optionally, an ID: ) and show tags [one, two] in notification"
         )
 
-    @with_feature("organizations:slack-block-kit")
+    @with_feature("organizations:slack-formatting-update")
     def test_render_label_with_mentions(self):
         rule = self.get_rule(
             data={
@@ -90,7 +90,7 @@ class SlackNotifyActionTest(RuleTestCase):
 
         assert (
             rule.render_label()
-            == "Send a notification to the Awesome Team Slack workspace to #my-channel (optionally, an ID: ) and show tags [one, two] and mentions  in notification"
+            == "Send a notification to the Awesome Team Slack workspace to #my-channel (optionally, an ID: ) and show tags [one, two] and mentions fix this @colleen in notification"
         )
 
     def test_render_label_without_integration(self):

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -10,6 +10,7 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.notifications.additional_attachment_manager import manager
 from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.helpers import install_slack
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
@@ -73,6 +74,23 @@ class SlackNotifyActionTest(RuleTestCase):
         assert (
             rule.render_label()
             == "Send a notification to the Awesome Team Slack workspace to #my-channel (optionally, an ID: ) and show tags [one, two] in notification"
+        )
+
+    @with_feature("organizations:slack-block-kit")
+    def test_render_label_with_mentions(self):
+        rule = self.get_rule(
+            data={
+                "workspace": self.integration.id,
+                "channel": "#my-channel",
+                "channel_id": "",
+                "tags": "one, two",
+                "mentions": "fix this @colleen",
+            }
+        )
+
+        assert (
+            rule.render_label()
+            == "Send a notification to the Awesome Team Slack workspace to #my-channel (optionally, an ID: ) and show tags [one, two] and mentions  in notification"
         )
 
     def test_render_label_without_integration(self):


### PR DESCRIPTION
Add a text field to issue alert Slack actions that can be used to mention users or user groups. We aren't doing validation on the users or user groups entered here - the user must type in the `@` symbol for this to actually notify (unless the recipient has highlight words enabled for their name). Adding validation would significantly slow down rule saving for users, and for user groups we'd need to request a new scope, both of which we want to avoid.


**With text**
<img width="940" alt="Screenshot 2024-01-17 at 4 04 42 PM" src="https://github.com/getsentry/sentry/assets/29959063/32e1a920-e80f-4155-b054-57204ebbdf5c">
**Placeholder text**
<img width="947" alt="Screenshot 2024-01-17 at 4 04 51 PM" src="https://github.com/getsentry/sentry/assets/29959063/70ad1b43-9b66-4c66-9558-f67996c734c8">
**Renders description with mentions**
<img width="362" alt="Screenshot 2024-01-17 at 4 04 59 PM" src="https://github.com/getsentry/sentry/assets/29959063/b70d8b19-d864-43b7-95dd-64689a7f4123">
**Shows mentions in notification**
<img width="433" alt="Screenshot 2024-01-17 at 4 05 27 PM" src="https://github.com/getsentry/sentry/assets/29959063/b008b321-7453-40eb-ad4a-9ba6993de70f">


Closes #62905 