### PR TITLE
feat(feedback): Poll for new feedbacks, and show a message so people can load them in

### DIFF
--- a/static/app/components/alertLink.tsx
+++ b/static/app/components/alertLink.tsx
@@ -22,7 +22,6 @@ type DefaultProps = {
   openInNewTab: boolean;
   priority: Priority;
   size: Size;
-  system: boolean;
   withoutMarginBottom: boolean;
   href?: string;
 };

--- a/static/app/components/alertLink.tsx
+++ b/static/app/components/alertLink.tsx
@@ -22,6 +22,7 @@ type DefaultProps = {
   openInNewTab: boolean;
   priority: Priority;
   size: Size;
+  system: boolean;
   withoutMarginBottom: boolean;
   href?: string;
 };
@@ -42,6 +43,7 @@ function AlertLink({
   openInNewTab = false,
   to,
   href,
+  system = false,
   ['data-test-id']: dataTestId,
 }: Props) {
   return (
@@ -54,6 +56,7 @@ function AlertLink({
       priority={priority}
       withoutMarginBottom={withoutMarginBottom}
       openInNewTab={openInNewTab}
+      system={system}
     >
       {icon && <IconWrapper>{icon}</IconWrapper>}
       <AlertLinkText>{children}</AlertLinkText>
@@ -79,7 +82,7 @@ const StyledLink = styled(({openInNewTab, to, href, ...props}: StyledLinkProps) 
   background-color: ${p => p.theme.alert[p.priority].backgroundLight};
   color: ${p => p.theme.textColor};
   font-size: ${p => p.theme.fontSizeMedium};
-  border: 1px dashed ${p => p.theme.alert[p.priority].border};
+  border: 1px solid ${p => p.theme.alert[p.priority].border};
   padding: ${p => (p.size === 'small' ? `${space(1)} ${space(1.5)}` : space(2))};
   margin-bottom: ${p => (p.withoutMarginBottom ? 0 : space(3))};
   border-radius: 0.25em;
@@ -89,6 +92,12 @@ const StyledLink = styled(({openInNewTab, to, href, ...props}: StyledLinkProps) 
     outline: none;
     box-shadow: ${p => p.theme.alert[p.priority].border}7f 0 0 0 2px;
   }
+  ${p =>
+    p.system &&
+    `
+      border-width: 0 0 1px 0;
+      border-radius: 0;
+    `}
 `;
 
 const IconWrapper = styled('span')`

--- a/static/app/components/alertLink.tsx
+++ b/static/app/components/alertLink.tsx
@@ -43,7 +43,6 @@ function AlertLink({
   openInNewTab = false,
   to,
   href,
-  system = false,
   ['data-test-id']: dataTestId,
 }: Props) {
   return (
@@ -56,7 +55,6 @@ function AlertLink({
       priority={priority}
       withoutMarginBottom={withoutMarginBottom}
       openInNewTab={openInNewTab}
-      system={system}
     >
       {icon && <IconWrapper>{icon}</IconWrapper>}
       <AlertLinkText>{children}</AlertLinkText>
@@ -82,7 +80,7 @@ const StyledLink = styled(({openInNewTab, to, href, ...props}: StyledLinkProps) 
   background-color: ${p => p.theme.alert[p.priority].backgroundLight};
   color: ${p => p.theme.textColor};
   font-size: ${p => p.theme.fontSizeMedium};
-  border: 1px solid ${p => p.theme.alert[p.priority].border};
+  border: 1px dashed ${p => p.theme.alert[p.priority].border};
   padding: ${p => (p.size === 'small' ? `${space(1)} ${space(1.5)}` : space(2))};
   margin-bottom: ${p => (p.withoutMarginBottom ? 0 : space(3))};
   border-radius: 0.25em;
@@ -92,12 +90,6 @@ const StyledLink = styled(({openInNewTab, to, href, ...props}: StyledLinkProps) 
     outline: none;
     box-shadow: ${p => p.theme.alert[p.priority].border}7f 0 0 0 2px;
   }
-  ${p =>
-    p.system &&
-    `
-      border-width: 0 0 1px 0;
-      border-radius: 0;
-    `}
 `;
 
 const IconWrapper = styled('span')`

--- a/static/app/components/feedback/list/feedbackListHeader.tsx
+++ b/static/app/components/feedback/list/feedbackListHeader.tsx
@@ -1,11 +1,15 @@
 import styled from '@emotion/styled';
 
+import AlertLink from 'sentry/components/alertLink';
 import Checkbox from 'sentry/components/checkbox';
 import decodeMailbox from 'sentry/components/feedback/decodeMailbox';
 import FeedbackListBulkSelection from 'sentry/components/feedback/list/feedbackListBulkSelection';
 import MailboxPicker from 'sentry/components/feedback/list/mailboxPicker';
 import type useListItemCheckboxState from 'sentry/components/feedback/list/useListItemCheckboxState';
-import PanelItem from 'sentry/components/panels/panelItem';
+import useFeedbackCache from 'sentry/components/feedback/useFeedbackCache';
+import useFeedbackHasNewItems from 'sentry/components/feedback/useFeedbackHasNewItems';
+import useFeedbackQueryKeys from 'sentry/components/feedback/useFeedbackQueryKeys';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useUrlParams from 'sentry/utils/useUrlParams';
@@ -36,35 +40,63 @@ export default function FeedbackListHeader({
   });
   const {setParamValue: setMailbox} = useUrlParams('mailbox');
 
+  const {listPrefetchQueryKey, resetListHeadTime} = useFeedbackQueryKeys();
+  const hasNewItems = useFeedbackHasNewItems({listPrefetchQueryKey});
+  const {invalidateListCache} = useFeedbackCache();
+
   return (
-    <HeaderPanelItem>
-      <Checkbox
-        checked={isAllSelected}
-        onChange={() => {
-          if (isAllSelected === true) {
-            deselectAll();
-          } else {
-            selectAll();
-          }
-        }}
-      />
-      {isAnySelected ? (
-        <FeedbackListBulkSelection
-          mailbox={mailbox}
-          countSelected={countSelected}
-          selectedIds={selectedIds}
-          deselectAll={deselectAll}
+    <HeaderPanel>
+      <HeaderPanelItem>
+        <Checkbox
+          checked={isAllSelected}
+          onChange={() => {
+            if (isAllSelected === true) {
+              deselectAll();
+            } else {
+              selectAll();
+            }
+          }}
         />
-      ) : (
-        <MailboxPicker value={mailbox} onChange={setMailbox} />
-      )}
-    </HeaderPanelItem>
+        {isAnySelected ? (
+          <FeedbackListBulkSelection
+            mailbox={mailbox}
+            countSelected={countSelected}
+            selectedIds={selectedIds}
+            deselectAll={deselectAll}
+          />
+        ) : (
+          <MailboxPicker value={mailbox} onChange={setMailbox} />
+        )}
+      </HeaderPanelItem>
+      {hasNewItems ? (
+        <AlertLink
+          system
+          priority="info"
+          size="small"
+          withoutMarginBottom
+          onClick={() => {
+            // Get a new date for polling:
+            resetListHeadTime();
+            // Clear the list cache and let people start over from the newest
+            // data in the list:
+            invalidateListCache();
+          }}
+        >
+          {t('Load new feedback')}
+        </AlertLink>
+      ) : null}
+    </HeaderPanel>
   );
 }
 
-const HeaderPanelItem = styled(PanelItem)`
-  display: flex;
+const HeaderPanel = styled('div')`
+  flex-direction: column;
+  border-bottom: 1px solid ${p => p.theme.innerBorder};
+`;
+
+const HeaderPanelItem = styled('div')`
   padding: ${space(1)} ${space(2)} ${space(1)} ${space(2)};
+  display: flex;
   gap: ${space(1)};
   align-items: center;
 `;

--- a/static/app/components/feedback/list/feedbackListHeader.tsx
+++ b/static/app/components/feedback/list/feedbackListHeader.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import AlertLink from 'sentry/components/alertLink';
+import {Button} from 'sentry/components/button';
 import Checkbox from 'sentry/components/checkbox';
 import decodeMailbox from 'sentry/components/feedback/decodeMailbox';
 import FeedbackListBulkSelection from 'sentry/components/feedback/list/feedbackListBulkSelection';
@@ -9,6 +9,7 @@ import type useListItemCheckboxState from 'sentry/components/feedback/list/useLi
 import useFeedbackCache from 'sentry/components/feedback/useFeedbackCache';
 import useFeedbackHasNewItems from 'sentry/components/feedback/useFeedbackHasNewItems';
 import useFeedbackQueryKeys from 'sentry/components/feedback/useFeedbackQueryKeys';
+import {IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
@@ -41,7 +42,7 @@ export default function FeedbackListHeader({
   const {setParamValue: setMailbox} = useUrlParams('mailbox');
 
   const {listPrefetchQueryKey, resetListHeadTime} = useFeedbackQueryKeys();
-  const hasNewItems = useFeedbackHasNewItems({listPrefetchQueryKey});
+  const hasNewItems = useFeedbackHasNewItems({listPrefetchQueryKey}) || true;
   const {invalidateListCache} = useFeedbackCache();
 
   return (
@@ -69,21 +70,22 @@ export default function FeedbackListHeader({
         )}
       </HeaderPanelItem>
       {hasNewItems ? (
-        <AlertLink
-          system
-          priority="info"
-          size="small"
-          withoutMarginBottom
-          onClick={() => {
-            // Get a new date for polling:
-            resetListHeadTime();
-            // Clear the list cache and let people start over from the newest
-            // data in the list:
-            invalidateListCache();
-          }}
-        >
-          {t('Load new feedback')}
-        </AlertLink>
+        <RefreshContainer>
+          <Button
+            priority="primary"
+            size="xs"
+            icon={<IconRefresh />}
+            onClick={() => {
+              // Get a new date for polling:
+              resetListHeadTime();
+              // Clear the list cache and let people start over from the newest
+              // data in the list:
+              invalidateListCache();
+            }}
+          >
+            {t('Load new feedback')}
+          </Button>
+        </RefreshContainer>
       ) : null}
     </HeaderPanel>
   );
@@ -91,7 +93,6 @@ export default function FeedbackListHeader({
 
 const HeaderPanel = styled('div')`
   flex-direction: column;
-  border-bottom: 1px solid ${p => p.theme.innerBorder};
 `;
 
 const HeaderPanelItem = styled('div')`
@@ -99,4 +100,13 @@ const HeaderPanelItem = styled('div')`
   display: flex;
   gap: ${space(1)};
   align-items: center;
+  border-bottom: 1px solid ${p => p.theme.innerBorder};
+`;
+
+const RefreshContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-grow: 1;
+  padding: ${space(0.5)};
 `;

--- a/static/app/components/feedback/list/useListItemCheckboxState.tsx
+++ b/static/app/components/feedback/list/useListItemCheckboxState.tsx
@@ -52,10 +52,9 @@ interface Return {
 }
 
 export default function useListItemCheckboxState({hits, knownIds}: Props): Return {
-  const {getListQueryKey} = useFeedbackQueryKeys();
+  const {listQueryKey} = useFeedbackQueryKeys();
   const [state, setState] = useState<State>({ids: new Set()});
 
-  const listQueryKey = getListQueryKey();
   useEffect(() => {
     // Reset the state when the list changes
     setState({ids: new Set()});

--- a/static/app/components/feedback/useFeedbackHasNewItems.tsx
+++ b/static/app/components/feedback/useFeedbackHasNewItems.tsx
@@ -3,7 +3,7 @@ import {useEffect, useState} from 'react';
 import {ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
 
 interface Props {
-  listPrefetchQueryKey: ApiQueryKey;
+  listPrefetchQueryKey: ApiQueryKey | undefined;
 }
 
 const POLLING_INTERVAL_MS = 10 * 1000;
@@ -11,10 +11,10 @@ const POLLING_INTERVAL_MS = 10 * 1000;
 export default function useFeedbackHasNewItems({listPrefetchQueryKey}: Props) {
   const [foundData, setFoundData] = useState(false);
 
-  const {data} = useApiQuery<unknown[]>(listPrefetchQueryKey, {
+  const {data} = useApiQuery<unknown[]>(listPrefetchQueryKey ?? [''], {
     refetchInterval: POLLING_INTERVAL_MS,
     staleTime: 0,
-    enabled: !foundData,
+    enabled: listPrefetchQueryKey && !foundData,
   });
 
   useEffect(() => {

--- a/static/app/components/feedback/useFeedbackHasNewItems.tsx
+++ b/static/app/components/feedback/useFeedbackHasNewItems.tsx
@@ -6,7 +6,7 @@ interface Props {
   listPrefetchQueryKey: ApiQueryKey | undefined;
 }
 
-const POLLING_INTERVAL_MS = 10 * 1000;
+const POLLING_INTERVAL_MS = 10_000;
 
 export default function useFeedbackHasNewItems({listPrefetchQueryKey}: Props) {
   const [foundData, setFoundData] = useState(false);

--- a/static/app/components/feedback/useFeedbackHasNewItems.tsx
+++ b/static/app/components/feedback/useFeedbackHasNewItems.tsx
@@ -1,0 +1,31 @@
+import {useEffect, useState} from 'react';
+
+import {ApiQueryKey, useApiQuery} from 'sentry/utils/queryClient';
+
+interface Props {
+  listPrefetchQueryKey: ApiQueryKey;
+}
+
+const POLLING_INTERVAL_MS = 10 * 1000;
+
+export default function useFeedbackHasNewItems({listPrefetchQueryKey}: Props) {
+  const [foundData, setFoundData] = useState(false);
+
+  const {data} = useApiQuery<unknown[]>(listPrefetchQueryKey, {
+    refetchInterval: POLLING_INTERVAL_MS,
+    staleTime: 0,
+    enabled: !foundData,
+  });
+
+  useEffect(() => {
+    // Once we found something, no need to keep polling.
+    setFoundData(Boolean(data?.length));
+  }, [data]);
+
+  useEffect(() => {
+    // New key, start polling again
+    setFoundData(false);
+  }, [listPrefetchQueryKey]);
+
+  return Boolean(data?.length);
+}

--- a/static/app/components/feedback/useFeedbackListQueryKey.tsx
+++ b/static/app/components/feedback/useFeedbackListQueryKey.tsx
@@ -48,6 +48,11 @@ export default function useFeedbackListQueryKey({
     // we remove that from the rest and do not use it to query.
     const {statsPeriod, ...rest} = queryView;
 
+    // Usually we want to fetch starting from `now` and looking back in time.
+    // `prefetch` in this case changes the mode: instead of looking back, we want
+    // to look forward for new data, and fetch it before it's time to render.
+    // Note: The ApiQueryKey that we return isn't actually for a full page of
+    // prefetched data, it's just one row actually.
     if (prefetch) {
       if (!statsPeriod) {
         // We shouldn't prefetch if the query uses an absolute date range

--- a/static/app/components/feedback/useFeedbackListQueryKey.tsx
+++ b/static/app/components/feedback/useFeedbackListQueryKey.tsx
@@ -14,6 +14,7 @@ interface Props {
 }
 
 const PER_PAGE = 25;
+const ONE_DAY_MS = intervalToMilliseconds('1d');
 
 export default function useFeedbackListQueryKey({
   listHeadTime,
@@ -60,7 +61,7 @@ export default function useFeedbackListQueryKey({
       }
       // Look 1 day into the future, from the time the page is loaded for new
       // feedbacks to come in.
-      const intervalMS = intervalToMilliseconds('1d');
+      const intervalMS = ONE_DAY_MS;
       const start = new Date(listHeadTime).toISOString();
       const end = new Date(listHeadTime + intervalMS).toISOString();
       return statsPeriod ? {...rest, limit: 1, start, end} : undefined;

--- a/static/app/components/feedback/useFeedbackQueryKeys.tsx
+++ b/static/app/components/feedback/useFeedbackQueryKeys.tsx
@@ -1,4 +1,4 @@
-import {createContext, ReactNode, useCallback, useContext, useRef} from 'react';
+import {createContext, ReactNode, useCallback, useContext, useRef, useState} from 'react';
 
 import getFeedbackItemQueryKey from 'sentry/components/feedback/getFeedbackItemQueryKey';
 import useFeedbackListQueryKey from 'sentry/components/feedback/useFeedbackListQueryKey';
@@ -14,19 +14,34 @@ type ItemQueryKeys = ReturnType<typeof getFeedbackItemQueryKey>;
 
 interface TContext {
   getItemQueryKeys: (id: string) => ItemQueryKeys;
-  getListQueryKey: () => ListQueryKey;
+  listHeadTime: number;
+  listPrefetchQueryKey: ListQueryKey;
+  listQueryKey: ListQueryKey;
+  resetListHeadTime: () => void;
 }
 
 const EMPTY_ITEM_QUERY_KEYS = {issueQueryKey: undefined, eventQueryKey: undefined};
 
 const DEFAULT_CONTEXT: TContext = {
   getItemQueryKeys: () => EMPTY_ITEM_QUERY_KEYS,
-  getListQueryKey: () => [''],
+  listHeadTime: 0,
+  listPrefetchQueryKey: [''],
+  listQueryKey: [''],
+  resetListHeadTime: () => undefined,
 };
 
 const FeedbackQueryKeysProvider = createContext<TContext>(DEFAULT_CONTEXT);
 
 export function FeedbackQueryKeys({children, organization}: Props) {
+  // The "Head time" is the timestamp of the newest feedback that we can show in
+  // the list (the head element in the array); the same time as when we loaded
+  // the page. It can be updated without loading the page, when we want to see
+  // fresh list items.
+  const [listHeadTime, setHeadTime] = useState(() => Date.now());
+  const resetListHeadTime = useCallback(() => {
+    setHeadTime(Date.now());
+  }, []);
+
   const itemQueryKeyRef = useRef<Map<string, ItemQueryKeys>>(new Map());
   const getItemQueryKeys = useCallback(
     (feedbackId: string) => {
@@ -41,14 +56,25 @@ export function FeedbackQueryKeys({children, organization}: Props) {
     [organization]
   );
 
-  const listQueryKey = useFeedbackListQueryKey({organization});
-  const getListQueryKey = useCallback(() => listQueryKey, [listQueryKey]);
+  const listQueryKey = useFeedbackListQueryKey({
+    listHeadTime,
+    organization,
+    prefetch: false,
+  });
+  const listPrefetchQueryKey = useFeedbackListQueryKey({
+    listHeadTime,
+    organization,
+    prefetch: true,
+  });
 
   return (
     <FeedbackQueryKeysProvider.Provider
       value={{
         getItemQueryKeys,
-        getListQueryKey,
+        listHeadTime,
+        listPrefetchQueryKey,
+        listQueryKey,
+        resetListHeadTime,
       }}
     >
       {children}

--- a/static/app/components/feedback/useFeedbackQueryKeys.tsx
+++ b/static/app/components/feedback/useFeedbackQueryKeys.tsx
@@ -1,4 +1,5 @@
 import {createContext, ReactNode, useCallback, useContext, useRef, useState} from 'react';
+import invariant from 'invariant';
 
 import getFeedbackItemQueryKey from 'sentry/components/feedback/getFeedbackItemQueryKey';
 import useFeedbackListQueryKey from 'sentry/components/feedback/useFeedbackListQueryKey';
@@ -16,7 +17,7 @@ interface TContext {
   getItemQueryKeys: (id: string) => ItemQueryKeys;
   listHeadTime: number;
   listPrefetchQueryKey: ListQueryKey;
-  listQueryKey: ListQueryKey;
+  listQueryKey: NonNullable<ListQueryKey>;
   resetListHeadTime: () => void;
 }
 
@@ -61,6 +62,8 @@ export function FeedbackQueryKeys({children, organization}: Props) {
     organization,
     prefetch: false,
   });
+  invariant(listQueryKey, 'listQueryKey cannot be nullable when prefetch=false');
+
   const listPrefetchQueryKey = useFeedbackListQueryKey({
     listHeadTime,
     organization,

--- a/static/app/components/feedback/useFetchFeedbackInfiniteListData.tsx
+++ b/static/app/components/feedback/useFetchFeedbackInfiniteListData.tsx
@@ -35,8 +35,8 @@ function uniqueIssues(issues: FeedbackIssueList) {
 }
 
 export default function useFetchFeedbackInfiniteListData() {
-  const {getListQueryKey} = useFeedbackQueryKeys();
-  const queryKey = getListQueryKey();
+  const {listQueryKey} = useFeedbackQueryKeys();
+
   const {
     data,
     error,
@@ -48,7 +48,7 @@ export default function useFetchFeedbackInfiniteListData() {
     isFetchingPreviousPage,
     isLoading, // If anything is loaded yet
   } = useInfiniteApiQuery<FeedbackIssueList>({
-    queryKey,
+    queryKey: listQueryKey,
   });
 
   const issues = useMemo(

--- a/static/app/components/feedback/useMutateFeedback.tsx
+++ b/static/app/components/feedback/useMutateFeedback.tsx
@@ -22,7 +22,7 @@ export default function useMutateFeedback({feedbackIds, organization}: Props) {
   const api = useApi({
     persistInFlight: false,
   });
-  const {getListQueryKey} = useFeedbackQueryKeys();
+  const {listQueryKey} = useFeedbackQueryKeys();
   const {updateCached, invalidateCached} = useFeedbackCache();
 
   const mutation = useMutation<TData, TError, TVariables, TContext>({
@@ -41,7 +41,7 @@ export default function useMutateFeedback({feedbackIds, organization}: Props) {
       const options = isSingleId
         ? {}
         : ids === 'all'
-        ? getListQueryKey()[1]!
+        ? listQueryKey[1]!
         : {query: {id: ids}};
       return fetchMutation(api)(['PUT', url, options, payload]);
     },


### PR DESCRIPTION
This PR adds code that polls in the background, every 30second when the feedback page is open, to see if there are newer feedbacks available.

Polling disables itself once it discovers that one new item is available (we're not asking for a count of new things). 
Polling won't start if the user picks an absolute date range.

The purple button takes up it's own row. So when it first appears the list will get a little shorter, and the list items will not scroll 'behind' it, no overlapping.

Clicking the button will reset the `listHeadTime` timestamp, then evict the list cache. Using the new `listHeadTime` a new 1st page will be fetched. If you had previously scrolled down a bunch and loaded in all that data.. it will be re-fetched as you scroll down again.

<img width="436" alt="SCR-20240119-mqvb" src="https://github.com/getsentry/sentry/assets/187460/18dba9bd-2389-48f0-aaf5-a2ff4aa3d363">

Fixes https://github.com/getsentry/sentry/issues/61474