### PR TITLE
ref(ddm): Refactor code of ddm/meta endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_ddm.py
+++ b/src/sentry/api/endpoints/organization_ddm.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 from enum import Enum
 from typing import Any, Sequence
 

--- a/src/sentry/api/endpoints/organization_ddm.py
+++ b/src/sentry/api/endpoints/organization_ddm.py
@@ -1,3 +1,4 @@
+import datetime
 from enum import Enum
 from typing import Any, Sequence
 
@@ -10,21 +11,30 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.code_locations import CodeLocationsSerializer
-from sentry.api.serializers.models.metric_spans import MetricSpansSerializer
+from sentry.api.serializers.models.correlations import CorrelationsSerializer
 from sentry.api.utils import get_date_range_from_params
 from sentry.exceptions import InvalidParams
-from sentry.sentry_metrics.querying.metadata.code_locations import get_code_locations
-from sentry.sentry_metrics.querying.metadata.metric_spans import get_correlations_of_metric
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.sentry_metrics.querying.metadata.code_locations import (
+    MetricCodeLocations,
+    get_metric_code_locations,
+)
+from sentry.sentry_metrics.querying.metadata.correlations import (
+    Correlations,
+    get_metric_correlations,
+)
 
 
 class MetaType(Enum):
     CODE_LOCATIONS = "codeLocations"
-    METRIC_SPANS = "metricSpans"
+    # TODO: change name when we settled on the naming.
+    CORRELATIONS = "metricSpans"
 
 
 META_TYPE_SERIALIZER = {
     MetaType.CODE_LOCATIONS.value: CodeLocationsSerializer(),
-    MetaType.METRIC_SPANS.value: MetricSpansSerializer(),
+    MetaType.CORRELATIONS.value: CorrelationsSerializer(),
 }
 
 
@@ -51,49 +61,61 @@ class OrganizationDDMMetaEndpoint(OrganizationEndpoint):
 
         return meta_types
 
-    def get(self, request: Request, organization) -> Response:
-        start, end = get_date_range_from_params(request.GET)
+    def _get_metric_code_locations(
+        self,
+        request: Request,
+        organization: Organization,
+        projects: Sequence[Project],
+        start: datetime,
+        end: datetime,
+    ) -> Sequence[MetricCodeLocations]:
+        return get_metric_code_locations(
+            metric_mris=[request.GET["metric"]],
+            start=start,
+            end=end,
+            organization=organization,
+            projects=projects,
+        )
 
+    def _get_metric_correlations(
+        self,
+        request: Request,
+        organization: Organization,
+        projects: Sequence[Project],
+        start: datetime,
+        end: datetime,
+    ) -> Correlations:
+        min_value = float(request.GET["min"]) if request.GET.get("min") else None
+        max_value = float(request.GET["max"]) if request.GET.get("max") else None
+
+        if min_value and max_value and min_value > max_value:
+            raise InvalidParams("The bounds are invalid, min can't be bigger than max")
+
+        return get_metric_correlations(
+            metric_mri=request.GET["metric"],
+            query=request.GET.get("query"),
+            start=start,
+            end=end,
+            min_value=min_value,
+            max_value=max_value,
+            organization=organization,
+            projects=projects,
+            environments=self.get_environments(request, organization),
+        )
+
+    def get(self, request: Request, organization) -> Response:
         response = {}
 
-        metric_mris = request.GET.getlist("metric", [])
+        start, end = get_date_range_from_params(request.GET)
         projects = self.get_projects(request, organization)
-
-        if len(metric_mris) != 1:
-            raise InvalidParams("You can only pass a single metric.")
 
         for meta_type in self._extract_meta_types(request):
             data: Any = {}
 
             if meta_type == MetaType.CODE_LOCATIONS:
