### PR TITLE
feat(replays): add analytics for masking banner & resource docs in replay details

### DIFF
--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -130,8 +130,20 @@ function BasePlayerRoot({className, isPreview = false}: Props) {
     subtitle: string;
     title: string;
   }) {
+    const organization = useOrganization();
     return (
-      <StyledLinkButton icon={<IconOpen />} borderless external href={link}>
+      <StyledLinkButton
+        icon={<IconOpen />}
+        borderless
+        external
+        href={link}
+        onClick={() => {
+          trackAnalytics('replay.details-resource-docs-clicked', {
+            organization,
+            title,
+          });
+        }}
+      >
         <ButtonContent>
           <ButtonTitle>{title}</ButtonTitle>
           <ButtonSubtitle>{subtitle}</ButtonSubtitle>

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -25,6 +25,7 @@ export type ReplayEventParameters = {
     chosen_layout: LayoutKey;
     default_layout: LayoutKey;
   };
+  'replay.details-mask-banner-link-clicked': {};
   'replay.details-network-panel-closed': {
     is_sdk_setup: boolean;
   };
@@ -45,6 +46,9 @@ export type ReplayEventParameters = {
   'replay.details-resized-panel': {
     layout: LayoutKey;
     slide_motion: 'toTop' | 'toBottom' | 'toLeft' | 'toRight';
+  };
+  'replay.details-resource-docs-clicked': {
+    title: string;
   };
   'replay.details-tab-changed': {
     tab: string;
@@ -112,10 +116,12 @@ export const replayEventMap: Record<ReplayEventKey, string | null> = {
   'replay.details-data-loaded': 'Replay Details Data Loaded',
   'replay.details-has-hydration-error': 'Replay Details Has Hydration Error',
   'replay.details-layout-changed': 'Changed Replay Details Layout',
+  'replay.details-mask-banner-link-clicked': 'Clicked Replay Details Masking Banner Link',
   'replay.details-network-panel-closed': 'Closed Replay Network Details Panel',
   'replay.details-network-panel-opened': 'Opened Replay Network Details Panel',
   'replay.details-network-tab-changed': 'Changed Replay Network Details Tab',
   'replay.details-resized-panel': 'Resized Replay Details Panel',
+  'replay.details-resource-docs-clicked': 'Replay Details Resource Docs Clicked',
   'replay.details-tab-changed': 'Changed Replay Details Tab',
   'replay.details-time-spent': 'Time Spent Viewing Replay Details',
   'replay.list-navigate-to-details': 'Replays List Navigate to Replay Details',

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -17,6 +17,7 @@ import useJumpButtons from 'sentry/components/replays/useJumpButtons';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import useExtractedDomNodes from 'sentry/utils/replays/hooks/useExtractedDomNodes';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
@@ -152,7 +153,14 @@ function Breadcrumbs() {
         >
           {tct('Learn how to unmask text (****) and unblock media [link:here].', {
             link: (
-              <ExternalLink href="https://docs.sentry.io/platforms/javascript/session-replay/privacy/" />
+              <ExternalLink
+                href="https://docs.sentry.io/platforms/javascript/session-replay/privacy/"
+                onClick={() => {
+                  trackAnalytics('replay.details-mask-banner-link-clicked', {
+                    organization,
+                  });
+                }}
+              />
             ),
           })}
         </StyledAlert>


### PR DESCRIPTION
Add some analytics surrounding the replay details masking banner:

<img width="623" alt="SCR-20240124-oysf" src="https://github.com/getsentry/sentry/assets/56095982/f8e024c8-8d13-447b-98cd-47fc015988f0">

and the resource docs:

<img width="277" alt="SCR-20240124-oytg" src="https://github.com/getsentry/sentry/assets/56095982/0c39d257-0fa0-42d0-bfb2-0124a9139781">
