### PR TITLE
fix(api): Allow API token deletion by id

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/__init__.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/__init__.py
@@ -10,7 +10,10 @@ from .installation.external_issue.index import SentryAppInstallationExternalIssu
 from .installation.external_requests import SentryAppInstallationExternalRequestsEndpoint
 from .installation.index import SentryAppInstallationsEndpoint
 from .interaction import SentryAppInteractionEndpoint
-from .internal_app_token.details import SentryInternalAppTokenDetailsEndpoint
+from .internal_app_token.details import (
+    NewSentryInternalAppTokenDetailsEndpoint,
+    SentryInternalAppTokenDetailsEndpoint,
+)
 from .internal_app_token.index import SentryInternalAppTokensEndpoint
 from .organization_sentry_apps import OrganizationSentryAppsEndpoint
 from .publish_request import SentryAppPublishRequestEndpoint
@@ -38,5 +41,6 @@ __all__ = (
     "SentryAppsStatsEndpoint",
     "SentryAppStatsEndpoint",
     "SentryInternalAppTokenDetailsEndpoint",
+    "NewSentryInternalAppTokenDetailsEndpoint",
     "SentryInternalAppTokensEndpoint",
 )

--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
@@ -73,7 +73,8 @@ class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
         return Response(status=204)
 
 
-# TODO: when the above endpoint is deprecated, simply move the convert method. This endpoint utilizes the id instead.
+# TODO: when the above endpoint is deprecated, simply move the convert method.
+# This endpoint handler utilizes the id instead.
 @control_silo_endpoint
 class NewSentryInternalAppTokenDetailsEndpoint(SentryInternalAppTokenDetailsEndpoint):
     owner = ApiOwner.INTEGRATIONS
@@ -81,17 +82,17 @@ class NewSentryInternalAppTokenDetailsEndpoint(SentryInternalAppTokenDetailsEndp
         "DELETE": ApiPublishStatus.EXPERIMENTAL,
     }
 
-    def convert_args(self, request: Request, sentry_app_slug, api_token_id, *args, **kwargs):
+    # The api_token is actually the id of the api token, but needs the same signature of the parent class method
+    def convert_args(self, request: Request, sentry_app_slug, api_token, *args, **kwargs):
         try:
-            api_token = ApiToken.objects.get(id=api_token_id)
+            api_token_obj = ApiToken.objects.get(id=api_token)
         except ApiToken.DoesNotExist:
             raise Http404
 
-        # get the sentry_app from the SentryAppBaseEndpoint class
         # We are doing the super call AFTER getting the api token because the parent class still needs the token
         # Once the token passing is deprecated, we can change the order to be similar to the parent
         (args, kwargs) = super().convert_args(
-            request, sentry_app_slug, api_token.token, *args, **kwargs
+            request, sentry_app_slug, api_token_obj.token, *args, **kwargs
         )
 
         return (args, kwargs)

--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
@@ -78,7 +78,7 @@ class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
 class NewSentryInternalAppTokenDetailsEndpoint(SentryInternalAppTokenDetailsEndpoint):
     owner = ApiOwner.INTEGRATIONS
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.EXPERIMENTAL,
     }
 
     def convert_args(self, request: Request, sentry_app_slug, api_token_id, *args, **kwargs):

--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
@@ -76,6 +76,11 @@ class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
 # TODO: when the above endpoint is deprecated, simply move the convert method. This endpoint utilizes the id instead.
 @control_silo_endpoint
 class NewSentryInternalAppTokenDetailsEndpoint(SentryInternalAppTokenDetailsEndpoint):
+    owner = ApiOwner.INTEGRATIONS
+    publish_status = {
+        "DELETE": ApiPublishStatus.UNKNOWN,
+    }
+
     def convert_args(self, request: Request, sentry_app_slug, api_token_id, *args, **kwargs):
         try:
             api_token = ApiToken.objects.get(id=api_token_id)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2745,7 +2745,7 @@ SENTRY_APP_URLS = [
     # The order of the next 2 urls matters. We want to let the numeric id handler try to match the regex first,
     # before moving to alphanumeric which is a catch-all.
     re_path(
-        r"^(?P<sentry_app_slug>[^\/]+)/api-tokens/(?P<api_token_id>\d+)/$",
+        r"^(?P<sentry_app_slug>[^\/]+)/api-tokens/(?P<api_token>\d+)/$",
         NewSentryInternalAppTokenDetailsEndpoint.as_view(),
         name="sentry-api-0-sentry-internal-app-token-details",
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -243,6 +243,7 @@ from .endpoints.integrations import (
     OrganizationPluginsEndpoint,
 )
 from .endpoints.integrations.sentry_apps import (
+    NewSentryInternalAppTokenDetailsEndpoint,
     OrganizationSentryAppComponentsEndpoint,
     OrganizationSentryAppsEndpoint,
     SentryAppAuthorizationsEndpoint,
@@ -2741,8 +2742,15 @@ SENTRY_APP_URLS = [
         SentryInternalAppTokensEndpoint.as_view(),
         name="sentry-api-0-sentry-internal-app-tokens",
     ),
+    # The order of the next 2 urls matters. We want to let the numeric id handler try to match the regex first,
+    # before moving to alphanumeric which is a catch-all.
     re_path(
-        r"^(?P<sentry_app_slug>[^\/]+)/api-tokens/(?P<api_token>[^\/]+)/$",
+        r"^(?P<sentry_app_slug>[^\/]+)/api-tokens/(?P<api_token_id>\d+)/$",
+        NewSentryInternalAppTokenDetailsEndpoint.as_view(),
+        name="sentry-api-0-sentry-internal-app-token-details",
+    ),
+    re_path(
+        r"^(?P<sentry_app_slug>[^\/]+)/api-tokens/(?P<api_token>\w+)/$",
         SentryInternalAppTokenDetailsEndpoint.as_view(),
         name="sentry-api-0-sentry-internal-app-token-details",
     ),

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
@@ -89,3 +89,28 @@ class SentryInternalAppTokenCreationTest(APITestCase):
         self.internal_sentry_app.update(metadata={"partnership_restricted": True})
         response = self.client.delete(self.url)
         assert response.status_code == 403
+
+
+@control_silo_test
+class NewSentryInternalAppTokenCreationTest(APITestCase):
+    def setUp(self):
+        self.user = self.create_user(email="boop@example.com")
+        self.org = self.create_organization(owner=self.user, name="My Org")
+        self.project = self.create_project(organization=self.org)
+
+        self.internal_sentry_app = self.create_internal_integration(
+            name="My Internal App", organization=self.org
+        )
+
+        self.api_token = ApiToken.objects.get(application=self.internal_sentry_app.application)
+
+        self.url = reverse(
+            "sentry-api-0-sentry-internal-app-token-details",
+            args=[self.internal_sentry_app.slug, self.api_token.id],
+        )
+
+    def test_delete_token(self):
+        self.login_as(user=self.user)
+        response = self.client.delete(self.url, format="json")
+        assert response.status_code == 204
+        assert not ApiToken.objects.filter(pk=self.api_token.id).exists()


### PR DESCRIPTION
We are exposing the API token secret value on the API route. To prevent exposing this secret value, which has the ability to make actions on behalf of the user, we need to be utilizing the id instead. We are creating a new regex path handler that allows utilizing of the id, and allowing the deprecation of the value endpoint once the FE moves off of it's usage.

Resolves: https://github.com/getsentry/team-enterprise/issues/21#issue-2047202292