### PR TITLE
ref: fix slow kafka rebalance tests

### DIFF
--- a/tests/sentry/utils/kafka/test_rebalance_delay.py
+++ b/tests/sentry/utils/kafka/test_rebalance_delay.py
@@ -1,10 +1,20 @@
 import time
+from unittest import mock
 
 import pytest
 
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils.kafka import delay_kafka_rebalance
 
 
+@pytest.fixture
+def frozen_time_with_warp():
+    with freeze_time() as frozen:
+        with mock.patch.object(time, "sleep", frozen.shift):
+            yield
+
+
+@pytest.mark.usefixtures("frozen_time_with_warp")
 @pytest.mark.parametrize("configured_delay", [5, 10, 15])
 def test_delay_tick(configured_delay) -> None:
     delay_kafka_rebalance(configured_delay)


### PR DESCRIPTION
these would previously take 30 seconds to run, now they take 5ms

<!-- Describe your PR here. -->