### PR TITLE
chore(apis): Set more API status or update owners

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -112,7 +112,7 @@ class OrganizationEventsRelatedIssuesEndpoint(OrganizationEventsEndpointBase, En
 @region_silo_endpoint
 class OrganizationSpansSamplesEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -80,7 +80,7 @@ class TrendQueryBuilder(QueryBuilder):
 
 class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     trend_columns = {
         "p50": "percentile_range({column}, 0.5, {condition}, {boundary}) as {query_alias}",
@@ -521,7 +521,7 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
 @region_silo_endpoint
 class OrganizationEventsTrendsStatsEndpoint(OrganizationEventsTrendsEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def build_result_handler(

--- a/src/sentry/api/endpoints/organization_events_vitals.py
+++ b/src/sentry/api/endpoints/organization_events_vitals.py
@@ -15,7 +15,7 @@ from sentry.snuba import discover
 @region_silo_endpoint
 class OrganizationEventsVitalsEndpoint(OrganizationEventsV2EndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     VITALS = {
         "measurements.lcp": {"thresholds": [0, 2500, 4000]},

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -24,7 +24,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrganizationEventPermission,)
     enforce_rate_limit = True
-    owner = ApiOwner.PERFORMANCE
+    owner = ApiOwner.ISSUES
 
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/organization_issues_count.py
+++ b/src/sentry/api/endpoints/organization_issues_count.py
@@ -27,7 +27,7 @@ class OrganizationIssuesCountEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
-    owner = ApiOwner.PERFORMANCE
+    owner = ApiOwner.ISSUES
     enforce_rate_limit = True
     rate_limits = {
         "GET": {

--- a/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
+++ b/src/sentry/api/endpoints/organization_metrics_estimation_stats.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEventsV2EndpointBase
@@ -53,6 +54,7 @@ class OrganizationMetricsEstimationStatsEndpoint(OrganizationEventsV2EndpointBas
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
     """Gets the estimated volume of an organization's metric events."""
 
     def get(self, request: Request, organization: Organization) -> Response:

--- a/src/sentry/api/endpoints/organization_metrics_meta.py
+++ b/src/sentry/api/endpoints/organization_metrics_meta.py
@@ -17,7 +17,7 @@ COUNT_NULL = "count_null_transactions()"
 @region_silo_endpoint
 class OrganizationMetricsCompatibility(OrganizationEventsEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     """Metrics data can contain less than great data like null or unparameterized transactions
 
@@ -67,7 +67,7 @@ class OrganizationMetricsCompatibility(OrganizationEventsEndpointBase):
 @region_silo_endpoint
 class OrganizationMetricsCompatibilitySums(OrganizationEventsEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     """Return the total sum of metrics data, the null transactions and unparameterized transactions
 

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -71,7 +71,7 @@ def serialize(data, projects):
 
 @region_silo_endpoint
 class OrganizationSdkUpdatesEndpoint(OrganizationEndpoint):
-    owner = ApiOwner.PERFORMANCE
+    owner = ApiOwner.UNOWNED
 
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -71,8 +71,6 @@ def serialize(data, projects):
 
 @region_silo_endpoint
 class OrganizationSdkUpdatesEndpoint(OrganizationEndpoint):
-    owner = ApiOwner.UNOWNED
-
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -71,6 +71,8 @@ def serialize(data, projects):
 
 @region_silo_endpoint
 class OrganizationSdkUpdatesEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
+
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }

--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -22,7 +22,7 @@ def validate_sort_field(field_name: str) -> str:
 @region_silo_endpoint
 class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, organization, key) -> Response:

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -17,7 +17,7 @@ from sentry.utils.sdk import set_measurement
 @region_silo_endpoint
 class OrganizationTagsEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.PERFORMANCE
 

--- a/src/sentry/api/endpoints/project_tagkey_details.py
+++ b/src/sentry/api/endpoints/project_tagkey_details.py
@@ -15,7 +15,7 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 @region_silo_endpoint
 class ProjectTagKeyDetailsEndpoint(ProjectEndpoint, EnvironmentMixin):
-    owner = ApiOwner.PERFORMANCE
+    owner = ApiOwner.UNOWNED
     publish_status = {
         "DELETE": ApiPublishStatus.UNKNOWN,
         "GET": ApiPublishStatus.UNKNOWN,

--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -14,7 +14,7 @@ from sentry.models.environment import Environment
 
 @region_silo_endpoint
 class ProjectTagKeyValuesEndpoint(ProjectEndpoint, EnvironmentMixin):
-    owner = ApiOwner.PERFORMANCE
+    owner = ApiOwner.UNOWNED
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }

--- a/src/sentry/api/endpoints/project_tags.py
+++ b/src/sentry/api/endpoints/project_tags.py
@@ -12,7 +12,7 @@ from sentry.models.environment import Environment
 
 @region_silo_endpoint
 class ProjectTagsEndpoint(ProjectEndpoint, EnvironmentMixin):
-    owner = ApiOwner.PERFORMANCE
+    owner = ApiOwner.UNOWNED
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
     }


### PR DESCRIPTION
The ones set to private are just specific variations of
either events/ or events-stats/ endpoints returning
specific data we need for the frontend. 

Also updates some API owners