### PR TITLE
fix(group-attributes): Stop manually sending `post_save` signals for `Group` after `Queryset.update`

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -15,7 +15,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics, features, options
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.actor import ActorSerializer
 from sentry.db.models.query import create_or_update
@@ -492,7 +492,7 @@ def update_groups(
                 group.status = GroupStatus.RESOLVED
                 group.substatus = None
                 group.resolved_at = now
-                if affected:
+                if affected and not options.get("groups.enable-post-update-signal"):
                     post_save.send(
                         sender=Group,
                         instance=group,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1755,12 +1755,13 @@ def _handle_regression(group: Group, event: Event, release: Optional[Release]) -
             transition_type="automatic",
             sender="handle_regression",
         )
-        post_save.send(
-            sender=Group,
-            instance=group,
-            created=False,
-            update_fields=["last_seen", "active_at", "status", "substatus"],
-        )
+        if not options.get("groups.enable-post-update-signal"):
+            post_save.send(
+                sender=Group,
+                instance=group,
+                created=False,
+                update_fields=["last_seen", "active_at", "status", "substatus"],
+            )
 
     follows_semver = False
     resolved_in_activity = None

--- a/src/sentry/issues/escalating.py
+++ b/src/sentry/issues/escalating.py
@@ -26,7 +26,7 @@ from snuba_sdk import (
 )
 from snuba_sdk.expressions import Granularity
 
-from sentry import features
+from sentry import features, options
 from sentry.eventstore.models import GroupEvent
 from sentry.issues.escalating_group_forecast import EscalatingGroupForecast
 from sentry.issues.escalating_issues_alg import GroupCount
@@ -500,12 +500,13 @@ def manage_issue_states(
         if updated:
             group.status = GroupStatus.UNRESOLVED
             group.substatus = GroupSubStatus.ESCALATING
-            post_save.send(
-                sender=Group,
-                instance=group,
-                created=False,
-                update_fields=["status", "substatus"],
-            )
+            if not options.get("groups.enable-post-update-signal"):
+                post_save.send(
+                    sender=Group,
+                    instance=group,
+                    created=False,
+                    update_fields=["status", "substatus"],
+                )
             add_group_to_inbox(group, GroupInboxReason.ESCALATING, snooze_details)
             record_group_history(group, GroupHistoryStatus.ESCALATING)
 
@@ -543,12 +544,13 @@ def manage_issue_states(
         if updated:
             group.status = GroupStatus.UNRESOLVED
             group.substatus = GroupSubStatus.ONGOING
-            post_save.send(
-                sender=Group,
-                instance=group,
-                created=False,
-                update_fields=["status", "substatus"],
-            )
+            if not options.get("groups.enable-post-update-signal"):
+                post_save.send(
+                    sender=Group,
+                    instance=group,
+                    created=False,
+                    update_fields=["status", "substatus"],
+                )
             add_group_to_inbox(group, GroupInboxReason.ONGOING, snooze_details)
             record_group_history(group, GroupHistoryStatus.ONGOING)
 
@@ -563,12 +565,13 @@ def manage_issue_states(
         if updated:
             group.status = GroupStatus.UNRESOLVED
             group.substatus = GroupSubStatus.ONGOING
-            post_save.send(
-                sender=Group,
-                instance=group,
-                created=False,
-                update_fields=["status", "substatus"],
-            )
+            if not options.get("groups.enable-post-update-signal"):
+                post_save.send(
+                    sender=Group,
+                    instance=group,
+                    created=False,
+                    update_fields=["status", "substatus"],
+                )
             add_group_to_inbox(group, GroupInboxReason.UNIGNORED, snooze_details)
             record_group_history(group, GroupHistoryStatus.UNIGNORED)
             Activity.objects.create_group_activity(

--- a/src/sentry/issues/status_change.py
+++ b/src/sentry/issues/status_change.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Sequence
 
 from django.db.models.signals import post_save
 
+from sentry import options
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphistory import record_group_history_from_activity_type
@@ -119,11 +120,12 @@ def handle_status_update(
                 kwargs={"project_id": group.project_id, "group_id": group.id}
             )
 
-        post_save.send(
-            sender=Group,
-            instance=group,
-            created=False,
-            update_fields=["status", "substatus"],
-        )
+        if not options.get("groups.enable-post-update-signal"):
+            post_save.send(
+                sender=Group,
+                instance=group,
+                created=False,
+                update_fields=["status", "substatus"],
+            )
 
     return ActivityInfo(activity_type, activity_data)


### PR DESCRIPTION
Once we have a `post_update` signal we no longer need to send these manual `post_save` signals. Putting them behind an option for now so that we'll switch when we enable the signal
