### PR TITLE
chore(hybrid-cloud): Fix region-by-default tests for vercel/vsts

### DIFF
--- a/fixtures/vsts.py
+++ b/fixtures/vsts.py
@@ -7,7 +7,9 @@ import pytest
 import responses
 
 from sentry.integrations.vsts import VstsIntegrationProvider
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationTestCase
+from sentry.testutils.silo import assume_test_silo_mode
 
 
 class VstsIntegrationTestCase(IntegrationTestCase):
@@ -186,6 +188,7 @@ class VstsIntegrationTestCase(IntegrationTestCase):
         assert response.status_code == 200
         assert f'<option value="{account_id}"'.encode() in response.content
 
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def assert_installation(self):
         # Initial request to the installation URL for VSTS
         resp = self.make_init_request()

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1543,6 +1543,29 @@ class Factories:
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)
+    def create_identity_integration(
+        user: User | RpcUser,
+        organization: Organization | RpcOrganization,
+        integration_params: Mapping[Any, Any],
+        identity_params: Mapping[Any, Any],
+    ) -> tuple[Integration, OrganizationIntegration, Identity, IdentityProvider]:
+        # Avoid common pitfalls in tests
+        assert "provider" in integration_params
+        assert "external_id" in integration_params
+        assert "external_id" in identity_params
+
+        integration = Factories.create_provider_integration(**integration_params)
+        identity_provider = Factories.create_identity_provider(integration=integration)
+        identity = Factories.create_identity(
+            user=user, identity_provider=identity_provider, **identity_params
+        )
+        organization_integration = integration.add_organization(
+            organization_id=organization.id, user=user, default_auth_id=identity.id
+        )
+        return integration, organization_integration, identity, identity_provider
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CONTROL)
     def create_organization_integration(**integration_params: Any) -> OrganizationIntegration:
         return OrganizationIntegration.objects.create(**integration_params)
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -75,6 +75,9 @@ from sentry.models.integrations.integration_feature import (
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
+from sentry.models.integrations.sentry_app_installation_for_provider import (
+    SentryAppInstallationForProvider,
+)
 from sentry.models.notificationaction import (
     ActionService,
     ActionTarget,
@@ -1081,6 +1084,22 @@ class Factories:
                 )
                 install = SentryAppInstallation.objects.get(id=install.id)
         return install
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CONTROL)
+    def create_sentry_app_installation_for_provider(
+        sentry_app_id: int,
+        organization_id: int,
+        provider: str,
+    ) -> SentryAppInstallationForProvider:
+        installation = SentryAppInstallation.objects.get(
+            sentry_app_id=sentry_app_id, organization_id=organization_id
+        )
+        return SentryAppInstallationForProvider.objects.create(
+            organization_id=organization_id,
+            provider=provider,
+            sentry_app_installation=installation,
+        )
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -11,7 +11,7 @@ from sentry.incidents.models import IncidentActivityType
 from sentry.models.activity import Activity
 from sentry.models.actor import Actor, get_actor_id_for_user
 from sentry.models.grouprelease import GroupRelease
-from sentry.models.identity import IdentityProvider
+from sentry.models.identity import Identity, IdentityProvider
 from sentry.models.integrations.integration import Integration
 from sentry.models.integrations.organization_integration import OrganizationIntegration
 from sentry.models.organization import Organization
@@ -468,6 +468,17 @@ class Fixtures:
     ) -> tuple[Integration, OrganizationIntegration]:
         """Create an integration tied to a provider, then add an organization."""
         return Factories.create_provider_integration_for(organization, user, **integration_params)
+
+    def create_identity_integration(
+        self,
+        user: User | RpcUser,
+        organization: Organization | RpcOrganization,
+        integration_params: Mapping[Any, Any],
+        identity_params: Mapping[Any, Any],
+    ) -> tuple[Integration, OrganizationIntegration, Identity, IdentityProvider]:
+        return Factories.create_identity_integration(
+            user, organization, integration_params, identity_params
+        )
 
     def create_organization_integration(self, **integration_params: Any) -> OrganizationIntegration:
         """Create an OrganizationIntegration entity."""

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -303,6 +303,9 @@ class Fixtures:
     def create_sentry_app_installation(self, *args, **kwargs):
         return Factories.create_sentry_app_installation(*args, **kwargs)
 
+    def create_sentry_app_installation_for_provider(self, *args, **kwargs):
+        return Factories.create_sentry_app_installation_for_provider(*args, **kwargs)
+
     def create_stacktrace_link_schema(self, *args, **kwargs):
         return Factories.create_stacktrace_link_schema(*args, **kwargs)
 

