### PR TITLE
ref(slack): Add more issue context and format notification

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -47,6 +47,11 @@ from sentry.utils import metrics
 delete_logger = logging.getLogger("sentry.deletions.api")
 
 
+def get_group_global_count(group: Group) -> str:
+    fetch_buffered_group_stats(group)
+    return str(group.times_seen_with_pending)
+
+
 @region_silo_endpoint
 class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
     publish_status = {
@@ -118,11 +123,6 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         )[group.id]
 
         return hourly_stats, daily_stats
-
-    @staticmethod
-    def __get_group_global_count(group: Group) -> str:
-        fetch_buffered_group_stats(group)
-        return str(group.times_seen_with_pending)
 
     def get(self, request: Request, group) -> Response:
         """
@@ -235,7 +235,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                     "pluginContexts": self._get_context_plugins(request, group),
                     "userReportCount": user_reports.count(),
                     "stats": {"24h": hourly_stats, "30d": daily_stats},
-                    "count": self.__get_group_global_count(group),
+                    "count": get_group_global_count(group),
                 }
             )
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1888,8 +1888,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:spike-protection-decay-heuristic": False,
     # Enable Slack messages using Block Kit
     "organizations:slack-block-kit": False,
-    # Enable new Slack message formatting
-    "organizations:slack-formatting-update": False,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -261,7 +261,6 @@ default_manager.add("organizations:session-replay-ui", OrganizationFeature, Feat
 default_manager.add("organizations:session-replay-weekly-email", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-block-kit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
-default_manager.add("organizations:slack-formatting-update", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:slack-overage-notifications", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:source-maps-debugger-blue-thunder-edition", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:sourcemaps-bundle-flat-file-indexing", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -192,7 +192,7 @@ def build_footer(
         text = rules[0].label if rules[0].label else "Test Alert"
         footer += f" via {url_format.format(text=text, url=rule_url)}"
 
-        if features.has("organizations:slack-formatting-update", project.organization):
+        if features.has("organizations:slack-block-kit", project.organization):
             footer = url_format.format(text=text, url=rule_url)
 
         if len(rules) > 1:

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -192,6 +192,9 @@ def build_footer(
         text = rules[0].label if rules[0].label else "Test Alert"
         footer += f" via {url_format.format(text=text, url=rule_url)}"
 
+        if features.has("organizations:slack-formatting-update", project.organization):
+            footer = url_format.format(text=text, url=rule_url)
+
         if len(rules) > 1:
             footer += f" (+{len(rules) - 1} other)"
 

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -30,7 +30,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         super().__init__(*args, **kwargs)
         # XXX(CEO): when removing the feature flag, put `label` back up as a class var
         self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"  # type: ignore
-        if features.has("organizations:slack-formatting-update", self.project.organization):
+        if features.has("organizations:slack-block-kit", self.project.organization):
             self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and mentions {mentions} in notification"  # type: ignore
         self.form_fields = {
             "workspace": {
@@ -41,7 +41,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             "channel_id": {"type": "string", "placeholder": "e.g., CA2FRA079 or UA1J9RTE1"},
             "tags": {"type": "string", "placeholder": "e.g., environment,user,my_tag"},
         }
-        if features.has("organizations:slack-formatting-update", self.project.organization):
+        if features.has("organizations:slack-block-kit", self.project.organization):
             self.form_fields["mentions"] = {
                 "type": "string",
                 "placeholder": "e.g. @jane, @on-call-team",
@@ -136,7 +136,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
     def render_label(self) -> str:
         tags = self.get_tags_list()
 
-        if features.has("organizations:slack-formatting-update", self.project.organization):
+        if features.has("organizations:slack-block-kit", self.project.organization):
             return self.label.format(
                 workspace=self.get_integration_name(),
                 channel=self.get_option("channel"),

--- a/src/sentry/integrations/slack/message_builder/__init__.py
+++ b/src/sentry/integrations/slack/message_builder/__init__.py
@@ -1,5 +1,7 @@
 from typing import Any, List, Mapping, Union
 
+from sentry.issues.grouptype import GroupCategory
+
 # TODO(mgaeta): Continue fleshing out these types.
 SlackAttachment = Mapping[str, Any]
 SlackBlock = Mapping[str, Any]
@@ -35,7 +37,7 @@ LEVEL_TO_EMOJI = {
 }
 
 CATEGORY_TO_EMOJI = {
-    "performance": ":chart_with_downwards_trend",
-    "feedback": "busts_in_silhouette",
-    "crons": "spiral_calendar_pad",
+    GroupCategory.PERFORMANCE: ":chart_with_downwards_trend:",
+    GroupCategory.FEEDBACK: ":busts_in_silhouette:",
+    GroupCategory.CRON: ":spiral_calendar_pad:",
 }

--- a/src/sentry/integrations/slack/message_builder/__init__.py
+++ b/src/sentry/integrations/slack/message_builder/__init__.py
@@ -27,9 +27,15 @@ SLACK_URL_FORMAT = "<{url}|{text}>"
 LEVEL_TO_EMOJI = {
     "_actioned_issue": ":white_check_mark:",
     "_incident_resolved": ":green_circle:",
-    "debug": ":yellow_circle:",
-    "error": ":red_circle:",
-    "fatal": ":red_circle:",
-    "info": ":large_blue_circle:",
-    "warning": ":yellow_circle:",
+    "debug": ":bug:",
+    "error": ":exclamation:",
+    "fatal": ":skull_and_crossbones:",
+    "info": ":information_source:",
+    "warning": ":warning:",
+}
+
+CATEGORY_TO_EMOJI = {
+    "performance": ":chart_with_downwards_trend",
+    "feedback": "busts_in_silhouette",
+    "crons": "spiral_calendar_pad",
 }

--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -40,12 +40,15 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
 
     @staticmethod
     def get_tags_block(tags) -> SlackBlock:
-        fields = []
+        text = ""
         for tag in tags:
             title = tag["title"]
             value = tag["value"]
-            fields.append({"type": "mrkdwn", "text": f"*{title}:*\n{value}"})
-        return {"type": "section", "fields": fields}
+            text += f"`{title}: {value}`  "
+        return {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": text},
+        }
 
     @staticmethod
     def get_divider() -> SlackBlock:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -141,6 +141,11 @@ def get_tags(
     if not tags:
         tags = set()
 
+    # XXX(CEO): context is passing tags as a list of tuples from self.event.tags
+    # we should standardize but it might break other notifications
+    if tags and type(tags) is list:
+        tags = set(tags[0])
+
     tags = tags | {"level", "release"}
     if tags:
         event_tags = event_for_tags.tags if event_for_tags else []

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -433,6 +433,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             text = f"```{text.lstrip(' ')}```"
             if self.actions:
                 text += "\n" + action_text
+        if not text:
+            text = action_text
         title_text = f"<{title_link}|*{escape_slack_text(title)}*>  \n{text}"
 
         if self.group.issue_category == GroupCategory.ERROR:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -422,9 +422,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             "organizations:slack-formatting-update", self.group.project.organization
         )
         # build title block
-        title_text = (
-            f"<{title_link}|*{escape_slack_text(build_attachment_title(obj))}*>  \n ```{text}```"
-        )
+        if text:
+            text = f"```{text}```"
+        title_text = f"<{title_link}|*{escape_slack_text(build_attachment_title(obj))}*>  \n{text}"
         if has_slack_formatting_update:
             if self.group.issue_category == GroupCategory.ERROR:
                 level_text = None
@@ -450,14 +450,14 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             # add event count, user count, substate, first seen
             context = {
                 "Events": get_group_global_count(self.group),
-                "Users affected": self.group.count_users_seen(),
+                "Users Affected": self.group.count_users_seen(),
                 "State": SUBSTATUS_TO_STR.get(self.group.substatus, "").title(),
                 "First Seen": time_since(self.group.first_seen),
             }
             context_text = ""
             for k, v in context.items():
                 context_text += f"{k}: *{v}*   "
-            blocks.append(self.get_markdown_block(context_text))
+            blocks.append(self.get_markdown_block(context_text[:-3]))
 
         # build footer block
         timestamp = None

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -143,7 +143,7 @@ def get_tags(
 
     # XXX(CEO): context is passing tags as a list of tuples from self.event.tags
     # we should standardize but it might break other notifications
-    if tags and type(tags) is list:
+    if tags and isinstance(tags, list):
         tags = set(tags[0])
 
     tags = tags | {"level", "release"}

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from typing import Any, Mapping, Sequence, Union
 
+from django.utils import timezone
+from django.utils.timesince import timesince
+from django.utils.translation import gettext as _
+
 from sentry import features, tagstore
+from sentry.api.endpoints.group_details import get_group_global_count
 from sentry.eventstore.models import GroupEvent
 from sentry.integrations.message_builder import (
     build_attachment_replay_link,
@@ -35,6 +41,7 @@ from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.utils.actions import MessageAction
 from sentry.services.hybrid_cloud.actor import ActorType, RpcActor
 from sentry.services.hybrid_cloud.identity import RpcIdentity, identity_service
+from sentry.types.group import SUBSTATUS_TO_STR
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 
@@ -330,6 +337,21 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         """
         return True
 
