### PR TITLE
fix(hybrid-cloud): Fix cross silo violation when disabling org integration

### DIFF
--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -446,10 +446,7 @@ class BaseApiClient(TrackResponseMixin):
         rpc_integration, rpc_org_integrations = integration_service.get_organization_contexts(
             integration_id=self.integration_id
         )
-        if (
-            integration_service.get_integration(integration_id=rpc_integration.id).status
-            == ObjectStatus.DISABLED
-        ):
+        if rpc_integration and rpc_integration.status == ObjectStatus.DISABLED:
             return
 
         org = None

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -16,7 +16,6 @@ from sentry.exceptions import RestrictedIPAddress
 from sentry.http import build_session
 from sentry.integrations.notify_disable import notify_disable
 from sentry.integrations.request_buffer import IntegrationRequestBuffer
-from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.integrations.utils import is_response_error, is_response_success
 from sentry.models.organization import Organization
 from sentry.net.http import SafeSession
@@ -444,7 +443,7 @@ class BaseApiClient(TrackResponseMixin):
             self.disable_integration(buffer)
 
     def disable_integration(self, buffer) -> None:
-        rpc_integration, rpc_org_integration = integration_service.get_organization_contexts(
+        rpc_integration, rpc_org_integrations = integration_service.get_organization_contexts(
             integration_id=self.integration_id
         )
         if (
@@ -452,32 +451,34 @@ class BaseApiClient(TrackResponseMixin):
             == ObjectStatus.DISABLED
         ):
             return
-        oi = OrganizationIntegration.objects.filter(integration_id=self.integration_id)[0]
-        org = Organization.objects.get(id=oi.organization_id)
+
+        org = None
+        if len(rpc_org_integrations) > 0:
+            org = Organization.objects.filter(id=rpc_org_integrations[0].organization_id).first()
 
         extra = {
             "integration_id": self.integration_id,
             "buffer_record": buffer._get_all_from_buffer(),
         }
-        if len(rpc_org_integration) == 0 and rpc_integration is None:
+        if len(rpc_org_integrations) == 0 and rpc_integration is None:
             extra["provider"] = "unknown"
             extra["organization_id"] = "unknown"
-        elif len(rpc_org_integration) == 0:
+        elif len(rpc_org_integrations) == 0:
             extra["provider"] = rpc_integration.provider
             extra["organization_id"] = "unknown"
         elif rpc_integration is None:
             extra["provider"] = "unknown"
-            extra["organization_id"] = rpc_org_integration[0].organization_id
+            extra["organization_id"] = rpc_org_integrations[0].organization_id
         else:
             extra["provider"] = rpc_integration.provider
-            extra["organization_id"] = rpc_org_integration[0].organization_id
+            extra["organization_id"] = rpc_org_integrations[0].organization_id
 
         self.logger.info(
             "integration.disabled",
             extra=extra,
         )
 
-        if (
+        if org and (
             (rpc_integration.provider == "slack" and buffer.is_integration_fatal_broken())
             or (rpc_integration.provider == "github")
             or (

--- a/tests/sentry/integrations/slack/test_disable.py
+++ b/tests/sentry/integrations/slack/test_disable.py
@@ -14,8 +14,11 @@ from sentry.integrations.slack.client import SlackClient
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.integrations.integration import Integration
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.silo import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import json
 
@@ -29,6 +32,7 @@ secret = "hush-hush-im-invisible"
     SENTRY_SUBNET_SECRET=secret,
     SENTRY_CONTROL_ADDRESS=control_address,
 )
+@region_silo_test
 class SlackClientDisable(TestCase):
     def setUp(self):
         self.resp = responses.mock
@@ -68,17 +72,18 @@ class SlackClientDisable(TestCase):
         )
         client = SlackClient(integration_id=self.integration.id)
 
-        with self.tasks() and pytest.raises(ApiError):
+        with outbox_runner(), self.tasks(), pytest.raises(ApiError):
             client.post("/chat.postMessage", data=self.payload)
         buffer = IntegrationRequestBuffer(client._get_redis_key())
-        integration = Integration.objects.get(id=self.integration.id)
-        assert integration.status == ObjectStatus.DISABLED
-        assert [len(item) == 0 for item in buffer._get_broken_range_from_buffer()]
-        assert len(buffer._get_all_from_buffer()) == 0
-        assert AuditLogEntry.objects.filter(
-            event=audit_log.get_event_id("INTEGRATION_DISABLED"),
-            organization_id=self.organization.id,
-        ).exists()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(id=self.integration.id)
+            assert integration.status == ObjectStatus.DISABLED
+            assert [len(item) == 0 for item in buffer._get_broken_range_from_buffer()]
+            assert len(buffer._get_all_from_buffer()) == 0
+            assert AuditLogEntry.objects.filter(
+                event=audit_log.get_event_id("INTEGRATION_DISABLED"),
+                organization_id=self.organization.id,
+            ).exists()
 
     @responses.activate
     def test_email(self):
@@ -154,7 +159,8 @@ class SlackClientDisable(TestCase):
         with pytest.raises(ApiError):
             client.post("/chat.postMessage", data=self.payload)
         assert buffer.is_integration_broken() is False
-        assert Integration.objects.get(id=self.integration.id).status == ObjectStatus.ACTIVE
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert Integration.objects.get(id=self.integration.id).status == ObjectStatus.ACTIVE
 
     @responses.activate
     def test_a_slow_integration_is_broken(self):
@@ -180,7 +186,8 @@ class SlackClientDisable(TestCase):
         with pytest.raises(ApiError):
             client.post("/chat.postMessage", data=self.payload)
         assert buffer.is_integration_broken() is True
-        assert Integration.objects.get(id=self.integration.id).status == ObjectStatus.ACTIVE
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert Integration.objects.get(id=self.integration.id).status == ObjectStatus.ACTIVE
 
     @responses.activate
     def test_expiry(self):


### PR DESCRIPTION
When disabling an org integration, the `OrganizationIntegration` model isn't available in the Region silo; so this pull request fixes that.

