### PR TITLE
fix: avoid using lodash/flatten and lodash/flattenDepth

### DIFF
--- a/static/app/actionCreators/formSearch.tsx
+++ b/static/app/actionCreators/formSearch.tsx
@@ -1,5 +1,3 @@
-import flatten from 'lodash/flatten';
-
 import {Field, JsonFormObject} from 'sentry/components/forms/types';
 import FormSearchStore, {FormSearchField} from 'sentry/stores/formSearchStore';
 
@@ -43,32 +41,28 @@ export function loadSearchMap() {
   const context = require.context('../data/forms', true, /\.tsx?$/);
 
   // Get a list of all form fields defined in `../data/forms`
-  const allFormFields = flatten(
-    context
-      .keys()
-      .map(key => {
-        const mod = context(key);
+  const allFormFields: FormSearchField[] = context.keys().flatMap(key => {
+    const mod = context(key);
 
-        // Since we're dynamically importing an entire directly, there could be malformed modules defined?
-        if (!mod) {
-          return null;
-        }
-        // Only look for module that have `route` exported
-        if (!mod.route) {
-          return null;
-        }
+    // Since we're dynamically importing an entire directly, there could be malformed modules defined?
+    // Only look for module that have `route` exported
+    if (!mod?.route) {
+      return [];
+    }
 
-        return createSearchMap({
-          // `formGroups` can be a default export or a named export :<
-          formGroups: mod.default || mod.formGroups,
-          fields: mod.fields,
-          route: mod.route,
-        });
-      })
-      .filter(function (i): i is FormSearchField[] {
-        return i !== null;
-      })
-  );
+    const searchMap = createSearchMap({
+      // `formGroups` can be a default export or a named export :<
+      formGroups: mod.default || mod.formGroups,
+      fields: mod.fields,
+      route: mod.route,
+    });
+
+    if (searchMap !== null) {
+      return searchMap;
+    }
+
+    return [];
+  });
 
   FormSearchStore.loadSearchMap(allFormFields);
 }

--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -6,7 +6,7 @@ import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilte
 import {t} from 'sentry/locale';
 import AlertStore from 'sentry/stores/alertStore';
 import TagStore from 'sentry/stores/tagStore';
-import {PageFilters, Tag} from 'sentry/types';
+import {PageFilters, Tag, TagValue} from 'sentry/types';
 
 const MAX_TAGS = 1000;
 
