### PR TITLE
chore(pr-comments): fix tests and IntegrityError

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -41,7 +41,7 @@ from sentry.tasks.integrations.github.constants import (
     STACKFRAME_COUNT,
 )
 from sentry.tasks.integrations.github.language_parsers import PATCH_PARSERS
-from sentry.tasks.integrations.github.pr_comment import format_comment_url, get_pr_comment
+from sentry.tasks.integrations.github.pr_comment import format_comment_url
 from sentry.tasks.integrations.github.utils import (
     GithubAPIErrorType,
     PullRequestFile,
@@ -463,11 +463,8 @@ def open_pr_comment_workflow(pr_id: int) -> None:
     issue_list: List[Dict[str, Any]] = list(itertools.chain.from_iterable(top_issues_per_file))
     issue_id_list: List[int] = [issue["group_id"] for issue in issue_list]
 
-    pr_comment = get_pr_comment(pr_id, comment_type=CommentType.OPEN_PR)
-
     try:
         create_or_update_comment(
-            pr_comment=pr_comment,
             client=client,
             repo=repo,
             pr_key=pull_request.key,

--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -161,8 +161,6 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
         logger.info("github.pr_comment.option_missing", extra={"organization_id": org_id})
         return
 
-    pr_comment = get_pr_comment(pr_id=pullrequest_id, comment_type=CommentType.MERGED_PR)
-
     try:
         project = Project.objects.get_from_cache(id=project_id)
     except Project.DoesNotExist:
@@ -211,6 +209,8 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
     logger.info("github.pr_comment.comment_body", extra={"body": comment_body})
 
     top_24_issues = issue_list[:24]  # 24 is the P99 for issues-per-PR
+
+    pr_comment = get_pr_comment(pr_id=pullrequest_id, comment_type=CommentType.MERGED_PR)
 
     try:
         create_or_update_comment(

--- a/src/sentry/tasks/integrations/github/utils.py
+++ b/src/sentry/tasks/integrations/github/utils.py
@@ -36,7 +36,6 @@ class GithubAPIErrorType(Enum):
 
 
 def create_or_update_comment(
-    pr_comment: PullRequestComment | None,
     client: GitHubAppsClient,
     repo: Repository,
     pr_key: int,
@@ -46,6 +45,11 @@ def create_or_update_comment(
     metrics_base: str,
     comment_type: int = CommentType.MERGED_PR,
 ):
+    pr_comment_query = PullRequestComment.objects.filter(
+        pull_request__id=pullrequest_id, comment_type=comment_type
+    )
+    pr_comment = pr_comment_query[0] if pr_comment_query.exists() else None
+
     # client will raise ApiError if the request is not successful
     if pr_comment is None:
         resp = client.create_comment(

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -1551,16 +1551,15 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
         integration = integration_service.get_integration(
             organization_id=self.code_mapping.organization_id
         )
-        if integration:
-            install = integration.get_installation(
-                organization_id=self.code_mapping.organization_id
-            )
+        assert integration
 
-            with self.tasks():
-                queue_comment_task_if_needed(
-                    commit=self.commit, group_owner=groupowner, repo=self.repo, installation=install
-                )
-                queue_comment_task_if_needed(
-                    commit=self.commit, group_owner=groupowner, repo=self.repo, installation=install
-                )
-                assert mock_comment_workflow.call_count == 1
+        install = integration.get_installation(organization_id=self.code_mapping.organization_id)
+
+        with self.tasks():
+            queue_comment_task_if_needed(
+                commit=self.commit, group_owner=groupowner, repo=self.repo, installation=install
+            )
+            queue_comment_task_if_needed(
+                commit=self.commit, group_owner=groupowner, repo=self.repo, installation=install
+            )
+            assert mock_comment_workflow.call_count == 1

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -1551,13 +1551,16 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
         integration = integration_service.get_integration(
             organization_id=self.code_mapping.organization_id
         )
-        install = integration.get_installation(organization_id=self.code_mapping.organization_id)
+        if integration:
+            install = integration.get_installation(
+                organization_id=self.code_mapping.organization_id
+            )
 
-        with self.tasks():
-            queue_comment_task_if_needed(
-                commit=self.commit, group_owner=groupowner, repo=self.repo, installation=install
-            )
-            queue_comment_task_if_needed(
-                commit=self.commit, group_owner=groupowner, repo=self.repo, installation=install
-            )
-            assert mock_comment_workflow.call_count == 1
+            with self.tasks():
+                queue_comment_task_if_needed(
+                    commit=self.commit, group_owner=groupowner, repo=self.repo, installation=install
+                )
+                queue_comment_task_if_needed(
+                    commit=self.commit, group_owner=groupowner, repo=self.repo, installation=install
+                )
+                assert mock_comment_workflow.call_count == 1

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -15,8 +15,13 @@ from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.pullrequest import PullRequest, PullRequestComment, PullRequestCommit
 from sentry.models.repository import Repository
+from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
-from sentry.tasks.commit_context import PR_COMMENT_WINDOW, process_commit_context
+from sentry.tasks.commit_context import (
+    PR_COMMENT_WINDOW,
+    process_commit_context,
+    queue_comment_task_if_needed,
+)
 from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
@@ -1531,21 +1536,28 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextMixin):
     def test_gh_comment_debounces(self, get_jwt, mock_comment_workflow):
         self.add_responses()
 
+        assert not GroupOwner.objects.filter(group=self.event.group).exists()
+
+        groupowner = GroupOwner.objects.create(
+            group_id=self.event.group_id,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            user_id="1",
+            project_id=self.event.project_id,
+            organization_id=self.project.organization_id,
+            context={"commitId": self.commit.id},
+            date_added=timezone.now(),
+        )
+
+        integration = integration_service.get_integration(
+            organization_id=self.code_mapping.organization_id
+        )
+        install = integration.get_installation(organization_id=self.code_mapping.organization_id)
+
         with self.tasks():
-            assert not GroupOwner.objects.filter(group=self.event.group).exists()
-            event_frames = get_frame_paths(self.event)
-            process_commit_context(
-                event_id=self.event.event_id,
-                event_platform=self.event.platform,
-                event_frames=event_frames,
-                group_id=self.event.group_id,
-                project_id=self.event.project_id,
+            queue_comment_task_if_needed(
+                commit=self.commit, group_owner=groupowner, repo=self.repo, installation=install
             )
-            process_commit_context(
-                event_id=self.event.event_id,
-                event_platform=self.event.platform,
-                event_frames=event_frames,
-                group_id=self.event.group_id,
-                project_id=self.event.project_id,
+            queue_comment_task_if_needed(
+                commit=self.commit, group_owner=groupowner, repo=self.repo, installation=install
             )
             assert mock_comment_workflow.call_count == 1


### PR DESCRIPTION
We are seeing some `IntegrityErrors` in [SENTRY-2EHQ](https://sentry.sentry.io/issues/4897265143/) where we try to create a new merged PR comment and a PR comment already exists.

I attempted to debug this by checking the debounce comment test, which queues the comment workflow to eventually POST the comment to the Github API. Firstly, the test wasn't testing the correct debounce -- which I fixed. Otherwise I could not figure out the issue, so for now I'm moving fetching the existing PR comment (if any) right before we attempt to create another comment.