### PR TITLE
fix(ddm): Do not reset query on project change

### DIFF
--- a/static/app/views/ddm/queryBuilder.tsx
+++ b/static/app/views/ddm/queryBuilder.tsx
@@ -8,7 +8,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {MetricMeta, MetricsOperation, MRI} from 'sentry/types';
 import {
-  emptyWidget,
   getDefaultMetricDisplayType,
   getReadableMetricType,
   isAllowedOp,
@@ -52,7 +51,7 @@ export const QueryBuilder = memo(function QueryBuilder({
   powerUserMode,
   onChange,
 }: QueryBuilderProps) {
-  const {data: meta, isLoading: isMetaLoading} = useMetricsMeta(projects);
+  const {data: meta} = useMetricsMeta(projects);
   const mriModeKeyPressed = useKeyPress('`', undefined, true);
   const [mriMode, setMriMode] = useState(powerUserMode); // power user mode that shows raw MRI instead of metrics names
   const breakpoints = useBreakpoints();
@@ -80,17 +79,6 @@ export const QueryBuilder = memo(function QueryBuilder({
   const selectedMeta = useMemo(() => {
     return meta.find(metric => metric.mri === metricsQuery.mri);
   }, [meta, metricsQuery.mri]);
-
-  // Reset the query data if the selected metric is no longer available
-  useEffect(() => {
-    if (
-      metricsQuery.mri !== emptyWidget.mri &&
-      !isMetaLoading &&
-      !displayedMetrics.find(metric => metric.mri === metricsQuery.mri)
-    ) {
-      onChange({mri: emptyWidget.mri, op: emptyWidget.op, groupBy: []});
-    }
-  }, [isMetaLoading, displayedMetrics, metricsQuery.mri, onChange]);
 
   const incrementQueryMetric = useIncrementQueryMetric({
     displayType,


### PR DESCRIPTION
### Problem
By auto-resetting MRI fields on project change users potentially loose multiple chart configurations while they are also presented with completely different data. 
Additionally, it created multiple corner cases we had to handle during implementation in the past and even caused bugs in production.

https://github.com/getsentry/sentry/assets/7033940/efcbc654-cc61-40ec-972e-50a50f09b086

### Solution
Remove the resetting logic. The Metric selector will keep the old value (even though it is not included in the options) and will query for it. The BE will return an empty time series.
This way the user clearly sees that there is no data for the selected metric in the new project and can easily go back to the previous state if they want to.

https://github.com/getsentry/sentry/assets/7033940/dfdf7f4f-b454-42dd-9f94-ba51c23330c7

#### Future improvements
* Displaying a fallback for no data in the chart