### PR TITLE
nit(pr-comments): move stuff into constants file and utils file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -491,7 +491,6 @@ module = [
     "sentry.tasks.digests",
     "sentry.tasks.groupowner",
     "sentry.tasks.integrations",
-    "sentry.tasks.integrations.github.pr_comment",
     "sentry.tasks.integrations.migrate_issues",
     "sentry.tasks.integrations.migrate_repo",
     "sentry.tasks.integrations.slack.find_channel_id_for_rule",

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -33,7 +33,7 @@ from sentry.services.hybrid_cloud.repository import RpcRepository, repository_se
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.tasks.integrations import migrate_repo
-from sentry.tasks.integrations.github.pr_comment import RATE_LIMITED_MESSAGE
+from sentry.tasks.integrations.github.constants import RATE_LIMITED_MESSAGE
 from sentry.tasks.integrations.link_all_repos import link_all_repos
 from sentry.utils import metrics
 from sentry.web.helpers import render_to_response

--- a/src/sentry/tasks/integrations/github/constants.py
+++ b/src/sentry/tasks/integrations/github/constants.py
@@ -2,57 +2,5 @@ ISSUE_LOCKED_ERROR_MESSAGE = "Unable to create comment because issue is locked."
 
 RATE_LIMITED_MESSAGE = "API rate limit exceeded"
 
-# ---
-
-# MERGED PR COMMENTS
-
-MERGED_PR_METRICS_BASE = "github_pr_comment.{key}"
-
-MERGED_PR_COMMENT_BODY_TEMPLATE = """## Suspect Issues
-This pull request was deployed and Sentry observed the following issues:
-
-{issue_list}
-
-<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
-
-MERGED_PR_SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url})"
-
-# ---
-
-# OPEN PR COMMENTS
-
-OPEN_PR_METRICS_BASE = "github_open_pr_comment.{key}"
-
-# Caps the number of files that can be modified in a PR to leave a comment
-OPEN_PR_MAX_FILES_CHANGED = 7
-# Caps the number of lines that can be modified in a PR to leave a comment
-OPEN_PR_MAX_LINES_CHANGED = 500
-
-OPEN_PR_COMMENT_BODY_TEMPLATE = """## 🔍 Existing Issues For Review
-Your pull request is modifying functions with the following pre-existing issues:
-
-{issue_tables}
----
-
-<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
-
-OPEN_PR_ISSUE_TABLE_TEMPLATE = """📄 File: **{filename}**
-
-| Function | Unhandled Issue |
-| :------- | :----- |
-{issue_rows}"""
-
-OPEN_PR_ISSUE_TABLE_TOGGLE_TEMPLATE = """<details>
-<summary><b>📄 File: {filename} (Click to Expand)</b></summary>
-
-| Function | Unhandled Issue |
-| :------- | :----- |
-{issue_rows}
-</details>"""
-
-OPEN_PR_ISSUE_ROW_TEMPLATE = "| **`{function_name}`** | [**{title}**]({url}) {subtitle} <br> `Event Count:` **{event_count}** |"
-
-OPEN_PR_ISSUE_DESCRIPTION_LENGTH = 52
-
 # Number of stackframes to check for filename + function combo, starting from the top
 STACKFRAME_COUNT = 6

--- a/src/sentry/tasks/integrations/github/constants.py
+++ b/src/sentry/tasks/integrations/github/constants.py
@@ -1,0 +1,58 @@
+ISSUE_LOCKED_ERROR_MESSAGE = "Unable to create comment because issue is locked."
+
+RATE_LIMITED_MESSAGE = "API rate limit exceeded"
+
+# ---
+
+# MERGED PR COMMENTS
+
+MERGED_PR_METRICS_BASE = "github_pr_comment.{key}"
+
+MERGED_PR_COMMENT_BODY_TEMPLATE = """## Suspect Issues
+This pull request was deployed and Sentry observed the following issues:
+
+{issue_list}
+
+<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
+
+MERGED_PR_SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url})"
+
+# ---
+
+# OPEN PR COMMENTS
+
+OPEN_PR_METRICS_BASE = "github_open_pr_comment.{key}"
+
+# Caps the number of files that can be modified in a PR to leave a comment
+OPEN_PR_MAX_FILES_CHANGED = 7
+# Caps the number of lines that can be modified in a PR to leave a comment
+OPEN_PR_MAX_LINES_CHANGED = 500
+
+OPEN_PR_COMMENT_BODY_TEMPLATE = """## 🔍 Existing Issues For Review
+Your pull request is modifying functions with the following pre-existing issues:
+
+{issue_tables}
+---
+
+<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
+
+OPEN_PR_ISSUE_TABLE_TEMPLATE = """📄 File: **{filename}**
+
+| Function | Unhandled Issue |
+| :------- | :----- |
+{issue_rows}"""
+
+OPEN_PR_ISSUE_TABLE_TOGGLE_TEMPLATE = """<details>
+<summary><b>📄 File: {filename} (Click to Expand)</b></summary>
+
+| Function | Unhandled Issue |
+| :------- | :----- |
+{issue_rows}
+</details>"""
+
+OPEN_PR_ISSUE_ROW_TEMPLATE = "| **`{function_name}`** | [**{title}**]({url}) {subtitle} <br> `Event Count:` **{event_count}** |"
+
+OPEN_PR_ISSUE_DESCRIPTION_LENGTH = 52
+
+# Number of stackframes to check for filename + function combo, starting from the top
+STACKFRAME_COUNT = 6

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -36,6 +36,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.integrations.github.constants import (
+    ISSUE_LOCKED_ERROR_MESSAGE,
     OPEN_PR_COMMENT_BODY_TEMPLATE,
     OPEN_PR_ISSUE_DESCRIPTION_LENGTH,
     OPEN_PR_ISSUE_ROW_TEMPLATE,
@@ -44,19 +45,20 @@ from sentry.tasks.integrations.github.constants import (
     OPEN_PR_MAX_FILES_CHANGED,
     OPEN_PR_MAX_LINES_CHANGED,
     OPEN_PR_METRICS_BASE,
+    RATE_LIMITED_MESSAGE,
     STACKFRAME_COUNT,
 )
 from sentry.tasks.integrations.github.patch_parsers import PATCH_PARSERS
 from sentry.tasks.integrations.github.pr_comment import (
-    ISSUE_LOCKED_ERROR_MESSAGE,
-    RATE_LIMITED_MESSAGE,
     GithubAPIErrorType,
-    PullRequestIssue,
-    create_or_update_comment,
     format_comment_url,
     get_pr_comment,
 )
-from sentry.tasks.integrations.github.utils import PullRequestFile
+from sentry.tasks.integrations.github.utils import (
+    PullRequestFile,
+    PullRequestIssue,
+    create_or_update_comment,
+)
 from sentry.templatetags.sentry_helpers import small_count
 from sentry.types.referrer_ids import GITHUB_OPEN_PR_BOT_REFERRER
 from sentry.utils import metrics

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import itertools
 import logging
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Set, Tuple
 
@@ -36,6 +35,17 @@ from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.base import instrumented_task
+from sentry.tasks.integrations.github.constants import (
+    OPEN_PR_COMMENT_BODY_TEMPLATE,
+    OPEN_PR_ISSUE_DESCRIPTION_LENGTH,
+    OPEN_PR_ISSUE_ROW_TEMPLATE,
+    OPEN_PR_ISSUE_TABLE_TEMPLATE,
+    OPEN_PR_ISSUE_TABLE_TOGGLE_TEMPLATE,
+    OPEN_PR_MAX_FILES_CHANGED,
+    OPEN_PR_MAX_LINES_CHANGED,
+    OPEN_PR_METRICS_BASE,
+    STACKFRAME_COUNT,
+)
 from sentry.tasks.integrations.github.patch_parsers import PATCH_PARSERS
 from sentry.tasks.integrations.github.pr_comment import (
     ISSUE_LOCKED_ERROR_MESSAGE,
@@ -46,6 +56,7 @@ from sentry.tasks.integrations.github.pr_comment import (
     format_comment_url,
     get_pr_comment,
 )
+from sentry.tasks.integrations.github.utils import PullRequestFile
 from sentry.templatetags.sentry_helpers import small_count
 from sentry.types.referrer_ids import GITHUB_OPEN_PR_BOT_REFERRER
 from sentry.utils import metrics
@@ -53,57 +64,14 @@ from sentry.utils.snuba import raw_snql_query
 
 logger = logging.getLogger(__name__)
 
-OPEN_PR_METRICS_BASE = "github_open_pr_comment.{key}"
-
-
-@dataclass
-class PullRequestFile:
-    filename: str
-    patch: str
-
-
-# Caps the number of files that can be modified in a PR to leave a comment
-OPEN_PR_MAX_FILES_CHANGED = 7
-# Caps the number of lines that can be modified in a PR to leave a comment
-OPEN_PR_MAX_LINES_CHANGED = 500
-
-# Number of stackframes to check for filename + function combo, starting from the top
-STACKFRAME_COUNT = 6
-
-COMMENT_BODY_TEMPLATE = """## 🔍 Existing Issues For Review
-Your pull request is modifying functions with the following pre-existing issues:
-
-{issue_tables}
----
-
-<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
-
-ISSUE_TABLE_TEMPLATE = """📄 File: **{filename}**
-
-| Function | Unhandled Issue |
-| :------- | :----- |
-{issue_rows}"""
-
-ISSUE_TABLE_TOGGLE_TEMPLATE = """<details>
-<summary><b>📄 File: {filename} (Click to Expand)</b></summary>
-
-| Function | Unhandled Issue |
-| :------- | :----- |
-{issue_rows}
-</details>"""
-
-ISSUE_ROW_TEMPLATE = "| **`{function_name}`** | [**{title}**]({url}) {subtitle} <br> `Event Count:` **{event_count}** |"
-
-ISSUE_DESCRIPTION_LENGTH = 52
-
 
 def format_open_pr_comment(issue_tables: List[str]) -> str:
-    return COMMENT_BODY_TEMPLATE.format(issue_tables="\n".join(issue_tables))
+    return OPEN_PR_COMMENT_BODY_TEMPLATE.format(issue_tables="\n".join(issue_tables))
 
 
 def format_open_pr_comment_subtitle(title_length, subtitle):
     # the title length + " " + subtitle should be <= 52
-    subtitle_length = ISSUE_DESCRIPTION_LENGTH - title_length - 1
+    subtitle_length = OPEN_PR_ISSUE_DESCRIPTION_LENGTH - title_length - 1
     return subtitle[: subtitle_length - 3] + "..." if len(subtitle) > subtitle_length else subtitle
 
 
@@ -111,7 +79,7 @@ def format_open_pr_comment_subtitle(title_length, subtitle):
 def format_issue_table(diff_filename: str, issues: List[PullRequestIssue], toggle=False) -> str:
     issue_rows = "\n".join(
         [
-            ISSUE_ROW_TEMPLATE.format(
+            OPEN_PR_ISSUE_ROW_TEMPLATE.format(
                 title=issue.title,
                 subtitle=format_open_pr_comment_subtitle(len(issue.title), issue.subtitle),
                 url=format_comment_url(issue.url, GITHUB_OPEN_PR_BOT_REFERRER),
@@ -123,9 +91,11 @@ def format_issue_table(diff_filename: str, issues: List[PullRequestIssue], toggl
     )
 
     if toggle:
-        return ISSUE_TABLE_TOGGLE_TEMPLATE.format(filename=diff_filename, issue_rows=issue_rows)
+        return OPEN_PR_ISSUE_TABLE_TOGGLE_TEMPLATE.format(
+            filename=diff_filename, issue_rows=issue_rows
+        )
 
-    return ISSUE_TABLE_TEMPLATE.format(filename=diff_filename, issue_rows=issue_rows)
+    return OPEN_PR_ISSUE_TABLE_TEMPLATE.format(filename=diff_filename, issue_rows=issue_rows)
 
 
 # for a single file, get the contents

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, List, Optional
+from typing import Any, List
 
 import sentry_sdk
 from django.db import connection
@@ -13,7 +12,6 @@ from sentry_sdk.crons.decorator import monitor
 from snuba_sdk import Column, Condition, Direction, Entity, Function, Op, OrderBy, Query
 from snuba_sdk import Request as SnubaRequest
 
-from sentry.integrations.github.client import GitHubAppsClient
 from sentry.models.group import Group
 from sentry.models.groupowner import GroupOwnerType
 from sentry.models.options.organization_option import OrganizationOption
@@ -28,6 +26,14 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.commit_context import DEBOUNCE_PR_COMMENT_CACHE_KEY
+from sentry.tasks.integrations.github.constants import (
+    ISSUE_LOCKED_ERROR_MESSAGE,
+    MERGED_PR_COMMENT_BODY_TEMPLATE,
+    MERGED_PR_METRICS_BASE,
+    MERGED_PR_SINGLE_ISSUE_TEMPLATE,
+    RATE_LIMITED_MESSAGE,
+)
+from sentry.tasks.integrations.github.utils import PullRequestIssue, create_or_update_comment
 from sentry.types.referrer_ids import GITHUB_PR_BOT_REFERRER
 from sentry.utils import metrics
 from sentry.utils.cache import cache
@@ -36,37 +42,11 @@ from sentry.utils.snuba import raw_snql_query
 
 logger = logging.getLogger(__name__)
 
-MERGED_PR_METRICS_BASE = "github_pr_comment.{key}"
-
-
-@dataclass
-class PullRequestIssue:
-    title: str
-    subtitle: str
-    url: str
-    affected_users: Optional[int] = None
-    event_count: Optional[int] = None
-    function_name: Optional[str] = None
-
 
 class GithubAPIErrorType(Enum):
     RATE_LIMITED = "gh_rate_limited"
     MISSING_PULL_REQUEST = "missing_gh_pull_request"
     UNKNOWN = "unknown_api_error"
-
-
-COMMENT_BODY_TEMPLATE = """## Suspect Issues
-This pull request was deployed and Sentry observed the following issues:
-
-{issue_list}
-
-<sub>Did you find this useful? React with a 👍 or 👎</sub>"""
-
-SINGLE_ISSUE_TEMPLATE = "- ‼️ **{title}** `{subtitle}` [View Issue]({url})"
-
-ISSUE_LOCKED_ERROR_MESSAGE = "Unable to create comment because issue is locked."
-
-RATE_LIMITED_MESSAGE = "API rate limit exceeded"
 
 
 def format_comment_subtitle(subtitle):
@@ -80,7 +60,7 @@ def format_comment_url(url, referrer):
 def format_comment(issues: List[PullRequestIssue]):
     issue_list = "\n".join(
         [
-            SINGLE_ISSUE_TEMPLATE.format(
+            MERGED_PR_SINGLE_ISSUE_TEMPLATE.format(
                 title=issue.title,
                 subtitle=format_comment_subtitle(issue.subtitle),
                 url=format_comment_url(issue.url, GITHUB_PR_BOT_REFERRER),
@@ -89,7 +69,7 @@ def format_comment(issues: List[PullRequestIssue]):
         ]
     )
 
-    return COMMENT_BODY_TEMPLATE.format(issue_list=issue_list)
+    return MERGED_PR_COMMENT_BODY_TEMPLATE.format(issue_list=issue_list)
 
 
 def pr_to_issue_query(pr_id: int):
@@ -153,49 +133,6 @@ def get_pr_comment(pr_id: int, comment_type: int) -> PullRequestComment | None:
         pull_request__id=pr_id, comment_type=comment_type
     )
     return pr_comment_query[0] if pr_comment_query.exists() else None
-
-
-def create_or_update_comment(
-    pr_comment: PullRequestComment | None,
-    client: GitHubAppsClient,
-    repo: Repository,
-    pr_key: int,
-    comment_body: str,
-    pullrequest_id: int,
-    issue_list: List[int],
-    comment_type: int = CommentType.MERGED_PR,
-    metrics_base=MERGED_PR_METRICS_BASE,
-):
-    # client will raise ApiError if the request is not successful
-    if pr_comment is None:
-        resp = client.create_comment(repo=repo.name, issue_id=pr_key, data={"body": comment_body})
-
-        current_time = timezone.now()
-        PullRequestComment.objects.create(
-            external_id=resp.body["id"],
-            pull_request_id=pullrequest_id,
-            created_at=current_time,
-            updated_at=current_time,
-            group_ids=issue_list,
-            comment_type=comment_type,
-        )
-        metrics.incr(metrics_base.format(key="comment_created"))
-    else:
-        resp = client.update_comment(
-            repo=repo.name, comment_id=pr_comment.external_id, data={"body": comment_body}
-        )
-        metrics.incr(metrics_base.format(key="comment_updated"))
-        pr_comment.updated_at = timezone.now()
-        pr_comment.group_ids = issue_list
-        pr_comment.save()
-
-    # TODO(cathy): Figure out a way to track average rate limit left for GH client
-
-    logger_event = metrics_base.format(key="create_or_update_comment")
-    logger.info(
-        logger_event,
-        extra={"new_comment": pr_comment is None, "pr_key": pr_key, "repo": repo.name},
-    )
 
 
 @instrumented_task(

--- a/src/sentry/tasks/integrations/github/utils.py
+++ b/src/sentry/tasks/integrations/github/utils.py
@@ -1,0 +1,72 @@
+import logging
+from dataclasses import dataclass
+from typing import List, Optional
+
+from django.utils import timezone
+
+from sentry.integrations.github.client import GitHubAppsClient
+from sentry.models.pullrequest import CommentType, PullRequestComment
+from sentry.models.repository import Repository
+from sentry.tasks.integrations.github.constants import MERGED_PR_METRICS_BASE
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PullRequestIssue:
+    title: str
+    subtitle: str
+    url: str
+    affected_users: Optional[int] = None
+    event_count: Optional[int] = None
+    function_name: Optional[str] = None
+
+
+@dataclass
+class PullRequestFile:
+    filename: str
+    patch: str
+
+
+def create_or_update_comment(
+    pr_comment: PullRequestComment | None,
+    client: GitHubAppsClient,
+    repo: Repository,
+    pr_key: int,
+    comment_body: str,
+    pullrequest_id: int,
+    issue_list: List[int],
+    comment_type: int = CommentType.MERGED_PR,
+    metrics_base=MERGED_PR_METRICS_BASE,
+):
+    # client will raise ApiError if the request is not successful
+    if pr_comment is None:
+        resp = client.create_comment(repo=repo.name, issue_id=pr_key, data={"body": comment_body})
+
+        current_time = timezone.now()
+        PullRequestComment.objects.create(
+            external_id=resp.body["id"],
+            pull_request_id=pullrequest_id,
+            created_at=current_time,
+            updated_at=current_time,
+            group_ids=issue_list,
+            comment_type=comment_type,
+        )
+        metrics.incr(metrics_base.format(key="comment_created"))
+    else:
+        resp = client.update_comment(
+            repo=repo.name, comment_id=pr_comment.external_id, data={"body": comment_body}
+        )
+        metrics.incr(metrics_base.format(key="comment_updated"))
+        pr_comment.updated_at = timezone.now()
+        pr_comment.group_ids = issue_list
+        pr_comment.save()
+
+    # TODO(cathy): Figure out a way to track average rate limit left for GH client
+
+    logger_event = metrics_base.format(key="create_or_update_comment")
+    logger.info(
+        logger_event,
+        extra={"new_comment": pr_comment is None, "pr_key": pr_key, "repo": repo.name},
+    )

--- a/src/sentry/tasks/integrations/github/utils.py
+++ b/src/sentry/tasks/integrations/github/utils.py
@@ -42,7 +42,9 @@ def create_or_update_comment(
 ):
     # client will raise ApiError if the request is not successful
     if pr_comment is None:
-        resp = client.create_comment(repo=repo.name, issue_id=pr_key, data={"body": comment_body})
+        resp = client.create_comment(
+            repo=repo.name, issue_id=str(pr_key), data={"body": comment_body}
+        )
 
         current_time = timezone.now()
         PullRequestComment.objects.create(

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -645,7 +645,7 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         "sentry.tasks.integrations.github.open_pr_comment.safe_for_comment",
         return_value=[{}],
     )
-    @patch("sentry.tasks.integrations.github.pr_comment.metrics")
+    @patch("sentry.tasks.integrations.github.utils.metrics")
     @responses.activate
     def test_comment_workflow(
         self,
@@ -698,7 +698,7 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         "sentry.tasks.integrations.github.open_pr_comment.safe_for_comment",
         return_value=[{}],
     )
-    @patch("sentry.tasks.integrations.github.pr_comment.metrics")
+    @patch("sentry.tasks.integrations.github.utils.metrics")
     @responses.activate
     def test_comment_workflow_comment_exists(
         self,

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -8,9 +8,8 @@ from sentry.models.group import Group, GroupStatus
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.pullrequest import CommentType, PullRequest, PullRequestComment
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.tasks.integrations.github.constants import STACKFRAME_COUNT
 from sentry.tasks.integrations.github.open_pr_comment import (
-    STACKFRAME_COUNT,
-    PullRequestFile,
     format_issue_table,
     format_open_pr_comment,
     get_issue_table_contents,
@@ -20,7 +19,7 @@ from sentry.tasks.integrations.github.open_pr_comment import (
     open_pr_comment_workflow,
     safe_for_comment,
 )
-from sentry.tasks.integrations.github.pr_comment import PullRequestIssue
+from sentry.tasks.integrations.github.utils import PullRequestFile, PullRequestIssue
 from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -21,7 +21,6 @@ from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.commit_context import DEBOUNCE_PR_COMMENT_CACHE_KEY
 from sentry.tasks.integrations.github.pr_comment import (
-    PullRequestIssue,
     format_comment,
     get_comment_contents,
     get_top_5_issues_by_count,
@@ -29,6 +28,7 @@ from sentry.tasks.integrations.github.pr_comment import (
     github_comment_workflow,
     pr_to_issue_query,
 )
+from sentry.tasks.integrations.github.utils import PullRequestIssue
 from sentry.testutils.cases import IntegrationTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
 from sentry.testutils.silo import region_silo_test

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -344,7 +344,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         self.cache_key = DEBOUNCE_PR_COMMENT_CACHE_KEY(self.pr.id)
 
     @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
-    @patch("sentry.tasks.integrations.github.pr_comment.metrics")
+    @patch("sentry.tasks.integrations.github.utils.metrics")
     @responses.activate
     def test_comment_workflow(self, mock_metrics, mock_issues):
         groups = [g.id for g in Group.objects.all()]
@@ -372,7 +372,7 @@ class TestCommentWorkflow(GithubCommentTestCase):
         mock_metrics.incr.assert_called_with("github_pr_comment.comment_created")
 
     @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")
-    @patch("sentry.tasks.integrations.github.pr_comment.metrics")
+    @patch("sentry.tasks.integrations.github.utils.metrics")
     @responses.activate
     @freeze_time(datetime(2023, 6, 8, 0, 0, 0, tzinfo=timezone.utc))
     def test_comment_workflow_updates_comment(self, mock_metrics, mock_issues):


### PR DESCRIPTION
Refactors the hodgepodge of constants and util functions that used to be in both `pr_comment.py` and `open_pr_comment.py` (and are used in both) into their own consolidated `constants.py` and `utils.py` files.