### PR TITLE
ref(crons): Rate limit in-stream-time

### DIFF
--- a/tests/sentry/monitors/test_monitor_consumer.py
+++ b/tests/sentry/monitors/test_monitor_consumer.py
@@ -373,21 +373,28 @@ class MonitorConsumerTest(TestCase):
         assert closed_checkin.guid != uuid.UUID(int=0)
 
     def test_rate_limit(self):
+        now = datetime.now()
         monitor = self._create_monitor(slug="my-monitor")
 
         with mock.patch("sentry.monitors.consumers.monitor_consumer.CHECKIN_QUOTA_LIMIT", 1):
             # Try to ingest two the second will be rate limited
-            self.send_checkin("my-monitor")
-            self.send_checkin("my-monitor")
+            self.send_checkin("my-monitor", ts=now)
+            self.send_checkin("my-monitor", ts=now)
 
             checkins = MonitorCheckIn.objects.filter(monitor_id=monitor.id)
             assert len(checkins) == 1
 
             # Same monitor, diff environments
-            self.send_checkin("my-monitor", environment="dev")
+            self.send_checkin("my-monitor", environment="dev", ts=now)
 
             checkins = MonitorCheckIn.objects.filter(monitor_id=monitor.id)
             assert len(checkins) == 2
+
+            # Same monitor same env but a minute later, shuld NOT be rate-limited
+            self.send_checkin("my-monitor", ts=now + timedelta(minutes=1))
+
+            checkins = MonitorCheckIn.objects.filter(monitor_id=monitor.id)
+            assert len(checkins) == 3
 
     def test_invalid_guid_environment_match(self):
         monitor = self._create_monitor(slug="my-monitor")


### PR DESCRIPTION
This adds the kafka message timestamp (rounded down to the minute) as part of the ratelimiting key for each monitor environment.

This fixes an issue where during backlogs we may have rate-limited check-ins that were processed quickly as we burned down the backlog.

By using the kafka message timestamp we can avoid this issue, effectively putting our rate limiter into "stream time"