### PR TITLE
fix(hybrid-cloud): Updates sentry avatar query to use RPC service

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/serial.py
+++ b/src/sentry/services/hybrid_cloud/user/serial.py
@@ -102,6 +102,15 @@ def serialize_rpc_user(user: User) -> RpcUser:
     return RpcUser(**args)
 
 
+def serialize_user_avatar(avatar: UserAvatar) -> RpcAvatar:
+    return RpcAvatar(
+        id=avatar.id,
+        file_id=avatar.file_id,
+        ident=avatar.ident,
+        avatar_type=avatar.get_avatar_type_display(),
+    )
+
+
 def _flatten(iter: Iterable[Any]) -> List[Any]:
     return (
         ((_flatten(iter[0]) + _flatten(iter[1:])) if len(iter) > 0 else [])

--- a/src/sentry/services/hybrid_cloud/user/serial.py
+++ b/src/sentry/services/hybrid_cloud/user/serial.py
@@ -79,12 +79,7 @@ def serialize_rpc_user(user: User) -> RpcUser:
     else:
         orm_avatar = user.avatar.first()
         if orm_avatar is not None:
-            avatar = RpcAvatar(
-                id=orm_avatar.id,
-                file_id=orm_avatar.file_id,
-                ident=orm_avatar.ident,
-                avatar_type=orm_avatar.get_avatar_type_display(),
-            )
+            avatar = serialize_user_avatar(avatar=orm_avatar)
     args["avatar"] = avatar
 
     args["authenticators"] = [

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -17,7 +17,7 @@ from sentry.services.hybrid_cloud.user import (
     UserSerializeType,
     UserUpdateArgs,
 )
-from sentry.services.hybrid_cloud.user.model import RpcVerifyUserEmail, UserIdEmailArgs
+from sentry.services.hybrid_cloud.user.model import RpcAvatar, RpcVerifyUserEmail, UserIdEmailArgs
 from sentry.silo import SiloMode
 
 
@@ -185,6 +185,11 @@ class UserService(RpcService):
     def verify_user_emails(
         self, *, user_id_emails: List[UserIdEmailArgs]
     ) -> Dict[int, RpcVerifyUserEmail]:
+        pass
+
+    @rpc_method
+    @abstractmethod
+    def get_user_avatar(self, *, user_id: int) -> RpcAvatar | None:
         pass
 
 

--- a/src/sentry/templatetags/sentry_avatars.py
+++ b/src/sentry/templatetags/sentry_avatars.py
@@ -3,9 +3,9 @@ from urllib.parse import urlencode
 from django import template
 from django.urls import reverse
 
-from sentry.models.avatars.user_avatar import UserAvatar
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.user import RpcUser
+from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.utils.avatar import get_email_avatar, get_gravatar_url, get_letter_avatar
 from sentry.utils.http import absolute_uri
 
@@ -27,11 +27,11 @@ def letter_avatar_svg(context, display_name, identifier, size=None):
 
 @register.simple_tag(takes_context=True)
 def profile_photo_url(context, user_id, size=None):
-    try:
-        avatar = UserAvatar.objects.get_from_cache(user=user_id)
-    except UserAvatar.DoesNotExist:
+    user_avatar = user_service.get_user_avatar(user_id=user_id)
+
+    if not user_avatar:
         return
-    url = reverse("sentry-user-avatar-url", args=[avatar.ident])
+    url = reverse("sentry-user-avatar-url", args=[user_avatar.ident])
     if size:
         url += "?" + urlencode({"s": size})
     return absolute_uri(url)

--- a/tests/sentry/hybridcloud/test_user.py
+++ b/tests/sentry/hybridcloud/test_user.py
@@ -58,6 +58,7 @@ def test_user_get_avatar():
 
     rpc_avatar = user_service.get_user_avatar(user_id=user.id)
 
+    assert rpc_avatar
     assert rpc_avatar.ident == avatar.ident
     assert rpc_avatar.file_id == avatar.file_id
     assert rpc_avatar.id == avatar.id

--- a/tests/sentry/hybridcloud/test_user.py
+++ b/tests/sentry/hybridcloud/test_user.py
@@ -1,4 +1,5 @@
 from sentry.models.avatars.user_avatar import UserAvatar
+from sentry.models.files import ControlFile
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.testutils.factories import Factories
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -43,3 +44,21 @@ def test_user_serialize_multiple_emails():
     assert len(rpc_user.useremails) == 3
     expected = {user.email, email.email, unverified_email.email}
     assert expected == {e.email for e in rpc_user.useremails}
+
+
+@django_db_all(transaction=True)
+def test_user_get_avatar():
+    user = Factories.create_user()
+
+    # Assert a query without an avatar returns none by default
+    assert user_service.get_user_avatar(user_id=user.id) is None
+
+    avatar_file = ControlFile.objects.create(name="avatar.png", type=UserAvatar.FILE_TYPE)
+    avatar = UserAvatar.objects.create(user=user, control_file_id=avatar_file.id)
+
+    rpc_avatar = user_service.get_user_avatar(user_id=user.id)
+
+    assert rpc_avatar.ident == avatar.ident
+    assert rpc_avatar.file_id == avatar.file_id
+    assert rpc_avatar.id == avatar.id
+    assert rpc_avatar.avatar_type == avatar.get_avatar_type_display()


### PR DESCRIPTION
Adds a new `user_service` RPC method to retrieve user avatars by user ID. This new RPC call is used by the `sentry-avatar` module when querying and populating avatar information in emails.