--- a/tests/sentry/integrations/test_base.py
+++ b/tests/sentry/integrations/test_base.py
@@ -29,8 +29,8 @@ class IntegrationTestCase(TestCase):
 
     def test_with_context(self):
         integration = IntegrationInstallation(self.model, self.organization.id)
-
         assert integration.model.id == self.model.id
+        assert integration.org_integration is not None
         assert integration.org_integration.id == self.org_integration.id
         assert integration.get_default_identity() == serialize_identity(self.identity)
 

--- a/tests/sentry/integrations/test_base.py
+++ b/tests/sentry/integrations/test_base.py
@@ -1,39 +1,37 @@
 from sentry.integrations import IntegrationInstallation
-from sentry.models.identity import Identity
 from sentry.services.hybrid_cloud.identity.serial import serialize_identity
-from sentry.services.hybrid_cloud.integration import integration_service
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 
 
+@all_silo_test
 class IntegrationTestCase(TestCase):
     def setUp(self):
         self.user = self.create_user()
         self.organization = self.create_organization()
         self.project = self.create_project()
-        self.identity = Identity.objects.create(
-            idp=self.create_identity_provider(type="base"),
+        (
+            self.model,
+            self.org_integration,
+            self.identity,
+            identity_provider,
+        ) = self.create_identity_integration(
             user=self.user,
-            external_id="base_id",
-            data={"access_token": "11234567"},
-        )
-        self.model = self.create_integration(
             organization=self.organization,
-            provider="integrations:base",
-            external_id="base_external_id",
-            name="base_name",
-            oi_params={"default_auth_id": self.identity.id},
-        )
-
-        self.org_integration = integration_service.get_organization_integration(
-            integration_id=self.model.id,
-            organization_id=self.organization.id,
+            integration_params={
+                "provider": "integrations:base",
+                "external_id": "base_external_id",
+                "name": "base_name",
+            },
+            identity_params={"external_id": "base_id", "data": {"access_token": "11234567"}},
         )
 
     def test_with_context(self):
         integration = IntegrationInstallation(self.model, self.organization.id)
 
-        assert integration.model == self.model
-        assert integration.org_integration == self.org_integration
+        assert integration.model.id == self.model.id
+        assert integration.org_integration.id == self.org_integration.id
         assert integration.get_default_identity() == serialize_identity(self.identity)
 
     def test_model_default_fields(self):
@@ -44,8 +42,8 @@ class IntegrationTestCase(TestCase):
         assert self.model.date_updated
 
         initial_value = self.model.date_updated
-        self.model.name = "cooler_name"
-        self.model.save()
-
-        self.model.refresh_from_db()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.model.name = "cooler_name"
+            self.model.save()
+            self.model.refresh_from_db()
         assert initial_value < self.model.date_updated

--- a/tests/sentry/integrations/vercel/test_uninstall.py
+++ b/tests/sentry/integrations/vercel/test_uninstall.py
@@ -60,6 +60,7 @@ POST_DELETE_RESPONSE_NEW = """{
 }"""
 
 
+@control_silo_test
 class VercelUninstallTest(APITestCase):
     def setUp(self):
         self.url = "/extensions/vercel/delete/"

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -15,10 +15,6 @@ from fixtures.vercel import (
     SIGNATURE_NEW,
 )
 from sentry import VERSION
-from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
-from sentry.models.integrations.sentry_app_installation_for_provider import (
-    SentryAppInstallationForProvider,
-)
 from sentry.models.integrations.sentry_app_installation_token import SentryAppInstallationToken
 from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase
@@ -48,6 +44,7 @@ class SignatureVercelTest(APITestCase):
             assert response.status_code == 401
 
 
+@control_silo_test
 class VercelReleasesTest(APITestCase):
     webhook_url = "/extensions/vercel/webhook/"
 
@@ -92,11 +89,10 @@ class VercelReleasesTest(APITestCase):
             name="Vercel Internal Integration",
             organization=self.organization,
         )
