### PR TITLE
fix(escalating-issues): Make sure `log_error_if_queue_has_items` can't cause a task to fail

### DIFF
--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -35,8 +35,8 @@ def log_error_if_queue_has_items(func):
     def inner(func):
         @wraps(func)
         def wrapped(*args, **kwargs):
+            assert backend is not None, "queues monitoring is not enabled"
             try:
-                assert backend is not None, "queues monitoring is not enabled"
                 queue_size = backend.get_size(CELERY_ISSUE_STATES_QUEUE.name)
                 if queue_size > 0:
                     logger.info(

--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -35,14 +35,17 @@ def log_error_if_queue_has_items(func):
     def inner(func):
         @wraps(func)
         def wrapped(*args, **kwargs):
-            assert backend is not None, "queues monitoring is not enabled"
-            queue_size = backend.get_size(CELERY_ISSUE_STATES_QUEUE.name)
-            if queue_size > 0:
-                logger.info(
-                    "%s queue size greater than 0.",
-                    CELERY_ISSUE_STATES_QUEUE.name,
-                    extra={"size": queue_size, "task": func.__name__},
-                )
+            try:
+                assert backend is not None, "queues monitoring is not enabled"
+                queue_size = backend.get_size(CELERY_ISSUE_STATES_QUEUE.name)
+                if queue_size > 0:
+                    logger.info(
+                        "%s queue size greater than 0.",
+                        CELERY_ISSUE_STATES_QUEUE.name,
+                        extra={"size": queue_size, "task": func.__name__},
+                    )
+            except Exception:
+                logger.exception("Failed to determine queue size")
 
             func(*args, **kwargs)
 


### PR DESCRIPTION
We're seeing this scheduler isn't running. The only error related to it seems to be related to this error logging function - Just adding safety around it so we can eliminate this possibility.
