### PR TITLE
chore(open-pr-comments): clean up test file

### DIFF
--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -590,6 +590,16 @@ Your pull request is modifying functions with the following pre-existing issues:
         )
 
 
+@patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_files")
+@patch(
+    "sentry.tasks.integrations.github.open_pr_comment.get_projects_and_filenames_from_source_file"
+)
+@patch(
+    "sentry.tasks.integrations.github.language_parsers.PythonParser.extract_functions_from_patch"
+)
+@patch("sentry.tasks.integrations.github.open_pr_comment.get_top_5_issues_by_count_for_file")
+@patch("sentry.tasks.integrations.github.open_pr_comment.safe_for_comment")
+@patch("sentry.tasks.integrations.github.utils.metrics")
 class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
     base_url = "https://api.github.com"
 
@@ -632,19 +642,6 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         ]
         self.groups.reverse()
 
-    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_files")
-    @patch(
-        "sentry.tasks.integrations.github.open_pr_comment.get_projects_and_filenames_from_source_file"
-    )
-    @patch(
-        "sentry.tasks.integrations.github.language_parsers.PythonParser.extract_functions_from_patch"
-    )
-    @patch("sentry.tasks.integrations.github.open_pr_comment.get_top_5_issues_by_count_for_file")
-    @patch(
-        "sentry.tasks.integrations.github.open_pr_comment.safe_for_comment",
-        return_value=[{}],
-    )
-    @patch("sentry.tasks.integrations.github.utils.metrics")
     @responses.activate
     def test_comment_workflow(
         self,
@@ -655,6 +652,7 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         mock_reverse_codemappings,
         mock_pr_filenames,
     ):
+        mock_safe_for_comment.return_value = [{}]
         # two filenames, the second one has a toggle table
         mock_pr_filenames.return_value = [
             PullRequestFile(filename="foo.py", patch="a"),
@@ -685,19 +683,6 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         assert pull_request_comment_query[0].comment_type == CommentType.OPEN_PR
         mock_metrics.incr.assert_called_with("github_open_pr_comment.comment_created")
 
-    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_files")
-    @patch(
-        "sentry.tasks.integrations.github.open_pr_comment.get_projects_and_filenames_from_source_file"
-    )
-    @patch(
-        "sentry.tasks.integrations.github.language_parsers.PythonParser.extract_functions_from_patch"
-    )
-    @patch("sentry.tasks.integrations.github.open_pr_comment.get_top_5_issues_by_count_for_file")
-    @patch(
-        "sentry.tasks.integrations.github.open_pr_comment.safe_for_comment",
-        return_value=[{}],
-    )
-    @patch("sentry.tasks.integrations.github.utils.metrics")
     @responses.activate
     def test_comment_workflow_comment_exists(
         self,
@@ -708,6 +693,7 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         mock_reverse_codemappings,
         mock_pr_filenames,
     ):
+        mock_safe_for_comment.return_value = [{}]
         # two filenames, the second one has a toggle table
         mock_pr_filenames.return_value = [
             PullRequestFile(filename="foo.py", patch="a"),
@@ -745,20 +731,14 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         assert pr_comment.created_at != pr_comment.updated_at
         mock_metrics.incr.assert_called_with("github_open_pr_comment.comment_updated")
 
-    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_files")
-    @patch(
-        "sentry.tasks.integrations.github.open_pr_comment.get_projects_and_filenames_from_source_file"
-    )
-    @patch(
-        "sentry.tasks.integrations.github.language_parsers.PythonParser.extract_functions_from_patch"
-    )
-    @patch("sentry.tasks.integrations.github.open_pr_comment.safe_for_comment")
     @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
     @responses.activate
     def test_comment_workflow_early_return(
         self,
         mock_metrics,
+        _,
         mock_safe_for_comment,
+        mock_issues,
         mock_function_names,
         mock_reverse_codemappings,
         mock_pr_filenames,
@@ -804,29 +784,19 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         assert len(pull_request_comment_query) == 0
         mock_metrics.incr.assert_called_with("github_open_pr_comment.no_issues")
 
-    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_files")
-    @patch(
-        "sentry.tasks.integrations.github.open_pr_comment.get_projects_and_filenames_from_source_file"
-    )
-    @patch(
-        "sentry.tasks.integrations.github.language_parsers.PythonParser.extract_functions_from_patch"
-    )
-    @patch("sentry.tasks.integrations.github.open_pr_comment.get_top_5_issues_by_count_for_file")
-    @patch(
-        "sentry.tasks.integrations.github.open_pr_comment.safe_for_comment",
-        return_value=[{}],
-    )
     @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
     @responses.activate
     def test_comment_workflow_api_error(
         self,
         mock_metrics,
+        _,
         mock_safe_for_comment,
         mock_issues,
         mock_function_names,
         mock_reverse_codemappings,
         mock_pr_filenames,
     ):
+        mock_safe_for_comment.return_value = [{}]
         mock_pr_filenames.return_value = [
             PullRequestFile(filename="foo.py", patch="a"),
         ]
@@ -888,9 +858,17 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
             "github_open_pr_comment.error", tags={"type": "rate_limited_error"}
         )
 
-    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_files")
     @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
-    def test_comment_workflow_missing_pr(self, mock_metrics, mock_pr_filenames):
+    def test_comment_workflow_missing_pr(
+        self,
+        mock_metrics,
+        _,
+        mock_safe_for_comment,
+        mock_issues,
+        mock_function_names,
+        mock_reverse_codemappings,
+        mock_pr_filenames,
+    ):
         PullRequest.objects.all().delete()
 
         open_pr_comment_workflow(0)
@@ -900,9 +878,17 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
             "github_open_pr_comment.error", tags={"type": "missing_pr"}
         )
 
-    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_files")
     @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
-    def test_comment_workflow_missing_org(self, mock_metrics, mock_pr_filenames):
+    def test_comment_workflow_missing_org(
+        self,
+        mock_metrics,
+        _,
+        mock_safe_for_comment,
+        mock_issues,
+        mock_function_names,
+        mock_reverse_codemappings,
+        mock_pr_filenames,
+    ):
         self.pr.organization_id = 0
         self.pr.save()
 
@@ -913,8 +899,15 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
             "github_open_pr_comment.error", tags={"type": "missing_org"}
         )
 