+    def timesince(value: datetime):
+        """
+        Display the relative time
+        """
+        now = timezone.now()
+        if value < (now - timedelta(days=5)):
+            return value.date()
+        diff = timesince(value, now)
+        # XXX(CEO): make sure to test each of these cases, it's funky
+        if diff == timesince(now, now):
+            return "Just now"
+        if diff == "1 day":
+            return _("Yesterday")
+        return f"{value} ago"
+
     def build(self, notification_uuid: str | None = None) -> Union[SlackBlock, SlackAttachment]:
         # XXX(dcramer): options are limited to 100 choices, even when nested
         text = build_attachment_text(self.group, self.event) or ""
@@ -409,10 +431,11 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             notification_uuid=notification_uuid,
         )
         title_text = f"<{title_link}|*{escape_slack_text(build_attachment_title(obj))}*>  \n{text}"
-        # if has_slack_formatting_update:
-        #     # if group category is not error:
-        #     category_emoji = CATEGORY_TO_EMOJI[self.group.category]
-        #     title_text = category_emoji + " " + title_text
+        if has_slack_formatting_update:
+            if self.group.issue_category != GroupCategory.ERROR:
+                category_emoji = CATEGORY_TO_EMOJI.get(self.group.issue_category)
+                if category_emoji:
+                    title_text = f"{category_emoji} {title_text}"
 
         blocks = [self.get_markdown_block(title_text)]
         # build tags block
@@ -420,27 +443,16 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if tags:
             blocks.append(self.get_tags_block(tags))
 
-        # add blocks for the new message content #
-
         # add event and user count
         if has_slack_formatting_update:
-
-            # copied from group_details.py, should move to a shared space
-            from sentry.tasks.post_process import fetch_buffered_group_stats
-
-            @staticmethod
-            def __get_group_global_count(group: Group) -> int:
-                fetch_buffered_group_stats(group)
-                return group.times_seen_with_pending
-
-            event_count = __get_group_global_count(self.group)
+            event_count = get_group_global_count(self.group)
             user_count = self.group.count_users_seen()
-            counts_text = f"Events: :chart_with_upwards_trend: *{event_count}*     Users Affected: :chart_with_upwards_trend: *{user_count}*"
+            counts_text = f"Events: *{event_count}*     Users Affected: *{user_count}*"
             blocks.append(self.get_markdown_block(counts_text))
 
             # add mentions
             if self.mentions:
-                mentions_text = f"Mentions: {self.mentions}"
+                mentions_text = f"Addt'l info: {self.mentions}"
                 blocks.append(self.get_markdown_block(mentions_text))
 
             # add project slug, error level, and substate
@@ -452,8 +464,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                     level_text = k
 
             level_emoji = LEVEL_TO_EMOJI[level_text]
-            # TODO: map substatus value to text, rn it's 7
-            context_text = f"Project: {self.group.project.slug}    Level: {level_emoji}{level_text.title()}    State: {self.group.substatus}"
+            formatted_substate = SUBSTATUS_TO_STR[self.group.substatus].title()
+            context_text = f"Project: {self.group.project.slug}    Level: {level_emoji}{level_text.title()}    State: {formatted_substate}"
             blocks.append(self.get_markdown_block(context_text))
 
         # build footer block
@@ -463,17 +475,12 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             timestamp = max(ts, self.event.datetime) if self.event else ts
 
         if has_slack_formatting_update:
-            from sentry.utils.dates import to_timestamp
-
-            def format_slack_time(timestamp):
-                return "<!date^{:.0f}^{} at {} | Sentry Issue>".format(
-                    to_timestamp(timestamp), "{date_short_pretty}", "{time}"
-                )
-
-            # ^ this isn't short enough, it looks bad.
-            # need to format last_seen and first_seen to relative time e.g. 12 minutes ago, 7 days ago
-            footer = f"{footer} | Last Seen: {format_slack_time(self.group.last_seen)}  | First Seen: {format_slack_time(self.group.first_seen)}"
-        blocks.append(self.get_context_block(text=footer, timestamp=timestamp))
+            footer = (
+                f"{footer} | First Seen: :information_source: {timesince(self.group.first_seen)}"
+            )
+            blocks.append(self.get_context_block(text=footer))
+        else:
+            blocks.append(self.get_context_block(text=footer, timestamp=timestamp))
 
         # build actions
         actions = []

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -461,7 +461,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             }
             context_text = ""
             for k, v in context.items():
-                context_text += f"{k}: *{v}*   "
+                if k and v:
+                    context_text += f"{k}: *{v}*   "
             blocks.append(self.get_markdown_block(context_text[:-3]))
 
         # build actions

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -134,15 +134,14 @@ def build_tag_fields(
 
 def get_tags(
     event_for_tags: Any,
-    has_slack_formatting_update: bool = False,
     tags: set[str] | None = None,
 ) -> Sequence[Mapping[str, str | bool]]:
     """Get tag keys and values for block kit"""
     fields = []
-    if has_slack_formatting_update:
-        if not tags:
-            tags = set()
-        tags = tags | {"level", "release"}
+    if not tags:
+        tags = set()
+
+    tags = tags | {"level", "release"}
     if tags:
         event_tags = event_for_tags.tags if event_for_tags else []
         for key, value in event_tags:
@@ -424,46 +423,43 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             )
 
         # build up the blocks for newer issue alert formatting #
-        has_slack_formatting_update = features.has(
-            "organizations:slack-formatting-update", self.group.project.organization
-        )
+
         # build title block
-        if text and has_slack_formatting_update and not self.actions:
+        if text and not self.actions:
             text = f"```{text.lstrip(' ')}```"
         title_text = f"<{title_link}|*{escape_slack_text(title)}*>  \n{text}"
-        if has_slack_formatting_update:
-            if self.group.issue_category == GroupCategory.ERROR:
-                level_text = None
-                for k, v in LOG_LEVELS_MAP.items():
-                    if self.group.level == v:
-                        level_text = k
 
-                title_emoji = LEVEL_TO_EMOJI.get(level_text)
-            else:
-                title_emoji = CATEGORY_TO_EMOJI.get(self.group.issue_category)
+        if self.group.issue_category == GroupCategory.ERROR:
+            level_text = None
+            for k, v in LOG_LEVELS_MAP.items():
+                if self.group.level == v:
+                    level_text = k
 
