### PR TITLE
feat(issues): Only show app icons for sentry apps

### DIFF
--- a/static/app/components/events/interfaces/frame/openInContextLine.spec.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.spec.tsx
@@ -1,9 +1,12 @@
 import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {SentryAppInstallationFixture} from 'sentry-fixture/sentryAppInstallation';
+import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {OpenInContextLine} from 'sentry/components/events/interfaces/frame/openInContextLine';
+import ConfigStore from 'sentry/stores/configStore';
 import {SentryAppComponent, SentryAppSchemaStacktraceLink} from 'sentry/types';
 import {addQueryParamsToExistingUrl} from 'sentry/utils/queryString';
 
@@ -66,6 +69,28 @@ describe('OpenInContextLine', function () {
         'href',
         'http://localhost:4000/something?filename=%2Fsentry%2Fapp.py&installationId=25d10adb-7b89-45ac-99b5-edaa714341ba&lineNo=233&projectSlug=internal'
       );
+    });
+
+    it('renders only app icons with issue-details-stacktrace-link-in-frame feature', function () {
+      ConfigStore.set(
+        'user',
+        UserFixture({
+          options: {
+            ...UserFixture().options,
+            issueDetailsNewExperienceQ42023: true,
+          },
+        })
+      );
+      const organization = OrganizationFixture({
+        features: ['issue-details-stacktrace-link-in-frame'],
+      });
+      render(
+        <OpenInContextLine filename={filename} lineNo={lineNo} components={components} />,
+        {organization}
+      );
+
+      expect(screen.getByRole('link', {name: 'Foo'})).toHaveTextContent('');
+      expect(screen.getByRole('link', {name: 'Tesla'})).toHaveTextContent('');
     });
   });
 });

--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {hasStacktraceLinkInFrameFeature} from 'sentry/components/events/interfaces/frame/utils';
 import ExternalLink from 'sentry/components/links/externalLink';
 import SentryAppComponentIcon from 'sentry/components/sentryAppComponentIcon';
+import {Tooltip} from 'sentry/components/tooltip';
 import {space} from 'sentry/styles/space';
 import type {SentryAppComponent, SentryAppSchemaStacktraceLink} from 'sentry/types';
 import {addQueryParamsToExistingUrl} from 'sentry/utils/queryString';
@@ -44,20 +45,26 @@ function OpenInContextLine({lineNo, filename, components}: Props) {
         const {slug} = component.sentryApp;
         const onClickRecordInteraction = handleRecordInteraction(slug);
         return (
-          <OpenInLink
+          <Tooltip
             key={component.uuid}
-            data-test-id={`stacktrace-link-${slug}`}
-            href={url}
-            onClick={onClickRecordInteraction}
-            onContextMenu={onClickRecordInteraction}
-            openInNewTab
-            hasInFrameFeature={hasInFrameFeature}
+            title={component.sentryApp.name}
+            disabled={!hasInFrameFeature}
+            skipWrapper
           >
-            <SentryAppComponentIcon sentryAppComponent={component} />
-            <OpenInName hasInFrameFeature={hasInFrameFeature}>
-              {component.sentryApp.name}
-            </OpenInName>
-          </OpenInLink>
+            <OpenInLink
+              aria-label={component.sentryApp.name}
+              href={url}
+              onClick={onClickRecordInteraction}
+              onContextMenu={onClickRecordInteraction}
+              openInNewTab
+            >
+              <SentryAppComponentIcon
+                sentryAppComponent={component}
+                size={hasInFrameFeature ? 16 : 20}
+              />
+              {!hasInFrameFeature && <span>{component.sentryApp.name}</span>}
+            </OpenInLink>
+          </Tooltip>
         );
       })}
     </OpenInContainer>
@@ -86,9 +93,8 @@ const OpenInContainer = styled('div')<{
   ${p =>
     p.hasInFrameFeature
       ? css`
-          color: ${p.theme.linkColor};
           animation: ${fadeIn} 0.2s ease-in-out forwards;
-          padding: ${space(0)};
+          padding: 0;
         `
       : css`
           color: ${p.theme.subText};
@@ -99,22 +105,9 @@ const OpenInContainer = styled('div')<{
         `}
 `;
 
-const OpenInLink = styled(ExternalLink)<{hasInFrameFeature: boolean}>`
+const OpenInLink = styled(ExternalLink)`
   display: flex;
   gap: ${space(0.75)};
   align-items: center;
-  ${p => (p.hasInFrameFeature ? `` : `color: ${p.theme.gray300};`)}
-`;
-
-export const OpenInName = styled('span')<{hasInFrameFeature: boolean}>`
-  ${p =>
-    p.hasInFrameFeature
-      ? css`
-          &:hover {
-            text-decoration: underline;
-            text-decoration-color: ${p.theme.linkUnderline};
-            text-underline-offset: ${space(0.5)};
-          }
-        `
-      : ``}
+  color: ${p => p.theme.gray300};
 `;

--- a/static/app/components/sentryAppComponentIcon.tsx
+++ b/static/app/components/sentryAppComponentIcon.tsx
@@ -6,13 +6,14 @@ import {SentryAppComponent} from 'sentry/types';
 
 type Props = {
   sentryAppComponent: SentryAppComponent;
+  size?: number;
 };
 
 /**
  * Icon Renderer for SentryAppComponents with UI
  * (e.g. Issue Linking, Stacktrace Linking)
  */
-function SentryAppComponentIcon({sentryAppComponent}: Props) {
+function SentryAppComponentIcon({sentryAppComponent, size}: Props) {
   const selectedAvatar = sentryAppComponent.sentryApp?.avatars?.find(
     ({color}) => color === false
   );
@@ -26,7 +27,7 @@ function SentryAppComponentIcon({sentryAppComponent}: Props) {
     >
       <SentryAppAvatar
         sentryApp={sentryAppComponent.sentryApp}
-        size={20}
+        size={size}
         isColor={false}
       />
     </SentryAppAvatarWrapper>


### PR DESCRIPTION
Sentry apps can be used in stacktrace links, this switches them to display only their icon.

before
![image](https://github.com/getsentry/sentry/assets/1400464/ada9ac4b-210e-47f7-a4f8-67871e617fb0)

after
![image](https://github.com/getsentry/sentry/assets/1400464/a499a0c8-14ef-43b0-ac03-5ff91d9fac07)

