### PR TITLE
feat(metrics-extraction): Add extended option limit

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1678,6 +1678,10 @@ register(
     default=100,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Some organizations can have more widget specs on a case-by-case basis. Widgets using this limit
+# are listed in 'extended_widget_spec_orgs' option.
+register("on_demand.extended_max_widget_specs", default=750, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("on_demand.extended_widget_spec_orgs", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 register(
     "on_demand.max_widget_cardinality.count",
     default=10000,

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -49,7 +49,6 @@ _METRIC_EXTRACTION_VERSION = 2
 # Maximum number of custom metrics that can be extracted for alerts and widgets with
 # advanced filter expressions.
 _MAX_ON_DEMAND_ALERTS = 50
-_MAX_ON_DEMAND_WIDGETS = 100
 
 # TTL for cardinality check
 _WIDGET_QUERY_CARDINALITY_TTL = 3600 * 24  # 24h
@@ -67,6 +66,16 @@ class MetricExtractionConfig(TypedDict):
 
     version: int
     metrics: List[MetricSpec]
+
+
+def get_max_widget_specs(organization: Organization) -> int:
+    if organization.id in options.get("on_demand.extended_widget_spec_orgs") and options.get(
+        "on_demand.extended_max_widget_specs"
+    ):
+        return options.get("on_demand.extended_max_widget_specs")
+
+    max_widget_specs = options.get("on_demand.max_widget_specs")
+    return max_widget_specs
 
 
 @metrics.wraps("on_demand_metrics.get_metric_extraction_config")
@@ -236,7 +245,7 @@ def _get_widget_metric_specs(
     metrics.incr("on_demand_metrics.widget_query_specs.pre_trim", amount=total_spec_count)
     specs = _trim_disabled_widgets(ignored_widget_ids, specs_for_widget)
     metrics.incr("on_demand_metrics.widget_query_specs.post_disabled_trim", amount=len(specs))
-    max_widget_specs = options.get("on_demand.max_widget_specs") or _MAX_ON_DEMAND_WIDGETS
+    max_widget_specs = get_max_widget_specs(project.organization)
     specs = _trim_if_above_limit(specs, max_widget_specs, project, "widgets")
 
     metrics.incr("on_demand_metrics.widget_query_specs", amount=len(specs))

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -477,6 +477,72 @@ def test_get_metric_extraction_config_multiple_widgets_above_max_limit(
 
 
 @django_db_all
+@override_options({"on_demand.max_widget_specs": 1, "on_demand.extended_max_widget_specs": 0})
+def test_get_metric_extraction_config_multiple_widgets_not_using_extended_specs(
+    capfd: Any,
+    default_project: Project,
+) -> None:
+    with Feature({ON_DEMAND_METRICS_WIDGETS: True}):
+        create_widget(["count()"], "transaction.duration:>=1100", default_project)
+        create_widget(["count()"], "transaction.duration:>=1000", default_project, "Dashboard 2")
+
+        config = get_metric_extraction_config(default_project)
+
+        assert config
+        # Since we have set a maximum of 1 we will not get 2
+        assert len(config["metrics"]) == 1
+
+        out, _ = capfd.readouterr()
+        assert out.splitlines()[0].split(": ")[1:3] == [
+            "Spec version 1",
+            "Too many (2) on demand metric widgets for project bar",
+        ]
+
+
+@django_db_all
+@override_options({"on_demand.max_widget_specs": 0, "on_demand.extended_max_widget_specs": 1})
+def test_get_metric_extraction_config_multiple_widgets_above_extended_max_limit(
+    capfd: Any,
+    default_project: Project,
+) -> None:
+    with Feature({ON_DEMAND_METRICS_WIDGETS: True}), override_options(
+        {"on_demand.extended_widget_spec_orgs": [default_project.organization.id]}
+    ):
+        create_widget(["count()"], "transaction.duration:>=1100", default_project)
+        create_widget(["count()"], "transaction.duration:>=1000", default_project, "Dashboard 2")
+
+        config = get_metric_extraction_config(default_project)
+
+        assert config
+        # Since we have set a maximum of 1 we will not get 2
+        assert len(config["metrics"]) == 1
+
+        out, _ = capfd.readouterr()
+        assert out.splitlines()[0].split(": ")[1:3] == [
+            "Spec version 1",
+            "Too many (2) on demand metric widgets for project bar",
+        ]
+
+
+@django_db_all
+@override_options({"on_demand.max_widget_specs": 0, "on_demand.extended_max_widget_specs": 2})
+def test_get_metric_extraction_config_multiple_widgets_under_extended_max_limit(
+    capfd: Any,
+    default_project: Project,
+) -> None:
+    with Feature({ON_DEMAND_METRICS_WIDGETS: True}), override_options(
+        {"on_demand.extended_widget_spec_orgs": [default_project.organization.id]}
+    ):
+        create_widget(["count()"], "transaction.duration:>=1100", default_project)
+        create_widget(["count()"], "transaction.duration:>=1000", default_project, "Dashboard 2")
+
+        config = get_metric_extraction_config(default_project)
+
+        assert config
+        assert len(config["metrics"]) == 2
+
+
+@django_db_all
 def test_get_metric_extraction_config_alerts_and_widgets_off(default_project: Project) -> None:
     # widgets should be skipped if the feature is off
     with Feature({ON_DEMAND_METRICS: True, ON_DEMAND_METRICS_WIDGETS: False}):


### PR DESCRIPTION
### Summary
In order to extract for all customers we want a lower limit for the majority of them. This adds an extended widget spec count that's opt-in (will be set to all AM1 customers), and will replace our 'max_widgets' being set to 750 in options automator.
