### PR TITLE
fix(perf): Improve sidebar accordion active state II

### DIFF
--- a/static/app/components/sidebar/sidebarAccordion.spec.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.spec.tsx
@@ -1,0 +1,37 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {SidebarAccordion} from 'sentry/components/sidebar/sidebarAccordion';
+import SidebarItem from 'sentry/components/sidebar/sidebarItem';
+import {IconStar} from 'sentry/icons';
+
+describe('SidebarAccordion', function () {
+  it('marks only the selected child as active', function () {
+    window.location.pathname = '/performance/queries?sort=tpm()';
+
+    render(
+      <SidebarAccordion
+        icon={<IconStar />}
+        label="Performance"
+        to="/performance/"
+        id="performance"
+        orientation="left"
+      >
+        <SidebarItem
+          label="Queries"
+          to="/performance/queries"
+          id="queries"
+          icon={<IconStar />}
+          orientation="left"
+        />
+      </SidebarAccordion>
+    );
+
+    expect(screen.getByRole('link', {name: 'Performance Queries'})).not.toHaveAttribute(
+      'aria-current'
+    );
+    expect(screen.getByRole('link', {name: 'Queries'})).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+});

--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -87,7 +87,7 @@ function recursivelyFindChildren(
   found: Array<React.ReactNode> = []
 ): React.ReactNode {
   Children.toArray(children).forEach(child => {
-    if (!isAReactElement(child)) {
+    if (!isValidElement(child)) {
       return;
     }
 
@@ -110,34 +110,6 @@ function recursivelyFindChildren(
   });
 
   return found;
-}
-
-function isAReactElement(element: React.ReactNode): element is React.ReactElement {
-  if (typeof element === 'string' || typeof element === 'number') {
-    return false;
-  }
-
-  if (element === null) {
-    return false;
-  }
-
-  if (element === undefined) {
-    return false;
-  }
-
-  if (typeof element === 'boolean') {
-    return false;
-  }
-
-  if (!('props' in element)) {
-    return false;
-  }
-
-  if (!('type' in element)) {
-    return false;
-  }
-
-  return true;
 }
 
 const SidebarAccordionWrapper = styled('div')`

--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -91,19 +91,17 @@ function findChildElementsInTree(
       return;
     }
 
-    if (child?.props?.children) {
-      findChildElementsInTree(child.props.children, componentName, found);
+    const currentComponentName: string =
+      typeof child.type === 'string' ? child.type : child.type.name;
+
+    if (currentComponentName === componentName) {
+      found.push(child);
       return;
     }
 
-    if (typeof child.type === 'string') {
-      if (child.type === componentName) {
-        found.push(child);
-      }
-    } else {
-      if (child?.type?.name === componentName) {
-        found.push(child);
-      }
+    if (child?.props?.children) {
+      findChildElementsInTree(child.props.children, componentName, found);
+      return;
     }
 
     return;

--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -24,7 +24,10 @@ function SidebarAccordion({children, ...itemProps}: SidebarAccordionProps) {
   const contentId = `sidebar-accordion-${id}-content`;
 
   const isActive = isItemActive(itemProps);
-  const hasActiveChildren = Children.toArray(children).some(child => {
+
+  const someChildren = recursivelyFindChildren(children, 'SidebarItem');
+
+  const hasActiveChildren = Children.toArray(someChildren).some(child => {
     if (isValidElement(child)) {
       return isItemActive(child.props);
     }
@@ -77,6 +80,65 @@ function SidebarAccordion({children, ...itemProps}: SidebarAccordionProps) {
 }
 
 export {SidebarAccordion};
+
+function recursivelyFindChildren(
+  children: React.ReactNode,
+  componentName: string,
+  found: Array<React.ReactNode> = []
+): React.ReactNode {
+  Children.toArray(children).forEach(child => {
+    if (!isAReactElement(child)) {
+      return;
+    }
+
+    if (child && child?.props && child?.props?.children) {
+      recursivelyFindChildren(child.props.children, componentName, found);
+      return;
+    }
+
+    if (typeof child.type === 'string') {
+      if (child.type === componentName) {
+        found.push(child);
+      }
+    } else {
+      if (child?.type?.name === componentName) {
+        found.push(child);
+      }
+    }
+
+    return;
+  });
+
+  return found;
+}
+
+function isAReactElement(element: React.ReactNode): element is React.ReactElement {
+  if (typeof element === 'string' || typeof element === 'number') {
+    return false;
+  }
+
+  if (element === null) {
+    return false;
+  }
+
+  if (element === undefined) {
+    return false;
+  }
+
+  if (typeof element === 'boolean') {
+    return false;
+  }
+
+  if (!('props' in element)) {
+    return false;
+  }
+
+  if (!('type' in element)) {
+    return false;
+  }
+
+  return true;
+}
 
 const SidebarAccordionWrapper = styled('div')`
   display: flex;

--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -25,9 +25,9 @@ function SidebarAccordion({children, ...itemProps}: SidebarAccordionProps) {
 
   const isActive = isItemActive(itemProps);
 
-  const someChildren = findChildElementsInTree(children, 'SidebarItem');
+  const childSidebarItems = findChildElementsInTree(children, 'SidebarItem');
 
-  const hasActiveChildren = Children.toArray(someChildren).some(child => {
+  const hasActiveChildren = Children.toArray(childSidebarItems).some(child => {
     if (isValidElement(child)) {
       return isItemActive(child.props);
     }

--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -25,7 +25,7 @@ function SidebarAccordion({children, ...itemProps}: SidebarAccordionProps) {
 
   const isActive = isItemActive(itemProps);
 
-  const someChildren = recursivelyFindChildren(children, 'SidebarItem');
+  const someChildren = findChildElementsInTree(children, 'SidebarItem');
 
   const hasActiveChildren = Children.toArray(someChildren).some(child => {
     if (isValidElement(child)) {
@@ -81,7 +81,7 @@ function SidebarAccordion({children, ...itemProps}: SidebarAccordionProps) {
 
 export {SidebarAccordion};
 
-function recursivelyFindChildren(
+function findChildElementsInTree(
   children: React.ReactNode,
   componentName: string,
   found: Array<React.ReactNode> = []
@@ -92,7 +92,7 @@ function recursivelyFindChildren(
     }
 
     if (child?.props?.children) {
-      recursivelyFindChildren(child.props.children, componentName, found);
+      findChildElementsInTree(child.props.children, componentName, found);
       return;
     }
 

--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -91,7 +91,7 @@ function recursivelyFindChildren(
       return;
     }
 
-    if (child && child?.props && child?.props?.children) {
+    if (child?.props?.children) {
       recursivelyFindChildren(child.props.children, componentName, found);
       return;
     }

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -198,6 +198,7 @@ function SidebarItem({
         active={isActive ? 'true' : undefined}
         to={toProps}
         className={className}
+        aria-current={isActive ? 'page' : undefined}
         onClick={handleItemClick}
       >
         <InteractionStateLayer isPressed={isActive} color="white" higherOpacity />


### PR DESCRIPTION
Follow-up to #56762. Since that PR, the `SidebarItem` elements got a `Feature` wrapper, so we lost the functionality. In this PR, I make sure to actually find the right elements to check again.

Recursion is a bit overkill here, but to be honest the best solution would probably be a totally different, more explicit logic which is a much bigger refactor.

This component is a little tricky to unit test, so I'm open to suggestions. Maybe test the helper function at least?