### PR TITLE
feat(metrics_extraction): Option to control org max limit reporting

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1675,6 +1675,13 @@ register(
     default=100,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+#
+register(
+    "on_demand.silence_orgs_above_max_limit",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 register(
     "on_demand.max_widget_cardinality.count",
     default=10000,

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -234,8 +234,8 @@ def _trim_if_above_limit(
 
     for version, specs_for_version in specs_per_version.items():
         if len(specs_for_version) > max_specs:
-            # Do not log for Sentry
-            if project.organization.id != 1:
+            # Certain orgs may be above the limit, however, we do not want to be informed
+            if project.organization.id not in options.get("on_demand.silence_orgs_above_max_limit"):
                 logger.error(
                     "Spec version %s: Too many (%s) on demand metric %s for project %s",
                     version,


### PR DESCRIPTION
This allows silencing reporting issues for the Sentry org in SaaS without impacting self-hosted customers.

Related options PR: https://github.com/getsentry/sentry-options-automator/pull/605