-            if title_emoji:
-                title_text = f"{title_emoji} {title_text}"
+            title_emoji = LEVEL_TO_EMOJI.get(level_text)
+        else:
+            title_emoji = CATEGORY_TO_EMOJI.get(self.group.issue_category)
+
+        if title_emoji:
+            title_text = f"{title_emoji} {title_text}"
 
         blocks = [self.get_markdown_block(title_text)]
         # build tags block
-        tags = get_tags(event_for_tags, has_slack_formatting_update, self.tags)
+        tags = get_tags(event_for_tags, self.tags)
         if tags:
             blocks.append(self.get_tags_block(tags))
 
-        if has_slack_formatting_update:
-            # add event count, user count, substate, first seen
-            context = {
-                "Events": get_group_global_count(self.group),
-                "Users Affected": self.group.count_users_seen(),
-                "State": SUBSTATUS_TO_STR.get(self.group.substatus, "").title(),
-                "First Seen": time_since(self.group.first_seen),
-            }
-            context_text = ""
-            for k, v in context.items():
-                if k and v:
-                    context_text += f"{k}: *{v}*   "
-            blocks.append(self.get_markdown_block(context_text[:-3]))
+        # add event count, user count, substate, first seen
+        context = {
+            "Events": get_group_global_count(self.group),
+            "Users Affected": self.group.count_users_seen(),
+            "State": SUBSTATUS_TO_STR.get(self.group.substatus, "").title(),
+            "First Seen": time_since(self.group.first_seen),
+        }
+        context_text = ""
+        for k, v in context.items():
+            if k and v:
+                context_text += f"{k}: *{v}*   "
+        blocks.append(self.get_markdown_block(context_text[:-3]))
 
         # build actions
         actions = []
@@ -490,11 +486,10 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             action_block = {"type": "actions", "elements": [action for action in actions]}
             blocks.append(action_block)
 
-        if has_slack_formatting_update:
-            # add mentions
-            if self.mentions:
-                mentions_text = f"Mentions: {self.mentions}"
-                blocks.append(self.get_markdown_block(mentions_text))
+        # add mentions
+        if self.mentions:
+            mentions_text = f"Mentions: {self.mentions}"
+            blocks.append(self.get_markdown_block(mentions_text))
 
         # build footer block
         timestamp = None
@@ -502,7 +497,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             ts = self.group.last_seen
             timestamp = max(ts, self.event.datetime) if self.event else ts
 
-        if has_slack_formatting_update and not self.notification:
+        if not self.notification:
             # the footer content differs if it's a workflow notification, so we must check for that
             footer = f"Project: <{project.get_absolute_url()}|{escape_slack_text(project.slug)}>    Alert: {footer}"
             blocks.append(self.get_context_block(text=footer))

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -134,7 +134,7 @@ def build_tag_fields(
 
 def get_tags(
     event_for_tags: Any,
-    has_slack_formatting_update: bool | False,
+    has_slack_formatting_update: bool = False,
     tags: set[str] | None = None,
 ) -> Sequence[Mapping[str, str | bool]]:
     """Get tag keys and values for block kit"""

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -134,10 +134,15 @@ def build_tag_fields(
 
 def get_tags(
     event_for_tags: Any,
+    has_slack_formatting_update: bool | False,
     tags: set[str] | None = None,
 ) -> Sequence[Mapping[str, str | bool]]:
     """Get tag keys and values for block kit"""
     fields = []
+    if has_slack_formatting_update:
+        if not tags:
+            tags = set()
+        tags = tags | {"level", "release"}
     if tags:
         event_tags = event_for_tags.tags if event_for_tags else []
         for key, value in event_tags:
@@ -402,6 +407,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             rule_id,
             notification_uuid=notification_uuid,
         )
+        title = build_attachment_title(obj)
 
         if not features.has("organizations:slack-block-kit", self.group.project.organization):
             return self._build(
@@ -412,7 +418,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                 fields=fields,
                 footer=footer,
                 text=text,
-                title=build_attachment_title(obj),
+                title=title,
                 title_link=title_link,
                 ts=get_timestamp(self.group, self.event) if not self.issue_details else None,
             )
@@ -422,9 +428,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             "organizations:slack-formatting-update", self.group.project.organization
         )
         # build title block
-        if text:
-            text = f"```{text}```"
-        title_text = f"<{title_link}|*{escape_slack_text(build_attachment_title(obj))}*>  \n{text}"
+        if text and has_slack_formatting_update and not self.actions:
+            text = f"```{text.lstrip(' ')}```"
+        title_text = f"<{title_link}|*{escape_slack_text(title)}*>  \n{text}"
         if has_slack_formatting_update:
             if self.group.issue_category == GroupCategory.ERROR:
                 level_text = None
@@ -441,8 +447,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         blocks = [self.get_markdown_block(title_text)]
         # build tags block
-        # TODO: add release and environment if available, but don't duplicate if already set in the rule config
-        tags = get_tags(event_for_tags, self.tags)
+        tags = get_tags(event_for_tags, has_slack_formatting_update, self.tags)
         if tags:
             blocks.append(self.get_tags_block(tags))
 
@@ -458,12 +463,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             for k, v in context.items():
                 context_text += f"{k}: *{v}*   "
             blocks.append(self.get_markdown_block(context_text[:-3]))
-
-        # build footer block
-        timestamp = None
-        if not self.issue_details:
-            ts = self.group.last_seen
-            timestamp = max(ts, self.event.datetime) if self.event else ts
 
         # build actions
         actions = []
@@ -496,11 +495,15 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                 mentions_text = f"Mentions: {self.mentions}"
                 blocks.append(self.get_markdown_block(mentions_text))
 
-        # update footer to be project slug + alert name/link
-        if has_slack_formatting_update:
-            # TODO linkify project
-            # XXX(CEO): note that this changes the footer for workflow alerts, should exclude adding the project there since it's duplicated
-            footer = f"Project: {project.slug}   Alert: {footer}"
+        # build footer block
+        timestamp = None
+        if not self.issue_details:
+            ts = self.group.last_seen
+            timestamp = max(ts, self.event.datetime) if self.event else ts
+
+        if has_slack_formatting_update and not self.notification:
+            # the footer content differs if it's a workflow notification, so we must check for that
+            footer = f"Project: <{project.get_absolute_url()}|{escape_slack_text(project.slug)}>    Alert: {footer}"
             blocks.append(self.get_context_block(text=footer))
         else:
             blocks.append(self.get_context_block(text=footer, timestamp=timestamp))

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -15,7 +15,13 @@ from sentry.integrations.message_builder import (
     get_timestamp,
     get_title_link,
 )
-from sentry.integrations.slack.message_builder import SLACK_URL_FORMAT, SlackAttachment, SlackBlock
+from sentry.integrations.slack.message_builder import (
+    CATEGORY_TO_EMOJI,
+    LEVEL_TO_EMOJI,
+    SLACK_URL_FORMAT,
+    SlackAttachment,
+    SlackBlock,
+)
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.utils.escape import escape_slack_text
 from sentry.issues.grouptype import GroupCategory
@@ -387,7 +393,10 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             )
 
         # build up the blocks for newer issue alert formatting #
-        tags = get_tags(event_for_tags, self.tags)
+        has_slack_formatting_update = features.has(
+            "organizations:slack-formatting-update", self.group.project.organization
+        )
+
         # build title block
         title_link = get_title_link(
             self.group,
@@ -399,28 +408,71 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             rule_id,
             notification_uuid=notification_uuid,
         )
