### PR TITLE
feat(superuser): create readonly scopes variable

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2421,6 +2421,15 @@ SENTRY_SCOPES = {
     "email",
 }
 
+SENTRY_READONLY_SCOPES = {
+    "org:read",
+    "member:read",
+    "team:read",
+    "project:read",
+    "event:read",
+    "alerts:read",
+}
+
 SENTRY_SCOPE_HIERARCHY_MAPPING = {
     "org:read": {"org:read"},
     "org:write": {"org:read", "org:write"},

--- a/tests/sentry/conf/test_scopes.py
+++ b/tests/sentry/conf/test_scopes.py
@@ -1,4 +1,4 @@
-from sentry.conf.server import SENTRY_SCOPE_HIERARCHY_MAPPING, SENTRY_SCOPES
+from sentry.conf.server import SENTRY_READONLY_SCOPES, SENTRY_SCOPE_HIERARCHY_MAPPING, SENTRY_SCOPES
 from sentry.testutils.cases import TestCase
 
 
@@ -24,3 +24,8 @@ class ScopesTest(TestCase):
             if access_level == "admin":
                 assert resource + ":read" in SENTRY_SCOPE_HIERARCHY_MAPPING[scope]
                 assert resource + ":write" in SENTRY_SCOPE_HIERARCHY_MAPPING[scope]
+
+    def test_readonly_scopes(self):
+        for scope in SENTRY_SCOPES:
+            if ":read" in scope:
+                assert scope in SENTRY_READONLY_SCOPES


### PR DESCRIPTION
For separating superuser into superuser read-only and superuser write. The read-only scopes will be given to superusers with read-only, and I added a test to make sure the variable is always up to date.

For https://github.com/getsentry/team-enterprise/issues/39