### PR TITLE
feat(issues): Add new prompt keys

### DIFF
--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -14,6 +14,8 @@ DEFAULT_PROMPTS = {
     "code_owners": {"required_fields": ["organization_id", "project_id"]},
     "vitals_alert": {"required_fields": ["organization_id"]},
     "github_missing_members": {"required_fields": ["organization_id"]},
+    "codecov_stacktrace_prompt": {"required_fields": ["organization_id", "project_id"]},
+    "metric_alert_ignore_archived_issues": {"required_fields": ["organization_id", "project_id"]},
 }
 
 


### PR DESCRIPTION
Looks like I missed adding `metric_alert_ignore_archived_issues` a bit ago. Also adds `codecov_stacktrace_prompt` as a key.

related #63406