### PR TITLE
feat(replay-clip): Add clip options to the replay context

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -19,7 +19,8 @@ import {useDimensions} from 'sentry/utils/useDimensions';
 type Props = {};
 
 function ReplayTimeline({}: Props) {
-  const {replay, currentTime, timelineScale} = useReplayContext();
+  const {replay, currentTime, timelineScale, startTimeOffsetMs, durationMs} =
+    useReplayContext();
 
   const panelRef = useRef<HTMLDivElement>(null);
   const mouseTrackingProps = useTimelineScrubberMouseTracking(
@@ -34,13 +35,12 @@ function ReplayTimeline({}: Props) {
     return <Placeholder height="20px" />;
   }
 
-  const durationMs = replay.getDurationMs();
-  const startTimestampMs = replay.getReplay().started_at.getTime();
+  const startTimestampMs = replay.getReplay().started_at.getTime() + startTimeOffsetMs;
   const chapterFrames = replay.getChapterFrames();
 
   // timeline is in the middle
   const initialTranslate = 0.5 / timelineScale;
-  const percentComplete = divide(currentTime, durationMs);
+  const percentComplete = divide(currentTime - startTimeOffsetMs, durationMs);
 
   const starting = percentComplete < initialTranslate;
   const ending = percentComplete + initialTranslate > 1;
@@ -52,7 +52,10 @@ function ReplayTimeline({}: Props) {
     if (ending) {
       return initialTranslate - (1 - initialTranslate);
     }
-    return initialTranslate - (currentTime > durationMs ? 1 : percentComplete);
+    return (
+      initialTranslate -
+      (currentTime - startTimeOffsetMs > durationMs ? 1 : percentComplete)
+    );
   };
 
   return (
@@ -73,6 +76,7 @@ function ReplayTimeline({}: Props) {
             frames={chapterFrames}
             startTimestampMs={startTimestampMs}
             width={width}
+            startTimeOffsetMs={startTimeOffsetMs}
           />
         </TimelineEventsContainer>
       </Stacked>

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -18,6 +18,7 @@ const NODE_SIZES = [8, 12, 16];
 interface Props {
   durationMs: number;
   frames: ReplayFrame[];
+  startTimeOffsetMs: number;
   startTimestampMs: number;
   width: number;
   className?: string;
@@ -28,12 +29,18 @@ function ReplayTimelineEvents({
   durationMs,
   frames,
   startTimestampMs,
+  startTimeOffsetMs,
   width,
 }: Props) {
   const markerWidth = frames.length < 200 ? 4 : frames.length < 500 ? 6 : 10;
 
   const totalColumns = Math.floor(width / markerWidth);
-  const framesByCol = getFramesByColumn(durationMs, frames, totalColumns);
+  const framesByCol = getFramesByColumn(
+    durationMs,
+    frames,
+    totalColumns,
+    startTimeOffsetMs
+  );
 
   return (
     <Timeline.Columns className={className} totalColumns={totalColumns} remainder={0}>

--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -16,13 +16,17 @@ type Props = {
 };
 
 function Scrubber({className, showZoomIndicators = false}: Props) {
-  const {currentHoverTime, currentTime, replay, setCurrentTime, timelineScale} =
-    useReplayContext();
+  const {
+    currentHoverTime,
+    currentTime,
+    setCurrentTime,
+    timelineScale,
+    startTimeOffsetMs,
+    durationMs,
+  } = useReplayContext();
 
-  const durationMs = replay?.getDurationMs() ?? 0;
-
-  const percentComplete = divide(currentTime, durationMs);
-  const hoverPlace = divide(currentHoverTime || 0, durationMs);
+  const percentComplete = divide(currentTime - startTimeOffsetMs, durationMs);
+  const hoverPlace = divide(currentHoverTime || 0 - startTimeOffsetMs, durationMs);
 
   const initialTranslate = 0.5 / timelineScale;
 
@@ -75,8 +79,8 @@ function Scrubber({className, showZoomIndicators = false}: Props) {
       <RangeWrapper>
         <Range
           name="replay-timeline"
-          min={0}
-          max={durationMs}
+          min={startTimeOffsetMs}
+          max={startTimeOffsetMs + durationMs}
           value={Math.round(currentTime)}
           onChange={value => setCurrentTime(value || 0)}
           showLabel={false}

--- a/static/app/components/replays/player/useScrubberMouseTracking.tsx
+++ b/static/app/components/replays/player/useScrubberMouseTracking.tsx
@@ -9,8 +9,7 @@ type Opts<T extends Element> = {
 };
 
 export function useScrubberMouseTracking<T extends Element>({elem}: Opts<T>) {
-  const {replay, setCurrentHoverTime} = useReplayContext();
-  const durationMs = replay?.getDurationMs();
+  const {setCurrentHoverTime, durationMs} = useReplayContext();
 
   const handlePositionChange = useCallback(
     params => {
@@ -42,8 +41,7 @@ export function useTimelineScrubberMouseTracking<T extends Element>(
   {elem}: Opts<T>,
   scale: number
 ) {
-  const {replay, currentTime, setCurrentHoverTime} = useReplayContext();
-  const durationMs = replay?.getDurationMs();
+  const {currentTime, setCurrentHoverTime, durationMs} = useReplayContext();
 
   const handlePositionChange = useCallback(
     params => {

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -5,6 +5,7 @@ import {Replayer, ReplayerEvents} from '@sentry-internal/rrweb';
 import useReplayHighlighting from 'sentry/components/replays/useReplayHighlighting';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import localStorage from 'sentry/utils/localStorage';
+import clamp from 'sentry/utils/number/clamp';
 import type useInitialOffsetMs from 'sentry/utils/replays/hooks/useInitialTimeOffsetMs';
 import useRAF from 'sentry/utils/replays/hooks/useRAF';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
@@ -48,6 +49,11 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
    * Original dimensions in pixels of the captured browser window
    */
   dimensions: Dimensions;
+
+  /**
+   * Total duration of the replay, in milliseconds
+   */
+  durationMs: number;
 
   /**
    * The calculated speed of the player when fast-forwarding through idle moments in the video
@@ -126,6 +132,11 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   speed: number;
 
   /**
+   *
+   */
+  startTimeOffsetMs: number;
+
+  /**
    * Scale of the timeline width, starts from 1x and increases by 1x
    */
   timelineScale: number;
@@ -136,7 +147,6 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
    * @param play
    */
   togglePlayPause: (play: boolean) => void;
-
   /**
    * Allow RRWeb to use Fast-Forward mode for idle moments in the video
    *
@@ -150,6 +160,7 @@ const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
   currentHoverTime: undefined,
   currentTime: 0,
   dimensions: {height: 0, width: 0},
+  durationMs: 0,
   fastForwardSpeed: 0,
   addHighlight: () => {},
   initRoot: () => {},
@@ -166,6 +177,7 @@ const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
   setSpeed: () => {},
   setTimelineScale: () => {},
   speed: 1,
+  startTimeOffsetMs: 0,
   timelineScale: 1,
   togglePlayPause: () => {},
   toggleSkipInactive: () => {},
@@ -180,6 +192,14 @@ type Props = {
   isFetching: boolean;
 
   replay: ReplayReader | null;
+
+  /**
+   * If provided, the replay will be clipped to this window.
+   */
+  clipWindow?: {
+    durationMs: number;
+    startTimeOffsetMs: number;
+  };
 
   /**
    * Time, in seconds, when the video should start
@@ -202,8 +222,53 @@ function updateSavedReplayConfig(config: ReplayConfig) {
   localStorage.setItem(ReplayLocalstorageKeys.REPLAY_CONFIG, JSON.stringify(config));
 }
 
+/**
+ * When a clip window is provided, this hook will automatically pause and end
+ * the replay when the provided window time has passed.
+ */
+function useClipWindow({
+  clipWindow,
+  replayer,
+  onFinished,
+  isPlaying,
+}: {
+  clipWindow: Props['clipWindow'];
+  isPlaying: boolean;
+  onFinished: () => void;
+  replayer: Replayer | null;
+}) {
+  useEffect(() => {
+    if (!replayer || !clipWindow || !isPlaying) {
+      return () => {};
+    }
+
+    let timer: number | undefined;
+
+    const checkForEndOfClip = () => {
+      const currentTime = replayer.getCurrentTime();
+      const endTimeOffsetMs = clipWindow.startTimeOffsetMs + clipWindow.durationMs;
+
+      if (currentTime >= endTimeOffsetMs) {
+        replayer.pause(endTimeOffsetMs);
+        onFinished();
+      }
+
+      timer = requestAnimationFrame(checkForEndOfClip);
+    };
+
+    timer = requestAnimationFrame(checkForEndOfClip);
+
+    return () => {
+      if (timer) {
+        cancelAnimationFrame(timer);
+      }
+    };
+  }, [clipWindow, isPlaying, onFinished, replayer]);
+}
+
 export function Provider({
   children,
+  clipWindow,
   initialTimeOffsetMs,
   isFetching,
   replay,
@@ -235,6 +300,14 @@ export function Provider({
   const didApplyInitialOffset = useRef(false);
   const [timelineScale, setTimelineScale] = useState(1);
 
+  const fullReplayDurationMs = replay?.getDurationMs() ?? 0;
+  const startTimeOffsetMs = clipWindow?.startTimeOffsetMs
+    ? clamp(clipWindow.startTimeOffsetMs, 0, fullReplayDurationMs)
+    : 0;
+  const durationMs = clipWindow?.durationMs
+    ? Math.min(clipWindow.durationMs, fullReplayDurationMs - startTimeOffsetMs)
+    : fullReplayDurationMs;
+
   const isFinished = replayerRef.current?.getCurrentTime() === finishedAtMS;
 
   const forceDimensions = (dimension: Dimensions) => {
@@ -261,6 +334,13 @@ export function Provider({
     []
   );
 
+  useClipWindow({
+    clipWindow,
+    replayer: replayerRef.current,
+    isPlaying,
+    onFinished: setReplayFinished,
+  });
+
   const privateSetCurrentTime = useCallback(
     (requestedTimeMs: number) => {
       const replayer = replayerRef.current;
@@ -275,8 +355,11 @@ export function Provider({
         replayer.setConfig({skipInactive: false});
       }
 
-      const maxTimeMs = replayerRef.current?.getMetaData().totalTime;
-      const time = requestedTimeMs > maxTimeMs ? 0 : Math.max(0, requestedTimeMs);
+      const time = clamp(
+        requestedTimeMs,
+        startTimeOffsetMs,
+        startTimeOffsetMs + durationMs
+      );
 
       // Sometimes rrweb doesn't get to the exact target time, as long as it has
       // changed away from the previous time then we can hide then buffering message.
@@ -298,7 +381,7 @@ export function Provider({
         setIsPlaying(false);
       }
     },
-    [getCurrentTime, isPlaying]
+    [startTimeOffsetMs, durationMs, getCurrentTime, isPlaying]
   );
 
   const setCurrentTime = useCallback(
@@ -473,10 +556,10 @@ export function Provider({
 
   const restart = useCallback(() => {
     if (replayerRef.current) {
-      replayerRef.current.play(0);
+      replayerRef.current.play(startTimeOffsetMs);
       setIsPlaying(true);
     }
-  }, []);
+  }, [startTimeOffsetMs]);
 
   const toggleSkipInactive = useCallback((skip: boolean) => {
     const replayer = replayerRef.current;
@@ -525,6 +608,7 @@ export function Provider({
         currentHoverTime,
         currentTime,
         dimensions,
+        durationMs,
         fastForwardSpeed,
         addHighlight,
         initRoot,
@@ -541,6 +625,7 @@ export function Provider({
         setSpeed,
         setTimelineScale,
         speed,
+        startTimeOffsetMs,
         timelineScale,
         togglePlayPause,
         toggleSkipInactive,

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -144,8 +144,7 @@ function ReplayOptionsMenu({speedOptions}: {speedOptions: number[]}) {
 }
 
 function TimelineSizeBar() {
-  const {timelineScale, setTimelineScale, replay} = useReplayContext();
-  const durationMs = replay?.getDurationMs();
+  const {timelineScale, setTimelineScale, durationMs} = useReplayContext();
   const maxScale = durationMs ? Math.ceil(durationMs / 60000) : 10;
   return (
     <ButtonBar>
@@ -184,8 +183,7 @@ function ReplayControls({
   const barRef = useRef<HTMLDivElement>(null);
   const [isCompact, setIsCompact] = useState(false);
   const isFullscreen = useIsFullscreen();
-  const {currentTime, replay} = useReplayContext();
-  const durationMs = replay?.getDurationMs();
+  const {currentTime, startTimeOffsetMs, durationMs} = useReplayContext();
 
   // If the browser supports going fullscreen or not. iPhone Safari won't do
   // it. https://caniuse.com/fullscreen
@@ -221,7 +219,9 @@ function ReplayControls({
       <ReplayPlayPauseBar />
       <Container>
         <TimeAndScrubberGrid id="replay-timeline-player" isCompact={isCompact}>
-          <Time style={{gridArea: 'currentTime'}}>{formatTime(currentTime)}</Time>
+          <Time style={{gridArea: 'currentTime'}}>
+            {formatTime(currentTime - startTimeOffsetMs)}
+          </Time>
           <div style={{gridArea: 'timeline'}}>
             <ReplayTimeline />
           </div>

--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -86,19 +86,28 @@ export function countColumns(durationMs: number, width: number, minWidth: number
 export function getFramesByColumn(
   durationMs: number,
   frames: ReplayFrame[],
-  totalColumns: number
+  totalColumns: number,
+  startTimeOffsetMs: number = 0
 ) {
   const safeDurationMs = isNaN(durationMs) ? 1 : durationMs;
 
-  const columnFramePairs = frames.map(frame => {
-    const columnPositionCalc =
-      Math.floor((frame.offsetMs / safeDurationMs) * (totalColumns - 1)) + 1;
+  const columnFramePairs = frames
+    .filter(
+      frame =>
+        frame.offsetMs >= startTimeOffsetMs &&
+        frame.offsetMs <= startTimeOffsetMs + safeDurationMs
+    )
+    .map(frame => {
+      const columnPositionCalc =
+        Math.floor(
+          ((frame.offsetMs - startTimeOffsetMs) / safeDurationMs) * (totalColumns - 1)
+        ) + 1;
 
-    // Should start at minimum in the first column
-    const column = Math.max(1, columnPositionCalc);
+      // Should start at minimum in the first column
+      const column = Math.max(1, columnPositionCalc);
 
-    return [column, frame] as [number, ReplayFrame];
-  });
+      return [column, frame] as [number, ReplayFrame];
+    });
 
   const framesByColumn = columnFramePairs.reduce<Map<number, ReplayFrame[]>>(
     (map, [column, frame]) => {


### PR DESCRIPTION
This is the first step towards https://github.com/getsentry/sentry/issues/63157

In order to display a trimmed-down clip on the issue details page, we need the replay to be able to restrict playtime to a particular window. To achieve this, I've added:

- `clipWindow` as an argument to the context provider
- `startTimeOffsetMs` to the context state
- `durationMs` to the context state

This means that we are no longer assuming that the start time is 0 or that the duration is `replay.getDurationMs()`. I found all the places I could that made those assumptions and modified them to use the new state. This should not have any effect on the behavior unless a `clipWindow` is provided, since the start time with default to 0 and the duration will default to the full duration.

I've also added a `useClipWindow` hook within the replay context to restrict the playtime to the intended window.

