### PR TITLE
ref: remove unused INTEGRATION_DOC_FOLDER environment variable

### DIFF
--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -103,12 +103,9 @@ def pytest_configure(config: pytest.Config) -> None:
 
     # override docs which are typically synchronized from an upstream server
     # to ensure tests are consistent
-    os.environ.setdefault(
-        "INTEGRATION_DOC_FOLDER", os.path.join(TEST_ROOT, os.pardir, "fixtures", "integration-docs")
-    )
     from sentry.utils import integrationdocs
 
-    integrationdocs.DOC_FOLDER = os.environ["INTEGRATION_DOC_FOLDER"]
+    integrationdocs.DOC_FOLDER = os.path.join(TEST_ROOT, os.pardir, "fixtures", "integration-docs")
 
     configure_split_db()
 

--- a/src/sentry/utils/integrationdocs.py
+++ b/src/sentry/utils/integrationdocs.py
@@ -38,10 +38,7 @@ class Platform(TypedDict):
 INTEGRATION_DOCS_URL = os.environ.get("INTEGRATION_DOCS_URL", "https://docs.sentry.io/_platforms/")
 BASE_URL = INTEGRATION_DOCS_URL + "{}"
 
-# Also see INTEGRATION_DOC_FOLDER in setup.py
-DOC_FOLDER = os.environ.get("INTEGRATION_DOC_FOLDER") or os.path.abspath(
-    os.path.join(os.path.dirname(sentry.__file__), "integration-docs")
-)
+DOC_FOLDER = os.path.abspath(os.path.join(os.path.dirname(sentry.__file__), "integration-docs"))
 
 
 class SuspiciousDocPathOperation(Exception):


### PR DESCRIPTION
no need to set two globals!

<!-- Describe your PR here. -->