### PR TITLE
fix(stats-detectors): Sync regression group with issue group

### DIFF
--- a/src/sentry/statistical_detectors/detector.py
+++ b/src/sentry/statistical_detectors/detector.py
@@ -454,7 +454,8 @@ class RegressionDetector(ABC):
         for bundles in chunked(bundles_to_escalate, batch_size):
             pairs = {
                 generate_issue_group_key(
-                    bundle.payload.project_id, cls.regression_type, bundle.payload.group
+                    bundle.payload.project_id,
+                    generate_fingerprint(cls.regression_type, bundle.payload.group),
                 ): bundle
                 for bundle in bundles
             }
@@ -486,7 +487,7 @@ class RegressionDetector(ABC):
         regressions: Generator[BreakpointData, None, None],
         batch_size=100,
     ) -> Generator[Tuple[int, datetime | None, BreakpointData], None, None]:
-        active_regressions = 0
+        active_regressions = []
 
         for regression_chunk in chunked(regressions, batch_size):
             existing_regression_groups = {
@@ -513,12 +514,41 @@ class RegressionDetector(ABC):
                 elif not group.active:
                     yield group.version, group.date_regressed, regression
                 else:
-                    # There is an active regression group already, so skip it
-                    active_regressions += 1
+                    # There is an active regression group already, so we need to sync with the
+                    # issue platform to detemine if a new regression group should be created.
+                    active_regressions.append(
+                        (generate_issue_group_key(project_id, fingerprint), group, regression)
+                    )
+
+        # Instead of doing it one by one, we opt to queue them into a list
+        # and fetching the issue group in batches for efficiency.
+        for triples in chunked(active_regressions, batch_size):
+            groups_to_close = []
+
+            # Sync the regression group with the issue group
+            issue_groups = bulk_get_groups_from_fingerprints(
+                [(project_id, [fingerprint]) for (project_id, fingerprint), _, _ in triples]
+            )
+
+            for key, regression_group, regression in triples:
+                issue_group = issue_groups.get(key)
+                if issue_group is None:
+                    sentry_sdk.capture_message("Missing issue group for regression issue")
+                    continue
+
+                # Only status we care about is if there is a resolved issue group that
+                # corresponds to the regression group. In that case, we should end
+                # the active regression group and create a new regression group.
+                if issue_group.status == GroupStatus.RESOLVED:
+                    regression_group.active = False
+                    groups_to_close.append(regression_group)
+                    yield regression_group.version, regression_group.date_regressed, regression
+
+            RegressionGroup.objects.bulk_update(groups_to_close, ["active"])
 
         metrics.incr(
             "statistical_detectors.breakpoint.skipped",
-            amount=active_regressions,
+            amount=len(active_regressions),
             tags={"source": cls.source, "kind": cls.kind},
             sample_rate=1.0,
         )
@@ -576,11 +606,9 @@ def generate_fingerprint(regression_type: RegressionType, name: str | int) -> st
         raise ValueError(f"Unsupported RegressionType: {regression_type}")
 
 
-def generate_issue_group_key(
-    project_id: int, regression_type: RegressionType, name: str | int
-) -> Tuple[int, str]:
+def generate_issue_group_key(project_id: int, fingerprint: str) -> Tuple[int, str]:
     data = {
-        "fingerprint": [generate_fingerprint(regression_type, name)],
+        "fingerprint": [fingerprint],
     }
     process_occurrence_data(data)
     return project_id, data["fingerprint"][0]

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -531,7 +531,7 @@ def test_limit_regressions_by_project(detector_cls, ratelimit, timestamp, expect
     ],
 )
 @pytest.mark.parametrize(
-    ["existing", "expected_versions"],
+    ["regression_groups", "expected_versions"],
     [
         pytest.param([], [0], id="no existing"),
         pytest.param(
@@ -575,12 +575,12 @@ def test_limit_regressions_by_project(detector_cls, ratelimit, timestamp, expect
 @django_db_all
 def test_get_regression_versions(
     detector_cls,
-    existing,
+    regression_groups,
     expected_versions,
     project,
     timestamp,
 ):
-    if existing:
+    if regression_groups:
         RegressionGroup.objects.bulk_create(
             RegressionGroup(
                 type=detector_cls.regression_type.value,
@@ -595,7 +595,7 @@ def test_get_regression_versions(
                 baseline=100000000.0,
                 regressed=500000000.0,
             )
-            for version, active, transaction in existing
+            for version, active, transaction in regression_groups
         )
 
     breakpoints: List[BreakpointData] = [
@@ -623,6 +623,127 @@ def test_get_regression_versions(
         for i, expected_version in enumerate(expected_versions)
         if expected_version is not None
     ]
+
+
+@pytest.mark.parametrize(
+    ["detector_cls", "object_name", "issue_type"],
+    [
+        pytest.param(
+            EndpointRegressionDetector,
+            "transaction_1",
+            PerformanceP95EndpointRegressionGroupType,
+            id="endpoint",
+        ),
+        pytest.param(
+            FunctionRegressionDetector,
+            123,
+            ProfileFunctionRegressionType,
+            id="function",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ["status", "substatus", "should_emit"],
+    [
+        pytest.param(GroupStatus.UNRESOLVED, GroupSubStatus.ESCALATING, False, id="escalating"),
+        pytest.param(GroupStatus.UNRESOLVED, GroupSubStatus.ONGOING, False, id="ongoing"),
+        pytest.param(GroupStatus.UNRESOLVED, GroupSubStatus.REGRESSED, False, id="regressed"),
+        pytest.param(GroupStatus.UNRESOLVED, GroupSubStatus.NEW, False, id="new"),
+        pytest.param(GroupStatus.RESOLVED, None, True, id="resolved"),
+        pytest.param(
+            GroupStatus.IGNORED, GroupSubStatus.UNTIL_ESCALATING, False, id="until escalating"
+        ),
+        pytest.param(
+            GroupStatus.IGNORED, GroupSubStatus.UNTIL_CONDITION_MET, False, id="until condition met"
+        ),
+        pytest.param(GroupStatus.IGNORED, GroupSubStatus.FOREVER, False, id="forever"),
+    ],
+)
+@django_db_all
+def test_get_regression_versions_active(
+    detector_cls,
+    object_name,
+    issue_type,
+    status,
+    substatus,
+    should_emit,
+    project,
+    timestamp,
+    django_cache,  # the environment can persist in the cache otherwise
+):
+    fingerprint = generate_fingerprint(detector_cls.regression_type, object_name)
+
+    RegressionGroup.objects.create(
+        type=detector_cls.regression_type.value,
+        date_regressed=timestamp,
+        version=1,
+        active=True,
+        project_id=project.id,
+        fingerprint=fingerprint,
+        baseline=1000,
+        regressed=2000,
+    )
+
+    event_id = uuid.uuid4().hex
+    message = {
+        "id": uuid.uuid4().hex,
+        "project_id": project.id,
+        "event_id": event_id,
+        "fingerprint": [fingerprint],
+        "issue_title": issue_type.description,
+        "subtitle": "",
+        "resource_id": None,
+        "evidence_data": {},
+        "evidence_display": [],
+        "type": issue_type.type_id,
+        "detection_time": timestamp.isoformat(),
+        "level": "info",
+        "culprit": "",
+        "payload_type": PayloadType.OCCURRENCE.value,
+        "event": {
+            "timestamp": timestamp.isoformat(),
+            "project_id": project.id,
+            "transaction": "",
+            "event_id": event_id,
+            "platform": "python",
+            "received": timestamp.isoformat(),
+            "tags": {},
+        },
+    }
+
+    result = _process_message(message)
+    assert result is not None
+    _, group_info = result
+    assert group_info is not None
+    group = group_info.group
+    group.status = status
+    group.substatus = substatus
+    group.save()
+
+    breakpoints: List[BreakpointData] = [
+        {
+            "absolute_percentage_change": 5.0,
+            "aggregate_range_1": 100000000.0,
+            "aggregate_range_2": 500000000.0,
+            "breakpoint": 1687323600,
+            "project": str(project.id),
+            "transaction": object_name,
+            "trend_difference": 400000000.0,
+            "trend_percentage": 5.0,
+            "unweighted_p_value": 0.0,
+            "unweighted_t_value": -float("inf"),
+        }
+    ]
+
+    def mock_regressions():
+        yield from breakpoints
+
+    regressions = list(detector_cls.get_regression_versions(mock_regressions()))
+
+    if should_emit:
+        assert regressions == [(1, timestamp, breakpoints[0])]
+    else:
+        assert regressions == []
 
 
 @mock.patch("sentry.tasks.statistical_detectors.query_functions")
@@ -1031,7 +1152,7 @@ def test_save_regressions_with_versions(
         ),
         pytest.param(
             FunctionRegressionDetector,
-            "123",
+            123,
             100_000_000,
             300_000_000,
             500_000_000,


### PR DESCRIPTION
If an issue group is manually resolved on the issue platform, this status change is not propagated to the regression group. So it's possible to land in a state where the regression group is active but the issue group is resolved. This has the implication that no regression will be emitted for the object ever again.