### PR TITLE
feat(stacktrace-link): Add platform to the analytics event

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -183,6 +183,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                 filepath=filepath,
                 status=error or "success",
                 link_fetch_iterations=result["iteration_count"],
+                platform=ctx["platform"],
             )
             return Response(
                 {

--- a/src/sentry/integrations/analytics.py
+++ b/src/sentry/integrations/analytics.py
@@ -120,6 +120,7 @@ class IntegrationStacktraceLinkEvent(analytics.Event):
         analytics.Attribute("filepath"),
         analytics.Attribute("status"),
         analytics.Attribute("link_fetch_iterations"),
+        analytics.Attribute("platform", required=False),
     )
 
 

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -220,7 +220,12 @@ class ProjectStacktraceLinkTest(BaseProjectStacktraceLink):
         self.get_success_response(
             self.organization.slug,
             self.project.slug,
-            qs_params={"file": self.filepath, "groupId": 1, "absPath": self.filepath},
+            qs_params={
+                "file": self.filepath,
+                "groupId": 1,
+                "absPath": self.filepath,
+                "platform": "python",
+            },
         )
 
         mock_record.assert_any_call(
@@ -241,6 +246,7 @@ class ProjectStacktraceLinkTest(BaseProjectStacktraceLink):
             filepath=self.filepath,
             status="success",
             link_fetch_iterations=1,
+            platform="python",
         )
 
 


### PR DESCRIPTION
Adds the event platform so we can see how much we've improved stack trace linking for native platforms (and which ones still need work).