### PR TITLE
ref(grouping): Always run background grouping first

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -516,9 +516,9 @@ class EventManager:
         _derive_plugin_tags_many(jobs, projects)
         _derive_interface_tags_many(jobs)
 
-        # Background grouping is a way for us to get performance metrics for a new
-        # config without having it actually affect on how events are grouped. It runs
-        # either before or after the main grouping logic, depending on the option value.
+        # Background grouping is a way for us to get performance metrics for a new config without
+        # having it actually affect how events are grouped. So as to not slow down overall
+        # ingestion too much, it only runs on a fraction of events.
         maybe_run_background_grouping(project, job)
 
         secondary_hashes = None

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -66,7 +66,7 @@ from sentry.grouping.ingest import (
     calculate_primary_hash,
     calculate_secondary_hash,
     find_existing_grouphash,
-    run_background_grouping,
+    maybe_run_background_grouping,
     should_run_secondary_grouping,
     update_grouping_config_if_needed,
 )
@@ -519,7 +519,7 @@ class EventManager:
         # Background grouping is a way for us to get performance metrics for a new
         # config without having it actually affect on how events are grouped. It runs
         # either before or after the main grouping logic, depending on the option value.
-        run_background_grouping(project, job)
+        maybe_run_background_grouping(project, job)
 
         secondary_hashes = None
         migrate_off_hierarchical = False

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -519,9 +519,7 @@ class EventManager:
         # Background grouping is a way for us to get performance metrics for a new
         # config without having it actually affect on how events are grouped. It runs
         # either before or after the main grouping logic, depending on the option value.
-        do_background_grouping_before = options.get("store.background-grouping-before")
-        if do_background_grouping_before:
-            run_background_grouping(project, job)
+        run_background_grouping(project, job)
 
         secondary_hashes = None
         migrate_off_hierarchical = False
@@ -597,9 +595,6 @@ class EventManager:
                 hashes.tree_labels or (secondary_hashes and secondary_hashes.tree_labels) or []
             ),
         )
-
-        if not do_background_grouping_before:
-            run_background_grouping(project, job)
 
         if hashes.tree_labels:
             job["finest_tree_label"] = hashes.finest_tree_label

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -143,7 +143,7 @@ def _calculate_event_grouping(
         return hashes
 
 
-def run_background_grouping(project: Project, job: Job) -> None:
+def maybe_run_background_grouping(project: Project, job: Job) -> None:
     """Optionally run a fraction of events with a third grouping config
     This can be helpful to measure its performance impact.
     This does not affect actual grouping.

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -144,9 +144,11 @@ def _calculate_event_grouping(
 
 
 def maybe_run_background_grouping(project: Project, job: Job) -> None:
-    """Optionally run a fraction of events with a third grouping config
-    This can be helpful to measure its performance impact.
-    This does not affect actual grouping.
+    """
+    Optionally run a fraction of events with an experimental grouping config.
+
+    This does not affect actual grouping, but can be helpful to measure the new config's performance
+    impact.
     """
     try:
         sample_rate = options.get("store.background-grouping-sample-rate")

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -815,7 +815,9 @@ register("store.background-grouping-config-id", default=None, flags=FLAG_AUTOMAT
 register("store.background-grouping-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # True if background grouping should run before secondary and primary grouping
-register("store.background-grouping-before", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register(
+    "store.background-grouping-before", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
+)  # TODO: remove, no longer used
 
 # Store release files bundled as zip files
 register(


### PR DESCRIPTION
Background grouping is a safe way for us to measure the performance of a new grouping config - we run the grouping algorithm with that config, time it, and then toss the results, so the change doesn't affect any events' eventual grouping. 

Currently, there is an option controlling whether to run this test before or after the main hash calculations, presumably because it has the possibility of modifying the event. Or rather, it _had_ the possibility of modifying the event. In https://github.com/getsentry/sentry/pull/62856, which moved the background grouping functions to the `grouping` module, a change was made so that background grouping is applied to a copy of the event rather than the event itself. It therefore no longer matters whether it happens before or after the main calculations. (It's blocking either way, so that's not a consideration here.)

This refactors the code such that background grouping is always run before the main calculations. (I chose before rather than after because that way it's not mixed in with other logic having to do with the main grouping process.) For safety, it doesn't yet remove the option from `defaults.py`, but it does mark it as unused. (The removal will come in a future PR.) 

In addition, this renames the background grouping function from `run_background_grouping` to `maybe_run_background_grouping` (to reflect the fact that background grouping only runs on a fraction of events) and fixes up the function's docstring.