### PR TITLE
fix: Don't use the resolver for everything

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -138,6 +138,7 @@ default_manager.add("organizations:large-debug-files", OrganizationFeature, Feat
 default_manager.add("organizations:latest-adopted-release-filter", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:legacy-browser-update", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:mep-rollout-flag", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:mep-use-default-tags", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:metric-alert-chartcuterie", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:metric-alert-ignore-archived", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:metric-alert-threshold-period", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/search/events/builder/spans_metrics.py
+++ b/src/sentry/search/events/builder/spans_metrics.py
@@ -32,6 +32,10 @@ class SpansMetricsQueryBuilder(MetricsQueryBuilder):
         kwargs["config"] = config
         super().__init__(*args, **kwargs)
 
+    @property
+    def use_default_tags(self) -> bool:
+        return False
+
     def get_field_type(self, field: str) -> Optional[str]:
         if field in self.meta_resolver_map:
             return self.meta_resolver_map[field]

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -288,6 +288,29 @@ METRICS_MAP = {
     "transaction.duration": "d:transactions/duration@millisecond",
     "user": "s:transactions/user@none",
 }
+# The assumed list of tags that all metrics have, some won't because we remove tags to reduce cardinality
+# Use the public api aliases here
+DEFAULT_METRIC_TAGS = {
+    "environment",
+    "release",
+    "transaction",
+    "transaction.status",
+    "transaction.op",
+    "http.method",
+    "browser.name",
+    "os.name",
+    "satisfaction",
+    "histogram_outlier",
+    "sdk",
+    "measurement_rating",
+    "http.status_code",
+    "geo.country_code",
+    "transaction.method",
+    "device.class",
+    "resource.render_blocking_status",
+    "has_profile",
+    "query_hash",
+}
 SPAN_METRICS_MAP = {
     "user": "s:spans/user@none",
     "span.self_time": "d:spans/exclusive_time@millisecond",

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3284,3 +3284,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     @pytest.mark.xfail(reason="Not implemented")
     def test_timestamp_groupby(self):
         super().test_timestamp_groupby()
+
+    @pytest.mark.xfail(reason="Not implemented")
+    def test_on_demand_with_mep(self):
+        super().test_on_demand_with_mep()

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3089,6 +3089,42 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[0]["transaction"] == "foo_transaction"
         assert meta["dataset"] == "metricsEnhanced"
 
+    def test_on_demand_with_mep(self):
+        # Store faketag as an OnDemandMetricSpec, which will put faketag into the metrics indexer
+        spec = OnDemandMetricSpec(
+            field="count()",
+            query="user.email:blah@example.com",
+            environment="prod",
+            groupbys=["faketag"],
+            spec_type=MetricSpecType.DYNAMIC_QUERY,
+        )
+        self.store_on_demand_metric(123, spec=spec)
+
+        # This is the event that we should actually return
+        transaction_data = load_data("transaction", timestamp=self.min_ago)
+        transaction_data["tags"].append(("faketag", "foo"))
+        self.store_event(transaction_data, self.project.id)
+
+        with self.feature({"organizations:mep-use-default-tags": True}):
+            response = self.do_request(
+                {
+                    "field": [
+                        "faketag",
+                        "count()",
+                    ],
+                    "query": "event.type:transaction",
+                    "dataset": "metricsEnhanced",
+                    "per_page": 50,
+                }
+            )
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        data = response.data["data"]
+        meta = response.data["meta"]
+
+        assert data[0]["faketag"] == "foo"
+        assert not meta["isMetricsData"]
+
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetrics(
     MetricsEnhancedPerformanceTestCase


### PR DESCRIPTION
- This aims to fix a bug where ondemand will write a tag key into the metrics indexer, which causes the metrics query builder to think the tag is now available and attempt to satisfy the query