### PR TITLE
fix(app-start): Add "by Device Class" to cold/warm start widget titles

### DIFF
--- a/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/widgets.tsx
@@ -96,7 +96,7 @@ function SummaryWidgets({additionalFilters}) {
       </div>
       <div style={{gridArea: '1 / 2 / 1 / 2'}}>
         <DeviceClassBreakdownBarChart
-          title={t('Cold Start')}
+          title={t('Cold Start by Device Class')}
           isLoading={isLoading}
           isError={isError}
           data={Object.values(transformedData[YAXIS_COLUMNS[YAxis.COLD_START]])}
@@ -105,7 +105,7 @@ function SummaryWidgets({additionalFilters}) {
       </div>
       <div style={{gridArea: '2 / 2 / 2 / 2'}}>
         <DeviceClassBreakdownBarChart
-          title={t('Warm Start')}
+          title={t('Warm Start by Device Class')}
           isLoading={isLoading}
           isError={isError}
           data={Object.values(transformedData[YAXIS_COLUMNS[YAxis.WARM_START]])}


### PR DESCRIPTION
It's unclear what the x-axis is referring to without this identifier.

![Screenshot 2024-01-22 at 2 00 29 PM](https://github.com/getsentry/sentry/assets/22846452/bbbd5c37-c914-43c5-82d8-b6c6d2ce6ea1)
