### PR TITLE
Only `load_grouping_config` once

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -454,7 +454,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
                 loaded_grouping_config = force_config
             else:
                 # A `GroupingConfig` dictionary
-                loaded_grouping_config = load_grouping_config(grouping_config)
+                loaded_grouping_config = load_grouping_config(force_config)
         # Otherwise we just use the same grouping config as stored.  if
         # this is None we use the project's default config.
         else:

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -443,6 +443,8 @@ class BaseEvent(metaclass=abc.ABCMeta):
         # config ID is given in which case it's merged with the stored or
         # default config dictionary
         if force_config is not None:
+            from sentry.grouping.strategies.base import StrategyConfiguration
+
             if isinstance(force_config, str):
                 # A string like `"mobile:2021-02-12"`
                 stored_config = self.get_grouping_config()

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -25,9 +25,7 @@ from django.utils.encoding import force_str
 
 from sentry import eventtypes
 from sentry.db.models import NodeData
-from sentry.grouping.api import GroupingConfig
 from sentry.grouping.result import CalculatedHashes
-from sentry.grouping.strategies.base import StrategyConfiguration
 from sentry.interfaces.base import Interface, get_interfaces
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -48,6 +46,8 @@ EVENTSTREAM_PRUNED_KEYS = ("debug_meta", "_meta")
 SEARCH_MESSAGE_SKIPPED_KEYS = frozenset(["in_app_frame_mix"])
 
 if TYPE_CHECKING:
+    from sentry.grouping.api import GroupingConfig
+    from sentry.grouping.strategies.base import StrategyConfiguration
     from sentry.interfaces.user import User
     from sentry.models.environment import Environment
     from sentry.models.group import Group

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -25,7 +25,9 @@ from django.utils.encoding import force_str
 
 from sentry import eventtypes
 from sentry.db.models import NodeData
+from sentry.grouping.api import GroupingConfig
 from sentry.grouping.result import CalculatedHashes
+from sentry.grouping.strategies.base import StrategyConfiguration
 from sentry.interfaces.base import Interface, get_interfaces
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -317,16 +319,13 @@ class BaseEvent(metaclass=abc.ABCMeta):
         # further.
         return self.data.get("metadata") or {}
 
-    def get_grouping_config(self) -> MutableMapping[str, Any]:
+    def get_grouping_config(self) -> GroupingConfig:
         """Returns the event grouping config."""
         from sentry.grouping.api import get_grouping_config_dict_for_event_data
 
-        return cast(
-            MutableMapping[str, Any],
-            get_grouping_config_dict_for_event_data(self.data, self.project),
-        )
+        return get_grouping_config_dict_for_event_data(self.data, self.project)
 
-    def get_hashes(self, force_config: str | Mapping[str, Any] | None = None) -> CalculatedHashes:
+    def get_hashes(self, force_config: StrategyConfiguration | None = None) -> CalculatedHashes:
         """
         Returns _all_ information that is necessary to group an event into
         issues. It returns two lists of hashes, `(flat_hashes, hierarchical_hashes)`:
@@ -381,7 +380,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
             hashes=flat_hashes, hierarchical_hashes=hierarchical_hashes, tree_labels=tree_labels
         )
 
-    def get_sorted_grouping_variants(self, force_config: str | Mapping[str, Any] | None = None):
+    def get_sorted_grouping_variants(self, force_config: StrategyConfiguration | None = None):
         """Get grouping variants sorted into flat and hierarchical variants"""
         from sentry.grouping.api import sort_grouping_variants
 
@@ -412,7 +411,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
 
         return filtered_hashes, tree_labels
 
-    def normalize_stacktraces_for_grouping(self, grouping_config) -> None:
+    def normalize_stacktraces_for_grouping(self, grouping_config: StrategyConfiguration) -> None:
         """Normalize stacktraces and clear memoized interfaces
 
         See stand-alone function normalize_stacktraces_for_grouping
@@ -424,7 +423,11 @@ class BaseEvent(metaclass=abc.ABCMeta):
         # We have modified event data, so any cached interfaces have to be reset:
         self.__dict__.pop("interfaces", None)
 
