### PR TITLE
fix: avoid using lodash/uniq

### DIFF
--- a/static/app/components/events/eventErrors.tsx
+++ b/static/app/components/events/eventErrors.tsx
@@ -1,7 +1,6 @@
 import {useEffect} from 'react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
-import uniq from 'lodash/uniq';
 import uniqWith from 'lodash/uniqWith';
 
 import {Alert} from 'sentry/components/alert';
@@ -24,6 +23,7 @@ import {Image} from 'sentry/types/debugImage';
 import {EntryType, Event, ExceptionValue, Thread} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {uniq} from 'sentry/utils/array/uniq';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {semverCompare} from 'sentry/utils/versions';

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
-import uniq from 'lodash/uniq';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -17,6 +16,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Integration, Organization, Project} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {uniq} from 'sentry/utils/array/uniq';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 
@@ -51,7 +51,7 @@ function StacktraceLinkModal({
   const [error, setError] = useState<null | string>(null);
   const [sourceCodeInput, setSourceCodeInput] = useState('');
 
-  const {data: sugestedCodeMappings} = useApiQuery<DerivedCodeMapping[]>(
+  const {data: suggestedCodeMappings} = useApiQuery<DerivedCodeMapping[]>(
     [
       `/organizations/${organization.slug}/derive-code-mappings/`,
       {
@@ -70,7 +70,7 @@ function StacktraceLinkModal({
   );
 
   const suggestions = uniq(
-    (sugestedCodeMappings ?? []).map(suggestion => {
+    suggestedCodeMappings?.map(suggestion => {
       return `https://github.com/${suggestion.repo_name}/blob/${suggestion.repo_branch}/${suggestion.filename}`;
     })
   ).slice(0, 2);

--- a/static/app/components/events/interfaces/request/graphQlRequestBody.tsx
+++ b/static/app/components/events/interfaces/request/graphQlRequestBody.tsx
@@ -1,7 +1,6 @@
 import {useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
-import uniq from 'lodash/uniq';
 import Prism from 'prismjs';
 
 import Alert from 'sentry/components/alert';
@@ -11,6 +10,7 @@ import {t, tn} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {EntryRequestDataGraphQl, Event} from 'sentry/types';
 import {defined} from 'sentry/utils';
+import {uniq} from 'sentry/utils/array/uniq';
 import {loadPrismLanguage} from 'sentry/utils/prism';
 
 type GraphQlBodyProps = {data: EntryRequestDataGraphQl['data']; event: Event};

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -1,12 +1,12 @@
 import {css, Theme, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import uniq from 'lodash/uniq';
 
 import BreadcrumbItem from 'sentry/components/replays/breadcrumbs/breadcrumbItem';
 import * as Timeline from 'sentry/components/replays/breadcrumbs/timeline';
 import {getFramesByColumn} from 'sentry/components/replays/utils';
 import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
+import {uniq} from 'sentry/utils/array/uniq';
 import getFrameDetails from 'sentry/utils/replays/getFrameDetails';
 import useActiveReplayTab from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';

--- a/static/app/utils/api/useAggregatedQueryKeys.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.tsx
@@ -1,8 +1,8 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import uniq from 'lodash/uniq';
 
 import {ApiResult} from 'sentry/api';
 import {defined} from 'sentry/utils';
+import {uniq} from 'sentry/utils/array/uniq';
 import {ApiQueryKey, fetchDataQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 

--- a/static/app/utils/array/uniq.spec.ts
+++ b/static/app/utils/array/uniq.spec.ts
@@ -1,0 +1,11 @@
+import {uniq} from 'sentry/utils/array/uniq';
+
+describe('uniq', () => {
+  it('should return unique elements', () => {
+    expect(uniq([1, 3, 5, 3])).toStrictEqual([1, 3, 5]);
+  });
+
+  it('should return empty array for undefined input', () => {
+    expect(uniq(undefined)).toStrictEqual([]);
+  });
+});

--- a/static/app/utils/array/uniq.ts
+++ b/static/app/utils/array/uniq.ts
@@ -1,0 +1,6 @@
+/**
+ * Returns unique values of the given array.
+ */
+export function uniq<T = unknown>(items: T[] | undefined): T[] {
+  return [...new Set(items)];
+}

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -1,5 +1,3 @@
-import uniq from 'lodash/uniq';
-
 import {SymbolicatorStatus} from 'sentry/components/events/interfaces/types';
 import ConfigStore from 'sentry/stores/configStore';
 import {
@@ -20,6 +18,7 @@ import {
 import {EntryType, Event, ExceptionValue, Thread} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 import type {BaseEventAnalyticsParams} from 'sentry/utils/analytics/workflowAnalyticsEvents';
+import {uniq} from 'sentry/utils/array/uniq';
 import {getDaysSinceDatePrecise} from 'sentry/utils/getDaysSinceDate';
 import {isMobilePlatform, isNativePlatform} from 'sentry/utils/platform';
 import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
@@ -208,7 +207,7 @@ export function getShortEventId(eventId: string) {
  * Returns a comma delineated list of errors
  */
 function getEventErrorString(event: Event) {
-  return uniq(event.errors?.map(error => error.type)).join(',') || '';
+  return uniq(event.errors?.map(error => error.type)).join(',');
 }
 
 function hasTrace(event: Event) {

--- a/static/app/views/alerts/list/rules/alertRulesList.tsx
+++ b/static/app/views/alerts/list/rules/alertRulesList.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import uniq from 'lodash/uniq';
 
 import {
   addErrorMessage,
@@ -20,6 +19,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
+import {uniq} from 'sentry/utils/array/uniq';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import Projects from 'sentry/utils/projects';
 import {

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
-import uniq from 'lodash/uniq';
 
 import {bulkDelete, bulkUpdate, mergeGroups} from 'sentry/actionCreators/group';
 import {Alert} from 'sentry/components/alert';
@@ -13,6 +12,7 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
 import {Group, PageFilters} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {uniq} from 'sentry/utils/array/uniq';
 import theme from 'sentry/utils/theme';
 import useApi from 'sentry/utils/useApi';
 import useMedia from 'sentry/utils/useMedia';

--- a/static/app/views/organizationStats/teamInsights/controls.tsx
+++ b/static/app/views/organizationStats/teamInsights/controls.tsx
@@ -3,7 +3,6 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {LocationDescriptorObject} from 'history';
 import pick from 'lodash/pick';
-import uniq from 'lodash/uniq';
 import moment from 'moment';
 
 import SelectControl from 'sentry/components/forms/controls/selectControl';
@@ -12,6 +11,7 @@ import {ChangeData, TimeRangeSelector} from 'sentry/components/timeRangeSelector
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {DateString, TeamWithProjects} from 'sentry/types';
+import {uniq} from 'sentry/utils/array/uniq';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import localStorage from 'sentry/utils/localStorage';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -125,9 +125,9 @@ function TeamStatsControls({
   }
 
   const {period, start, end, utc} = dataDatetime(query);
-  const environmentOptions = uniq(
-    projects.map(project => project.environments).flat()
-  ).map(env => ({label: env, value: env}));
+  const environmentOptions = uniq(projects.flatMap(project => project.environments)).map(
+    env => ({label: env, value: env})
+  );
 
   return (
     <ControlsWrapper showEnvironment={showEnvironment}>

--- a/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
@@ -1,6 +1,6 @@
 import {RefObject, useCallback, useMemo, useRef} from 'react';
-import uniq from 'lodash/uniq';
 
+import {uniq} from 'sentry/utils/array/uniq';
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import useFiltersInLocationQuery from 'sentry/utils/replays/hooks/useFiltersInLocationQuery';
 import {getFrameOpOrCategory, ReplayFrame} from 'sentry/utils/replays/types';

--- a/static/app/views/replays/detail/perfTable/usePerfFilters.tsx
+++ b/static/app/views/replays/detail/perfTable/usePerfFilters.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useMemo} from 'react';
-import uniq from 'lodash/uniq';
 
 import type {SelectOption} from 'sentry/components/compactSelect';
+import {uniq} from 'sentry/utils/array/uniq';
 import {decodeList} from 'sentry/utils/queryString';
 import useFiltersInLocationQuery from 'sentry/utils/replays/hooks/useFiltersInLocationQuery';
 import {getFrameOpOrCategory} from 'sentry/utils/replays/types';

--- a/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
@@ -5,7 +5,6 @@ import debounce from 'lodash/debounce';
 import flatten from 'lodash/flatten';
 import groupBy from 'lodash/groupBy';
 import startCase from 'lodash/startCase';
-import uniq from 'lodash/uniq';
 import * as qs from 'query-string';
 
 import DocIntegrationAvatar from 'sentry/components/avatar/docIntegrationAvatar';
@@ -30,6 +29,7 @@ import {
   SentryApp,
   SentryAppInstallation,
 } from 'sentry/types';
+import {uniq} from 'sentry/utils/array/uniq';
 import {createFuzzySearch, Fuse} from 'sentry/utils/fuzzySearch';
 import {
   getAlertText,

--- a/static/app/views/settings/project/projectOwnership/modal.tsx
+++ b/static/app/views/settings/project/projectOwnership/modal.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
-import uniq from 'lodash/uniq';
 
 import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -9,6 +8,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import {space} from 'sentry/styles/space';
 import {Frame, Organization, Project, TagWithTopValues} from 'sentry/types';
 import type {Event} from 'sentry/types/event';
+import {uniq} from 'sentry/utils/array/uniq';
 import {safeURL} from 'sentry/utils/url/safeURL';
 import OwnerInput from 'sentry/views/settings/project/projectOwnership/ownerInput';
 

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -4,10 +4,10 @@ import {Location} from 'history';
 import debounce from 'lodash/debounce';
 import flatten from 'lodash/flatten';
 import omit from 'lodash/omit';
-import uniq from 'lodash/uniq';
 
 import SelectControl from 'sentry/components/forms/controls/selectControl';
 import {t} from 'sentry/locale';
+import {uniq} from 'sentry/utils/array/uniq';
 import EventView from 'sentry/utils/discover/eventView';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';


### PR DESCRIPTION
Removes the usage of `lodash/uniq` and replaces it with `[...Set(input)]`

Ref: https://github.com/getsentry/frontend-tsc/issues/55