### PR TITLE
fix(issues): Change copy on setup code mappings

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -134,9 +134,7 @@ describe('StacktraceLink', function () {
     render(<StacktraceLink frame={frame} event={event} line="foo()" />, {
       context: RouterContextFixture(),
     });
-    expect(
-      await screen.findByText('Tell us where your source code is')
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Set up Code Mapping')).toBeInTheDocument();
   });
 
   it('renders source url link', async function () {
@@ -165,9 +163,7 @@ describe('StacktraceLink', function () {
       context: RouterContextFixture(),
     });
     expect(
-      await screen.findByRole('button', {
-        name: 'Tell us where your source code is',
-      })
+      await screen.findByRole('button', {name: 'Set up Code Mapping'})
     ).toBeInTheDocument();
   });
 

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -519,7 +519,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
             ));
           }}
         >
-          {t('Tell us where your source code is')}
+          {t('Set up Code Mapping')}
         </FixMappingButton>
       </StacktraceLinkWrapper>
     );

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
@@ -73,7 +73,7 @@ describe('StacktraceLinkModal', () => {
       ))
     );
 
-    expect(screen.getByText('Tell us where your source code is')).toBeInTheDocument();
+    expect(screen.getByText('Set up Code Mapping')).toBeInTheDocument();
 
     // Links to GitHub with one integration
     expect(screen.getByText('GitHub')).toBeInTheDocument();

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
@@ -153,7 +153,7 @@ function StacktraceLinkModal({
   return (
     <Fragment>
       <Header closeButton>
-        <h4>{t('Tell us where your source code is')}</h4>
+        <h4>{t('Set up Code Mapping')}</h4>
       </Header>
       <Body>
         <ModalContainer>


### PR DESCRIPTION
Changes "Tell us where your code is" to "Set up Code Mapping" https://www.figma.com/file/2dB17mHtkpvIJNXyCnwNlA/Q4-Stack-Trace?type=design&node-id=687-1305&mode=design&t=h4PZOr3ApiHF1SfV-0
