### PR TITLE
ref(slack): Rename mentions to notes

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -31,7 +31,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         # XXX(CEO): when removing the feature flag, put `label` back up as a class var
         self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"  # type: ignore
         if features.has("organizations:slack-block-kit", self.project.organization):
-            self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and mentions {mentions} in notification"  # type: ignore
+            self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and description {description} in notification"  # type: ignore
         self.form_fields = {
             "workspace": {
                 "type": "choice",
@@ -42,7 +42,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             "tags": {"type": "string", "placeholder": "e.g., environment,user,my_tag"},
         }
         if features.has("organizations:slack-block-kit", self.project.organization):
-            self.form_fields["mentions"] = {
+            self.form_fields["description"] = {
                 "type": "string",
                 "placeholder": "e.g. @jane, @on-call-team",
             }
@@ -73,7 +73,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     tags=tags,
                     rules=rules,
                     notification_uuid=notification_uuid,
-                    mentions=self.get_option("mentions", ""),
+                    description=self.get_option("description", ""),
                 )
                 if additional_attachment:
                     for block in additional_attachment:
@@ -142,7 +142,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 channel=self.get_option("channel"),
                 channel_id=self.get_option("channel_id"),
                 tags="[{}]".format(", ".join(tags)),
-                mentions=self.get_option("mentions", ""),
+                description=self.get_option("description", ""),
             )
 
         return self.label.format(

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -31,7 +31,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         # XXX(CEO): when removing the feature flag, put `label` back up as a class var
         self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"  # type: ignore
         if features.has("organizations:slack-block-kit", self.project.organization):
-            self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and description {description} in notification"  # type: ignore
+            self.label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} and notes {notes} in notification"  # type: ignore
         self.form_fields = {
             "workspace": {
                 "type": "choice",
@@ -42,7 +42,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             "tags": {"type": "string", "placeholder": "e.g., environment,user,my_tag"},
         }
         if features.has("organizations:slack-block-kit", self.project.organization):
-            self.form_fields["description"] = {
+            self.form_fields["notes"] = {
                 "type": "string",
                 "placeholder": "e.g. @jane, @on-call-team",
             }
@@ -73,7 +73,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                     tags=tags,
                     rules=rules,
                     notification_uuid=notification_uuid,
-                    description=self.get_option("description", ""),
+                    notes=self.get_option("notes", ""),
                 )
                 if additional_attachment:
                     for block in additional_attachment:
@@ -142,7 +142,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
                 channel=self.get_option("channel"),
                 channel_id=self.get_option("channel_id"),
                 tags="[{}]".format(", ".join(tags)),
-                description=self.get_option("description", ""),
+                notes=self.get_option("notes", ""),
             )
 
         return self.label.format(

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -573,8 +573,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         # add notes
         if self.notes:
-            mentions_text = f"notes: {self.notes}"
-            blocks.append(self.get_markdown_block(mentions_text))
+            notes_text = f"notes: {self.notes}"
+            blocks.append(self.get_markdown_block(notes_text))
 
         # build footer block
         timestamp = None

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -398,7 +398,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         recipient: RpcActor | None = None,
         is_unfurl: bool = False,
         skip_fallback: bool = False,
-        mentions: str | None = None,
+        description: str | None = None,
     ) -> None:
         super().__init__()
         self.group = group
@@ -413,7 +413,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self.recipient = recipient
         self.is_unfurl = is_unfurl
         self.skip_fallback = skip_fallback
-        self.mentions = mentions
+        self.description = description
 
     @property
     def escape_text(self) -> bool:
@@ -571,9 +571,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                 self.get_context_block(suggested_assignee_text[:-2])
             )  # get rid of comma at the end
 
-        # add mentions
-        if self.mentions:
-            mentions_text = f"Mentions: {self.mentions}"
+        # add description
+        if self.description:
+            mentions_text = f"description: {self.description}"
             blocks.append(self.get_markdown_block(mentions_text))
 
         # build footer block
