### PR TITLE
fix(hc): Fix null arg to user_service from BaseQueryBuilder

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -170,7 +170,8 @@ class BaseQueryBuilder:
             else:
                 environments = []
 
-        user = user_service.get_user(user_id=params["user_id"]) if "user_id" in params else None
+        user_id = params.get("user_id")
+        user = user_service.get_user(user_id=user_id) if user_id is not None else None
         teams = (
             Team.objects.filter(id__in=params["team_id"])
             if "team_id" in params and isinstance(params["team_id"], list)

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -45,6 +45,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQueryEventType
 from sentry.testutils.cases import BaseMetricsTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time, iso_format
+from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 from sentry.utils.dates import to_timestamp
 
@@ -173,6 +174,7 @@ class ProcessUpdateBaseClass(TestCase, SnubaTestCase):
         assert last_incident == incident
 
 
+@region_silo_test
 @freeze_time()
 class ProcessUpdateTest(ProcessUpdateBaseClass):
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Prevent passing a null argument to `user_service.get_user` from BaseQueryBuilder. The bug is newly exposed by running `test_subscription_processor.ProcessUpdateTest` in region silo mode. The null value causes an error when we attempt to serialize it, but gives a correct result when we don't.

An alternative fix would be to prevent `params` from having an entry of `"user_id": None` at all, which [originates from](https://github.com/getsentry/sentry/blob/b21d5b453c7f1d760ca9fb972a2151bde4b7c2aa/src/sentry/api/bases/organization_events.py#L140)
`OrganizationEventsEndpointBase.get_snuba_params`. Tolerating the null entry seems more robust in general, but is a little inconsistent with the rest of the `... in params` expressions in
`BaseQueryBuilder._dataclass_params`. (Unless we want to change more of them?)