-    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_files")
-    def test_comment_workflow_missing_org_option(self, mock_pr_filenames):
+    def test_comment_workflow_missing_org_option(
+        self,
+        mock_metrics,
+        mock_safe_for_comment,
+        mock_issues,
+        mock_function_names,
+        mock_reverse_codemappings,
+        mock_pr_filenames,
+    ):
         OrganizationOption.objects.set_value(
             organization=self.organization, key="sentry:github_open_pr_bot", value=False
         )
@@ -922,9 +915,17 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
 
         assert not mock_pr_filenames.called
 
-    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_files")
     @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
-    def test_comment_workflow_missing_repo(self, mock_metrics, mock_pr_filenames):
+    def test_comment_workflow_missing_repo(
+        self,
+        mock_metrics,
+        _,
+        mock_safe_for_comment,
+        mock_issues,
+        mock_function_names,
+        mock_reverse_codemappings,
+        mock_pr_filenames,
+    ):
         self.pr.repository_id = 0
         self.pr.save()
 
@@ -935,9 +936,17 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
             "github_open_pr_comment.error", tags={"type": "missing_repo"}
         )
 
-    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_files")
     @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
-    def test_comment_workflow_missing_integration(self, mock_metrics, mock_pr_filenames):
+    def test_comment_workflow_missing_integration(
+        self,
+        mock_metrics,
+        _,
+        mock_safe_for_comment,
+        mock_issues,
+        mock_function_names,
+        mock_reverse_codemappings,
+        mock_pr_filenames,
+    ):
         # invalid integration id
         self.gh_repo.integration_id = 0
         self.gh_repo.save()
@@ -949,15 +958,18 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
             "github_open_pr_comment.error", tags={"type": "missing_integration"}
         )
 
-    @patch(
-        "sentry.tasks.integrations.github.open_pr_comment.safe_for_comment",
-        return_value=[],
-    )
-    @patch("sentry.tasks.integrations.github.open_pr_comment.get_pr_files")
     @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
     def test_comment_workflow_not_safe_for_comment(
-        self, mock_metrics, mock_pr_filenames, mock_safe_for_comment
+        self,
+        mock_metrics,
+        _,
+        mock_safe_for_comment,
+        mock_issues,
+        mock_function_names,
+        mock_reverse_codemappings,
+        mock_pr_filenames,
     ):
+        mock_safe_for_comment.return_value = []
         open_pr_comment_workflow(self.pr.id)
 
         assert not mock_pr_filenames.called


### PR DESCRIPTION
This PR cleans up the `TestOpenPRCommentWorkflow` test class. The `open_pr_comment_workflow` function being tested is a giant function that calls many other functions, so there are many `@patch` decorators before each test function. However, since these are shared (but might not necessarily be used) for each function in the class, they can be moved to the class instead of before each function. It makes the test cases a bit easier to read since many of the patches are repeated, and they are replaced by function arguments.