### PR TITLE
fix(api): Allow token endpoint to be delete by id

### DIFF
--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -46,7 +46,11 @@ class ApiTokensEndpoint(Endpoint):
                 "application"
             )
         )
-        # TODO: when the delete endpoint no longer requires the full token value, update this to stop including token
+        """
+        TODO:
+        - when the delete endpoint no longer requires the full token value, update this to stop including token
+        - update the endpoint to use pagination instead of unbounded return
+        """
         return Response(serialize(token_list, request.user))
 
     @method_decorator(never_cache)
@@ -83,15 +87,23 @@ class ApiTokensEndpoint(Endpoint):
         if is_active_superuser(request):
             user_id = request.data.get("userId", user_id)
         # TODO: we should not be requiring full token value in the delete endpoint, and should instead be using the id
-        token = request.data.get("token")
-        if not token:
-            return Response({"token": ""}, status=400)
+        token = request.data.get("token", None)
+        token_id = request.data.get("tokenId", None)
+        # Account for token_id being 0, which can be considered valid
+        if not token and token_id is None:
+            return Response({"token": token, "tokenId": token_id}, status=400)
 
         with outbox_context(transaction.atomic(router.db_for_write(ApiToken)), flush=False):
-            for token in ApiToken.objects.filter(
-                user_id=user_id, token=token, application__isnull=True
-            ):
-                token.delete()
+            if token:
+                for token in ApiToken.objects.filter(
+                    user_id=user_id, token=token, application__isnull=True
+                ):
+                    token.delete()
+            else:
+                token_to_delete = ApiToken.objects.get(
+                    id=token_id, application__isnull=True, user_id=user_id
+                )
+                token_to_delete.delete()
 
         analytics.record("api_token.deleted", user_id=request.user.id)
 

--- a/tests/sentry/api/endpoints/test_api_tokens.py
+++ b/tests/sentry/api/endpoints/test_api_tokens.py
@@ -103,6 +103,22 @@ class ApiTokensDeleteTest(APITestCase):
             == "max-age=0, no-cache, no-store, must-revalidate, private"
         )
 
+    def test_with_id(self) -> None:
+        token = ApiToken.objects.create(user=self.user)
+        self.login_as(self.user)
+        url = reverse("sentry-api-0-api-tokens")
+        response = self.client.delete(url, data={"tokenId": token.id})
+        assert response.status_code == 204
+        assert not ApiToken.objects.filter(id=token.id).exists()
+
+    def test_returns_400_when_no_token_param_is_sent(self) -> None:
+        token = ApiToken.objects.create(user=self.user)
+        self.login_as(self.user)
+        url = reverse("sentry-api-0-api-tokens")
+        response = self.client.delete(url, data={})
+        assert response.status_code == 400
+        assert ApiToken.objects.filter(id=token.id).exists()
+
 
 @control_silo_test
 class ApiTokensSuperUserTest(APITestCase):


### PR DESCRIPTION
To reduce exposing the full api token value throughout the ecosystem, we need to ensure our flows allow for usage of the id and not the value. This will allow the endpoint to start accepting the id so that we can deprecate using the full token value. Another FE change will need to be made to start using the id instead of the full value, and should be in another PR.

Resolves: https://github.com/getsentry/team-enterprise/issues/21#issue-2047202292