### PR TITLE
fix(clickhouse): Change groupby filters in sessions metrics

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -669,14 +669,18 @@ def _get_group_limit_filters(
     # Get an ordered list of tuples containing the values of the group keys.
     # This needs to be deduplicated since in timeseries queries the same
     # grouping key will reappear for every time bucket.
+    # If there is only one value, then we don't need to preserve the order with tuples
     values = list({tuple(row[col] for col in aliased_group_keys): None for row in results})
-    conditions = [
-        Condition(
-            Function("tuple", list(key_to_condition_dict.values())),
-            Op.IN,
-            Function("tuple", values),
-        )
-    ]
+    conditions = []
+    if len(aliased_group_keys) > 1:
+        conditions = [
+            Condition(
+                Function("tuple", list(key_to_condition_dict.values())),
+                Op.IN,
+                Function("tuple", values),
+            )
+        ]
+
     # In addition to filtering down on the tuple combination of the fields in
     # the group by columns, we need a separate condition for each of the columns
     # in the group by with their respective values so Clickhouse can filter the

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -488,15 +488,19 @@ def _run_sessions_query(query):
     # We only get the time series for groups which also have a total:
     if query.query_groupby:
         # E.g. (release, environment) IN [(1, 2), (3, 4), ...]
-        groups = {tuple(row[column] for column in query.query_groupby) for row in result_totals}
+        extra_conditions = []
+        if len(query.query_groupby) > 1:
+            groups = {tuple(row[column] for column in query.query_groupby) for row in result_totals}
 
-        extra_conditions = [
-            Condition(
-                Function("tuple", [Column(col) for col in query.query_groupby]),
-                Op.IN,
-                Function("tuple", list(groups)),
-            )
-        ] + [
+            extra_conditions = [
+                Condition(
+                    Function("tuple", [Column(col) for col in query.query_groupby]),
+                    Op.IN,
+                    Function("tuple", list(groups)),
+                )
+            ]
+
+        extra_conditions += [
             Condition(
                 Column(column),
                 Op.IN,


### PR DESCRIPTION
This change should have no impact at the moment, but in Clickhouse 22.8 queries
that have tuple filters with single values, e.g. `tuple(project_id) IN
tuple(tuple(1), tuple(2))` are broken. The issue is fixed again in Clickhouse
23.8, but better to have this work properly in all versions.