### PR TITLE
feat(replays): add resources menu to replay details

### DIFF
--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -43,6 +43,15 @@ jest.mocked(useReplayReader).mockImplementation(() => {
   };
 });
 
+jest.mock('screenfull', () => ({
+  enabled: true,
+  isFullscreen: false,
+  request: jest.fn(),
+  exit: jest.fn(),
+  on: jest.fn(),
+  off: jest.fn(),
+}));
+
 describe('EventReplay', function () {
   const MockUseReplayOnboardingSidebarPanel = jest.mocked(
     useReplayOnboardingSidebarPanel

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -167,7 +167,7 @@ const Header = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   background: ${p => p.theme.backgroundSecondary};
   border-bottom: 1px solid ${p => p.theme.border};
-  border-radius: ${p => p.theme.borderRadiusTop};
+  border-radius: 8px 8px 0 0;
   font-weight: 600;
   word-wrap: break-word;
   padding: ${space(1.5)};

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -182,7 +182,7 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
       {isBuffering ? <PositionedBuffering /> : null}
       {isPreview ? null : <PlayerDOMAlert />}
       {isFetching ? <PositionedLoadingIndicator /> : null}
-      {isFullscreen ? null : <ResourceCard />}
+      {!(isFullscreen || isPreview) && <ResourceCard />}
     </NegativeSpaceContainer>
   );
 }

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -144,7 +144,7 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
         <Resource
           title={t('General')}
           subtitle={t('Configure sampling rates and recording thresholds')}
-          link="https://docs.sentry.io/platforms/javascript/session-replay"
+          link="https://docs.sentry.io/platforms/javascript/session-replay/configuration/#general-integration-configuration"
         />
         <Resource
           title={t('Element Masking/Blocking')}
@@ -154,7 +154,7 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
         <Resource
           title={t('Network Details')}
           subtitle={t('Capture request and response headers or bodies')}
-          link="https://docs.sentry.io/platforms/javascript/session-replay/configuration/"
+          link="https://docs.sentry.io/platforms/javascript/session-replay/configuration/#network-details"
         />
       </ButtonContainer>
     );

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -2,11 +2,16 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useResizeObserver} from '@react-aria/utils';
 
+import {Button, LinkButton} from 'sentry/components/button';
 import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceContainer';
+import {Hovercard} from 'sentry/components/hovercard';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import BufferingOverlay from 'sentry/components/replays/player/bufferingOverlay';
 import FastForwardBadge from 'sentry/components/replays/player/fastForwardBadge';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {IconOpen, IconQuestion} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -113,6 +118,62 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
     }
   }, [windowDimensions, videoDimensions]);
 
+  function Resource({
+    title,
+    subtitle,
+    link,
+  }: {
+    link: string;
+    subtitle: string;
+    title: string;
+  }) {
+    return (
+      <StyledLinkButton icon={<IconOpen />} borderless external href={link}>
+        <ButtonContent>
+          <ButtonTitle>{title}</ButtonTitle>
+          <ButtonSubtitle>{subtitle}</ButtonSubtitle>
+        </ButtonContent>
+      </StyledLinkButton>
+    );
+  }
+
+  function ResourceButtons() {
+    return (
+      <ButtonContainer>
+        <HoverTitle>{t('Documentation Resources')}</HoverTitle>
+        <Resource
+          title={t('General')}
+          subtitle={t('Configure sampling rates and recording thresholds')}
+          link="https://docs.sentry.io/platforms/javascript/session-replay"
+        />
+        <Resource
+          title={t('Element Masking/Blocking')}
+          subtitle={t(
+            'description description description description description description description'
+          )}
+          link=""
+        />
+        <Resource
+          title={t('General')}
+          subtitle={t(
+            'description description description description description description description'
+          )}
+          link=""
+        />
+      </ButtonContainer>
+    );
+  }
+
+  function ResourceCard() {
+    return (
+      <ResourceCardContainer>
+        <Hovercard body={<ResourceButtons />} position="top-end">
+          <Button icon={<IconQuestion />} aria-label="replay resources" />
+        </Hovercard>
+      </ResourceCardContainer>
+    );
+  }
+
   return (
     <NegativeSpaceContainer ref={windowEl} className="sentry-block">
       <div ref={viewEl} className={className} />
@@ -120,6 +181,7 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
       {isBuffering ? <PositionedBuffering /> : null}
       {isPreview ? null : <PlayerDOMAlert />}
       {isFetching ? <PositionedLoadingIndicator /> : null}
+      <ResourceCard />
     </NegativeSpaceContainer>
   );
 }
