### PR TITLE
Integrate Rust Enhancements

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -62,6 +62,7 @@ rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=2.16.0
 sentry-kafka-schemas>=0.1.38
+sentry-ophio==0.1.1
 sentry-redis-tools>=0.1.7
 sentry-relay>=0.8.45
 sentry-sdk>=1.39.2

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -178,6 +178,7 @@ sentry-devenv==1.2.2
 sentry-forked-django-stubs==4.2.7.post1
 sentry-forked-djangorestframework-stubs==3.14.5.post1
 sentry-kafka-schemas==0.1.38
+sentry-ophio==0.1.1
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.45
 sentry-sdk==1.39.2

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -119,6 +119,7 @@ rsa==4.8
 s3transfer==0.10.0
 sentry-arroyo==2.16.0
 sentry-kafka-schemas==0.1.38
+sentry-ophio==0.1.1
 sentry-redis-tools==0.1.7
 sentry-relay==0.8.45
 sentry-sdk==1.39.2

--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -76,6 +76,9 @@ def create_match_frame(frame_data: dict, platform: Optional[str]) -> dict:
                 value = match_frame[key] = value.encode("utf-8")
 
             if key in ("package", "path"):
+                # NOTE: path-like matchers are case insensitive, and normalize
+                # file-system separators to `/`.
+                # We do this here in a central place instead of in each matcher separately.
                 value = match_frame[key] = value.lower().replace(b"\\", b"/")
 
     return match_frame

--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -72,11 +72,11 @@ def create_match_frame(frame_data: dict, platform: Optional[str]) -> dict:
     for key in list(match_frame.keys()):
         value = match_frame[key]
         if isinstance(value, (bytes, str)):
-            if key in ("package", "path"):
-                value = match_frame[key] = value.lower()
-
             if isinstance(value, str):
-                match_frame[key] = value.encode("utf-8")
+                value = match_frame[key] = value.encode("utf-8")
+
+            if key in ("package", "path"):
+                value = match_frame[key] = value.lower().replace(b"\\", b"/")
 
     return match_frame
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1991,3 +1991,20 @@ register(
     default=False,
     flags=FLAG_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Sampling rates for testing Rust-based grouping enhancers
+
+# Rate at which to parse enhancers in Rust in addition to Python
+register(
+    "grouping.rust_enhancers.parse_rate",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+# Rate at which to run the Rust implementation of `apply_modifications_to_frames
+# and compare the results`
+register(
+    "grouping.rust_enhancers.modify_frames_rate",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -19,6 +19,8 @@ def dump_obj(obj):
     for key, value in obj.__dict__.items():
         if key.startswith("_"):
             continue
+        elif key == "rust_enhancements":
+            continue
         elif isinstance(value, list):
             rv[key] = [dump_obj(x) for x in value]
         elif isinstance(value, dict):
@@ -30,6 +32,7 @@ def dump_obj(obj):
 
 @pytest.mark.parametrize("version", [1, 2])
 @django_db_all
+@override_options({"grouping.rust_enhancers.parse_rate": 1.0})
 def test_basic_parsing(insta_snapshot, version):
     enhancement = Enhancements.from_config_string(
         """
@@ -85,6 +88,10 @@ def test_callee_recursion():
         Enhancements.from_config_string(" category:foo | [ category:bar ] | [ category:baz ] +app")
 
 
+@django_db_all
+@override_options(
+    {"grouping.rust_enhancers.parse_rate": 1.0, "grouping.rust_enhancers.modify_frames_rate": 1.0}
+)
 def test_flipflop_inapp():
     enhancement = Enhancements.from_config_string(
         """
@@ -479,6 +486,10 @@ def test_sentinel_and_prefix(action, type):
     assert getattr(component, f"is_{type}_frame") is expected
 
 
+@django_db_all
+@override_options(
+    {"grouping.rust_enhancers.parse_rate": 1.0, "grouping.rust_enhancers.modify_frames_rate": 1.0}
+)
 @pytest.mark.parametrize(
     "frame",
     [


### PR DESCRIPTION
This hooks up the Rust Enhancements code which was developed in the `ophio` repo.

It is hooked up to parse all the BASE enhancement rules which are initialized at module loading time.
Parsing custom enhancement rules and applying those to stack traces (only in comparison mode for now) is gated behind `options` which will be sampled up after deployment.