### PR TITLE
fix(metrics_extraction): Print specs over two lines

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -262,11 +262,11 @@ def _merge_metric_specs(
         already_present = specs.get(query_hash)
         if already_present and not are_specs_equal(already_present, spec):
             logger.warning(
-                "Duplicate metric spec found for hash %s with different specs: %s != %s",
-                query_hash,
-                already_present,
-                spec,
+                "Duplicate metric spec found for hash %s with different specs.", query_hash
             )
+            # Printing over two lines to prevent trimming
+            logger.info("Spec 1: %s", already_present)
+            logger.info("Spec 2: %s", spec)
             duplicated_specs += 1
             continue
 


### PR DESCRIPTION
We are seeing the log message being trimmed, thus, making it impossible to check the values.
<img width="299" alt="image" src="https://github.com/getsentry/sentry/assets/44410/4c737f7e-0005-4916-9b24-4c2a6849e069">
