### PR TITLE
nit(open-pr-comments): reduce number of stackframes checked

### DIFF
--- a/src/sentry/tasks/integrations/github/constants.py
+++ b/src/sentry/tasks/integrations/github/constants.py
@@ -3,4 +3,4 @@ ISSUE_LOCKED_ERROR_MESSAGE = "Unable to create comment because issue is locked."
 RATE_LIMITED_MESSAGE = "API rate limit exceeded"
 
 # Number of stackframes to check for filename + function combo, starting from the top
-STACKFRAME_COUNT = 6
+STACKFRAME_COUNT = 4


### PR DESCRIPTION
We currently search for matching filenames + functions up to 6 frames deep within the stacktrace of an issue. Reducing this to 4 to hopefully make the issues commented on open PRs more relevant to what's actually causing errors.