-        blocks = [
-            self.get_markdown_block(
-                text=f"<{title_link}|*{escape_slack_text(build_attachment_title(obj))}*>  \n{text}",
-            )
-        ]
+        title_text = f"<{title_link}|*{escape_slack_text(build_attachment_title(obj))}*>  \n{text}"
+        # if has_slack_formatting_update:
+        #     # if group category is not error:
+        #     category_emoji = CATEGORY_TO_EMOJI[self.group.category]
+        #     title_text = category_emoji + " " + title_text
+
+        blocks = [self.get_markdown_block(title_text)]
         # build tags block
+        tags = get_tags(event_for_tags, self.tags)
         if tags:
             blocks.append(self.get_tags_block(tags))
 
-        # add mentions
-        if (
-            features.has("organizations:slack-formatting-update", self.group.project.organization)
-            and self.mentions
-        ):
-            mentions_text = f"Mentions: {self.mentions}"
-            blocks.append(self.get_markdown_block(mentions_text))
+        # add blocks for the new message content #
+
+        # add event and user count
+        if has_slack_formatting_update:
+
+            # copied from group_details.py, should move to a shared space
+            from sentry.tasks.post_process import fetch_buffered_group_stats
+
+            @staticmethod
+            def __get_group_global_count(group: Group) -> int:
+                fetch_buffered_group_stats(group)
+                return group.times_seen_with_pending
+
+            event_count = __get_group_global_count(self.group)
+            user_count = self.group.count_users_seen()
+            counts_text = f"Events: :chart_with_upwards_trend: *{event_count}*     Users Affected: :chart_with_upwards_trend: *{user_count}*"
+            blocks.append(self.get_markdown_block(counts_text))
+
+            # add mentions
+            if self.mentions:
+                mentions_text = f"Mentions: {self.mentions}"
+                blocks.append(self.get_markdown_block(mentions_text))
+
+            # add project slug, error level, and substate
+            from sentry.constants import LOG_LEVELS_MAP
+
+            level_text = None
+            for k, v in LOG_LEVELS_MAP.items():
+                if self.group.level == v:
+                    level_text = k
+
+            level_emoji = LEVEL_TO_EMOJI[level_text]
+            # TODO: map substatus value to text, rn it's 7
+            context_text = f"Project: {self.group.project.slug}    Level: {level_emoji}{level_text.title()}    State: {self.group.substatus}"
+            blocks.append(self.get_markdown_block(context_text))
 
         # build footer block
         timestamp = None
         if not self.issue_details:
             ts = self.group.last_seen
             timestamp = max(ts, self.event.datetime) if self.event else ts
+
+        if has_slack_formatting_update:
+            from sentry.utils.dates import to_timestamp
+
+            def format_slack_time(timestamp):
+                return "<!date^{:.0f}^{} at {} | Sentry Issue>".format(
+                    to_timestamp(timestamp), "{date_short_pretty}", "{time}"
+                )
+
+            # ^ this isn't short enough, it looks bad.
+            # need to format last_seen and first_seen to relative time e.g. 12 minutes ago, 7 days ago
+            footer = f"{footer} | Last Seen: {format_slack_time(self.group.last_seen)}  | First Seen: {format_slack_time(self.group.first_seen)}"
         blocks.append(self.get_context_block(text=footer, timestamp=timestamp))
 
         # build actions
@@ -447,6 +499,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if actions:
             action_block = {"type": "actions", "elements": [action for action in actions]}
             blocks.append(action_block)
+
+        blocks.append(self.get_divider())
 
         return self._build_blocks(
             *blocks,

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -392,35 +392,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if self.rules:
             rule_id = self.rules[0].id
 
-        if not features.has("organizations:slack-block-kit", self.group.project.organization):
-            return self._build(
-                actions=payload_actions,
-                callback_id=json.dumps({"issue": self.group.id}),
-                color=color,
-                fallback=self.build_fallback_text(obj, project.slug),
-                fields=fields,
-                footer=footer,
-                text=text,
-                title=build_attachment_title(obj),
-                title_link=get_title_link(
-                    self.group,
-                    self.event,
-                    self.link_to_event,
-                    self.issue_details,
-                    self.notification,
-                    ExternalProviders.SLACK,
-                    rule_id,
-                    notification_uuid=notification_uuid,
-                ),
-                ts=get_timestamp(self.group, self.event) if not self.issue_details else None,
-            )
-
-        # build up the blocks for newer issue alert formatting #
-        has_slack_formatting_update = features.has(
-            "organizations:slack-formatting-update", self.group.project.organization
-        )
-
-        # build title block
         title_link = get_title_link(
             self.group,
             self.event,
@@ -431,40 +402,61 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             rule_id,
             notification_uuid=notification_uuid,
         )
-        title_text = f"<{title_link}|*{escape_slack_text(build_attachment_title(obj))}*>  \n{text}"
+
+        if not features.has("organizations:slack-block-kit", self.group.project.organization):
+            return self._build(
+                actions=payload_actions,
+                callback_id=json.dumps({"issue": self.group.id}),
+                color=color,
+                fallback=self.build_fallback_text(obj, project.slug),
+                fields=fields,
+                footer=footer,
+                text=text,
+                title=build_attachment_title(obj),
+                title_link=title_link,
+                ts=get_timestamp(self.group, self.event) if not self.issue_details else None,
+            )
+
+        # build up the blocks for newer issue alert formatting #
+        has_slack_formatting_update = features.has(
+            "organizations:slack-formatting-update", self.group.project.organization
+        )
+        # build title block
+        title_text = (
+            f"<{title_link}|*{escape_slack_text(build_attachment_title(obj))}*>  \n ```{text}```"
+        )
         if has_slack_formatting_update:
-            if self.group.issue_category != GroupCategory.ERROR:
-                category_emoji = CATEGORY_TO_EMOJI.get(self.group.issue_category)
-                if category_emoji:
-                    title_text = f"{category_emoji} {title_text}"
+            if self.group.issue_category == GroupCategory.ERROR:
+                level_text = None
+                for k, v in LOG_LEVELS_MAP.items():
+                    if self.group.level == v:
+                        level_text = k
+
+                title_emoji = LEVEL_TO_EMOJI.get(level_text)
+            else:
+                title_emoji = CATEGORY_TO_EMOJI.get(self.group.issue_category)
+
+            if title_emoji:
+                title_text = f"{title_emoji} {title_text}"
 
         blocks = [self.get_markdown_block(title_text)]
         # build tags block
+        # TODO: add release and environment if available, but don't duplicate if already set in the rule config
         tags = get_tags(event_for_tags, self.tags)
         if tags:
             blocks.append(self.get_tags_block(tags))
 
-        # add event and user count
         if has_slack_formatting_update:
-            event_count = get_group_global_count(self.group)
-            user_count = self.group.count_users_seen()
-            counts_text = f"Events: *{event_count}*     Users Affected: *{user_count}*"
-            blocks.append(self.get_markdown_block(counts_text))
-
-            # add mentions
-            if self.mentions:
-                mentions_text = f"Addt'l info: {self.mentions}"
-                blocks.append(self.get_markdown_block(mentions_text))
-
-            # add project slug, error level, and substate
-            level_text = None
-            for k, v in LOG_LEVELS_MAP.items():
-                if self.group.level == v:
-                    level_text = k
-
-            level_emoji = LEVEL_TO_EMOJI[level_text]
-            formatted_substate = SUBSTATUS_TO_STR[self.group.substatus].title()
-            context_text = f"Project: {project.slug}    Level: {level_emoji}{level_text.title()}    State: {formatted_substate}"
+            # add event count, user count, substate, first seen
+            context = {
+                "Events": get_group_global_count(self.group),
+                "Users affected": self.group.count_users_seen(),
+                "State": SUBSTATUS_TO_STR.get(self.group.substatus, "").title(),
+                "First Seen": time_since(self.group.first_seen),
+            }
+            context_text = ""
+            for k, v in context.items():
+                context_text += f"{k}: *{v}*   "
             blocks.append(self.get_markdown_block(context_text))
 
         # build footer block
@@ -472,13 +464,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if not self.issue_details:
             ts = self.group.last_seen
             timestamp = max(ts, self.event.datetime) if self.event else ts
-
-        if has_slack_formatting_update:
-            first_seen = time_since(self.group.first_seen)
-            footer = f"{footer} | First Seen: {first_seen}"
-            blocks.append(self.get_context_block(text=footer))
-        else:
-            blocks.append(self.get_context_block(text=footer, timestamp=timestamp))
 
         # build actions
         actions = []
@@ -504,6 +489,21 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if actions:
             action_block = {"type": "actions", "elements": [action for action in actions]}
             blocks.append(action_block)
+
+        if has_slack_formatting_update:
+            # add mentions
+            if self.mentions:
+                mentions_text = f"Mentions: {self.mentions}"
+                blocks.append(self.get_markdown_block(mentions_text))
+
+        # update footer to be project slug + alert name/link
+        if has_slack_formatting_update:
+            # TODO linkify project
+            # XXX(CEO): note that this changes the footer for workflow alerts, should exclude adding the project there since it's duplicated
+            footer = f"Project: {project.slug}   Alert: {footer}"
+            blocks.append(self.get_context_block(text=footer))
+        else:
+            blocks.append(self.get_context_block(text=footer, timestamp=timestamp))
 
         blocks.append(self.get_divider())
 

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -450,7 +450,7 @@ class SlackActionEndpoint(Endpoint):
                 identity=identity,
                 actions=[action],
                 tags=original_tags_from_request,
-                rules=[rule],
+                rules=[rule] if rule else None,
                 skip_fallback=True,
             ).build()
             body = self.construct_reply(
@@ -486,7 +486,7 @@ class SlackActionEndpoint(Endpoint):
                 identity=identity,
                 actions=[action],
                 tags=original_tags_from_request,
-                rules=[rule],
+                rules=[rule] if rule else None,
             ).build()
             body = self.construct_reply(
                 attachment, is_message=slack_request.callback_data["is_message"]
@@ -542,7 +542,7 @@ class SlackActionEndpoint(Endpoint):
                 identity=identity,
                 actions=action_list,
                 tags=original_tags_from_request,
-                rules=[rule],
+                rules=[rule] if rule else None,
             ).build()
             # XXX(isabella): for actions on link unfurls, we omit the fallback text from the
             # response so the unfurling endpoint understands the payload