@@ -614,7 +614,7 @@ def build_group_attachment(
     issue_details: bool = False,
     is_unfurl: bool = False,
     notification_uuid: str | None = None,
-    mentions: str | None = None,
+    description: str | None = None,
 ) -> Union[SlackBlock, SlackAttachment]:
 
     return SlackIssuesMessageBuilder(
@@ -627,5 +627,5 @@ def build_group_attachment(
         link_to_event,
         issue_details,
         is_unfurl=is_unfurl,
-        mentions=mentions,
+        description=description,
     ).build(notification_uuid=notification_uuid)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -398,7 +398,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         recipient: RpcActor | None = None,
         is_unfurl: bool = False,
         skip_fallback: bool = False,
-        description: str | None = None,
+        notes: str | None = None,
     ) -> None:
         super().__init__()
         self.group = group
@@ -413,7 +413,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self.recipient = recipient
         self.is_unfurl = is_unfurl
         self.skip_fallback = skip_fallback
-        self.description = description
+        self.notes = notes
 
     @property
     def escape_text(self) -> bool:
@@ -571,9 +571,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                 self.get_context_block(suggested_assignee_text[:-2])
             )  # get rid of comma at the end
 
-        # add description
-        if self.description:
-            mentions_text = f"description: {self.description}"
+        # add notes
+        if self.notes:
+            mentions_text = f"notes: {self.notes}"
             blocks.append(self.get_markdown_block(mentions_text))
 
         # build footer block
@@ -614,7 +614,7 @@ def build_group_attachment(
     issue_details: bool = False,
     is_unfurl: bool = False,
     notification_uuid: str | None = None,
-    description: str | None = None,
+    notes: str | None = None,
 ) -> Union[SlackBlock, SlackAttachment]:
 
     return SlackIssuesMessageBuilder(
@@ -627,5 +627,5 @@ def build_group_attachment(
         link_to_event,
         issue_details,
         is_unfurl=is_unfurl,
-        description=description,
+        notes=notes,
     ).build(notification_uuid=notification_uuid)

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -55,13 +55,9 @@ def build_test_message_blocks(
     event: Event | None = None,
     link_to_event: bool = False,
     tags: dict[str, str] | None = None,
-<<<<<<< HEAD
     suggested_assignees: str | None = None,
-    mentions: str | None = None,
     initial_assignee: Team | User | None = None,
-=======
-    description: str | None = None,
->>>>>>> 94287fdb742 (ref(slack): Rename mentions to description)
+    notes: str | None = None,
 ) -> dict[str, Any]:
     project = group.project
 
@@ -145,7 +141,6 @@ def build_test_message_blocks(
             }
     blocks.append(actions)
 
-<<<<<<< HEAD
     if suggested_assignees:
         suggested_assignees_text = f"Suggested Assignees: {suggested_assignees}"
         suggested_assignees_section = {
@@ -154,14 +149,9 @@ def build_test_message_blocks(
         }
         blocks.append(suggested_assignees_section)
 
-    if mentions:
-        mentions_text = f"Mentions: {mentions}"
-        mentions_section = {
-=======
-    if description:
-        description_text = f"Description: {description}"
+    if notes:
+        description_text = f"notes: {notes}"
         description_section = {
->>>>>>> 94287fdb742 (ref(slack): Rename mentions to description)
             "type": "section",
             "text": {"type": "mrkdwn", "text": description_text},
         }
@@ -319,7 +309,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         self.project.flags.has_releases = True
         self.project.save(update_fields=["flags"])
         tags = {"foo": "bar"}
-        description = "hey @colleen fix it"
+        notes = "hey @colleen fix it"
 
         assert SlackIssuesMessageBuilder(group).build() == build_test_message_blocks(
             teams={self.team},
@@ -338,25 +328,25 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             event=event,
         )
 
-        # add description to message
+        # add notes to message
         assert SlackIssuesMessageBuilder(
-            group, event.for_group(group), description=description
+            group, event.for_group(group), notes=notes
         ).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},
             group=group,
-            description=description,
+            notes=notes,
             event=event,
         )
-        # add extra tag and description to message
+        # add extra tag and notes to message
         assert SlackIssuesMessageBuilder(
-            group, event.for_group(group), tags={"foo"}, description=description
+            group, event.for_group(group), tags={"foo"}, notes=notes
         ).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},
             group=group,
             tags=tags,
