### PR TITLE
ref(api): Cleanup token last characters

### DIFF
--- a/src/sentry/api/serializers/models/apitoken.py
+++ b/src/sentry/api/serializers/models/apitoken.py
@@ -33,7 +33,10 @@ class ApiTokenSerializer(Serializer):
 
             data["refreshToken"] = obj.refresh_token
 
-        data["tokenLastCharacters"] = (
-            obj.token_last_characters if obj.token_last_characters else obj.token[-4:]
-        )
+        """
+        While this is a nullable column at the db level, this should never be empty. If it is, it's a sign that the
+        token was created through improper channels, and might actually be invalid. If that's the case, it can be
+        considered a security risk, and better for this to throw an exception than to leak a dangerous token.
+        """
+        data["tokenLastCharacters"] = obj.token_last_characters
         return data


### PR DESCRIPTION
Removes the last token characters logic at the serializer level that is no longer needed. Previously we had to do this because the column was always empty, as we didn't have save logic. Now that it exists, the column value should always be populated, and we don't need to have unnecessary code.

The backfill has happened for the model as well, and the ReDash query shows 0 remaining rows that have pending values.

Resolves: https://github.com/getsentry/team-enterprise/issues/22#issue-2047371811