-    def get_grouping_variants(self, force_config=None, normalize_stacktraces: bool = False):
+    def get_grouping_variants(
+        self,
+        force_config: StrategyConfiguration | GroupingConfig | str | None = None,
+        normalize_stacktraces: bool = False,
+    ):
         """
         This is similar to `get_hashes` but will instead return the
         grouping components for each variant in a dictionary.
@@ -441,30 +444,34 @@ class BaseEvent(metaclass=abc.ABCMeta):
         # default config dictionary
         if force_config is not None:
             if isinstance(force_config, str):
+                # A string like `"mobile:2021-02-12"`
                 stored_config = self.get_grouping_config()
-                config = dict(stored_config)
-                config["id"] = force_config
+                grouping_config = dict(stored_config)
+                grouping_config["id"] = force_config
+                loaded_grouping_config = load_grouping_config(grouping_config)
+            elif isinstance(force_config, StrategyConfiguration):
+                # A fully initialized `StrategyConfiguration`
+                loaded_grouping_config = force_config
             else:
-                config = force_config
-
+                # A `GroupingConfig` dictionary
+                loaded_grouping_config = load_grouping_config(grouping_config)
         # Otherwise we just use the same grouping config as stored.  if
         # this is None we use the project's default config.
         else:
-            config = self.get_grouping_config()
-
-        config = load_grouping_config(config)
+            grouping_config = self.get_grouping_config()
+            loaded_grouping_config = load_grouping_config(grouping_config)
 
         if normalize_stacktraces:
             with sentry_sdk.start_span(op="grouping.normalize_stacktraces_for_grouping") as span:
                 span.set_tag("project", self.project_id)
                 span.set_tag("event_id", self.event_id)
-                self.normalize_stacktraces_for_grouping(config)
+                self.normalize_stacktraces_for_grouping(loaded_grouping_config)
 
         with sentry_sdk.start_span(op="grouping.get_grouping_variants") as span:
             span.set_tag("project", self.project_id)
             span.set_tag("event_id", self.event_id)
 
-            return get_grouping_variants_for_event(self, config)
+            return get_grouping_variants_for_event(self, loaded_grouping_config)
 
     def get_primary_hash(self) -> str | None:
         hashes = self.get_hashes()

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -397,14 +397,13 @@ def sort_grouping_variants(variants):
     return flat_variants, hierarchical_variants
 
 
-def detect_synthetic_exception(event_data: NodeData, grouping_config: GroupingConfig):
+def detect_synthetic_exception(event_data: NodeData, loaded_grouping_config: StrategyConfiguration):
     """Detect synthetic exception and write marker to event data
 
     This only runs if detect_synthetic_exception_types is True, so
     it is effectively only enabled for grouping strategy mobile:2021-04-02.
 
     """
-    loaded_grouping_config = load_grouping_config(grouping_config)
     should_detect = loaded_grouping_config.initial_context["detect_synthetic_exception_types"]
     if not should_detect:
         return

--- a/src/sentry/grouping/ingest.py
+++ b/src/sentry/grouping/ingest.py
@@ -110,12 +110,14 @@ def _calculate_event_grouping(
     }
 
     with metrics.timer("save_event._calculate_event_grouping", tags=metric_tags):
+        loaded_grouping_config = load_grouping_config(grouping_config)
+
         with metrics.timer("event_manager.normalize_stacktraces_for_grouping", tags=metric_tags):
             with sentry_sdk.start_span(op="event_manager.normalize_stacktraces_for_grouping"):
-                event.normalize_stacktraces_for_grouping(load_grouping_config(grouping_config))
+                event.normalize_stacktraces_for_grouping(loaded_grouping_config)
 
         # Detect & set synthetic marker if necessary
-        detect_synthetic_exception(event.data, grouping_config)
+        detect_synthetic_exception(event.data, loaded_grouping_config)
 
         with metrics.timer("event_manager.apply_server_fingerprinting", tags=metric_tags):
             # The active grouping config was put into the event in the
@@ -137,7 +139,7 @@ def _calculate_event_grouping(
             # default long before we get here. Should we consolidate bogus config handling into the
             # code actually getting the config?
             try:
-                hashes = event.get_hashes(grouping_config)
+                hashes = event.get_hashes(loaded_grouping_config)
             except GroupingConfigNotFound:
                 event.data["grouping_config"] = get_grouping_config_dict_for_project(project)
                 hashes = event.get_hashes()

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Mapping, MutableMapping, NamedTuple, Optional,
 
 import sentry_sdk
 
+from sentry.grouping.strategies.base import StrategyConfiguration
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.stacktraces.functions import set_in_app, trim_function_name
@@ -290,7 +291,7 @@ def _normalize_in_app(stacktrace: Sequence[dict[str, str]]) -> str:
 
 
 def normalize_stacktraces_for_grouping(
-    data: MutableMapping[str, Any], grouping_config=None
+    data: MutableMapping[str, Any], grouping_config: StrategyConfiguration | None = None
 ) -> None:
     """
     Applies grouping enhancement rules and ensure in_app is set on all frames.

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -2,11 +2,19 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Callable, Mapping, MutableMapping, NamedTuple, Optional, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Mapping,
+    MutableMapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+)
 
 import sentry_sdk
 
