### PR TITLE
feat(open-pr-comments): snuba query conditions for javascript

### DIFF
--- a/src/sentry/tasks/integrations/github/language_parsers.py
+++ b/src/sentry/tasks/integrations/github/language_parsers.py
@@ -4,7 +4,7 @@ import re
 from abc import ABC, abstractmethod
 from typing import List, Set
 
-from snuba_sdk import BooleanCondition, Column, Condition, Function, Op
+from snuba_sdk import BooleanCondition, BooleanOp, Column, Condition, Function, Op
 
 from sentry.tasks.integrations.github.constants import STACKFRAME_COUNT
 
@@ -130,5 +130,89 @@ class JavascriptParser(LanguageParser):
 
         return functions
 
+    def _get_function_name_conditions(stackframe_level: int, function_names: List[str]):
+        """
+        For Javascript we need a special case of matching both for the function name itself and for
+        "." + the function name, because sometimes Snuba stores the function name as "className.FunctionName".
+        """
+        prepended_function_names = ["%." + function_name for function_name in function_names]
+        function_name_conditions = [
+            Condition(
+                stackframe_function_name(stackframe_level),
+                Op.LIKE,
+                function_name,
+            )
+            for function_name in prepended_function_names
+        ]
+        function_name_conditions.append(
+            Condition(
+                stackframe_function_name(stackframe_level),
+                Op.IN,
+                function_names,
+            ),
+        )
+        return function_name_conditions
+
+    def _get_function_name_functions(stackframe_level: int, function_names: List[str]):
+        """
+        This is used in the multi_if. We need to account for the special Javascript cases in order to
+        properly fetch the function name -- "className.FunctionName" or simply "functionName" depending
+        on what matches in the stack trace.
+        """
+        prepended_function_names = ["%." + function_name for function_name in function_names]
+        function_name_conditions = [
+            Function(
+                "like",
+                [
+                    stackframe_function_name(stackframe_level),
+                    function_name,
+                ],
+            )
+            for function_name in prepended_function_names
+        ]
+        function_name_conditions.append(
+            Function(
+                "in",
+                [
+                    stackframe_function_name(stackframe_level),
+                    function_names,
+                ],
+            )
+        )
+        return function_name_conditions
+
+    @staticmethod
+    def generate_multi_if(function_names: List[str]) -> List[Function]:
+        """
+        Fetch the function name from the stackframe that matches a name within the list of function names.
+        """
+        multi_if = []
+        for i in range(-STACKFRAME_COUNT, 0):
+            # if, then conditions
+            stackframe_function_name_conditions = JavascriptParser._get_function_name_functions(
+                i, function_names
+            )
+            multi_if.extend(
+                [
+                    Function("or", stackframe_function_name_conditions),
+                    stackframe_function_name(i),
+                ]
+            )
+        # else condition
+        multi_if.append(stackframe_function_name(-1))
+
+        return multi_if
+
+    @staticmethod
+    def generate_function_name_conditions(function_names: List[str], stack_frame: int) -> Condition:
+        """Check if the function name in the stack frame is within the list of function names."""
+        return BooleanCondition(
+            BooleanOp.OR,
+            JavascriptParser._get_function_name_conditions(stack_frame, function_names),
+        )
+
 
 PATCH_PARSERS = {"py": PythonParser}
+
+# for testing the Javascript parser, feature flagged
+BETA_PATCH_PARSERS = {"py": PythonParser, "js": JavascriptParser, "jsx": JavascriptParser}

--- a/src/sentry/tasks/integrations/github/language_parsers.py
+++ b/src/sentry/tasks/integrations/github/language_parsers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
-from typing import List, Set
+from typing import Any, List, Set
 
 from snuba_sdk import BooleanCondition, BooleanOp, Column, Condition, Function, Op
 
@@ -130,6 +130,7 @@ class JavascriptParser(LanguageParser):
 
         return functions
 
+    @staticmethod
     def _get_function_name_conditions(stackframe_level: int, function_names: List[str]):
         """
         For Javascript we need a special case of matching both for the function name itself and for
@@ -153,6 +154,7 @@ class JavascriptParser(LanguageParser):
         )
         return function_name_conditions
 
+    @staticmethod
     def _get_function_name_functions(stackframe_level: int, function_names: List[str]):
         """
         This is used in the multi_if. We need to account for the special Javascript cases in order to
@@ -212,7 +214,11 @@ class JavascriptParser(LanguageParser):
         )
 
 
-PATCH_PARSERS = {"py": PythonParser}
+PATCH_PARSERS: dict[str, Any] = {"py": PythonParser}
 
 # for testing the Javascript parser, feature flagged
