### PR TITLE
fix(metrics_extraction): Allow iterating on specs even if one fails

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -527,6 +527,12 @@ def _convert_aggregate_and_query_to_metrics(
         return None
 
     metric_specs_and_hashes = []
+    extra = {
+        "dataset": dataset,
+        "aggregate": aggregate,
+        "query": query,
+        "groupbys": groupbys,
+    }
     # Create as many specs as we support
     for spec_version in OnDemandMetricSpecVersioning.get_spec_versions():
         try:
@@ -544,35 +550,20 @@ def _convert_aggregate_and_query_to_metrics(
                 validate_sampling_condition(json.dumps(condition))
             else:
                 metrics.incr(
-                    "on_demand_metrics.missing_condition_spec",
-                    tags={"prefilling": prefilling},
+                    "on_demand_metrics.missing_condition_spec", tags={"prefilling": prefilling}
                 )
 
             metric_specs_and_hashes.append((on_demand_spec.query_hash, metric_spec, spec_version))
-        except UnicodeEncodeError:
-            # Known issue let's continue
-            continue
         except ValueError:
             # raised by validate_sampling_condition or metric_spec lacking "condition"
             metrics.incr("on_demand_metrics.invalid_metric_spec", tags={"prefilling": prefilling})
-            logger.exception(
-                "Invalid on-demand metric spec",
-                extra={
-                    "dataset": dataset,
-                    "aggregate": aggregate,
-                    "query": query,
-                    "groupbys": groupbys,
-                },
-            )
-
-            return None
-        except Exception as e:
+            logger.exception("Invalid on-demand metric spec", extra=extra)
+        except Exception:
             # Since prefilling might include several non-ondemand-compatible alerts, we want to not trigger errors in the
             # Sentry console.
             if not prefilling:
-                logger.exception(str(e))
+                logger.exception("Failed on-demand metric spec creation.", extra=extra)
 
-            return None
     return metric_specs_and_hashes
 
 

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -519,16 +519,17 @@ def _convert_aggregate_and_query_to_metrics(
     Extra metric specs will be returned if we need to maintain various versions of it.
     This makes it easier to maintain multiple spec versions when a mistake is made.
     """
-    try:
-        # We can avoid injection of the environment in the query, since it's supported by standard, thus it won't change
-        # the supported state of a query, since if it's standard, and we added environment it will still be standard
-        # and if it's on demand, it will always be on demand irrespectively of what we add.
-        if not should_use_on_demand_metrics(dataset, aggregate, query, groupbys, prefilling):
-            return None
 
-        metric_specs_and_hashes = []
-        # Create as many specs as we support
-        for spec_version in OnDemandMetricSpecVersioning.get_spec_versions():
+    # We can avoid injection of the environment in the query, since it's supported by standard, thus it won't change
+    # the supported state of a query, since if it's standard, and we added environment it will still be standard
+    # and if it's on demand, it will always be on demand irrespectively of what we add.
+    if not should_use_on_demand_metrics(dataset, aggregate, query, groupbys, prefilling):
+        return None
+
+    metric_specs_and_hashes = []
+    # Create as many specs as we support
+    for spec_version in OnDemandMetricSpecVersioning.get_spec_versions():
+        try:
             on_demand_spec = OnDemandMetricSpec(
                 field=aggregate,
                 query=query,
@@ -548,31 +549,31 @@ def _convert_aggregate_and_query_to_metrics(
                 )
 
             metric_specs_and_hashes.append((on_demand_spec.query_hash, metric_spec, spec_version))
-        return metric_specs_and_hashes
-    except ValueError:
-        # raised by validate_sampling_condition or metric_spec lacking "condition"
-        metrics.incr(
-            "on_demand_metrics.invalid_metric_spec",
-            tags={"prefilling": prefilling},
-        )
-        logger.exception(
-            "Invalid on-demand metric spec",
-            extra={
-                "dataset": dataset,
-                "aggregate": aggregate,
-                "query": query,
-                "groupbys": groupbys,
-            },
-        )
+        except UnicodeEncodeError:
+            # Known issue let's continue
+            continue
+        except ValueError:
+            # raised by validate_sampling_condition or metric_spec lacking "condition"
+            metrics.incr("on_demand_metrics.invalid_metric_spec", tags={"prefilling": prefilling})
+            logger.exception(
+                "Invalid on-demand metric spec",
+                extra={
+                    "dataset": dataset,
+                    "aggregate": aggregate,
+                    "query": query,
+                    "groupbys": groupbys,
+                },
+            )
 
-        return None
-    except Exception as e:
-        # Since prefilling might include several non-ondemand-compatible alerts, we want to not trigger errors in the
-        # Sentry console.
-        if not prefilling:
-            logger.exception(str(e))
+            return None
+        except Exception as e:
+            # Since prefilling might include several non-ondemand-compatible alerts, we want to not trigger errors in the
+            # Sentry console.
+            if not prefilling:
+                logger.exception(str(e))
 
-        return None
+            return None
+    return metric_specs_and_hashes
 
 
 def _log_on_demand_metric_spec(

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -900,6 +900,31 @@ def test_get_metric_extraction_config_with_low_cardinality(default_project: Proj
 
 
 @django_db_all
+def test_get_metric_extraction_config_with_unicode_character(default_project: Project) -> None:
+    with Feature({ON_DEMAND_METRICS_WIDGETS: True}):
+        # This will cause the Unicode bug to be raised
+        create_widget(["count()"], "user.name:Armén", default_project)
+        create_widget(["count()"], "user.name:Kevan", default_project, title="Dashboard Foo")
+        config = get_metric_extraction_config(default_project)
+        assert config
+        assert config == {
+            "metrics": [
+                {
+                    "category": "transaction",
+                    "condition": {"name": "event.tags.user.name", "op": "eq", "value": "Kevan"},
+                    "field": None,
+                    "mri": "c:transactions/on_demand@none",
+                    "tags": [
+                        {"key": "query_hash", "value": "5142a1f7"},
+                        {"field": "event.environment", "key": "environment"},
+                    ],
+                }
+            ],
+            "version": 2,
+        }
+
+
+@django_db_all
 @pytest.mark.parametrize("metric", [("epm()"), ("eps()")])
 def test_get_metric_extraction_config_with_no_tag_spec(
     default_project: Project, metric: str


### PR DESCRIPTION
When creating a spec raises an error, it causes generating widget specs for that org. This has been preventing some customers (outside of our initial set
of orgs) from getting their specs being extracted. Specifically, the Unicode bug.

This change allows iterating through the specs even if one fails. It also silences the Unicode encoding errors since we plan to fix it.