-from sentry.grouping.strategies.base import StrategyConfiguration
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.stacktraces.functions import set_in_app, trim_function_name
@@ -16,6 +24,9 @@ from sentry.utils.safe import get_path, safe_execute
 
 logger = logging.getLogger(__name__)
 op = "stacktrace_processing"
+
+if TYPE_CHECKING:
+    from sentry.grouping.strategies.base import StrategyConfiguration
 
 
 class StacktraceInfo(NamedTuple):

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -46,6 +46,7 @@ from sentry.event_manager import (
 )
 from sentry.eventstore.models import Event
 from sentry.exceptions import HashDiscarded
+from sentry.grouping.api import GroupingConfig, load_grouping_config
 from sentry.grouping.utils import hash_from_values
 from sentry.ingest.inbound_filters import FilterStatKeys
 from sentry.issues.grouptype import (
@@ -2116,7 +2117,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         manager = EventManager(event)
         manager.normalize()
 
-        grouping_config = {
+        grouping_config: GroupingConfig = {
             "enhancements": enhancement.dumps(),
             "id": "mobile:2021-02-12",
         }
@@ -2126,7 +2127,10 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
         event2 = Event(event1.project_id, event1.event_id, data=event1.data)
 
-        assert event1.get_hashes().hashes == event2.get_hashes(grouping_config).hashes
+        assert (
+            event1.get_hashes().hashes
+            == event2.get_hashes(load_grouping_config(grouping_config)).hashes
+        )
 
     def test_write_none_tree_labels(self):
         """Write tree labels even if None"""

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -6,6 +6,7 @@ import pytest
 from sentry import eventstore, nodestore
 from sentry.db.models.fields.node import NodeData, NodeIntegrityFailure
 from sentry.eventstore.models import Event, GroupEvent
+from sentry.grouping.api import GroupingConfig
 from sentry.grouping.enhancer import Enhancements
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.environment import Environment
@@ -360,7 +361,7 @@ class EventTest(TestCase, PerformanceIssueTestCase):
             category:foo_like -group
             """,
         )
-        grouping_config = {
+        grouping_config: GroupingConfig = {
             "enhancements": enhancement.dumps(),
             "id": "mobile:2021-02-12",
         }

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import pytest
 
 from sentry.eventtypes.base import format_title_from_tree_label
-from sentry.grouping.api import detect_synthetic_exception, get_default_grouping_config_dict
+from sentry.grouping.api import (
+    detect_synthetic_exception,
+    get_default_grouping_config_dict,
+    load_grouping_config,
+)
 from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from sentry.utils import json
@@ -34,7 +38,7 @@ def dump_variant(variant, lines=None, indent=0):
 
     lines.append("{}hash: {}".format("  " * indent, json.dumps(variant.get_hash())))
 
-    for (key, value) in sorted(variant.__dict__.items()):
+    for key, value in sorted(variant.__dict__.items()):
         if isinstance(value, GroupingComponent):
             if value.tree_label:
                 lines.append(
@@ -64,10 +68,10 @@ def test_event_hash_variant(config_name, grouping_input, insta_snapshot, log):
     evt.project = None
 
     # Set the synthetic marker if detected
-    detect_synthetic_exception(evt.data, grouping_config)
+    detect_synthetic_exception(evt.data, load_grouping_config(grouping_config))
 
     rv: list[str] = []
-    for (key, value) in sorted(evt.get_grouping_variants().items()):
+    for key, value in sorted(evt.get_grouping_variants().items()):
         if rv:
             rv.append("-" * 74)
         rv.append("%s:" % key)


### PR DESCRIPTION
Previously, the main `calculate_event_grouping` method would load / deserialize the same grouping config multiple times in a bunch of child functions.

![Bildschirmfoto 2024-01-24 um 15 07 28](https://github.com/getsentry/sentry/assets/580492/ecbf2d3b-20c1-40e7-9315-03123e696aae)

This will avoid the unnecessary work.

This is on top of https://github.com/getsentry/sentry/pull/63666
