### PR TITLE
fix(ddm): Fix empty list instead of None when injecting environment

### DIFF
--- a/src/sentry/sentry_metrics/querying/visitors.py
+++ b/src/sentry/sentry_metrics/querying/visitors.py
@@ -45,13 +45,15 @@ class EnvironmentsInjectionVisitor(QueryExpressionVisitor[QueryExpression]):
         self._environment_names = [environment.name for environment in environments]
 
     def _visit_timeseries(self, timeseries: Timeseries) -> QueryExpression:
-        current_filters = timeseries.filters if timeseries.filters else []
         if self._environment_names:
+            current_filters = timeseries.filters if timeseries.filters else []
             current_filters.extend(
                 [Condition(Column("environment"), Op.IN, self._environment_names)]
             )
 
-        return timeseries.set_filters(current_filters)
+            return timeseries.set_filters(current_filters)
+
+        return timeseries
 
 
 class ValidationVisitor(QueryExpressionVisitor[QueryExpression]):


### PR DESCRIPTION
This PR fixes an issue in which we were creating an empty list if `None` was set when injecting the environment. The PR itself is not really a fix since there is a problem on the snuba-sdk end when generating an mql query with `filters=[]` that results in a query in the form `aggregate(metric){}`, that is unparsable by the grammar.