### PR TITLE
chore(pr-comments): add logger to investigate duplicate group_ids

### DIFF
--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -173,6 +173,15 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
 
     top_5_issues = get_top_5_issues_by_count(issue_list, project)
     top_5_issue_ids = [issue["group_id"] for issue in top_5_issues]
+    logger.info(
+        "github.pr_comment.top_5_issues",
+        extra={
+            "top_5_issue_ids": top_5_issue_ids,
+            "issue_list": issue_list,
+            "pr_id": pullrequest_id,
+        },
+    )
+
     issue_comment_contents = get_comment_contents(top_5_issue_ids)
 
     try:


### PR DESCRIPTION
In the db I'm seeing that we're commenting duplicate issue ids for merged PR comments. Throwing a logger in the PR comment workflow to see if these are coming directly from Snuba.