### PR TITLE
chore(grouping): Remove `store.background_grouping_before` option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -821,11 +821,6 @@ register("store.background-grouping-config-id", default=None, flags=FLAG_AUTOMAT
 # Fraction of events that will pass through background grouping
 register("store.background-grouping-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# True if background grouping should run before secondary and primary grouping
-register(
-    "store.background-grouping-before", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
-)  # TODO: remove, no longer used
-
 # Store release files bundled as zip files
 register(
     "processing.save-release-archives", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE


### PR DESCRIPTION
This removes the `store.background-grouping-before` option, which is no longer used as of https://github.com/getsentry/sentry/pull/63715, and which was removed from the options automator in https://github.com/getsentry/sentry-options-automator/pull/622.