### PR TITLE
test(hc): Introduce create_provider_integration_for factory

### DIFF
--- a/src/sentry/models/integrations/integration.py
+++ b/src/sentry/models/integrations/integration.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
         IntegrationInstallation,
         IntegrationProvider,
     )
+    from sentry.models.organization import Organization
+    from sentry.models.user import User
+    from sentry.services.hybrid_cloud.user import RpcUser
 
 logger = logging.getLogger(__name__)
 
@@ -108,8 +111,11 @@ class Integration(DefaultFieldsModel):
         ]
 
     def add_organization(
-        self, organization_id: int | RpcOrganization, user=None, default_auth_id=None
-    ):
+        self,
+        organization_id: int | Organization | RpcOrganization,
+        user: User | RpcUser | None = None,
+        default_auth_id: int | None = None,
+    ) -> OrganizationIntegration | None:
         """
         Add an organization to this integration.
 
@@ -147,7 +153,7 @@ class Integration(DefaultFieldsModel):
                     "default_auth_id": default_auth_id,
                 },
             )
-            return False
+            return None
 
     def disable(self):
         """

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -114,6 +114,8 @@ from sentry.sentry_apps.installations import (
 )
 from sentry.services.hybrid_cloud.app.serial import serialize_sentry_app_installation
 from sentry.services.hybrid_cloud.hook import hook_service
+from sentry.services.hybrid_cloud.organization import RpcOrganization
+from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.signals import project_created
 from sentry.silo import SiloMode
 from sentry.snuba.dataset import Dataset
@@ -1525,6 +1527,18 @@ class Factories:
     @assume_test_silo_mode(SiloMode.CONTROL)
     def create_provider_integration(**integration_params: Any) -> Integration:
         return Integration.objects.create(**integration_params)
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CONTROL)
+    def create_provider_integration_for(
+        organization: Organization | RpcOrganization,
+        user: User | RpcUser | None,
+        **integration_params: Any,
+    ) -> tuple[Integration, OrganizationIntegration]:
+        integration = Integration.objects.create(**integration_params)
+        org_integration = integration.add_organization(organization, user)
+        assert org_integration is not None
+        return integration, org_integration
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -19,6 +19,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
 from sentry.models.user import User
+from sentry.services.hybrid_cloud.organization import RpcOrganization
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.silo import SiloMode
 from sentry.testutils.factories import Factories
@@ -458,6 +459,15 @@ class Fixtures:
     def create_provider_integration(self, **integration_params: Any) -> Integration:
         """Create an integration tied to a provider but no particular organization."""
         return Factories.create_provider_integration(**integration_params)
+
+    def create_provider_integration_for(
+        self,
+        organization: Organization | RpcOrganization,
+        user: User | RpcUser | None,
+        **integration_params: Any,
+    ) -> Integration:
+        """Create an integration tied to a provider, then add an organization."""
+        return Factories.create_provider_integration_for(organization, user, **integration_params)
 
     def create_organization_integration(self, **integration_params: Any) -> OrganizationIntegration:
         """Create an OrganizationIntegration entity."""

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -465,7 +465,7 @@ class Fixtures:
         organization: Organization | RpcOrganization,
         user: User | RpcUser | None,
         **integration_params: Any,
-    ) -> Integration:
+    ) -> tuple[Integration, OrganizationIntegration]:
         """Create an integration tied to a provider, then add an organization."""
         return Factories.create_provider_integration_for(organization, user, **integration_params)
 

--- a/tests/sentry/api/endpoints/test_external_user.py
+++ b/tests/sentry/api/endpoints/test_external_user.py
@@ -1,6 +1,5 @@
-from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test
@@ -13,12 +12,10 @@ class ExternalUserTest(APITestCase):
         self.login_as(self.user)
 
         self.org_slug = self.organization.slug  # force creation
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(
-                provider="github", name="GitHub", external_id="github:1"
-            )
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization, self.user, provider="github", name="GitHub", external_id="github:1"
+        )
 