@@ -569,7 +569,7 @@ class SlackActionEndpoint(Endpoint):
             identity=identity,
             actions=action_list,
             tags=original_tags_from_request,
-            rules=[rule],
+            rules=[rule] if rule else None,
         ).build()
         body = self.construct_reply(attachment, is_message=_is_message(slack_request.data))
 

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -29,6 +29,7 @@ from sentry.integrations.utils.scope import bind_org_context_from_integration
 from sentry.models.activity import ActivityIntegration
 from sentry.models.group import Group
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
+from sentry.models.rule import Rule
 from sentry.notifications.utils.actions import BlockKitMessageAction, MessageAction
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.services.hybrid_cloud.notifications import notifications_service
@@ -104,6 +105,14 @@ def update_group(
         user=user,
         data=data,
     )
+
+
+def get_rule(slack_request: SlackActionRequest) -> Group | None:
+    """Get the rule that fired"""
+    rule_id = slack_request.callback_data.get("rule")
+    if not rule_id:
+        return None
+    return Rule.objects.get(id=rule_id)
 
 
 def get_group(slack_request: SlackActionRequest) -> Group | None:
@@ -328,7 +337,7 @@ class SlackActionEndpoint(Endpoint):
         }
         if use_block_kit and slack_request.data.get("channel"):
             callback_id["channel_id"] = slack_request.data["channel"]["id"]
-
+            callback_id["rule"] = slack_request.callback_data.get("rule")
         callback_id = json.dumps(callback_id)
 
         dialog = {
@@ -389,6 +398,11 @@ class SlackActionEndpoint(Endpoint):
         if not group:
             return self.respond(status=403)
 
+        use_block_kit = features.has("organizations:slack-block-kit", group.project.organization)
+        rule = None
+        if use_block_kit:
+            rule = get_rule(slack_request)
+
         identity = slack_request.get_identity()
         # Determine the acting user by Slack identity.
         identity_user = slack_request.get_identity_user()
@@ -404,7 +418,6 @@ class SlackActionEndpoint(Endpoint):
 
         original_tags_from_request = slack_request.get_tags()
 
-        use_block_kit = features.has("organizations:slack-block-kit", group.project.organization)
         if use_block_kit and slack_request.type == "view_submission":
             # TODO: if we use modals for something other than resolve, this will need to be more specific
 
@@ -437,6 +450,7 @@ class SlackActionEndpoint(Endpoint):
                 identity=identity,
                 actions=[action],
                 tags=original_tags_from_request,
+                rules=[rule],
                 skip_fallback=True,
             ).build()
             body = self.construct_reply(
@@ -468,7 +482,11 @@ class SlackActionEndpoint(Endpoint):
                 return self.api_error(slack_request, group, identity_user, error, "status_dialog")
 
             attachment = SlackIssuesMessageBuilder(
-                group, identity=identity, actions=[action], tags=original_tags_from_request
+                group,
+                identity=identity,
+                actions=[action],
+                tags=original_tags_from_request,
+                rules=[rule],
             ).build()
             body = self.construct_reply(
                 attachment, is_message=slack_request.callback_data["is_message"]
@@ -520,7 +538,11 @@ class SlackActionEndpoint(Endpoint):
 
         if use_block_kit:
             response = SlackIssuesMessageBuilder(
-                group, identity=identity, actions=action_list, tags=original_tags_from_request
+                group,
+                identity=identity,
+                actions=action_list,
+                tags=original_tags_from_request,
+                rules=[rule],
             ).build()
             # XXX(isabella): for actions on link unfurls, we omit the fallback text from the
             # response so the unfurling endpoint understands the payload
@@ -543,7 +565,11 @@ class SlackActionEndpoint(Endpoint):
             return self.respond(response)
 
         attachment = SlackIssuesMessageBuilder(
-            group, identity=identity, actions=action_list, tags=original_tags_from_request
+            group,
+            identity=identity,
+            actions=action_list,
+            tags=original_tags_from_request,
+            rules=[rule],
         ).build()
         body = self.construct_reply(attachment, is_message=_is_message(slack_request.data))
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2793,10 +2793,10 @@ class SlackActivityNotificationTest(ActivityTestCase):
             issue_link += issue_link_extra_params
         assert (
             blocks[1]["text"]["text"]
-            == f"<{issue_link}|*N+1 Query*>  \ndb - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+            == f":chart_with_downwards_trend: <{issue_link}|*N+1 Query*>  \n```db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21```"
         )
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[4]["elements"][0]["text"]
             == f"{project_slug} | production | <http://testserver/settings/account/notifications/{alert_type}/?referrer={referrer}-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -2827,10 +2827,10 @@ class SlackActivityNotificationTest(ActivityTestCase):
             issue_link += issue_link_extra_params
         assert (
             blocks[1]["text"]["text"]
-            == f"<{issue_link}|*{TEST_ISSUE_OCCURRENCE.issue_title}*>  \n{TEST_ISSUE_OCCURRENCE.evidence_display[0].value}"
+            == f":exclamation: <{issue_link}|*{TEST_ISSUE_OCCURRENCE.issue_title}*>  \n```{TEST_ISSUE_OCCURRENCE.evidence_display[0].value}```"
         )
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[4]["elements"][0]["text"]
             == f"{project_slug} | <http://testserver/settings/account/notifications/{alert_type}/?referrer={referrer}-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -149,10 +149,10 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
+            == f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
         )
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -115,10 +115,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={self.rule.id}&alert_type=issue|*Hello world*>  \n"
+            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={self.rule.id}&alert_type=issue|*Hello world*>  \n"
         )
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[4]["elements"][0]["text"]
             == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -350,10 +350,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
