### PR TITLE
feat(ddm): Implement a new op-based system for changing metrics visibility

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -1,3 +1,6 @@
+from enum import Enum
+from typing import Optional, Sequence
+
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,6 +13,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import get_date_range_from_params
 from sentry.exceptions import InvalidParams
+from sentry.models.project import Project
 from sentry.sentry_metrics.querying.api import run_metrics_query
 from sentry.sentry_metrics.querying.errors import (
     InvalidMetricsQueryError,
@@ -18,11 +22,7 @@ from sentry.sentry_metrics.querying.errors import (
 )
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.sentry_metrics.utils import string_to_use_case_id
-from sentry.sentry_metrics.visibility import (
-    BlockedMetric,
-    MalformedBlockedMetricsPayloadError,
-    block_metric,
-)
+from sentry.sentry_metrics.visibility import MalformedBlockedMetricsPayloadError
 from sentry.snuba.metrics import (
     QueryDefinition,
     get_all_tags,
@@ -53,10 +53,38 @@ def get_use_case_id(request: Request) -> UseCaseID:
         )
 
 
+class MetricOperationType(Enum):
+    BLOCK_METRIC = "blockMetric"
+    BLOCK_TAGS = "blockTags"
+    UNBLOCK_METRIC = "unblockMetric"
+    UNBLOCK_TAGS = "unblockTags"
+
+    @classmethod
+    def from_request(cls, request: Request) -> Optional["MetricOperationType"]:
+        operation_type = request.data.get("operationType")
+        if not operation_type:
+            return None
+
+        for operation in cls:
+            if operation.value == operation_type:
+                return operation
+
+        return None
+
+    @classmethod
+    def available_ops(cls) -> Sequence[str]:
+        return [operation.value for operation in cls]
+
+
 @region_silo_endpoint
 class OrganizationMetricsEndpoint(OrganizationEndpoint):
-    publish_status = {"GET": ApiPublishStatus.EXPERIMENTAL, "POST": ApiPublishStatus.EXPERIMENTAL}
+    publish_status = {"GET": ApiPublishStatus.EXPERIMENTAL, "PUT": ApiPublishStatus.EXPERIMENTAL}
     owner = ApiOwner.TELEMETRY_EXPERIENCE
+
+    def _handle_by_operation_type(
+        self, request: Request, project: Project, metric_operation_type: MetricOperationType
+    ):
+        pass
 
     def get(self, request: Request, organization) -> Response:
         projects = self.get_projects(request, organization)
@@ -67,27 +95,25 @@ class OrganizationMetricsEndpoint(OrganizationEndpoint):
 
         return Response(metrics, status=200)
 
-    def post(self, request: Request, organization) -> Response:
+    def put(self, request: Request, organization) -> Response:
         projects = self.get_projects(request, organization)
-        if not projects:
+        if len(projects) != 1:
+            raise InvalidParams("You can only apply an operation on a metric on a single project")
+
+        metric_operation_type = MetricOperationType.from_request(request)
+        if not metric_operation_type:
             raise InvalidParams(
-                "You must supply at least one projects of which metrics will be blocked"
+                f"You must supply a valid operation, which must be one of {MetricOperationType.available_ops()}"
             )
 
-        metrics = request.data.get("metrics", [])
-        if not metrics:
-            raise InvalidParams("You must supply at least one metric to block")
-
-        for metric in metrics:
-            try:
-                blocked_metric = BlockedMetric(metric_mri=metric, tags=request.GET.getlist("tag"))
-                block_metric(blocked_metric, projects)
-            except MalformedBlockedMetricsPayloadError:
-                # In case one metric fails to be inserted, we abort the entire insertion since the project options are
-                # likely to be corrupted.
-                return Response(
-                    {"detail": "The blocked metrics settings are corrupted, try again"}, status=500
-                )
+        try:
+            self._handle_by_operation_type(request, projects[0], metric_operation_type)
+        except MalformedBlockedMetricsPayloadError:
+            # In case one metric fails to be inserted, we abort the entire insertion since the project options are
+            # likely to be corrupted.
+            return Response(
+                {"detail": "The blocked metrics settings are corrupted, try again"}, status=500
+            )
 
         return Response(status=200)
 

--- a/src/sentry/sentry_metrics/visibility/__init__.py
+++ b/src/sentry/sentry_metrics/visibility/__init__.py
@@ -1,15 +1,19 @@
 from .errors import MalformedBlockedMetricsPayloadError
 from .metrics_blocking import (
-    BlockedMetric,
     block_metric,
+    block_tags_of_metric,
     get_blocked_metrics,
     get_blocked_metrics_for_relay_config,
+    unblock_metric,
+    unblock_tags_of_metric,
 )
 
 __all__ = [
     "block_metric",
+    "block_tags_of_metric",
+    "unblock_metric",
+    "unblock_tags_of_metric",
     "get_blocked_metrics",
     "get_blocked_metrics_for_relay_config",
-    "BlockedMetric",
     "MalformedBlockedMetricsPayloadError",
 ]

--- a/src/sentry/sentry_metrics/visibility/metrics_blocking.py
+++ b/src/sentry/sentry_metrics/visibility/metrics_blocking.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, TypedDict
+from typing import Any, Dict, Mapping, Optional, Sequence, Set, TypedDict
 
 import sentry_sdk
 
@@ -15,9 +15,26 @@ class BlockedMetricsRelayConfig(TypedDict):
 
 
 @dataclass(frozen=True)
+class MetricOperation:
+    metric_mri: str
+    block_tags: Set[str]
+    unblock_tags: Set[str]
+    # This can be None, since if it is None, it implies that no state change will be applied to the metric.
+    block_metric: Optional[bool] = None
+
+    def to_blocked_metric(self) -> "BlockedMetric":
+        return BlockedMetric(
+            metric_mri=self.metric_mri,
+            is_blocked=self.block_metric is True,
+            blocked_tags=self.block_tags,
+        )
+
+
+@dataclass(frozen=True)
 class BlockedMetric:
     metric_mri: str
-    tags: Set[str]
+    is_blocked: bool
+    blocked_tags: Set[str]
 
     @classmethod
     def from_dict(cls, dictionary: Mapping[str, Any]) -> Optional["BlockedMetric"]:
@@ -25,11 +42,20 @@ class BlockedMetric:
             return None
 
         return BlockedMetric(
-            metric_mri=dictionary["metric_mri"], tags=set(dictionary.get("tags") or [])
+            metric_mri=dictionary["metric_mri"],
+            is_blocked=dictionary["is_blocked"],
+            blocked_tags=set(dictionary.get("blocked_tags") or []),
         )
 
-    def merge(self, other: "BlockedMetric") -> "BlockedMetric":
-        return BlockedMetric(metric_mri=self.metric_mri, tags=self.tags.union(other.tags))
+    def apply(self, other: MetricOperation) -> "BlockedMetric":
+        return BlockedMetric(
+            metric_mri=self.metric_mri,
+            is_blocked=other.block_metric if other.block_metric is not None else self.is_blocked,
+            blocked_tags=self.blocked_tags.union(other.block_tags) - other.unblock_tags,
+        )
+
+    def is_useless(self):
+        return not self.is_blocked and not self.blocked_tags
 
     def to_dict(self) -> Mapping[str, Any]:
         return self.__dict__
@@ -37,13 +63,14 @@ class BlockedMetric:
 
 @dataclass
 class BlockedMetrics:
-    metrics: List[BlockedMetric]
+    # We store the data in a map keyed by the metric_mri in order to make the merging of `BlockedMetric`(s) easier.
+    metrics: Dict[str, BlockedMetric]
 
     @classmethod
     def load_from_project(cls, project: Project, repair: bool = False) -> "BlockedMetrics":
         json_payload = project.get_option(BLOCKED_METRICS_PROJECT_OPTION_KEY)
         if not json_payload:
-            return BlockedMetrics(metrics=[])
+            return BlockedMetrics(metrics={})
 
         try:
             blocked_metrics_payload = json.loads(json_payload)
@@ -63,36 +90,78 @@ class BlockedMetrics:
                 f"The blocked metrics payload is not a list for {project.id}"
             )
 
