### PR TITLE
feat(sdk-crashes): Add RN production paths

### DIFF
--- a/fixtures/sdk_crash_detection/crash_event_react_native.py
+++ b/fixtures/sdk_crash_detection/crash_event_react_native.py
@@ -25,8 +25,9 @@ def get_frames(filename: str) -> Sequence[MutableMapping[str, str]]:
         },
         {
             "function": "ReactNativeClient#nativeCrash",
+            "module": filename.replace("node_modules/", "").replace(".js", ""),
             "filename": filename,
-            "abs_path": "/Users/sentry.user/git-repos/sentry-react-native/dist/js/client.js",
+            "abs_path": f"app:///{filename}",
         },
     ]
     return frames

--- a/src/sentry/utils/sdk_crashes/path_replacer.py
+++ b/src/sentry/utils/sdk_crashes/path_replacer.py
@@ -4,6 +4,10 @@ from typing import Set
 
 
 class PathReplacer(ABC):
+    """
+    Replaces SDK frame paths with a new path. Runs only for SDK frames.
+    """
+
     @abstractmethod
     def replace_path(self, path: str) -> str:
         pass

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -122,9 +122,27 @@ def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
             },
             sdk_frame_config=SDKFrameConfig(
                 function_patterns=set(),
-                filename_patterns={r"**/sentry-react-native/dist/**"},
+                filename_patterns={
+                    # Development path
+                    r"**/sentry-react-native/dist/**",
+                    # Production paths taken from https://github.com/getsentry/sentry-react-native/blob/037d5fa2f38b02eaf4ca92fda569e0acfd6c3ebe/package.json#L68-L77
+                    r"**/@sentry/react-native/**",
+                    r"**/@sentry/browser/**",
+                    r"**/@sentry/cli/**",
+                    r"**/@sentry/core/**",
+                    r"**/@sentry/hub/**",
+                    r"**/@sentry/integrations/**",
+                    r"**/@sentry/react/**",
+                    r"**/@sentry/types/**",
+                    r"**/@sentry/utils/**",
+                },
                 path_replacer=KeepAfterPatternMatchPathReplacer(
-                    patterns={r"\/sentry-react-native\/.*", r"\/@sentry.*"},
+                    patterns={
+                        r"\/sentry-react-native\/.*",
+                        # We don't add the first / here because module isn't prefixed with /.
+                        # We don't need to specify all production paths because the path replacer only runs for SDK frames.
+                        r"@sentry\/*",
+                    },
                     fallback_path="sentry-react-native",
                 ),
             ),

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_react_native.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection_react_native.py
@@ -41,61 +41,139 @@ def configs() -> Sequence[SDKCrashDetectionConfig]:
         return build_sdk_crash_detection_configs()
 
 
+@pytest.mark.parametrize(
+    ["filename", "expected_stripped_filename", "detected"],
+    [
+        (
+            "/Users/sentry.user/git-repos/sentry-react-native/dist/js/client.js",
+            "/sentry-react-native/dist/js/client.js",
+            True,
+        ),
+        (
+            "/Users/sentry.user/git-repos/sentry-react-native/samples/react-native/src/Screens/HomeScreen.tsx",
+            "empty_on_purpose",
+            False,
+        ),
+    ],
+)
 @decorators
-def test_sdk_crash_is_reported(mock_sdk_crash_reporter, mock_random, store_event, configs):
-    event = store_event(data=get_crash_event())
+def test_sdk_crash_is_reported_development_paths(
+    mock_sdk_crash_reporter,
+    mock_random,
+    store_event,
+    configs,
+    filename,
+    expected_stripped_filename,
+    detected,
+):
+    event = store_event(data=get_crash_event(filename=filename))
 
     configs[1].organization_allowlist = [event.project.organization_id]
 
     sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)
 
-    assert mock_sdk_crash_reporter.report.call_count == 1
-    reported_event_data = mock_sdk_crash_reporter.report.call_args.args[0]
+    if detected:
+        assert mock_sdk_crash_reporter.report.call_count == 1
+        reported_event_data = mock_sdk_crash_reporter.report.call_args.args[0]
 
