### PR TITLE
fix(hybridcloud) Extend the reattempt counter duration

### DIFF
--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from typing import FrozenSet
 
 REQUEST_ATTEMPTS_LIMIT = 10
-CACHE_TIMEOUT = 600  # 10 minutes = 600 seconds
+CACHE_TIMEOUT = 43200  # 12 hours = 60 * 60 * 12 seconds
 
 
 class SiloClientError(Exception):


### PR DESCRIPTION
We have a bunch of webhooks that are stuck in delivery reattempt loops. Because the messages are retried hourly, our 10m cache can't ever detect that we should give up on those messages. Extending the cache TTL should allow us to capture all of the reattempts