### PR TITLE
feat(ddm): Add hardcoded limit for queries

### DIFF
--- a/src/sentry/sentry_metrics/querying/api.py
+++ b/src/sentry/sentry_metrics/querying/api.py
@@ -16,6 +16,7 @@ from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.search.utils import parse_datetime_string
+from sentry.sentry_metrics.querying.common import DEFAULT_QUERY_INTERVALS, SNUBA_QUERY_LIMIT
 from sentry.sentry_metrics.querying.errors import (
     InvalidMetricsQueryError,
     MetricsQueryExecutionError,
@@ -39,20 +40,6 @@ from sentry.snuba.metrics import to_intervals
 from sentry.snuba.metrics_layer.query import run_query
 from sentry.utils import metrics
 from sentry.utils.snuba import SnubaError
-
-# Snuba can return at most 10.000 rows.
-SNUBA_QUERY_LIMIT = 10000
-# Intervals in seconds which are used by the product to query data.
-DEFAULT_QUERY_INTERVALS = [
-    60 * 60 * 24,  # 1 day
-    60 * 60 * 12,  # 12 hours
-    60 * 60 * 4,  # 4 hours
-    60 * 60 * 2,  # 2 hours
-    60 * 60,  # 1 hour
-    60 * 30,  # 30 min
-    60 * 5,  # 5 min
-    60,  # 1 min
-]
 
 
 @dataclass(frozen=True)

--- a/src/sentry/sentry_metrics/querying/common.py
+++ b/src/sentry/sentry_metrics/querying/common.py
@@ -1,0 +1,13 @@
+# Snuba can return at most 10.000 rows.
+SNUBA_QUERY_LIMIT = 10000
+# Intervals in seconds which are used by the product to query data.
+DEFAULT_QUERY_INTERVALS = [
+    60 * 60 * 24,  # 1 day
+    60 * 60 * 12,  # 12 hours
+    60 * 60 * 4,  # 4 hours
+    60 * 60 * 2,  # 2 hours
+    60 * 60,  # 1 hour
+    60 * 30,  # 30 min
+    60 * 5,  # 5 min
+    60,  # 1 min
+]

--- a/src/sentry/sentry_metrics/querying/metadata/correlations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/correlations.py
@@ -22,6 +22,7 @@ from sentry.exceptions import InvalidParams
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.sentry_metrics.querying.common import SNUBA_QUERY_LIMIT
 from sentry.sentry_metrics.querying.metadata.utils import (
     add_environments_condition,
     get_snuba_conditions_from_query,
@@ -199,6 +200,7 @@ class MetricsSummariesCorrelationsSource(CorrelationsSource):
             ]
             + where,
             groupby=[Column("span_id")],
+            limit=Limit(SNUBA_QUERY_LIMIT),
         )
 
         request = Request(
@@ -240,6 +242,7 @@ class MetricsSummariesCorrelationsSource(CorrelationsSource):
                 Condition(Column("timestamp"), Op.LT, end),
                 Condition(Column("span_id"), Op.IN, list(span_ids)),
             ],
+            limit=Limit(SNUBA_QUERY_LIMIT),
         )
 
         request = Request(


### PR DESCRIPTION
This PR adds a hardcoded query limit to test the system's scalability. This is done since Snuba defaults to its own limit in case it's not supplied.