### PR TITLE
ref(hybrid-cloud): Changes shard ID for new webhook outboxes to integration ID

### DIFF
--- a/src/sentry/middleware/integrations/parsers/bitbucket.py
+++ b/src/sentry/middleware/integrations/parsers/bitbucket.py
@@ -45,7 +45,9 @@ class BitbucketRequestParser(BaseRequestParser):
             logging_extra["mapping_id"] = mapping.id
             logger.info("%s.no_region", self.provider, extra=logging_extra)
             return self.get_response_from_control_silo()
-        return self.get_response_from_outbox_creation(regions=[region])
+        return self.get_response_from_outbox_creation(
+            regions=[region], shard_identifier_override=mapping.organization_id
+        )
 
     def get_response(self):
         if self.view_class == BitbucketWebhookEndpoint:

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -56,8 +56,14 @@ class GithubRequestParser(BaseRequestParser):
             return self.get_response_from_control_silo()
 
         try:
+            integration = self.get_integration_from_request()
+            if not integration:
+                return self.get_default_missing_integration_response()
+
             regions = self.get_regions_from_organizations()
         except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
             return self.get_default_missing_integration_response()
 
-        return self.get_response_from_outbox_creation(regions=regions)
+        return self.get_response_from_outbox_creation_for_integration(
+            regions=regions, integration=integration
+        )

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -77,7 +77,9 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
         except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
             return self.get_default_missing_integration_response()
 
-        return self.get_response_from_outbox_creation(regions=regions)
+        return self.get_response_from_outbox_creation_for_integration(
+            regions=regions, integration=integration
+        )
 
     def get_response(self) -> HttpResponseBase:
         if self.view_class == GitlabWebhookEndpoint:

--- a/src/sentry/middleware/integrations/parsers/gitlab.py
+++ b/src/sentry/middleware/integrations/parsers/gitlab.py
@@ -60,6 +60,7 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
                 return self._integration
         except Exception:
             pass
+
         return None
 
     def get_response_from_gitlab_webhook(self):
@@ -68,6 +69,10 @@ class GitlabRequestParser(BaseRequestParser, GitlabWebhookMixin):
             return maybe_http_response
 
         try:
+            integration = self.get_integration_from_request()
+            if not integration:
+                return self.get_default_missing_integration_response()
+
             regions = self.get_regions_from_organizations()
         except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
             return self.get_default_missing_integration_response()

--- a/src/sentry/middleware/integrations/parsers/jira.py
+++ b/src/sentry/middleware/integrations/parsers/jira.py
@@ -53,7 +53,12 @@ class JiraRequestParser(BaseRequestParser):
         if self.view_class in self.control_classes:
             return self.get_response_from_control_silo()
 
+        integration = self.get_integration_from_request()
+        if not integration:
+            raise Integration.DoesNotExist()
+
         regions = self.get_regions_from_organizations()
+
         if len(regions) == 0:
             logger.info("%s.no_regions", self.provider, extra={"path": self.request.path})
             return self.get_response_from_control_silo()
@@ -71,6 +76,8 @@ class JiraRequestParser(BaseRequestParser):
             return self.get_response_from_region_silo(region=regions[0])
 
         if self.view_class in self.outbox_response_region_classes:
-            return self.get_response_from_outbox_creation(regions=regions)
+            return self.get_response_from_outbox_creation_for_integration(
+                regions=regions, integration=integration
+            )
 
         return self.get_response_from_control_silo()

--- a/src/sentry/middleware/integrations/parsers/jira_server.py
+++ b/src/sentry/middleware/integrations/parsers/jira_server.py
@@ -25,7 +25,9 @@ class JiraServerRequestParser(BaseRequestParser):
             return self.get_response_from_control_silo()
         organizations = self.get_organizations_from_integration(integration=integration)
         regions = self.get_regions_from_organizations(organizations=organizations)
-        return self.get_response_from_outbox_creation(regions=regions)
+        return self.get_response_from_outbox_creation_for_integration(
+            regions=regions, integration=integration
+        )
 
     def get_response(self):
         if self.view_class == JiraServerIssueUpdatedWebhook:

--- a/src/sentry/middleware/integrations/parsers/msteams.py
+++ b/src/sentry/middleware/integrations/parsers/msteams.py
@@ -53,6 +53,10 @@ class MsTeamsRequestParser(BaseRequestParser, MsTeamsWebhookMixin):
 
         regions: Sequence[Region] = []
         try:
+            integration = self.get_integration_from_request()
+            if not integration:
+                return self.get_default_missing_integration_response()
+
             regions = self.get_regions_from_organizations()
         except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
             return self.get_default_missing_integration_response()
@@ -72,4 +76,6 @@ class MsTeamsRequestParser(BaseRequestParser, MsTeamsWebhookMixin):
             logger.info("%s.no_regions", self.provider, extra={"path": self.request.path})
             return self.get_response_from_control_silo()
 
-        return self.get_response_from_outbox_creation(regions=regions)
+        return self.get_response_from_outbox_creation_for_integration(
+            regions=regions, integration=integration
+        )

--- a/src/sentry/middleware/integrations/parsers/plugin.py
+++ b/src/sentry/middleware/integrations/parsers/plugin.py
@@ -51,4 +51,9 @@ class PluginRequestParser(BaseRequestParser):
             logging_extra["mapping_id"] = mapping.id
             logger.info("%s.no_region", self.provider, extra=logging_extra)
             return self.get_response_from_control_silo()
-        return self.get_response_from_outbox_creation(regions=[region])
+
+        # Because outboxes are now sharded by integration, and plugins don't have one,
+        # we use the org ID to batch + shard processing.
+        return self.get_response_from_outbox_creation(
+            regions=[region], shard_identifier_override=mapping.organization_id
+        )

--- a/src/sentry/middleware/integrations/parsers/plugin.py
+++ b/src/sentry/middleware/integrations/parsers/plugin.py
@@ -52,8 +52,8 @@ class PluginRequestParser(BaseRequestParser):
             logger.info("%s.no_region", self.provider, extra=logging_extra)
             return self.get_response_from_control_silo()
 
-        # Because outboxes are now sharded by integration, and plugins don't have one,
-        # we use the org ID to batch + shard processing.
+        # Because outboxes are now sharded by integration and plugins don't have one,
+        # we use the org ID as the shard ID to batch these changes.
         return self.get_response_from_outbox_creation(
             regions=[region], shard_identifier_override=mapping.organization_id
         )

--- a/src/sentry/middleware/integrations/parsers/vsts.py
+++ b/src/sentry/middleware/integrations/parsers/vsts.py
@@ -37,8 +37,14 @@ class VstsRequestParser(BaseRequestParser):
             return self.get_response_from_control_silo()
 
         try:
+            integration = self.get_integration_from_request()
+            if not integration:
+                return self.get_default_missing_integration_response()
+
             regions = self.get_regions_from_organizations()
         except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
             return self.get_default_missing_integration_response()
 
-        return self.get_response_from_outbox_creation(regions=regions)
+        return self.get_response_from_outbox_creation_for_integration(
+            regions=regions, integration=integration
+        )

--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -769,14 +769,14 @@ class ControlOutboxBase(OutboxBase):
     def for_webhook_update(
         cls,
         *,
-        webhook_identifier: WebhookProviderIdentifier,
+        shard_identifier: int,
         region_names: List[str],
         request: HttpRequest,
     ) -> Iterable[Self]:
         for region_name in region_names:
             result = cls()
             result.shard_scope = OutboxScope.WEBHOOK_SCOPE
-            result.shard_identifier = webhook_identifier.value
+            result.shard_identifier = shard_identifier
             result.object_identifier = cls.next_object_identifier()
             result.category = OutboxCategory.WEBHOOK_PROXY
             result.region_name = region_name

--- a/src/sentry/testutils/outbox.py
+++ b/src/sentry/testutils/outbox.py
@@ -64,11 +64,34 @@ def assert_no_webhook_outboxes():
     assert outboxes == 0, "No outboxes should be created"
 
 
