### PR TITLE
feat(stats-detectors): Spread tasks across the hour

### DIFF
--- a/src/sentry/statistical_detectors/detector.py
+++ b/src/sentry/statistical_detectors/detector.py
@@ -97,7 +97,7 @@ class RegressionDetector(ABC):
 
     @classmethod
     def detect_trends(
-        cls, projects: List[Project], start: datetime
+        cls, projects: List[Project], start: datetime, batch_size=100
     ) -> Generator[TrendBundle, None, None]:
         unique_project_ids: Set[int] = set()
 
@@ -108,7 +108,7 @@ class RegressionDetector(ABC):
         algorithm = cls.detector_algorithm_factory()
         store = cls.detector_store_factory()
 
-        for payloads in chunked(cls.all_payloads(projects, start), 100):
+        for payloads in chunked(cls.all_payloads(projects, start), batch_size):
             total_count += len(payloads)
 
             raw_states = store.bulk_read_states(payloads)

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -137,13 +137,10 @@ def compute_delay(
     end = start + duration
 
     remaining = end - now.replace(microsecond=0)
-    # ensure there is some padding before the first task
+    # ensure there is some padding before the end of the duration
     remaining -= step
 
-    offset = batch_index * int(step.total_seconds()) % int(remaining.total_seconds())
-
-    # ensure there is some padding before the first task
-    return offset + int(step.total_seconds())
+    return batch_index * int(step.total_seconds()) % int(remaining.total_seconds())
 
 
 def dispatch_performance_projects(

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -116,7 +116,7 @@ def run_detection() -> None:
     projects = dispatch_performance_projects(projects, now)
     projects = dispatch_profiling_projects(projects, now)
 
-    # make sure to consume the iterator
+    # make sure to consume the generator
     for _ in projects:
         pass
 

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -68,6 +68,9 @@ TRANSACTIONS_PER_PROJECT = 50
 TRANSACTIONS_PER_BATCH = 1_000
 PROJECTS_PER_BATCH = 1_000
 TIMESERIES_PER_BATCH = 10
+RUN_FREQUENCY = timedelta(hours=1)  # runs hourly
+# pick a prime number so when it wraps around, it doesn't over lap
+DISPATCH_STEP = timedelta(seconds=7)
 
 
 def get_performance_issue_settings(projects: List[Project]):
@@ -91,6 +94,13 @@ def get_performance_issue_settings(projects: List[Project]):
     return project_settings
 
 
+def all_projects_with_flags() -> Generator[Tuple[int, int], None, None]:
+    yield from RangeQuerySetWrapper(
+        Project.objects.filter(status=ObjectStatus.ACTIVE).values_list("id", "flags"),
+        result_value_getter=lambda item: item[0],
+    )
+
+
 @instrumented_task(
     name="sentry.tasks.statistical_detectors.run_detection",
     queue="performance.statistical_detector",
@@ -102,56 +112,107 @@ def run_detection() -> None:
 
     now = django_timezone.now()
 
-    performance_projects = []
-    profiling_projects = []
+    projects = all_projects_with_flags()
+    projects = dispatch_performance_projects(projects, now)
+    projects = dispatch_profiling_projects(projects, now)
 
-    performance_projects_count = 0
-    profiling_projects_count = 0
+    # make sure to consume the iterator
+    for _ in projects:
+        pass
 
-    for project_id, flags in RangeQuerySetWrapper(
-        Project.objects.filter(status=ObjectStatus.ACTIVE).values_list("id", "flags"),
-        result_value_getter=lambda item: item[0],
-    ):
+
+def compute_delay(
+    timestamp: datetime,
+    batch_index: int,
+    duration: timedelta = RUN_FREQUENCY,
+    step: timedelta = DISPATCH_STEP,
+) -> int:
+    now = django_timezone.now()
+
+    start = timestamp.replace(minute=0, second=0, microsecond=0)
+    end = start + duration
+
+    # ensure there is some padding before the first task
+    remaining = end - now.replace(microsecond=0) - step
+
+    return int((step + batch_index * step % remaining).total_seconds())
+
+
+def dispatch_performance_projects(
+    all_projects: Generator[Tuple[int, int], None, None],
+    timestamp: datetime,
+) -> Generator[Tuple[int, int], None, None]:
+    projects = []
+    count = 0
+
+    for project_id, flags in all_projects:
         if flags & Project.flags.has_transactions:
-            performance_projects.append(project_id)
-            performance_projects_count += 1
+            projects.append(project_id)
+            count += 1
 
-            if len(performance_projects) >= PROJECTS_PER_BATCH:
-                detect_transaction_trends.delay(
+        if len(projects) >= PROJECTS_PER_BATCH:
+            detect_transaction_trends.apply_async(
+                args=[
                     [],
-                    performance_projects,
-                    now,
-                )
-                performance_projects = []
+                    projects,
+                    timestamp,
+                ],
+                countdown=compute_delay(timestamp, (count - 1) // PROJECTS_PER_BATCH),
+            )
+            projects = []
 
-        if flags & Project.flags.has_profiles:
-            profiling_projects.append(project_id)
-            profiling_projects_count += 1
-
-            if len(profiling_projects) >= PROJECTS_PER_BATCH:
-                detect_function_trends.delay(profiling_projects, now)
-                profiling_projects = []
+        yield project_id, flags
 
     # make sure to dispatch a task to handle the remaining projects
-    if performance_projects:
-        detect_transaction_trends.delay(
-            [],
-            performance_projects,
-            now,
+    if projects:
+        detect_transaction_trends.apply_async(
+            args=[
+                [],
+                projects,
+                timestamp,
+            ],
+            countdown=compute_delay(timestamp, (count - 1) // PROJECTS_PER_BATCH),
         )
-    if profiling_projects:
-        detect_function_trends.delay(profiling_projects, now)
 
     metrics.incr(
         "statistical_detectors.projects.total",
-        amount=performance_projects_count,
+        amount=count,
         tags={"source": "transaction"},
         sample_rate=1.0,
     )
 
+
+def dispatch_profiling_projects(
+    all_projects: Generator[Tuple[int, int], None, None],
+    timestamp: datetime,
+) -> Generator[Tuple[int, int], None, None]:
+    projects = []
+    count = 0
+
+    for project_id, flags in all_projects:
+        if flags & Project.flags.has_profiles:
+            projects.append(project_id)
+            count += 1
+
+        if len(projects) >= PROJECTS_PER_BATCH:
+            detect_function_trends.apply_async(
+                args=[projects, timestamp],
+                countdown=compute_delay(timestamp, (count - 1) // PROJECTS_PER_BATCH),
+            )
+            projects = []
+
+        yield project_id, flags
+
+    # make sure to dispatch a task to handle the remaining projects
+    if projects:
+        detect_function_trends.apply_async(
+            args=[projects, timestamp],
+            countdown=compute_delay(timestamp, (count - 1) // PROJECTS_PER_BATCH),
+        )
+
     metrics.incr(
         "statistical_detectors.projects.total",
-        amount=profiling_projects_count,
+        amount=count,
         tags={"source": "profile"},
         sample_rate=1.0,
     )

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -128,7 +128,7 @@ def test_run_detection_options(
     if expected_performance_project:
         assert detect_transaction_trends.apply_async.called
         detect_transaction_trends.apply_async.assert_has_calls(
-            [mock.call(args=[[], [project.id], timestamp], countdown=7)]
+            [mock.call(args=[[], [project.id], timestamp], countdown=17)]
         )
     else:
         assert not detect_transaction_trends.apply_async.called
@@ -136,7 +136,7 @@ def test_run_detection_options(
     if expected_profiling_project:
         assert detect_function_trends.apply_async.called
         detect_function_trends.apply_async.assert_has_calls(
-            [mock.call(args=[[project.id], timestamp], countdown=7)]
+            [mock.call(args=[[project.id], timestamp], countdown=17)]
         )
     else:
         assert not detect_function_trends.apply_async.called
@@ -185,7 +185,7 @@ def test_run_detection_options_multiple_batches(
                 ],
                 countdown=countdown,
             )
-            for i, countdown in zip(range(0, len(projects), 5), itertools.count(start=7, step=7))
+            for i, countdown in zip(range(0, len(projects), 5), itertools.count(start=17, step=17))
         ]
     )
     assert detect_function_trends.apply_async.called
@@ -195,7 +195,7 @@ def test_run_detection_options_multiple_batches(
                 args=[[project.id for project in projects[i : i + 5]], timestamp],
                 countdown=countdown,
             )
-            for i, countdown in zip(range(0, len(projects), 5), itertools.count(start=7, step=7))
+            for i, countdown in zip(range(0, len(projects), 5), itertools.count(start=17, step=17))
         ]
     )
 

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -128,7 +128,7 @@ def test_run_detection_options(
     if expected_performance_project:
         assert detect_transaction_trends.apply_async.called
         detect_transaction_trends.apply_async.assert_has_calls(
-            [mock.call(args=[[], [project.id], timestamp], countdown=17)]
+            [mock.call(args=[[], [project.id], timestamp], countdown=0)]
         )
     else:
         assert not detect_transaction_trends.apply_async.called
@@ -136,7 +136,7 @@ def test_run_detection_options(
     if expected_profiling_project:
         assert detect_function_trends.apply_async.called
         detect_function_trends.apply_async.assert_has_calls(
-            [mock.call(args=[[project.id], timestamp], countdown=17)]
+            [mock.call(args=[[project.id], timestamp], countdown=0)]
         )
     else:
         assert not detect_function_trends.apply_async.called
@@ -185,7 +185,7 @@ def test_run_detection_options_multiple_batches(
                 ],
                 countdown=countdown,
             )
-            for i, countdown in zip(range(0, len(projects), 5), itertools.count(start=17, step=17))
+            for i, countdown in zip(range(0, len(projects), 5), itertools.count(start=0, step=17))
         ]
     )
     assert detect_function_trends.apply_async.called
@@ -195,7 +195,7 @@ def test_run_detection_options_multiple_batches(
                 args=[[project.id for project in projects[i : i + 5]], timestamp],
                 countdown=countdown,
             )
-            for i, countdown in zip(range(0, len(projects), 5), itertools.count(start=17, step=17))
+            for i, countdown in zip(range(0, len(projects), 5), itertools.count(start=0, step=17))
         ]
     )
 


### PR DESCRIPTION
Currently, this dispatches all the tasks immediately. This starts a few thousand tasks and saturates the workers all at once. This change introduces a delay to the tasks to spread them across the hour.