### PR TITLE
feat(replay): Add analytics event to "canvas supported" banner

### DIFF
--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -55,7 +55,7 @@ export function CanvasSupportNotice() {
       {tct(
         'This replay contains a [code:canvas] element. Support for recording [code:canvas] data was added in SDK version 7.98.0. [link:Learn more].',
         {
-          code: <code />,
+          canvas: <code />,
           link: (
             <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
           ),

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -66,5 +66,5 @@ export function CanvasSupportNotice() {
 }
 
 const StyledAlert = styled(Alert)`
-  margin-bottom: ${space(1)};;
+  margin-bottom: ${space(1)};
 `;

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -7,6 +7,7 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -57,7 +58,7 @@ export function CanvasSupportNotice() {
         {
           canvas: <code />,
           link: (
-            <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
+            <ExternalLink onClick={() => {trackAnalytics('replay.canvas-detected-banner-clicked', {organization});}} href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
           ),
         }
       )}

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -6,6 +6,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -65,7 +66,5 @@ export function CanvasSupportNotice() {
 }
 
 const StyledAlert = styled(Alert)`
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  margin-bottom: 0;
+  margin-bottom: ${space(1)};;
 `;

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -6,7 +6,6 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -66,5 +65,7 @@ export function CanvasSupportNotice() {
 }
 
 const StyledAlert = styled(Alert)`
-  margin-bottom: ${space(1)};
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  margin-bottom: 0;
 `;

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -56,7 +56,7 @@ export function CanvasSupportNotice() {
       {tct(
         'This replay contains a [code:canvas] element. Support for recording [code:canvas] data was added in SDK version 7.98.0. [link:Learn more].',
         {
-          canvas: <code />,
+          code: <code />,
           link: (
             <ExternalLink
               onClick={() => {

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -58,7 +58,12 @@ export function CanvasSupportNotice() {
         {
           canvas: <code />,
           link: (
-            <ExternalLink onClick={() => {trackAnalytics('replay.canvas-detected-banner-clicked', {organization});}} href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording" />
+            <ExternalLink
+              onClick={() => {
+                trackAnalytics('replay.canvas-detected-banner-clicked', {organization});
+              }}
+              href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording"
+            />
           ),
         }
       )}

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -49,6 +49,7 @@ function ReplayView({toggleFullscreen}: Props) {
             <FluidHeight>
               <CanvasSupportNotice />
               <Panel>
+                <CanvasSupportNotice />
                 <ReplayPlayer />
               </Panel>
             </FluidHeight>

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -49,7 +49,6 @@ function ReplayView({toggleFullscreen}: Props) {
             <FluidHeight>
               <CanvasSupportNotice />
               <Panel>
-                <CanvasSupportNotice />
                 <ReplayPlayer />
               </Panel>
             </FluidHeight>

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -7,6 +7,7 @@ export type ReplayEventParameters = {
     issue_description: string;
     issue_impact: string | undefined;
   };
+  'replay.canvas-detected-banner-clicked': {},
   'replay.details-data-loaded': {
     be_errors: number;
     fe_errors: number;
@@ -113,6 +114,7 @@ export type ReplayEventKey = keyof ReplayEventParameters;
 
 export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.accessibility-issue-clicked': 'Clicked Replay Accessibility Issue',
+  'replay.canvas-detected-banner-clicked': 'Clicked Canvas Detected in Replay Banner',
   'replay.details-data-loaded': 'Replay Details Data Loaded',
   'replay.details-has-hydration-error': 'Replay Details Has Hydration Error',
   'replay.details-layout-changed': 'Changed Replay Details Layout',

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -7,7 +7,7 @@ export type ReplayEventParameters = {
     issue_description: string;
     issue_impact: string | undefined;
   };
-  'replay.canvas-detected-banner-clicked': {},
+  'replay.canvas-detected-banner-clicked': {};
   'replay.details-data-loaded': {
     be_errors: number;
     fe_errors: number;


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/63223 - adds an analytics event when docs link is clicked in the banner
