### PR TITLE
fix(hybridcloud) Record rpc tags when when requests fail

### DIFF
--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -526,6 +526,10 @@ class _RemoteSiloCall:
         return RpcRemoteException(self.service_name, self.method_name, message)
 
     def _raise_from_response_status_error(self, response: requests.Response) -> NoReturn:
+        with sentry_sdk.configure_scope() as scope:
+            scope.set_tag("rpc_service", self.service_name)
+            scope.set_tag("rpc_method", self.method_name)
+
         if in_test_environment():
             if response.status_code == 500:
                 raise self._remote_exception(


### PR DESCRIPTION
Add tags for the rpc service/method that fail. I've updated grouping rules so that we only get one RPC failure issue from each environment/region. Having more tags will help in figuring out which RPC calls are failing.