-    stripped_frames = get_path(
-        reported_event_data, "exception", "values", -1, "stacktrace", "frames"
-    )
-
-    assert len(stripped_frames) == 4
-    assert stripped_frames[0]["function"] == "dispatchEvent"
-    assert stripped_frames[1]["function"] == "community.lib.dosomething"
-    assert stripped_frames[2]["function"] == "nativeCrash"
-    assert stripped_frames[3]["function"] == "ReactNativeClient#nativeCrash"
-
-
-@decorators
-def test_sdk_crash_sample_app_not_reported(
-    mock_sdk_crash_reporter, mock_random, store_event, configs
-):
-    event = store_event(
-        data=get_crash_event(
-            filename="/Users/sentry.user/git-repos/sentry-react-native/samples/react-native/src/Screens/HomeScreen.tsx"
+        stripped_frames = get_path(
+            reported_event_data, "exception", "values", -1, "stacktrace", "frames"
         )
-    )
+
+        assert len(stripped_frames) == 4
+        assert stripped_frames[0]["function"] == "dispatchEvent"
+        assert stripped_frames[1]["function"] == "community.lib.dosomething"
+        assert stripped_frames[2]["function"] == "nativeCrash"
+
+        sdk_frame = stripped_frames[3]
+        assert sdk_frame["function"] == "ReactNativeClient#nativeCrash"
+        assert sdk_frame["filename"] == expected_stripped_filename
+        assert sdk_frame["abs_path"] == expected_stripped_filename
+    else:
+        assert mock_sdk_crash_reporter.report.call_count == 0
+
+
+@pytest.mark.parametrize(
+    ["package_name", "detected"],
+    [
+        (
+            "/@sentry/react-native/",
+            True,
+        ),
+        (
+            "/@sentry/reactnative/",
+            False,
+        ),
+        (
+            "/@sentry/browser/",
+            True,
+        ),
+        (
+            "/@sentry/cli/",
+            True,
+        ),
+        (
+            "/@sentry/core/",
+            True,
+        ),
+        (
+            "/@sentry/hub/",
+            True,
+        ),
+        (
+            "/@sentry/integrations/",
+            True,
+        ),
+        (
+            "/@sentry/react/",
+            True,
+        ),
+        (
+            "/@sentry/types/",
+            True,
+        ),
+        (
+            "/@sentry/utils/",
+            True,
+        ),
+    ],
+)
+@decorators
+def test_sdk_crash_is_reported_production_paths(
+    mock_sdk_crash_reporter, mock_random, store_event, configs, package_name, detected
+):
+    expected_stripped_filename = f"{package_name}dist/js/integrations/reactnativeerrorhandlers.js"
+    # Remove the first / from the path because the module is not prefixed with /.
+    expected_stripped_filename = expected_stripped_filename[1:]
+
+    filename = f"node_modules/{expected_stripped_filename}"
+    event = store_event(data=get_crash_event(filename=filename))
 
     configs[1].organization_allowlist = [event.project.organization_id]
 
-    sdk_crash_detection.detect_sdk_crash(
-        event=event,
-        configs=configs,
-    )
-
-    assert mock_sdk_crash_reporter.report.call_count == 0
-
-
-@decorators
-def test_sdk_crash_react_natives_not_reported(
-    mock_sdk_crash_reporter, mock_random, store_event, configs
-):
-    event = store_event(
-        data=get_crash_event(
-            filename="/Users/sentry.user/git-repos/sentry-react-natives/dist/js/client.js"
-        )
-    )
-
     sdk_crash_detection.detect_sdk_crash(event=event, configs=configs)
 
-    assert mock_sdk_crash_reporter.report.call_count == 0
+    if detected:
+        assert mock_sdk_crash_reporter.report.call_count == 1
+        reported_event_data = mock_sdk_crash_reporter.report.call_args.args[0]
+
+        stripped_frames = get_path(
+            reported_event_data, "exception", "values", -1, "stacktrace", "frames"
+        )
+
+        assert len(stripped_frames) == 4
+        assert stripped_frames[0]["function"] == "dispatchEvent"
+        assert stripped_frames[1]["function"] == "community.lib.dosomething"
+        assert stripped_frames[2]["function"] == "nativeCrash"
+
+        sdk_frame = stripped_frames[3]
+        assert sdk_frame["function"] == "ReactNativeClient#nativeCrash"
+        expected_module = expected_stripped_filename.replace(".js", "")
+        assert sdk_frame["module"] == expected_module
+        assert sdk_frame["filename"] == expected_stripped_filename
+        assert sdk_frame["abs_path"] == expected_stripped_filename
+    else:
+        assert mock_sdk_crash_reporter.report.call_count == 0
 
 
 @decorators


### PR DESCRIPTION
The SDK crash detection config for RN now includes production paths of all the Sentry JavaScript packages used by RN, so the detection can now detect crashes of production events.
