### PR TITLE
feat(issue-details): Add inline replay viewer to issue details

### DIFF
--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -74,43 +74,27 @@ function EventReplayContent({
   const timeOfEvent = event.dateCreated ?? startTimestampMS ?? event.dateReceived;
   const eventTimestampMs = timeOfEvent ? Math.floor(new Date(timeOfEvent).getTime()) : 0;
 
+  const replayComponent = hasReplayClipFeature ? replayClipPreview : replayPreview;
+
   return (
     <ReplaySectionMinHeight>
       <ErrorBoundary mini>
         <ReactLazyLoad debounce={50} height={448} offset={0} once>
-          {!hasReplayClipFeature ? (
-            <LazyLoad
-              component={replayPreview}
-              replaySlug={replayId}
-              orgSlug={organization.slug}
-              eventTimestampMs={eventTimestampMs}
-              buttonProps={{
-                analyticsEventKey: 'issue_details.open_replay_details_clicked',
-                analyticsEventName: 'Issue Details: Open Replay Details Clicked',
-                analyticsParams: {
-                  ...getAnalyticsDataForEvent(event),
-                  ...getAnalyticsDataForGroup(group),
-                  organization,
-                },
-              }}
-            />
-          ) : (
-            <LazyLoad
-              component={replayClipPreview}
-              replaySlug={replayId}
-              orgSlug={organization.slug}
-              eventTimestampMs={eventTimestampMs}
-              fullReplayButtonProps={{
-                analyticsEventKey: 'issue_details.open_replay_details_clicked',
-                analyticsEventName: 'Issue Details: Open Replay Details Clicked',
-                analyticsParams: {
-                  ...getAnalyticsDataForEvent(event),
-                  ...getAnalyticsDataForGroup(group),
-                  organization,
-                },
-              }}
-            />
-          )}
+          <LazyLoad
+            component={replayComponent}
+            replaySlug={replayId}
+            orgSlug={organization.slug}
+            eventTimestampMs={eventTimestampMs}
+            buttonProps={{
+              analyticsEventKey: 'issue_details.open_replay_details_clicked',
+              analyticsEventName: 'Issue Details: Open Replay Details Clicked',
+              analyticsParams: {
+                ...getAnalyticsDataForEvent(event),
+                ...getAnalyticsDataForGroup(group),
+                organization,
+              },
+            }}
+          />
         </ReactLazyLoad>
       </ErrorBoundary>
     </ReplaySectionMinHeight>

--- a/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
@@ -1,0 +1,188 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {RRWebInitFrameEventsFixture} from 'sentry-fixture/replay/rrweb';
+import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render as baseRender, screen} from 'sentry-test/reactTestingLibrary';
+
+import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import ReplayReader from 'sentry/utils/replays/replayReader';
+import type RequestError from 'sentry/utils/requestError/requestError';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+import {RouteContext} from 'sentry/views/routeContext';
+
+import ReplayClipPreview from './replayClipPreview';
+
+jest.mock('sentry/utils/replays/hooks/useReplayReader');
+
+const mockUseReplayReader = jest.mocked(useReplayReader);
+
+const mockOrgSlug = 'sentry-emerging-tech';
+const mockReplaySlug = 'replays:761104e184c64d439ee1014b72b4d83b';
+const mockReplayId = '761104e184c64d439ee1014b72b4d83b';
+
+const mockEventTimestampMs = new Date('2022-09-22T16:59:41Z').getTime();
+
+const mockButtonHref = `/organizations/${mockOrgSlug}/replays/761104e184c64d439ee1014b72b4d83b/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&t=52&t_main=errors`;
+
+// Mock screenfull library
+jest.mock('screenfull', () => ({
+  enabled: true,
+  isFullscreen: false,
+  request: jest.fn(),
+  exit: jest.fn(),
+  on: jest.fn(),
+  off: jest.fn(),
+}));
+
+// Get replay data with the mocked replay reader params
+const mockReplay = ReplayReader.factory({
+  replayRecord: ReplayRecordFixture({
+    browser: {
+      name: 'Chrome',
+      version: '110.0.0',
+    },
+  }),
+  errors: [],
+  attachments: RRWebInitFrameEventsFixture({
+    timestamp: new Date('Sep 22, 2022 4:58:39 PM UTC'),
+  }),
+});
+
+mockUseReplayReader.mockImplementation(() => {
+  return {
+    attachments: [],
+    errors: [],
+    fetchError: undefined,
+    fetching: false,
+    onRetry: jest.fn(),
+    projectSlug: ProjectFixture().slug,
+    replay: mockReplay,
+    replayId: mockReplayId,
+    replayRecord: ReplayRecordFixture(),
+  };
+});
+
+const render: typeof baseRender = children => {
+  const {router, routerContext} = initializeOrg({
+    router: {
+      routes: [
+        {path: '/'},
+        {path: '/organizations/:orgId/issues/:groupId/'},
+        {path: 'replays/'},
+      ],
+      location: {
+        pathname: '/organizations/org-slug/replays/',
+        query: {},
+      },
+    },
+  });
+
+  return baseRender(
+    <RouteContext.Provider
+      value={{
+        router,
+        location: router.location,
+        params: router.params,
+        routes: router.routes,
+      }}
+    >
+      <OrganizationContext.Provider value={OrganizationFixture({slug: mockOrgSlug})}>
+        {children}
+      </OrganizationContext.Provider>
+    </RouteContext.Provider>,
+    {context: routerContext}
+  );
+};
+
+describe('ReplayPreview', () => {
+  it('Should render a placeholder when is fetching the replay data', () => {
+    // Change the mocked hook to return a loading state
+    mockUseReplayReader.mockImplementationOnce(() => {
+      return {
+        attachments: [],
+        errors: [],
+        fetchError: undefined,
+        fetching: true,
+        onRetry: jest.fn(),
+        projectSlug: ProjectFixture().slug,
+        replay: mockReplay,
+        replayId: mockReplayId,
+        replayRecord: ReplayRecordFixture(),
+      };
+    });
+
+    render(
+      <ReplayClipPreview
+        orgSlug={mockOrgSlug}
+        replaySlug={mockReplaySlug}
+        eventTimestampMs={mockEventTimestampMs}
+      />
+    );
+
+    expect(screen.getByTestId('replay-loading-placeholder')).toBeInTheDocument();
+  });
+
+  it('Should throw error when there is a fetch error', () => {
+    // Change the mocked hook to return a fetch error
+    mockUseReplayReader.mockImplementationOnce(() => {
+      return {
+        attachments: [],
+        errors: [],
+        fetchError: {status: 400} as RequestError,
+        fetching: false,
+        onRetry: jest.fn(),
+        projectSlug: ProjectFixture().slug,
+        replay: null,
+        replayId: mockReplayId,
+        replayRecord: ReplayRecordFixture(),
+      };
+    });
+
+    render(
+      <ReplayClipPreview
+        orgSlug={mockOrgSlug}
+        replaySlug={mockReplaySlug}
+        eventTimestampMs={mockEventTimestampMs}
+      />
+    );
+
+    expect(screen.getByTestId('replay-error')).toBeVisible();
+  });
+
+  it('Should have the correct time range', () => {
+    render(
+      <ReplayClipPreview
+        orgSlug={mockOrgSlug}
+        replaySlug={mockReplaySlug}
+        eventTimestampMs={mockEventTimestampMs}
+      />
+    );
+
+    // Should be two sliders, one for the scrubber and one for timeline
+    const sliders = screen.getAllByRole('slider', {name: 'Seek slider'});
+
+    // Replay should start at 52000ms because event happened at 62000ms
+    expect(sliders[0]).toHaveValue('52000');
+    expect(sliders[0]).toHaveAttribute('min', '52000');
+
+    // End of range should be 5 seconds after at 67000ms
+    expect(sliders[0]).toHaveAttribute('max', '67000');
+  });
+
+  it('Should link to the full replay correctly', () => {
+    render(
+      <ReplayClipPreview
+        orgSlug={mockOrgSlug}
+        replaySlug={mockReplaySlug}
+        eventTimestampMs={mockEventTimestampMs}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'See Full Replay'})).toHaveAttribute(
+      'href',
+      mockButtonHref
+    );
+  });
+});

