### PR TITLE
fix(webvitals): makes cls and lcp optional in chrome, edge, and opera

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -410,7 +410,7 @@ def _get_project_config(
                             "weight": 0.30,
                             "p10": 1200.0,
                             "p50": 2400.0,
-                            "optional": False,
+                            "optional": True,
                         },
                         {
                             "measurement": "fid",
@@ -424,7 +424,7 @@ def _get_project_config(
                             "weight": 0.15,
                             "p10": 0.1,
                             "p50": 0.25,
-                            "optional": False,
+                            "optional": True,
                         },
                         {
                             "measurement": "ttfb",
@@ -545,7 +545,7 @@ def _get_project_config(
                             "weight": 0.30,
                             "p10": 1200.0,
                             "p50": 2400.0,
-                            "optional": False,
+                            "optional": True,
                         },
                         {
                             "measurement": "fid",
@@ -559,7 +559,7 @@ def _get_project_config(
                             "weight": 0.15,
                             "p10": 0.1,
                             "p50": 0.25,
-                            "optional": False,
+                            "optional": True,
                         },
                         {
                             "measurement": "ttfb",
@@ -590,7 +590,7 @@ def _get_project_config(
                             "weight": 0.30,
                             "p10": 1200.0,
                             "p50": 2400.0,
-                            "optional": False,
+                            "optional": True,
                         },
                         {
                             "measurement": "fid",
@@ -604,7 +604,7 @@ def _get_project_config(
                             "weight": 0.15,
                             "p10": 0.1,
                             "p50": 0.25,
-                            "optional": False,
+                            "optional": True,
                         },
                         {
                             "measurement": "ttfb",

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -758,7 +758,7 @@ def test_performance_calculate_score(default_project):
             "name": "Chrome",
             "scoreComponents": [
                 {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600, "optional": False},
-                {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": False},
+                {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": True},
                 {
                     "measurement": "fid",
                     "weight": 0.3,
@@ -766,7 +766,7 @@ def test_performance_calculate_score(default_project):
                     "p50": 300,
                     "optional": True,
                 },
-                {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": False},
+                {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
                 {"measurement": "ttfb", "weight": 0.1, "p10": 200, "p50": 400, "optional": False},
             ],
             "condition": {
@@ -857,7 +857,7 @@ def test_performance_calculate_score(default_project):
             "name": "Edge",
             "scoreComponents": [
                 {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600, "optional": False},
-                {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": False},
+                {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": True},
                 {
                     "measurement": "fid",
                     "weight": 0.3,
@@ -865,7 +865,7 @@ def test_performance_calculate_score(default_project):
                     "p50": 300,
                     "optional": True,
                 },
-                {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": False},
+                {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
                 {"measurement": "ttfb", "weight": 0.1, "p10": 200, "p50": 400, "optional": False},
             ],
             "condition": {
@@ -878,7 +878,7 @@ def test_performance_calculate_score(default_project):
             "name": "Opera",
             "scoreComponents": [
                 {"measurement": "fcp", "weight": 0.15, "p10": 900, "p50": 1600, "optional": False},
-                {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": False},
+                {"measurement": "lcp", "weight": 0.3, "p10": 1200, "p50": 2400, "optional": True},
                 {
                     "measurement": "fid",
                     "weight": 0.3,
@@ -886,7 +886,7 @@ def test_performance_calculate_score(default_project):
                     "p50": 300,
                     "optional": True,
                 },
-                {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": False},
+                {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": True},
                 {"measurement": "ttfb", "weight": 0.1, "p10": 200, "p50": 400, "optional": False},
             ],
             "condition": {


### PR DESCRIPTION
Since sdks do not always report LCP and CLS vitals, we can make LCP and CLS optional for chrome, edge, and opera to allow more perf score data.