### PR TITLE
fix(hybridcloud) Fixate region order in integration middleware

### DIFF
--- a/src/sentry/middleware/integrations/parsers/base.py
+++ b/src/sentry/middleware/integrations/parsers/base.py
@@ -219,7 +219,8 @@ class BaseRequestParser(abc.ABC):
         if not organizations:
             organizations = self.get_organizations_from_integration()
 
-        return [get_region_for_organization(organization.slug) for organization in organizations]
+        regions = [get_region_for_organization(organization.slug) for organization in organizations]
+        return sorted(regions, key=lambda r: r.name)
 
     def get_default_missing_integration_response(self) -> HttpResponse:
         return HttpResponse(status=400)

--- a/tests/sentry/middleware/integrations/parsers/test_jira.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira.py
@@ -18,7 +18,7 @@ from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
 
 region = Region("us", 1, "http://us.testserver", RegionCategory.MULTI_TENANT)
-eu_region = Region("eu", 1, "http://eu.testserver", RegionCategory.MULTI_TENANT)
+eu_region = Region("eu", 2, "http://eu.testserver", RegionCategory.MULTI_TENANT)
 
 region_config = (region, eu_region)
 


### PR DESCRIPTION
I ran into flaky tests running parser tests as a module as the order of results in multi-region tests is not fixated and the order can wobble.

The wobbly order could also have impacts in production as a customer could have webhooks delivered to non-deterministic regions if they connect multiple orgs in multiple regions to a jira integration.