### PR TITLE
feat(webvitals): adds lcp as an optional component to firefox scores

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -452,10 +452,10 @@ def _get_project_config(
                         },
                         {
                             "measurement": "lcp",
-                            "weight": 0.0,
+                            "weight": 0.30,
                             "p10": 1200.0,
                             "p50": 2400.0,
-                            "optional": False,
+                            "optional": True,
                         },
                         {
                             "measurement": "fid",

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -787,10 +787,10 @@ def test_performance_calculate_score(default_project):
                 },
                 {
                     "measurement": "lcp",
-                    "weight": 0.0,
+                    "weight": 0.3,
                     "p10": 1200.0,
                     "p50": 2400.0,
-                    "optional": False,
+                    "optional": True,
                 },
                 {
                     "measurement": "fid",


### PR DESCRIPTION
Recent firefox versions should now contain lcp (version 122 releasing on 2024-01-23). Adds lcp as an optional component to firefox scores to support old and new versions of firefox.