-            self.integration.add_organization(self.organization, self.user)
         self.data = {
             "externalName": "@NisanthanNanthakumar",
             "provider": "github",

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -22,11 +22,14 @@ class GroupNotesDetailsTest(APITestCase):
         self.activity.data["external_id"] = "123"
         self.activity.save()
 
+        self.integration, org_integration = self.create_provider_integration_for(
+            self.organization,
+            user=None,
+            provider="example",
+            external_id="example12345",
+            name="Example 12345",
+        )
         with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(
-                provider="example", external_id="example12345", name="Example 12345"
-            )
-            org_integration = self.integration.add_organization(self.organization)
             org_integration.config = {"sync_comments": True}
             org_integration.save()
 

--- a/tests/sentry/api/endpoints/test_organization_code_mapping_details.py
+++ b/tests/sentry/api/endpoints/test_organization_code_mapping_details.py
@@ -3,9 +3,8 @@ from django.urls import reverse
 from sentry.api.serializers import serialize
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.repository import Repository
-from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test
@@ -30,11 +29,9 @@ class OrganizationCodeMappingDetailsTest(APITestCase):
             teams=[self.team2],
         )
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(
-                provider="github", name="Example", external_id="abcd"
-            )
-            self.org_integration = self.integration.add_organization(self.org, self.user)
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            self.org, self.user, provider="github", name="Example", external_id="abcd"
+        )
         self.repo = Repository.objects.create(
             name="example", organization_id=self.org.id, integration_id=self.integration.id
         )

--- a/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
@@ -22,16 +22,17 @@ class AbstractServerlessTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.project = self.create_project(organization=self.organization)
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            self.organization,
+            user=None,
+            provider="aws_lambda",
+            metadata={
+                "region": "us-east-2",
+                "account_number": "599817902985",
+                "aws_external_id": "599817902985",
+            },
+        )
         with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(
-                provider="aws_lambda",
-                metadata={
-                    "region": "us-east-2",
-                    "account_number": "599817902985",
-                    "aws_external_id": "599817902985",
-                },
-            )
-            self.org_integration = self.integration.add_organization(self.organization)
             self.org_integration.config = {"default_project_id": self.project.id}
             self.org_integration.save()
         self.login_as(self.user)

