### PR TITLE
feat(snuba): Add MQL string to stack trace of sentry issue (SNS-2585)

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -959,7 +959,8 @@ def _bulk_snuba_query(
             ]
 
     results = []
-    for response, _, reverse in query_results:
+    for index, item in enumerate(query_results):
+        response, _, reverse = item
         try:
             body = json.loads(response.data)
             if SNUBA_INFO:
@@ -981,6 +982,12 @@ def _bulk_snuba_query(
             raise UnexpectedResponseError(f"Could not decode JSON response: {response.data!r}")
 
         if response.status != 200:
+            if use_mql:
+                error_request = snuba_param_list[index][0]
+                error_request = (
+                    error_request.serialize_mql()
+                )  # never used, only for sentry visibility
+
             if body.get("error"):
                 error = body["error"]
                 if response.status == 429:


### PR DESCRIPTION
This PR relates to this jira ticket [https://getsentry.atlassian.net/browse/SNS-2585](https://getsentry.atlassian.net/browse/SNS-2585). Please read this ticket for a description.

In my ticket I recompute the query serialization which has already been computed at another point in the code. In order to do less computation, I could have just "grabbed" the other computation to use it in my part of the code. In order to do this however would have required significant refactoring of multiple method signatures (either input parameters, or output returns). I deemed this not worth the computational savings, especially since my code is only executed in the case of error anyways.