--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -13,8 +13,8 @@ import {
   Provider as ReplayContextProvider,
   useReplayContext,
 } from 'sentry/components/replays/replayContext';
-import {ReplayPlayPauseBar} from 'sentry/components/replays/replayController';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
+import ReplayPlayPauseButton from 'sentry/components/replays/replayPlayPauseButton';
 import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
 import TimeAndScrubberGrid from 'sentry/components/replays/timeAndScrubberGrid';
 import {IconContract, IconDelete, IconExpand} from 'sentry/icons';
@@ -100,7 +100,7 @@ function ReplayPreviewPlayer({
       </StaticPanel>
       <ErrorBoundary mini>
         <ButtonGrid>
-          <ReplayPlayPauseBar />
+          <ReplayPlayPauseButton />
           <Container>
             <TimeAndScrubberGrid />
           </Container>
@@ -236,6 +236,7 @@ const StyledPlaceholder = styled(Placeholder)`
 
 const ButtonGrid = styled('div')`
   display: flex;
+  align-items: center;
   gap: 0 ${space(2)};
   flex-direction: row;
   justify-content: space-between;

--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -6,12 +6,9 @@ import {Alert} from 'sentry/components/alert';
 import {Button, LinkButton} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import ExternalLink from 'sentry/components/links/externalLink';
-import Link from 'sentry/components/links/link';
-import List from 'sentry/components/list';
-import ListItem from 'sentry/components/list/listItem';
 import Placeholder from 'sentry/components/placeholder';
 import {Flex} from 'sentry/components/profiling/flex';
+import MissingReplayAlert from 'sentry/components/replays/alerts/missingReplayAlert';
 import ReplayTimeline from 'sentry/components/replays/breadcrumbs/replayTimeline';
 import {PlayerScrubber} from 'sentry/components/replays/player/scrubber';
 import useScrubberMouseTracking from 'sentry/components/replays/player/useScrubberMouseTracking';
@@ -24,7 +21,7 @@ import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
 import {formatTime} from 'sentry/components/replays/utils';
 import {IconContract, IconDelete, IconExpand} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
@@ -200,50 +197,7 @@ function ReplayClipPreview({
   }
 
   if (fetchError) {
-    const reasons = [
-      t('The replay is still processing'),
-      tct(
-        'The replay was rate-limited and could not be accepted. [link:View the stats page] for more information.',
-        {
-          link: <Link to={`/organizations/${orgSlug}/stats/?dataCategory=replays`} />,
-        }
-      ),
-      t('The replay has been deleted by a member in your organization.'),
-      t('There were network errors and the replay was not saved.'),
-      tct('[link:Read the docs] to understand why.', {
-        link: (
-          <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#error-linking" />
-        ),
-      }),
-    ];
-
-    return (
-      <Alert
-        type="info"
-        showIcon
-        data-test-id="replay-error"
-        trailingItems={
-          <LinkButton
-            external
-            href="https://docs.sentry.io/platforms/javascript/session-replay/#error-linking"
-            size="xs"
-          >
-            {t('Read Docs')}
-          </LinkButton>
-        }
-      >
-        <p>
-          {t(
-            'The replay for this event cannot be found. This could be due to these reasons:'
-          )}
-        </p>
-        <List symbol="bullet">
-          {reasons.map((reason, i) => (
-            <ListItem key={i}>{reason}</ListItem>
-          ))}
-        </List>
-      </Alert>
-    );
+    return <MissingReplayAlert orgSlug={orgSlug} />;
   }
 
   if (fetching || !replayRecord || !replay) {

--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -81,11 +81,7 @@ function ReplayPreviewPlayer({
   const routes = useRoutes();
   const organization = useOrganization();
   const isFullscreen = useIsFullscreen();
-  const {
-    currentTime,
-    startTimeOffsetMs: startTime,
-    durationMs: duration,
-  } = useReplayContext();
+  const {currentTime, startTimeOffsetMs, durationMs} = useReplayContext();
 
   // If the browser supports going fullscreen or not. iPhone Safari won't do
   // it. https://caniuse.com/fullscreen
@@ -114,7 +110,7 @@ function ReplayPreviewPlayer({
           <Container>
             <TimeAndScrubberGrid>
               <Time style={{gridArea: 'currentTime'}}>
-                {formatTime(currentTime - startTime)}
+                {formatTime(currentTime - startTimeOffsetMs)}
               </Time>
               <div style={{gridArea: 'timeline'}}>
                 <ReplayTimeline />
@@ -127,7 +123,7 @@ function ReplayPreviewPlayer({
                 <PlayerScrubber showZoomIndicators />
               </StyledScrubber>
               <Time style={{gridArea: 'duration'}}>
-                {duration ? formatTime(duration) : '--:--'}
+                {durationMs ? formatTime(durationMs) : '--:--'}
               </Time>
             </TimeAndScrubberGrid>
           </Container>

--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -9,9 +9,6 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import Placeholder from 'sentry/components/placeholder';
 import {Flex} from 'sentry/components/profiling/flex';
 import MissingReplayAlert from 'sentry/components/replays/alerts/missingReplayAlert';
-import ReplayTimeline from 'sentry/components/replays/breadcrumbs/replayTimeline';
-import {PlayerScrubber} from 'sentry/components/replays/player/scrubber';
-import useScrubberMouseTracking from 'sentry/components/replays/player/useScrubberMouseTracking';
 import {
   Provider as ReplayContextProvider,
   useReplayContext,
@@ -19,7 +16,7 @@ import {
 import {ReplayPlayPauseBar} from 'sentry/components/replays/replayController';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
-import {formatTime} from 'sentry/components/replays/utils';
+import TimeAndScrubberGrid from 'sentry/components/replays/timeAndScrubberGrid';
 import {IconContract, IconDelete, IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
@@ -81,14 +78,11 @@ function ReplayPreviewPlayer({
   const routes = useRoutes();
   const organization = useOrganization();
   const isFullscreen = useIsFullscreen();
-  const {currentTime, startTimeOffsetMs, durationMs} = useReplayContext();
+  const {currentTime} = useReplayContext();
 
   // If the browser supports going fullscreen or not. iPhone Safari won't do
   // it. https://caniuse.com/fullscreen
   const showFullscreenButton = screenfull.isEnabled;
-
-  const elem = useRef<HTMLDivElement>(null);
-  const mouseTrackingProps = useScrubberMouseTracking({elem});
 
   const fullReplayUrl = {
     pathname: normalizeUrl(`/organizations/${organization.slug}/replays/${replayId}/`),
@@ -108,24 +102,7 @@ function ReplayPreviewPlayer({
         <ButtonGrid>
           <ReplayPlayPauseBar />
           <Container>
-            <TimeAndScrubberGrid>
-              <Time style={{gridArea: 'currentTime'}}>
-                {formatTime(currentTime - startTimeOffsetMs)}
-              </Time>
-              <div style={{gridArea: 'timeline'}}>
-                <ReplayTimeline />
-              </div>
-              <StyledScrubber
-                style={{gridArea: 'scrubber'}}
-                ref={elem}
-                {...mouseTrackingProps}
-              >
-                <PlayerScrubber showZoomIndicators />
-              </StyledScrubber>
-              <Time style={{gridArea: 'duration'}}>
-                {durationMs ? formatTime(durationMs) : '--:--'}
-              </Time>
-            </TimeAndScrubberGrid>
+            <TimeAndScrubberGrid />
           </Container>
           <ButtonBar gap={1}>
             <LinkButton size="sm" to={fullReplayUrl}>
@@ -269,28 +246,6 @@ const Container = styled('div')`
   flex-direction: column;
   flex: 1 1;
   justify-content: center;
-`;
-
-const TimeAndScrubberGrid = styled('div')`
-  width: 100%;
-  display: grid;
-  grid-template-areas:
-    '. timeline .'
-    'currentTime scrubber duration';
-  grid-column-gap: ${space(1)};
-  grid-template-columns: max-content auto max-content;
-  align-items: center;
-`;
-
-const Time = styled('span')`
-  font-variant-numeric: tabular-nums;
-  padding: 0 ${space(1.5)};
-`;
-
-const StyledScrubber = styled('div')`
-  height: 32px;
-  display: flex;
-  align-items: center;
 `;
 
 export default ReplayClipPreview;

--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -1,0 +1,333 @@
+import {ComponentProps, Fragment, useMemo, useRef} from 'react';
+import styled from '@emotion/styled';
+import screenfull from 'screenfull';
+
+import {Alert} from 'sentry/components/alert';
+import {Button, LinkButton} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import ExternalLink from 'sentry/components/links/externalLink';
+import Link from 'sentry/components/links/link';
+import List from 'sentry/components/list';
+import ListItem from 'sentry/components/list/listItem';
+import Placeholder from 'sentry/components/placeholder';
+import {Flex} from 'sentry/components/profiling/flex';
+import ReplayTimeline from 'sentry/components/replays/breadcrumbs/replayTimeline';
+import {PlayerScrubber} from 'sentry/components/replays/player/scrubber';
+import useScrubberMouseTracking from 'sentry/components/replays/player/useScrubberMouseTracking';
+import {
+  Provider as ReplayContextProvider,
+  useReplayContext,
+} from 'sentry/components/replays/replayContext';
+import {ReplayPlayPauseBar} from 'sentry/components/replays/replayController';
+import ReplayPlayer from 'sentry/components/replays/replayPlayer';
+import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
+import {formatTime} from 'sentry/components/replays/utils';
+import {IconContract, IconDelete, IconExpand} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
+import {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
+import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
+import RequestError from 'sentry/utils/requestError/requestError';
+import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useRoutes} from 'sentry/utils/useRoutes';
+import useFullscreen from 'sentry/utils/window/useFullscreen';
+import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
+import {ReplayRecord} from 'sentry/views/replays/types';
+
+type Props = {
+  eventTimestampMs: number;
+  orgSlug: string;
+  replaySlug: string;
+  focusTab?: TabKey;
+  fullReplayButtonProps?: Partial<ComponentProps<typeof LinkButton>>;
+};
+
+function getReplayAnalyticsStatus({
+  fetchError,
+  replayRecord,
+}: {
+  fetchError?: RequestError;
+  replayRecord?: ReplayRecord;
+}) {
+  if (fetchError) {
+    return 'error';
+  }
+
+  if (replayRecord?.is_archived) {
+    return 'archived';
+  }
+
+  if (replayRecord) {
+    return 'success';
+  }
+
+  return 'none';
+}
+
+function ReplayPreviewPlayer({
+  toggleFullscreen,
+  replayId,
+  fullReplayButtonProps,
+}: {
+  replayId: string;
+  toggleFullscreen: () => void;
+  fullReplayButtonProps?: Partial<ComponentProps<typeof LinkButton>>;
+}) {
+  const routes = useRoutes();
+  const organization = useOrganization();
+  const isFullscreen = useIsFullscreen();
+  const {
+    currentTime,
+    startTimeOffsetMs: startTime,
+    durationMs: duration,
+  } = useReplayContext();
+
+  // If the browser supports going fullscreen or not. iPhone Safari won't do
+  // it. https://caniuse.com/fullscreen
+  const showFullscreenButton = screenfull.isEnabled;
+
+  const elem = useRef<HTMLDivElement>(null);
+  const mouseTrackingProps = useScrubberMouseTracking({elem});
+
+  const fullReplayUrl = {
+    pathname: normalizeUrl(`/organizations/${organization.slug}/replays/${replayId}/`),
+    query: {
+      referrer: getRouteStringFromRoutes(routes),
+      t_main: TabKey.ERRORS,
+      t: currentTime / 1000,
+    },
+  };
+
+  return (
+    <Fragment>
+      <StaticPanel>
+        <ReplayPlayer />
+      </StaticPanel>
+      <ErrorBoundary mini>
+        <ButtonGrid>
+          <ReplayPlayPauseBar />
+          <Container>
+            <TimeAndScrubberGrid>
+              <Time style={{gridArea: 'currentTime'}}>
+                {formatTime(currentTime - startTime)}
+              </Time>
+              <div style={{gridArea: 'timeline'}}>
+                <ReplayTimeline />
+              </div>
+              <StyledScrubber
+                style={{gridArea: 'scrubber'}}
+                ref={elem}
+                {...mouseTrackingProps}
+              >
+                <PlayerScrubber showZoomIndicators />
+              </StyledScrubber>
+              <Time style={{gridArea: 'duration'}}>
+                {duration ? formatTime(duration) : '--:--'}
+              </Time>
+            </TimeAndScrubberGrid>
+          </Container>
+          <ButtonBar gap={1}>
+            <LinkButton size="sm" to={fullReplayUrl}>
+              {t('See Full Replay')}
+            </LinkButton>
+            {showFullscreenButton ? (
+              <Button
+                size="sm"
+                title={isFullscreen ? t('Exit full screen') : t('Enter full screen')}
+                aria-label={isFullscreen ? t('Exit full screen') : t('Enter full screen')}
+                icon={
+                  isFullscreen ? <IconContract size="sm" /> : <IconExpand size="sm" />
+                }
+                onClick={toggleFullscreen}
+                {...fullReplayButtonProps}
+              />
+            ) : null}
+          </ButtonBar>
+        </ButtonGrid>
+      </ErrorBoundary>
+    </Fragment>
+  );
+}
+
+function ReplayClipPreview({
+  eventTimestampMs,
+  orgSlug,
+  replaySlug,
+  fullReplayButtonProps,
+}: Props) {
+  const {fetching, replay, replayRecord, fetchError, replayId} = useReplayReader({
+    orgSlug,
+    replaySlug,
+  });
+  const fullscreenRef = useRef(null);
+  const {toggle: toggleFullscreen} = useFullscreen({
+    elementRef: fullscreenRef,
+  });
+
+  const startTimestampMs = replayRecord?.started_at?.getTime() ?? 0;
+  const eventTimeOffsetMs = Math.abs(eventTimestampMs - startTimestampMs);
+
+  useRouteAnalyticsParams({
+    event_replay_status: getReplayAnalyticsStatus({fetchError, replayRecord}),
+  });
+
+  const clipWindow = useMemo(
+    () => ({
+      startTimeOffsetMs: Math.max(eventTimeOffsetMs - 10e3, 0),
+      durationMs: 15e3,
+    }),
+    [eventTimeOffsetMs]
+  );
+  const offset = useMemo(
+    () => ({offsetMs: clipWindow.startTimeOffsetMs}),
+    [clipWindow.startTimeOffsetMs]
+  );
+
+  if (replayRecord?.is_archived) {
+    return (
+      <Alert type="warning" data-test-id="replay-error">
+        <Flex gap={space(0.5)}>
+          <IconDelete color="gray500" size="sm" />
+          {t('The replay for this event has been deleted.')}
+        </Flex>
+      </Alert>
+    );
+  }
+
+  if (fetchError) {
+    const reasons = [
+      t('The replay is still processing'),
+      tct(
+        'The replay was rate-limited and could not be accepted. [link:View the stats page] for more information.',
+        {
+          link: <Link to={`/organizations/${orgSlug}/stats/?dataCategory=replays`} />,
+        }
+      ),
+      t('The replay has been deleted by a member in your organization.'),
+      t('There were network errors and the replay was not saved.'),
+      tct('[link:Read the docs] to understand why.', {
+        link: (
+          <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/#error-linking" />
+        ),
+      }),
+    ];
+
+    return (
+      <Alert
+        type="info"
+        showIcon
+        data-test-id="replay-error"
+        trailingItems={
+          <LinkButton
+            external
+            href="https://docs.sentry.io/platforms/javascript/session-replay/#error-linking"
+            size="xs"
+          >
+            {t('Read Docs')}
+          </LinkButton>
+        }
+      >
+        <p>
+          {t(
+            'The replay for this event cannot be found. This could be due to these reasons:'
+          )}
+        </p>
+        <List symbol="bullet">
+          {reasons.map((reason, i) => (
+            <ListItem key={i}>{reason}</ListItem>
+          ))}
+        </List>
+      </Alert>
+    );
+  }
+
+  if (fetching || !replayRecord || !replay) {
+    return (
+      <StyledPlaceholder
+        testId="replay-loading-placeholder"
+        height="400px"
+        width="100%"
+      />
+    );
+  }
+
+  return (
+    <ReplayContextProvider
+      isFetching={fetching}
+      replay={replay}
+      initialTimeOffsetMs={offset}
+      clipWindow={clipWindow}
+    >
+      <PlayerContainer data-test-id="player-container" ref={fullscreenRef}>
+        {replay?.hasProcessingErrors() ? (
+          <ReplayProcessingError processingErrors={replay.processingErrors()} />
+        ) : (
+          <ReplayPreviewPlayer
+            toggleFullscreen={toggleFullscreen}
+            replayId={replayId}
+            fullReplayButtonProps={fullReplayButtonProps}
+          />
+        )}
+      </PlayerContainer>
+    </ReplayContextProvider>
+  );
+}
+
+const PlayerContainer = styled(FluidHeight)`
+  position: relative;
+  background: ${p => p.theme.background};
+  gap: ${space(1)};
+  max-height: 448px;
+`;
+
+const StaticPanel = styled(FluidHeight)`
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
+const StyledPlaceholder = styled(Placeholder)`
+  margin-bottom: ${space(2)};
+`;
+
+const ButtonGrid = styled('div')`
+  display: flex;
+  gap: 0 ${space(2)};
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+const Container = styled('div')`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1;
+  justify-content: center;
+`;
+
+const TimeAndScrubberGrid = styled('div')`
+  width: 100%;
+  display: grid;
+  grid-template-areas:
+    '. timeline .'
+    'currentTime scrubber duration';
+  grid-column-gap: ${space(1)};
+  grid-template-columns: max-content auto max-content;
+  align-items: center;
+`;
+
+const Time = styled('span')`
+  font-variant-numeric: tabular-nums;
+  padding: 0 ${space(1.5)};
+`;
+
+const StyledScrubber = styled('div')`
+  height: 32px;
+  display: flex;
+  align-items: center;
+`;
+
+export default ReplayClipPreview;

--- a/static/app/components/forms/controls/rangeSlider/index.tsx
+++ b/static/app/components/forms/controls/rangeSlider/index.tsx
@@ -27,6 +27,8 @@ type SliderProps = {
    */
   allowedValues?: number[];
 
+  'aria-label'?: string;
+
   className?: string;
 
   disabled?: boolean;
@@ -199,6 +201,7 @@ function RangeSlider({
             value={sliderValue}
             hasLabel={!showCustomInput}
             aria-valuetext={labelText}
+            aria-label={props['aria-label']}
           />
           {showCustomInput && (
             <Input

--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -7,6 +7,7 @@ import TimelineTooltip from 'sentry/components/replays/breadcrumbs/replayTimelin
 import * as Progress from 'sentry/components/replays/progress';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {divide, formatTime} from 'sentry/components/replays/utils';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import toPercent from 'sentry/utils/number/toPercent';
 
@@ -84,6 +85,7 @@ function Scrubber({className, showZoomIndicators = false}: Props) {
           value={Math.round(currentTime)}
           onChange={value => setCurrentTime(value || 0)}
           showLabel={false}
+          aria-label={t('Seek slider')}
         />
       </RangeWrapper>
     </Wrapper>

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -132,7 +132,7 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   speed: number;
 
   /**
-   *
+   * The time, in milliseconds, where the video should start
    */
   startTimeOffsetMs: number;
 

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -40,7 +40,7 @@ interface Props {
   speedOptions?: number[];
 }
 
-function ReplayPlayPauseBar() {
+export function ReplayPlayPauseBar() {
   const {
     currentTime,
     isFinished,
@@ -271,7 +271,7 @@ const Container = styled('div')`
   justify-content: center;
 `;
 
-const TimeAndScrubberGrid = styled('div')<{isCompact: boolean}>`
+export const TimeAndScrubberGrid = styled('div')<{isCompact: boolean}>`
   width: 100%;
   display: grid;
   grid-template-areas:
@@ -290,7 +290,7 @@ const TimeAndScrubberGrid = styled('div')<{isCompact: boolean}>`
       : ''}
 `;
 
-const Time = styled('span')`
+export const Time = styled('span')`
   font-variant-numeric: tabular-nums;
   padding: 0 ${space(1.5)};
 `;

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -7,14 +7,12 @@ import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {CompositeSelect} from 'sentry/components/compactSelect/composite';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import ReplayPlayPauseButton from 'sentry/components/replays/replayPlayPauseButton';
 import TimeAndScrubberGrid from 'sentry/components/replays/timeAndScrubberGrid';
 import {
   IconContract,
   IconExpand,
   IconNext,
-  IconPause,
-  IconPlay,
-  IconPrevious,
   IconRewind10,
   IconSettings,
 } from 'sentry/icons';
@@ -35,16 +33,8 @@ interface Props {
   speedOptions?: number[];
 }
 
-export function ReplayPlayPauseBar() {
-  const {
-    currentTime,
-    isFinished,
-    isPlaying,
-    replay,
-    restart,
-    setCurrentTime,
-    togglePlayPause,
-  } = useReplayContext();
+function ReplayPlayPauseBar() {
+  const {currentTime, replay, setCurrentTime} = useReplayContext();
 
   return (
     <ButtonBar gap={1}>
@@ -55,23 +45,7 @@ export function ReplayPlayPauseBar() {
         onClick={() => setCurrentTime(currentTime - 10 * SECOND)}
         aria-label={t('Rewind 10 seconds')}
       />
-      {isFinished ? (
-        <Button
-          title={t('Restart Replay')}
-          icon={<IconPrevious size="md" />}
-          onClick={restart}
-          aria-label={t('Restart Replay')}
-          priority="primary"
-        />
-      ) : (
-        <Button
-          title={isPlaying ? t('Pause') : t('Play')}
-          icon={isPlaying ? <IconPause size="md" /> : <IconPlay size="md" />}
-          onClick={() => togglePlayPause(!isPlaying)}
-          aria-label={isPlaying ? t('Pause') : t('Play')}
-          priority="primary"
-        />
-      )}
+      <ReplayPlayPauseButton />
       <Button
         size="sm"
         title={t('Next breadcrumb')}

--- a/static/app/components/replays/replayPlayPauseButton.tsx
+++ b/static/app/components/replays/replayPlayPauseButton.tsx
@@ -1,0 +1,28 @@
+import {Button} from 'sentry/components/button';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {IconPause, IconPlay, IconPrevious} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+function ReplayPlayPauseButton() {
+  const {isFinished, isPlaying, restart, togglePlayPause} = useReplayContext();
+
+  return isFinished ? (
+    <Button
+      title={t('Restart Replay')}
+      icon={<IconPrevious size="md" />}
+      onClick={restart}
+      aria-label={t('Restart Replay')}
+      priority="primary"
+    />
+  ) : (
+    <Button
+      title={isPlaying ? t('Pause') : t('Play')}
+      icon={isPlaying ? <IconPause size="md" /> : <IconPlay size="md" />}
+      onClick={() => togglePlayPause(!isPlaying)}
+      aria-label={isPlaying ? t('Pause') : t('Play')}
+      priority="primary"
+    />
+  );
+}
+
+export default ReplayPlayPauseButton;

--- a/static/app/components/replays/timeAndScrubberGrid.tsx
+++ b/static/app/components/replays/timeAndScrubberGrid.tsx
@@ -1,0 +1,111 @@
+import {useRef} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import ReplayTimeline from 'sentry/components/replays/breadcrumbs/replayTimeline';
+import {PlayerScrubber} from 'sentry/components/replays/player/scrubber';
+import useScrubberMouseTracking from 'sentry/components/replays/player/useScrubberMouseTracking';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {formatTime} from 'sentry/components/replays/utils';
+import {IconAdd, IconSubtract} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+type TimeAndScrubberGridProps = {
+  isCompact?: boolean;
+  showZoom?: boolean;
+};
+
+function TimelineSizeBar() {
+  const {timelineScale, setTimelineScale, durationMs} = useReplayContext();
+  const maxScale = durationMs ? Math.ceil(durationMs / 60000) : 10;
+
+  return (
+    <ButtonBar>
+      <Button
+        size="xs"
+        title={t('Zoom out')}
+        icon={<IconSubtract />}
+        borderless
+        onClick={() => setTimelineScale(Math.max(timelineScale - 1, 1))}
+        aria-label={t('Zoom out')}
+        disabled={timelineScale === 1}
+      />
+      <span style={{padding: `0 ${space(0.5)}`}}>
+        {timelineScale}
+        {t('x')}
+      </span>
+      <Button
+        size="xs"
+        title={t('Zoom in')}
+        icon={<IconAdd />}
+        borderless
+        onClick={() => setTimelineScale(Math.min(timelineScale + 1, maxScale))}
+        aria-label={t('Zoom in')}
+        disabled={timelineScale === maxScale}
+      />
+    </ButtonBar>
+  );
+}
+
+function TimeAndScrubberGrid({
+  isCompact = false,
+  showZoom = false,
+}: TimeAndScrubberGridProps) {
+  const {currentTime, startTimeOffsetMs, durationMs} = useReplayContext();
+  const elem = useRef<HTMLDivElement>(null);
+  const mouseTrackingProps = useScrubberMouseTracking({elem});
+
+  return (
+    <Grid id="replay-timeline-player" isCompact={isCompact}>
+      <Time style={{gridArea: 'currentTime'}}>
+        {formatTime(currentTime - startTimeOffsetMs)}
+      </Time>
+      <div style={{gridArea: 'timeline'}}>
+        <ReplayTimeline />
+      </div>
+      <div style={{gridArea: 'timelineSize', fontVariantNumeric: 'tabular-nums'}}>
+        {showZoom ? <TimelineSizeBar /> : null}
+      </div>
+      <StyledScrubber style={{gridArea: 'scrubber'}} ref={elem} {...mouseTrackingProps}>
+        <PlayerScrubber showZoomIndicators={showZoom} />
+      </StyledScrubber>
+      <Time style={{gridArea: 'duration'}}>
+        {durationMs ? formatTime(durationMs) : '--:--'}
+      </Time>
+    </Grid>
+  );
+}
+
+export const Grid = styled('div')<{isCompact: boolean}>`
+  width: 100%;
+  display: grid;
+  grid-template-areas:
+    '. timeline timelineSize'
+    'currentTime scrubber duration';
+  grid-column-gap: ${space(1)};
+  grid-template-columns: max-content auto max-content;
+  align-items: center;
+  ${p =>
+    p.isCompact
+      ? `
+        order: -1;
+        min-width: 100%;
+        margin-top: -8px;
+      `
+      : ''}
+`;
+
+const StyledScrubber = styled('div')`
+  height: 32px;
+  display: flex;
+  align-items: center;
+`;
+
+const Time = styled('span')`
+  font-variant-numeric: tabular-nums;
+  padding: 0 ${space(1.5)};
+`;
+
+export default TimeAndScrubberGrid;

--- a/static/app/components/replays/timeAndScrubberGrid.tsx
+++ b/static/app/components/replays/timeAndScrubberGrid.tsx
@@ -78,7 +78,7 @@ function TimeAndScrubberGrid({
   );
 }
 
-export const Grid = styled('div')<{isCompact: boolean}>`
+const Grid = styled('div')<{isCompact: boolean}>`
   width: 100%;
   display: grid;
   grid-template-areas:


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/63157

Adds a new `ReplayClipPreview` which replaces the old `ReplayPreview` on the issue details page when the flag `organizations:issue-details-inline-replay-viewer` is enabled (and you have the new issue experience toggle).

Note that the fullscreen view isn't finished yet. That will be done in a followup PR.

https://github.com/getsentry/sentry/assets/10888943/571f9333-e4e8-425f-bea6-fb771b4245a4

