### PR TITLE
ref(ui): Allow empty organization in TimeRangeSelector

### DIFF
--- a/static/app/components/timeRangeSelector/dateRange.tsx
+++ b/static/app/components/timeRangeSelector/dateRange.tsx
@@ -54,11 +54,6 @@ type Props = WithRouterProps & {
   onChangeUtc: () => void;
 
   /**
-   * Just used for metrics
-   */
-  organization: Organization;
-
-  /**
    * Start date value for absolute date selector
    */
   start: Date | null;
@@ -71,6 +66,11 @@ type Props = WithRouterProps & {
    * The largest date range (ie. end date - start date) allowed
    */
   maxDateRange?: number;
+
+  /**
+   * Just used for metrics
+   */
+  organization?: Organization;
 
   /**
    * Should we have a time selector?
@@ -127,7 +127,7 @@ class BaseDateRange extends Component<Props, State> {
     }
 
     trackAnalytics('dateselector.time_changed', {
-      organization,
+      organization: organization ?? null,
       field_changed: 'start',
       time: startTime,
       path: getRouteStringFromRoutes(router.routes),
@@ -156,7 +156,7 @@ class BaseDateRange extends Component<Props, State> {
     }
 
     trackAnalytics('dateselector.time_changed', {
-      organization,
+      organization: organization ?? null,
       field_changed: 'end',
       time: endTime,
       path: getRouteStringFromRoutes(router.routes),

--- a/static/app/components/timeRangeSelector/index.tsx
+++ b/static/app/components/timeRangeSelector/index.tsx
@@ -164,7 +164,7 @@ export function TimeRangeSelector({
   ...selectProps
 }: TimeRangeSelectorProps) {
   const router = useRouter();
-  const organization = useOrganization();
+  const organization = useOrganization({allowNull: true});
 
   const [search, setSearch] = useState('');
   const [hasChanges, setHasChanges] = useState(false);
@@ -372,7 +372,7 @@ export function TimeRangeSelector({
                       start={internalValue.start ?? null}
                       end={internalValue.end ?? null}
                       utc={internalValue.utc}
-                      organization={organization}
+                      organization={organization ?? undefined}
                       showTimePicker
                       onChange={val => {
                         if (val.hasDateRangeErrors) {


### PR DESCRIPTION
This is only used for analytics, it should not be required.