### PR TITLE
feat(browser-starfish): add relative image support in ui

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.spec.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.spec.tsx
@@ -9,9 +9,10 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import SampleImages from 'sentry/views/performance/browser/resources/resourceSummaryPage/sampleImages';
-import {SpanMetricsField} from 'sentry/views/starfish/types';
+import {SpanIndexedField} from 'sentry/views/starfish/types';
 
-const {SPAN_GROUP, HTTP_RESPONSE_CONTENT_LENGTH, SPAN_DESCRIPTION} = SpanMetricsField;
+const {SPAN_GROUP, HTTP_RESPONSE_CONTENT_LENGTH, RAW_DOMAIN, SPAN_DESCRIPTION} =
+  SpanIndexedField;
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/utils/usePageFilters');
@@ -117,6 +118,7 @@ const setupMockRequests = (
           project: 'javascript',
           [SPAN_DESCRIPTION]: 'https://cdn.com/image.png',
           'any(id)': 'anyId123',
+          [RAW_DOMAIN]: '',
         },
       ],
     },

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -127,14 +127,24 @@ function SampleImagesChartPanelBody(props: {
       {images.map(resource => {
         const hasRawDomain = Boolean(resource[RAW_DOMAIN]);
         const isRelativeUrl = resource[SPAN_DESCRIPTION].startsWith('/');
+        let src = resource[SPAN_DESCRIPTION];
+        if (isRelativeUrl && hasRawDomain) {
+          try {
+            const url = new URL(resource[SPAN_DESCRIPTION], resource[RAW_DOMAIN]);
+            src = url.href;
+          } catch {
+            Sentry.captureException(new Error('Invalid URL'), {
+              data: {
+                [SPAN_DESCRIPTION]: resource[SPAN_DESCRIPTION],
+                [RAW_DOMAIN]: resource[RAW_DOMAIN],
+              },
+            });
+          }
+        }
 
-        const src =
-          isRelativeUrl && hasRawDomain
-            ? `${resource[RAW_DOMAIN]}${resource[SPAN_DESCRIPTION]}`
-            : resource[SPAN_DESCRIPTION];
         return (
           <ImageContainer
-            src={new URL(src).toString()}
+            src={src}
             showImage={isImagesEnabled}
             fileName={getFileNameFromDescription(resource[SPAN_DESCRIPTION])}
             size={resource[`measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`]}

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -134,7 +134,7 @@ function SampleImagesChartPanelBody(props: {
             : resource[SPAN_DESCRIPTION];
         return (
           <ImageContainer
-            src={src}
+            src={new URL(src).toString()}
             showImage={isImagesEnabled}
             fileName={getFileNameFromDescription(resource[SPAN_DESCRIPTION])}
             size={resource[`measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`]}

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -26,7 +26,7 @@ type Props = {groupId: string; projectId?: number};
 
 export const LOCAL_STORAGE_SHOW_LINKS = 'performance-resources-images-showLinks';
 
-const {SPAN_GROUP, SPAN_DOMAIN, SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH, SPAN_OP} =
+const {SPAN_GROUP, RAW_DOMAIN, SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH, SPAN_OP} =
   SpanIndexedField;
 const imageWidth = '200px';
 const imageHeight = '180px';
@@ -125,12 +125,12 @@ function SampleImagesChartPanelBody(props: {
   return (
     <ImageWrapper>
       {images.map(resource => {
-        const hasSpanDomain = Boolean(resource[SPAN_DOMAIN]);
+        const hasRawDomain = Boolean(resource[RAW_DOMAIN]);
         const isRelativeUrl = resource[SPAN_DESCRIPTION].startsWith('/');
 
         const src =
-          isRelativeUrl && hasSpanDomain
-            ? `${resource[SPAN_DOMAIN]}${resource[SPAN_DESCRIPTION]}`
+          isRelativeUrl && hasRawDomain
+            ? `${resource[RAW_DOMAIN]}${resource[SPAN_DESCRIPTION]}`
             : resource[SPAN_DESCRIPTION];
         return (
           <ImageContainer

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -26,7 +26,7 @@ type Props = {groupId: string; projectId?: number};
 
 export const LOCAL_STORAGE_SHOW_LINKS = 'performance-resources-images-showLinks';
 
-const {SPAN_GROUP, SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH, SPAN_OP} =
+const {SPAN_GROUP, SPAN_DOMAIN, SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH, SPAN_OP} =
   SpanIndexedField;
 const imageWidth = '200px';
 const imageHeight = '180px';
@@ -125,9 +125,16 @@ function SampleImagesChartPanelBody(props: {
   return (
     <ImageWrapper>
       {images.map(resource => {
+        const hasSpanDomain = Boolean(resource[SPAN_DOMAIN]);
+        const isRelativeUrl = resource[SPAN_DESCRIPTION].startsWith('/');
+
+        const src =
+          isRelativeUrl && hasSpanDomain
+            ? `${resource[SPAN_DOMAIN]}${resource[SPAN_DESCRIPTION]}`
+            : resource[SPAN_DESCRIPTION];
         return (
           <ImageContainer
-            src={resource[SPAN_DESCRIPTION]}
+            src={src}
             showImage={isImagesEnabled}
             fileName={getFileNameFromDescription(resource[SPAN_DESCRIPTION])}
             size={resource[`measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`]}

--- a/static/app/views/performance/browser/resources/utils/useIndexedResourceQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useIndexedResourceQuery.ts
@@ -7,7 +7,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
 
-const {SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH, SPAN_DOMAIN} = SpanIndexedField;
+const {SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH, RAW_DOMAIN} = SpanIndexedField;
 
 type Options = {
   enabled?: boolean;
@@ -35,7 +35,7 @@ export const useIndexedResourcesQuery = ({
         `any(id)`,
         'project',
         'span.group',
-        SPAN_DOMAIN,
+        RAW_DOMAIN,
         SPAN_DESCRIPTION,
         `measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`,
       ],
@@ -68,7 +68,7 @@ export const useIndexedResourcesQuery = ({
       project: row.project as string,
       'transaction.id': row['transaction.id'] as string,
       [SPAN_DESCRIPTION]: row[SPAN_DESCRIPTION]?.toString(),
-      [SPAN_DOMAIN]: row[SPAN_DOMAIN][0]?.toString(),
+      [RAW_DOMAIN]: row[RAW_DOMAIN][0]?.toString(),
       'measurements.http.response_content_length': row[
         `measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`
       ] as number,

--- a/static/app/views/performance/browser/resources/utils/useIndexedResourceQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useIndexedResourceQuery.ts
@@ -7,7 +7,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {SpanIndexedField} from 'sentry/views/starfish/types';
 
-const {SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH} = SpanIndexedField;
+const {SPAN_DESCRIPTION, HTTP_RESPONSE_CONTENT_LENGTH, SPAN_DOMAIN} = SpanIndexedField;
 
 type Options = {
   enabled?: boolean;
@@ -35,6 +35,7 @@ export const useIndexedResourcesQuery = ({
         `any(id)`,
         'project',
         'span.group',
+        SPAN_DOMAIN,
         SPAN_DESCRIPTION,
         `measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`,
       ],
@@ -67,6 +68,7 @@ export const useIndexedResourcesQuery = ({
       project: row.project as string,
       'transaction.id': row['transaction.id'] as string,
       [SPAN_DESCRIPTION]: row[SPAN_DESCRIPTION]?.toString(),
+      [SPAN_DOMAIN]: row[SPAN_DOMAIN][0]?.toString(),
       'measurements.http.response_content_length': row[
         `measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`
       ] as number,

--- a/static/app/views/starfish/types.tsx
+++ b/static/app/views/starfish/types.tsx
@@ -113,6 +113,7 @@ export enum SpanIndexedField {
   TRANSACTION_OP = 'transaction.op',
   SPAN_DOMAIN = 'span.domain',
   TIMESTAMP = 'timestamp',
+  RAW_DOMAIN = 'raw_domain',
   PROJECT = 'project',
   PROJECT_ID = 'project_id',
   PROFILE_ID = 'profile_id',


### PR DESCRIPTION
Once this https://github.com/getsentry/relay/pull/2975 is merged and we update our JS SDK, we can grab the `raw_domain` field from spansIndexed in order to support the sample image view for relative urls.