### PR TITLE
fix(issues): Hide stacktrace link when unminify button is present

### DIFF
--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -391,7 +391,7 @@ export class DeprecatedLine extends Component<Props, State> {
                 {t('Suspect Frame')}
               </Tag>
             ) : null}
-            {showStacktraceLinkInFrame && (
+            {showStacktraceLinkInFrame && !shouldShowSourceMapDebuggerButton && (
               <ErrorBoundary>
                 <StacktraceLink
                   frame={data}


### PR DESCRIPTION
before
![image](https://github.com/getsentry/sentry/assets/1400464/dc0ad622-bfdb-4243-a557-10a82937141d)
