### PR TITLE
feat(relocation): Add relocation link on org creation page

### DIFF
--- a/static/app/views/organizationCreate/index.spec.tsx
+++ b/static/app/views/organizationCreate/index.spec.tsx
@@ -59,6 +59,7 @@ describe('OrganizationCreate', function () {
     expect(
       screen.getByText('Relocating from self-hosted?', {exact: false})
     ).toBeInTheDocument();
+    expect(screen.getByText('here')).toHaveAttribute('href', '/relocation/');
 
     await userEvent.type(screen.getByPlaceholderText('e.g. My Company'), 'Good Burger');
     await userEvent.click(

--- a/static/app/views/organizationCreate/index.spec.tsx
+++ b/static/app/views/organizationCreate/index.spec.tsx
@@ -34,6 +34,17 @@ describe('OrganizationCreate', function () {
     render(<OrganizationCreate />);
   });
 
+  it('does not render relocation url for self-hosted', function () {
+    ConfigStore.set('termsUrl', 'https://example.com/terms');
+    ConfigStore.set('privacyUrl', 'https://example.com/privacy');
+    ConfigStore.set('isSelfHosted', true);
+    render(<OrganizationCreate />);
+
+    expect(() =>
+      screen.getByText('Relocating from self-hosted?', {exact: false})
+    ).toThrow();
+  });
+
   it('creates a new org', async function () {
     const orgCreateMock = MockApiClient.addMockResponse({
       url: '/organizations/',
@@ -42,8 +53,12 @@ describe('OrganizationCreate', function () {
     });
     ConfigStore.set('termsUrl', 'https://example.com/terms');
     ConfigStore.set('privacyUrl', 'https://example.com/privacy');
+    ConfigStore.set('isSelfHosted', false);
     render(<OrganizationCreate />);
     expect(screen.getByText('Create a New Organization')).toBeInTheDocument();
+    expect(
+      screen.getByText('Relocating from self-hosted?', {exact: false})
+    ).toBeInTheDocument();
 
     await userEvent.type(screen.getByPlaceholderText('e.g. My Company'), 'Good Burger');
     await userEvent.click(

--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -26,6 +26,8 @@ function removeDataStorageLocationFromFormData(
 function OrganizationCreate() {
   const termsUrl = ConfigStore.get('termsUrl');
   const privacyUrl = ConfigStore.get('privacyUrl');
+  const isSelfHosted = ConfigStore.get('isSelfHosted');
+  const relocationUrl = normalizeUrl(`/relocation/`);
   const regionChoices = getRegionChoices();
   const client = useApi();
 
@@ -121,6 +123,13 @@ function OrganizationCreate() {
               stacked
               required
             />
+          )}
+          {!isSelfHosted && (
+            <div>
+              {tct('Relocating from self-hosted? Click [relocationLink:here]', {
+                relocationLink: <a href={relocationUrl} />,
+              })}
+            </div>
           )}
         </Form>
       </NarrowLayout>


### PR DESCRIPTION
Allows orgless users to go back to the relocation flow if they exit the onboarding process before finishing. 

<img width="801" alt="Screenshot 2024-01-17 at 6 04 28 PM" src="https://github.com/getsentry/sentry/assets/25517925/1e61423b-63ff-4cf4-950d-f89396c1c7b8">
