### PR TITLE
ref(grouping): Pre-`get_hash_values` refactor

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -522,7 +522,6 @@ class EventManager:
         maybe_run_background_grouping(project, job)
 
         secondary_hashes = None
-        migrate_off_hierarchical = False
 
         if should_run_secondary_grouping(project):
             with metrics.timer("event_manager.secondary_grouping", tags=metric_tags):

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1515,12 +1515,12 @@ def _save_aggregate(
             span.set_tag("create_group_transaction.outcome", "no_group")
             metric_tags["create_group_transaction.outcome"] = "no_group"
 
-            all_hash_ids = [h.id for h in flat_grouphashes]
+            all_grouphash_ids = [h.id for h in flat_grouphashes]
             if root_hierarchical_grouphash is not None:
-                all_hash_ids.append(root_hierarchical_grouphash.id)
+                all_grouphash_ids.append(root_hierarchical_grouphash.id)
 
             all_grouphashes = list(
-                GroupHash.objects.filter(id__in=all_hash_ids).select_for_update()
+                GroupHash.objects.filter(id__in=all_grouphash_ids).select_for_update()
             )
 
             flat_grouphashes = [gh for gh in all_grouphashes if gh.hash in hashes.hashes]

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1519,9 +1519,11 @@ def _save_aggregate(
             if root_hierarchical_grouphash is not None:
                 all_hash_ids.append(root_hierarchical_grouphash.id)
 
-            all_hashes = list(GroupHash.objects.filter(id__in=all_hash_ids).select_for_update())
+            all_grouphashes = list(
+                GroupHash.objects.filter(id__in=all_hash_ids).select_for_update()
+            )
 
-            flat_grouphashes = [gh for gh in all_hashes if gh.hash in hashes.hashes]
+            flat_grouphashes = [gh for gh in all_grouphashes if gh.hash in hashes.hashes]
 
             existing_grouphash, root_hierarchical_hash = find_existing_grouphash(
                 project, flat_grouphashes, hashes.hierarchical_hashes

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -574,16 +574,6 @@ class EventManager:
         # count to get an average number of calculations per event
         metrics.incr("grouping.hashes_calculated", amount=2 if secondary_hashes else 1)
 
-        # Because this logic is not complex enough we want to special case the situation where we
-        # migrate from a hierarchical hash to a non hierarchical hash.  The reason being that
-        # `_save_aggregate` needs special logic to not create orphaned hashes in migration cases
-        # but it wants a different logic to implement splitting of hierarchical hashes.
-        migrate_off_hierarchical = bool(
-            secondary_hashes
-            and secondary_hashes.hierarchical_hashes
-            and not primary_hashes.hierarchical_hashes
-        )
-
         all_hashes = CalculatedHashes(
             hashes=list(primary_hashes.hashes)
             + list(secondary_hashes and secondary_hashes.hashes or []),
@@ -600,6 +590,16 @@ class EventManager:
 
         if all_hashes.tree_labels:
             job["finest_tree_label"] = all_hashes.finest_tree_label
+
+        # Because this logic is not complex enough we want to special case the situation where we
+        # migrate from a hierarchical hash to a non hierarchical hash.  The reason being that
+        # `_save_aggregate` needs special logic to not create orphaned hashes in migration cases
+        # but it wants a different logic to implement splitting of hierarchical hashes.
+        migrate_off_hierarchical = bool(
+            secondary_hashes
+            and secondary_hashes.hierarchical_hashes
+            and not primary_hashes.hierarchical_hashes
+        )
 
         _materialize_metadata_many(jobs)
 

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -174,12 +174,10 @@ def _calculate_background_grouping(
 
 
 def should_run_secondary_grouping(project: Project) -> bool:
-    result = False
     secondary_grouping_config = project.get_option("sentry:secondary_grouping_config")
     secondary_grouping_expiry = project.get_option("sentry:secondary_grouping_expiry")
-    if secondary_grouping_config and (secondary_grouping_expiry or 0) >= time.time():
-        result = True
-    return result
+
+    return secondary_grouping_config and (secondary_grouping_expiry or 0) >= time.time()
 
 
 def calculate_secondary_hash(


### PR DESCRIPTION
This includes a number of small fixes pulled from a more substantive upcoming PR, in order to make that one easier to review. Specifically:

- In `save_error_events`, we reuse the name `hashes` at two points in the function. This renames both to make the purpose of each one clearer.
- In `_save_aggregate`, we conflate hash values and `GroupHash` objects in our naming of variables. This fixes that.
- `migrate_off_hierarchical` will eventually go away, and so I'm going to leave it out of the new helper function I'm creating. This moves it so that all code for that helper is grouped.
- As suggested by @vartec [here](https://github.com/getsentry/sentry/pull/62887#discussion_r1464136958), this simplifies `should_run_secondary_grouping` to not use an unnecessary `result` variable.