### PR TITLE
ref(mql): Stop metrics layer using SnQL

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -503,7 +503,6 @@ register("snuba.search.max-chunk-size", default=2000, flags=FLAG_AUTOMATOR_MODIF
 register("snuba.search.max-total-chunk-time-seconds", default=30.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("snuba.search.hits-sample-size", default=100, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("snuba.track-outcomes-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
-register("snuba.use-mql-endpoint", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # The percentage of tagkeys that we want to cache. Set to 1.0 in order to cache everything, <=0.0 to stop caching
 register(

--- a/src/sentry/snuba/metrics_layer/query.py
+++ b/src/sentry/snuba/metrics_layer/query.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import logging
-import random
 from dataclasses import replace
 from datetime import datetime
 from typing import Any, List, Mapping, Union, cast
 
 from snuba_sdk import (
-    AliasedExpression,
     BooleanCondition,
     Column,
     Condition,
@@ -20,7 +18,6 @@ from snuba_sdk import (
 )
 from snuba_sdk.formula import FormulaParameterGroup
 
-from sentry import options
 from sentry.exceptions import InvalidParams
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.sentry_metrics.utils import resolve_weak, reverse_resolve_weak, string_to_use_case_id
@@ -29,7 +26,7 @@ from sentry.snuba.metrics.naming_layer.mapping import get_mri
 from sentry.snuba.metrics.naming_layer.mri import parse_mri
 from sentry.snuba.metrics.utils import to_intervals
 from sentry.utils import metrics
-from sentry.utils.snuba import bulk_snuba_queries, raw_snql_query
+from sentry.utils.snuba import bulk_snuba_queries
 
 logger = logging.getLogger(__name__)
 
@@ -123,11 +120,7 @@ def run_query(request: Request) -> Mapping[str, Any]:
         )
     request.query = metrics_query
 
-    use_mql_endpoint = float(options.get("snuba.use-mql-endpoint"))
-    if use_mql_endpoint and random.random() < use_mql_endpoint:
-        return mql_query(request, start, end)
-
-    return snql_query(request, start, end)
+    return mql_query(request, start, end)
 
 
 def _resolve_aggregate_aliases(exp: Timeseries | Formula) -> MetricsQuery:
@@ -500,12 +493,12 @@ def _lookup_resolve_filters(
 
 
 def convert_snuba_result(
-    snuba_result: Any,
+    snuba_result: Mapping[str, Any],
     reverse_mappings: ReverseMappings,
     dataset: str,
     use_case_id_str: str,
     org_id: int,
-):
+) -> Mapping[str, Any]:
     """
     If the dataset is metrics (release-health), then we need to convert the resultant tag values from
     their resolved integers back into their original strings.
@@ -526,304 +519,3 @@ def convert_snuba_result(
                     if reverse_resolve:
                         data_point[key] = reverse_resolve
     return snuba_result
-
-
-####################
-# TO BE DEPRECATED #
-####################
-
-# TODO: This can all be removed once we are using `mql_query` at 100%.
-
-
-def snql_query(request: Request, start: datetime, end: datetime) -> Mapping[str, Any]:
-    metrics_query = request.query
-    logging_tags = {"referrer": request.tenant_ids["referrer"] or "unknown", "lang": "snql"}
-    # Resolves MRI or public name in metrics_query
-    try:
-        # Replace any aggregate aliases with the appropriate aggregate
-        metrics_query = metrics_query.set_query(_resolve_aggregate_aliases(metrics_query.query))
-        resolved_metrics_query, mappings, reverse_mappings = _resolve_metrics_query(
-            metrics_query, request.dataset
-        )
-        request.query = resolved_metrics_query.set_indexer_mappings(mappings)
-        request.tenant_ids["use_case_id"] = resolved_metrics_query.scope.use_case_id
-        # Release health AKA sessions uses a separate Dataset. Change the dataset based on the use case id.
-        # This is necessary here because the product code that uses this isn't aware of which feature is
-        # using it.
-        if resolved_metrics_query.scope.use_case_id == UseCaseID.SESSIONS.value:
-            request.dataset = Dataset.Metrics.value
-        else:
-            request.dataset = Dataset.PerformanceMetrics.value
-
-    except Exception:
-        metrics.incr(
-            "metrics_layer.query",
-            tags={**logging_tags, "status": "resolve_error"},
-        )
-        raise
-
-    try:
-        snuba_results = raw_snql_query(request, request.tenant_ids["referrer"], use_cache=True)
-    except Exception:
-        metrics.incr(
-            "metrics_layer.query",
-            tags={**logging_tags, "status": "query_error"},
-        )
-        raise
-
-    snuba_results = convert_snuba_result(
-        snuba_results,
-        reverse_mappings,
-        request.dataset,
-        metrics_query.scope.use_case_id,
-        metrics_query.scope.org_ids[0],
-    )
-
-    # If we normalized the start/end, return those values in the response so the caller is aware
-    results = {
-        **snuba_results,
-        "modified_start": start,
-        "modified_end": end,
-        "indexer_mappings": mappings,
-    }
-    metrics.incr(
-        "metrics_layer.query",
-        tags={**logging_tags, "status": "success"},
-    )
-    return results
-
-
-def _resolve_query_metrics(
-    metrics_query: MetricsQuery,
-    use_case_id: UseCaseID,
-    org_id: int,
-) -> tuple[MetricsQuery, dict[str, str | int]]:
-    """
-    Resolves all the fields of the Metric in the query. Public name -> MRI -> ID -> Entity.
-    Returns a mapping dictionary that shows any resolving that the function did.
-    """
-    assert metrics_query.query is not None
-    if isinstance(metrics_query.query, Timeseries):
-        series, mappings = _resolve_timeseries_metric(metrics_query.query, use_case_id, org_id)
-        metrics_query = metrics_query.set_query(series)
-    elif isinstance(metrics_query.query, Formula):
-        formula, mappings = _resolve_formula_metrics(metrics_query.query, use_case_id, org_id)
-        metrics_query = metrics_query.set_query(formula)
-
-    return metrics_query, mappings
-
-
-def _resolve_timeseries_metric(
-    series: Timeseries, use_case_id: UseCaseID, org_id: int
-) -> tuple[Timeseries, dict[str, str | int]]:
-    metric = series.metric
-    mappings: dict[str, str | int] = {}
-    if not metric.mri and not metric.public_name:
-        raise InvalidParams("Metric must have either an MRI or a public name")
-
-    if not metric.mri and metric.public_name:
-        mri = get_mri(metric.public_name)
-        metric = metric.set_mri(mri)
-        mappings[metric.public_name] = mri
-
-    if metric.id is None:
-        metric_id = resolve_weak(
-            use_case_id, org_id, metric.mri
-        )  # only support raw metrics for now
-        metric = metric.set_id(metric_id)
-        mappings[metric.mri] = metric_id
-
-    if not metric.entity:
-        entity = _resolve_metrics_entity(metric.mri)
-        metric = metric.set_entity(entity.value)
-
-    series = series.set_metric(metric)
-    return series, mappings
-
-
-def _resolve_formula_metrics(
-    formula: Formula, use_case_id: UseCaseID, org_id: int
-) -> tuple[Formula, dict[str, str | int]]:
-    # TODO: This will eventually need to recursively resolve Formulas as Formula becomes a valid paramaeter
-    parameters = formula.parameters
-    formula_mappings = {}
-    for i, p in enumerate(parameters):
-        if isinstance(p, Timeseries):
-            series, mappings = _resolve_timeseries_metric(p, use_case_id, org_id)
-            parameters[i] = series
-            formula_mappings.update(mappings)
-
-    formula = formula.set_parameters(parameters)
-    return formula, mappings
-
-
-def _resolve_metrics_query(
-    metrics_query: MetricsQuery, dataset: str
-) -> tuple[MetricsQuery, Mapping[str, str | int], ReverseMappings]:
-    """
-    Returns an updated metrics query with all the indexer resolves complete. Also returns a mapping
-    that shows all the strings that were resolved and what they were resolved too.
-    """
-
-    org_id = metrics_query.scope.org_ids[0]
-    use_case_id_str = _resolve_use_case_id_str(metrics_query.query)
-    if metrics_query.scope.use_case_id is None:
-        metrics_query = metrics_query.set_scope(
-            metrics_query.scope.set_use_case_id(use_case_id_str)
-        )
-
-    use_case_id = string_to_use_case_id(use_case_id_str)
-    metrics_query, mappings = _resolve_query_metrics(metrics_query, use_case_id, org_id)
-    reverse_mappings = ReverseMappings()
-
-    # Release health AKA sessions uses a separate Dataset. Change the dataset based on the use case id.
-    # This is necessary here because the product code that uses this isn't aware of which feature is
-    # using it.
-    if metrics_query.scope.use_case_id == UseCaseID.SESSIONS.value:
-        dataset = Dataset.Metrics.value
-    else:
-        dataset = Dataset.PerformanceMetrics.value
-
-    new_groupby, new_mappings = _resolve_groupby(
-        metrics_query.query.groupby, use_case_id, org_id, dataset, reverse_mappings
-    )
-    metrics_query = metrics_query.set_query(metrics_query.query.set_groupby(new_groupby))
-    mappings.update(new_mappings)
-
-    if isinstance(metrics_query.query, Formula):
-        parameters = metrics_query.query.parameters
-        for i, p in enumerate(parameters):
-            if isinstance(p, Timeseries):
-                new_groupby, new_mappings = _resolve_groupby(
-                    p.groupby, use_case_id, org_id, dataset, reverse_mappings
-                )
-                parameters[i] = p.set_groupby(new_groupby)
-                mappings.update(new_mappings)
-
-        metrics_query = metrics_query.set_query(metrics_query.query.set_parameters(parameters))
-
-    new_filters, new_mappings = _resolve_filters(
-        metrics_query.query.filters, use_case_id, org_id, dataset, reverse_mappings
-    )
-    metrics_query = metrics_query.set_query(metrics_query.query.set_filters(new_filters))
-    mappings.update(new_mappings)
-
-    if isinstance(metrics_query.query, Formula):
-        parameters = metrics_query.query.parameters
-        for i, p in enumerate(parameters):
-            if isinstance(p, Timeseries):
-                new_filters, new_mappings = _resolve_filters(
-                    p.filters, use_case_id, org_id, dataset, reverse_mappings
-                )
-                parameters[i] = p.set_filters(new_filters)
-                mappings.update(new_mappings)
-
-        metrics_query = metrics_query.set_query(metrics_query.query.set_parameters(parameters))
-
-    return metrics_query, mappings, reverse_mappings
-
-
-def _resolve_groupby(
-    groupby: list[Column] | None,
-    use_case_id: UseCaseID,
-    org_id: int,
-    dataset: str,
-    reverse_mappings: ReverseMappings,
-) -> tuple[list[Column] | None, Mapping[str, int]]:
-    """
-    Go through the groupby columns and resolve any that need to be resolved.
-    We also return a reverse mapping of the resolved columns to the original
-    so that they can be added to the results.
-    """
-    if not groupby:
-        return groupby, {}
-
-    new_groupby = []
-    mappings = {}
-    for col in groupby:
-        resolved = resolve_weak(use_case_id, org_id, col.name)
-        if resolved > -1:
-            if dataset == Dataset.Metrics.value:
-                new_groupby.append(
-                    AliasedExpression(exp=replace(col, name=f"tags[{resolved}]"), alias=col.name)
-                )
-                reverse_mappings.tag_keys.add(col.name)
-            else:
-                new_groupby.append(
-                    AliasedExpression(
-                        exp=replace(col, name=f"tags_raw[{resolved}]"), alias=col.name
-                    )
-                )
-            mappings[col.name] = resolved
-        else:
-            new_groupby.append(col)
-
-    return new_groupby, mappings
-
-
-def _resolve_filters(
-    filters: list[Condition | BooleanCondition],
-    use_case_id: UseCaseID,
-    org_id: int,
-    dataset: str,
-    reverse_mappings: ReverseMappings,
-) -> tuple[list[Condition | BooleanCondition] | None, Mapping[str, int]]:
-    """
-    Go through the columns in the filter and resolve any that can be resolved.
-    We also return a reverse mapping of the resolved columns to the original
-    so that they can be added to the results.
-    """
-    if not filters:
-        return filters, {}
-
-    mappings = {}
-
-    def resolve_exp(
-        exp: FilterTypes, dataset: str, reverse_mappings: ReverseMappings
-    ) -> FilterTypes:
-        if dataset == Dataset.Metrics.value and (isinstance(exp, str) or isinstance(exp, list)):
-            if isinstance(exp, str):
-                resolved = resolve_weak(use_case_id, org_id, exp)
-                if resolved > -1:
-                    mappings[exp] = resolved
-                    reverse_mappings.reverse_mappings[resolved] = exp
-                    return resolved
-            elif isinstance(exp, list):
-                resolved_values: list[int] = []
-                for value in exp:
-                    assert isinstance(value, str)
-                    resolved = resolve_weak(use_case_id, org_id, value)
-                    if resolved > -1:
-                        resolved_values.append(resolved)
-                        mappings[value] = resolved
-                        reverse_mappings.reverse_mappings[resolved] = value
-                    return resolved_values
-            else:
-                raise InvalidParams("Invalid filter tag value type")
-        elif isinstance(exp, Column):
-            resolved = resolve_weak(use_case_id, org_id, exp.name)
-            if resolved > -1:
-                mappings[exp.name] = resolved
-                if dataset == Dataset.Metrics.value:
-                    reverse_mappings.tag_keys.add(exp.name)
-                    return replace(exp, name=f"tags[{resolved}]")
-                else:
-                    return replace(exp, name=f"tags_raw[{resolved}]")
-        elif isinstance(exp, CurriedFunction):
-            return replace(
-                exp, parameters=[resolve_exp(p, dataset, reverse_mappings) for p in exp.parameters]
-            )
-        elif isinstance(exp, BooleanCondition):
-            return replace(
-                exp, conditions=[resolve_exp(c, dataset, reverse_mappings) for c in exp.conditions]
-            )
-        elif isinstance(exp, Condition):
-            exp = replace(exp, lhs=resolve_exp(exp.lhs, dataset, reverse_mappings))
-            # If the dataset is metrics, then we need to resolve the tag values as well
-            if dataset == Dataset.Metrics.value:
-                exp = replace(exp, rhs=resolve_exp(exp.rhs, dataset, reverse_mappings))
-            return exp
-        return exp
-
-    new_filters = [resolve_exp(exp, dataset, reverse_mappings) for exp in filters]
-    return new_filters, mappings

--- a/tests/sentry/snuba/metrics/test_metrics_query_layer/test_metrics_query_layer.py
+++ b/tests/sentry/snuba/metrics/test_metrics_query_layer/test_metrics_query_layer.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 
 import pytest
 from snuba_sdk import (
-    AliasedExpression,
     ArithmeticOperator,
     Column,
     Condition,
@@ -22,7 +21,11 @@ from snuba_sdk import (
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.metrics.naming_layer import SessionMRI, TransactionMRI
-from sentry.snuba.metrics_layer.query import _resolve_granularity, _resolve_metrics_query
+from sentry.snuba.metrics_layer.query import (
+    _lookup_indexer_resolve,
+    _resolve_granularity,
+    _resolve_query_metadata,
+)
 from sentry.testutils.cases import BaseMetricsLayerTestCase, TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 
@@ -51,9 +54,8 @@ class MetricsQueryLayerTest(BaseMetricsLayerTestCase, TestCase):
             ),
         )
 
-        resolved_metrics_query, mappings, reverse_mapping = _resolve_metrics_query(
-            metrics_query, "generic_metrics"
-        )
+        resolved_metrics_query, mappings = _resolve_query_metadata(metrics_query)
+        _, reverse_mappings = _lookup_indexer_resolve(metrics_query, "generic_metrics")
         expected_metric_id = indexer.resolve(
             UseCaseID.TRANSACTIONS,
             self.project.organization_id,
@@ -61,7 +63,7 @@ class MetricsQueryLayerTest(BaseMetricsLayerTestCase, TestCase):
         )
         assert resolved_metrics_query.query.metric.id == expected_metric_id
         assert mappings[TransactionMRI.DURATION.value] == expected_metric_id
-        assert reverse_mapping.tag_keys == set()
+        assert reverse_mappings.tag_keys == set()
 
     def test_resolve_formula_metrics_query(self) -> None:
         self.store_performance_metric(
@@ -85,9 +87,11 @@ class MetricsQueryLayerTest(BaseMetricsLayerTestCase, TestCase):
             ),
         )
 
-        resolved_metrics_query, mappings, reverse_mapping = _resolve_metrics_query(
+        resolved_metrics_query, mappings = _resolve_query_metadata(metrics_query)
+        indexer_mappings, reverse_mappings = _lookup_indexer_resolve(
             metrics_query, "generic_metrics"
         )
+        mappings.update(indexer_mappings)
         expected_metric_id = indexer.resolve(
             UseCaseID.TRANSACTIONS,
             self.project.organization_id,
@@ -95,7 +99,7 @@ class MetricsQueryLayerTest(BaseMetricsLayerTestCase, TestCase):
         )
         assert resolved_metrics_query.query.parameters[0].metric.id == expected_metric_id
         assert mappings[TransactionMRI.DURATION.value] == expected_metric_id
-        assert reverse_mapping.tag_keys == set()
+        assert reverse_mappings.tag_keys == set()
 
     def test_resolve_metrics_query_with_groupby(self) -> None:
         self.store_performance_metric(
@@ -127,18 +131,17 @@ class MetricsQueryLayerTest(BaseMetricsLayerTestCase, TestCase):
             "transaction",
         )
 
-        resolved_metrics_query, mappings, reverse_mapping = _resolve_metrics_query(
+        resolved_metrics_query, mappings = _resolve_query_metadata(metrics_query)
+        indexer_mappings, reverse_mapping = _lookup_indexer_resolve(
             metrics_query, "generic_metrics"
         )
+        mappings.update(indexer_mappings)
         assert resolved_metrics_query.query.metric.public_name == "transaction.duration"
         assert resolved_metrics_query.query.metric.mri == TransactionMRI.DURATION.value
         assert resolved_metrics_query.query.metric.id == expected_metric_id
-        assert resolved_metrics_query.query.groupby == [
-            AliasedExpression(Column(f"tags_raw[{expected_transaction_id}]"), "transaction")
-        ]
         assert mappings[TransactionMRI.DURATION.value] == expected_metric_id
         assert mappings["transaction"] == expected_transaction_id
-        assert reverse_mapping.tag_keys == set()
+        assert reverse_mapping.tag_keys == {"transaction"}
 
     def test_resolve_formula_metrics_query_with_groupby(self) -> None:
         self.store_performance_metric(
@@ -186,9 +189,11 @@ class MetricsQueryLayerTest(BaseMetricsLayerTestCase, TestCase):
             "status_code",
         )
 
-        resolved_metrics_query, mappings, reverse_mapping = _resolve_metrics_query(
+        resolved_metrics_query, mappings = _resolve_query_metadata(metrics_query)
+        indexer_mappings, reverse_mapping = _lookup_indexer_resolve(
             metrics_query, "generic_metrics"
         )
+        mappings.update(indexer_mappings)
         assert (
             resolved_metrics_query.query.parameters[0].metric.public_name == "transaction.duration"
         )
@@ -196,19 +201,10 @@ class MetricsQueryLayerTest(BaseMetricsLayerTestCase, TestCase):
             resolved_metrics_query.query.parameters[0].metric.mri == TransactionMRI.DURATION.value
         )
         assert resolved_metrics_query.query.parameters[0].metric.id == expected_metric_id
-        assert resolved_metrics_query.query.parameters[0].groupby == [
-            AliasedExpression(Column(f"tags_raw[{expected_transaction_id}]"), "transaction")
-        ]
-        assert resolved_metrics_query.query.parameters[1].groupby == [
-            AliasedExpression(Column(f"tags_raw[{expected_transaction_id}]"), "transaction")
-        ]
-        assert resolved_metrics_query.query.groupby == [
-            AliasedExpression(Column(f"tags_raw[{expected_status_code_id}]"), "status_code")
-        ]
         assert mappings[TransactionMRI.DURATION.value] == expected_metric_id
         assert mappings["transaction"] == expected_transaction_id
         assert mappings["status_code"] == expected_status_code_id
-        assert reverse_mapping.tag_keys == set()
+        assert reverse_mapping.tag_keys == {"transaction", "status_code"}
 
     def test_resolve_metrics_query_with_filters(self) -> None:
         self.store_performance_metric(
@@ -254,23 +250,16 @@ class MetricsQueryLayerTest(BaseMetricsLayerTestCase, TestCase):
             "device",
         )
 
-        resolved_metrics_query, mappings, reverse_mapping = _resolve_metrics_query(
+        resolved_metrics_query, mappings = _resolve_query_metadata(metrics_query)
+        indexer_mappings, reverse_mapping = _lookup_indexer_resolve(
             metrics_query, "generic_metrics"
         )
+        mappings.update(indexer_mappings)
         assert resolved_metrics_query.query.metric.id == expected_metric_id
-        assert resolved_metrics_query.query.filters == [
-            Condition(Column(f"tags_raw[{expected_transaction_id}]"), Op.EQ, "/checkout"),
-            Or(
-                [
-                    Condition(Column(f"tags_raw[{expected_device_id}]"), Op.EQ, "BlackBerry"),
-                    Condition(Column(f"tags_raw[{expected_device_id}]"), Op.EQ, "Nokia"),
-                ]
-            ),
-        ]
         assert mappings[TransactionMRI.DURATION.value] == expected_metric_id
         assert mappings["transaction"] == expected_transaction_id
         assert mappings["device"] == expected_device_id
-        assert reverse_mapping.tag_keys == set()
+        assert reverse_mapping.tag_keys == {"transaction"}
 
     def test_resolve_formula_metrics_query_with_filters(self) -> None:
         self.store_performance_metric(
@@ -341,36 +330,17 @@ class MetricsQueryLayerTest(BaseMetricsLayerTestCase, TestCase):
             "status_code",
         )
 
-        resolved_metrics_query, mappings, reverse_mapping = _resolve_metrics_query(
+        resolved_metrics_query, mappings = _resolve_query_metadata(metrics_query)
+        indexer_mappings, reverse_mapping = _lookup_indexer_resolve(
             metrics_query, "generic_metrics"
         )
+        mappings.update(indexer_mappings)
         assert resolved_metrics_query.query.parameters[0].metric.id == expected_metric_id
-        assert resolved_metrics_query.query.parameters[0].filters == [
-            Condition(Column(f"tags_raw[{expected_transaction_id}]"), Op.EQ, "/checkout"),
-            Or(
-                [
-                    Condition(Column(f"tags_raw[{expected_device_id}]"), Op.EQ, "BlackBerry"),
-                    Condition(Column(f"tags_raw[{expected_device_id}]"), Op.EQ, "Nokia"),
-                ]
-            ),
-        ]
-        assert resolved_metrics_query.query.parameters[1].filters == [
-            Condition(Column(f"tags_raw[{expected_transaction_id}]"), Op.EQ, "/cart"),
-            Or(
-                [
-                    Condition(Column(f"tags_raw[{expected_device_id}]"), Op.EQ, "Android"),
-                    Condition(Column(f"tags_raw[{expected_device_id}]"), Op.EQ, "Palm"),
-                ]
-            ),
-        ]
-        assert resolved_metrics_query.query.filters == [
-            Condition(Column(f"tags_raw[{expected_status_code_id}]"), Op.EQ, "200"),
-        ]
         assert mappings[TransactionMRI.DURATION.value] == expected_metric_id
         assert mappings["transaction"] == expected_transaction_id
         assert mappings["device"] == expected_device_id
         assert mappings["status_code"] == expected_status_code_id
-        assert reverse_mapping.tag_keys == set()
+        assert reverse_mapping.tag_keys == {"transaction"}
 
     def test_resolve_metrics_query_with_filters_release_health(self) -> None:
         self.store_release_health_metric(
@@ -426,19 +396,10 @@ class MetricsQueryLayerTest(BaseMetricsLayerTestCase, TestCase):
             "BlackBerry",
         )
 
-        resolved_metrics_query, mappings, reverse_mapping = _resolve_metrics_query(
-            metrics_query, "metrics"
-        )
+        resolved_metrics_query, mappings = _resolve_query_metadata(metrics_query)
+        indexer_mappings, reverse_mapping = _lookup_indexer_resolve(metrics_query, "metrics")
+        mappings.update(indexer_mappings)
         assert resolved_metrics_query.query.metric.id == expected_metric_id
-        assert resolved_metrics_query.query.filters == [
-            Condition(Column(f"tags[{expected_transaction_id}]"), Op.EQ, expected_checkout),
-            Or(
-                [
-                    Condition(Column(f"tags[{expected_device_id}]"), Op.EQ, expected_blackberry),
-                    Condition(Column(f"tags[{expected_device_id}]"), Op.EQ, "Nokia"),
-                ]
-            ),
-        ]
         assert mappings[SessionMRI.RAW_DURATION.value] == expected_metric_id
         assert mappings["transaction"] == expected_transaction_id
         assert mappings["device"] == expected_device_id
@@ -471,6 +432,9 @@ class MetricsQueryLayerTest(BaseMetricsLayerTestCase, TestCase):
 )
 def test_resolve_granularity(day_range: int, sec_offset: int, interval: int, expected: int) -> None:
     now = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    start = now - timedelta(days=day_range) - timedelta(seconds=sec_offset)
+    end = now - timedelta(seconds=sec_offset)
+    assert _resolve_granularity(start, end, interval) == expected
     start = now - timedelta(days=day_range) - timedelta(seconds=sec_offset)
     end = now - timedelta(seconds=sec_offset)
     assert _resolve_granularity(start, end, interval) == expected

--- a/tests/snuba/test_metrics_layer.py
+++ b/tests/snuba/test_metrics_layer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Literal, Mapping
+from typing import Literal, Mapping
 
 import pytest
 from snuba_sdk import (
@@ -23,30 +23,18 @@ from sentry.exceptions import InvalidParams
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba.metrics.naming_layer import SessionMRI, TransactionMRI
 from sentry.snuba.metrics.naming_layer.public import TransactionStatusTagValue, TransactionTagsKey
-from sentry.snuba.metrics_layer.query import run_query as layer_run_query
+from sentry.snuba.metrics_layer.query import run_query
 from sentry.testutils.cases import BaseMetricsTestCase, TestCase
 
 pytestmark = pytest.mark.sentry_metrics
 
 
-# TODO: This is only needed while we support SnQL and MQL. Once SnQL is removed, this can be removed.
-LayerQuery = Callable[[Request], Mapping[str, Any]]
-
-
 class MQLTest(TestCase, BaseMetricsTestCase):
-    @property
-    def run_query(self) -> LayerQuery:
-        def mql_query_fn(request: Request) -> Mapping[str, Any]:
-            with self.options({"snuba.use-mql-endpoint": 1.0}):
-                return layer_run_query(request)
-
-        return mql_query_fn
-
     def ts(self, dt: datetime) -> int:
         return int(dt.timestamp())
 
     def setUp(self) -> None:
-        super().setUp()
+        super().setUp()  # type: ignore
 
         self.generic_metrics: Mapping[str, Literal["counter", "set", "distribution", "gauge"]] = {
             TransactionMRI.DURATION.value: "distribution",
@@ -132,7 +120,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert len(result["data"]) == 10
         rows = result["data"]
         for i in range(10):
@@ -171,7 +159,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert len(result["data"]) == 10
         rows = result["data"]
         for i in range(10):
@@ -214,7 +202,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert len(result["data"]) == 2
         rows = result["data"]
         assert rows[0]["aggregate_value"] == [0]
@@ -251,7 +239,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert len(result["data"]) == 2
         rows = result["data"]
         assert rows[0]["aggregate_value"] == [0]
@@ -286,7 +274,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert len(result["data"]) == 2
         rows = result["data"]
 
@@ -319,7 +307,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert result["modified_start"] == self.hour_ago.replace(minute=16, second=0)
         assert result["modified_end"] == self.now.replace(minute=17, second=0)
         assert result["indexer_mappings"] == {
@@ -354,7 +342,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
         )
 
         with pytest.raises(InvalidParams):
-            self.run_query(request)
+            run_query(request)
 
     def test_interval_with_totals(self) -> None:
         query = MetricsQuery(
@@ -383,7 +371,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert len(result["data"]) == 6
         assert result["totals"]["aggregate_value"] == 8.0
 
@@ -411,7 +399,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
 
         # There's a flaky off by one error here that is very difficult to track down
         # TODO: figure out why this is flaky and assert to one specific value
@@ -442,7 +430,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert request.dataset == "metrics"
         assert len(result["data"]) == 10
 
@@ -470,7 +458,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
 
         assert len(result["data"]) == 10
         assert result["totals"]["aggregate_value"] == 9.0
@@ -501,7 +489,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert request.dataset == "metrics"
         assert len(result["data"]) == 10
         for data_point in result["data"]:
@@ -535,7 +523,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert request.dataset == "metrics"
         assert len(result["data"]) == 5
 
@@ -568,7 +556,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert request.dataset == "metrics"
         assert len(result["data"]) == 5
         assert any(data_point["release"] == "release_even" for data_point in result["data"])
@@ -603,7 +591,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert request.dataset == "metrics"
         assert len(result["data"]) == 5
         assert any(data_point["release"] == "release_even" for data_point in result["data"])
@@ -654,7 +642,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
 
         assert len(result["data"]) == 10
         assert result["totals"]["aggregate_value"] == 1.0
@@ -684,7 +672,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert len(result["data"]) == 10
         rows = result["data"]
         for i in range(10):
@@ -726,7 +714,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
             query=query,
             tenant_ids={"referrer": "metrics.testing.test", "organization_id": self.org_id},
         )
-        result = self.run_query(request)
+        result = run_query(request)
         assert len(result["data"]) == 10
         rows = result["data"]
         for i in range(10):
@@ -738,16 +726,3 @@ class MQLTest(TestCase, BaseMetricsTestCase):
                     self.hour_ago.replace(second=0, microsecond=0) + timedelta(minutes=1 * i)
                 ).isoformat()
             )
-
-
-class SnQLTest(MQLTest):
-    @property
-    def run_query(self) -> LayerQuery:
-        def snql_query_fn(request: Request) -> Mapping[str, Any]:
-            with self.options({"snuba.use-mql-endpoint": 0}):
-                return layer_run_query(request)
-
-        return snql_query_fn
-
-    def test_failure_rate(self) -> None:
-        super().test_failure_rate()

--- a/tests/snuba/test_metrics_layer.py
+++ b/tests/snuba/test_metrics_layer.py
@@ -34,7 +34,7 @@ class MQLTest(TestCase, BaseMetricsTestCase):
         return int(dt.timestamp())
 
     def setUp(self) -> None:
-        super().setUp()  # type: ignore
+        super().setUp()
 
         self.generic_metrics: Mapping[str, Literal["counter", "set", "distribution", "gauge"]] = {
             TransactionMRI.DURATION.value: "distribution",


### PR DESCRIPTION
The MQL endpoint has been active for some time and is working correctly, so
remove all the SnQL translation code since it's now obsolete.