### PR TITLE
ref(relay): Only emit cardinality limits if feature is enabled for org

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -208,40 +208,41 @@ class CardinalityLimit(TypedDict):
     namespace: Optional[str]
 
 
-def get_metrics_config() -> Mapping[str, Any]:
+def get_metrics_config(project: Project) -> Optional[Mapping[str, Any]]:
     metrics_config = {}
 
-    cardinality_limits: List[CardinalityLimit] = []
-    cardinality_options = {
-        "unsupported": "sentry-metrics.cardinality-limiter.limits.generic-metrics.per-org"
-    }
-    cardinality_options.update(
-        (namespace.value, option)
-        for namespace, option in USE_CASE_ID_CARDINALITY_LIMIT_QUOTA_OPTIONS.items()
-    )
-    for namespace, option_name in cardinality_options.items():
-        option = options.get(option_name)
-        if not option or not len(option) == 1:
-            # Multiple quotas are not supported
-            continue
-
-        quota = option[0]
-
-        cardinality_limits.append(
-            {
-                "id": namespace,
-                "window": {
-                    "windowSeconds": quota["window_seconds"],
-                    "granularitySeconds": quota["granularity_seconds"],
-                },
-                "limit": quota["limit"],
-                "scope": "organization",
-                "namespace": namespace,
-            }
+    if features.has("organizations:relay-cardinality-limiter", project.organization):
+        cardinality_limits: List[CardinalityLimit] = []
+        cardinality_options = {
+            "unsupported": "sentry-metrics.cardinality-limiter.limits.generic-metrics.per-org"
+        }
+        cardinality_options.update(
+            (namespace.value, option)
+            for namespace, option in USE_CASE_ID_CARDINALITY_LIMIT_QUOTA_OPTIONS.items()
         )
-    metrics_config["cardinalityLimits"] = cardinality_limits
+        for namespace, option_name in cardinality_options.items():
+            option = options.get(option_name)
+            if not option or not len(option) == 1:
+                # Multiple quotas are not supported
+                continue
 
-    return metrics_config
+            quota = option[0]
+
+            cardinality_limits.append(
+                {
+                    "id": namespace,
+                    "window": {
+                        "windowSeconds": quota["window_seconds"],
+                        "granularitySeconds": quota["granularity_seconds"],
+                    },
+                    "limit": quota["limit"],
+                    "scope": "organization",
+                    "namespace": namespace,
+                }
+            )
+        metrics_config["cardinalityLimits"] = cardinality_limits
+
+    return metrics_config or None
 
 
 def get_project_config(
@@ -414,7 +415,7 @@ def _get_project_config(
 
     config["breakdownsV2"] = project.get_option("sentry:breakdowns")
 
-    add_experimental_config(config, "metrics", get_metrics_config)
+    add_experimental_config(config, "metrics", get_metrics_config, project)
 
     if _should_extract_transaction_metrics(project):
         add_experimental_config(

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -1,4 +1,6 @@
 ---
+created: '2024-01-24T14:07:55.778589Z'
+creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 config:
@@ -99,43 +101,6 @@ config:
   groupingConfig:
     enhancements: eJybzDRxc15qeXFJZU6qlZGBkbGugaGuoeEEAHJMCAM
     id: newstyle:2023-01-11
-  metrics:
-    cardinalityLimits:
-    - id: unsupported
-      limit: 10000
-      namespace: unsupported
-      scope: organization
-      window:
-        granularitySeconds: 600
-        windowSeconds: 3600
-    - id: transactions
-      limit: 10000
-      namespace: transactions
-      scope: organization
-      window:
-        granularitySeconds: 600
-        windowSeconds: 3600
-    - id: sessions
-      limit: 10000
-      namespace: sessions
-      scope: organization
-      window:
-        granularitySeconds: 600
-        windowSeconds: 3600
-    - id: spans
-      limit: 10000
-      namespace: spans
-      scope: organization
-      window:
-        granularitySeconds: 600
-        windowSeconds: 3600
-    - id: custom
-      limit: 10000
-      namespace: custom
-      scope: organization
-      window:
-        granularitySeconds: 600
-        windowSeconds: 3600
   piiConfig:
     applications:
       $string:


### PR DESCRIPTION
We don't always need to emit the limits only when the feature is enabled.