### PR TITLE
Only set `orig_in_app` once

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -170,6 +170,9 @@ class Enhancements:
                 ):
                     # Both frames and match_frames are updated
                     action.apply_modifications_to_frame(frames, match_frames, idx, rule=rule)
+            for frame, match_frame in zip(frames, match_frames):
+                if (in_app := match_frame["in_app"]) is not None:
+                    set_in_app(frame, in_app)
 
         if use_cache:
             _cache_changed_frame_values(frames, cache_key, platform)

--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -63,7 +63,7 @@ def create_match_frame(frame_data: dict, platform: Optional[str]) -> dict:
         category=get_path(frame_data, "data", "category"),
         family=get_behavior_family_for_platform(frame_data.get("platform") or platform),
         function=_get_function_name(frame_data, platform),
-        in_app=frame_data.get("in_app") or False,
+        in_app=frame_data.get("in_app"),
         module=get_path(frame_data, "module"),
         package=frame_data.get("package"),
         path=frame_data.get("abs_path") or frame_data.get("filename"),
@@ -234,7 +234,7 @@ class InAppMatch(FrameMatch):
         self._ref_val = bool(get_rule_bool(self.pattern))
 
     def _positive_frame_match(self, match_frame, exception_data, cache):
-        return self._ref_val == match_frame["in_app"]
+        return self._ref_val == bool(match_frame["in_app"])
 
 
 class FrameFieldMatch(FrameMatch):

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -85,6 +85,33 @@ def test_callee_recursion():
         Enhancements.from_config_string(" category:foo | [ category:bar ] | [ category:baz ] +app")
 
 
+def test_flipflop_inapp():
+    enhancement = Enhancements.from_config_string(
+        """
+        family:all +app
+        family:all -app
+    """
+    )
+
+    frames = [{}]
+    enhancement.apply_modifications_to_frame(frames, "javascript", {})
+
+    assert frames[0]["data"]["orig_in_app"] == -1  # == None
+    assert frames[0]["in_app"] is False
+
+    frames = [{"in_app": False}]
+    enhancement.apply_modifications_to_frame(frames, "javascript", {})
+
+    assert "data" not in frames[0]  # no changes were made
+    assert frames[0]["in_app"] is False
+
+    frames = [{"in_app": True}]
+    enhancement.apply_modifications_to_frame(frames, "javascript", {})
+
+    assert frames[0]["data"]["orig_in_app"] == 1  # == True
+    assert frames[0]["in_app"] is False
+
+
 def _get_matching_frame_actions(rule, frames, platform, exception_data=None, cache=None):
     """Convenience function for rule tests"""
     if cache is None:

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -93,7 +93,7 @@ def test_flipflop_inapp():
     """
     )
 
-    frames = [{}]
+    frames: list[dict[str, Any]] = [{}]
     enhancement.apply_modifications_to_frame(frames, "javascript", {})
 
     assert frames[0]["data"]["orig_in_app"] == -1  # == None


### PR DESCRIPTION
Previously, the `orig_in_app` was being set to the previous value of `in_app` every time the `app` action was applied to a frame. However, judging by its name and other parts of the code, the intention is to retain the value prior to any of the enhancers running.