### PR TITLE
fix(perf): Generate instrumentation gap spans before spans groups

### DIFF
--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -482,6 +482,18 @@ class SpanTreeModel {
                 endTimestamp: spanModel.span.timestamp,
               });
 
+              const gapSpan = this.generateSpanGap(
+                group[0].span,
+                event,
+                acc.previousSiblingEndTimestamp,
+                treeDepth + 1,
+                continuingTreeDepths
+              );
+
+              if (gapSpan) {
+                acc.descendants.push(gapSpan);
+              }
+
               acc.previousSiblingEndTimestamp = spanModel.span.timestamp;
 
               // It's possible that a section in the minimap is selected so some spans in this group may be out of view
@@ -526,6 +538,18 @@ class SpanTreeModel {
             })
           );
           return acc;
+        }
+
+        const gapSpan = this.generateSpanGap(
+          group[0].span,
+          event,
+          acc.previousSiblingEndTimestamp,
+          treeDepth + 1,
+          continuingTreeDepths
+        );
+
+        if (gapSpan) {
+          acc.descendants.push(gapSpan);
         }
 
         // Since the group is not expanded, return a singular grouped span bar

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -149,6 +149,7 @@ class SpanTreeModel {
   };
 
   generateSpanGap(
+    span: SpanType,
     event: Readonly<EventTransaction | AggregateEventTransaction>,
     previousSiblingEndTimestamp: number | undefined,
     treeDepth: number,
@@ -161,9 +162,9 @@ class SpanTreeModel {
     const isValidGap =
       shouldIncludeGap &&
       typeof previousSiblingEndTimestamp === 'number' &&
-      previousSiblingEndTimestamp < this.span.start_timestamp &&
+      previousSiblingEndTimestamp < span.start_timestamp &&
       // gap is at least 100 ms
-      this.span.start_timestamp - previousSiblingEndTimestamp >= 0.1;
+      span.start_timestamp - previousSiblingEndTimestamp >= 0.1;
     if (!isValidGap) {
       return undefined;
     }
@@ -172,10 +173,10 @@ class SpanTreeModel {
       type: 'gap',
       span: {
         type: 'gap',
-        start_timestamp: previousSiblingEndTimestamp || this.span.start_timestamp,
-        timestamp: this.span.start_timestamp, // this is essentially end_timestamp
+        start_timestamp: previousSiblingEndTimestamp || span.start_timestamp,
+        timestamp: span.start_timestamp, // this is essentially end_timestamp
         description: t('Missing span instrumentation'),
-        isOrphan: isOrphanSpan(this.span),
+        isOrphan: isOrphanSpan(span),
       },
       numOfSpanChildren: 0,
       treeDepth,
@@ -669,6 +670,7 @@ class SpanTreeModel {
     }
 
     const gapSpan = this.generateSpanGap(
+      this.span,
       event,
       previousSiblingEndTimestamp,
       treeDepth,


### PR DESCRIPTION
There's a bug in the span waterfall model in which if there's a long gap between a span and a _span group_, we don't show a "Missing span instrumentation" span! As far as I can tell, this is due to a small gap (ha) in logic. I went through and made sure that we also calculate gaps before creating a collapsed span group, and before an expanded span group.

**e.g.,**
![Screenshot 2024-01-19 at 3 23 17 PM](https://github.com/getsentry/sentry/assets/989898/f054d5b9-2f13-422d-b31d-b0b0c71ec35d)
