### PR TITLE
Skip flaky tests

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_ddm_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_ddm_meta.py
@@ -329,6 +329,7 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             codeLocations="true",
         )
 
+    @pytest.mark.skip(reason="flaky test, fix incoming")
     def test_get_metric_spans(self):
         mri = "g:custom/page_load@millisecond"
 
@@ -409,6 +410,7 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
             {"spanDuration": 2, "spanOp": "rpc"},
         ]
 
+    @pytest.mark.skip(reason="flaky test, fix incoming")
     def test_get_metric_spans_with_environment(self):
         mri = "g:custom/page_load@millisecond"
 
@@ -477,6 +479,7 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
         assert len(metric_spans) == 1
         assert metric_spans[0]["transactionId"] == transaction_id_2
 
+    @pytest.mark.skip(reason="flaky test, fix incoming")
     def test_get_metric_spans_with_bounds(self):
         mri = "g:custom/page_load@millisecond"
 


### PR DESCRIPTION
This PR skips flaky tests which are fixed in a follow-up PR that will be deployed next week. The reason for why that PR is not deployed is because it's risky and needs to be deployed carefully.

Follow up fix available here: https://github.com/getsentry/sentry/pull/63500