### PR TITLE
feat(open-pr-comments): add feature flag for javascript

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1588,6 +1588,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:integrations-issue-sync": True,
     # Enable comments of related issues on open PRs
     "organizations:integrations-open-pr-comment": False,
+    # Enable comments of related issues on open PRs for Javascript
+    "organizations:integrations-open-pr-comment-js": False,
     # Enable Opsgenie integration
     "organizations:integrations-opsgenie": True,
     # Enable one-click migration from Opsgenie plugin

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -114,6 +114,7 @@ default_manager.add("organizations:integrations-deployment", OrganizationFeature
 default_manager.add("organizations:integrations-feature-flag-integration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:integrations-gh-invite", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:integrations-open-pr-comment", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:integrations-open-pr-comment-js", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:integrations-opsgenie-migration", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:investigation-bias", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:invite-members-rate-limits", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION
We have known grouping problems with Javascript, so we will be using a feature flag to release Open PR Comments in Javascript to a beta cohort before releasing it to EA, then GA-ing the feature with Python and Javascript support.