+            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
         )
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[4]["elements"][0]["text"]
             == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -458,10 +458,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment={environment.name}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
+            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment={environment.name}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
         )
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[4]["elements"][0]["text"]
             == f"{event.project.slug} | {environment.name} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -651,10 +651,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
+            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
         )
         assert (
-            blocks[3]["elements"][0]["text"]
+            blocks[5]["elements"][0]["text"]
             == f"{event.project.slug} | <http://testserver/settings/{event.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -982,10 +982,10 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
+            == f":exclamation: <http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
         )
         assert (
-            blocks[3]["elements"][0]["text"]
+            blocks[5]["elements"][0]["text"]
             == f"{event.project.slug} | <http://example.com/settings/{event.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -1244,9 +1244,9 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
+            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
         )
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[4]["elements"][0]["text"]
             == f"{event.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -654,7 +654,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             == f"<http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
         )
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[3]["elements"][0]["text"]
             == f"{event.project.slug} | <http://testserver/settings/{event.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -985,7 +985,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             == f"<http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
         )
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[3]["elements"][0]["text"]
             == f"{event.project.slug} | <http://example.com/settings/{event.organization.slug}/teams/{self.team.slug}/notifications/?referrer=issue_alert-slack-team&notification_uuid={notification_uuid}|Notification Settings>"
         )
 

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -59,9 +59,9 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         assert blocks[0]["text"]["text"] == fallback_text
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert blocks[1]["text"]["text"] == (
-            f"<http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
+            f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
         )
-        assert blocks[2]["elements"][0]["text"] == (
+        assert blocks[3]["elements"][0]["text"] == (
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -105,9 +105,9 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert blocks[1]["text"]["text"] == (
-            f"<http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
+            f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
         )
-        assert blocks[2]["elements"][0]["text"] == (
+        assert blocks[3]["elements"][0]["text"] == (
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -67,10 +67,11 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert blocks[0]["text"]["text"] == fallback_text
         assert (
             blocks[1]["text"]["text"]
-            == f"<{issue_link}/?referrer=resolved_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
+            == f":exclamation: <{issue_link}/?referrer=resolved_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
         )
+        # import pdb; pdb.set_trace()
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -64,10 +64,10 @@ class SlackResolvedInReleaseNotificationTest(
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_release_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
+            == f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_release_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
         )
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -211,6 +211,6 @@ class SlackResolvedInReleaseNotificationTest(
         assert blocks[0]["text"]["text"] == fallback_text
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -58,10 +58,10 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         assert blocks[0]["text"]["text"] == fallback_text
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert blocks[1]["text"]["text"] == (
-            f"<http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
+            f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
         )
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -929,15 +929,14 @@ class ActionsTest(TestCase):
     def test_identity_and_action(self):
         group = self.create_group(project=self.project)
         MOCKIDENTITY = Mock()
-
         assert build_actions(
             group, self.project, "test txt", "red", [MessageAction(name="TEST")], MOCKIDENTITY
-        ) == ([], "test txt\n", "_actioned_issue")
+        ) == ([], "", "_actioned_issue")
 
         with self.feature("organizations:slack-block-kit"):
             assert build_actions(
                 group, self.project, "test txt", "red", [MessageAction(name="TEST")], MOCKIDENTITY
-            ) == ([], "test txt\n", "_actioned_issue")
+            ) == ([], "", "_actioned_issue")
 
     def _assert_message_actions_list(self, actions, expected):
         actions_dict = [

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -100,7 +100,7 @@ def build_test_message_blocks(
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"Events: *1*   Users Affected: *0*   State: *Ongoing*   First Seen: *{time_since(group.first_seen)}*",
+                "text": f"Events: *1*   State: *Ongoing*   First Seen: *{time_since(group.first_seen)}*",
             },
         }
         blocks.append(counts_section)
@@ -141,15 +141,13 @@ def build_test_message_blocks(
         }
         blocks.append(mentions_section)
 
+    context_text = f"BAR-{group.short_id} | {event_date}"
+    if extra_content:
+        context_text = f"Project: <http://testserver/organizations/{project.organization.slug}/issues/?project={project.id}|{project.slug}>    Alert: BAR-{group.short_id}"
     context = {
         "type": "context",
-        "elements": [{"type": "mrkdwn", "text": f"BAR-{group.short_id} | {event_date}"}],
+        "elements": [{"type": "mrkdwn", "text": context_text}],
     }
-
-    if extra_content:
-        context["elements"][0][
-            "text"
-        ] = f"Project: <http://testserver/organizations/{project.organization.slug}/issues/?project={project.id}|{project.slug}>    Alert: BAR-{group.short_id}"
     blocks.append(context)
 
     blocks.append({"type": "divider"})

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -462,10 +462,10 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         ).build()
         assert isinstance(ret, dict)
         assert (
-            ret["blocks"][2]["elements"][2]["initial_option"]["text"]["text"]
+            ret["blocks"][1]["elements"][2]["initial_option"]["text"]["text"]
             == self.user.get_display_name()
         )
-        assert ret["blocks"][2]["elements"][2]["initial_option"]["value"] == f"user:{self.user.id}"
+        assert ret["blocks"][1]["elements"][2]["initial_option"]["value"] == f"user:{self.user.id}"
 
     # XXX(CEO): skipping replicating tests relating to color since there is no block kit equivalent
     def test_build_group_attachment_color_no_event_error_fallback(self):

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -82,10 +82,14 @@ def build_test_message_blocks(
             "block_id": f'{{"issue":{group.id}}}',
         },
     ]
-    if tags:
+    if tags or extra_content:
         tags_text = ""
-        for k, v in tags.items():
-            tags_text += f"`{k}: {v}`  "
+        if tags:
+            for k, v in tags.items():
+                tags_text += f"`{k}: {v}`  "
+        else:
+            for k, v in {"level": "error"}.items():
+                tags_text += f"`{k}: {v}`  "
 
         tags_section = {"type": "section", "text": {"type": "mrkdwn", "text": tags_text}}
         blocks.append(tags_section)
@@ -143,7 +147,9 @@ def build_test_message_blocks(
     }
 
     if extra_content:
-        context["elements"][0]["text"] = f"Project: {project.slug}   Alert: BAR-{group.short_id}"
+        context["elements"][0][
+            "text"
+        ] = f"Project: <http://testserver/organizations/{project.organization.slug}/issues/?project={project.id}|{project.slug}>    Alert: BAR-{group.short_id}"
     blocks.append(context)
 
     blocks.append({"type": "divider"})

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -45,13 +45,11 @@ pytestmark = [requires_snuba]
 def build_test_message_blocks(
     teams: set[Team],
     users: set[User],
-    timestamp: datetime,
     group: Group,
     event: Event | None = None,
     link_to_event: bool = False,
     tags: dict[str, str] | None = None,
     mentions: str | None = None,
-    extra_content: bool = False,
 ) -> dict[str, Any]:
     project = group.project
 
@@ -65,15 +63,7 @@ def build_test_message_blocks(
         if link_to_event:
             title_link += f"/events/{event.event_id}"
     title_link += "/?referrer=slack"
-    ts = group.last_seen
-    timestamp = max(ts, event.datetime) if event else ts
-    event_date = "<!date^{:.0f}^{} at {} | Sentry Issue>".format(
-        to_timestamp(timestamp), "{date_pretty}", "{time}"
-    )
-
-    title_text = f"<{title_link}|*{formatted_title}*>  \n"
-    if extra_content:
-        title_text = f":exclamation: {title_text}"
+    title_text = f":exclamation: <{title_link}|*{formatted_title}*>  \n"
 
     blocks: list[dict[str, Any]] = [
         {
@@ -82,28 +72,27 @@ def build_test_message_blocks(
             "block_id": f'{{"issue":{group.id}}}',
         },
     ]
-    if tags or extra_content:
-        tags_text = ""
-        if tags:
-            for k, v in tags.items():
-                tags_text += f"`{k}: {v}`  "
-        else:
-            for k, v in {"level": "error"}.items():
-                tags_text += f"`{k}: {v}`  "
 
-        tags_section = {"type": "section", "text": {"type": "mrkdwn", "text": tags_text}}
-        blocks.append(tags_section)
+    tags_text = ""
+    if not tags:
+        tags = {}
+    tags["level"] = "error"
 
-    if extra_content:
-        # add event and user count, state, first seen
-        counts_section = {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"Events: *1*   State: *Ongoing*   First Seen: *{time_since(group.first_seen)}*",
-            },
-        }
-        blocks.append(counts_section)
+    for k, v in tags.items():
+        tags_text += f"`{k}: {v}`  "
+
+    tags_section = {"type": "section", "text": {"type": "mrkdwn", "text": tags_text}}
+    blocks.append(tags_section)
+
+    # add event and user count, state, first seen
+    counts_section = {
+        "type": "section",
+        "text": {
+            "type": "mrkdwn",
+            "text": f"Events: *1*   State: *Ongoing*   First Seen: *{time_since(group.first_seen)}*",
+        },
+    }
+    blocks.append(counts_section)
 
     actions = {
         "type": "actions",
@@ -141,9 +130,7 @@ def build_test_message_blocks(
         }
         blocks.append(mentions_section)
 
-    context_text = f"BAR-{group.short_id} | {event_date}"
-    if extra_content:
-        context_text = f"Project: <http://testserver/organizations/{project.organization.slug}/issues/?project={project.id}|{project.slug}>    Alert: BAR-{group.short_id}"
+    context_text = f"Project: <http://testserver/organizations/{project.organization.slug}/issues/?project={project.id}|{project.slug}>    Alert: BAR-{group.short_id}"
     context = {
         "type": "context",
         "elements": [{"type": "mrkdwn", "text": context_text}],
@@ -282,6 +269,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         event = self.store_event(
             data={
                 "event_id": "a" * 32,
+                "tags": {"foo": "bar"},
                 "timestamp": iso_format(before_now(minutes=1)),
                 "logentry": {"formatted": "bar"},
                 "_meta": {"logentry": {"formatted": {"": {"err": ["some error"]}}}},
@@ -293,62 +281,53 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert group
         self.project.flags.has_releases = True
         self.project.save(update_fields=["flags"])
-        tags = {"level": "error"}
+        tags = {"foo": "bar"}
         mentions = "hey @colleen fix it"
 
         assert SlackIssuesMessageBuilder(group).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},
-            timestamp=group.last_seen,
             group=group,
         )
 
-        # add tags to message
+        # add extra tag to message
         assert SlackIssuesMessageBuilder(
-            group, event.for_group(group), tags={"level"}
+            group, event.for_group(group), tags={"foo"}
         ).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},
-            timestamp=group.last_seen,
             group=group,
             tags=tags,
             event=event,
         )
 
-        # add extra content to message
-        with self.feature("organizations:slack-formatting-update"):
-            assert SlackIssuesMessageBuilder(
-                group, event.for_group(group), mentions=mentions
-            ).build() == build_test_message_blocks(
-                teams={self.team},
-                users={self.user},
-                timestamp=group.last_seen,
-                group=group,
-                mentions=mentions,
-                event=event,
-                extra_content=True,
-            )
-        # add tags and extra content to message
-        with self.feature("organizations:slack-formatting-update"):
-            assert SlackIssuesMessageBuilder(
-                group, event.for_group(group), tags={"level"}, mentions=mentions
-            ).build() == build_test_message_blocks(
-                teams={self.team},
-                users={self.user},
-                timestamp=group.last_seen,
-                group=group,
-                tags=tags,
-                mentions=mentions,
-                event=event,
-                extra_content=True,
-            )
+        # add mentions to message
+        assert SlackIssuesMessageBuilder(
+            group, event.for_group(group), mentions=mentions
+        ).build() == build_test_message_blocks(
+            teams={self.team},
+            users={self.user},
+            group=group,
+            mentions=mentions,
+            event=event,
+        )
+        # add extra tag and mentions to message
+        assert SlackIssuesMessageBuilder(
+            group, event.for_group(group), tags={"foo"}, mentions=mentions
+        ).build() == build_test_message_blocks(
+            teams={self.team},
+            users={self.user},
+            group=group,
+            tags=tags,
+            mentions=mentions,
+            event=event,
+        )
 
         assert SlackIssuesMessageBuilder(
             group, event.for_group(group)
         ).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},
-            timestamp=event.datetime,
             group=group,
             event=event,
         )
