### PR TITLE
fix(platform): Indicate that electron has release health support

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -297,6 +297,8 @@ export const releaseHealth: PlatformKey[] = [
   'native-crashpad',
   'native-breakpad',
   'native-qt',
+  'electron',
+  'javascript-electron',
 ];
 
 // These are the backend platforms that can set up replay -- e.g. they can be set up via a linked JS framework or via JS loader.


### PR DESCRIPTION
This is done so that we don't show a warning when trying to create alerts for electron sessions.

https://github.com/getsentry/sentry/blob/0f678dcb5b176f865354c58a51b9e89621d4420b/static/app/views/alerts/rules/issue/ruleNode.tsx#L431-L443

Electron has had release health support since forever. https://docs.sentry.io/platforms/javascript/guides/electron/configuration/releases/#release-health