### PR TITLE
chore(hybrid-cloud): Remove rate-limit from internal integration endpoint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -148,7 +148,8 @@ yarn.lock                                                @getsentry/owners-js-de
 /src/sentry/middleware/customer_domain.py                @getsentry/hybrid-cloud
 /src/sentry/middleware/subdomain.py                      @getsentry/hybrid-cloud
 /src/sentry/middleware/integration/                      @getsentry/hybrid-cloud
-/src/sentry/api/endpoints/rpc.py                         @getsentry/hybrid-cloud
+/src/sentry/api/endpoints/internal/integration_proxy.py  @getsentry/hybrid-cloud
+/src/sentry/api/endpoints/internal/rpc.py                @getsentry/hybrid-cloud
 /src/sentry/models/outbox.py                             @getsentry/hybrid-cloud
 /src/sentry/tasks/deliver_from_outbox.py                 @getsentry/hybrid-cloud
 /src/sentry/tasks/deletion/hybrid_cloud.py               @getsentry/hybrid-cloud

--- a/src/sentry/api/endpoints/internal/__init__.py
+++ b/src/sentry/api/endpoints/internal/__init__.py
@@ -1,19 +1,23 @@
 from .beacon import InternalBeaconEndpoint
 from .environment import InternalEnvironmentEndpoint
+from .integration_proxy import InternalIntegrationProxyEndpoint
 from .mail import InternalMailEndpoint
 from .packages import InternalPackagesEndpoint
 from .queue_tasks import InternalQueueTasksEndpoint
 from .quotas import InternalQuotasEndpoint
+from .rpc import InternalRpcServiceEndpoint
 from .stats import InternalStatsEndpoint
 from .warnings import InternalWarningsEndpoint
 
 __all__ = (
     "InternalBeaconEndpoint",
     "InternalEnvironmentEndpoint",
+    "InternalIntegrationProxyEndpoint",
     "InternalMailEndpoint",
     "InternalPackagesEndpoint",
     "InternalQueueTasksEndpoint",
     "InternalQuotasEndpoint",
     "InternalStatsEndpoint",
+    "InternalRpcServiceEndpoint",
     "InternalWarningsEndpoint",
 )

--- a/src/sentry/api/endpoints/internal/__init__.py
+++ b/src/sentry/api/endpoints/internal/__init__.py
@@ -1,5 +1,6 @@
 from .beacon import InternalBeaconEndpoint
 from .environment import InternalEnvironmentEndpoint
+from .feature_flags import InternalFeatureFlagsEndpoint
 from .integration_proxy import InternalIntegrationProxyEndpoint
 from .mail import InternalMailEndpoint
 from .packages import InternalPackagesEndpoint