-        blocked_metrics = []
-        for blocked_metric in blocked_metrics_payload:
-            blocked_metric_obj = BlockedMetric.from_dict(blocked_metric)
-            # We want to implement a best effort mechanism in which we will notify Sentry in case of invalid blocked
-            # metrics, but this won't have effect on the other metrics.
-            if blocked_metric_obj is not None:
-                blocked_metrics.append(blocked_metric_obj)
+        blocked_metrics: Dict[str, BlockedMetric] = {}
+        for blocked_metric_payload in blocked_metrics_payload:
+            blocked_metric = BlockedMetric.from_dict(blocked_metric_payload)
+            # When reading we deduplicate by taking the last version of a blocking.
+            blocked_metrics[blocked_metric.metric_mri] = blocked_metric
 
-        return BlockedMetrics(metrics=blocked_metrics)._merge_blocked_metrics()
-
-    def _merge_blocked_metrics(self) -> "BlockedMetrics":
-        metrics_map: Dict[str, BlockedMetric] = {}
-        for metric in self.metrics:
-            if (duplicated_metric := metrics_map.get(metric.metric_mri)) is not None:
-                metrics_map[metric.metric_mri] = metric.merge(duplicated_metric)
-            else:
-                metrics_map[metric.metric_mri] = metric
-
-        self.metrics = list(metrics_map.values())
-        return self
+        return BlockedMetrics(metrics=blocked_metrics)
 
     def save_to_project(self, project: Project):
