### PR TITLE
fix(replay/issues): make replay badge & table `statsPeriod` consistent

### DIFF
--- a/static/app/utils/replayCount/useReplayCountForIssues.tsx
+++ b/static/app/utils/replayCount/useReplayCountForIssues.tsx
@@ -11,7 +11,7 @@ export default function useReplayCountForIssues() {
     dataSource: 'discover',
     fieldName: 'issue.id',
     organization,
-    statsPeriod: '90d',
+    statsPeriod: '14d',
   });
 
   return {


### PR DESCRIPTION
Make the `statsPeriod` in `useReplayCountForIssues.tsx` (which fetches the replay count for badges and the issue list) consistent with `useReplaysFromIssue.tsx` (which fetches the replay IDs for displaying in the issue replay table). 

The former was querying for `90d` previously. The latter file has queries for replay IDs from `14d` [due to performance limitations], leading to inconsistent counts:

```

          query: {
            returnIds: true,
            query: `issue.id:[${group.id}]`,
            data_source: dataSource,
            statsPeriod: '14d',
            environment: location.query.environment,
            project: ALL_ACCESS_PROJECTS,
          },
        
```

Before (list says 5, badge says 11, actual replay count is 13):

<img width="506" alt="SCR-20240118-mtwb" src="https://github.com/getsentry/sentry/assets/56095982/200d4c9f-8863-4740-832e-4066c2a9873c">
<img width="788" alt="SCR-20240118-mtye" src="https://github.com/getsentry/sentry/assets/56095982/7dfbecec-3cca-480f-ba74-adf771960188">
<img width="937" alt="SCR-20240118-mugr" src="https://github.com/getsentry/sentry/assets/56095982/1ab8910d-b71e-4391-8289-b79b36b8baff">


After (list says 13, badge says 13, actual replay count is 13):

<img width="396" alt="SCR-20240118-mwap" src="https://github.com/getsentry/sentry/assets/56095982/1021d2e1-69ff-4789-aca8-201a63867b1d">
<img width="691" alt="SCR-20240118-mwdd" src="https://github.com/getsentry/sentry/assets/56095982/54308e77-3d80-4bc6-89d0-3e41a7871617">
<img width="799" alt="SCR-20240118-mwei" src="https://github.com/getsentry/sentry/assets/56095982/a0621705-c95c-47ed-9997-c7f5951daf5f">


Note that the badge count reflects the **total** number of replays available across all environments. So if we have
- environment A: 3 replays
- environment B: 4 replays

The badge will always say **7 replays**, even though the table may show 3 or 4 or 7 replays depending on the environment selected.

This change doesn't fix a lot of the replay count issues we're experiencing, but it does **make the counts more consistent across issues.**