@@ -251,6 +313,49 @@ const SentryPlayerRoot = styled(PlayerRoot)`
       height: 10px;
     }
   }
+`;
+
+const ResourceCardContainer = styled('div')`
+  position: absolute;
+  bottom: ${space(1)};
+  right: 1%;
+`;
+
+const ButtonContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
+  align-items: flex-start;
+`;
+
+const ButtonContent = styled('div')`
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  white-space: pre-line;
+  gap: ${space(0.25)};
+`;
+
+const ButtonTitle = styled('div')`
+  font-weight: normal;
+`;
+
+const ButtonSubtitle = styled('div')`
+  color: ${p => p.theme.gray300};
+  font-weight: normal;
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const StyledLinkButton = styled(LinkButton)`
+  padding: ${space(1.5)} ${space(1)};
+  height: auto;
+`;
+
+const HoverTitle = styled('div')`
+  font-weight: bold;
+  border-bottom: 1px solid ${p => p.theme.gray200};
+  line-height: 2em;
+  width: 100%;
 `;
 
 export default SentryPlayerRoot;

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
+import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useResizeObserver} from '@react-aria/utils';
 
@@ -164,13 +165,20 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
   function ResourceCard() {
     return (
       <ResourceCardContainer>
-        <Hovercard
-          body={<ResourceButtons />}
-          header={t('Documentation Resources')}
-          position="top-end"
-        >
-          <Button icon={<IconQuestion />} aria-label="replay resources" />
-        </Hovercard>
+        <ClassNames>
+          {({css}) => (
+            <Hovercard
+              body={<ResourceButtons />}
+              bodyClassName={css`
+                padding: ${space(1)};
+              `}
+              header={t('Documentation Resources')}
+              position="top-end"
+            >
+              <Button icon={<IconQuestion />} aria-label="replay resources" />
+            </Hovercard>
+          )}
+        </ClassNames>
       </ResourceCardContainer>
     );
   }
@@ -319,7 +327,7 @@ const SentryPlayerRoot = styled(PlayerRoot)`
 const ResourceCardContainer = styled('div')`
   position: absolute;
   bottom: ${space(1)};
-  right: 1%;
+  right: 8px;
 `;
 
 const ButtonContainer = styled('div')`

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -14,6 +14,7 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
+import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
 
 import PlayerDOMAlert from './playerDOMAlert';
 
@@ -77,6 +78,7 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
   });
 
   useVideoSizeLogger({videoDimensions, windowDimensions});
+  const isFullscreen = useIsFullscreen();
 
   // Create the `rrweb` instance which creates an iframe inside `viewEl`
   useEffect(() => initRoot(viewEl.current), [initRoot]);
@@ -140,7 +142,6 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
   function ResourceButtons() {
     return (
       <ButtonContainer>
-        <HoverTitle>{t('Documentation Resources')}</HoverTitle>
         <Resource
           title={t('General')}
           subtitle={t('Configure sampling rates and recording thresholds')}
@@ -163,7 +164,11 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
   function ResourceCard() {
     return (
       <ResourceCardContainer>
-        <Hovercard body={<ResourceButtons />} position="top-end">
+        <Hovercard
+          body={<ResourceButtons />}
+          header={t('Documentation Resources')}
+          position="top-end"
+        >
           <Button icon={<IconQuestion />} aria-label="replay resources" />
         </Hovercard>
       </ResourceCardContainer>
@@ -177,7 +182,7 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
       {isBuffering ? <PositionedBuffering /> : null}
       {isPreview ? null : <PlayerDOMAlert />}
       {isFetching ? <PositionedLoadingIndicator /> : null}
-      <ResourceCard />
+      {isFullscreen ? null : <ResourceCard />}
     </NegativeSpaceContainer>
   );
 }
@@ -343,15 +348,8 @@ const ButtonSubtitle = styled('div')`
 `;
 
 const StyledLinkButton = styled(LinkButton)`
-  padding: ${space(1)} ${space(1)};
+  padding: ${space(1)};
   height: auto;
-`;
-
-const HoverTitle = styled('div')`
-  font-weight: bold;
-  border-bottom: 1px solid ${p => p.theme.gray200};
-  line-height: 2em;
-  width: 100%;
 `;
 
 export default SentryPlayerRoot;

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -175,7 +175,7 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
               header={t('Documentation Resources')}
               position="top-end"
             >
-              <Button icon={<IconQuestion />} aria-label="replay resources" />
+              <Button icon={<IconQuestion />} aria-label={t('replay resources')} />
             </Hovercard>
           )}
         </ClassNames>

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -148,17 +148,13 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
         />
         <Resource
           title={t('Element Masking/Blocking')}
