### PR TITLE
nit(staff): Add deprecation comment

### DIFF
--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -47,7 +47,7 @@ class BroadcastIndexEndpoint(ControlSiloOrganizationEndpoint):
         return serialize(items, request.user, serializer=serializer_cls())
 
     def _secondary_filtering(self, request: Request, organization_slug, queryset):
-        # used in the SASS product
+        # used in the SAAS product
         return list(queryset)
 
     def convert_args(self, request: Request, organization_slug=None, *args, **kwargs):

--- a/src/sentry/middleware/superuser.py
+++ b/src/sentry/middleware/superuser.py
@@ -21,6 +21,7 @@ class SuperuserMiddleware(MiddlewareMixin):
         su = Superuser(request)
 
         request.superuser = su
+        # XXX(schew2381): is_superuser is a DEPRECATED property. Please use is_active_superuser(request) instead.
         request.is_superuser = lambda: request.superuser.is_active
 
         if su.is_active:


### PR DESCRIPTION
People are still using `request.is_superuser()` so hopefully they read this comment before using it