### PR TITLE
ref(tx-clusterer): Increase soft limit timeout to 0.3s/project

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -36,7 +36,7 @@ PROJECTS_PER_TASK = 100
 #: Estimated limit for a clusterer run per project, in seconds.
 #: NOTE: using this in a per-project basis may not be enough. Consider using
 #: this estimation for project batches instead.
-CLUSTERING_TIMEOUT_PER_PROJECT = 0.15
+CLUSTERING_TIMEOUT_PER_PROJECT = 0.3
 
 
 @instrumented_task(


### PR DESCRIPTION
There has been an [increase of soft limit timeouts](https://sentry.sentry.io/issues/4217650707/) in the transaction clusterer task, resulting in an [increase of missed projects](https://sentry.sentry.io/issues/4515145465/).

This PR bumps the soft limit timeout from 0.15 to 0.3 seconds per project. Since tasks run batches of 100 projects, the maximum task duration is 30s (+2s for the hard limit), which is still acceptable. This new limit should avoid these issues for a while.