### PR TITLE
feat(replays): Add canvas linkout and metrics in loader settings

### DIFF
--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -7,6 +7,7 @@ export type ReplayEventParameters = {
     issue_description: string;
     issue_impact: string | undefined;
   };
+  'replay.canvas-loader-clicked': {};
   'replay.details-data-loaded': {
     be_errors: number;
     fe_errors: number;
@@ -109,6 +110,7 @@ export type ReplayEventKey = keyof ReplayEventParameters;
 
 export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.accessibility-issue-clicked': 'Clicked Replay Accessibility Issue',
+  'replay.canvas-loader-clicked': 'Clicked Canvas Linkout in Loader',
   'replay.details-data-loaded': 'Replay Details Data Loaded',
   'replay.details-has-hydration-error': 'Replay Details Has Hydration Error',
   'replay.details-layout-changed': 'Changed Replay Details Layout',

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
@@ -250,7 +250,7 @@ describe('Loader Script Settings', function () {
     expect(debugCheckbox).toBeChecked();
 
     expect(
-      screen.getAllByText('Only available in SDK version 7.x and above')
+      screen.getAllByText('Only available in SDK version 7.x and above', {exact: false})
     ).toHaveLength(2);
   });
 
@@ -278,7 +278,8 @@ describe('Loader Script Settings', function () {
 
     expect(
       screen.getByText(
-        'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
+        'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.',
+        {exact: false}
       )
     ).toBeInTheDocument();
 

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -215,9 +215,9 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
             help={
               !sdkVersionSupportsPerformanceAndReplay(data.browserSdkVersion)
                 ? tct(
-                    `Only available in SDK version 7.x and above [br]We now support [code:canvas] recording in SDK version 7.94.1. [link:Learn more]`,
+                    `Only available in SDK version 7.x and above. [br]We now support [code:canvas] recording in SDK version 7.94.1. [link:Set up now!]`,
                     {
-                      canvas: <code />,
+                      code: <code />,
                       br: <br />,
                       link: (
                         <ExternalLink
@@ -233,9 +233,9 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
                   )
                 : data.dynamicSdkLoaderOptions.hasReplay
                 ? tct(
-                    `When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle [br]We now support [code:canvas] recording in SDK version 7.94.1. [link:Learn more]`,
+                    `When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle. [br]We now support [code:canvas] recording in SDK version 7.94.1. [link:Set up now!]`,
                     {
-                      canvas: <code />,
+                      code: <code />,
                       br: <br />,
                       link: (
                         <ExternalLink
@@ -250,9 +250,9 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
                     }
                   )
                 : tct(
-                    `We now support [code:canvas] recording in SDK version 7.94.1. [link:Learn more]`,
+                    `We now support [code:canvas] recording in SDK version 7.94.1. [link:Set up now!]`,
                     {
-                      canvas: <code />,
+                      code: <code />,
                       br: <br />,
                       link: (
                         <ExternalLink

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -13,9 +13,11 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
 import {Project, ProjectKey} from 'sentry/types';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
   data: ProjectKey;
@@ -27,6 +29,7 @@ type Props = {
 
 export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Props) {
   const api = useApi();
+  const organization = useOrganization();
 
   const [requestPending, setRequestPending] = useState(false);
 
@@ -211,12 +214,58 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
             }
             help={
               !sdkVersionSupportsPerformanceAndReplay(data.browserSdkVersion)
-                ? t('Only available in SDK version 7.x and above')
-                : data.dynamicSdkLoaderOptions.hasReplay
-                ? t(
-                    'When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle.'
+                ? tct(
+                    `Only available in SDK version 7.x and above [br]We now support [code:canvas] recording in SDK version 7.94.1. [link:Learn more]`,
+                    {
+                      canvas: <code />,
+                      br: <br />,
+                      link: (
+                        <ExternalLink
+                          onClick={() => {
+                            trackAnalytics('replay.canvas-loader-clicked', {
+                              organization,
+                            });
+                          }}
+                          href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording"
+                        />
+                      ),
+                    }
                   )
-                : undefined
+                : data.dynamicSdkLoaderOptions.hasReplay
+                ? tct(
+                    `When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle [br]We now support [code:canvas] recording in SDK version 7.94.1. [link:Learn more]`,
+                    {
+                      canvas: <code />,
+                      br: <br />,
+                      link: (
+                        <ExternalLink
+                          onClick={() => {
+                            trackAnalytics('replay.canvas-loader-clicked', {
+                              organization,
+                            });
+                          }}
+                          href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording"
+                        />
+                      ),
+                    }
+                  )
+                : tct(
+                    `We now support [code:canvas] recording in SDK version 7.94.1. [link:Learn more]`,
+                    {
+                      canvas: <code />,
+                      br: <br />,
+                      link: (
+                        <ExternalLink
+                          onClick={() => {
+                            trackAnalytics('replay.canvas-loader-clicked', {
+                              organization,
+                            });
+                          }}
+                          href="https://docs.sentry.io/platforms/javascript/session-replay/#canvas-recording"
+                        />
+                      ),
+                    }
+                  )
             }
             disabledReason={
               !hasAccess

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -215,7 +215,7 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
             help={
               !sdkVersionSupportsPerformanceAndReplay(data.browserSdkVersion)
                 ? tct(
-                    `Only available in SDK version 7.x and above. [br]We now support [code:canvas] recording in SDK version 7.94.1. [link:Set up now!]`,
+                    `Only available in SDK version 7.x and above. [br]We now support [code:canvas] recording in SDK version 7.94.1. [link:Set it up here.]`,
                     {
                       code: <code />,
                       br: <br />,
@@ -233,7 +233,7 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
                   )
                 : data.dynamicSdkLoaderOptions.hasReplay
                 ? tct(
-                    `When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle. [br]We now support [code:canvas] recording in SDK version 7.94.1. [link:Set up now!]`,
+                    `When using Replay, the loader will load the ES6 bundle instead of the ES5 bundle. [br]We now support [code:canvas] recording in SDK version 7.94.1. [link:Set it up here.]`,
                     {
                       code: <code />,
                       br: <br />,
@@ -250,7 +250,7 @@ export function LoaderSettings({keyId, orgSlug, project, data, updateData}: Prop
                     }
                   )
                 : tct(
-                    `We now support [code:canvas] recording in SDK version 7.94.1. [link:Set up now!]`,
+                    `We now support [code:canvas] recording in SDK version 7.94.1. [link:Set it up here.]`,
                     {
                       code: <code />,
                       br: <br />,


### PR DESCRIPTION
Adds a linkout with metrics about canvas underneath the replay loader option
<img width="1218" alt="image" src="https://github.com/getsentry/sentry/assets/55311782/ff3570fe-f973-4b53-85a0-6f08ddd66169">

Closes: https://github.com/getsentry/team-replay/issues/347