-        self._merge_blocked_metrics()
-        blocked_metrics_payload = [blocked_metric.to_dict() for blocked_metric in self.metrics]
+        # We store the payload as a list of objects to give us more flexibility, since if we were to store a dict keyed
+        # by the mri, we would need a migration of the options in case something in the data changes.
+        blocked_metrics_payload = [
+            blocked_metric.to_dict() for blocked_metric in self.metrics.values()
+        ]
         json_payload = json.dumps(blocked_metrics_payload)
         project.update_option(BLOCKED_METRICS_PROJECT_OPTION_KEY, json_payload)
 
-    def add_blocked_metric(self, blocked_metric: BlockedMetric) -> "BlockedMetrics":
-        self.metrics.append(blocked_metric)
-        return self
+    def apply_metric_operation(self, metric_operation: MetricOperation):
+        metric_mri = metric_operation.metric_mri
+        if (existing_metric := self.metrics.get(metric_mri)) is not None:
+            blocked_metric = existing_metric.apply(metric_operation)
+            # If the new blocked metric is useless, we will just delete it from the dictionary since it's not
+            # needed. For example, if you unblock all tags from a metric, when applying the operation we will delete
+            # the actual entry, whereas if you block a new tag, we will update the entry with the new one.
+            if blocked_metric.is_useless():
+                del self.metrics[metric_mri]
+            else:
+                self.metrics[metric_mri] = blocked_metric
+        else:
+            blocked_metric = metric_operation.to_blocked_metric()
+            # If the merged blocked metric can't be cleared, it means that it will have an actual effect on metrics
+            # ingestion, thus we add it to the dictionary. For example, if you block a new metric we will add it but if
+            # you pass an operation that doesn't do anything we won't even apply the update.
+            if not blocked_metric.is_useless():
+                self.metrics[metric_mri] = metric_operation.to_blocked_metric()
+
+
+def _apply_operation(metric_operation: MetricOperation, projects: Sequence[Project]):
+    for project in projects:
+        blocked_metrics = BlockedMetrics.load_from_project(project=project, repair=True)
+        blocked_metrics.apply_metric_operation(metric_operation=metric_operation)
+        blocked_metrics.save_to_project(project=project)
+
+
+def block_metric(metric_mri: str, projects: Sequence[Project]):
+    _apply_operation(
+        MetricOperation(
+            metric_mri=metric_mri, block_metric=True, block_tags=set(), unblock_tags=set()
+        ),
+        projects,
+    )
+
+
+def unblock_metric(metric_mri: str, projects: Sequence[Project]):
+    _apply_operation(
+        MetricOperation(
+            metric_mri=metric_mri, block_metric=False, block_tags=set(), unblock_tags=set()
+        ),
+        projects,
+    )
+
+
+def block_tags_of_metric(metric_mri: str, tags: Set[str], projects: Sequence[Project]):
+    _apply_operation(
+        MetricOperation(metric_mri=metric_mri, block_tags=tags, unblock_tags=set()), projects
+    )
+
+
+def unblock_tags_of_metric(metric_mri: str, tags: Set[str], projects: Sequence[Project]):
+    _apply_operation(
+        MetricOperation(metric_mri=metric_mri, block_tags=set(), unblock_tags=tags), projects
+    )
 
 
 def get_blocked_metrics(projects: Sequence[Project]) -> Mapping[int, BlockedMetrics]:
@@ -115,14 +184,12 @@ def get_blocked_metrics_for_relay_config(project: Project) -> BlockedMetricsRela
         # situation, unless we want to force overwrite the config.
         return BlockedMetricsRelayConfig(deniedNames=[])
 
+    # For now, we just return the metric mris of the blocked metrics. Once tags are supported in Relay, we will return
+    # also the blocked tags for the metric.
     return BlockedMetricsRelayConfig(
-        deniedNames=[blocked_metric.metric_mri for blocked_metric in blocked_metrics.metrics]
+        deniedNames=[
+            blocked_metric.metric_mri
+            for blocked_metric in blocked_metrics.metrics.values()
+            if blocked_metric.is_blocked
+        ]
     )
-
-
-def block_metric(blocked_metric: BlockedMetric, projects: Sequence[Project]):
-    for project in projects:
-        # We want to repair the settings in case of issues only when writing data.
-        BlockedMetrics.load_from_project(project=project, repair=True).add_blocked_metric(
-            blocked_metric=blocked_metric
-        ).save_to_project(project=project)

--- a/src/sentry/sentry_metrics/visibility/metrics_blocking.py
+++ b/src/sentry/sentry_metrics/visibility/metrics_blocking.py
@@ -93,8 +93,9 @@ class BlockedMetrics:
         blocked_metrics: Dict[str, BlockedMetric] = {}
         for blocked_metric_payload in blocked_metrics_payload:
             blocked_metric = BlockedMetric.from_dict(blocked_metric_payload)
-            # When reading we deduplicate by taking the last version of a blocking.
-            blocked_metrics[blocked_metric.metric_mri] = blocked_metric
+            if blocked_metric is not None:
+                # When reading we deduplicate by taking the last version of a blocking.
+                blocked_metrics[blocked_metric.metric_mri] = blocked_metric
 
         return BlockedMetrics(metrics=blocked_metrics)
 

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -283,8 +283,9 @@ class TagValue(TypedDict):
 
 
 class BlockedMetric(TypedDict):
-    projectId: int
+    isBlocked: bool
     blockedTags: Sequence[str]
