### PR TITLE
ref: remove USE_L10N -- default true in django 4, always true in django 5

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -316,10 +316,6 @@ SITE_ID = 1
 # to load the internationalization machinery.
 USE_I18N = True
 
-# If you set this to False, Django will not format dates, numbers and
-# calendars according to the current locale
-USE_L10N = True
-
 USE_TZ = True
 
 # CAVEAT: If you're adding a middleware that modifies a response's content,


### PR DESCRIPTION
going to wait a few days before merging since this solidifies in django 4.x

<!-- Describe your PR here. -->