### PR TITLE
[Hack] Add hashing indexer and experimental indexer pipeline

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -260,6 +260,17 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
         "dlq_max_invalid_ratio": 0.01,
         "dlq_max_consecutive_count": 1000,
     },
+    "ingest-generic-metrics-experimental": {
+        "topic": settings.KAFKA_INGEST_PERFORMANCE_METRICS,
+        "strategy_factory": "sentry.sentry_metrics.consumers.indexer.parallel.MetricsConsumerStrategyFactory",
+        "click_options": [
+            *_METRICS_INDEXER_OPTIONS,
+            click.Option(["--indexer-db"], default="experimental"),
+        ],
+        "static_args": {
+            "ingest_profile": "experimental",
+        },
+    },
     "generic-metrics-last-seen-updater": {
         "topic": settings.KAFKA_SNUBA_GENERIC_METRICS,
         "strategy_factory": "sentry.sentry_metrics.consumers.last_seen_updater.LastSeenUpdaterStrategyFactory",

--- a/src/sentry/sentry_metrics/configuration.py
+++ b/src/sentry/sentry_metrics/configuration.py
@@ -17,6 +17,7 @@ MAX_INDEXED_COLUMN_LENGTH = 200
 class UseCaseKey(Enum):
     RELEASE_HEALTH = "release-health"
     PERFORMANCE = "performance"
+    EXPERIMENTAL = "experimental"
 
 
 # Rate limiter namespaces, the postgres (PG)
@@ -26,6 +27,7 @@ RELEASE_HEALTH_PG_NAMESPACE = "releasehealth"
 PERFORMANCE_PG_NAMESPACE = "performance"
 RELEASE_HEALTH_CS_NAMESPACE = "releasehealth.cs"
 PERFORMANCE_CS_NAMESPACE = "performance.cs"
+REBALANCING_EXP_NAMESPACE = "rebalancing.experiment"
 
 RELEASE_HEALTH_SCHEMA_VALIDATION_RULES_OPTION_NAME = (
     "sentry-metrics.indexer.release-health.schema-validation-rules"
@@ -38,6 +40,7 @@ GENERIC_METRICS_SCHEMA_VALIDATION_RULES_OPTION_NAME = (
 class IndexerStorage(Enum):
     POSTGRES = "postgres"
     MOCK = "mock"
+    EXPERIMENRAL = "experimental"
 
 
 @dataclass(frozen=True)
@@ -102,6 +105,24 @@ def get_ingest_config(
                 writes_limiter_namespace=PERFORMANCE_PG_NAMESPACE,
                 cardinality_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_CARDINALITY_LIMITER_OPTIONS_PERFORMANCE,
                 cardinality_limiter_namespace=PERFORMANCE_PG_NAMESPACE,
+                is_output_sliced=settings.SENTRY_METRICS_INDEXER_ENABLE_SLICED_PRODUCER,
+                should_index_tag_values=False,
+                schema_validation_rule_option_name=GENERIC_METRICS_SCHEMA_VALIDATION_RULES_OPTION_NAME,
+            )
+        )
+
+        _register_ingest_config(
+            MetricsIngestConfiguration(
+                db_backend=IndexerStorage.EXPERIMENRAL,
+                db_backend_options={},
+                input_topic=settings.KAFKA_INGEST_PERFORMANCE_METRICS,
+                output_topic=settings.KAFKA_SNUBA_GENERIC_METRICS,  # TODO: this needs to change
+                use_case_id=UseCaseKey.EXPERIMENTAL,
+                internal_metrics_tag="rebalance-exp",
+                writes_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS_PERFORMANCE,
+                writes_limiter_namespace=REBALANCING_EXP_NAMESPACE,
+                cardinality_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_CARDINALITY_LIMITER_OPTIONS_PERFORMANCE,
+                cardinality_limiter_namespace=REBALANCING_EXP_NAMESPACE,
                 is_output_sliced=settings.SENTRY_METRICS_INDEXER_ENABLE_SLICED_PRODUCER,
                 should_index_tag_values=False,
                 schema_validation_rule_option_name=GENERIC_METRICS_SCHEMA_VALIDATION_RULES_OPTION_NAME,

--- a/src/sentry/sentry_metrics/configuration.py
+++ b/src/sentry/sentry_metrics/configuration.py
@@ -116,7 +116,7 @@ def get_ingest_config(
                 db_backend=IndexerStorage.EXPERIMENRAL,
                 db_backend_options={},
                 input_topic=settings.KAFKA_INGEST_PERFORMANCE_METRICS,
-                output_topic=settings.KAFKA_SNUBA_GENERIC_METRICS,  # TODO: this needs to change
+                output_topic="snuba-generic-metrics-experimental",
                 use_case_id=UseCaseKey.EXPERIMENTAL,
                 internal_metrics_tag="rebalance-exp",
                 writes_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS_PERFORMANCE,

--- a/src/sentry/sentry_metrics/consumers/indexer/processing.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/processing.py
@@ -21,6 +21,7 @@ from sentry.sentry_metrics.consumers.indexer.tags_validator import (
     ReleaseHealthTagsValidator,
 )
 from sentry.sentry_metrics.indexer.base import StringIndexer
+from sentry.sentry_metrics.indexer.hash import StaticSha1Indexer
 from sentry.sentry_metrics.indexer.limiters.cardinality import cardinality_limiter_factory
 from sentry.sentry_metrics.indexer.mock import MockIndexer
 from sentry.sentry_metrics.indexer.postgres.postgres_v2 import PostgresIndexer
@@ -31,6 +32,7 @@ logger = logging.getLogger(__name__)
 STORAGE_TO_INDEXER: Mapping[IndexerStorage, Callable[[], StringIndexer]] = {
     IndexerStorage.POSTGRES: PostgresIndexer,
     IndexerStorage.MOCK: MockIndexer,
+    IndexerStorage.EXPERIMENRAL: StaticSha1Indexer,
 }
 
 INGEST_CODEC: sentry_kafka_schemas.codecs.Codec[Any] = sentry_kafka_schemas.get_codec(

--- a/src/sentry/sentry_metrics/indexer/hash.py
+++ b/src/sentry/sentry_metrics/indexer/hash.py
@@ -1,0 +1,43 @@
+import hashlib
+from typing import Mapping, Set
+
+from django.conf import settings
+
+from sentry.sentry_metrics.indexer.base import (
+    FetchType,
+    OrgId,
+    StringIndexer,
+    UseCaseKeyCollection,
+    UseCaseKeyResult,
+    UseCaseKeyResults,
+)
+from sentry.sentry_metrics.indexer.cache import CachingIndexer, StringIndexerCache
+from sentry.sentry_metrics.indexer.strings import StaticStringIndexer
+from sentry.sentry_metrics.use_case_id_registry import UseCaseID
+
+
+class Sha1Indexer(StringIndexer):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def bulk_record(
+        self, strings: Mapping[UseCaseID, Mapping[OrgId, Set[str]]]
+    ) -> UseCaseKeyResults:
+        keys = UseCaseKeyCollection(strings)
+        res = UseCaseKeyResults()
+        for use_case_id, org_id, string in keys.as_tuples():
+            id = int(hashlib.sha1(string.encode("utf-8")).hexdigest(), 16) % 10**64
+            res.add_use_case_key_result(
+                UseCaseKeyResult(use_case_id, org_id, string, id), FetchType.DB_READ
+            )
+        return res
+
+
+indexer_cache = StringIndexerCache(
+    **settings.SENTRY_STRING_INDEXER_CACHE_OPTIONS, partition_key="exp"
+)
+
+
+class StaticSha1Indexer(StaticStringIndexer):
+    def __init__(self) -> None:
+        super().__init__(CachingIndexer(indexer_cache, Sha1Indexer()))

--- a/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
+++ b/src/sentry/sentry_metrics/indexer/limiters/cardinality.py
@@ -90,6 +90,7 @@ class TimeseriesCardinalityLimiter:
         # for each metric path. ultimately, this can be moved into the
         # loop below to make rollout options occur on a per use case-basis
         rollout_option = {
+            UseCaseKey.EXPERIMENTAL: "sentry-metrics.cardinality-limiter.orgs-rollout-rate",
             UseCaseKey.PERFORMANCE: "sentry-metrics.cardinality-limiter.orgs-rollout-rate",
             UseCaseKey.RELEASE_HEALTH: "sentry-metrics.cardinality-limiter-rh.orgs-rollout-rate",
         }[metric_path_key]


### PR DESCRIPTION
### Overview

Adds another metrics pipeline that consumes from the same topic as generic metrics indexer to assess the viability of static membership.

The idea is to spin up another indexer cluster but with static membership, monitor the deployment metrics.

The generic metrics indexers has the following structure:
`hardcoded strings indexer → caching indexer → postgres indexer`

In order for this indexer to have similar runtime performance as the original, without corrupting the datastores, it will be configured as:
`hardcoded strings indexer → caching indexer → sha1 indexer`
Where the caching indexer will have a different namespace.

### Testing
<details>
  <summary>Local tests</summary>

Start experimental consumer

```bash
sentry run consumer ingest-generic-metrics-experimental --consumer-group ingest-metrics-consumers-generic-experimental --no-strict-offset-reset \
-- \
--processes 1 \
--input-block-size 50000000 \
--output-block-size 100000000 \
--max-msg-batch-size 50 \
--max-msg-batch-time-ms 500 \
--max-parallel-batch-size 25 \
--max-parallel-batch-time-ms 500
INFO:The Sentry runner will report development issues to Sentry.io. Use SENTRY_DEVENV_NO_REPORT to avoid reporting issues.
22:37:09 [INFO] arroyo.processing.processor: New partitions assigned: {Partition(topic=Topic(name='ingest-performance-metrics'), index=0): 3}
```

Send 3 messages

```bash
python bin/send_metrics.py \
--start-org-id 1 \
--rand-str TRXRC0fjdkaljR \
--use-cases custom
```

Verify that the hashing indexer is indeed working

```json
...
{
  "mapping_meta": {
    "h": {
      "9223372036854776017": "session.status",
      "9223372036854776010": "environment"
    },
    "c": {
      "1453580562982971816267085117112340803382358827360": "d:custom/duration@second"
    },
    "d": {
      "198243186713647166688135742539493041485540540712": "metric_e2e_custom_dist_k_TRXRC0fjdkaljR"
    }
  }
}
...
```

Send the same 3 messages again to verify that the values are cached

```json
...
{
  "mapping_meta": {
    "h": {
      "9223372036854776017": "session.status",
      "9223372036854776010": "environment"
    },
    "c": {
      "1453580562982971816267085117112340803382358827360": "d:custom/duration@second",
      "198243186713647166688135742539493041485540540712": "metric_e2e_custom_dist_k_TRXRC0fjdkaljR"
    }
  }
}
...
```

Verify data is not in db

```sql
docker exec -it sentry_postgres psql sentry -U postgres
psql (14.9)
Type "help" for help.

sentry=# SELECT string,
sentry-#        organization_id,
sentry-#        use_case_id,
sentry-#        date_added,
sentry-#        last_seen
sentry-#     FROM sentry_perfstringindexer
sentry-#     WHERE string ~ 'metric_e2e_.*TRXRC0fjdkaljR';
 string | organization_id | use_case_id | date_added | last_seen
--------+-----------------+-------------+------------+-----------
(0 rows)
```

Start regular consumer

```
sentry run consumer ingest-generic-metrics --consumer-group ingest-metrics-consumers-generic-experimental --no-strict-offset-reset \
-- \
--processes 1 \
--input-block-size 50000000 \
--output-block-size 100000000 \
--max-msg-batch-size 50 \
--max-msg-batch-time-ms 500 \
--max-parallel-batch-size 25 \
--max-parallel-batch-time-ms 500
INFO:The Sentry runner will report development issues to Sentry.io. Use SENTRY_DEVENV_NO_REPORT to avoid reporting issues.
22:46:58 [INFO] arroyo.processing.processor: New partitions assigned: {Partition(topic=Topic(name='ingest-performance-metrics'), index=0): 15}
```

Verify that the values are considered first seen

```json
...
{
  "mapping_meta": {
    "h": {
      "9223372036854776017": "session.status",
      "9223372036854776010": "environment"
    },
    "f": {
      "65538": "metric_e2e_custom_dist_k_TRXRC0fjdkaljR",
      "65541": "d:custom/duration@second"
    }
  }
}
...
```

Verify new data is in db

```sql
sentry=# SELECT string,
sentry-#        organization_id,
sentry-#        use_case_id,
sentry-#        date_added,
sentry-#        last_seen
sentry-#     FROM sentry_perfstringindexer
sentry-#     WHERE string ~ 'metric_e2e_.*TRXRC0fjdkaljR';
                   string                   | organization_id | use_case_id |          date_added           |           last_seen
--------------------------------------------+-----------------+-------------+-------------------------------+-------------------------------
 metric_e2e_custom_dist_k_TRXRC0fjdkaljR    |               1 | custom      | 2024-01-23 22:47:11.210973+00 | 2024-01-23 22:47:11.210976+00
 metric_e2e_custom_set_k_TRXRC0fjdkaljR     |               1 | custom      | 2024-01-23 22:47:11.210985+00 | 2024-01-23 22:47:11.210988+00
 metric_e2e_custom_counter_k_TRXRC0fjdkaljR |               1 | custom      | 2024-01-23 22:47:11.210997+00 | 2024-01-23 22:47:11.210999+00
(3 rows)
```

</details>