### PR TITLE
fix(escalating): Mark unignored issues as ongoing when ignored for a duration

### DIFF
--- a/src/sentry/tasks/clear_expired_snoozes.py
+++ b/src/sentry/tasks/clear_expired_snoozes.py
@@ -31,7 +31,7 @@ def clear_expired_snoozes():
     GroupSnooze.objects.filter(id__in=group_snooze_ids).delete()
 
     for group in ignored_groups:
-        manage_issue_states(group, GroupInboxReason.ESCALATING)
+        manage_issue_states(group, GroupInboxReason.ONGOING)
 
         issue_unignored.send_robust(
             project=group.project,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -959,7 +959,13 @@ def process_snoozes(job: PostProcessJob) -> None:
                 "user_window": snooze.user_window,
             }
 
-            manage_issue_states(group, GroupInboxReason.ESCALATING, event, snooze_details)
+            # issues snoozed with a specific time duration should be marked ONGOING when the window expires
+            reason = (
+                GroupInboxReason.ONGOING
+                if snooze.until is not None
+                else GroupInboxReason.ESCALATING
+            )
+            manage_issue_states(group, reason, event, snooze_details)
 
             snooze.delete()
 

--- a/tests/sentry/tasks/test_clear_expired_snoozes.py
+++ b/tests/sentry/tasks/test_clear_expired_snoozes.py
@@ -33,18 +33,16 @@ class ClearExpiredSnoozesTest(TestCase):
         group2.refresh_from_db()
 
         assert group1.status == GroupStatus.UNRESOLVED
-        assert group1.substatus == GroupSubStatus.ESCALATING
+        assert group1.substatus == GroupSubStatus.ONGOING
 
         # Check if unexpired snooze got cleared
         assert group2.status == GroupStatus.IGNORED
 
         assert not GroupSnooze.objects.filter(id=snooze1.id).exists()
         assert GroupSnooze.objects.filter(id=snooze2.id).exists()
-        assert GroupHistory.objects.filter(
-            group=group1, status=GroupHistoryStatus.ESCALATING
-        ).exists()
+        assert GroupHistory.objects.filter(group=group1, status=GroupHistoryStatus.ONGOING).exists()
         assert not GroupHistory.objects.filter(
-            group=group2, status=GroupHistoryStatus.ESCALATING
+            group=group2, status=GroupHistoryStatus.ONGOING
         ).exists()
 
         assert send_robust.called
@@ -67,16 +65,14 @@ class ClearExpiredSnoozesTest(TestCase):
         group2.refresh_from_db()
 
         assert group1.status == GroupStatus.UNRESOLVED
-        assert group1.substatus == GroupSubStatus.ESCALATING
+        assert group1.substatus == GroupSubStatus.ONGOING
 
         # Check if unexpired snooze got cleared
         assert group2.status == GroupStatus.IGNORED
 
         assert not GroupSnooze.objects.filter(id=snooze1.id).exists()
         assert GroupSnooze.objects.filter(id=snooze2.id).exists()
-        assert GroupHistory.objects.filter(
-            group=group1, status=GroupHistoryStatus.ESCALATING
-        ).exists()
+        assert GroupHistory.objects.filter(group=group1, status=GroupHistoryStatus.ONGOING).exists()
         assert not GroupHistory.objects.filter(
             group=group2, status=GroupHistoryStatus.UNIGNORED
         ).exists()

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -21,7 +21,6 @@ from sentry.eventstore.processing import event_processing_store
 from sentry.feedback.usecases.create_feedback import FeedbackCreationSource
 from sentry.ingest.transaction_clusterer import ClustererNamespace
 from sentry.integrations.mixins.commit_context import CommitInfo, FileBlameInfo
