### PR TITLE
fix(slack): prevent 500 errors from existing block kit static_select menus

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -581,7 +581,7 @@ class SlackActionEndpoint(Endpoint):
             if action_data[0].get("action_id"):
                 action_list = []
                 for action_data in action_data:
-                    if action_data.get("type") == "external_select":
+                    if action_data.get("type") in ("static_select", "external_select"):
                         action = BlockKitMessageAction(
                             name=action_data["action_id"],
                             label=action_data["selected_option"]["text"]["text"],


### PR DESCRIPTION
In #63379 I had removed the specific case for building a `BlockKitMessageAction` for static select menus, replacing it with external select menus for the assignment dropdown, forgetting that there were still static select menus that existed (resolve immediately/in current release/in next release). 

While using the resolve dropdown would still resolve issues as expected when the dialog is confirmed, using the dropdown would yield a 500 internal error because the action is not built correctly for the actions list. The error went unseen by tests as the resolve dialog submission is handled without the actions list, however, the actions list builder method is called for every action that is taken on a Slack issue alert so this PR stops the 500 error from occurring.