@@ -358,7 +337,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         ).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},
-            timestamp=event.datetime,
             group=group,
             event=event,
             link_to_event=True,
@@ -367,7 +345,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         test_message = build_test_message_blocks(
             teams={self.team},
             users={self.user},
-            timestamp=group.last_seen,
             group=group,
         )
 
@@ -465,11 +442,12 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             issue_alert_group, recipient=RpcActor.from_object(self.team)
         ).build()
         assert isinstance(ret, dict)
+        # import pdb; pdb.set_trace()
         assert (
-            ret["blocks"][1]["elements"][2]["initial_option"]["text"]["text"]
+            ret["blocks"][2]["elements"][2]["initial_option"]["text"]["text"]
             == self.user.get_display_name()
         )
-        assert ret["blocks"][1]["elements"][2]["initial_option"]["value"] == f"user:{self.user.id}"
+        assert ret["blocks"][2]["elements"][2]["initial_option"]["value"] == f"user:{self.user.id}"
 
     # XXX(CEO): skipping replicating tests relating to color since there is no block kit equivalent
     def test_build_group_attachment_color_no_event_error_fallback(self):

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -442,7 +442,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             issue_alert_group, recipient=RpcActor.from_object(self.team)
         ).build()
         assert isinstance(ret, dict)
-        # import pdb; pdb.set_trace()
         assert (
             ret["blocks"][2]["elements"][2]["initial_option"]["text"]["text"]
             == self.user.get_display_name()

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -95,7 +95,7 @@ def build_test_message_blocks(
         blocks.append(counts_section)
 
     if mentions:
-        mentions_text = f"Addt'l info: {mentions}"
+        mentions_text = f"Mentions: {mentions}"
         mentions_section = {
             "type": "section",
             "text": {"type": "mrkdwn", "text": mentions_text},

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -10,6 +10,7 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.notifications.additional_attachment_manager import manager
 from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.helpers import install_slack
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
@@ -75,6 +76,7 @@ class SlackNotifyActionTest(RuleTestCase):
             == "Send a notification to the Awesome Team Slack workspace to #my-channel (optionally, an ID: ) and show tags [one, two] in notification"
         )
 
+    @with_feature("organizations:slack-block-kit")
     def test_render_label_with_mentions(self):
         rule = self.get_rule(
             data={

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -10,7 +10,6 @@ from sentry.models.integrations.organization_integration import OrganizationInte
 from sentry.notifications.additional_attachment_manager import manager
 from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.helpers import install_slack
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
@@ -76,7 +75,6 @@ class SlackNotifyActionTest(RuleTestCase):
             == "Send a notification to the Awesome Team Slack workspace to #my-channel (optionally, an ID: ) and show tags [one, two] in notification"
         )
 
-    @with_feature("organizations:slack-formatting-update")
     def test_render_label_with_mentions(self):
         rule = self.get_rule(
             data={

--- a/tests/sentry/integrations/slack/webhooks/actions/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/__init__.py
@@ -16,6 +16,8 @@ class BaseEventTest(APITestCase):
         self.response_url = (
             "https://hooks.slack.com/actions/T47563693/6204672533/x7ZLaiVMoECAW50Gw1ZYAXEM"
         )
+        self.project = self.create_project()
+        self.rule = self.create_project_rule(project=self.project)
 
     @patch(
         "sentry.integrations.slack.requests.base.SlackRequest._check_signing_secret",
@@ -37,7 +39,7 @@ class BaseEventTest(APITestCase):
             slack_user = {"id": self.external_id, "domain": "example"}
 
         if callback_id is None:
-            callback_id = json.dumps({"issue": self.group.id})
+            callback_id = json.dumps({"issue": self.group.id, "rule": self.rule.id})
 
         if original_message is None:
             original_message = {}

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -174,6 +174,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             assert resp.status_code == 200, resp.content
             assert self.group.get_status() == GroupStatus.IGNORED
             assert self.group.substatus == GroupSubStatus.FOREVER
+            expect_status = f"```Identity not found.```\n*Issue archived by <@{self.external_id}>*"
             assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
 
     def test_ignore_issue_block_kit(self):
@@ -196,7 +197,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             assert resp.status_code == 200, resp.content
             assert self.group.get_status() == GroupStatus.IGNORED
             assert self.group.substatus == GroupSubStatus.FOREVER
-            expect_status = f"Identity not found.\n*Issue archived by <@{self.external_id}>*"
+            expect_status = f"```Identity not found.```\n*Issue archived by <@{self.external_id}>*"
             assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
 
     def test_ignore_issue_block_kit_through_unfurl(self):
@@ -218,7 +219,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             assert resp.status_code == 200, resp.content
             assert self.group.get_status() == GroupStatus.IGNORED
             assert self.group.substatus == GroupSubStatus.FOREVER
-            expect_status = f"Identity not found.\n*Issue archived by <@{self.external_id}>*"
+            expect_status = f"```Identity not found.```\n*Issue archived by <@{self.external_id}>*"
             assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
 
     def test_archive_issue(self):
@@ -256,6 +257,8 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             assert resp.status_code == 200, resp.content
             assert self.group.get_status() == GroupStatus.IGNORED
             assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
+            # XXX(CEO): it's kind of odd to code format this but would be tricky to avoid
+            expect_status = f"```Identity not found.```\n*Issue archived by <@{self.external_id}>*"
             assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
 
     def test_archive_issue_block_kit(self):
@@ -277,7 +280,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert self.group.get_status() == GroupStatus.IGNORED
         assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
 
-        expect_status = f"Identity not found.\n*Issue archived by <@{self.external_id}>*"
+        expect_status = f"```Identity not found.```\n*Issue archived by <@{self.external_id}>*"
         assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
 
     def test_archive_issue_block_kit_through_unfurl(self):
@@ -300,7 +303,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert self.group.get_status() == GroupStatus.IGNORED
         assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
 
-        expect_status = f"Identity not found.\n*Issue archived by <@{self.external_id}>*"
+        expect_status = f"```Identity not found.```\n*Issue archived by <@{self.external_id}>*"
         assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
 
     def test_ignore_issue_with_additional_user_auth(self):
@@ -446,7 +449,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
                 "assigneeType": "user",
                 "integration": ActivityIntegration.SLACK.value,
             }
-
+            expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
             assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
 
     def test_assign_issue_block_kit(self):

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -279,28 +279,28 @@ class DigestSlackNotification(SlackActivityNotificationTest):
             fallback_text
             == f"<!date^{timestamp_secs}^2 issues detected {{date_pretty}} in| Digest Report for> <http://testserver/organizations/{self.organization.slug}/projects/{self.project.slug}/|{self.project.name}>"
         )
-        assert len(blocks) == 7
+        assert len(blocks) == 11
         assert blocks[0]["text"]["text"] == fallback_text
 
         assert event1.group
-        event1_alert_title = f"<http://testserver/organizations/{self.organization.slug}/issues/{event1.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event1.group.title}*>  \n"
+        event1_alert_title = f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{event1.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event1.group.title}*>  \n"
 
         assert event2.group
-        event2_alert_title = f"<http://testserver/organizations/{self.organization.slug}/issues/{event2.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event2.group.title}*>  \n"
+        event2_alert_title = f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{event2.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event2.group.title}*>  \n"
 
         # digest order not definitive
         try:
             assert blocks[1]["text"]["text"] == event1_alert_title
-            assert blocks[4]["text"]["text"] == event2_alert_title
+            assert blocks[6]["text"]["text"] == event2_alert_title
         except AssertionError:
             assert blocks[1]["text"]["text"] == event2_alert_title
-            assert blocks[4]["text"]["text"] == event1_alert_title
+            assert blocks[6]["text"]["text"] == event1_alert_title
 
         assert (
-            blocks[2]["elements"][0]["text"]
+            blocks[4]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/?referrer=digest-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
         assert (
-            blocks[5]["elements"][0]["text"]
+            blocks[9]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/?referrer=digest-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -279,7 +279,7 @@ class DigestSlackNotification(SlackActivityNotificationTest):
             fallback_text
             == f"<!date^{timestamp_secs}^2 issues detected {{date_pretty}} in| Digest Report for> <http://testserver/organizations/{self.organization.slug}/projects/{self.project.slug}/|{self.project.name}>"
         )
-        assert len(blocks) == 5
+        assert len(blocks) == 7
         assert blocks[0]["text"]["text"] == fallback_text
 
         assert event1.group
@@ -291,16 +291,16 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         # digest order not definitive
         try:
             assert blocks[1]["text"]["text"] == event1_alert_title
-            assert blocks[3]["text"]["text"] == event2_alert_title
+            assert blocks[4]["text"]["text"] == event2_alert_title
         except AssertionError:
             assert blocks[1]["text"]["text"] == event2_alert_title
-            assert blocks[3]["text"]["text"] == event1_alert_title
+            assert blocks[4]["text"]["text"] == event1_alert_title
 
         assert (
             blocks[2]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/?referrer=digest-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
         assert (
-            blocks[4]["elements"][0]["text"]
+            blocks[5]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/?referrer=digest-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
         )


### PR DESCRIPTION
Adds issue context to Slack alert notifications and attempts to match the [designs](https://www.figma.com/file/aqQIFNXUURbHZKHEO0oYxf/Ecosystem-Notifications?type=design&node-id=318-39553&mode=design&t=6THjvg2mTmQzWI1K-0). This adds: 
* project slug (linkified)
* event count
* user count
* substate
* first seen
* error level as an emoji if the issue type is error
* issue category as an emoji if the issue type is not error
* Adds `level` and `release` tags by default, does not duplicate if explicitly requested

This also strips any empty spaces before the error text, since we were seeing some notifications come in like that.

**Issue alert**
<img width="636" alt="Screenshot 2024-01-23 at 2 55 45 PM" src="https://github.com/getsentry/sentry/assets/29959063/2410eb81-7b8d-4c7e-9eaa-add574618790">

**After Archiving**
<img width="635" alt="Screenshot 2024-01-23 at 2 55 56 PM" src="https://github.com/getsentry/sentry/assets/29959063/006108d0-e62f-4744-8d1e-ceea728845b4">

**Workflow notification post resolution**
<img width="681" alt="Screenshot 2024-01-23 at 3 12 16 PM" src="https://github.com/getsentry/sentry/assets/29959063/830d69a1-f6fa-42aa-ba2f-45d16762b16f">


Closes #62902  and #62904 

Requires https://github.com/getsentry/getsentry/pull/12690