### PR TITLE
chore(hybrid-cloud): Smaller timeout value for Integration Proxy client

### DIFF
--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -54,6 +54,10 @@ class BaseApiClient(TrackResponseMixin):
 
     integration_name: str
 
+    # Timeout for both the connect and the read timeouts.
+    # See: https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
+    timeout: int = 30
+
     def __init__(
         self,
         integration_id: int | None = None,
@@ -190,7 +194,7 @@ class BaseApiClient(TrackResponseMixin):
             allow_redirects = method.upper() == "GET"
 
         if timeout is None:
-            timeout = 30
+            timeout = self.timeout
 
         full_url = self.build_url(path)
 

--- a/src/sentry/shared_integrations/client/proxy.py
+++ b/src/sentry/shared_integrations/client/proxy.py
@@ -125,6 +125,12 @@ class IntegrationProxyClient(ApiClient):
         self.org_integration_id = org_integration_id
         self.keyid = keyid
 
+        # The default timeout value for the APIClient and the RegionSiloClient is 30 seconds.
+        # If the request flow for processing a Webhook outbox message is between the RegionSiloClient and the
+        # IntegrationProxyClient, then the IntegrationProxyClient will need to have a smaller timeout value.
+        # Otherwise, the RegionSiloClient will timeout before it can receive a response from the IntegrationProxyClient.
+        self.timeout = 20
+
         if self.determine_whether_should_proxy_to_control():
             self._should_proxy_to_control = True
             self.proxy_url = get_proxy_url()

--- a/tests/sentry/shared_integrations/client/test_base.py
+++ b/tests/sentry/shared_integrations/client/test_base.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import responses
 from pytest import raises
@@ -72,3 +72,14 @@ class BaseApiClientTest(TestCase):
         with raises(ApiHostError):
             self.api_client.get("https://172.31.255.255")
         assert mock_finalize_request.called
+
+
+    @patch.object(Session, "send")
+    def test_default_timeout(self, mock_session_send):
+        response = MagicMock()
+        response.status_code = 204
+        mock_session_send.return_value = response
+
+        self.api_client.get("https://172.31.255.255")
+        assert mock_session_send.call_count == 1
+        assert mock_session_send.mock_calls[0].kwargs['timeout'] == 30

--- a/tests/sentry/shared_integrations/client/test_base.py
+++ b/tests/sentry/shared_integrations/client/test_base.py
@@ -73,7 +73,6 @@ class BaseApiClientTest(TestCase):
             self.api_client.get("https://172.31.255.255")
         assert mock_finalize_request.called
 
-
     @patch.object(Session, "send")
     def test_default_timeout(self, mock_session_send):
         response = MagicMock()
@@ -82,4 +81,4 @@ class BaseApiClientTest(TestCase):
 
         self.api_client.get("https://172.31.255.255")
         assert mock_session_send.call_count == 1
-        assert mock_session_send.mock_calls[0].kwargs['timeout'] == 30
+        assert mock_session_send.mock_calls[0].kwargs["timeout"] == 30

--- a/tests/sentry/shared_integrations/client/test_proxy.py
+++ b/tests/sentry/shared_integrations/client/test_proxy.py
@@ -173,7 +173,7 @@ class IntegrationProxyClientTest(TestCase):
 
         client.get(f"{self.base_url}/some/endpoint", params={"query": 1, "user": "me"})
         assert mock_session_send.call_count == 1
-        assert mock_session_send.mock_calls[0].kwargs['timeout'] == 20
+        assert mock_session_send.mock_calls[0].kwargs["timeout"] == 20
 
 
 def test_get_control_silo_ip_address():

--- a/tests/sentry/shared_integrations/client/test_proxy.py
+++ b/tests/sentry/shared_integrations/client/test_proxy.py
@@ -5,6 +5,7 @@ from django.test import override_settings
 from pytest import raises
 from requests import Request
 
+from sentry.net.http import Session
 from sentry.shared_integrations.client.proxy import (
     IntegrationProxyClient,
     get_control_silo_ip_address,
@@ -162,6 +163,17 @@ class IntegrationProxyClientTest(TestCase):
         # Assert control silo ip address was not validated
         assert mock_get_control_silo_ip_address.call_count == 0
         assert mock_is_control_silo_ip_address.call_count == 0
+
+    @patch.object(Session, "send")
+    def test_custom_timeout(self, mock_session_send):
+        client = self.client_cls(org_integration_id=self.oi_id)
+        response = MagicMock()
+        response.status_code = 204
+        mock_session_send.return_value = response
+
+        client.get(f"{self.base_url}/some/endpoint", params={"query": 1, "user": "me"})
+        assert mock_session_send.call_count == 1
+        assert mock_session_send.mock_calls[0].kwargs['timeout'] == 20
 
 
 def test_get_control_silo_ip_address():


### PR DESCRIPTION
There may be a race condition between `RegionSiloClient` and `IntegrationProxyClient` when they both timeout at 30 seconds. Specifically, the `RegionSiloClient` will timeout before it can receive an http response from the integration endpoint that wraps an `IntegrationProxyClient`.

Here, I'm making the `IntegrationProxyClient` timeout smaller so that the integration endpoint can have an opportunity to respond back to the `RegionSiloClient` within the 30 second timeout window.