### PR TITLE
chore(hybrid-cloud): Adds outbox maximum shard depth metric

### DIFF
--- a/src/sentry/models/outbox.py
+++ b/src/sentry/models/outbox.py
@@ -676,13 +676,39 @@ class OutboxBase(Model):
                     _test_processing_barrier.wait()
 
     @classmethod
-    def get_shard_depths_descending(cls):
-        return list(
-            {"shard_identifier": aggregate_row["shard_identifier"], "depth": aggregate_row["depth"]}
-            for aggregate_row in cls.objects.values(*cls.sharding_columns)
-            .annotate(depth=Count("pk"))
-            .order_by("-depth")
+    def get_shard_depths_descending(cls, limit: Optional[int] = 10) -> list[dict[str, int | str]]:
+        """
+        Queries all outbox shards for their total depth, aggregated by their
+        sharding columns as specified by the outbox class implementation.
+
+        :param limit: Limits the query to the top N rows with the greatest shard
+        depth. If limit is None, the entire set of rows will be returned.
+        :return: A list of dictionaries, containing shard depths and shard
+        relevant column values.
+        """
+        if limit is not None:
+            assert limit > 0, "Limit must be a positive integer if specified"
+
+        base_depth_query = (
+            cls.objects.values(*cls.sharding_columns).annotate(depth=Count("*")).order_by("-depth")
         )
+
+        if limit is not None:
+            base_depth_query = base_depth_query[0:limit]
+
+        aggregated_shard_information = list()
+        for shard_row in base_depth_query:
+            shard_information = {
+                shard_column: shard_row[shard_column] for shard_column in cls.sharding_columns
+            }
+            shard_information["depth"] = shard_row["depth"]
+            aggregated_shard_information.append(shard_information)
+
+        return aggregated_shard_information
+
+    @classmethod
+    def get_total_outbox_count(cls) -> int:
+        return cls.objects.count()
 
 
 # Outboxes bound from region silo -> control silo

--- a/src/sentry/tasks/deliver_from_outbox.py
+++ b/src/sentry/tasks/deliver_from_outbox.py
@@ -97,7 +97,7 @@ def schedule_batch(
             metrics.gauge(
                 "deliver_from_outbox.maximum_shard_depth",
                 value=shard_depths[0]["depth"] if shard_depths else 0,
-                tags=dict(silo_mode=silo_mode.name),
+                tags=dict(silo_mode=silo_mode.name, outbox_name=outbox_name),
                 sample_rate=1.0,
             )
         if process_outbox_backfills:

--- a/src/sentry/tasks/deliver_from_outbox.py
+++ b/src/sentry/tasks/deliver_from_outbox.py
@@ -92,8 +92,17 @@ def schedule_batch(
                     outbox_identifier_low=lo + i * batch_size,
                     outbox_identifier_hi=lo + (i + 1) * batch_size,
                 )
+
+            shard_depths = outbox_model.get_shard_depths_descending()
+            metrics.gauge(
+                "deliver_from_outbox.maximum_shard_depth",
+                value=shard_depths[0]["depth"] if shard_depths else 0,
+                tags=dict(silo_mode=silo_mode.name),
+                sample_rate=1.0,
+            )
         if process_outbox_backfills:
             backfill_outboxes_for(silo_mode, scheduled_count)
+
     except Exception:
         sentry_sdk.capture_exception()
         raise

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -673,3 +673,10 @@ class OutboxAggregationTest(TestCase):
             dict(shard_identifier=1, depth=456),
             dict(shard_identifier=3, depth=123),
         ]
+
+    def test_calculate_sharding_depths_empty(self):
+        with outbox_runner():
+            pass
+
+        assert ControlOutbox.objects.count() == 0
+        assert ControlOutbox.get_shard_depths_descending() == []

--- a/tests/sentry/models/test_outbox.py
+++ b/tests/sentry/models/test_outbox.py
@@ -653,7 +653,7 @@ class TestOutboxesManager(TestCase):
 
 class OutboxAggregationTest(TestCase):
     def setUp(self):
-        shard_counts = {1: (456, "eu"), 2: (789, "us"), 3: (123, "us")}
+        shard_counts = {1: (4, "eu"), 2: (7, "us"), 3: (1, "us")}
         with outbox_runner():
             pass
 
@@ -676,19 +676,19 @@ class OutboxAggregationTest(TestCase):
                 shard_identifier=2,
                 region_name="us",
                 shard_scope=OutboxScope.WEBHOOK_SCOPE.value,
-                depth=789,
+                depth=7,
             ),
             dict(
                 shard_identifier=1,
                 region_name="eu",
                 shard_scope=OutboxScope.WEBHOOK_SCOPE.value,
-                depth=456,
+                depth=4,
             ),
             dict(
                 shard_identifier=3,
                 region_name="us",
                 shard_scope=OutboxScope.WEBHOOK_SCOPE.value,
-                depth=123,
+                depth=1,
             ),
         ]
 
@@ -699,7 +699,7 @@ class OutboxAggregationTest(TestCase):
                 shard_identifier=2,
                 region_name="us",
                 shard_scope=OutboxScope.WEBHOOK_SCOPE.value,
-                depth=789,
+                depth=7,
             )
         ]
 
@@ -709,4 +709,4 @@ class OutboxAggregationTest(TestCase):
         assert ControlOutbox.get_shard_depths_descending() == []
 
     def test_total_count(self):
-        assert ControlOutbox.get_total_outbox_count() == 789 + 456 + 123
+        assert ControlOutbox.get_total_outbox_count() == 7 + 4 + 1


### PR DESCRIPTION
Adds a new metric called `deliver_from_outbox.maximum_shard_depth`, which calculates the maximum depth of all shards across the given outbox type. This PR also adds a new helper method to the Outbox base class which calculates all current shard depths for the outbox class.