+    projectId: int
 
 
 class MetricMeta(TypedDict):

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from sentry.models.apitoken import ApiToken
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.sentry_metrics.visibility import BlockedMetric, block_metric, get_blocked_metrics
+from sentry.sentry_metrics.visibility import block_metric, block_tags_of_metric, get_blocked_metrics
 from sentry.silo import SiloMode
 from sentry.snuba.metrics import (
     DERIVED_METRICS,
@@ -131,7 +131,8 @@ class OrganizationMetricsTest(OrganizationMetricsIntegrationTestCase):
         project_1 = self.create_project()
         project_2 = self.create_project()
 
-        block_metric(BlockedMetric("s:custom/user@none", set()), [project_1])
+        block_metric("s:custom/user@none", [project_1])
+        block_tags_of_metric("d:custom/page_load@millisecond", {"release"}, [project_2])
 
         metrics = (
             ("s:custom/user@none", "set", project_1),
@@ -159,13 +160,17 @@ class OrganizationMetricsTest(OrganizationMetricsIntegrationTestCase):
         data = sorted(response.data, key=lambda d: d["mri"])
         assert data[0]["mri"] == "c:custom/clicks@none"
         assert data[0]["project_ids"] == [project_1.id]
-        assert data[0]["blockedForProjects"] == []
+        assert data[0]["blockingStatus"] == []
         assert data[1]["mri"] == "d:custom/page_load@millisecond"
         assert data[1]["project_ids"] == [project_2.id]
-        assert data[1]["blockedForProjects"] == []
+        assert data[1]["blockingStatus"] == [
+            {"isBlocked": False, "blockedTags": ["release"], "projectId": project_2.id}
+        ]
         assert data[2]["mri"] == "s:custom/user@none"
         assert sorted(data[2]["project_ids"]) == sorted([project_1.id, project_2.id])
-        assert data[2]["blockedForProjects"] == [{"blockedTags": [], "projectId": project_1.id}]
+        assert data[2]["blockingStatus"] == [
+            {"isBlocked": True, "blockedTags": [], "projectId": project_1.id}
+        ]
 
     def test_block_metric(self):
         metrics = ["s:custom/user@none", "c:custom/clicks@none"]

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -173,10 +173,61 @@ class OrganizationMetricsTest(OrganizationMetricsIntegrationTestCase):
         ]
 
     def test_block_metric(self):
-        metrics = ["s:custom/user@none", "c:custom/clicks@none"]
+        response = self.get_success_response(
+            self.organization.slug,
+            method="PUT",
+            project=[self.project.id],
+            operationType="blockMetric",
+            metric_mri="s:custom/user@none",
+        )
+
+        assert response.status_code == 200
+        assert len(get_blocked_metrics([self.project])[self.project.id].metrics) == 1
 
         response = self.get_success_response(
-            self.organization.slug, method="POST", project=[self.project.id], metrics=metrics
+            self.organization.slug,
+            method="PUT",
+            project=[self.project.id],
+            operationType="unblockMetric",
+            metric_mri="s:custom/user@none",
         )
+
         assert response.status_code == 200
-        assert len(get_blocked_metrics([self.project])[self.project.id].metrics) == 2
+        assert len(get_blocked_metrics([self.project])[self.project.id].metrics) == 0
+
+    def test_block_metric_tag(self):
+        response = self.get_success_response(
+            self.organization.slug,
+            method="PUT",
+            project=[self.project.id],
+            operationType="blockTags",
+            metric_mri="s:custom/user@none",
+            tags=["release", "transaction"],
+        )
+
+        assert response.status_code == 200
+        assert len(get_blocked_metrics([self.project])[self.project.id].metrics) == 1
+
+        response = self.get_success_response(
+            self.organization.slug,
+            method="PUT",
+            project=[self.project.id],
+            operationType="unblockTags",
+            metric_mri="s:custom/user@none",
+            tags=["transaction"],
+        )
+
+        assert response.status_code == 200
+        assert len(get_blocked_metrics([self.project])[self.project.id].metrics) == 1
+
+        response = self.get_success_response(
+            self.organization.slug,
+            method="PUT",
+            project=[self.project.id],
+            operationType="unblockTags",
+            metric_mri="s:custom/user@none",
+            tags=["release"],
+        )
+
+        assert response.status_code == 200
+        assert len(get_blocked_metrics([self.project])[self.project.id].metrics) == 0

--- a/tests/sentry/sentry_metrics/querying/visibility/test_metrics_blocking.py
+++ b/tests/sentry/sentry_metrics/querying/visibility/test_metrics_blocking.py
@@ -1,50 +1,112 @@
-from typing import Set, Tuple
-
 import pytest
 
 from sentry.sentry_metrics.visibility import (
-    BlockedMetric,
     MalformedBlockedMetricsPayloadError,
     block_metric,
     get_blocked_metrics,
     get_blocked_metrics_for_relay_config,
 )
-from sentry.sentry_metrics.visibility.metrics_blocking import BLOCKED_METRICS_PROJECT_OPTION_KEY
+from sentry.sentry_metrics.visibility.metrics_blocking import (
+    BLOCKED_METRICS_PROJECT_OPTION_KEY,
+    BlockedMetric,
+    block_tags_of_metric,
+    unblock_metric,
+    unblock_tags_of_metric,
+)
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json
 
 
 @django_db_all
-def test_block_metric(default_project):
-    data: Tuple[Tuple[str, Set[str]], ...] = (
-        ("c:custom/page_click@none", set()),
-        # We test with duplicated tags.
-        ("c:custom/page_click@none", {"release", "release"}),
-        ("g:custom/page_load@millisecond", set()),
+def test_apply_multiple_operations(default_project):
+    mri_1 = "c:custom/page_click@none"
+    mri_2 = "g:custom/page_load@millisecond"
+
+    # We block a single metric.
+    block_metric(mri_1, [default_project])
+
+    blocked_metrics = sorted(
+        json.loads(default_project.get_option(BLOCKED_METRICS_PROJECT_OPTION_KEY)),
+        key=lambda v: v["metric_mri"],
     )
-    for mri, tags in data:
-        block_metric(BlockedMetric(metric_mri=mri, tags=set(tags)), [default_project])
+    assert len(blocked_metrics) == 1
+    assert blocked_metrics[0]["metric_mri"] == mri_1
+    assert blocked_metrics[0]["is_blocked"] is True
+    assert blocked_metrics[0]["blocked_tags"] == []
+
+    # We block tags of a blocked metric.
+    block_tags_of_metric(mri_1, {"release", "transaction", "release"}, [default_project])
 
     blocked_metrics = json.loads(default_project.get_option(BLOCKED_METRICS_PROJECT_OPTION_KEY))
-    assert sorted(blocked_metrics, key=lambda v: v["metric_mri"]) == [
-        {"metric_mri": data[0][0], "tags": ["release"]},
-        {"metric_mri": data[2][0], "tags": []},
-    ]
+    assert len(blocked_metrics) == 1
+    assert blocked_metrics[0]["metric_mri"] == mri_1
+    assert blocked_metrics[0]["is_blocked"] is True
+    assert sorted(blocked_metrics[0]["blocked_tags"]) == ["release", "transaction"]
+
+    # We unblock a tag of a blocked metric.
+    unblock_tags_of_metric(mri_1, {"transaction"}, [default_project])
+
+    blocked_metrics = json.loads(default_project.get_option(BLOCKED_METRICS_PROJECT_OPTION_KEY))
+    assert len(blocked_metrics) == 1
+    assert blocked_metrics[0]["metric_mri"] == mri_1
+    assert blocked_metrics[0]["is_blocked"]
+    assert sorted(blocked_metrics[0]["blocked_tags"]) == ["release"]
+
+    # We block tags of an unblocked metric.
+    block_tags_of_metric(mri_2, {"environment", "transaction"}, [default_project])
+
+    blocked_metrics = json.loads(default_project.get_option(BLOCKED_METRICS_PROJECT_OPTION_KEY))
+    assert len(blocked_metrics) == 2
+    assert blocked_metrics[0]["metric_mri"] == mri_1
+    assert blocked_metrics[0]["is_blocked"] is True
+    assert sorted(blocked_metrics[0]["blocked_tags"]) == ["release"]
+    assert blocked_metrics[1]["metric_mri"] == mri_2
+    assert blocked_metrics[1]["is_blocked"] is False
+    assert sorted(blocked_metrics[1]["blocked_tags"]) == ["environment", "transaction"]
+
+    # We unblock all the tags of an unblocked metric.
+    unblock_tags_of_metric(mri_2, {"environment", "transaction"}, [default_project])
+
+    blocked_metrics = json.loads(default_project.get_option(BLOCKED_METRICS_PROJECT_OPTION_KEY))
+    assert len(blocked_metrics) == 1
+    assert blocked_metrics[0]["metric_mri"] == mri_1
+    assert blocked_metrics[0]["is_blocked"] is True
+    assert sorted(blocked_metrics[0]["blocked_tags"]) == ["release"]
+
+    # We unblock a blocked metric with blocked tags.
+    unblock_metric(mri_1, [default_project])
+
+    blocked_metrics = json.loads(default_project.get_option(BLOCKED_METRICS_PROJECT_OPTION_KEY))
+    assert len(blocked_metrics) == 1
+    assert blocked_metrics[0]["metric_mri"] == mri_1
+    assert blocked_metrics[0]["is_blocked"] is False
+    assert sorted(blocked_metrics[0]["blocked_tags"]) == ["release"]
+
+    # We unblock all the tags of an unblocked metric.
+    unblock_tags_of_metric(mri_1, {"release", "transaction"}, [default_project])
+
+    blocked_metrics = json.loads(default_project.get_option(BLOCKED_METRICS_PROJECT_OPTION_KEY))
+    assert len(blocked_metrics) == 0
 
 
 @django_db_all
 def test_get_blocked_metrics(default_project):
-    data: Tuple[Tuple[str, Set[str]], ...] = (
-        ("c:custom/page_click@none", {"release", "release"}),
-        ("g:custom/page_load@millisecond", {"transaction"}),
-    )
-    for mri, tags in data:
-        block_metric(BlockedMetric(metric_mri=mri, tags=set(tags)), [default_project])
+    mri_1 = "c:custom/page_click@none"
+    mri_2 = "g:custom/page_load@millisecond"
+
+    block_metric(mri_1, [default_project])
+    block_tags_of_metric(mri_2, {"release", "environment", "transaction"}, [default_project])
 
     blocked_metrics = get_blocked_metrics([default_project])[default_project.id]
     assert len(blocked_metrics.metrics) == 2
-    assert blocked_metrics.metrics[0] == BlockedMetric(data[0][0], data[0][1])
-    assert blocked_metrics.metrics[1] == BlockedMetric(data[1][0], data[1][1])
+    assert sorted(blocked_metrics.metrics.values(), key=lambda v: v.metric_mri) == [
+        BlockedMetric(metric_mri="c:custom/page_click@none", is_blocked=True, blocked_tags=set()),
+        BlockedMetric(
+            metric_mri="g:custom/page_load@millisecond",
+            is_blocked=False,
+            blocked_tags={"environment", "transaction", "release"},
+        ),
+    ]
 
 
 @django_db_all
@@ -64,16 +126,14 @@ def test_get_blocked_metrics_with_invalid_payload(default_project, json_payload)
 
 @django_db_all
 def test_get_blocked_metrics_for_relay_config(default_project):
-    data = (
-        ("c:custom/page_click@none", {"release", "release"}),
-        ("g:custom/page_load@millisecond", {"transaction"}),
-    )
-    for mri, tags in data:
-        block_metric(BlockedMetric(metric_mri=mri, tags=set(tags)), [default_project])
+    mri_1 = "c:custom/page_click@none"
+    mri_2 = "g:custom/page_load@millisecond"
+
+    block_metric(mri_1, [default_project])
+    block_tags_of_metric(mri_2, {"release", "environment", "transaction"}, [default_project])
 
     blocked_metrics = get_blocked_metrics_for_relay_config(default_project)
-    # For now, no tags are emitted to Relay, even though they are supported by the backend.
+    # For now, no tags are emitted to Relay, thus we expect only the blocked metric to be there.
     assert sorted(blocked_metrics["deniedNames"]) == [
         "c:custom/page_click@none",
-        "g:custom/page_load@millisecond",
     ]


### PR DESCRIPTION
This PRs implements a way better mechanism to handle blocking of metrics as opposed to before. The previous implementation was faulty because it didn't distinguish between a metric being blocked and only the tags of the metric being blocked. The new system does this differentiation and is built with an op-based approach that makes state changes very easy from the outside.