### PR TITLE
feat(ddm): Add support for release:latest in the metrics api and ddm/meta endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -13,6 +13,7 @@ from sentry.exceptions import InvalidParams
 from sentry.sentry_metrics.querying.api import run_metrics_query
 from sentry.sentry_metrics.querying.errors import (
     InvalidMetricsQueryError,
+    LatestReleaseNotFoundError,
     MetricsQueryExecutionError,
 )
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
@@ -201,6 +202,8 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
             )
         except InvalidMetricsQueryError as e:
             return Response(status=400, data={"detail": str(e)})
+        except LatestReleaseNotFoundError as e:
+            return Response(status=404, data={"detail": str(e)})
         except MetricsQueryExecutionError as e:
             return Response(status=500, data={"detail": str(e)})
 

--- a/src/sentry/sentry_metrics/querying/api.py
+++ b/src/sentry/sentry_metrics/querying/api.py
@@ -31,7 +31,9 @@ from sentry.sentry_metrics.querying.types import (
 )
 from sentry.sentry_metrics.querying.utils import remove_if_match
 from sentry.sentry_metrics.querying.visitors import (
+    ConditionsCompositeVisitor,
     EnvironmentsInjectionVisitor,
+    LatestReleaseTransformationVisitor,
     QueryExpressionVisitor,
     ValidationVisitor,
 )
@@ -427,10 +429,12 @@ class QueryParser:
 
     def __init__(
         self,
+        projects: Sequence[Project],
         fields: Sequence[str],
         query: Optional[str],
         group_bys: Optional[Sequence[str]],
     ):
+        self._projects = projects
         self._fields = fields
         self._query = query
         self._group_bys = group_bys
@@ -526,9 +530,15 @@ class QueryParser:
             mql_query = self._build_mql_query(field, mql_filters, mql_group_bys)
             yield (
                 field,
-                self._parse_mql(mql_query).add_visitor(ValidationVisitor())
-                # We purposefully want to inject environments after the final query expression tree is expanded.
-                .add_visitor(EnvironmentsInjectionVisitor(environments)).get(),
+                self._parse_mql(mql_query)
+                # We validate the query.
+                .add_visitor(ValidationVisitor())
+                # We inject the environment filter in each timeseries.
+                .add_visitor(EnvironmentsInjectionVisitor(environments))
+                # We transform all `release:latest` filters into the actual latest releases.
+                .add_visitor(
+                    ConditionsCompositeVisitor(LatestReleaseTransformationVisitor(self._projects))
+                ).get(),
             )
 
 
