### PR TITLE
fix(hybridcloud) Fix N+1 query when serializing rpc orgs

### DIFF
--- a/src/sentry/services/hybrid_cloud/organization/serial.py
+++ b/src/sentry/services/hybrid_cloud/organization/serial.py
@@ -58,7 +58,7 @@ def serialize_member(member: OrganizationMember) -> RpcOrganizationMember:
 
     omts = OrganizationMemberTeam.objects.filter(
         organizationmember=member, is_active=True, team__status=TeamStatus.ACTIVE
-    )
+    ).select_related("team")
 
     all_project_ids: Set[int] = set()
     project_ids_by_team_id: MutableMapping[int, List[int]] = defaultdict(list)

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -47,7 +47,9 @@ class OrganizationService(RpcService):
         return DatabaseBackedOrganizationService()
 
     def get(self, id: int) -> Optional[RpcOrganization]:
-        org_context = self.get_organization_by_id(id=id)
+        org_context = self.get_organization_by_id(
+            id=id, include_projects=False, include_teams=False
+        )
         return org_context.organization if org_context else None
 
     @regional_rpc_method(resolve=ByOrganizationId("id"))

--- a/src/sentry/services/hybrid_cloud/organization/service.py
+++ b/src/sentry/services/hybrid_cloud/organization/service.py
@@ -47,9 +47,8 @@ class OrganizationService(RpcService):
         return DatabaseBackedOrganizationService()
 
     def get(self, id: int) -> Optional[RpcOrganization]:
-        org_context = self.get_organization_by_id(
-            id=id, include_projects=False, include_teams=False
-        )
+        org_context = self.get_organization_by_id(id=id)
+
         return org_context.organization if org_context else None
 
     @regional_rpc_method(resolve=ByOrganizationId("id"))


### PR DESCRIPTION
When serializing organization we should prefetch the teams for each teammember. 