### PR TITLE
fix(inbound-filters): Update types of analytics event

### DIFF
--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -11,7 +11,7 @@ import {defined} from 'sentry/utils';
 type Snapshot = Map<string, FieldValue>;
 type SaveSnapshot = (() => number) | null;
 
-export type FieldValue = string | number | boolean | Choice | undefined; // is undefined valid here?
+export type FieldValue = string | number | boolean | Choice | Set<string> | undefined; // is undefined valid here?
 
 export type FormOptions = {
   /**

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -215,7 +215,7 @@ export type IssueEventParameters = {
   resolve_issue: {release: string};
   'settings.inbound_filter_updated': {
     filter: string;
-    new_state: FieldValue;
+    new_state: FieldValue | string[];
     project_id: number;
   };
   'source_map_debug.docs_link_clicked': SourceMapDebugParam;

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -215,7 +215,7 @@ export type IssueEventParameters = {
   resolve_issue: {release: string};
   'settings.inbound_filter_updated': {
     filter: string;
-    new_state: FieldValue | string[];
+    new_state: FieldValue;
     project_id: number;
   };
   'source_map_debug.docs_link_clicked': SourceMapDebugParam;

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -388,8 +388,8 @@ export function ProjectFiltersSettings({project, params, features}: Props) {
                           project_id: parseInt(project.id as string, 10),
                           filter: name,
                           new_state:
-                            filter.id === 'legacy-browsers'
-                              ? value
+                            filter.id === 'legacy-browsers' && value instanceof Set
+                              ? [...value].sort()
                               : value
                               ? 'enabled'
                               : 'disabled',

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -389,7 +389,7 @@ export function ProjectFiltersSettings({project, params, features}: Props) {
                           filter: name,
                           new_state:
                             filter.id === 'legacy-browsers' && value instanceof Set
-                              ? [...value].sort()
+                              ? [...value].sort().join(',')
                               : value
                               ? 'enabled'
                               : 'disabled',


### PR DESCRIPTION
right now, the subfilters for legacy browser are being send as a Set which doesn't show up in Amplitude. This updates it to be a sorted array, while also updating the FieldValue to reflect that it can be a set