@@ -998,7 +1008,7 @@ def run_metrics_query(
     executor = QueryExecutor(organization=organization, referrer=referrer)
 
     # Parsing the input and iterating over each timeseries.
-    parser = QueryParser(fields=fields, query=query, group_bys=group_bys)
+    parser = QueryParser(projects=projects, fields=fields, query=query, group_bys=group_bys)
 
     applied_order_by = False
     for field, timeseries in parser.generate_queries(environments=environments):

--- a/src/sentry/sentry_metrics/querying/api.py
+++ b/src/sentry/sentry_metrics/querying/api.py
@@ -31,8 +31,8 @@ from sentry.sentry_metrics.querying.types import (
 )
 from sentry.sentry_metrics.querying.utils import remove_if_match
 from sentry.sentry_metrics.querying.visitors import (
-    ConditionsCompositeVisitor,
     EnvironmentsInjectionVisitor,
+    FiltersCompositeVisitor,
     LatestReleaseTransformationVisitor,
     QueryExpressionVisitor,
     ValidationVisitor,
@@ -537,7 +537,7 @@ class QueryParser:
                 .add_visitor(EnvironmentsInjectionVisitor(environments))
                 # We transform all `release:latest` filters into the actual latest releases.
                 .add_visitor(
-                    ConditionsCompositeVisitor(LatestReleaseTransformationVisitor(self._projects))
+                    FiltersCompositeVisitor(LatestReleaseTransformationVisitor(self._projects))
                 ).get(),
             )
 

--- a/src/sentry/sentry_metrics/querying/errors.py
+++ b/src/sentry/sentry_metrics/querying/errors.py
@@ -4,3 +4,7 @@ class InvalidMetricsQueryError(Exception):
 
 class MetricsQueryExecutionError(Exception):
     pass
+
+
+class LatestReleaseNotFoundError(Exception):
+    pass

--- a/src/sentry/sentry_metrics/querying/metadata/correlations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/correlations.py
@@ -28,6 +28,7 @@ from sentry.sentry_metrics.querying.metadata.utils import (
     get_snuba_conditions_from_query,
     transform_conditions_to_tags,
     transform_conditions_with,
+    transform_latest_release_condition,
 )
 from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.naming_layer.mri import (
@@ -152,6 +153,7 @@ class CorrelationsSource(ABC):
     ) -> Sequence[Segment]:
         conditions = get_snuba_conditions_from_query(query)
         conditions = add_environments_condition(conditions, environments)
+        conditions = transform_latest_release_condition(conditions, self.projects)
 
         return self._get_segments(
             metric_mri=metric_mri,

--- a/src/sentry/sentry_metrics/querying/metadata/utils.py
+++ b/src/sentry/sentry_metrics/querying/metadata/utils.py
@@ -110,17 +110,17 @@ def transform_latest_release_condition(
     conditions: Optional[ConditionGroup], projects: Sequence[Project]
 ):
     """
-    Transforms all the conditions in the form `release:latest` in `release:x OR release:y` where `x` and `y` are
+    Transforms all the conditions in the form `release:latest` in `release:[x, y...]` where `x` and `y` are
     the latest releases of the supplied projects.
     """
     if conditions is None:
         return None
 
     def _transform_latest_release_condition(condition: Condition) -> Optional[ConditionGroup]:
+        # TODO: move to the visitors implementation by using `QueryCondition` visitors from `visitors.py`.
         if not isinstance(condition.lhs, Column):
             return None
 
-        # If it's not the latest release, we want to early return for efficiency.
         if not (
             condition.lhs.name == "release"
             and isinstance(condition.rhs, str)

--- a/src/sentry/sentry_metrics/querying/metadata/utils.py
+++ b/src/sentry/sentry_metrics/querying/metadata/utils.py
@@ -7,7 +7,10 @@ from snuba_sdk.mql.mql import parse_mql
 from sentry.api.serializers import bulk_fetch_project_latest_releases
 from sentry.models.environment import Environment
 from sentry.models.project import Project
-from sentry.sentry_metrics.querying.errors import InvalidMetricsQueryError
+from sentry.sentry_metrics.querying.errors import (
+    InvalidMetricsQueryError,
+    LatestReleaseNotFoundError,
+)
 
 
 def _visit_conditions(
@@ -129,6 +132,11 @@ def transform_latest_release_condition(
             return None
 
         latest_releases = bulk_fetch_project_latest_releases(projects)
+        if not latest_releases:
+            raise LatestReleaseNotFoundError(
+                "Latest release(s) not found for the supplied projects"
+            )
+
         return [
             Condition(
                 lhs=condition.lhs,

--- a/src/sentry/sentry_metrics/querying/types.py
+++ b/src/sentry/sentry_metrics/querying/types.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Sequence, Tuple, Union
 
-from snuba_sdk import Formula, Timeseries
+from snuba_sdk import BooleanCondition, Condition, Formula, Timeseries
 
 # Type representing the aggregate value from Snuba, which can be null, int, float or list.
 ResultValue = Optional[Union[int, float, List[Optional[Union[int, float]]]]]
@@ -16,3 +16,5 @@ GroupKey = Tuple[Group, ...]
 GroupsCollection = Sequence[Sequence[Group]]
 # Type representing the possible expressions for a query.
 QueryExpression = Union[Timeseries, Formula]
+# Type representing the possible conditions for a query.
+QueryCondition = Union[BooleanCondition, Condition]

--- a/src/sentry/sentry_metrics/querying/visitors.py
+++ b/src/sentry/sentry_metrics/querying/visitors.py
@@ -112,7 +112,7 @@ class ValidationVisitor(QueryExpressionVisitor[QueryExpression]):
                 self._validate_filters(f.conditions)
 
 
-class ConditionsCompositeVisitor(QueryExpressionVisitor[QueryExpression]):
+class FiltersCompositeVisitor(QueryExpressionVisitor[QueryExpression]):
     """
     Visitor that runs a series of `QueryConditionVisitor`(s) on each filters of elements of a `QueryExpression`.
     """

--- a/src/sentry/sentry_metrics/querying/visitors.py
+++ b/src/sentry/sentry_metrics/querying/visitors.py
@@ -4,9 +4,11 @@ from typing import Generic, Optional, Sequence, TypeVar
 from snuba_sdk import BooleanCondition, BooleanOp, Column, Condition, Formula, Op, Timeseries
 from snuba_sdk.conditions import ConditionGroup
 
+from sentry.api.serializers import bulk_fetch_project_latest_releases
 from sentry.models.environment import Environment
+from sentry.models.project import Project
 from sentry.sentry_metrics.querying.errors import InvalidMetricsQueryError
-from sentry.sentry_metrics.querying.types import QueryExpression
+from sentry.sentry_metrics.querying.types import QueryCondition, QueryExpression
 
 TVisited = TypeVar("TVisited")
 
@@ -16,13 +18,13 @@ class QueryExpressionVisitor(ABC, Generic[TVisited]):
     Abstract visitor that defines a visiting behavior of a `QueryExpression`.
     """
 
-    def visit(self, query: QueryExpression) -> TVisited:
-        if isinstance(query, Formula):
-            return self._visit_formula(query)
-        elif isinstance(query, Timeseries):
-            return self._visit_timeseries(query)
+    def visit(self, query_expression: QueryExpression) -> TVisited:
+        if isinstance(query_expression, Formula):
+            return self._visit_formula(query_expression)
+        elif isinstance(query_expression, Timeseries):
+            return self._visit_timeseries(query_expression)
 
-        raise AssertionError(f"Unhandled expression {query}")
+        raise AssertionError(f"Unhandled expression {query_expression}")
 
     def _visit_formula(self, formula: Formula) -> TVisited:
         # The default implementation just mutates the parameters of the `Formula`.
@@ -36,6 +38,39 @@ class QueryExpressionVisitor(ABC, Generic[TVisited]):
         raise NotImplementedError
 
 
+class QueryConditionVisitor(ABC, Generic[TVisited]):
+    """
+    Abstract visitor that defines a visiting behavior of a `QueryCondition`.
+    """
+
+    def visit_group(self, condition_group: Optional[ConditionGroup]) -> TVisited:
+        if not condition_group:
+            return condition_group
+
+        visited_conditions = []
+        for condition in condition_group:
+            visited_conditions.append(self.visit(condition))
+
+        return visited_conditions
+
+    def visit(self, query_condition: QueryCondition) -> TVisited:
+        if isinstance(query_condition, BooleanCondition):
+            return self._visit_boolean_condition(query_condition)
+        elif isinstance(query_condition, Condition):
+            return self._visit_condition(query_condition)
+
+    def _visit_boolean_condition(self, boolean_condition: BooleanCondition) -> TVisited:
+        conditions = []
+
+        for condition in boolean_condition.conditions:
+            conditions.append(self.visit(condition))
+
+        return BooleanCondition(op=boolean_condition.op, conditions=conditions)
+
+    def _visit_condition(self, condition: Condition) -> TVisited:
+        raise NotImplementedError
+
+
 class EnvironmentsInjectionVisitor(QueryExpressionVisitor[QueryExpression]):
     """
     Visitor that recursively injects the environments filter into all `Timeseries`.
@@ -45,6 +80,7 @@ class EnvironmentsInjectionVisitor(QueryExpressionVisitor[QueryExpression]):
         self._environment_names = [environment.name for environment in environments]
 
     def _visit_timeseries(self, timeseries: Timeseries) -> QueryExpression:
+        # TODO: inject the filter in the formula filters also.
         if self._environment_names:
             current_filters = timeseries.filters if timeseries.filters else []
             current_filters.extend(
@@ -72,3 +108,58 @@ class ValidationVisitor(QueryExpressionVisitor[QueryExpression]):
                     raise InvalidMetricsQueryError("The OR operator is not supported")
 
                 self._validate_filters(f.conditions)
+
+
+class ConditionsCompositeVisitor(QueryExpressionVisitor[QueryExpression]):
+    """
+    Visitor that runs a series of `QueryConditionVisitor`(s) on each filters of elements of a `QueryExpression`.
+    """
+
+    def __init__(self, *visitors: QueryConditionVisitor):
+        self._visitors = list(visitors)
+
+    def _visit_formula(self, formula: Formula) -> QueryExpression:
+        # We call the super method in order to recursively visit all the parameters of a formula and then apply the
+        # visitors on the filters of the formula itself.
+        visited_formula = super()._visit_formula(formula)
+        return visited_formula.set_filters(
+            self._apply_visitors_on_condition_group(visited_formula.filters)
+        )
+
+    def _visit_timeseries(self, timeseries: Timeseries) -> QueryExpression:
+        return timeseries.set_filters(self._apply_visitors_on_condition_group(timeseries.filters))
+
+    def _apply_visitors_on_condition_group(self, condition_group: ConditionGroup):
+        visited_condition_group = condition_group
+        for visitor in self._visitors:
+            visited_condition_group = visitor.visit_group(visited_condition_group)
+
+        return visited_condition_group
+
+
+class LatestReleaseTransformationVisitor(QueryConditionVisitor[QueryCondition]):
+    """
+    Visitor that recursively transforms all the conditions in the form `release:latest` by transforming them to
+    `release IN [x, y, ...]` where `x` and `y` are the latest releases belonging to the supplied projects.
+    """
+
+    def __init__(self, projects: Sequence[Project]):
+        self._projects = projects
+
+    def _visit_condition(self, condition: Condition) -> QueryCondition:
+        if not isinstance(condition.lhs, Column):
+            return condition
+
+        if not (
+            condition.lhs.name == "release"
+            and isinstance(condition.rhs, str)
+            and condition.rhs == "latest"
+        ):
+            return condition
+
+        latest_releases = bulk_fetch_project_latest_releases(self._projects)
+        return Condition(
+            lhs=condition.lhs,
+            op=Op.IN,
+            rhs=[latest_release.version for latest_release in latest_releases],
+        )

--- a/tests/sentry/api/endpoints/test_organization_ddm_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_ddm_meta.py
@@ -545,6 +545,17 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
         assert metric_spans[0]["transactionId"] == transaction_id_2
         assert metric_spans[1]["transactionId"] == transaction_id_1
 
+    def test_get_metric_spans_with_latest_release_not_found(self):
+        self.get_error_response(
+            self.organization.slug,
+            metric=["g:custom/page_load@millisecond"],
+            project=[self.project.id],
+            statsPeriod="1d",
+            metricSpans="true",
+            query="release:latest",
+            status_code=404,
+        )
+
     def test_get_metric_spans_with_bounds(self):
         mri = "g:custom/page_load@millisecond"
 

--- a/tests/sentry/sentry_metrics/querying/test_api.py
+++ b/tests/sentry/sentry_metrics/querying/test_api.py
@@ -26,20 +26,35 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
     def setUp(self):
         super().setUp()
 
-        for value, transaction, platform, env, time in (
-            (1, "/hello", "android", "prod", self.now()),
-            (6, "/hello", "ios", "dev", self.now()),
-            (5, "/world", "windows", "prod", self.now() + timedelta(minutes=30)),
-            (3, "/hello", "ios", "dev", self.now() + timedelta(hours=1)),
-            (2, "/hello", "android", "dev", self.now() + timedelta(hours=1)),
-            (4, "/world", "windows", "prod", self.now() + timedelta(hours=1, minutes=30)),
+        release_1 = self.create_release(project=self.project, version="1.0")
+        release_2 = self.create_release(project=self.project, version="2.0")
+
+        for value, transaction, platform, env, release, time in (
+            (1, "/hello", "android", "prod", release_1.version, self.now()),
+            (6, "/hello", "ios", "dev", release_2.version, self.now()),
+            (5, "/world", "windows", "prod", release_1.version, self.now() + timedelta(minutes=30)),
+            (3, "/hello", "ios", "dev", release_2.version, self.now() + timedelta(hours=1)),
+            (2, "/hello", "android", "dev", release_1.version, self.now() + timedelta(hours=1)),
+            (
+                4,
+                "/world",
+                "windows",
+                "prod",
+                release_2.version,
+                self.now() + timedelta(hours=1, minutes=30),
+            ),
         ):
             self.store_metric(
                 self.project.organization.id,
                 self.project.id,
                 "distribution",
                 TransactionMRI.DURATION.value,
-                {"transaction": transaction, "platform": platform, "environment": env},
+                {
+                    "transaction": transaction,
+                    "platform": platform,
+                    "environment": env,
+                    "release": release,
+                },
                 self.ts(time),
                 value,
                 UseCaseID.TRANSACTIONS,
@@ -83,7 +98,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             assert groups[0]["totals"] == {field: expected_identity}
 
     def test_query_with_one_aggregation(self) -> None:
-        # Query with just one aggregation.
         field = f"sum({TransactionMRI.DURATION.value})"
         results = run_metrics_query(
             fields=[field],
@@ -104,7 +118,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert groups[0]["totals"] == {field: 21.0}
 
     def test_query_with_one_aggregation_and_environment(self) -> None:
-        # Query with just one aggregation.
         field = f"sum({TransactionMRI.DURATION.value})"
         results = run_metrics_query(
             fields=[field],
@@ -123,6 +136,26 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert groups[0]["by"] == {}
         assert groups[0]["series"] == {field: [0.0, 6.0, 4.0]}
         assert groups[0]["totals"] == {field: 10.0}
+
+    def test_query_with_one_aggregation_and_latest_release(self) -> None:
+        field = f"sum({TransactionMRI.DURATION.value})"
+        results = run_metrics_query(
+            fields=[field],
+            query="release:latest",
+            group_bys=None,
+            start=self.now() - timedelta(minutes=30),
+            end=self.now() + timedelta(hours=1, minutes=30),
+            interval=3600,
+            organization=self.project.organization,
+            projects=[self.project],
+            environments=[],
+            referrer="metrics.data.api",
+        )
+        groups = results["groups"]
+        assert len(groups) == 1
+        assert groups[0]["by"] == {}
+        assert groups[0]["series"] == {field: [0.0, 6.0, 7.0]}
+        assert groups[0]["totals"] == {field: 13.0}
 
     def test_query_with_percentile(self) -> None:
         field = f"p90({TransactionMRI.DURATION.value})"
@@ -182,7 +215,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
                 )
 
     def test_query_with_group_by(self) -> None:
-        # Query with one aggregation and two group by.
         field = f"sum({TransactionMRI.DURATION.value})"
         results = run_metrics_query(
             fields=[field],
@@ -228,7 +260,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
                 UseCaseID.TRANSACTIONS,
             )
 
-        # Query with one aggregation and two group by.
         field = f"sum({TransactionMRI.MEASUREMENTS_FCP.value})"
         results = run_metrics_query(
             fields=[field],
@@ -252,7 +283,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert groups[1]["totals"] == {field: 1.0}
 
     def test_query_with_two_simple_filters(self) -> None:
-        # Query with one aggregation, one group by and two filters.
         field = f"sum({TransactionMRI.DURATION.value})"
         results = run_metrics_query(
             fields=[field],
@@ -276,7 +306,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert groups[1]["totals"] == {field: 9.0}
 
     def test_query_one_negated_filter(self) -> None:
-        # Query with one aggregation, one group by and two filters.
         field = f"sum({TransactionMRI.DURATION.value})"
         results = run_metrics_query(
             fields=[field],
@@ -297,7 +326,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert groups[0]["totals"] == {field: 3.0}
 
     def test_query_one_in_filter(self) -> None:
-        # Query with one aggregation, one group by and two filters.
         field = f"sum({TransactionMRI.DURATION.value})"
         results = run_metrics_query(
             fields=[field],
@@ -321,7 +349,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert groups[1]["totals"] == {field: 9.0}
 
     def test_query_one_not_in_filter(self) -> None:
-        # Query with one aggregation, one group by and two filters.
         field = f"sum({TransactionMRI.DURATION.value})"
         results = run_metrics_query(
             fields=[field],
@@ -342,7 +369,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
         assert groups[0]["totals"] == {field: 9.0}
 
     def test_query_with_multiple_aggregations(self) -> None:
-        # Query with two aggregations.
         field_1 = f"min({TransactionMRI.DURATION.value})"
         field_2 = f"max({TransactionMRI.DURATION.value})"
         results = run_metrics_query(
@@ -535,7 +561,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
             )
 
     def test_query_with_invalid_filters(self) -> None:
-        # Query with one aggregation, one group by and two filters.
         field = f"sum({TransactionMRI.DURATION.value})"
 
         with pytest.raises(InvalidMetricsQueryError):
@@ -604,7 +629,6 @@ class MetricsAPITestCase(TestCase, BaseMetricsTestCase):
 
     @patch("sentry.sentry_metrics.querying.api.SNUBA_QUERY_LIMIT", 5)
     def test_query_with_too_many_results(self) -> None:
-        # Query with one aggregation and two group by.
         field = f"sum({TransactionMRI.DURATION.value})"
         results = run_metrics_query(
             fields=[field],


### PR DESCRIPTION
This PR adds the support for `release:latest` intrinsic filter to both the metrics API and correlations endpoint. The implementation performs the transformation of the AST from `release=latest` to `release IN [x, y, ...]` where `x` and `y` are the latest releases of two supplied projects (assuming two projects).

_Currently the code has duplication but a follow-up PR will address it. It was not done in this PR to not increase its complexity._

Closes: https://github.com/getsentry/sentry/issues/63566