--- a/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
+++ b/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
@@ -30,14 +30,14 @@ class ProjectStacktraceLinkGithubTest(BaseStacktraceLinkTest):
     def setUp(self):
         super().setUp()
         with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(
+            self.integration, self.oi = self.create_provider_integration_for(
+                self.org,
+                self.user,
                 provider="github",
                 name="getsentry",
                 external_id="1234",
                 metadata={"domain_name": "github.com/getsentry"},
             )
-
-            self.oi = self.integration.add_organization(self.org, self.user)
 
         self.repo = self.create_repo(
             project=self.project,

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -3,7 +3,6 @@ from unittest.mock import PropertyMock, patch
 
 from sentry.integrations.example.integration import ExampleIntegration
 from sentry.models.integrations.integration import Integration
-from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
@@ -78,9 +77,9 @@ class BaseProjectStacktraceLink(APITestCase):
 
     def setUp(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(provider="example", name="Example")
-            self.integration.add_organization(self.organization, self.user)
-            self.oi = OrganizationIntegration.objects.get(integration_id=self.integration.id)
+            self.integration, self.oi = self.create_provider_integration_for(
+                self.organization, self.user, provider="example", name="Example"
+            )
 
         self.repo = self.create_repo(
             project=self.project,

--- a/tests/sentry/api/endpoints/test_project_stacktrace_links.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_links.py
@@ -4,11 +4,9 @@ from rest_framework.exceptions import ErrorDetail
 
 from sentry.integrations.example.integration import ExampleIntegration
 from sentry.integrations.utils.code_mapping import get_sorted_code_mapping_configs
-from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test
@@ -18,10 +16,9 @@ class ProjectStacktraceLinksTest(APITestCase):
     url = "https://example.com/example/foo/blob/master/src/foo/bar/baz.py"
 
     def setUp(self):
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(provider="example", name="Example")
-            self.integration.add_organization(self.organization, self.user)
-            self.oi = OrganizationIntegration.objects.get(integration_id=self.integration.id)
+        self.integration, self.oi = self.create_provider_integration_for(
+            self.organization, self.user, provider="example", name="Example"
+        )
 
         self.repo = self.create_repo(
             project=self.project,

--- a/tests/sentry/api/serializers/test_external_actor.py
+++ b/tests/sentry/api/serializers/test_external_actor.py
@@ -6,9 +6,8 @@ from sentry.api.bases.external_actor import (
 from sentry.api.serializers import serialize
 from sentry.models.actor import Actor, get_actor_id_for_user
 from sentry.models.integrations.external_actor import ExternalActor
-from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.testutils.silo import region_silo_test
 from sentry.types.integrations import ExternalProviders, get_provider_name
 
 
@@ -17,17 +16,17 @@ class ExternalActorSerializerTest(TestCase):
     def setUp(self):
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(
-                provider="slack",
-                name="Team A",
-                external_id="TXXXXXXX1",
-                metadata={
-                    "access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
-                    "installation_type": "born_as_bot",
-                },
-            )
-            self.org_integration = self.integration.add_organization(self.organization, self.user)
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            self.organization,
+            self.user,
+            provider="slack",
+            name="Team A",
+            external_id="TXXXXXXX1",
+            metadata={
+                "access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
+                "installation_type": "born_as_bot",
+            },
+        )
 
     def test_idempotent_actor(self):
         actor_id = get_actor_id_for_user(self.user)

--- a/tests/sentry/deletions/test_organizationintegration.py
+++ b/tests/sentry/deletions/test_organizationintegration.py
@@ -20,8 +20,9 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 class DeleteOrganizationIntegrationTest(TransactionTestCase, HybridCloudTestMixin):
     def test_simple(self):
         org = self.create_organization()
-        integration = self.create_provider_integration(provider="example", name="Example")
-        organization_integration = integration.add_organization(org, self.user)
+        integration, organization_integration = self.create_provider_integration_for(
+            org, self.user, provider="example", name="Example"
+        )
 
         with assume_test_silo_mode(SiloMode.REGION):
             external_issue = ExternalIssue.objects.create(
@@ -44,6 +45,7 @@ class DeleteOrganizationIntegrationTest(TransactionTestCase, HybridCloudTestMixi
         org = self.create_organization()
         integration = self.create_provider_integration(provider="example", name="Example")
         organization_integration = integration.add_organization(org, self.user)
+        assert organization_integration is not None
 
         ScheduledDeletion.schedule(instance=organization_integration, days=0)
 
@@ -61,6 +63,7 @@ class DeleteOrganizationIntegrationTest(TransactionTestCase, HybridCloudTestMixi
             user=self.user, identity_provider=provider, external_id="abc123"
         )
         organization_integration = integration.add_organization(org, self.user, identity.id)
+        assert organization_integration is not None
         repository = self.create_repo(
             project=project, name="testrepo", provider="gitlab", integration_id=integration.id
         )
@@ -94,6 +97,7 @@ class DeleteOrganizationIntegrationTest(TransactionTestCase, HybridCloudTestMixi
             project=project, name="testrepo", provider="gitlab", integration_id=integration.id
         )
         organization_integration = integration.add_organization(org, self.user)
+        assert organization_integration is not None
 
         code_mapping = self.create_code_mapping(
             project=project, repo=repository, organization_integration=organization_integration

--- a/tests/sentry/deletions/test_repository.py
+++ b/tests/sentry/deletions/test_repository.py
@@ -12,11 +12,10 @@ from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.models.pullrequest import CommentType, PullRequest, PullRequestComment
 from sentry.models.repository import Repository
-from sentry.silo.base import SiloMode
 from sentry.tasks.deletion.scheduled import run_scheduled_deletions
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
-from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test
@@ -79,11 +78,9 @@ class DeleteRepositoryTest(TransactionTestCase, HybridCloudTestMixin):
 
     def test_codeowners(self):
         org = self.create_organization(owner=self.user)
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(
-                provider="github", name="Example", external_id="abcd"
-            )
-            org_integration = self.integration.add_organization(org, self.user)
+        self.integration, org_integration = self.create_provider_integration_for(
+            org, self.user, provider="github", name="Example", external_id="abcd"
+        )
         project = self.create_project(organization=org)
         repo = Repository.objects.create(
             organization_id=org.id,

--- a/tests/sentry/hybridcloud/test_integration.py
+++ b/tests/sentry/hybridcloud/test_integration.py
@@ -287,6 +287,7 @@ class OrganizationIntegrationServiceTest(BaseIntegrationServiceTest):
         new_org = self.create_organization()
         with assume_test_silo_mode(SiloMode.CONTROL):
             org_integration = self.integration3.add_organization(new_org.id)
+        assert org_integration is not None
 
         result_integration, result_org_integration = integration_service.get_organization_context(
             organization_id=new_org.id,

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -25,13 +25,14 @@ class PagerDutyActionHandlerTest(FireTest):
                 "service_name": "hellboi",
             }
         ]
-        self.integration = self.create_provider_integration(
+        self.integration, org_integration = self.create_provider_integration_for(
+            self.organization,
+            self.user,
             provider="pagerduty",
             name="Example PagerDuty",
             external_id="example-pagerduty",
             metadata={"service": service},
         )
-        org_integration = self.integration.add_organization(self.organization, self.user)
 
         self.service = add_service(
             org_integration,

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -263,9 +263,10 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         assert build_action_response(self.email) in response.data
 
     def test_org_integration_disabled(self):
+        integration, org_integration = self.create_provider_integration_for(
+            self.organization, user=None, external_id="1", provider="slack"
+        )
         with assume_test_silo_mode(SiloMode.CONTROL):
-            integration = self.create_provider_integration(external_id="1", provider="slack")
-            org_integration = integration.add_organization(self.organization)
             org_integration.update(status=ObjectStatus.DISABLED)
 
         with self.feature("organizations:incidents"):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -667,14 +667,14 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
         )
         self.login_as(self.user)
         mock_uuid4.return_value = self.get_mock_uuid()
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(
-                provider="slack",
-                name="Team A",
-                external_id="TXXXXXXX1",
-                metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
-            )
-            self.integration.add_organization(self.organization, self.user)
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization,
+            self.user,
+            provider="slack",
+            name="Team A",
+            external_id="TXXXXXXX1",
+            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+        )
         test_params = self.valid_params.copy()
         test_params["triggers"] = [
             {

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -584,14 +584,14 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase):
         self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id
     ):
         mock_uuid4.return_value = self.get_mock_uuid()
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(
-                provider="slack",
-                name="Team A",
-                external_id="TXXXXXXX1",
-                metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
-            )
-            self.integration.add_organization(self.organization, self.user)
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization,
+            self.user,
+            provider="slack",
+            name="Team A",
+            external_id="TXXXXXXX1",
+            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+        )
         valid_alert_rule = {
             **self.alert_rule_dict,
             "triggers": [
@@ -997,14 +997,14 @@ class AlertRuleCreateEndpointTestCrashRateAlert(AlertRuleIndexBase):
         self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id
     ):
         mock_uuid4.return_value = self.get_mock_uuid()
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(
-                provider="slack",
-                name="Team A",
-                external_id="TXXXXXXX1",
-                metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
-            )
-            self.integration.add_organization(self.organization, self.user)
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization,
+            self.user,
+            provider="slack",
+            name="Team A",
+            external_id="TXXXXXXX1",
+            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+        )
         self.valid_alert_rule["triggers"] = [
             {
                 "label": "critical",

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -46,14 +46,14 @@ pytestmark = [pytest.mark.sentry_metrics, requires_snuba]
 
 
 class TestAlertRuleSerializerBase(TestCase):
-    @assume_test_silo_mode(SiloMode.CONTROL)
     def setUp(self):
-        self.integration = self.create_provider_integration(
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization,
+            self.user,
             external_id="1",
             provider="slack",
             metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
         )
-        self.integration.add_organization(self.organization, self.user)
 
 
 @region_silo_test

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -1525,7 +1525,9 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         slack_handler = SlackActionHandler
 
         # Create Slack Integration
-        integration = self.create_provider_integration(
+        integration, _ = self.create_provider_integration_for(
+            self.project.organization,
+            self.user,
             provider="slack",
             name="Team A",
             external_id="TXXXXXXX1",
@@ -1534,7 +1536,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                 "installation_type": "born_as_bot",
             },
         )
-        integration.add_organization(self.project.organization, self.user)
 
         # Register Slack Handler
         AlertRuleTriggerAction.register_type(
@@ -1593,7 +1594,9 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         slack_handler = SlackActionHandler
 
         # Create Slack Integration
-        integration = self.create_provider_integration(
+        integration, _ = self.create_provider_integration_for(
+            self.project.organization,
+            self.user,
             provider="slack",
             name="Team A",
             external_id="TXXXXXXX1",
@@ -1602,7 +1605,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                 "installation_type": "born_as_bot",
             },
         )
-        integration.add_organization(self.project.organization, self.user)
 
         # Register Slack Handler
         AlertRuleTriggerAction.register_type(

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -45,6 +45,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQueryEventType
 from sentry.testutils.cases import BaseMetricsTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time, iso_format
+from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 from sentry.utils.dates import to_timestamp
 
@@ -173,6 +174,7 @@ class ProcessUpdateBaseClass(TestCase, SnubaTestCase):
         assert last_incident == incident
 
 
+@region_silo_test
 @freeze_time()
 class ProcessUpdateTest(ProcessUpdateBaseClass):
     @pytest.fixture(autouse=True)
@@ -1669,7 +1671,9 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
         slack_handler = SlackActionHandler
 
         # Create Slack Integration
-        integration = self.create_provider_integration(
+        integration, _ = self.create_provider_integration_for(
+            self.project.organization,
+            self.user,
             provider="slack",
             name="Team A",
             external_id="TXXXXXXX1",
@@ -1678,7 +1682,6 @@ class ProcessUpdateTest(ProcessUpdateBaseClass):
                 "installation_type": "born_as_bot",
             },
         )
-        integration.add_organization(self.project.organization, self.user)
 
         # Register Slack Handler
         AlertRuleTriggerAction.register_type(

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -45,7 +45,6 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQueryEventType
 from sentry.testutils.cases import BaseMetricsTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time, iso_format
-from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 from sentry.utils.dates import to_timestamp
 
@@ -174,7 +173,6 @@ class ProcessUpdateBaseClass(TestCase, SnubaTestCase):
         assert last_incident == incident
 
 
-@region_silo_test
 @freeze_time()
 class ProcessUpdateTest(ProcessUpdateBaseClass):
     @pytest.fixture(autouse=True)

--- a/tests/sentry/integrations/bitbucket/test_repository.py
+++ b/tests/sentry/integrations/bitbucket/test_repository.py
@@ -21,18 +21,18 @@ class BitbucketRepositoryProviderTest(TestCase):
         self.base_url = "https://api.bitbucket.org"
         self.shared_secret = "234567890"
         self.subject = "connect:1234567"
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(
-                provider="bitbucket",
-                external_id=self.subject,
-                name="MyBitBucket",
-                metadata={
-                    "base_url": self.base_url,
-                    "shared_secret": self.shared_secret,
-                    "subject": self.subject,
-                },
-            )
-            self.integration.add_organization(self.organization, self.user)
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization,
+            self.user,
+            provider="bitbucket",
+            external_id=self.subject,
+            name="MyBitBucket",
+            metadata={
+                "base_url": self.base_url,
+                "shared_secret": self.shared_secret,
+                "subject": self.subject,
+            },
+        )
         self.repo = Repository.objects.create(
             provider="bitbucket",
             name="sentryuser/newsdiffs",

--- a/tests/sentry/integrations/bitbucket/test_search.py
+++ b/tests/sentry/integrations/bitbucket/test_search.py
@@ -11,7 +11,9 @@ class BitbucketSearchEndpointTest(APITestCase):
         self.base_url = "https://api.bitbucket.org"
         self.shared_secret = "234567890"
         self.subject = "connect:1234567"
-        self.integration = self.create_provider_integration(
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization,
+            self.user,
             provider="bitbucket",
             external_id=self.subject,
             name="meredithanya",
@@ -21,7 +23,6 @@ class BitbucketSearchEndpointTest(APITestCase):
                 "subject": self.subject,
             },
         )
-        self.integration.add_organization(self.organization, self.user)
 
         self.login_as(self.user)
         self.path = reverse(

--- a/tests/sentry/integrations/jira/test_client.py
+++ b/tests/sentry/integrations/jira/test_client.py
@@ -34,7 +34,9 @@ def mock_authorize_request(prepared_request: PreparedRequest):
 @control_silo_test
 class JiraClientTest(TestCase):
     def setUp(self):
-        self.integration = self.create_provider_integration(
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization,
+            self.user,
             provider="jira",
             name="Jira Cloud",
             metadata={
@@ -44,7 +46,6 @@ class JiraClientTest(TestCase):
                 "domain_name": "example.atlassian.net",
             },
         )
-        self.integration.add_organization(self.organization, self.user)
         install = self.integration.get_installation(self.organization.id)
         self.jira_client = install.get_client()
 

--- a/tests/sentry/integrations/jira/test_ticket_action.py
+++ b/tests/sentry/integrations/jira/test_ticket_action.py
@@ -27,7 +27,9 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
     def setUp(self):
         super().setUp()
         self.project_name = "Jira Cloud"
-        self.integration = self.create_provider_integration(
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization,
+            self.user,
             provider="jira",
             name=self.project_name,
             metadata={
@@ -37,7 +39,6 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
                 "domain_name": "example.atlassian.net",
             },
         )
-        self.integration.add_organization(self.organization, self.user)
         self.installation = self.integration.get_installation(self.organization.id)
 
         self.login_as(user=self.user)

--- a/tests/sentry/integrations/jira_server/test_ticket_action.py
+++ b/tests/sentry/integrations/jira_server/test_ticket_action.py
@@ -18,13 +18,14 @@ class JiraServerTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
 
     def setUp(self):
         super().setUp()
-        self.integration = self.create_provider_integration(
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization,
+            self.user,
             provider="jira_server",
             name="Jira Server",
             metadata={"base_url": "https://jira.example.com", "verify_ssl": True},
         )
 
-        self.integration.add_organization(self.organization, self.user)
         self.installation = self.integration.get_installation(self.organization.id)
 
         self.login_as(user=self.user)

--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -22,7 +22,9 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
     def setUp(self):
         event = self.get_event()
 
-        self.integration = self.create_provider_integration(
+        self.integration, _ = self.create_provider_integration_for(
+            event.project.organization,
+            self.user,
             provider="msteams",
             name="Galactic Empire",
             external_id="D4r7h_Pl4gu315_th3_w153",
@@ -32,8 +34,6 @@ class MsTeamsNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
                 "expires_at": int(time.time()) + 86400,
             },
         )
-        with assume_test_silo_mode_of(Integration):
-            self.integration.add_organization(event.project.organization, self.user)
 
     def assert_form_valid(self, form, expected_channel_id, expected_channel):
         assert form.is_valid()

--- a/tests/sentry/integrations/msteams/test_utils.py
+++ b/tests/sentry/integrations/msteams/test_utils.py
@@ -14,7 +14,9 @@ class GetChannelIdTest(TestCase):
     def setUp(self):
         responses.reset()
 
-        self.integration = self.create_provider_integration(
+        self.integration, _ = self.create_provider_integration_for(
+            self.event.project.organization,
+            self.user,
             provider="msteams",
             name="Brute Squad",
             external_id="3x73rna1-id",
@@ -24,7 +26,6 @@ class GetChannelIdTest(TestCase):
                 "expires_at": int(time.time()) + 86400,
             },
         )
-        self.integration.add_organization(self.event.project.organization, self.user)
         channels = [
             {"id": "g_c"},
             {"id": "p_o_d", "name": "Pit of Despair"},

--- a/tests/sentry/integrations/opsgenie/test_client.py
+++ b/tests/sentry/integrations/opsgenie/test_client.py
@@ -18,10 +18,14 @@ METADATA = {
 
 class OpsgenieClientTest(APITestCase):
     def create_integration(self):
-        integration = self.create_provider_integration(
-            provider="opsgenie", name="test-app", external_id=EXTERNAL_ID, metadata=METADATA
+        integration, org_integration = self.create_provider_integration_for(
+            self.organization,
+            self.user,
+            provider="opsgenie",
+            name="test-app",
+            external_id=EXTERNAL_ID,
+            metadata=METADATA,
         )
-        org_integration = integration.add_organization(self.organization, self.user)
         org_integration.config = {
             "team_table": [
                 {"id": "team-123", "integration_key": "1234-ABCD", "team": "default team"},

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -41,13 +41,14 @@ class PagerDutyProxyClientTest(APITestCase):
 
     def setUp(self):
         self.login_as(self.user)
-        self.integration = self.create_provider_integration(
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization,
+            self.user,
             provider=self.provider,
             name="Example PagerDuty",
             external_id=EXTERNAL_ID,
             metadata={"services": SERVICES},
         )
-        self.integration.add_organization(self.organization, self.user)
         self.service = add_service(
             self.integration.organizationintegration_set.first(),
             service_name=SERVICES[0]["service_name"],

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -35,17 +35,15 @@ class PagerDutyNotifyActionTest(RuleTestCase, PerformanceIssueTestCase):
 
     def setUp(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(
+            self.integration, org_integration = self.create_provider_integration_for(
+                self.organization,
+                self.user,
                 provider="pagerduty",
                 name="Example",
                 external_id=EXTERNAL_ID,
                 metadata={"services": SERVICES},
             )
-            self.integration.add_organization(self.organization, self.user)
         with assume_test_silo_mode(SiloMode.CONTROL):
-            org_integration = OrganizationIntegration.objects.get(
-                integration_id=self.integration.id, organization_id=self.organization.id
-            )
             self.service = add_service(
                 org_integration,
                 service_name=SERVICES[0]["service_name"],

--- a/tests/sentry/integrations/slack/test_disable.py
+++ b/tests/sentry/integrations/slack/test_disable.py
@@ -36,7 +36,9 @@ class SlackClientDisable(TestCase):
 
         self.organization = self.create_organization(owner=self.user)
 
-        self.integration = self.create_provider_integration(
+        self.integration, _ = self.create_provider_integration_for(
+            self.event.project.organization,
+            self.user,
             provider="slack",
             name="Awesome Team",
             external_id="TXXXXXXX1",
@@ -45,7 +47,6 @@ class SlackClientDisable(TestCase):
                 "installation_type": "born_as_bot",
             },
         )
-        self.integration.add_organization(self.event.project.organization, self.user)
         self.payload = {"channel": "#announcements", "message": "i'm ooo next week"}
 
     def tearDown(self):

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -238,7 +238,9 @@ class SlackIntegrationPostInstallTest(APITestCase):
             role="manager",
             teams=[self.team],
         )
-        self.integration = self.create_provider_integration(
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization,
+            self.user,
             provider="slack",
             name="Team A",
             external_id="TXXXXXXX1",
@@ -247,7 +249,6 @@ class SlackIntegrationPostInstallTest(APITestCase):
                 "installation_type": "born_as_bot",
             },
         )
-        self.integration.add_organization(self.organization, self.user)
         self.idp = self.create_identity_provider(type="slack", external_id="TXXXXXXX1")
         Identity.objects.create(
             external_id="UXXXXXXX4",

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -333,10 +333,9 @@ class TestDerivedCodeMappings(TestCase):
 class TestConvertStacktraceFramePathToSourcePath(TestCase):
     def setUp(self):
         super()
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            self.integration = self.create_provider_integration(provider="example", name="Example")
-            self.integration.add_organization(self.organization, self.user)
-            self.oi = OrganizationIntegration.objects.get(integration_id=self.integration.id)
+        self.integration, self.oi = self.create_provider_integration_for(
+            self.organization, self.user, provider="example", name="Example"
+        )
 
         self.repo = self.create_repo(
             project=self.project,

--- a/tests/sentry/integrations/vercel/test_uninstall.py
+++ b/tests/sentry/integrations/vercel/test_uninstall.py
@@ -69,13 +69,14 @@ class VercelUninstallTest(APITestCase):
             "installation_type": "team",
             "webhook_id": "my_webhook_id",
         }
-        self.integration = self.create_provider_integration(
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization,
+            user=None,
             provider="vercel",
             external_id="vercel_team_id",
             name="My Vercel Team",
             metadata=metadata,
         )
-        self.integration.add_organization(self.organization)
 
     def _get_delete_response(self):
         # https://vercel.com/docs/integrations?query=event%20paylo#webhooks/events/integration-configuration-removed

--- a/tests/sentry/integrations/vsts/test_webhooks.py
+++ b/tests/sentry/integrations/vsts/test_webhooks.py
@@ -55,6 +55,7 @@ class VstsWebhookWorkItemTest(APITestCase):
             self.org_integration = self.model.add_organization(
                 self.organization, self.user, self.identity.id
             )
+            assert self.org_integration is not None
             self.org_integration.config = {
                 "sync_status_reverse": True,
                 "sync_status_forward": True,

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -71,7 +71,9 @@ class ActivityNotificationTest(APITestCase):
     """
 
     def setUp(self):
-        self.integration = self.create_provider_integration(
+        self.integration, _ = self.create_provider_integration_for(
+            self.organization,
+            self.user,
             provider="slack",
             name="Team A",
             external_id="TXXXXXXX1",
@@ -80,7 +82,6 @@ class ActivityNotificationTest(APITestCase):
                 "installation_type": "born_as_bot",
             },
         )
-        self.integration.add_organization(self.organization, self.user)
         self.idp = self.create_identity_provider(type="slack", external_id="TXXXXXXX1")
         self.identity = Identity.objects.create(
             external_id="UXXXXXXX1",


### PR DESCRIPTION
Introduce a new test factory method to combine creating an Integration entity with adding an OrganizationIntegration, which is often done immediately after. This lets both steps be done without a `with assume...` block in the test case.

Add type hints to Integration.add_organization according to extant usage. Tweak the return behavior.