### PR TITLE
feat(snuba): ensure MetricsQuery objects are properly represented in spans

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1070,12 +1070,13 @@ def _raw_mql_query(
     # Enter hub such that http spans are properly nested
     with thread_hub, timer("mql_query"):
         referrer = headers.get("referer", "unknown")
+        # TODO: This can be changed back to just `serialize` after we remove SnQL support for MetricsQuery
+        serialized_req = request.serialize_mql()
         with thread_hub.start_span(op="snuba_mql.validation", description=referrer) as span:
             span.set_tag("snuba.referrer", referrer)
-            # TODO: This can be changed back to just `serialize` after we remove SnQL support for MetricsQuery
-            body = request.serialize_mql()
+            body = serialized_req
 
-        with thread_hub.start_span(op="snuba_mql.run", description=str(request)) as span:
+        with thread_hub.start_span(op="snuba_mql.run", description=serialized_req) as span:
             span.set_tag("snuba.referrer", referrer)
             return _snuba_pool.urlopen(
                 "POST", f"/{request.dataset}/mql", body=body, headers=headers
@@ -1088,11 +1089,12 @@ def _raw_snql_query(
     # Enter hub such that http spans are properly nested
     with thread_hub, timer("snql_query"):
         referrer = headers.get("referer", "<unknown>")
+        serialized_req = request.serialize()
         with thread_hub.start_span(op="snuba_snql.validation", description=referrer) as span:
             span.set_tag("snuba.referrer", referrer)
-            body = request.serialize()
+            body = serialized_req
 
-        with thread_hub.start_span(op="snuba_snql.run", description=str(request)) as span:
+        with thread_hub.start_span(op="snuba_snql.run", description=serialized_req) as span:
             span.set_tag("snuba.referrer", referrer)
             return _snuba_pool.urlopen(
                 "POST", f"/{request.dataset}/snql", body=body, headers=headers


### PR DESCRIPTION
The change for this pr is described here [https://getsentry.atlassian.net/browse/SNS-2586](https://getsentry.atlassian.net/browse/SNS-2586). It will make it so MQL queries show up properly in spans. 

I changed the span description within _raw_mql_query to use the serialize_mql function rather than str. This will make the span contain the MQL query rather than Snql. I also changed _raw_snql_query to use serialize rather than str, but this isnt strictly necessary.

I stepped through the debugger to where the span description is set in _raw_mql_query to verify that the new description is indeed the MQL and not snql. I also verified via code and debugger that the str -> serialize conversion in _raw_snql_query doesn't change anything.
