### PR TITLE
feat(ai/ml): AI Autofix POC on Issue Details page

### DIFF
--- a/static/app/components/events/aiAutofix/banner.tsx
+++ b/static/app/components/events/aiAutofix/banner.tsx
@@ -1,0 +1,203 @@
+import styled from '@emotion/styled';
+
+import bannerBackground from 'sentry-images/spot/ai-suggestion-banner-background.svg';
+import bannerSentaur from 'sentry-images/spot/ai-suggestion-banner-sentaur.svg';
+import bannerStars from 'sentry-images/spot/ai-suggestion-banner-stars.svg';
+
+import {Button} from 'sentry/components/button';
+import TextArea from 'sentry/components/forms/controls/textarea';
+import ExternalLink from 'sentry/components/links/externalLink';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import TextBlock from 'sentry/views/settings/components/text/textBlock';
+
+import {ExperimentalFeatureBadge} from '../aiSuggestedSolution/experimentalFeatureBadge';
+
+type Props = {
+  additionalContext: string;
+  onButtonClick: () => void;
+  setAdditionalContext: (value: string) => void;
+};
+
+export function Banner({onButtonClick, additionalContext, setAdditionalContext}: Props) {
+  return (
+    <Wrapper>
+      <Body>
+        <Header>
+          <TitleContent>
+            <Title>
+              {t('AI Autofix')}
+              <MoreInfoTooltip
+                isHoverable
+                size="sm"
+                title={tct(
+                  'This is an OpenAI generated solution that automatically creates a pull request for this issue. Be aware that this may not be accurate. [learnMore:Learn more]',
+                  {
+                    learnMore: (
+                      <ExternalLink href="https://docs.sentry.io/product/issues/issue-details/ai-suggested-solution/" />
+                    ),
+                  }
+                )}
+              />
+              <ExperimentalFeatureBadge />
+            </Title>
+            <Description>
+              {t('You might get lucky, but again, maybe not\u2026')}
+            </Description>
+          </TitleContent>
+          <Action>
+            <Background src={bannerBackground} />
+            <Stars src={bannerStars} />
+            <Sentaur src={bannerSentaur} />
+            <ViewSuggestionButton size="xs" onClick={onButtonClick}>
+              {t('Try your luck')}
+            </ViewSuggestionButton>
+          </Action>
+        </Header>
+        <AdditionalContextArea>
+          <AdditionalContextLabel>
+            {t('Additional Context (Optional)')}
+          </AdditionalContextLabel>
+          <StyledTextArea
+            value={additionalContext}
+            placeholder={t(
+              'Add additional context to help the AI find a better solution'
+            )}
+            onChange={e => setAdditionalContext(e.target.value)}
+          />
+        </AdditionalContextArea>
+      </Body>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled(Panel)`
+  margin-bottom: 0;
+`;
+
+const Body = styled(PanelBody)`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Header = styled('div')`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: ${space(1)};
+
+  > *:first-child {
+    flex: 1;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
+    display: grid;
+    grid-template-columns: 42% 1fr;
+    height: 80px;
+    position: relative;
+  }
+`;
+
+const Title = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  text-transform: uppercase;
+  color: ${p => p.theme.gray300};
+  display: flex;
+  align-items: center;
+  /* to be consistent with the feature badge size */
+  height: ${space(2)};
+  line-height: ${space(2)};
+  white-space: nowrap;
+`;
+
+const TitleContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+  padding-left: ${space(2)};
+`;
+
+const Description = styled(TextBlock)`
+  margin: ${space(1)} 0 0 0;
+`;
+
+const Action = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+`;
+
+const Sentaur = styled('img')`
+  display: none;
+  @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
+    display: block;
+    height: 8.563rem;
+    position: absolute;
+    bottom: 0;
+    right: 6.608rem;
+    object-fit: cover;
+    z-index: 1;
+    pointer-events: none;
+  }
+`;
+
+const Background = styled('img')`
+  display: none;
+  @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
+    display: block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    object-fit: cover;
+    max-width: 100%;
+    height: 100%;
+    border-top-right-radius: ${p => p.theme.panelBorderRadius};
+  }
+`;
+
+const Stars = styled('img')`
+  display: none;
+  @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
+    display: block;
+    height: 8.563rem;
+    position: absolute;
+    right: -1rem;
+    bottom: -0.125rem;
+    object-fit: cover;
+    /* workaround to remove a  extra svg on the bottom right */
+    border-radius: ${p => p.theme.panelBorderRadius};
+  }
+`;
+
+const ViewSuggestionButton = styled(Button)`
+  @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
+    position: absolute;
+    right: 1rem;
+    top: 1.5rem;
+  }
+`;
+
+const MoreInfoTooltip = styled(QuestionTooltip)`
+  margin-left: ${space(0.5)};
+`;
+
+const AdditionalContextLabel = styled('label')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.gray300};
+  margin-bottom: ${space(1)};
+`;
+
+const AdditionalContextArea = styled('div')`
+  display: flex;
+  flex-direction: column;
+  padding: ${space(2)};
+  background-color: ${p => p.theme.backgroundSecondary};
+  border-radius: ${p => p.theme.panelBorderRadius};
+`;
+
+const StyledTextArea = styled(TextArea)`
+  resize: vertical;
+  min-height: 80px;
+`;

--- a/static/app/components/events/aiAutofix/fixResult.tsx
+++ b/static/app/components/events/aiAutofix/fixResult.tsx
@@ -25,7 +25,7 @@ const makeGithubRepoUrl = (repoName: string) => {
 
 export function FixResult({autofixData, onRetry}: Props) {
   const isLoading = autofixData.status === 'PROCESSING';
-  const hasNoFix = autofixData.status === 'COMPLETED' && !autofixData.fix;
+  const hasNoFix = !autofixData.fix;
   const hasError = autofixData.status === 'ERROR';
 
   return (
@@ -71,9 +71,9 @@ export function FixResult({autofixData, onRetry}: Props) {
           <Content>
             <PreviewContent>
               <PrefixText>
-                Pull request #63088 created in{' '}
+                {`Pull request #${autofixData.fix!.prNumber} created in `}
                 <RepoLink href={makeGithubRepoUrl(autofixData.fix!.repoName)}>
-                  getsentry/sentry
+                  {autofixData.fix!.repoName}
                 </RepoLink>
                 :
               </PrefixText>

--- a/static/app/components/events/aiAutofix/fixResult.tsx
+++ b/static/app/components/events/aiAutofix/fixResult.tsx
@@ -8,7 +8,7 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import {IconOpen} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 import {ExperimentalFeatureBadge} from '../aiSuggestedSolution/experimentalFeatureBadge';
@@ -47,11 +47,11 @@ export function FixResult({autofixData, onRetry}: Props) {
             <PreviewContent>
               {autofixData.errorMessage ? (
                 <Fragment>
-                  <PrefixText>Something went wrong:</PrefixText>
+                  <PrefixText>{t('Something went wrong:')}</PrefixText>
                   {autofixData.errorMessage && <span>{autofixData.errorMessage}</span>}
                 </Fragment>
               ) : (
-                <span>Something went wrong.</span>
+                <span>{t('Something went wrong.')}</span>
               )}
             </PreviewContent>
             <Button size="xs" onClick={onRetry}>
@@ -61,7 +61,7 @@ export function FixResult({autofixData, onRetry}: Props) {
         ) : hasNoFix ? (
           <Content>
             <PreviewContent>
-              <span>Could not find a fix.</span>
+              <span>{t('Could not find a fix.')}</span>
             </PreviewContent>
             <Button size="xs" onClick={onRetry}>
               {t('Try Again')}
@@ -71,11 +71,14 @@ export function FixResult({autofixData, onRetry}: Props) {
           <Content>
             <PreviewContent>
               <PrefixText>
-                {`Pull request #${autofixData.fix!.prNumber} created in `}
-                <RepoLink href={makeGithubRepoUrl(autofixData.fix!.repoName)}>
-                  {autofixData.fix!.repoName}
-                </RepoLink>
-                :
+                {tct('Pull request #[prNumber] created in [repository]:', {
+                  prNumber: autofixData.fix!.prNumber,
+                  repository: (
+                    <RepoLink href={makeGithubRepoUrl(autofixData.fix!.repoName)}>
+                      {autofixData.fix!.repoName}
+                    </RepoLink>
+                  ),
+                })}
               </PrefixText>
               <PrTitle>{autofixData.fix!.title}</PrTitle>
             </PreviewContent>

--- a/static/app/components/events/aiAutofix/fixResult.tsx
+++ b/static/app/components/events/aiAutofix/fixResult.tsx
@@ -1,0 +1,146 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import {AutofixData} from 'sentry/components/events/aiAutofix/types';
+import Anchor from 'sentry/components/links/anchor';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import PanelHeader from 'sentry/components/panels/panelHeader';
+import {IconOpen} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+import {ExperimentalFeatureBadge} from '../aiSuggestedSolution/experimentalFeatureBadge';
+import {SuggestionLoaderMessage} from '../aiSuggestedSolution/suggestionLoaderMessage';
+
+type Props = {
+  autofixData: AutofixData;
+  onRetry: () => void;
+};
+
+const makeGithubRepoUrl = (repoName: string) => {
+  return `https://github.com/${repoName}/`;
+};
+
+export function FixResult({autofixData, onRetry}: Props) {
+  const isLoading = autofixData.status === 'PROCESSING';
+  const hasNoFix = autofixData.status === 'COMPLETED' && !autofixData.fix;
+  const hasError = autofixData.status === 'ERROR';
+
+  return (
+    <Panel>
+      <Header>
+        <Title>
+          {t('AI Autofix')}
+          <ExperimentalFeatureBadge />
+        </Title>
+      </Header>
+      <PanelBody>
+        {isLoading ? (
+          <LoaderWrapper>
+            <SmallerAiLoader className="ai-suggestion-wheel-of-fortune" />
+            <SuggestionLoaderMessage />
+          </LoaderWrapper>
+        ) : hasError ? (
+          <Content>
+            <PreviewContent>
+              {autofixData.errorMessage ? (
+                <Fragment>
+                  <PrefixText>Something went wrong:</PrefixText>
+                  {autofixData.errorMessage && <span>{autofixData.errorMessage}</span>}
+                </Fragment>
+              ) : (
+                <span>Something went wrong.</span>
+              )}
+            </PreviewContent>
+            <Button size="xs" onClick={onRetry}>
+              {t('Try Again')}
+            </Button>
+          </Content>
+        ) : hasNoFix ? (
+          <Content>
+            <PreviewContent>
+              <span>Could not find a fix.</span>
+            </PreviewContent>
+            <Button size="xs" onClick={onRetry}>
+              {t('Try Again')}
+            </Button>
+          </Content>
+        ) : (
+          <Content>
+            <PreviewContent>
+              <PrefixText>
+                Pull request #63088 created in{' '}
+                <RepoLink href={makeGithubRepoUrl(autofixData.fix!.repoName)}>
+                  getsentry/sentry
+                </RepoLink>
+                :
+              </PrefixText>
+              <PrTitle>{autofixData.fix!.title}</PrTitle>
+            </PreviewContent>
+            <Anchor href={autofixData.fix!.prUrl}>
+              <Button size="xs" icon={<IconOpen size="xs" />}>
+                {t('View Pull Request')}
+              </Button>
+            </Anchor>
+          </Content>
+        )}
+      </PanelBody>
+    </Panel>
+  );
+}
+
+const Header = styled(PanelHeader)`
+  background: transparent;
+  padding: ${space(1)} ${space(2)};
+  align-items: center;
+  color: ${p => p.theme.gray300};
+`;
+
+const LoaderWrapper = styled('div')`
+  padding: ${space(4)} 0;
+  text-align: center;
+  gap: ${space(2)};
+  display: flex;
+  flex-direction: column;
+`;
+
+const PreviewContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+`;
+
+const PrefixText = styled('span')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.gray300};
+`;
+
+const PrTitle = styled('div')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-weight: 600;
+`;
+
+const RepoLink = styled(Anchor)`
+  text-decoration: underline;
+`;
+
+const Content = styled('div')`
+  padding: ${space(2)};
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const SmallerAiLoader = styled('div')`
+  height: 128px;
+`;
+
+const Title = styled('div')`
+  /* to be consistent with the feature badge size */
+  height: ${space(2)};
+  line-height: ${space(2)};
+  display: flex;
+  align-items: center;
+`;

--- a/static/app/components/events/aiAutofix/index.spec.tsx
+++ b/static/app/components/events/aiAutofix/index.spec.tsx
@@ -1,29 +1,18 @@
+import {GroupFixture} from 'sentry-fixture/group';
+
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {AiAutofix} from 'sentry/components/events/aiAutofix';
-import {useAiAutofix} from 'sentry/components/events/aiAutofix/useAiAutofix';
-import {Group} from 'sentry/types';
+import {EventMetadataWithAutofix} from 'sentry/components/events/aiAutofix/types';
 
-jest.mock('sentry/components/events/aiAutofix/useAiAutofix', () => ({
-  useAiAutofix: jest.fn(() => ({
-    autofixData: null,
-    triggerAutofix: jest.fn(),
-    additionalContext: '',
-    setAdditionalContext: jest.fn(),
-    error: null,
-    isError: false,
-    isPolling: false,
-  })),
-}));
-
-const group = {
-  /* Mock group data */
-  id: 1,
-} as unknown as Group;
+const group = GroupFixture();
 
 describe('AiAutofix', () => {
-  afterEach(() => {
-    jest.resetAllMocks();
+  beforeAll(() => {
+    MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/ai-autofix/`,
+      body: null,
+    });
   });
 
   it('renders the Banner component when autofixData is null', () => {
@@ -33,22 +22,23 @@ describe('AiAutofix', () => {
   });
 
   it('renders the FixResult component when autofixData is present', () => {
-    (useAiAutofix as jest.Mock).mockReturnValue({
-      autofixData: {
-        status: 'SUCCESS',
-        fix: {
-          title: 'Fixed the bug!',
-        },
-      },
-      triggerAutofix: jest.fn(),
-      additionalContext: '',
-      setAdditionalContext: jest.fn(),
-      error: null,
-      isError: false,
-      isPolling: false,
-    });
-
-    render(<AiAutofix group={group} />);
+    render(
+      <AiAutofix
+        group={{
+          ...group,
+          metadata: {
+            autofix: {
+              status: 'COMPLETED',
+              completedAt: '',
+              createdAt: '',
+              fix: {
+                title: 'Fixed the bug!',
+              },
+            },
+          } as EventMetadataWithAutofix,
+        }}
+      />
+    );
 
     expect(screen.getByText('Fixed the bug!')).toBeInTheDocument();
     expect(screen.getByText('View Pull Request')).toBeInTheDocument();

--- a/static/app/components/events/aiAutofix/index.spec.tsx
+++ b/static/app/components/events/aiAutofix/index.spec.tsx
@@ -1,0 +1,56 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {AiAutofix} from 'sentry/components/events/aiAutofix';
+import {useAiAutofix} from 'sentry/components/events/aiAutofix/useAiAutofix';
+import {Group} from 'sentry/types';
+
+jest.mock('sentry/components/events/aiAutofix/useAiAutofix', () => ({
+  useAiAutofix: jest.fn(() => ({
+    autofixData: null,
+    triggerAutofix: jest.fn(),
+    additionalContext: '',
+    setAdditionalContext: jest.fn(),
+    error: null,
+    isError: false,
+    isPolling: false,
+  })),
+}));
+
+const group = {
+  /* Mock group data */
+  id: 1,
+} as unknown as Group;
+
+describe('AiAutofix', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders the Banner component when autofixData is null', () => {
+    render(<AiAutofix group={group} />);
+
+    expect(screen.getByText('AI Autofix')).toBeInTheDocument();
+  });
+
+  it('renders the FixResult component when autofixData is present', () => {
+    (useAiAutofix as jest.Mock).mockReturnValue({
+      autofixData: {
+        status: 'SUCCESS',
+        fix: {
+          title: 'Fixed the bug!',
+        },
+      },
+      triggerAutofix: jest.fn(),
+      additionalContext: '',
+      setAdditionalContext: jest.fn(),
+      error: null,
+      isError: false,
+      isPolling: false,
+    });
+
+    render(<AiAutofix group={group} />);
+
+    expect(screen.getByText('Fixed the bug!')).toBeInTheDocument();
+    expect(screen.getByText('View Pull Request')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/aiAutofix/index.tsx
+++ b/static/app/components/events/aiAutofix/index.tsx
@@ -1,0 +1,27 @@
+import {Banner} from 'sentry/components/events/aiAutofix/banner';
+import {FixResult} from 'sentry/components/events/aiAutofix/fixResult';
+import {useAiAutofix} from 'sentry/components/events/aiAutofix/useAiAutofix';
+import {Group} from 'sentry/types';
+
+type Props = {
+  group: Group;
+};
+
+export function AiAutofix({group}: Props) {
+  const {autofixData, triggerAutofix, additionalContext, setAdditionalContext} =
+    useAiAutofix(group);
+
+  return (
+    <div>
+      {autofixData ? (
+        <FixResult autofixData={autofixData} onRetry={triggerAutofix} />
+      ) : (
+        <Banner
+          onButtonClick={triggerAutofix}
+          additionalContext={additionalContext}
+          setAdditionalContext={setAdditionalContext}
+        />
+      )}
+    </div>
+  );
+}

--- a/static/app/components/events/aiAutofix/types.ts
+++ b/static/app/components/events/aiAutofix/types.ts
@@ -1,0 +1,19 @@
+import {EventMetadata} from 'sentry/types';
+
+export type AutofixData = {
+  completedAt: string | null;
+  createdAt: string;
+  status: 'PROCESSING' | 'COMPLETED' | 'ERROR';
+  errorMessage?: string;
+  fix?: {
+    description: string;
+    prNumber: number;
+    prUrl: string;
+    repoName: string;
+    title: string;
+  };
+};
+
+export type EventMetadataWithAutofix = EventMetadata & {
+  autofix?: AutofixData;
+};

--- a/static/app/components/events/aiAutofix/types.ts
+++ b/static/app/components/events/aiAutofix/types.ts
@@ -1,4 +1,4 @@
-import {EventMetadata} from 'sentry/types';
+import {EventMetadata, Group} from 'sentry/types';
 
 export type AutofixData = {
   completedAt: string | null;
@@ -16,4 +16,8 @@ export type AutofixData = {
 
 export type EventMetadataWithAutofix = EventMetadata & {
   autofix?: AutofixData;
+};
+
+export type GroupWithAutofix = Group & {
+  metadata?: EventMetadataWithAutofix;
 };

--- a/static/app/components/events/aiAutofix/useAiAutofix.tsx
+++ b/static/app/components/events/aiAutofix/useAiAutofix.tsx
@@ -1,0 +1,70 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+import {EventMetadataWithAutofix} from 'sentry/components/events/aiAutofix/types';
+import {Group} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+const POLL_INTERVAL = 5000;
+
+export const useAiAutofix = (_group: Group) => {
+  const organization = useOrganization();
+  const api = useApi();
+  const {
+    data: group,
+    isError,
+    refetch: dataRefetch,
+    error,
+    dataUpdatedAt,
+  } = useApiQuery<Group>([`/organizations/${organization.slug}/issues/${_group.id}/`], {
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  const [additionalContext, setAdditionalContext] = useState<string>('');
+
+  const metadata = (group?.metadata ?? _group.metadata) as
+    | EventMetadataWithAutofix
+    | undefined;
+  const autofixData = metadata?.autofix;
+  const isPolling = autofixData?.status === 'PROCESSING';
+
+  const timeoutId = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (autofixData && autofixData.status === 'PROCESSING') {
+      if (timeoutId.current !== null) {
+        clearTimeout(timeoutId.current);
+      }
+      timeoutId.current = setTimeout(() => {
+        timeoutId.current = null;
+        dataRefetch();
+      }, POLL_INTERVAL);
+    } else if (timeoutId.current !== null) {
+      clearTimeout(timeoutId.current);
+      timeoutId.current = null;
+    }
+  }, [autofixData, dataUpdatedAt, dataRefetch]);
+
+  const triggerAutofix = useCallback(async () => {
+    await api.requestPromise(`/issues/${_group.id}/ai-autofix/`, {
+      method: 'POST',
+      data: {
+        additional_context: additionalContext,
+      },
+    });
+
+    dataRefetch();
+  }, [api, _group.id, dataRefetch, additionalContext]);
+
+  return {
+    additionalContext,
+    autofixData,
+    error,
+    isError,
+    isPolling,
+    setAdditionalContext,
+    triggerAutofix,
+  };
+};

--- a/static/app/components/events/aiAutofix/useAiAutofix.tsx
+++ b/static/app/components/events/aiAutofix/useAiAutofix.tsx
@@ -9,16 +9,16 @@ const POLL_INTERVAL = 5000;
 export const useAiAutofix = (group: GroupWithAutofix) => {
   const api = useApi();
   const {
-    data: apiAutofixData,
+    data: apiData,
     isError,
     refetch: dataRefetch,
     error,
-  } = useApiQuery<AutofixData | null>([`/issues/${group.id}/ai-autofix/`], {
+  } = useApiQuery<{autofix: AutofixData | null}>([`/issues/${group.id}/ai-autofix/`], {
     staleTime: Infinity,
     retry: false,
     enabled: !group.metadata?.autofix, // Enabled only when no autofix data present
     refetchInterval: data => {
-      if (data?.[0]?.status === 'PROCESSING') {
+      if (data?.[0]?.autofix?.status === 'PROCESSING') {
         return POLL_INTERVAL;
       }
       return false;
@@ -27,7 +27,7 @@ export const useAiAutofix = (group: GroupWithAutofix) => {
 
   const [additionalContext, setAdditionalContext] = useState<string>('');
 
-  const autofixData = apiAutofixData ?? group.metadata?.autofix ?? null;
+  const autofixData = apiData?.autofix ?? group.metadata?.autofix ?? null;
   const isPolling = autofixData?.status === 'PROCESSING';
 
   const triggerAutofix = useCallback(async () => {

--- a/static/app/components/events/aiAutofix/useAiAutofix.tsx
+++ b/static/app/components/events/aiAutofix/useAiAutofix.tsx
@@ -1,54 +1,37 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useState} from 'react';
 
-import {EventMetadataWithAutofix} from 'sentry/components/events/aiAutofix/types';
-import {Group} from 'sentry/types';
+import {AutofixData, GroupWithAutofix} from 'sentry/components/events/aiAutofix/types';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
-import useOrganization from 'sentry/utils/useOrganization';
 
 const POLL_INTERVAL = 5000;
 
-export const useAiAutofix = (_group: Group) => {
-  const organization = useOrganization();
+export const useAiAutofix = (group: GroupWithAutofix) => {
   const api = useApi();
   const {
-    data: group,
+    data: apiAutofixData,
     isError,
     refetch: dataRefetch,
     error,
-    dataUpdatedAt,
-  } = useApiQuery<Group>([`/organizations/${organization.slug}/issues/${_group.id}/`], {
+  } = useApiQuery<AutofixData | null>([`/issues/${group.id}/ai-autofix/`], {
     staleTime: Infinity,
     retry: false,
+    enabled: !group.metadata?.autofix, // Enabled only when no autofix data present
+    refetchInterval: data => {
+      if (data?.[0]?.status === 'PROCESSING') {
+        return POLL_INTERVAL;
+      }
+      return false;
+    },
   });
 
   const [additionalContext, setAdditionalContext] = useState<string>('');
 
-  const metadata = (group?.metadata ?? _group.metadata) as
-    | EventMetadataWithAutofix
-    | undefined;
-  const autofixData = metadata?.autofix;
+  const autofixData = apiAutofixData ?? group.metadata?.autofix ?? null;
   const isPolling = autofixData?.status === 'PROCESSING';
 
-  const timeoutId = useRef<NodeJS.Timeout | null>(null);
-
-  useEffect(() => {
-    if (autofixData && autofixData.status === 'PROCESSING') {
-      if (timeoutId.current !== null) {
-        clearTimeout(timeoutId.current);
-      }
-      timeoutId.current = setTimeout(() => {
-        timeoutId.current = null;
-        dataRefetch();
-      }, POLL_INTERVAL);
-    } else if (timeoutId.current !== null) {
-      clearTimeout(timeoutId.current);
-      timeoutId.current = null;
-    }
-  }, [autofixData, dataUpdatedAt, dataRefetch]);
-
   const triggerAutofix = useCallback(async () => {
-    await api.requestPromise(`/issues/${_group.id}/ai-autofix/`, {
+    await api.requestPromise(`/issues/${group.id}/ai-autofix/`, {
       method: 'POST',
       data: {
         additional_context: additionalContext,
@@ -56,7 +39,7 @@ export const useAiAutofix = (_group: Group) => {
     });
 
     dataRefetch();
-  }, [api, _group.id, dataRefetch, additionalContext]);
+  }, [api, group.id, dataRefetch, additionalContext]);
 
   return {
     additionalContext,

--- a/static/app/components/events/aiSuggestedSolution/suggestion.tsx
+++ b/static/app/components/events/aiSuggestedSolution/suggestion.tsx
@@ -123,7 +123,7 @@ export function Suggestion({onHideSuggestion, projectSlug, event}: Props) {
       },
     ],
     {
-      enabled: false,
+      enabled: isStaff ? (piiCertified ? true : false) : true,
       staleTime: Infinity,
       retry: false,
     }

--- a/static/app/views/issueDetails/resourcesAndMaybeSolutions.tsx
+++ b/static/app/views/issueDetails/resourcesAndMaybeSolutions.tsx
@@ -1,6 +1,7 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {AiAutofix} from 'sentry/components/events/aiAutofix';
 import {AiSuggestedSolution} from 'sentry/components/events/aiSuggestedSolution';
 import {EventDataSection} from 'sentry/components/events/eventDataSection';
 import {Resources} from 'sentry/components/events/interfaces/performance/resources';
@@ -23,12 +24,18 @@ type Props = {
 export function ResourcesAndMaybeSolutions({event, project, group}: Props) {
   const organization = useOrganization();
   const config = getConfigForIssueType(group, project);
+
+  // NOTE: AI Autofix is for INTERNAL testing only for now.
+  const displayAiAutofix =
+    project.features.includes('ai-autofix') &&
+    !shouldShowCustomErrorResourceConfig(group, project);
   const displayAiSuggestedSolution =
     // Skip showing AI suggested solution if the issue has a custom resource
     organization.aiSuggestedSolution &&
-    !shouldShowCustomErrorResourceConfig(group, project);
+    !shouldShowCustomErrorResourceConfig(group, project) &&
+    !displayAiAutofix;
 
-  if (!config.resources && !displayAiSuggestedSolution) {
+  if (!config.resources && !(displayAiSuggestedSolution || displayAiAutofix)) {
     return null;
   }
 
@@ -49,6 +56,7 @@ export function ResourcesAndMaybeSolutions({event, project, group}: Props) {
         {displayAiSuggestedSolution && (
           <AiSuggestedSolution event={event} projectSlug={project.slug} />
         )}
+        {displayAiAutofix && <AiAutofix group={group} />}
       </Content>
     </Wrapper>
   );


### PR DESCRIPTION
Introduces a new AI autofix feature on the issue details page with the option for additional context. Disabled behind feature flag `projects:ai-autofix`

NOTE: Feature will only be enabled for the internal sentry project (id=1) thru getsentry

Backend PR: #63550 

<img width="912" alt="Screenshot 2024-01-19 at 3 57 14 PM" src="https://github.com/getsentry/sentry/assets/30991498/4e1756fd-9378-4280-a4b4-eb4c8ac4a733">