-from sentry.issues.escalating import manage_issue_states
 from sentry.issues.grouptype import (
     FeedbackGroup,
     GroupCategory,
@@ -1555,13 +1554,10 @@ class ProcessCommitsTestMixin(BasePostProgressGroupMixin):
 
 
 class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
-    @patch("sentry.signals.issue_escalating.send_robust")
     @patch("sentry.signals.issue_unignored.send_robust")
     @patch("sentry.rules.processor.RuleProcessor")
     @with_feature("organizations:issue-platform-crons-sd")
-    def test_invalidates_snooze_ff_on(
-        self, mock_processor, mock_send_unignored_robust, mock_send_escalating_robust
-    ):
+    def test_invalidates_snooze_ff_on(self, mock_processor, mock_send_unignored_robust):
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
         group = event.group
         should_detect_escalation = group.issue_type.should_detect_escalation(
@@ -1599,27 +1595,19 @@ class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
         mock_processor.assert_called_with(EventMatcher(event), False, False, True, True, False)
 
         if should_detect_escalation:
-            mock_send_escalating_robust.assert_called_once_with(
-                project=group.project,
-                group=group,
-                event=EventMatcher(event),
-                sender=manage_issue_states,
-                was_until_escalating=False,
-            )
             assert not GroupSnooze.objects.filter(id=snooze.id).exists()
         else:
-            mock_send_escalating_robust.assert_not_called()
             assert GroupSnooze.objects.filter(id=snooze.id).exists()
 
         group.refresh_from_db()
         if should_detect_escalation:
             assert group.status == GroupStatus.UNRESOLVED
-            assert group.substatus == GroupSubStatus.ESCALATING
+            assert group.substatus == GroupSubStatus.ONGOING
             assert GroupInbox.objects.filter(
-                group=group, reason=GroupInboxReason.ESCALATING.value
+                group=group, reason=GroupInboxReason.ONGOING.value
             ).exists()
             assert Activity.objects.filter(
-                group=group, project=group.project, type=ActivityType.SET_ESCALATING.value
+                group=group, project=group.project, type=ActivityType.SET_UNRESOLVED.value
             ).exists()
             assert mock_send_unignored_robust.called
         else:
@@ -1635,12 +1623,9 @@ class SnoozeTestSkipSnoozeMixin(BasePostProgressGroupMixin):
 
 
 class SnoozeTestMixin(BasePostProgressGroupMixin):
-    @patch("sentry.signals.issue_escalating.send_robust")
     @patch("sentry.signals.issue_unignored.send_robust")
     @patch("sentry.rules.processor.RuleProcessor")
-    def test_invalidates_snooze(
-        self, mock_processor, mock_send_unignored_robust, mock_send_escalating_robust
-    ):
+    def test_invalidates_snooze(self, mock_processor, mock_send_unignored_robust):
         event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
 
         group = event.group
@@ -1675,23 +1660,16 @@ class SnoozeTestMixin(BasePostProgressGroupMixin):
         )
 
         mock_processor.assert_called_with(EventMatcher(event), False, False, True, True, False)
-        mock_send_escalating_robust.assert_called_once_with(
-            project=group.project,
-            group=group,
-            event=EventMatcher(event),
-            sender=manage_issue_states,
-            was_until_escalating=False,
-        )
         assert not GroupSnooze.objects.filter(id=snooze.id).exists()
 
         group.refresh_from_db()
         assert group.status == GroupStatus.UNRESOLVED
-        assert group.substatus == GroupSubStatus.ESCALATING
+        assert group.substatus == GroupSubStatus.ONGOING
         assert GroupInbox.objects.filter(
-            group=group, reason=GroupInboxReason.ESCALATING.value
+            group=group, reason=GroupInboxReason.ONGOING.value
         ).exists()
         assert Activity.objects.filter(
-            group=group, project=group.project, type=ActivityType.SET_ESCALATING.value
+            group=group, project=group.project, type=ActivityType.SET_UNRESOLVED.value
         ).exists()
         assert mock_send_unignored_robust.called
 


### PR DESCRIPTION
From https://sentry.slack.com/archives/C04KZQBNQ2U/p1705532089940439, we shouldn't mark issues as escalating if they get unignored because the duration expires. 