### PR TITLE
ref(InviteModal): Refactor InviteModalHook into its own file

### DIFF
--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -6,13 +6,13 @@ import type {
   AsyncComponentState,
 } from 'sentry/components/deprecatedAsyncComponent';
 import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
-import HookOrDefault from 'sentry/components/hookOrDefault';
 import InviteMembersModalView from 'sentry/components/modals/inviteMembersModal/inviteMembersModalview';
 import {
   InviteRow,
   InviteStatus,
   NormalizedInvite,
 } from 'sentry/components/modals/inviteMembersModal/types';
+import {InviteModalHook} from 'sentry/components/modals/memberInviteModalCustomization';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -33,16 +33,6 @@ interface State extends AsyncComponentState {
 }
 
 const DEFAULT_ROLE = 'member';
-
-export const InviteModalHook = HookOrDefault({
-  hookName: 'member-invite-modal:customization',
-  defaultComponent: ({onSendInvites, children}) =>
-    children({sendInvites: onSendInvites, canSend: true}),
-});
-
-export type InviteModalRenderFunc = React.ComponentProps<
-  typeof InviteModalHook
->['children'];
 
 class InviteMembersModal extends DeprecatedAsyncComponent<
   InviteMembersModalProps,

--- a/static/app/components/modals/inviteMissingMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.tsx
@@ -7,13 +7,13 @@ import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import Checkbox from 'sentry/components/checkbox';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {
-  InviteModalHook,
-  InviteModalRenderFunc,
-} from 'sentry/components/modals/inviteMembersModal';
 import {StatusMessage} from 'sentry/components/modals/inviteMembersModal/inviteStatusMessage';
 import {InviteStatus} from 'sentry/components/modals/inviteMembersModal/types';
 import {MissingMemberInvite} from 'sentry/components/modals/inviteMissingMembersModal/types';
+import {
+  InviteModalHook,
+  InviteModalRenderFunc,
+} from 'sentry/components/modals/memberInviteModalCustomization';
 import PanelItem from 'sentry/components/panels/panelItem';
 import PanelTable from 'sentry/components/panels/panelTable';
 import RoleSelectControl from 'sentry/components/roleSelectControl';

--- a/static/app/components/modals/memberInviteModalCustomization.tsx
+++ b/static/app/components/modals/memberInviteModalCustomization.tsx
@@ -1,0 +1,11 @@
+import HookOrDefault from 'sentry/components/hookOrDefault';
+
+export const InviteModalHook = HookOrDefault({
+  hookName: 'member-invite-modal:customization',
+  defaultComponent: ({onSendInvites, children}) =>
+    children({sendInvites: onSendInvites, canSend: true}),
+});
+
+export type InviteModalRenderFunc = React.ComponentProps<
+  typeof InviteModalHook
+>['children'];

--- a/static/app/views/settings/organizationMembers/inviteRequestRow.tsx
+++ b/static/app/views/settings/organizationMembers/inviteRequestRow.tsx
@@ -3,7 +3,10 @@ import styled from '@emotion/styled';
 
 import {Button} from 'sentry/components/button';
 import Confirm from 'sentry/components/confirm';
-import HookOrDefault from 'sentry/components/hookOrDefault';
+import {
+  InviteModalHook,
+  InviteModalRenderFunc,
+} from 'sentry/components/modals/memberInviteModalCustomization';
 import PanelItem from 'sentry/components/panels/panelItem';
 import RoleSelectControl from 'sentry/components/roleSelectControl';
 import Tag from 'sentry/components/tag';
@@ -23,14 +26,6 @@ type Props = {
   onUpdate: (data: Partial<Member>) => void;
   organization: Organization;
 };
-
-const InviteModalHook = HookOrDefault({
-  hookName: 'member-invite-modal:customization',
-  defaultComponent: ({onSendInvites, children}) =>
-    children({sendInvites: onSendInvites, canSend: true}),
-});
-
-type InviteModalRenderFunc = React.ComponentProps<typeof InviteModalHook>['children'];
 
 function InviteRequestRow({
   inviteRequest,


### PR DESCRIPTION
Quick refactor to make this it's own file. It's used equally in three spots, so by splitting it out it's bit easier to have a single name for it, and avoid copy+paste errors down the line.