### PR TITLE
fix(hybrid-cloud): Fix RPC call with invalid parameters

### DIFF
--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -221,10 +221,11 @@ class ApiInviteHelper:
 
         if self.member_already_exists:
             self.handle_member_already_exists()
-            organization_service.delete_organization_member(
-                organization_member_id=self.invite_context.invite_organization_member_id,
-                organization_id=self.invite_context.organization.id,
-            )
+            if self.invite_context.invite_organization_member_id is not None:
+                organization_service.delete_organization_member(
+                    organization_member_id=self.invite_context.invite_organization_member_id,
+                    organization_id=self.invite_context.organization.id,
+                )
             return None
 
         try:

--- a/tests/sentry/api/test_invite_helper.py
+++ b/tests/sentry/api/test_invite_helper.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 from django.http import HttpRequest
 
 from sentry.api.invite_helper import ApiInviteHelper
@@ -51,6 +52,41 @@ class ApiInviteHelperTest(TestCase):
         om = OrganizationMember.objects.get(id=self.member.id)
         assert om.email is None
         assert om.user_id == self.user.id
+
+    @patch("sentry.api.invite_helper.create_audit_entry")
+    @patch("sentry.api.invite_helper.RpcOrganizationMember.get_audit_log_metadata")
+    def test_accept_invite_already_exists(self, get_audit, create_audit):
+        om = OrganizationMember.objects.get(id=self.member.id)
+        assert om.email == self.member.email
+
+        invite_context = organization_service.get_invite_by_id(
+            organization_member_id=om.id, organization_id=om.organization_id
+        )
+        assert invite_context is not None
+
+        helper = ApiInviteHelper(self.request, invite_context, None)
+        helper.accept_invite()
+        invite_context = organization_service.get_invite_by_id(
+            organization_member_id=om.id, organization_id=om.organization_id
+        )
+        assert invite_context is not None
+        member_id = invite_context.invite_organization_member_id
+        assert member_id is not None
+
+        # Without this member_id, don't delete the organization member
+        invite_context.invite_organization_member_id = None
+        helper = ApiInviteHelper(self.request, invite_context, None)
+        helper.accept_invite()
+        om = OrganizationMember.objects.get(id=self.member.id)
+        assert om.email is None
+        assert om.user_id == self.user.id
+
+        # With the member_id, ensure it's deleted
+        invite_context.invite_organization_member_id = member_id
+        helper = ApiInviteHelper(self.request, invite_context, None)
+        helper.accept_invite()
+        with pytest.raises(OrganizationMember.DoesNotExist):
+            OrganizationMember.objects.get(id=self.member.id)
 
     @patch("sentry.api.invite_helper.create_audit_entry")
     @patch("sentry.api.invite_helper.RpcOrganizationMember.get_audit_log_metadata")


### PR DESCRIPTION
Fixes [SENTRY-2E0H](https://sentry.sentry.io/issues/4876240226/) - The RPC call was being made with invalid parameters. This doesn't really address the root problem of why the member_id supplied was None, but the `context` object has that attribute as optional, so I'm guessing it's not unexpected.

That said, I don't really understand the goal of this behaviour to delete the organization member if we accept the invite a second time, but I've put together tests for the code as written. If someone has context on why we delete the OM, please let me know.