### PR TITLE
feat(ddm): Serialize transaction metrics summary

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -292,12 +292,18 @@ class EventSerializer(Serializer):
         """
         Add attributes that are only present on transaction events.
         """
-        return {
+        transaction_attrs = {
             "startTimestamp": obj.data.get("start_timestamp"),
             "endTimestamp": obj.data.get("timestamp"),
             "measurements": obj.data.get("measurements"),
             "breakdowns": obj.data.get("breakdowns"),
         }
+
+        # The _ reflects the temporary nature of this field.
+        if (transaction_metrics_summary := obj.data.get("_metrics_summary")) is not None:
+            transaction_attrs["_metricsSummary"] = transaction_metrics_summary
+
+        return transaction_attrs
 
     def __serialize_error_attrs(self, attrs, obj):
         """

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -116,6 +116,7 @@ def load_data(
     trace_context=None,
     fingerprint=None,
     event_id=None,
+    metrics_summary=None,
 ):
     # NOTE: Before editing this data, make sure you understand the context
     # in which its being used. It is NOT only used for local development and
@@ -194,6 +195,9 @@ def load_data(
         else:
             start_timestamp = start_timestamp.replace(tzinfo=timezone.utc)
         data["start_timestamp"] = to_timestamp(start_timestamp)
+
+        if metrics_summary is not None:
+            data["_metrics_summary"] = metrics_summary
 
         if trace is None:
             trace = uuid4().hex

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -224,6 +224,29 @@ class EventSerializerTest(TestCase, OccurrenceTestMixin):
         assert "breakdowns" in result
         assert result["breakdowns"] == event_data["breakdowns"]
 
+    def test_transaction_event_with_metrics_summary(self):
+        metrics_summary = {
+            "d:custom/sentry.event_manager.get_event_instance@second": [
+                {
+                    "min": 10.0,
+                    "max": 20.0,
+                    "sum": 30.0,
+                    "count": 2,
+                    "tags": {
+                        "environment": "prod",
+                        "event_type": "default",
+                        "release": "backend",
+                        "result": "success",
+                        "transaction": "sentry.tasks.store.save_event",
+                    },
+                }
+            ]
+        }
+        event_data = load_data("transaction", metrics_summary=metrics_summary)
+        event = self.store_event(data=event_data, project_id=self.project.id)
+        result = serialize(event)
+        assert result["_metricsSummary"] == metrics_summary
+
     def test_transaction_event_empty_spans(self):
         event_data = load_data("transaction")
         event_data["spans"] = []


### PR DESCRIPTION
This PR returns the `_metrics_summary` of the transaction as `_metricsSummary` in the event payload.

Closes: https://github.com/getsentry/sentry/issues/63741