-        sentry_app_installation = SentryAppInstallation.objects.get(sentry_app=self.sentry_app)
-        self.installation_for_provider = SentryAppInstallationForProvider.objects.create(
+        self.installation_for_provider = self.create_sentry_app_installation_for_provider(
+            sentry_app_id=self.sentry_app.id,
             organization_id=self.organization.id,
             provider="vercel",
-            sentry_app_installation=sentry_app_installation,
         )
 
     def tearDown(self):
@@ -307,7 +303,6 @@ class VercelReleasesTest(APITestCase):
         assert "Could not determine repository" == response.data["detail"]
 
 
-@control_silo_test
 class VercelReleasesNewTest(VercelReleasesTest):
     webhook_url = "/extensions/vercel/delete/"
 

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -17,7 +17,7 @@ from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_PATH, PROXY_SIGNATURE_HEADER
-from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, region_silo_test
 from sentry.utils import json
 
 
@@ -310,11 +310,28 @@ def assert_proxy_request(request, is_proxy=True):
         assert request.headers[PROXY_OI_HEADER] is not None
 
 
-@override_settings(
-    SENTRY_SUBNET_SECRET="hush-hush-im-invisible",
-    SENTRY_CONTROL_ADDRESS="http://controlserver",
-)
+@region_silo_test
 class VstsProxyApiClientTest(VstsIntegrationTestCase):
+    def setUp(self):
+        super().setUp()
+        self.integration, _, _, _ = self.create_identity_integration(
+            user=self.user,
+            organization=self.organization,
+            integration_params={
+                "provider": "vsts",
+                "external_id": "vsts:1",
+                "name": "fabrikam-fiber-inc",
+                "metadata": {
+                    "domain_name": "https://fabrikam-fiber-inc.visualstudio.com/",
+                    "default_project": "0987654321",
+                },
+            },
+            identity_params={
+                "external_id": "vsts",
+                "data": {"access_token": self.access_token, "expires": time() + 1234567},
+            },
+        )
+
     @responses.activate
     def test_integration_proxy_is_active(self):
         responses.add(
@@ -352,32 +369,32 @@ class VstsProxyApiClientTest(VstsIntegrationTestCase):
                 ),
             ],
         )
+
         self.assert_installation()
 
-        integration = Integration.objects.get(provider="vsts")
-        installation = integration.get_installation(
-            integration.organizationintegration_set.first().organization_id
-        )
+        installation = self.integration.get_installation(self.organization.id)
         repo = Repository.objects.create(
             provider="visualstudio",
             name="example",
             organization_id=self.organization.id,
             config={"instance": self.vsts_base_url, "project": "project-name", "name": "example"},
-            integration_id=integration.id,
+            integration_id=self.integration.id,
             external_id="albertos-apples",
         )
 
         class VstsProxyApiTestClient(VstsApiClient):
             _use_proxy_url_for_tests = True
 
+        client_kwargs = {
+            "base_url": self.vsts_base_url,
+            "oauth_redirect_url": VstsIntegrationProvider.oauth_redirect_url,
+            "org_integration_id": installation.org_integration.id,
+            "identity_id": installation.org_integration.default_auth_id,
+        }
+
         responses.calls.reset()
         with override_settings(SILO_MODE=SiloMode.MONOLITH):
-            client = VstsProxyApiTestClient(
-                base_url=self.vsts_base_url,
-                oauth_redirect_url=VstsIntegrationProvider.oauth_redirect_url,
-                org_integration_id=installation.org_integration.id,
-                identity_id=installation.org_integration.default_auth_id,
-            )
+            client = VstsProxyApiTestClient(**client_kwargs)
             client.get_commits(repo_id=repo.external_id, commit="b", limit=10)
 
             assert len(responses.calls) == 1
@@ -391,12 +408,7 @@ class VstsProxyApiClientTest(VstsIntegrationTestCase):
 
         responses.calls.reset()
         with override_settings(SILO_MODE=SiloMode.CONTROL):
-            client = VstsProxyApiTestClient(
-                base_url=self.vsts_base_url,
-                oauth_redirect_url=VstsIntegrationProvider.oauth_redirect_url,
-                org_integration_id=installation.org_integration.id,
-                identity_id=installation.org_integration.default_auth_id,
-            )
+            client = VstsProxyApiTestClient(**client_kwargs)
             client.get_commits(repo_id=repo.external_id, commit="b", limit=10)
 
             assert len(responses.calls) == 1
@@ -410,12 +422,7 @@ class VstsProxyApiClientTest(VstsIntegrationTestCase):
 
         responses.calls.reset()
         with override_settings(SILO_MODE=SiloMode.REGION):
-            client = VstsProxyApiTestClient(
-                base_url=self.vsts_base_url,
-                oauth_redirect_url=VstsIntegrationProvider.oauth_redirect_url,
-                org_integration_id=installation.org_integration.id,
-                identity_id=installation.org_integration.default_auth_id,
-            )
+            client = VstsProxyApiTestClient(**client_kwargs)
             client.get_commits(repo_id=repo.external_id, commit="b", limit=10)
 
             assert len(responses.calls) == 1


### PR DESCRIPTION
Starting from the bottom, working my way up. The Vercel webhook endpoinst are handled at the control silo so they should be safe to tag with `@control_silo_test`. I added `create_sentry_app_installation_for_provider` as a factory, which ended up not being necessary since I tagged the test like I'd mentionned above, but I guess it's not a downside to have another factory for our models.