-                # TODO: refactor code locations to support only a single mri.
-                data = get_code_locations(
-                    metric_mris=metric_mris[:1],
-                    start=start,
-                    end=end,
-                    organization=organization,
-                    projects=projects,
-                )
-            elif meta_type == MetaType.METRIC_SPANS:
-                min_value = float(request.GET["min"]) if request.GET.get("min") else None
-                max_value = float(request.GET["max"]) if request.GET.get("max") else None
-
-                if min_value and max_value and min_value > max_value:
-                    raise InvalidParams("The bounds are invalid, min can't be bigger than max")
-
-                query = request.GET.get("query")
-
-                data = get_correlations_of_metric(
-                    metric_mri=metric_mris[0],
-                    query=query,
-                    start=start,
-                    end=end,
-                    min_value=min_value,
-                    max_value=max_value,
-                    organization=organization,
-                    projects=projects,
-                    environments=self.get_environments(request, organization),
-                )
+                data = self._get_metric_code_locations(request, organization, projects, start, end)
+            elif meta_type == MetaType.CORRELATIONS:
+                data = self._get_metric_correlations(request, organization, projects, start, end)
 
             response[meta_type.value] = serialize(
                 data, request.user, META_TYPE_SERIALIZER[meta_type.value]

--- a/src/sentry/api/serializers/models/correlations.py
+++ b/src/sentry/api/serializers/models/correlations.py
@@ -1,7 +1,7 @@
 from sentry.api.serializers import Serializer
 
 
-class MetricSpansSerializer(Serializer):
+class CorrelationsSerializer(Serializer):
     def __init__(self, *args, **kwargs):
         Serializer.__init__(self, *args, **kwargs)
 

--- a/src/sentry/sentry_metrics/querying/metadata/code_locations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/code_locations.py
@@ -184,7 +184,7 @@ class CodeLocationsFetcher:
             yield batch
 
 
-def get_code_locations(
+def get_metric_code_locations(
     metric_mris: Sequence[str],
     start: datetime,
     end: datetime,

--- a/src/sentry/sentry_metrics/querying/metadata/correlations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/correlations.py
@@ -104,7 +104,7 @@ class Segment:
 
 
 @dataclass(frozen=True)
-class MetricCorrelations:
+class Correlations:
     metric_mri: str
     segments: Sequence[Segment]
 
@@ -577,7 +577,7 @@ def get_correlations_source(
     return None
 
 
-def get_correlations_of_metric(
+def get_metric_correlations(
     metric_mri: str,
     query: Optional[str],
     start: datetime,
@@ -587,7 +587,7 @@ def get_correlations_of_metric(
     organization: Organization,
     projects: Sequence[Project],
     environments: Sequence[Environment],
-) -> MetricCorrelations:
+) -> Correlations:
     """
     Returns the spans in which the metric with `metric_mri` was emitted.
 
@@ -604,7 +604,7 @@ def get_correlations_of_metric(
         segments = correlations_source.get_segments(
             metric_mri, query, start, end, min_value, max_value, environments
         )
-        return MetricCorrelations(
+        return Correlations(
             metric_mri=metric_mri,
             segments=segments,
         )

--- a/src/sentry/sentry_metrics/querying/metadata/correlations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/correlations.py
@@ -104,7 +104,7 @@ class Segment:
 
 
 @dataclass(frozen=True)
-class Correlations:
+class MetricCorrelations:
     metric_mri: str
     segments: Sequence[Segment]
 
@@ -587,7 +587,7 @@ def get_metric_correlations(
     organization: Organization,
     projects: Sequence[Project],
     environments: Sequence[Environment],
-) -> Correlations:
+) -> MetricCorrelations:
     """
     Returns the spans in which the metric with `metric_mri` was emitted.
 
@@ -604,7 +604,7 @@ def get_metric_correlations(
         segments = correlations_source.get_segments(
             metric_mri, query, start, end, min_value, max_value, environments
         )
-        return Correlations(
+        return MetricCorrelations(
             metric_mri=metric_mri,
             segments=segments,
         )


### PR DESCRIPTION
This PR renames `metric_spans` to `correlations` and aligns namings across the entire metrics metadata code.