-            description=description,
+            notes=notes,
             event=event,
         )
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -55,9 +55,13 @@ def build_test_message_blocks(
     event: Event | None = None,
     link_to_event: bool = False,
     tags: dict[str, str] | None = None,
+<<<<<<< HEAD
     suggested_assignees: str | None = None,
     mentions: str | None = None,
     initial_assignee: Team | User | None = None,
+=======
+    description: str | None = None,
+>>>>>>> 94287fdb742 (ref(slack): Rename mentions to description)
 ) -> dict[str, Any]:
     project = group.project
 
@@ -141,6 +145,7 @@ def build_test_message_blocks(
             }
     blocks.append(actions)
 
+<<<<<<< HEAD
     if suggested_assignees:
         suggested_assignees_text = f"Suggested Assignees: {suggested_assignees}"
         suggested_assignees_section = {
@@ -152,10 +157,15 @@ def build_test_message_blocks(
     if mentions:
         mentions_text = f"Mentions: {mentions}"
         mentions_section = {
+=======
+    if description:
+        description_text = f"Description: {description}"
+        description_section = {
+>>>>>>> 94287fdb742 (ref(slack): Rename mentions to description)
             "type": "section",
-            "text": {"type": "mrkdwn", "text": mentions_text},
+            "text": {"type": "mrkdwn", "text": description_text},
         }
-        blocks.append(mentions_section)
+        blocks.append(description_section)
 
     context_text = f"Project: <http://testserver/organizations/{project.organization.slug}/issues/?project={project.id}|{project.slug}>    Alert: BAR-{group.short_id}"
     context = {
@@ -309,7 +319,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         self.project.flags.has_releases = True
         self.project.save(update_fields=["flags"])
         tags = {"foo": "bar"}
-        mentions = "hey @colleen fix it"
+        description = "hey @colleen fix it"
 
         assert SlackIssuesMessageBuilder(group).build() == build_test_message_blocks(
             teams={self.team},
@@ -328,25 +338,25 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             event=event,
         )
 
-        # add mentions to message
+        # add description to message
         assert SlackIssuesMessageBuilder(
-            group, event.for_group(group), mentions=mentions
+            group, event.for_group(group), description=description
         ).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},
             group=group,
-            mentions=mentions,
+            description=description,
             event=event,
         )
-        # add extra tag and mentions to message
+        # add extra tag and description to message
         assert SlackIssuesMessageBuilder(
-            group, event.for_group(group), tags={"foo"}, mentions=mentions
+            group, event.for_group(group), tags={"foo"}, description=description
         ).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},
             group=group,
             tags=tags,
-            mentions=mentions,
+            description=description,
             event=event,
         )
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -150,12 +150,12 @@ def build_test_message_blocks(
         blocks.append(suggested_assignees_section)
 
     if notes:
-        description_text = f"notes: {notes}"
-        description_section = {
+        notes_text = f"notes: {notes}"
+        notes_section = {
             "type": "section",
-            "text": {"type": "mrkdwn", "text": description_text},
+            "text": {"type": "mrkdwn", "text": notes_text},
         }
-        blocks.append(description_section)
+        blocks.append(notes_section)
 
     context_text = f"Project: <http://testserver/organizations/{project.organization.slug}/issues/?project={project.id}|{project.slug}>    Alert: BAR-{group.short_id}"
     context = {

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -77,20 +77,20 @@ class SlackNotifyActionTest(RuleTestCase):
         )
 
     @with_feature("organizations:slack-block-kit")
-    def test_render_label_with_mentions(self):
+    def test_render_label_with_notes(self):
         rule = self.get_rule(
             data={
                 "workspace": self.integration.id,
                 "channel": "#my-channel",
                 "channel_id": "",
                 "tags": "one, two",
-                "mentions": "fix this @colleen",
+                "notes": "fix this @colleen",
             }
         )
 
         assert (
             rule.render_label()
-            == "Send a notification to the Awesome Team Slack workspace to #my-channel (optionally, an ID: ) and show tags [one, two] and mentions fix this @colleen in notification"
+            == "Send a notification to the Awesome Team Slack workspace to #my-channel (optionally, an ID: ) and show tags [one, two] and notes fix this @colleen in notification"
         )
 
     def test_render_label_without_integration(self):


### PR DESCRIPTION
Instead of calling the [mentions feature](https://github.com/getsentry/sentry/pull/63390) "mentions", we're renaming it to "notes". 