### PR TITLE
ref(AlertLink): Update AlertLink border style to match Alert, and add `system` style

### DIFF
--- a/static/app/components/alertLink.stories.tsx
+++ b/static/app/components/alertLink.stories.tsx
@@ -73,6 +73,19 @@ export default storyBook(AlertLink, story => {
     );
   });
 
+  story('system', () => {
+    return (
+      <Fragment>
+        <p>
+          The <JSXProperty name="system" value /> prop is a boolean that's{' '}
+          <code>false</code> by default.
+        </p>
+        <AlertLink>The default style.</AlertLink>
+        <AlertLink system>This is in the system style.</AlertLink>
+      </Fragment>
+    );
+  });
+
   story('withoutMarginBottom', () => {
     return (
       <Fragment>

--- a/static/app/components/alertLink.tsx
+++ b/static/app/components/alertLink.tsx
@@ -22,9 +22,9 @@ type DefaultProps = {
   openInNewTab: boolean;
   priority: Priority;
   size: Size;
-  system: boolean;
   withoutMarginBottom: boolean;
   href?: string;
+  system?: boolean;
 };
 
 type Props = OtherProps & Partial<DefaultProps> & Partial<Pick<LinkProps, 'to'>>;

--- a/static/app/components/alertLink.tsx
+++ b/static/app/components/alertLink.tsx
@@ -22,6 +22,7 @@ type DefaultProps = {
   openInNewTab: boolean;
   priority: Priority;
   size: Size;
+  system: boolean;
   withoutMarginBottom: boolean;
   href?: string;
 };
@@ -38,6 +39,7 @@ function AlertLink({
   icon,
   children,
   onClick,
+  system = false,
   withoutMarginBottom = false,
   openInNewTab = false,
   to,
@@ -52,6 +54,7 @@ function AlertLink({
       onClick={onClick}
       size={size}
       priority={priority}
+      system={system}
       withoutMarginBottom={withoutMarginBottom}
       openInNewTab={openInNewTab}
     >
@@ -79,7 +82,7 @@ const StyledLink = styled(({openInNewTab, to, href, ...props}: StyledLinkProps) 
   background-color: ${p => p.theme.alert[p.priority].backgroundLight};
   color: ${p => p.theme.textColor};
   font-size: ${p => p.theme.fontSizeMedium};
-  border: 1px dashed ${p => p.theme.alert[p.priority].border};
+  border: 1px solid ${p => p.theme.alert[p.priority].border};
   padding: ${p => (p.size === 'small' ? `${space(1)} ${space(1.5)}` : space(2))};
   margin-bottom: ${p => (p.withoutMarginBottom ? 0 : space(3))};
   border-radius: 0.25em;
@@ -89,6 +92,13 @@ const StyledLink = styled(({openInNewTab, to, href, ...props}: StyledLinkProps) 
     outline: none;
     box-shadow: ${p => p.theme.alert[p.priority].border}7f 0 0 0 2px;
   }
+
+  ${p =>
+    p.system &&
+    `
+      border-width: 0 0 1px 0;
+      border-radius: 0;
+    `}
 `;
 
 const IconWrapper = styled('span')`

--- a/static/app/components/alertLink.tsx
+++ b/static/app/components/alertLink.tsx
@@ -69,14 +69,16 @@ function AlertLink({
 
 export default AlertLink;
 
-const StyledLink = styled(({openInNewTab, to, href, ...props}: StyledLinkProps) => {
-  const linkProps = omit(props, ['withoutMarginBottom', 'priority', 'size']);
-  if (href) {
-    return <ExternalLink {...linkProps} href={href} openInNewTab={openInNewTab} />;
-  }
+const StyledLink = styled(
+  ({openInNewTab, to, href, system: _, ...props}: StyledLinkProps) => {
+    const linkProps = omit(props, ['withoutMarginBottom', 'priority', 'size']);
+    if (href) {
+      return <ExternalLink {...linkProps} href={href} openInNewTab={openInNewTab} />;
+    }
 
-  return <Link {...linkProps} to={to || ''} />;
-})`
+    return <Link {...linkProps} to={to || ''} />;
+  }
+)`
   display: flex;
   align-items: center;
   background-color: ${p => p.theme.alert[p.priority].backgroundLight};


### PR DESCRIPTION
Before:
<img width="537" alt="SCR-20240119-lltj" src="https://github.com/getsentry/sentry/assets/187460/d4f57224-cba5-488f-9522-c2a2cab71144">

After:
<img width="528" alt="SCR-20240119-llkw" src="https://github.com/getsentry/sentry/assets/187460/230c7d01-280c-4e5e-a5d0-59e5fae81385">
