### PR TITLE
ref(js): Only load OrganizationContext once OrganizationLayout renders

### DIFF
--- a/static/app/views/organizationContext.spec.tsx
+++ b/static/app/views/organizationContext.spec.tsx
@@ -19,7 +19,7 @@ import TeamStore from 'sentry/stores/teamStore';
 import {Organization} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 
-import {OrganizationContextProvider} from './organizationContext';
+import {OrganizationContextProvider, useEnsureOrganization} from './organizationContext';
 import {RouteContext} from './routeContext';
 
 jest.mock('sentry/actionCreators/sudoModal');
@@ -79,6 +79,11 @@ describe('OrganizationContext', function () {
     jest.mocked(console.error).mockRestore();
   });
 
+  function OrganizationLoaderStub() {
+    useEnsureOrganization();
+    return null;
+  }
+
   /**
    * Used to test that the organization context is propegated
    */
@@ -104,6 +109,7 @@ describe('OrganizationContext', function () {
   it('fetches org, projects, teams, and provides organization context', async function () {
     render(
       <OrganizationContextProvider>
+        <OrganizationLoaderStub />
         <OrganizationName />
       </OrganizationContextProvider>
     );
@@ -117,6 +123,7 @@ describe('OrganizationContext', function () {
   it('provides legacy organization context', async function () {
     render(
       <OrganizationContextProvider>
+        <OrganizationLoaderStub />
         <OrganizationNameLegacyConsumer />
       </OrganizationContextProvider>
     );
@@ -129,6 +136,7 @@ describe('OrganizationContext', function () {
 
     render(
       <OrganizationContextProvider>
+        <OrganizationLoaderStub />
         <OrganizationName />
       </OrganizationContextProvider>
     );
@@ -142,6 +150,7 @@ describe('OrganizationContext', function () {
     const {rerender} = render(
       <RouteContext.Provider value={router}>
         <OrganizationContextProvider>
+          <OrganizationLoaderStub />
           <OrganizationName />
         </OrganizationContextProvider>
       </RouteContext.Provider>
@@ -158,6 +167,7 @@ describe('OrganizationContext', function () {
     rerender(
       <RouteContext.Provider value={{...router, params: {orgId: 'another-org'}}}>
         <OrganizationContextProvider>
+          <OrganizationLoaderStub />
           <OrganizationName />
         </OrganizationContextProvider>
       </RouteContext.Provider>
@@ -180,6 +190,7 @@ describe('OrganizationContext', function () {
 
     render(
       <OrganizationContextProvider>
+        <OrganizationLoaderStub />
         <OrganizationName />
       </OrganizationContextProvider>
     );
@@ -205,6 +216,7 @@ describe('OrganizationContext', function () {
     render(
       <RouteContext.Provider value={{...router, params: {}}}>
         <OrganizationContextProvider>
+          <OrganizationLoaderStub />
           <OrganizationName />
         </OrganizationContextProvider>
       </RouteContext.Provider>

--- a/static/app/views/organizationLayout.tsx
+++ b/static/app/views/organizationLayout.tsx
@@ -13,6 +13,8 @@ import OrganizationStore from 'sentry/stores/organizationStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
 
+import {useEnsureOrganization} from './organizationContext';
+
 interface OrganizationLayoutProps {
   children: React.ReactNode;
   /**
@@ -30,6 +32,7 @@ const OrganizationHeader = HookOrDefault({
  */
 function OrganizationLayout({includeSidebar, children}: OrganizationLayoutProps) {
   const {organization, loading, error, errorType} = useLegacyStore(OrganizationStore);
+  useEnsureOrganization();
 
   if (loading) {
     return <LoadingTriangle>{t('Loading data for your organization.')}</LoadingTriangle>;


### PR DESCRIPTION
This adjust the way the OrganizationContext is populated to be more in-line with how we rendered the OrganizationContextContainer before, it will only load the organizationLayout once a organization route view is rendered.

Previous behavior before this change is that the org would load immediately for ALL App routes (which not all should necessarily do, such as accept org invite)