+# DEPRECATED: use assert_webhook_outboxes_for_integration instead
 def assert_webhook_outboxes(
     factory_request: WSGIRequest,
     webhook_identifier: WebhookProviderIdentifier,
     region_names: List[str],
 ):
+    assert_webhook_outboxes_with_shard_id(
+        factory_request=factory_request,
+        expected_shard_id=webhook_identifier.value,
+        region_names=region_names,
+    )
+
+
+def assert_webhook_outboxes_with_shard_id(
+    factory_request: WSGIRequest,
+    expected_shard_id: int,
+    region_names: List[str],
+):
+    """
+    A test method for asserting that a webhook outbox is properly queued for
+     the given request
+
+    :param factory_request:
+    :param expected_shard_id: Usually the integration ID associated with the
+     request. The main exception is Plugins, which provides a different shard
+     ID in the form of an organization ID instead.
+    :param region_names: The regions each outbox should be queued for
+    """
     expected_payload = ControlOutbox.get_webhook_payload_from_request(request=factory_request)
     expected_payload_dict = dataclasses.asdict(expected_payload)
     region_names_set = set(region_names)
@@ -81,7 +104,7 @@ def assert_webhook_outboxes(
     for cob in outboxes:
         assert cob.payload == expected_payload_dict
         assert cob.shard_scope == OutboxScope.WEBHOOK_SCOPE
-        assert cob.shard_identifier == webhook_identifier
+        assert cob.shard_identifier == expected_shard_id
         assert cob.category == OutboxCategory.WEBHOOK_PROXY
         try:
             region_names_set.remove(cob.region_name)

--- a/tests/sentry/middleware/integrations/parsers/test_bitbucket.py
+++ b/tests/sentry/middleware/integrations/parsers/test_bitbucket.py
@@ -5,10 +5,12 @@ from django.urls import reverse
 from sentry.middleware.integrations.parsers.bitbucket import BitbucketRequestParser
 from sentry.models.integrations.integration import Integration
 from sentry.models.organizationmapping import OrganizationMapping
-from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.outbox import assert_no_webhook_outboxes, assert_webhook_outboxes
+from sentry.testutils.outbox import (
+    assert_no_webhook_outboxes,
+    assert_webhook_outboxes_with_shard_id,
+)
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
@@ -94,8 +96,8 @@ class BitbucketRequestParserTest(TestCase):
         assert isinstance(response, HttpResponse)
         assert response.status_code == 202
         assert response.content == b""
-        assert_webhook_outboxes(
+        assert_webhook_outboxes_with_shard_id(
             factory_request=request,
-            webhook_identifier=WebhookProviderIdentifier.BITBUCKET,
+            expected_shard_id=self.organization.id,
             region_names=[self.region.name],
         )

--- a/tests/sentry/middleware/integrations/parsers/test_bitbucket_server.py
+++ b/tests/sentry/middleware/integrations/parsers/test_bitbucket_server.py
@@ -7,10 +7,9 @@ from django.urls import reverse
 
 from sentry.middleware.integrations.parsers.bitbucket_server import BitbucketServerRequestParser
 from sentry.models.organizationmapping import OrganizationMapping
-from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.outbox import assert_webhook_outboxes, outbox_runner
+from sentry.testutils.outbox import assert_webhook_outboxes_with_shard_id, outbox_runner
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
@@ -60,8 +59,8 @@ class BitbucketServerRequestParserTest(TestCase):
             region_name="us"
         )
         parser.get_response()
-        assert_webhook_outboxes(
+        assert_webhook_outboxes_with_shard_id(
             factory_request=request,
-            webhook_identifier=WebhookProviderIdentifier.BITBUCKET_SERVER,
+            expected_shard_id=self.organization.id,
             region_names=[self.region.name],
         )

--- a/tests/sentry/middleware/integrations/parsers/test_gitlab.py
+++ b/tests/sentry/middleware/integrations/parsers/test_gitlab.py
@@ -9,15 +9,13 @@ from sentry.middleware.integrations.classifications import IntegrationClassifica
 from sentry.middleware.integrations.parsers.gitlab import GitlabRequestParser
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
-from sentry.models.outbox import (
-    ControlOutbox,
-    OutboxCategory,
-    WebhookProviderIdentifier,
-    outbox_context,
-)
+from sentry.models.outbox import ControlOutbox, OutboxCategory, outbox_context
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.outbox import assert_no_webhook_outboxes, assert_webhook_outboxes
+from sentry.testutils.outbox import (
+    assert_no_webhook_outboxes,
+    assert_webhook_outboxes_with_shard_id,
+)
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
@@ -116,7 +114,7 @@ class GitlabRequestParserTest(TestCase):
     @override_regions(region_config)
     @responses.activate
     def test_routing_webhook_properly_with_regions(self):
-        self.get_integration()
+        integration = self.get_integration()
         request = self.factory.post(
             self.path,
             data=PUSH_EVENT,
@@ -131,9 +129,9 @@ class GitlabRequestParserTest(TestCase):
         assert response.status_code == 202
         assert response.content == b""
         assert len(responses.calls) == 0
-        assert_webhook_outboxes(
+        assert_webhook_outboxes_with_shard_id(
             factory_request=request,
-            webhook_identifier=WebhookProviderIdentifier.GITLAB,
+            expected_shard_id=integration.id,
             region_names=[region.name],
         )
 
@@ -185,7 +183,7 @@ class GitlabRequestParserTest(TestCase):
             HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
             HTTP_X_GITLAB_EVENT="Push Hook",
         )
-        self.get_integration()
+        integration = self.get_integration()
         parser = GitlabRequestParser(request=request, response_handler=self.get_response)
 
         assert ControlOutbox.objects.filter(category=OutboxCategory.WEBHOOK_PROXY).count() == 0
@@ -195,8 +193,8 @@ class GitlabRequestParserTest(TestCase):
         assert response.status_code == 202
         assert response.content == b""
         assert len(responses.calls) == 0
-        assert_webhook_outboxes(
+        assert_webhook_outboxes_with_shard_id(
             factory_request=request,
-            webhook_identifier=WebhookProviderIdentifier.GITLAB,
+            expected_shard_id=integration.id,
             region_names=[region.name],
         )

--- a/tests/sentry/middleware/integrations/parsers/test_jira.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira.py
@@ -9,10 +9,12 @@ from django.test import RequestFactory, override_settings
 from sentry.middleware.integrations.classifications import IntegrationClassification
 from sentry.middleware.integrations.parsers.jira import JiraRequestParser
 from sentry.models.integrations.integration import Integration
-from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.outbox import assert_no_webhook_outboxes, assert_webhook_outboxes
+from sentry.testutils.outbox import (
+    assert_no_webhook_outboxes,
+    assert_webhook_outboxes_with_shard_id,
+)
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
@@ -101,9 +103,10 @@ class JiraRequestParserTest(TestCase):
         request = self.factory.post(path=f"{self.path_base}/issue-updated/")
         parser = JiraRequestParser(request, self.get_response)
 
+        integration = self.get_integration()
         assert_no_webhook_outboxes()
         with patch.object(parser, "get_integration_from_request") as method:
-            method.return_value = self.get_integration()
+            method.return_value = integration
             response = parser.get_response()
 
         assert isinstance(response, HttpResponse)
@@ -111,9 +114,9 @@ class JiraRequestParserTest(TestCase):
         assert response.content == b""
 
         assert len(responses.calls) == 0
-        assert_webhook_outboxes(
+        assert_webhook_outboxes_with_shard_id(
             factory_request=request,
-            webhook_identifier=WebhookProviderIdentifier.JIRA,
+            expected_shard_id=integration.id,
             region_names=[region.name],
         )
 

--- a/tests/sentry/middleware/integrations/parsers/test_jira_server.py
+++ b/tests/sentry/middleware/integrations/parsers/test_jira_server.py
@@ -7,10 +7,12 @@ from django.urls import reverse
 
 from sentry.middleware.integrations.parsers.jira_server import JiraServerRequestParser
 from sentry.models.organizationmapping import OrganizationMapping
-from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.outbox import assert_no_webhook_outboxes, assert_webhook_outboxes
+from sentry.testutils.outbox import (
+    assert_no_webhook_outboxes,
+    assert_webhook_outboxes_with_shard_id,
+)
 from sentry.testutils.region import override_regions
 from sentry.testutils.silo import control_silo_test
 from sentry.types.region import Region, RegionCategory
@@ -74,9 +76,9 @@ class JiraServerRequestParserTest(TestCase):
         assert response.status_code == 202
         assert response.content == b""
         assert len(responses.calls) == 0
-        assert_webhook_outboxes(
+        assert_webhook_outboxes_with_shard_id(
             factory_request=request,
-            webhook_identifier=WebhookProviderIdentifier.JIRA_SERVER,
+            expected_shard_id=self.integration.id,
             region_names=[region.name],
         )
 

--- a/tests/sentry/middleware/integrations/parsers/test_msteams.py
+++ b/tests/sentry/middleware/integrations/parsers/test_msteams.py
@@ -8,9 +8,11 @@ from django.urls import reverse
 from sentry.integrations.msteams.utils import ACTION_TYPE
 from sentry.middleware.integrations.classifications import IntegrationClassification
 from sentry.middleware.integrations.parsers.msteams import MsTeamsRequestParser
-from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.testutils.cases import TestCase
-from sentry.testutils.outbox import assert_no_webhook_outboxes, assert_webhook_outboxes
+from sentry.testutils.outbox import (
+    assert_no_webhook_outboxes,
+    assert_webhook_outboxes_with_shard_id,
+)
 from sentry.testutils.silo import control_silo_test, create_test_regions
 from tests.sentry.integrations.msteams.test_helpers import (
     EXAMPLE_MENTIONED,
@@ -91,9 +93,9 @@ class MsTeamsRequestParserTest(TestCase):
         assert isinstance(response, HttpResponse)
         assert response.status_code == 202
         assert len(responses.calls) == 0
-        assert_webhook_outboxes(
+        assert_webhook_outboxes_with_shard_id(
             factory_request=request,
-            webhook_identifier=WebhookProviderIdentifier.MSTEAMS,
+            expected_shard_id=self.integration.id,
             region_names=["us"],
         )
 

--- a/tests/sentry/middleware/integrations/parsers/test_plugin.py
+++ b/tests/sentry/middleware/integrations/parsers/test_plugin.py
@@ -5,9 +5,12 @@ from django.urls import reverse
 
 from sentry.middleware.integrations.parsers.plugin import PluginRequestParser
 from sentry.models.organizationmapping import OrganizationMapping
-from sentry.models.outbox import ControlOutbox, WebhookProviderIdentifier
+from sentry.models.outbox import ControlOutbox
 from sentry.testutils.cases import TestCase
-from sentry.testutils.outbox import assert_no_webhook_outboxes, assert_webhook_outboxes
+from sentry.testutils.outbox import (
+    assert_no_webhook_outboxes,
+    assert_webhook_outboxes_with_shard_id,
+)
 from sentry.testutils.silo import control_silo_test, create_test_regions
 
 
@@ -51,9 +54,9 @@ class PluginRequestParserTest(TestCase):
             request = self.factory.post(route)
             parser = PluginRequestParser(request=request, response_handler=self.get_response)
             parser.get_response()
-            assert_webhook_outboxes(
+            assert_webhook_outboxes_with_shard_id(
                 factory_request=request,
-                webhook_identifier=WebhookProviderIdentifier.LEGACY_PLUGIN,
+                expected_shard_id=self.organization.id,
                 region_names=["us"],
             )
             # Purge outboxes after checking each route

--- a/tests/sentry/middleware/integrations/parsers/test_vsts.py
+++ b/tests/sentry/middleware/integrations/parsers/test_vsts.py
@@ -8,9 +8,11 @@ from django.urls import reverse
 from fixtures.vsts import WORK_ITEM_UNASSIGNED, WORK_ITEM_UPDATED, WORK_ITEM_UPDATED_STATUS
 from sentry.middleware.integrations.classifications import IntegrationClassification
 from sentry.middleware.integrations.parsers.vsts import VstsRequestParser
-from sentry.models.outbox import WebhookProviderIdentifier
 from sentry.testutils.cases import TestCase
-from sentry.testutils.outbox import assert_no_webhook_outboxes, assert_webhook_outboxes
+from sentry.testutils.outbox import (
+    assert_no_webhook_outboxes,
+    assert_webhook_outboxes_with_shard_id,
+)
 from sentry.testutils.silo import control_silo_test, create_test_regions
 
 
@@ -69,9 +71,9 @@ class VstsRequestParserTest(TestCase):
         response = parser.get_response()
         assert isinstance(response, HttpResponse)
         assert response.status_code == 202
-        assert_webhook_outboxes(
+        assert_webhook_outboxes_with_shard_id(
             factory_request=request,
-            webhook_identifier=WebhookProviderIdentifier.VSTS,
+            expected_shard_id=self.integration.id,
             region_names=["us"],
         )
 
@@ -137,8 +139,8 @@ class VstsRequestParserTest(TestCase):
 
         assert_no_webhook_outboxes()
         parser.get_response()
-        assert_webhook_outboxes(
+        assert_webhook_outboxes_with_shard_id(
             factory_request=request,
-            webhook_identifier=WebhookProviderIdentifier.VSTS,
+            expected_shard_id=self.integration.id,
             region_names=["us"],
         )

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -99,14 +99,14 @@ class ControlOutboxTest(TestCase):
                 inst.save()
 
             for inst in ControlOutbox.for_webhook_update(
-                webhook_identifier=WebhookProviderIdentifier.SLACK,
+                shard_identifier=WebhookProviderIdentifier.SLACK,
                 region_names=[settings.SENTRY_MONOLITH_REGION, "special-slack-region"],
                 request=request,
             ):
                 inst.save()
 
             for inst in ControlOutbox.for_webhook_update(
-                webhook_identifier=WebhookProviderIdentifier.GITHUB,
+                shard_identifier=WebhookProviderIdentifier.GITHUB,
                 region_names=[settings.SENTRY_MONOLITH_REGION, "special-github-region"],
                 request=request,
             ):
@@ -175,7 +175,7 @@ class ControlOutboxTest(TestCase):
 
     def test_control_outbox_for_webhooks(self):
         [outbox] = ControlOutbox.for_webhook_update(
-            webhook_identifier=WebhookProviderIdentifier.GITHUB,
+            shard_identifier=WebhookProviderIdentifier.GITHUB,
             region_names=["webhook-region"],
             request=self.webhook_request,
         )
@@ -217,7 +217,7 @@ class ControlOutboxTest(TestCase):
             )
             expected_request_count = 1 if SiloMode.get_current_mode() == SiloMode.CONTROL else 0
             [outbox] = ControlOutbox.for_webhook_update(
-                webhook_identifier=WebhookProviderIdentifier.GITHUB,
+                shard_identifier=WebhookProviderIdentifier.GITHUB,
                 region_names=[self.region.name],
                 request=self.webhook_request,
             )
@@ -238,7 +238,7 @@ class ControlOutboxTest(TestCase):
                 status=status.HTTP_502_BAD_GATEWAY,
             )
             [outbox] = ControlOutbox.for_webhook_update(
-                webhook_identifier=WebhookProviderIdentifier.GITHUB,
+                shard_identifier=WebhookProviderIdentifier.GITHUB,
                 region_names=[self.region.name],
                 request=self.webhook_request,
             )

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -45,7 +45,7 @@ class ProcessControlOutboxTest(TestCase):
             HTTP_X_GITHUB_EMOTICON=">:^]",
         )
         [outbox] = ControlOutbox.for_webhook_update(
-            webhook_identifier=WebhookProviderIdentifier.GITHUB,
+            shard_identifier=WebhookProviderIdentifier.GITHUB,
             region_names=[_TEST_REGION.name],
             request=request,
         )


### PR DESCRIPTION
Fixes an issue with webhook outboxes being relegated to a small number of shards. This reduced shard count results in lower concurrent processing and bottlenecks the system. By changing the shard ID to a value with higher cardinality (integration ID), we can concurrently process future webhooks at a much faster pace.

There will also be a follow-up PR to backfill existing webhook outboxes to use updated shard identifiers.
