### PR TITLE
ref(crons): Refactor makeMonitorListQueryKey to accept params instead of location

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/index.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/index.tsx
@@ -32,11 +32,11 @@ interface Props {
 }
 
 export function OverviewTimeline({monitorList}: Props) {
-  const {location} = useRouter();
   const organization = useOrganization();
   const api = useApi();
   const queryClient = useQueryClient();
   const router = useRouter();
+  const location = router.location;
 
   const timeWindow: TimeWindow = location.query?.timeWindow ?? '24h';
   const nowRef = useRef(new Date());
@@ -77,7 +77,7 @@ export function OverviewTimeline({monitorList}: Props) {
       return;
     }
 
-    const queryKey = makeMonitorListQueryKey(organization, router.location);
+    const queryKey = makeMonitorListQueryKey(organization, location.query);
     setApiQueryData(queryClient, queryKey, (oldMonitorList: Monitor[]) => {
       const oldMonitorIdx = oldMonitorList.findIndex(m => m.slug === monitor.slug);
       if (oldMonitorIdx < 0) {
@@ -116,7 +116,7 @@ export function OverviewTimeline({monitorList}: Props) {
       return;
     }
 
-    const queryKey = makeMonitorListQueryKey(organization, router.location);
+    const queryKey = makeMonitorListQueryKey(organization, location.query);
     setApiQueryData(queryClient, queryKey, (oldMonitorList: Monitor[]) => {
       const monitorIdx = oldMonitorList.findIndex(m => m.slug === monitor.slug);
       // TODO(davidenwang): in future only change the specifically modified environment for optimistic updates
@@ -133,7 +133,7 @@ export function OverviewTimeline({monitorList}: Props) {
       return;
     }
 
-    const queryKey = makeMonitorListQueryKey(organization, router.location);
+    const queryKey = makeMonitorListQueryKey(organization, location.query);
     setApiQueryData(queryClient, queryKey, (oldMonitorList: Monitor[]) => {
       const monitorIdx = oldMonitorList.findIndex(m => m.slug === monitor.slug);
       oldMonitorList[monitorIdx] = {...oldMonitorList[monitorIdx], status: resp.status};

--- a/static/app/views/monitors/overview.tsx
+++ b/static/app/views/monitors/overview.tsx
@@ -62,7 +62,7 @@ export default function Monitors() {
   const platform = decodeScalar(router.location.query?.platform) ?? null;
   const guide = decodeScalar(router.location.query?.guide);
 
-  const queryKey = makeMonitorListQueryKey(organization, router.location);
+  const queryKey = makeMonitorListQueryKey(organization, router.location.query);
 
   const {
     data: monitorList,

--- a/static/app/views/monitors/utils.tsx
+++ b/static/app/views/monitors/utils.tsx
@@ -1,14 +1,16 @@
 import {Theme} from '@emotion/react';
 import cronstrue from 'cronstrue';
-import {Location} from 'history';
 
 import {t, tn} from 'sentry/locale';
 import {Organization, SelectValue} from 'sentry/types';
 import {shouldUse24Hours} from 'sentry/utils/dates';
 import {CheckInStatus, MonitorConfig, ScheduleType} from 'sentry/views/monitors/types';
 
-export function makeMonitorListQueryKey(organization: Organization, location: Location) {
-  const {query, project, environment, cursor} = location.query;
+export function makeMonitorListQueryKey(
+  organization: Organization,
+  params: Record<string, any>
+) {
+  const {query, project, environment, cursor} = params;
 
   return [
     `/organizations/${organization.slug}/monitors/`,


### PR DESCRIPTION
Will allow other components to call this function without forcing them to only supply parameters from the current url