### PR TITLE
fix(ui): Remove unused withOrganization from U2fInterface

### DIFF
--- a/static/app/components/u2f/u2finterface.tsx
+++ b/static/app/components/u2f/u2finterface.tsx
@@ -5,8 +5,7 @@ import * as cbor from 'cbor-web';
 import {base64urlToBuffer, bufferToBase64url} from 'sentry/components/u2f/webAuthnHelper';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
-import {ChallengeData, Organization} from 'sentry/types';
-import withOrganization from 'sentry/utils/withOrganization';
+import {ChallengeData} from 'sentry/types';
 
 type TapParams = {
   challenge: string;
@@ -26,7 +25,6 @@ type Props = {
     superuserAccessCategory,
     superuserReason,
   }: TapParams) => Promise<void>;
-  organization: Organization;
   silentIfUnsupported: boolean;
   children?: React.ReactNode;
   style?: React.CSSProperties;
@@ -376,4 +374,4 @@ class U2fInterface extends Component<Props, State> {
   }
 }
 
-export default withOrganization(U2fInterface);
+export default U2fInterface;


### PR DESCRIPTION
This is breaking U2F authentication since `withOrganization` now uses the `useOrganization` hook.