### PR TITLE
ref(slack): Use a context block for event counts, substate, etc.

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -467,7 +467,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         for k, v in context.items():
             if k and v:
                 context_text += f"{k}: *{v}*   "
-        blocks.append(self.get_markdown_block(context_text[:-3]))
+        blocks.append(self.get_context_block(context_text[:-3]))
 
         # build actions
         actions = []

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -86,12 +86,15 @@ def build_test_message_blocks(
 
     # add event and user count, state, first seen
     counts_section = {
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": f"Events: *1*   State: *Ongoing*   First Seen: *{time_since(group.first_seen)}*",
-        },
+        "type": "context",
+        "elements": [
+            {
+                "type": "mrkdwn",
+                "text": f"Events: *1*   State: *Ongoing*   First Seen: *{time_since(group.first_seen)}*",
+            }
+        ],
     }
+
     blocks.append(counts_section)
 
     actions = {


### PR DESCRIPTION
Accidentally used a markdown block for this stuff when we wanted it to be a context block. 

<img width="680" alt="Screenshot 2024-01-25 at 10 30 37 AM" src="https://github.com/getsentry/sentry/assets/29959063/1113a329-15c7-4d82-8ce9-ba0cb5f67a0e">
