### PR TITLE
fix(feedback): account for 'other' platform in replay section

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackReplay.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackReplay.tsx
@@ -28,7 +28,7 @@ export default function FeedbackReplay({eventData, feedbackItem, organization}: 
     useHaveSelectedProjectsSentAnyReplayEvents();
   const platformSupported = replayPlatforms.includes(feedbackItem.platform);
 
-  if (!platformSupported) {
+  if (!platformSupported && !(feedbackItem.platform === 'other')) {
     return (
       <ReplayUnsupportedAlert
         primaryAction="create"


### PR DESCRIPTION
Fixes this bug:
<img width="799" alt="SCR-20240124-nbmj" src="https://github.com/getsentry/sentry/assets/56095982/87a5c9fd-3454-4c76-b1ad-9be684d68783">
which was happening because the platform was `other` rather than `javascript` 

If the platform is `other`, let's be conservative and just say 'no replay captured'
<img width="409" alt="SCR-20240124-nwqd" src="https://github.com/getsentry/sentry/assets/56095982/92165fb1-f9ba-4cdb-b177-6b8def183926">
