### PR TITLE
fix(integrations): consistently use external_key in ExternalIssue creation

### DIFF
--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -37,10 +37,13 @@ def create_link(
         - key: String. The unique ID of the external resource
         - metadata: Optional Object. Can contain `display_name`.
     """
+
+    external_issue_key = installation.make_external_key(response)
+
     external_issue = ExternalIssue.objects.create(
         organization_id=event.group.project.organization_id,
         integration_id=integration.id,
-        key=response["key"],
+        key=external_issue_key,
         title=event.title,
         description=installation.get_group_description(event.group, event),
         metadata=response.get("metadata"),

--- a/tests/sentry/integrations/github/test_ticket_action.py
+++ b/tests/sentry/integrations/github/test_ticket_action.py
@@ -137,6 +137,7 @@ class GitHubTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
 
         # assert ticket created in DB
         key = self.get_key(event)
+        assert key == f"{self.repo}#{self.issue_num}"
         external_issue_count = len(ExternalIssue.objects.filter(key=key))
         assert external_issue_count == 1
 


### PR DESCRIPTION
Attempts to fix SENTRY-1811 and SENTRY-1810

The root cause of this issue can be seen in the following redash query: 

```
select
  sentry_externalissue.key
from
  sentry_groupedmessage
  join sentry_grouplink on sentry_groupedmessage.id = sentry_grouplink.group_id
  join sentry_externalissue on sentry_externalissue.id = sentry_grouplink.linked_id
where
  sentry_groupedmessage.id = 4908197495 or sentry_groupedmessage.id = 4912026516
```

where the key for ExternalIssues created from manual action (hitting `group_integration_details` endpoint), is `getsentry/sentry#63756` and the other from creating a rule which creates github issues automatically is `63757`.

the get_issue_url [function](https://github.com/getsentry/sentry/blob/686e812373eb4060f3532439c077ab88984ac1d2/src/sentry/integrations/github/issues.py#L26) expects the `key` to look like the former, attempting to split on `#`. 


Github ExternalIssues created from rules seem to pass the incorrect key to `ExternalIssue`, as it is not using the `installation.make_external_key` function the endpoint code uses.

(See
https://github.com/getsentry/sentry/blob/f91048925f8ba28c35d91e19ebb078d35e44220a/src/sentry/api/endpoints/group_integration_details.py#L248
vs
https://github.com/getsentry/sentry/blob/f91048925f8ba28c35d91e19ebb078d35e44220a/src/sentry/rules/actions/integrations/create_ticket/utils.py#L40)



This PR updates the call to use the function and pass in the correct key to `ExternalIssue` creation.












