### PR TITLE
fix: remove lodash/mean usage

### DIFF
--- a/static/app/utils/sessions.tsx
+++ b/static/app/utils/sessions.tsx
@@ -1,6 +1,5 @@
 import {Theme} from '@emotion/react';
 import compact from 'lodash/compact';
-import mean from 'lodash/mean';
 import moment from 'moment';
 
 import {
@@ -327,8 +326,8 @@ export function filterSessionsInTimeWindow(
   });
 
   const groups = sessions.groups.map(group => {
-    const series = {};
-    const totals = {};
+    const series: Record<string, number[]> = {};
+    const totals: Record<string, number> = {};
     Object.keys(group.series).forEach(field => {
       totals[field] = 0;
       series[field] = group.series[field].filter((value, index) => {
@@ -340,7 +339,9 @@ export function filterSessionsInTimeWindow(
         return isBetween;
       });
       if (field.startsWith('p50')) {
-        totals[field] = mean(series[field]);
+        // Calculate the mean of the current field.
+        const base = series[field] ?? [];
+        totals[field] = base.reduce((acc, curr) => acc + curr, 0) / base.length;
       }
       if (field.startsWith('count_unique')) {
         // E.g. users


### PR DESCRIPTION
Lodash/mean implementation lives in: https://github.com/lodash/lodash/blob/main/src/meanBy.ts

Ref: https://github.com/getsentry/frontend-tsc/issues/55