### PR TITLE
chore: Add mypy-edited-files to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,5 +212,9 @@ lint-js:
 	bin/lint --js --parseable
 	@echo ""
 
+mypy-edited-files:
+	@echo "--> Running mypy on edited files"
+	git diff --name-only HEAD | grep '\.py$$' | xargs -r mypy
+	@echo ""
 
 .PHONY: build


### PR DESCRIPTION
Add a command to the Makefile to run mypy on only edited files.

I sometimes forget to run mypy on my edited files. Running it on all files takes a long time. Therefore, I manually run `git diff --name-only HEAD | grep '\.py$$' | xargs -r mypy` from the command line so CI doesn't point out mypy issues after I opened the PR. I added this command to the Makefile so more people can use it. 

