### PR TITLE
fix(sidebar): Adjust alignment of alpha/beta badges in the purple sidebar

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -379,7 +379,7 @@ const SidebarItemLabel = styled('span')`
   opacity: 1;
   flex: 1;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   overflow: hidden;
 `;


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="505" alt="before" src="https://github.com/getsentry/sentry/assets/187460/7b96431a-6110-4090-bd56-84b0758d071b"> | <img width="505" alt="after" src="https://github.com/getsentry/sentry/assets/187460/540d46d9-702d-4b5e-9255-d8af587f57f8"> |

Some marked up images too show alignments. Each shape is copy+pasted, so heights of the boxes are the same inside each image.
- We can see that the badge text is centered vertically inside it's background. ✅
- The label and badge have a slightly different baseline in the Before example

The problem seems to be that the badge text shouldn't try to sit on the same baseline as the main text, because that makes the background drop down -> per the red boxes in the Before example.
So I shifted the whole badge up, putting the badge text in the center of the main label. The badge is a touch higher than I'd pick, but I think from far away it's more balanced looking, without the badge background dropping down so low.

Before:
<img width="665" alt="before - marked up" src="https://github.com/getsentry/sentry/assets/187460/1e8b1680-9339-4696-a9a3-d2933ac1ba11">
After: 
![after - markup](https://github.com/getsentry/sentry/assets/187460/8024844f-345d-4167-a7b5-ef134668a362)




Fixes https://github.com/getsentry/sentry/issues/63515