### PR TITLE
ref(open-pr-comments): move generating snuba conditions into parser class

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -248,6 +248,11 @@ def get_top_5_issues_by_count_for_file(
     projects: List[Project], sentry_filenames: List[str], function_names: List[str]
 ) -> List[Dict[str, Any]]:
     """Given a list of issue group ids, return a sublist of the top 5 ordered by event count"""
+    language_parser = PATCH_PARSERS.get(sentry_filenames[0].split(".")[-1], None)
+
+    if not language_parser:
+        return []
+
     group_ids = list(
         Group.objects.filter(
             first_seen__gte=datetime.now() - timedelta(days=90),
@@ -258,27 +263,7 @@ def get_top_5_issues_by_count_for_file(
     )
     project_ids = [p.id for p in projects]
 
-    stackframe_function_name = lambda i: Function(
-        "arrayElement",
-        (Column("exception_frames.function"), i),
-    )
-    multi_if = []
-    for i in range(-STACKFRAME_COUNT, 0):
-        # if, then conditions
-        multi_if.extend(
-            [
-                Function(
-                    "in",
-                    [
-                        stackframe_function_name(i),
-                        function_names,
-                    ],
-                ),
-                stackframe_function_name(i),
-            ]
-        )
-    # else condition
-    multi_if.append(stackframe_function_name(-1))
+    multi_if = language_parser.generate_multi_if(function_names)
 
     request = SnubaRequest(
         dataset=Dataset.Events.value,
@@ -325,10 +310,8 @@ def get_top_5_issues_by_count_for_file(
                                         Op.IN,
                                         sentry_filenames,
                                     ),
-                                    Condition(
-                                        stackframe_function_name(i),
-                                        Op.IN,
-                                        function_names,
+                                    language_parser.generate_function_name_conditions(
+                                        function_names, i
                                     ),
                                 ],
                             )

--- a/src/sentry/tasks/integrations/github/patch_parsers.py
+++ b/src/sentry/tasks/integrations/github/patch_parsers.py
@@ -1,12 +1,41 @@
+from __future__ import annotations
+
 import re
-from abc import abstractmethod
-from typing import Set
+from abc import ABC, abstractmethod
+from typing import List, Set
+
+from snuba_sdk import BooleanCondition, Column, Condition, Function, Op
+
+stackframe_function_name = lambda i: Function(
+    "arrayElement",
+    (Column("exception_frames.function"), i),
+)
 
 
-class LanguageParser:
+class LanguageParser(ABC):
     @staticmethod
     @abstractmethod
     def extract_functions_from_patch(patch: str) -> Set[str]:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def generate_multi_if(function_names: List[str]) -> List[Function]:
+        """
+        Function to generate the multi-if condition for the Snuba request.
+        This is to fetch the proper function name from the stacktrace, which is an array.
+        """
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def generate_function_name_conditions(
+        function_names: List[str], stack_frame: int
+    ) -> BooleanCondition | Condition:
+        """
+        Function to generate the WHERE condition for matching function names from a list to function names in the stack trace in the Snuba request.
+        Must be applied to each frame of the stacktrace up to STACKFRAME_COUNT.
+        """
         pass
 
 
@@ -29,6 +58,43 @@ class PythonParser(LanguageParser):
         """
         python_function_regex = r"^@@.*@@\s+def\s+(?P<fnc>.*)\(.*$"
         return set(re.findall(python_function_regex, patch, flags=re.M))
+
+    @staticmethod
+    def generate_multi_if(function_names: List[str]) -> List[Function]:
+        """
+        Fetch the function name from the stackframe that matches a name within the list of function names.
+        """
+        # circular import
+        from sentry.tasks.integrations.github.open_pr_comment import STACKFRAME_COUNT
+
+        multi_if = []
+        for i in range(-STACKFRAME_COUNT, 0):
+            # if, then conditions
+            multi_if.extend(
+                [
+                    Function(
+                        "in",
+                        [
+                            stackframe_function_name(i),
+                            function_names,
+                        ],
+                    ),
+                    stackframe_function_name(i),
+                ]
+            )
+        # else condition
+        multi_if.append(stackframe_function_name(-1))
+
+        return multi_if
+
+    @staticmethod
+    def generate_function_name_conditions(function_names: List[str], stack_frame: int) -> Condition:
+        """Check if the function name in the stack frame is within the list of function names."""
+        return Condition(
+            stackframe_function_name(stack_frame),
+            Op.IN,
+            function_names,
+        )
 
 
 PATCH_PARSERS = {"py": PythonParser}

--- a/src/sentry/tasks/integrations/github/patch_parsers.py
+++ b/src/sentry/tasks/integrations/github/patch_parsers.py
@@ -6,6 +6,8 @@ from typing import List, Set
 
 from snuba_sdk import BooleanCondition, Column, Condition, Function, Op
 
+from sentry.tasks.integrations.github.constants import STACKFRAME_COUNT
+
 stackframe_function_name = lambda i: Function(
     "arrayElement",
     (Column("exception_frames.function"), i),
@@ -64,9 +66,6 @@ class PythonParser(LanguageParser):
         """
         Fetch the function name from the stackframe that matches a name within the list of function names.
         """
-        # circular import
-        from sentry.tasks.integrations.github.open_pr_comment import STACKFRAME_COUNT
-
         multi_if = []
         for i in range(-STACKFRAME_COUNT, 0):
             # if, then conditions


### PR DESCRIPTION
Python and Javascript events store function names differently in the Snuba `events` table.

Python stores function names as the function names themselves, whereas Javascript occasionally stores them like `className.functionName` in addition to the function name itself. Parsing the git diff hunk headers in any language only gives us the function name (and not the class), so we will need some different logic for Javascript to match `functionName` from Github to `functionName` and `className.functionName` in Snuba.

At the moment, 1 Snuba request is being made per file modified in a PR to find the top 5 recent issues in terms of event count that are related to the functions modified in the file. We reverse-codemap the Github filename into the (possible) multiple ways a file may be represented in Sentry due to how we collect stacktraces. There are two areas where the Snuba request will differ between Python and Javascript.
- The `multiIf` is currently being used to return the function name from the stack trace (an array column) that matches the boolean condition in the `WHERE` clause; this result is stored in a column.
- Imagine the stacktrace as `[(filename_1, function_name_1), (filename_2, function_name_2), (filename_3, function_name_3), ...]`. The boolean condition checks that there exists a frame in the stack trace where the filename exists in the list of filenames (reverse-codemapped from a single Github filename) and the function name exists in the list of functions modified in the file.

^ Given this, I have moved generating the `multiIf` conditions and the boolean conditions for matching the function name into the language parser class. The part of the boolean condition for matching the filename is the same for all languages due to the codemappings logic being the same.