### PR TITLE
feat(superuser): assign readonly scopes

### DIFF
--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -76,9 +76,12 @@ SUPERUSER_READONLY_SCOPES = settings.SENTRY_READONLY_SCOPES.union({"org:superuse
 
 def get_superuser_scopes(auth_state: RpcAuthState, member: Any | OrganizationMember | None):
     superuser_scopes = SUPERUSER_SCOPES
-    if not is_self_hosted() and features.has("auth:enterprise-superuser-read-write", member):
-        if "superuser.write" not in auth_state.permissions:
-            superuser_scopes = SUPERUSER_READONLY_SCOPES
+    if (
+        not is_self_hosted()
+        and features.has("auth:enterprise-superuser-read-write", member)
+        and "superuser.write" not in auth_state.permissions
+    ):
+        superuser_scopes = SUPERUSER_READONLY_SCOPES
 
     return superuser_scopes
 

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import ipaddress
 import logging
 from datetime import datetime, timedelta
-from typing import Tuple
+from typing import Any, Tuple
 
 from django.conf import settings
 from django.core.signing import BadSignature
@@ -22,9 +22,12 @@ from django.utils import timezone
 from django.utils.crypto import constant_time_compare, get_random_string
 from rest_framework import serializers, status
 
+from sentry import features
 from sentry.api.exceptions import SentryAPIException
 from sentry.auth.elevated_mode import ElevatedMode, InactiveReason
 from sentry.auth.system import is_system_auth
+from sentry.models.organizationmember import OrganizationMember
+from sentry.services.hybrid_cloud.auth.model import RpcAuthState
 from sentry.utils import json, metrics
 from sentry.utils.auth import has_completed_sso
 from sentry.utils.settings import is_self_hosted
@@ -66,9 +69,21 @@ UNSET = object()
 
 ENABLE_SU_UPON_LOGIN_FOR_LOCAL_DEV = getattr(settings, "ENABLE_SU_UPON_LOGIN_FOR_LOCAL_DEV", False)
 
+SUPERUSER_SCOPES = settings.SENTRY_SCOPES.union({"org:superuser"})
+
+SUPERUSER_READONLY_SCOPES = settings.SENTRY_READONLY_SCOPES.union({"org:superuser"})
+
+
+def get_superuser_scopes(auth_state: RpcAuthState, member: Any | OrganizationMember | None):
+    superuser_scopes = SUPERUSER_SCOPES
+    if not is_self_hosted() and features.has("auth:enterprise-superuser-read-write", member):
+        if "superuser.write" not in auth_state.permissions:
+            superuser_scopes = SUPERUSER_READONLY_SCOPES
+
+    return superuser_scopes
+
 
 def is_active_superuser(request):
-    breakpoint()
     if is_system_auth(getattr(request, "auth", None)):
         return True
     su = getattr(request, "superuser", None) or Superuser(request)

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -68,6 +68,7 @@ ENABLE_SU_UPON_LOGIN_FOR_LOCAL_DEV = getattr(settings, "ENABLE_SU_UPON_LOGIN_FOR
 
 
 def is_active_superuser(request):
+    breakpoint()
     if is_system_auth(getattr(request, "auth", None)):
         return True
     su = getattr(request, "superuser", None) or Superuser(request)

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
 
 from sentry.auth import access
-from sentry.auth.access import Access, NoAccess
+from sentry.auth.access import SUPERUSER_SCOPES, Access, NoAccess
 from sentry.auth.providers.dummy import DummyProvider
 from sentry.constants import ObjectStatus
 from sentry.models.apikey import ApiKey
@@ -537,6 +537,13 @@ class FromRequestTest(AccessFactoryTestCase):
         request = self.make_request(user=self.superuser, is_superuser=True)
         result = self.from_request(request)
         assert result.has_permission("test.permission")
+
+    @patch("sentry.auth.access.is_active_superuser", return_value=True)
+    def test_superuser_active_scopes(self, mock_is_active_superuser):
+        request = self.make_request(user=self.superuser, is_superuser=True)
+
+        result = self.from_request(request)
+        assert result.scopes == SUPERUSER_SCOPES
 
     def test_superuser_in_organization(self):
         self.create_member(

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -542,7 +542,7 @@ class FromRequestTest(AccessFactoryTestCase):
 
     @patch("sentry.auth.access.is_active_superuser", return_value=True)
     def test_superuser_in_organization_scopes(self, mock_is_active_superuser):
-        request = self.make_request(user=self.superuser, is_superuser=True)
+        request = self.make_request(user=self.superuser)
 
         # needs org in request in order to assign any scopes
         result = self.from_request(request, self.org)
@@ -552,7 +552,7 @@ class FromRequestTest(AccessFactoryTestCase):
     @override_settings(SENTRY_SELF_HOSTED=False)
     @patch("sentry.auth.access.is_active_superuser", return_value=True)
     def test_superuser_in_organization_readonly_scopes(self, mock_is_active_superuser):
-        request = self.make_request(user=self.superuser, is_superuser=True)
+        request = self.make_request(user=self.superuser)
 
         # needs org in request in order to assign any scopes
         result = self.from_request(request, self.org)
@@ -565,7 +565,7 @@ class FromRequestTest(AccessFactoryTestCase):
         with assume_test_silo_mode(SiloMode.CONTROL):
             UserPermission.objects.create(user=self.superuser, permission="superuser.write")
 
-        request = self.make_request(user=self.superuser, is_superuser=True)
+        request = self.make_request(user=self.superuser)
 
         # needs org in request in order to assign any scopes
         result = self.from_request(request, self.org)

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -557,7 +557,8 @@ class FromRequestTest(AccessFactoryTestCase):
             result = self.from_request(request, self.org)
             assert result.scopes == SUPERUSER_READONLY_SCOPES
 
-            UserPermission.objects.create(user=self.superuser, permission="superuser.write")
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                UserPermission.objects.create(user=self.superuser, permission="superuser.write")
 
             result = self.from_request(request, self.org)
             assert result.scopes == SUPERUSER_SCOPES


### PR DESCRIPTION
Assign readonly scopes to a superuser user if all of the following conditions are met:

1. Superuser is active
2. The org is not self-hosted
3. The feature flag is on for the user
4. The user does not have `superuser.write` permission

For https://github.com/getsentry/team-enterprise/issues/39