### PR TITLE
fix(integrations): use region silo for external install view

### DIFF
--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -16,7 +16,7 @@ import NarrowLayout from 'sentry/components/narrowLayout';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {Integration, IntegrationProvider, Organization} from 'sentry/types';
-import {generateBaseControlSiloUrl, generateOrgSlugUrl} from 'sentry/utils';
+import {generateOrgSlugUrl} from 'sentry/utils';
 import {IntegrationAnalyticsKey} from 'sentry/utils/analytics/integrations';
 import {
   getIntegrationFeatureGate,
@@ -57,7 +57,7 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
   disableErrorReport = false;
   // TODO: stop using control silo which is dependent on figuring out how to
   // check the Github installation data which is on the control silo
-  controlSiloApi = new Client({baseUrl: generateBaseControlSiloUrl() + '/api/0'});
+  api = new Client();
 
   getEndpoints(): ReturnType<DeprecatedAsyncView['getEndpoints']> {
     return [['organizations', '/organizations/']];
@@ -142,8 +142,8 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
         Organization,
         {providers: IntegrationProvider[]},
       ] = await Promise.all([
-        this.controlSiloApi.requestPromise(`/organizations/${orgSlug}/`),
-        this.controlSiloApi.requestPromise(
+        this.api.requestPromise(`/organizations/${orgSlug}/`),
+        this.api.requestPromise(
           `/organizations/${orgSlug}/config/integrations/?provider_key=${this.integrationSlug}`
         ),
       ]);
@@ -158,7 +158,7 @@ export default class IntegrationOrganizationLink extends DeprecatedAsyncView<
         try {
           // The API endpoint /extensions/github/installation is not prefixed with /api/0
           // so we have to use this workaround.
-          installationData = await this.controlSiloApi.requestPromise(
+          installationData = await this.api.requestPromise(
             `/../../extensions/github/installation/${installationId}/`
           );
         } catch (_err) {


### PR DESCRIPTION
Stop using the control silo in the external install view. We can do this because when the user changes orgs we redirect them to that domain.