@@ -12,6 +13,7 @@ from .warnings import InternalWarningsEndpoint
 __all__ = (
     "InternalBeaconEndpoint",
     "InternalEnvironmentEndpoint",
+    "InternalFeatureFlagsEndpoint",
     "InternalIntegrationProxyEndpoint",
     "InternalMailEndpoint",
     "InternalPackagesEndpoint",

--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -7,6 +7,8 @@ from urllib.parse import urljoin
 from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
 from requests import Request, Response
 
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
 from sentry.constants import ObjectStatus
 from sentry.models.integrations.organization_integration import OrganizationIntegration
@@ -28,6 +30,10 @@ logger = logging.getLogger(__name__)
 
 @control_silo_endpoint
 class InternalIntegrationProxyEndpoint(Endpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.HYBRID_CLOUD
     authentication_classes = ()
     permission_classes = ()
     log_extra: Dict[str, str | int] = {}

--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 from typing import Dict
 from urllib.parse import urljoin
 
@@ -30,9 +31,7 @@ logger = logging.getLogger(__name__)
 
 @control_silo_endpoint
 class InternalIntegrationProxyEndpoint(Endpoint):
-    publish_status = {
-        "POST": ApiPublishStatus.PRIVATE,
-    }
+    publish_status = defaultdict(lambda: ApiPublishStatus.PRIVATE)
     owner = ApiOwner.HYBRID_CLOUD
     authentication_classes = ()
     permission_classes = ()

--- a/src/sentry/api/endpoints/internal/integration_proxy.py
+++ b/src/sentry/api/endpoints/internal/integration_proxy.py
@@ -31,6 +31,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
     log_extra: Dict[str, str | int] = {}
+    enforce_rate_limit = False
     """
     This endpoint is used to proxy requests from region silos to the third-party
     integration on behalf of credentials stored in the control silo.

--- a/src/sentry/api/endpoints/internal/rpc.py
+++ b/src/sentry/api/endpoints/internal/rpc.py
@@ -17,7 +17,7 @@ from sentry.utils.env import in_test_environment
 
 
 @all_silo_endpoint
-class RpcServiceEndpoint(Endpoint):
+class InternalRpcServiceEndpoint(Endpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -4,8 +4,6 @@ from django.conf.urls import include
 from django.urls import URLPattern, URLResolver, re_path
 
 from sentry.api.endpoints.group_event_details import GroupEventDetailsEndpoint
-from sentry.api.endpoints.internal.feature_flags import InternalFeatureFlagsEndpoint
-from sentry.api.endpoints.internal.integration_proxy import InternalIntegrationProxyEndpoint
 from sentry.api.endpoints.org_auth_token_details import OrgAuthTokenDetailsEndpoint
 from sentry.api.endpoints.org_auth_tokens import OrgAuthTokensEndpoint
 from sentry.api.endpoints.organization_events_root_cause_analysis import (
@@ -268,10 +266,13 @@ from .endpoints.integrations.sentry_apps import (
 from .endpoints.internal import (
     InternalBeaconEndpoint,
     InternalEnvironmentEndpoint,
+    InternalFeatureFlagsEndpoint,
+    InternalIntegrationProxyEndpoint,
     InternalMailEndpoint,
     InternalPackagesEndpoint,
     InternalQueueTasksEndpoint,
     InternalQuotasEndpoint,
+    InternalRpcServiceEndpoint,
     InternalStatsEndpoint,
     InternalWarningsEndpoint,
 )
@@ -554,7 +555,6 @@ from .endpoints.relay import (
     RelayRegisterResponseEndpoint,
 )
 from .endpoints.release_deploys import ReleaseDeploysEndpoint
-from .endpoints.rpc import RpcServiceEndpoint
 from .endpoints.rule_snooze import MetricRuleSnoozeEndpoint, RuleSnoozeEndpoint
 from .endpoints.setup_wizard import SetupWizard
 from .endpoints.shared_group_details import SharedGroupDetailsEndpoint
@@ -2876,7 +2876,7 @@ INTERNAL_URLS = [
     ),
     re_path(
         r"^rpc/(?P<service_name>\w+)/(?P<method_name>\w+)/$",
-        RpcServiceEndpoint.as_view(),
+        InternalRpcServiceEndpoint.as_view(),
         name="sentry-api-0-rpc-service",
     ),
     re_path(

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
 from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrganizationEndpoint
-from sentry.api.endpoints.rpc import RpcServiceEndpoint
+from sentry.api.endpoints.internal.rpc import InternalRpcServiceEndpoint
 from sentry.models.apitoken import ApiToken
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.silo.base import SiloMode
@@ -105,7 +105,7 @@ urlpatterns = [
     # Need to retain RPC endpoint for cross-silo calls
     re_path(
         r"^rpc/(?P<service_name>\w+)/(?P<method_name>\w+)/$",
-        RpcServiceEndpoint.as_view(),
+        InternalRpcServiceEndpoint.as_view(),
         name="sentry-api-0-rpc-service",
     ),
 ]
@@ -160,7 +160,6 @@ class LogCaptureAPITestCase(APITestCase):
 @all_silo_test
 @override_settings(SENTRY_SELF_HOSTED=False)
 class TestAccessLogRateLimited(LogCaptureAPITestCase):
-
     endpoint = "ratelimit-endpoint"
 
     def test_access_log_rate_limited(self):
@@ -177,7 +176,6 @@ class TestAccessLogRateLimited(LogCaptureAPITestCase):
 @all_silo_test
 @override_settings(SENTRY_SELF_HOSTED=False)
 class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
-
     endpoint = "concurrent-ratelimit-endpoint"
 
     def test_concurrent_request_finishes(self):
@@ -202,7 +200,6 @@ class TestAccessLogConcurrentRateLimited(LogCaptureAPITestCase):
 
 @all_silo_test
 class TestAccessLogSuccess(LogCaptureAPITestCase):
-
     endpoint = "dummy-endpoint"
 
     def test_access_log_success(self):
@@ -219,7 +216,6 @@ class TestAccessLogSuccess(LogCaptureAPITestCase):
 @all_silo_test
 @override_settings(LOG_API_ACCESS=False)
 class TestAccessLogSuccessNotLoggedInDev(LogCaptureAPITestCase):
-
     endpoint = "dummy-endpoint"
 
     def test_access_log_success(self):


### PR DESCRIPTION
Should resolve 429s on rollout also moving rpc to the `internal/` dir, and prefixing it with `Internal`