### PR TITLE
feat(crons): Add flag to toggle the consumer rate-limiter

### DIFF
--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -18,7 +18,7 @@ from arroyo.types import BrokerValue, Commit, Message, Partition
 from django.db import router, transaction
 from sentry_sdk.tracing import Span, Transaction
 
-from sentry import features, quotas, ratelimits
+from sentry import features, options, quotas, ratelimits
 from sentry.constants import DataCategory, ObjectStatus
 from sentry.killswitches import killswitch_matches_context
 from sentry.models.project import Project
@@ -164,6 +164,9 @@ def check_ratelimit(
     """
     Enforce check-in rate limits. Returns True if rate limit is enforced.
     """
+    if not options.get("crons.consumer-rate-limiter-enabled"):
+        return False
+
     ratelimit_key = f"{project.organization_id}:{monitor_slug}:{environment}"
 
     is_blocked = ratelimits.backend.is_limited(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1586,6 +1586,9 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Toggle the monitor consumer check-in rate-limiter
+register("crons.consumer-rate-limiter-enabled", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 # Killswitch for monitor check-ins
 register("crons.organization.disable-check-in", type=Sequence, default=[])
 


### PR DESCRIPTION
Will be used to turn off consumer based rate-limits once we're at 100% roll-out of `QuotaConfing` relay-based rate limits.