@@ -106,7 +106,7 @@ export function fetchTagValues({
   projectIds?: string[];
   search?: string;
   sort?: string;
-}) {
+}): Promise<TagValue[]> {
   const url = `/organizations/${orgSlug}/tags/${tagKey}/values/`;
 
   const query: Query = {};

--- a/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/useSourceMapDebug.tsx
@@ -1,4 +1,3 @@
-import flatten from 'lodash/flatten';
 import uniqBy from 'lodash/uniqBy';
 
 import type {ExceptionValue, Frame, Organization} from 'sentry/types';
@@ -173,25 +172,23 @@ export function getUniqueFilesFromException(
   excValues: ExceptionValue[],
   props: Omit<UseSourceMapDebugProps, 'frameIdx' | 'exceptionIdx'>
 ): StacktraceFilenameQuery[] {
-  const fileFrame = flatten(
-    excValues.map((excValue, exceptionIdx) => {
-      return (excValue.stacktrace?.frames || [])
-        .map<[Frame, number]>((frame, idx) => [frame, idx])
-        .filter(
-          ([frame]) =>
-            // Only debug inApp frames
-            frame.inApp &&
-            // Only debug frames with a filename that are not <anonymous> etc.
-            !isFrameFilenamePathlike(frame) &&
-            // Line number might not work for non-javascript languages
-            defined(frame.lineNo)
-        )
-        .map<StacktraceFilenameQuery>(([frame, idx]) => ({
-          filename: frame.filename!,
-          query: {...props, frameIdx: idx, exceptionIdx},
-        }));
-    })
-  );
+  const fileFrame = excValues.flatMap((excValue, exceptionIdx) => {
+    return (excValue.stacktrace?.frames || [])
+      .map<[Frame, number]>((frame, idx) => [frame, idx])
+      .filter(
+        ([frame]) =>
+          // Only debug inApp frames
+          frame.inApp &&
+          // Only debug frames with a filename that are not <anonymous> etc.
+          !isFrameFilenamePathlike(frame) &&
+          // Line number might not work for non-javascript languages
+          defined(frame.lineNo)
+      )
+      .map<StacktraceFilenameQuery>(([frame, idx]) => ({
+        filename: frame.filename!,
+        query: {...props, frameIdx: idx, exceptionIdx},
+      }));
+  });
 
   // Return only the first MAX_FRAMES unique filenames
   return uniqBy(fileFrame.reverse(), ({filename}) => filename).slice(0, MAX_FRAMES);

--- a/static/app/components/events/interfaces/spans/traceErrorList.tsx
+++ b/static/app/components/events/interfaces/spans/traceErrorList.tsx
@@ -1,5 +1,4 @@
 import {Fragment, memo} from 'react';
-import flatten from 'lodash/flatten';
 import groupBy from 'lodash/groupBy';
 
 import List from 'sentry/components/list';
@@ -22,39 +21,35 @@ function TraceErrorList({trace, errors, performanceIssues}: TraceErrorListProps)
   return (
     <List symbol="bullet" data-test-id="trace-error-list">
       <Fragment>
-        {flatten(
-          Object.entries(groupBy(errors, 'span')).map(([spanId, spanErrors]) => {
-            return Object.entries(groupBy(spanErrors, 'level')).map(
-              ([level, spanLevelErrors]) => (
-                <ListItem key={`${spanId}-${level}`}>
-                  {tct('[errors] [link]', {
-                    errors: tn(
-                      '%s %s error in ',
-                      '%s %s errors in ',
-                      spanLevelErrors.length,
-                      level === 'error' ? '' : level // Prevents awkward "error errors" copy if the level is "error"
-                    ),
-                    link: findSpanById(trace, spanId).op,
-                  })}
-                </ListItem>
-              )
-            );
-          })
-        )}
-        {flatten(
-          Object.entries(groupBy(performanceIssues, 'span')).map(
-            ([spanId, spanErrors]) => (
-              <ListItem key={`${spanId}`}>
+        {Object.entries(groupBy(errors, 'span')).flatMap(([spanId, spanErrors]) => {
+          return Object.entries(groupBy(spanErrors, 'level')).map(
+            ([level, spanLevelErrors]) => (
+              <ListItem key={`${spanId}-${level}`}>
                 {tct('[errors] [link]', {
                   errors: tn(
-                    '%s performance issue in ',
-                    '%s performance issues in ',
-                    spanErrors.length
+                    '%s %s error in ',
+                    '%s %s errors in ',
+                    spanLevelErrors.length,
+                    level === 'error' ? '' : level // Prevents awkward "error errors" copy if the level is "error"
                   ),
                   link: findSpanById(trace, spanId).op,
                 })}
               </ListItem>
             )
+          );
+        })}
+        {Object.entries(groupBy(performanceIssues, 'span')).flatMap(
+          ([spanId, spanErrors]) => (
+            <ListItem key={`${spanId}`}>
+              {tct('[errors] [link]', {
+                errors: tn(
+                  '%s performance issue in ',
+                  '%s performance issues in ',
+                  spanErrors.length
+                ),
+                link: findSpanById(trace, spanId).op,
+              })}
+            </ListItem>
           )
         )}
       </Fragment>

--- a/static/app/components/events/searchBar.tsx
+++ b/static/app/components/events/searchBar.tsx
@@ -1,5 +1,4 @@
 import {useEffect, useMemo} from 'react';
-import flatten from 'lodash/flatten';
 import memoize from 'lodash/memoize';
 import omit from 'lodash/omit';
 
@@ -220,8 +219,7 @@ function SearchBar(props: SearchBarProps) {
         // allows searching for tags on sessions as well
         includeSessions: includeSessionTagsValues,
       }).then(
-        results =>
-          flatten(results.filter(({name}) => defined(name)).map(({name}) => name)),
+        results => results.filter(({name}) => defined(name)).map(({name}) => name),
         () => {
           throw new Error('Unable to fetch event field values');
         }

--- a/static/app/components/forms/fields/tableField.tsx
+++ b/static/app/components/forms/fields/tableField.tsx
@@ -1,6 +1,5 @@
 import {Component, Fragment} from 'react';
 import styled from '@emotion/styled';
-import flatten from 'lodash/flatten';
 
 import {Alert} from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
@@ -65,9 +64,11 @@ export default class TableField extends Component<InputFieldProps> {
       onChange?.(nextValue, []);
 
       // nextValue is an array of ObservableObjectAdministration objects
-      const validValues = !flatten(Object.values(nextValue).map(Object.entries)).some(
-        ([key, val]) => key !== 'id' && !val // don't allow empty values except if it's the ID field
-      );
+      const validValues = !Object.values(nextValue)
+        .flatMap(Object.entries)
+        .some(
+          ([key, val]) => key !== 'id' && !val // don't allow empty values except if it's the ID field
+        );
 
       if (allowEmpty || validValues) {
         // TOOD: add debouncing or use a form save button

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -2,7 +2,6 @@ import {Component} from 'react';
 import {WithRouterProps} from 'react-router';
 import * as Sentry from '@sentry/react';
 import debounce from 'lodash/debounce';
-import flatten from 'lodash/flatten';
 
 import {fetchOrganizations} from 'sentry/actionCreators/organizations';
 import {Client, ResponseMeta} from 'sentry/api';
@@ -41,65 +40,61 @@ async function createOrganizationResults(
   organizationsPromise: Promise<Organization[]>
 ): Promise<ResultItem[]> {
   const organizations = (await organizationsPromise) || [];
-  return flatten(
-    organizations.map(org => [
-      {
-        title: t('%s Dashboard', org.slug),
-        description: t('Organization Dashboard'),
-        model: org,
-        sourceType: 'organization',
-        resultType: 'route',
-        to: `/${org.slug}/`,
-      },
-      {
-        title: t('%s Settings', org.slug),
-        description: t('Organization Settings'),
-        model: org,
-        sourceType: 'organization',
-        resultType: 'settings',
-        to: `/settings/${org.slug}/`,
-      },
-    ])
-  );
+  return organizations.flatMap(org => [
+    {
+      title: t('%s Dashboard', org.slug),
+      description: t('Organization Dashboard'),
+      model: org,
+      sourceType: 'organization',
+      resultType: 'route',
+      to: `/${org.slug}/`,
+    },
+    {
+      title: t('%s Settings', org.slug),
+      description: t('Organization Settings'),
+      model: org,
+      sourceType: 'organization',
+      resultType: 'settings',
+      to: `/settings/${org.slug}/`,
+    },
+  ]);
 }
 async function createProjectResults(
   projectsPromise: Promise<Project[]>,
   orgId?: string
 ): Promise<ResultItem[]> {
   const projects = (await projectsPromise) || [];
-  return flatten(
-    projects.map(project => {
-      const projectResults: ResultItem[] = [
-        {
-          title: t('%s Settings', project.slug),
-          description: t('Project Settings'),
-          model: project,
-          sourceType: 'project',
-          resultType: 'settings',
-          to: `/settings/${orgId}/projects/${project.slug}/`,
-        },
-        {
-          title: t('%s Alerts', project.slug),
-          description: t('List of project alert rules'),
-          model: project,
-          sourceType: 'project',
-          resultType: 'route',
-          to: `/organizations/${orgId}/alerts/rules/?project=${project.id}`,
-        },
-      ];
-
-      projectResults.unshift({
-        title: t('%s Dashboard', project.slug),
-        description: t('Project Details'),
+  return projects.flatMap(project => {
+    const projectResults: ResultItem[] = [
+      {
+        title: t('%s Settings', project.slug),
+        description: t('Project Settings'),
+        model: project,
+        sourceType: 'project',
+        resultType: 'settings',
+        to: `/settings/${orgId}/projects/${project.slug}/`,
+      },
+      {
+        title: t('%s Alerts', project.slug),
+        description: t('List of project alert rules'),
         model: project,
         sourceType: 'project',
         resultType: 'route',
-        to: `/organizations/${orgId}/projects/${project.slug}/?project=${project.id}`,
-      });
+        to: `/organizations/${orgId}/alerts/rules/?project=${project.id}`,
+      },
+    ];
 
-      return projectResults;
-    })
-  );
+    projectResults.unshift({
+      title: t('%s Dashboard', project.slug),
+      description: t('Project Details'),
+      model: project,
+      sourceType: 'project',
+      resultType: 'route',
+      to: `/organizations/${orgId}/projects/${project.slug}/?project=${project.id}`,
+    });
+
+    return projectResults;
+  });
 }
 async function createTeamResults(
   teamsPromise: Promise<Team[]>,
@@ -476,20 +471,18 @@ class ApiSource extends Component<Props, State> {
       sentryApps,
       docIntegrations,
     ] = requests;
-    const searchResults = flatten(
-      await Promise.all([
-        createOrganizationResults(organizations),
-        createProjectResults(projects, orgId),
-        createTeamResults(teams, orgId),
-        createMemberResults(members, orgId),
-        createIntegrationResults(integrations, orgId),
-        createPluginResults(plugins, orgId),
-        createSentryAppResults(sentryApps, orgId),
-        createDocIntegrationResults(docIntegrations, orgId),
-      ])
-    );
+    const searchResults = await Promise.all([
+      createOrganizationResults(organizations),
+      createProjectResults(projects, orgId),
+      createTeamResults(teams, orgId),
+      createMemberResults(members, orgId),
+      createIntegrationResults(integrations, orgId),
+      createPluginResults(plugins, orgId),
+      createSentryAppResults(sentryApps, orgId),
+      createDocIntegrationResults(docIntegrations, orgId),
+    ]);
 
-    return searchResults;
+    return searchResults.flat();
   }
 
   // Create result objects from API requests that do not require fuzzy search
@@ -518,7 +511,7 @@ class ApiSource extends Component<Props, State> {
 
     return children({
       isLoading: this.state.loading,
-      results: flatten([results, directResults].filter(defined)) || [],
+      results: [results, directResults].flat().filter(defined),
     });
   }
 }

--- a/static/app/components/search/sources/index.tsx
+++ b/static/app/components/search/sources/index.tsx
@@ -1,5 +1,4 @@
 import {Component} from 'react';
-import flatten from 'lodash/flatten';
 
 import type {Fuse} from 'sentry/utils/fuzzySearch';
 
@@ -34,9 +33,9 @@ class SearchSources extends Component<Props> {
 
     const foundResults = isLoading
       ? []
-      : flatten(allSources.map(({results}) => results || [])).sort(
-          (a, b) => (a.score ?? 0) - (b.score ?? 0)
-        );
+      : allSources
+          .flatMap(({results}) => results ?? [])
+          .sort((a, b) => (a.score ?? 0) - (b.score ?? 0));
     const hasAnyResults = !!foundResults.length;
 
     return children({

--- a/static/app/components/search/sources/routeSource.tsx
+++ b/static/app/components/search/sources/routeSource.tsx
@@ -1,6 +1,5 @@
 import {Component} from 'react';
 import {RouteComponentProps} from 'react-router';
-import flattenDepth from 'lodash/flattenDepth';
 
 import HookStore from 'sentry/stores/hookStore';
 import {Organization, Project} from 'sentry/types';
@@ -117,15 +116,12 @@ class RouteSource extends Component<Props, State> {
       features: new Set(project?.features ?? []),
     } as Context;
 
-    const searchMap = flattenDepth<NavigationItem>(
-      [
-        mapFunc(accountSettingsNavigation, context),
-        mapFunc(projectSettingsNavigation, context),
-        mapFunc(organizationSettingsNavigation, context),
-        mapFunc(this.getHookConfigs(), context),
-      ],
-      2
-    );
+    const searchMap: NavigationItem[] = [
+      mapFunc(accountSettingsNavigation, context),
+      mapFunc(projectSettingsNavigation, context),
+      mapFunc(organizationSettingsNavigation, context),
+      mapFunc(this.getHookConfigs(), context),
+    ].flat(2);
 
     const options = {
       ...this.props.searchOptions,

--- a/static/app/views/alerts/rules/metric/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/thresholdsChart.tsx
@@ -2,7 +2,6 @@ import {PureComponent} from 'react';
 import color from 'color';
 import type {TooltipComponentFormatterCallbackParams} from 'echarts';
 import debounce from 'lodash/debounce';
-import flatten from 'lodash/flatten';
 
 import {extrapolatedAreaStyle} from 'sentry/components/alerts/onDemandMetricAlert';
 import {AreaChart} from 'sentry/components/charts/areaChart';
@@ -430,12 +429,10 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
         grid={CHART_GRID}
         {...chartOptions}
         graphic={Graphic({
-          elements: flatten(
-            triggers.map((trigger: Trigger) => [
-              ...this.getThresholdLine(trigger, 'alertThreshold', false),
-              ...this.getThresholdLine(trigger, 'resolveThreshold', true),
-            ])
-          ),
+          elements: triggers.flatMap((trigger: Trigger) => [
+            ...this.getThresholdLine(trigger, 'alertThreshold', false),
+            ...this.getThresholdLine(trigger, 'resolveThreshold', true),
+          ]),
         })}
         colors={CHART_PALETTE[0]}
         series={[...dataWithoutRecentBucket, ...comparisonMarkLines]}

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -4,7 +4,6 @@ import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import {withProfiler} from '@sentry/react';
 import debounce from 'lodash/debounce';
-import flatten from 'lodash/flatten';
 import uniqBy from 'lodash/uniqBy';
 
 import {Client} from 'sentry/api';
@@ -105,10 +104,13 @@ function Dashboard({teams, organization, loadingTeams, error, router, location}:
   const filteredTeams = teams.filter(team => selectedTeams.includes(team.id));
 
   const filteredTeamProjects = uniqBy(
-    flatten((filteredTeams ?? teams).map(team => team.projects)),
+    (filteredTeams ?? teams).flatMap(team => team.projects),
     'id'
   );
-  const projects = uniqBy(flatten(teams.map(teamObj => teamObj.projects)), 'id');
+  const projects = uniqBy(
+    teams.flatMap(teamObj => teamObj.projects),
+    'id'
+  );
   setGroupedEntityTag('projects.total', 1000, projects.length);
 
   const currentProjects = selectedTeams.length === 0 ? projects : filteredTeamProjects;

--- a/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
@@ -2,7 +2,6 @@ import {Fragment} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
-import flatten from 'lodash/flatten';
 import groupBy from 'lodash/groupBy';
 import startCase from 'lodash/startCase';
 import * as qs from 'query-string';
@@ -508,7 +507,7 @@ export class IntegrationListDirectory extends DeprecatedAsyncComponent<
     const {organization} = this.props;
     const {displayedList, list, searchInput, selectedCategory, integrations} = this.state;
     const title = t('Integrations');
-    const categoryList = uniq(flatten(list.map(getCategoriesForIntegration))).sort();
+    const categoryList = uniq(list.flatMap(getCategoriesForIntegration)).sort();
 
     return (
       <Fragment>

--- a/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
+++ b/static/app/views/starfish/views/spans/selectors/domainSelector.tsx
@@ -2,7 +2,6 @@ import {ReactNode, useCallback, useEffect, useRef, useState} from 'react';
 import {browserHistory} from 'react-router';
 import {Location} from 'history';
 import debounce from 'lodash/debounce';
-import flatten from 'lodash/flatten';
 import omit from 'lodash/omit';
 
 import SelectControl from 'sentry/components/forms/controls/selectControl';
@@ -76,7 +75,7 @@ export function DomainSelector({
   });
 
   const incomingDomains = uniq(
-    flatten(domainData?.map(row => row[SpanMetricsField.SPAN_DOMAIN]))
+    domainData?.flatMap(row => row[SpanMetricsField.SPAN_DOMAIN])
   );
 
   // Cache for all previously seen domains


### PR DESCRIPTION
Removes the usage of `lodash/flatten` and `lodash/flattenDepth`

Ref: https://github.com/getsentry/frontend-tsc/issues/55