### PR TITLE
feat(crons): Give additional issue list controls in monitor details

### DIFF
--- a/static/app/views/monitors/components/monitorIssues.tsx
+++ b/static/app/views/monitors/components/monitorIssues.tsx
@@ -64,9 +64,10 @@ function MonitorIssues({orgSlug, monitor, monitorEnvs}: Props) {
 
   const [issuesType, setIssuesType] = useState<IssuesType>(IssuesType.UNRESOLVED);
 
-  const issueQuery = `monitor.slug:"${monitor.slug}" environment:[${monitorEnvs
-    .map(e => e.name)
-    .join(',')}] ${issuesType === IssuesType.UNRESOLVED ? 'is:unresolved' : ''}`;
+  const monitorFilter = `monitor.slug:${monitor.slug}`;
+  const envFilter = `environment:[${monitorEnvs.map(e => e.name).join(',')}]`;
+  const issueTypeFilter = issuesType === IssuesType.UNRESOLVED ? 'is:unresolved' : '';
+  const issueQuery = `${monitorFilter} ${envFilter} ${issueTypeFilter}`;
 
   const issueSearchLocation = {
     pathname: `/organizations/${orgSlug}/issues/`,

--- a/static/app/views/monitors/components/monitorIssues.tsx
+++ b/static/app/views/monitors/components/monitorIssues.tsx
@@ -1,4 +1,5 @@
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
 import {Button, LinkButton} from 'sentry/components/button';
@@ -7,13 +8,25 @@ import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import GroupList from 'sentry/components/issues/groupList';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
+import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {getUtcDateString} from 'sentry/utils/dates';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
 import {Monitor, MonitorEnvironment} from '../types';
+
+enum IssuesType {
+  ALL = 'all',
+  UNRESOLVED = 'unresolved',
+}
+
+const ISSUE_TYPES = [
+  {value: IssuesType.UNRESOLVED, label: t('Unresolved Issues')},
+  {value: IssuesType.ALL, label: t('All Issues')},
+];
 
 type Props = {
   monitor: Monitor;
@@ -49,6 +62,21 @@ function MonitorIssues({orgSlug, monitor, monitorEnvs}: Props) {
           statsPeriod: period,
         };
 
+  const [issuesType, setIssuesType] = useState<IssuesType>(IssuesType.UNRESOLVED);
+
+  const issueQuery = `monitor.slug:"${monitor.slug}" environment:[${monitorEnvs
+    .map(e => e.name)
+    .join(',')}] ${issuesType === IssuesType.UNRESOLVED ? 'is:unresolved' : ''}`;
+
+  const issueSearchLocation = {
+    pathname: `/organizations/${orgSlug}/issues/`,
+    query: {
+      query: issueQuery,
+      project: monitor.project.id,
+      ...timeProps,
+    },
+  };
+
   // TODO(epurkhiser): We probably want to filter on envrionemnt
   return (
     <Fragment>
@@ -83,13 +111,28 @@ function MonitorIssues({orgSlug, monitor, monitorEnvs}: Props) {
           {t('Too many issues? Configure thresholds in your monitor settings')}
         </Alert>
       )}
+      <ControlsWrapper>
+        <SegmentedControl
+          aria-label={t('Issue category')}
+          value={issuesType}
+          size="xs"
+          onChange={setIssuesType}
+        >
+          {ISSUE_TYPES.map(({value, label}) => (
+            <SegmentedControl.Item key={value} textValue={label}>
+              {label}
+            </SegmentedControl.Item>
+          ))}
+        </SegmentedControl>
+        <LinkButton size="xs" to={issueSearchLocation}>
+          {t('Open In Issues')}
+        </LinkButton>
+      </ControlsWrapper>
       <GroupList
         orgSlug={orgSlug}
         endpointPath={`/organizations/${orgSlug}/issues/`}
         queryParams={{
-          query: `monitor.slug:"${monitor.slug}" environment:[${monitorEnvs
-            .map(e => e.name)
-            .join(',')}]`,
+          query: issueQuery,
           project: monitor.project.id,
           limit: 20,
           ...timeProps,
@@ -105,5 +148,13 @@ function MonitorIssues({orgSlug, monitor, monitorEnvs}: Props) {
     </Fragment>
   );
 }
+
+const ControlsWrapper = styled('div')`
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin-bottom: ${space(1)};
+  flex-wrap: wrap;
+`;
 
 export default MonitorIssues;


### PR DESCRIPTION
Much inspiration taken from the project details issues view, adds
- Segmented control to pick between all issues and only showing unresolved (default)
- `Open In Issues` button which provides a link to view the currently selected issue type in issues search

<img width="904" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/167fd9b6-514a-47e4-92ae-a6a1a50ff80d">
