### PR TITLE
feat(trace): Don't open txn on open

### DIFF
--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -87,6 +87,7 @@ export type SpanDetailProps = {
   childTransactions: QuickTraceEvent[] | null;
   event: Readonly<EventTransaction>;
   isRoot: boolean;
+  openPanel: string | undefined;
   organization: Organization;
   relatedErrors: TraceErrorOrIssue[] | null;
   resetCellMeasureCache: () => void;

--- a/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsContent.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useMemo, useState} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
+import omit from 'lodash/omit';
 
 import {Alert} from 'sentry/components/alert';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
@@ -70,6 +71,7 @@ export enum TraceType {
 
 export type EventDetail = {
   event: EventTransaction | undefined;
+  openPanel: string | undefined;
   traceFullDetailedEvent: TraceFullDetailed;
 };
 
@@ -409,6 +411,9 @@ function NewTraceDetailsContent(props: Props) {
             router.replace({
               ...location,
               hash: undefined,
+              query: {
+                ...omit(location.query, 'openPanel'),
+              },
             });
             setDetail(undefined);
           }}

--- a/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
+++ b/static/app/views/performance/traceDetails/newTraceDetailsTransactionBar.tsx
@@ -72,6 +72,7 @@ import {
 } from 'sentry/utils/performance/quickTrace/utils';
 import Projects from 'sentry/utils/projects';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {decodeScalar} from 'sentry/utils/queryString';
 import useRouter from 'sentry/utils/useRouter';
 import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
 import {ProfileContext, ProfilesProvider} from 'sentry/views/profiling/profilesProvider';
@@ -114,6 +115,7 @@ type Props = {
 
 function NewTraceDetailsTransactionBar(props: Props) {
   const hashValues = parseTraceDetailsURLHash(props.location.hash);
+  const openPanel = decodeScalar(props.location.query.openPanel);
   const eventIDInQueryParam = !!(
     isTraceTransaction(props.transaction) &&
     hashValues?.eventId &&
@@ -251,10 +253,11 @@ function NewTraceDetailsTransactionBar(props: Props) {
         props.onRowClick({
           traceFullDetailedEvent: props.transaction,
           event: embeddedChildren,
+          openPanel,
         });
       }
     }
-  }, [isHighlighted, embeddedChildren, props, props.transaction]);
+  }, [isHighlighted, embeddedChildren, props, props.transaction, openPanel]);
 
   const renderEmbeddedChildrenState = () => {
     if (showEmbeddedChildren) {
@@ -290,6 +293,10 @@ function NewTraceDetailsTransactionBar(props: Props) {
       router.replace({
         ...location,
         hash: transactionTargetHash(transaction.event_id),
+        query: {
+          ...location.query,
+          openPanel: 'open',
+        },
       });
     }
   };

--- a/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
+++ b/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
@@ -535,7 +535,10 @@ function TraceViewDetailPanel({detail, onClose}: DetailPanelProps) {
   const location = useLocation();
   return (
     <PageErrorProvider>
-      <DetailPanel detailKey={detail ? 'open' : undefined} onClose={onClose}>
+      <DetailPanel
+        detailKey={detail && detail.openPanel === 'open' ? 'open' : undefined}
+        onClose={onClose}
+      >
         {detail &&
           (isEventDetail(detail) ? (
             <EventDetails


### PR DESCRIPTION
- This updates the trace view so we dont open the linked transaction on pageload
- Whether the panel is open or not is encoded into the URL that way if a link is shared the panel state is preserved