### PR TITLE
fix(hybrid-cloud): Avoid Google identity requests failing in middleware

### DIFF
--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -130,7 +130,7 @@ class IntegrationClassification(BaseClassification):
             with sentry_sdk.configure_scope() as scope:
                 scope.set_tag("provider", provider)
                 scope.set_tag("path", request.path)
-                sentry_sdk.capture_exception(Exception("Unexpected provider was parsed from path"))
+                sentry_sdk.capture_exception(Exception("Unknown provider was extracted from integration extension url"))
             return self.response_handler(request)
 
         parser = parser_class(

--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -5,6 +5,7 @@ import logging
 import re
 from typing import TYPE_CHECKING, List, Mapping, Type, cast
 
+import sentry_sdk
 from django.http import HttpRequest, HttpResponse
 from django.http.response import HttpResponseBase
 from rest_framework import status
@@ -70,6 +71,7 @@ class IntegrationClassification(BaseClassification):
             GithubEnterpriseRequestParser,
             GithubRequestParser,
             GitlabRequestParser,
+            GoogleRequestParser,
             JiraRequestParser,
             JiraServerRequestParser,
             MsTeamsRequestParser,
@@ -82,6 +84,7 @@ class IntegrationClassification(BaseClassification):
             BitbucketRequestParser,
             BitbucketServerRequestParser,
             DiscordRequestParser,
+            GoogleRequestParser,
             GithubEnterpriseRequestParser,
             GithubRequestParser,
             GitlabRequestParser,
@@ -124,10 +127,10 @@ class IntegrationClassification(BaseClassification):
 
         parser_class = self.integration_parsers.get(provider)
         if not parser_class:
-            self.logger.error(
-                "integration_control.unknown_provider",
-                extra={"path": request.path, "provider": provider},
-            )
+            with sentry_sdk.configure_scope() as scope:
+                scope.set_tag("provider", provider)
+                scope.set_tag("path", request.path)
+                sentry_sdk.capture_exception(Exception("Unexpected provider was parsed from path"))
             return self.response_handler(request)
 
         parser = parser_class(

--- a/src/sentry/middleware/integrations/classifications.py
+++ b/src/sentry/middleware/integrations/classifications.py
@@ -130,7 +130,9 @@ class IntegrationClassification(BaseClassification):
             with sentry_sdk.configure_scope() as scope:
                 scope.set_tag("provider", provider)
                 scope.set_tag("path", request.path)
-                sentry_sdk.capture_exception(Exception("Unknown provider was extracted from integration extension url"))
+                sentry_sdk.capture_exception(
+                    Exception("Unknown provider was extracted from integration extension url")
+                )
             return self.response_handler(request)
 
         parser = parser_class(

--- a/src/sentry/middleware/integrations/parsers/__init__.py
+++ b/src/sentry/middleware/integrations/parsers/__init__.py
@@ -4,6 +4,7 @@ from .discord import DiscordRequestParser
 from .github import GithubRequestParser
 from .github_enterprise import GithubEnterpriseRequestParser
 from .gitlab import GitlabRequestParser
+from .google import GoogleRequestParser
 from .jira import JiraRequestParser
 from .jira_server import JiraServerRequestParser
 from .msteams import MsTeamsRequestParser
@@ -16,6 +17,7 @@ __all__ = (
     "BitbucketRequestParser",
     "BitbucketServerRequestParser",
     "DiscordRequestParser",
+    "GoogleRequestParser",
     "GithubEnterpriseRequestParser",
     "GithubRequestParser",
     "GitlabRequestParser",

--- a/src/sentry/middleware/integrations/parsers/google.py
+++ b/src/sentry/middleware/integrations/parsers/google.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class GoogleRequestParser(BaseRequestParser):
     provider = "google"
-    webhook_identifier = WebhookProviderIdentifier.GETSENTRY
+    webhook_identifier = WebhookProviderIdentifier.GOOGLE
 
     def get_response(self):
         return self.get_response_from_control_silo()

--- a/src/sentry/middleware/integrations/parsers/google.py
+++ b/src/sentry/middleware/integrations/parsers/google.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import logging
+
+from sentry.middleware.integrations.parsers.base import BaseRequestParser
+from sentry.models.outbox import WebhookProviderIdentifier
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleRequestParser(BaseRequestParser):
+    provider = "google"
+    webhook_identifier = WebhookProviderIdentifier.GETSENTRY
+
+    def get_response(self):
+        return self.get_response_from_control_silo()

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -408,6 +408,7 @@ class WebhookProviderIdentifier(IntEnum):
     GETSENTRY = 11
     DISCORD = 12
     VERCEL = 13
+    GOOGLE = 14
 
 
 def _ensure_not_null(k: str, v: Any) -> Any:

--- a/tests/sentry/middleware/integrations/parsers/test_google.py
+++ b/tests/sentry/middleware/integrations/parsers/test_google.py
@@ -1,0 +1,34 @@
+import responses
+from django.http import HttpRequest, HttpResponse
+from django.test import RequestFactory
+
+from sentry.middleware.integrations.parsers.google import GoogleRequestParser
+from sentry.testutils.cases import TestCase
+from sentry.testutils.outbox import assert_no_webhook_outboxes
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test
+class GoogleRequestParserTest(TestCase):
+    factory = RequestFactory()
+    google_dummy_requests = [
+        factory.get("/extensions/google/setup/"),
+        # Unsure how these requests are getting generated, but they shouldn't fail in the middleware
+        factory.get("/extensions/google/setup/null/"),
+        factory.get("/extensions/google/setup/null/api/0/organizations/"),
+    ]
+
+    def get_response(self, request: HttpRequest) -> HttpResponse:
+        return HttpResponse(status=200, content="passthrough")
+
+    @responses.activate
+    def test_routing_all_to_control(self):
+        for request in self.google_dummy_requests:
+            parser = GoogleRequestParser(request=request, response_handler=self.get_response)
+            assert parser.get_integration_from_request() is None
+            response = parser.get_response()
+            assert isinstance(response, HttpResponse)
+            assert response.status_code == 200
+            assert response.content == b"passthrough"
+            assert len(responses.calls) == 0
+            assert_no_webhook_outboxes()


### PR DESCRIPTION
Resolves [SENTRY-2BD9](https://sentry.sentry.io/issues/4742426529/) sort of. I wasn't able to trace exactly where these oddly shaped requests are coming from (e.g. `/extensions/google/setup/null/api/0/organizations/`), but since they are related to google auth, they should be managed entirely in the control silo, so we can set up a parser for them.