-          subtitle={t(
-            'description description description description description description description'
-          )}
-          link=""
+          subtitle={t('Unmask text (****) and unblock media (img, svg, video, etc.)')}
+          link="https://docs.sentry.io/platforms/javascript/session-replay/privacy/"
         />
         <Resource
-          title={t('General')}
-          subtitle={t(
-            'description description description description description description description'
-          )}
-          link=""
+          title={t('Network Details')}
+          subtitle={t('Capture request and response headers or bodies')}
+          link="https://docs.sentry.io/platforms/javascript/session-replay/configuration/"
         />
       </ButtonContainer>
     );
@@ -347,7 +343,7 @@ const ButtonSubtitle = styled('div')`
 `;
 
 const StyledLinkButton = styled(LinkButton)`
-  padding: ${space(1.5)} ${space(1)};
+  padding: ${space(1)} ${space(1)};
   height: auto;
 `;
 

--- a/static/images/spot/replay-onboarding-backend.svg
+++ b/static/images/spot/replay-onboarding-backend.svg
@@ -3,7 +3,6 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 358 99" style="enable-background:new 0 0 358 99;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#FFFFFF;}
 	.st1{fill:#FFC1A9;}
 	.st2{fill:#E7E1EC;}
 	.st3{fill:#FF9C88;}
@@ -12,7 +11,7 @@
 	.st6{fill:none;stroke:#2F1D4A;stroke-width:1.3333;stroke-linecap:round;stroke-linejoin:round;}
 	.st7{fill:#2F1D4A;}
 </style>
-<rect class="st0" width="358" height="99"/>
+<rect width="358" height="99"/>
 <path class="st1" d="M358,99V0H140.1L0,14.5l13.5,65L146,98.8L358,99z"/>
 <polygon class="st2" points="82.1,99 150.5,99 151.3,80.8 148.6,75.8 47,60.7 42.4,63.4 44.8,92.8 "/>
 <path class="st3" d="M100.6,68.7V52.5l-3.2-0.5l-1.2,16L100.6,68.7z"/>

--- a/static/images/spot/replay-onboarding-backend.svg
+++ b/static/images/spot/replay-onboarding-backend.svg
@@ -3,6 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 358 99" style="enable-background:new 0 0 358 99;" xml:space="preserve">
 <style type="text/css">
+	.st0{fill:#FFFFFF;}
 	.st1{fill:#FFC1A9;}
 	.st2{fill:#E7E1EC;}
 	.st3{fill:#FF9C88;}
@@ -11,7 +12,7 @@
 	.st6{fill:none;stroke:#2F1D4A;stroke-width:1.3333;stroke-linecap:round;stroke-linejoin:round;}
 	.st7{fill:#2F1D4A;}
 </style>
-<rect width="358" height="99"/>
+<rect class="st0" width="358" height="99"/>
 <path class="st1" d="M358,99V0H140.1L0,14.5l13.5,65L146,98.8L358,99z"/>
 <polygon class="st2" points="82.1,99 150.5,99 151.3,80.8 148.6,75.8 47,60.7 42.4,63.4 44.8,92.8 "/>
 <path class="st3" d="M100.6,68.7V52.5l-3.2-0.5l-1.2,16L100.6,68.7z"/>


### PR DESCRIPTION
- Add resource docs hovercard to replay details 
- Does not appear on full screen
- Based on [this design](https://www.figma.com/file/eOC1hwNbHMzFhJsZGkU3UH/Specs%3A-Touchpoints-for-Configuration-Resources?type=design&node-id=0-1&mode=design&t=Mdq8Z9K9PWiKSLOG-0)


https://github.com/getsentry/sentry/assets/56095982/280746e3-34d4-42fc-85a6-6e4b2cae83a9

Closes https://github.com/getsentry/team-replay/issues/323