-BETA_PATCH_PARSERS = {"py": PythonParser, "js": JavascriptParser, "jsx": JavascriptParser}
+BETA_PATCH_PARSERS: dict[str, Any] = {
+    "py": PythonParser,
+    "js": JavascriptParser,
+    "jsx": JavascriptParser,
+}

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -21,6 +21,7 @@ from snuba_sdk import (
 )
 from snuba_sdk import Request as SnubaRequest
 
+from sentry import features
 from sentry.integrations.github.client import GitHubAppsClient
 from sentry.models.group import Group, GroupStatus
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
@@ -40,7 +41,7 @@ from sentry.tasks.integrations.github.constants import (
     RATE_LIMITED_MESSAGE,
     STACKFRAME_COUNT,
 )
-from sentry.tasks.integrations.github.language_parsers import PATCH_PARSERS
+from sentry.tasks.integrations.github.language_parsers import BETA_PATCH_PARSERS, PATCH_PARSERS
 from sentry.tasks.integrations.github.pr_comment import format_comment_url
 from sentry.tasks.integrations.github.utils import (
     GithubAPIErrorType,
@@ -183,10 +184,21 @@ def safe_for_comment(
     changed_lines_count = 0
     filtered_pr_files = []
 
+    try:
+        organization = Organization.objects.get_from_cache(id=repository.organization_id)
+    except Organization.DoesNotExist:
+        logger.exception("github.open_pr_comment.org_missing")
+        metrics.incr(OPEN_PR_METRICS_BASE.format(key="error"), tags={"type": "missing_org"})
+        return []
+
+    patch_parsers = PATCH_PARSERS
+    if features.has("organizations:integrations-open-pr-comment-js", organization):
+        patch_parsers = BETA_PATCH_PARSERS
+
     for file in pr_files:
         filename = file["filename"]
         # don't count the file if it was added or is not a Python file
-        if file["status"] == "added" or filename.split(".")[-1] not in PATCH_PARSERS:
+        if file["status"] == "added" or filename.split(".")[-1] not in patch_parsers:
             continue
 
         changed_file_count += 1
@@ -252,9 +264,18 @@ def get_top_5_issues_by_count_for_file(
     and function names representing the list of functions changed in a PR file, return a
     sublist of the top 5 recent unhandled issues ordered by event count.
     """
+    if not len(projects):
+        return []
+
+    organization = projects[0].organization
+
+    patch_parsers = PATCH_PARSERS
+    if features.has("organizations:integrations-open-pr-comment-js", organization):
+        patch_parsers = BETA_PATCH_PARSERS
+
     # fetches the appropriate parser for formatting the snuba query given the file extension
     # the extension is never replaced in reverse codemapping
-    language_parser = PATCH_PARSERS.get(sentry_filenames[0].split(".")[-1], None)
+    language_parser = patch_parsers.get(sentry_filenames[0].split(".")[-1], None)
 
     if not language_parser:
         return []
@@ -405,6 +426,10 @@ def open_pr_comment_workflow(pr_id: int) -> None:
     issue_table_contents = {}
     top_issues_per_file = []
 
+    patch_parsers = PATCH_PARSERS
+    if features.has("organizations:integrations-open-pr-comment-js", organization):
+        patch_parsers = BETA_PATCH_PARSERS
+
     # fetch issues related to the files
     for file in pullrequest_files:
         projects, sentry_filenames = get_projects_and_filenames_from_source_file(
@@ -413,8 +438,16 @@ def open_pr_comment_workflow(pr_id: int) -> None:
         if not len(projects) or not len(sentry_filenames):
             continue
 
-        language_parser = PATCH_PARSERS.get(file.filename.split(".")[-1], None)
+        file_extension = file.filename.split(".")[-1]
+        language_parser = patch_parsers.get(file.filename.split(".")[-1], None)
         if not language_parser:
+            logger.info(
+                "github.open_pr_comment.missing_parser", extra={"extension": file_extension}
+            )
+            metrics.incr(
+                OPEN_PR_METRICS_BASE.format(key="missing_parser"),
+                tags={"extension": file_extension},
+            )
             continue
 
         function_names = language_parser.extract_functions_from_patch(file.patch)


### PR DESCRIPTION
This PR adds Snuba query conditions for Javascript. This is the last part that needs to go in before we can enable Javascript open PR comments for a beta cohort.

These conditions account for the fact that we sometimes store function names as `functionName` OR `className.functionName` for Javascript. We need conditions to filter for and fetch the proper function name that matches, "proper" meaning whatever is stored in Snuba (`functionName` or `className.functionName`).

The Javascript parsing is feature flagged everywhere that we look up a file extension in the list of supported extensions.

For https://github.com/getsentry/team-enterprise/issues/41