### PR TITLE
ref: add a knob to toggle process_incr sample rate

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3674,6 +3674,8 @@ SENTRY_EXTRA_WORKERS: MutableSequence[str] = []
 
 SAMPLED_DEFAULT_RATE = 1.0
 
+SENTRY_PROCESS_INCR_SAMPLE_RATE = 0.01
+
 # A set of extra URLs to sample
 ADDITIONAL_SAMPLED_URLS: dict[str, float] = {}
 

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -60,7 +60,7 @@ SAMPLED_TASKS = {
     "sentry.tasks.relay.invalidate_project_config": settings.SENTRY_RELAY_TASK_APM_SAMPLING,
     "sentry.ingest.transaction_clusterer.tasks.spawn_clusterers": settings.SENTRY_RELAY_TASK_APM_SAMPLING,
     "sentry.ingest.transaction_clusterer.tasks.cluster_projects": settings.SENTRY_RELAY_TASK_APM_SAMPLING,
-    "sentry.tasks.process_buffer.process_incr": 0.01,
+    "sentry.tasks.process_buffer.process_incr": settings.SENTRY_PROCESS_INCR_SAMPLE_RATE,
     "sentry.replays.tasks.delete_recording_segments": settings.SAMPLED_DEFAULT_RATE,
     "sentry.tasks.weekly_reports.schedule_organizations": 1.0,
     "sentry.tasks.weekly_reports.prepare_organization_report": 0.1,


### PR DESCRIPTION
I plan to crank this up in s4s to debug this in python 3.11

<!-- Describe your PR here. -->