### PR TITLE
fix(profiling): account for offset view when computing viewport

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
@@ -209,12 +209,13 @@ function FlamegraphZoomViewMinimap({
         return;
       }
 
-      const configSpaceMouse = flamegraphMiniMapView.getTransformedConfigSpaceCursor(
-        vec2.fromValues(evt.nativeEvent.offsetX, evt.nativeEvent.offsetY),
-        flamegraphMiniMapCanvas
-      );
+      const currentConfigSpaceCursor =
+        flamegraphMiniMapView.getTransformedConfigSpaceCursor(
+          vec2.fromValues(evt.nativeEvent.offsetX, evt.nativeEvent.offsetY),
+          flamegraphMiniMapCanvas
+        );
 
-      setConfigSpaceCursor(configSpaceMouse);
+      setConfigSpaceCursor(currentConfigSpaceCursor);
 
       if (!prevConfigSpaceCursor.current) {
         return;
@@ -227,53 +228,60 @@ function FlamegraphZoomViewMinimap({
       }
 
       if (lastInteraction === 'resize') {
-        const configView = flamegraphMiniMapView.configView;
+        const configView = flamegraphMiniMapView.toOriginConfigView(
+          flamegraphMiniMapView.configView
+        );
 
         const configViewCenter = configView.width / 2 + configView.x;
-        const mouseX = configSpaceMouse[0];
+        const mouseX = currentConfigSpaceCursor[0];
         const dragDelta = prevConfigSpaceCursor.current
-          ? configSpaceMouse[0] - prevConfigSpaceCursor.current[0]
+          ? currentConfigSpaceCursor[0] - prevConfigSpaceCursor.current[0]
           : 0;
-        const x = mouseX < configViewCenter ? configSpaceMouse[0] : configView.left;
+        const x =
+          mouseX < configViewCenter ? currentConfigSpaceCursor[0] : configView.left;
         const dragDirection = mouseX < configViewCenter ? -1 : 1;
 
         const rect = new Rect(
           x,
-          configSpaceMouse[1] - flamegraphMiniMapView.configView.height / 2,
+          currentConfigSpaceCursor[1] - flamegraphMiniMapView.configView.height / 2,
           configView.width + dragDelta * dragDirection,
           configView.height
-        );
+        ).transformRect(flamegraphMiniMapView.configSpaceTransform);
 
         canvasPoolManager.dispatch('set config view', [rect, flamegraphMiniMapView]);
-        prevConfigSpaceCursor.current = configSpaceMouse;
+        prevConfigSpaceCursor.current = currentConfigSpaceCursor;
         return;
       }
 
       if (startInteractionVector) {
+        const configView = flamegraphMiniMapView.toOriginConfigView(
+          flamegraphMiniMapView.configView
+        );
+
         const start = vec2.min(
           vec2.create(),
           prevConfigSpaceCursor.current,
-          configSpaceMouse
+          currentConfigSpaceCursor
         );
         const end = vec2.max(
           vec2.create(),
           prevConfigSpaceCursor.current,
-          configSpaceMouse
+          currentConfigSpaceCursor
         );
 
         const rect = new Rect(
           start[0],
-          configSpaceMouse[1] - flamegraphMiniMapView.configView.height / 2,
+          currentConfigSpaceCursor[1] - configView.height / 2,
           end[0] - start[0],
-          flamegraphMiniMapView.configView.height
-        );
+          configView.height
+        ).transformRect(flamegraphMiniMapView.configSpaceTransform);
 
         canvasPoolManager.dispatch('set config view', [rect, flamegraphMiniMapView]);
         setLastInteraction('select');
         return;
       }
 
-      prevConfigSpaceCursor.current = configSpaceMouse;
+      prevConfigSpaceCursor.current = currentConfigSpaceCursor;
       setLastInteraction(null);
     },
     [
@@ -318,11 +326,15 @@ function FlamegraphZoomViewMinimap({
         return;
       }
 
+      const configView = flamegraphMiniMapView.toOriginConfigView(
+        flamegraphMiniMapView.configView
+      );
+
       if (
         miniMapConfigSpaceBorderSize >=
         Math.min(
-          Math.abs(flamegraphMiniMapView.configView.left - configSpaceCursor[0]),
-          Math.abs(flamegraphMiniMapView.configView.right - configSpaceCursor[0])
+          Math.abs(configView.left - configSpaceCursor[0]),
+          Math.abs(configView.right - configSpaceCursor[0])
         )
       ) {
         setLastInteraction('resize');
@@ -335,7 +347,7 @@ function FlamegraphZoomViewMinimap({
         return;
       }
 
-      if (flamegraphMiniMapView.configView.contains(configSpaceCursor)) {
+      if (configView.contains(configSpaceCursor)) {
         setLastInteraction('pan');
         setLastDragVector(
           getPhysicalSpacePositionFromOffset(


### PR DESCRIPTION
When there is drift between profiles and txns, we need to normalize our vector distance by the offset of the drift, else our positions are wrong by the distance of the two drifts.

Fixes https://sentry.slack.com/archives/C02N5PB50JH/p1705522298422519