### PR TITLE
chore(hybrid-cloud): Adds get_user_avatar RPC method

### DIFF
--- a/src/sentry/services/hybrid_cloud/user/serial.py
+++ b/src/sentry/services/hybrid_cloud/user/serial.py
@@ -79,12 +79,7 @@ def serialize_rpc_user(user: User) -> RpcUser:
     else:
         orm_avatar = user.avatar.first()
         if orm_avatar is not None:
-            avatar = RpcAvatar(
-                id=orm_avatar.id,
-                file_id=orm_avatar.file_id,
-                ident=orm_avatar.ident,
-                avatar_type=orm_avatar.get_avatar_type_display(),
-            )
+            avatar = serialize_user_avatar(avatar=orm_avatar)
     args["avatar"] = avatar
 
     args["authenticators"] = [
@@ -100,6 +95,15 @@ def serialize_rpc_user(user: User) -> RpcUser:
     ]
 
     return RpcUser(**args)
+
+
+def serialize_user_avatar(avatar: UserAvatar) -> RpcAvatar:
+    return RpcAvatar(
+        id=avatar.id,
+        file_id=avatar.file_id,
+        ident=avatar.ident,
+        avatar_type=avatar.get_avatar_type_display(),
+    )
 
 
 def _flatten(iter: Iterable[Any]) -> List[Any]:

--- a/src/sentry/services/hybrid_cloud/user/service.py
+++ b/src/sentry/services/hybrid_cloud/user/service.py
@@ -17,7 +17,7 @@ from sentry.services.hybrid_cloud.user import (
     UserSerializeType,
     UserUpdateArgs,
 )
-from sentry.services.hybrid_cloud.user.model import RpcVerifyUserEmail, UserIdEmailArgs
+from sentry.services.hybrid_cloud.user.model import RpcAvatar, RpcVerifyUserEmail, UserIdEmailArgs
 from sentry.silo import SiloMode
 
 
@@ -185,6 +185,11 @@ class UserService(RpcService):
     def verify_user_emails(
         self, *, user_id_emails: List[UserIdEmailArgs]
     ) -> Dict[int, RpcVerifyUserEmail]:
+        pass
+
+    @rpc_method
+    @abstractmethod
+    def get_user_avatar(self, *, user_id: int) -> RpcAvatar | None:
         pass
 
 

--- a/tests/sentry/hybridcloud/test_user.py
+++ b/tests/sentry/hybridcloud/test_user.py
@@ -1,4 +1,5 @@
 from sentry.models.avatars.user_avatar import UserAvatar
+from sentry.models.files import ControlFile
 from sentry.services.hybrid_cloud.user.service import user_service
 from sentry.testutils.factories import Factories
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -43,3 +44,22 @@ def test_user_serialize_multiple_emails():
     assert len(rpc_user.useremails) == 3
     expected = {user.email, email.email, unverified_email.email}
     assert expected == {e.email for e in rpc_user.useremails}
+
+
+@django_db_all(transaction=True)
+def test_user_get_avatar():
+    user = Factories.create_user()
+
+    # Assert a query without an avatar returns none by default
+    assert user_service.get_user_avatar(user_id=user.id) is None
+
+    avatar_file = ControlFile.objects.create(name="avatar.png", type=UserAvatar.FILE_TYPE)
+    avatar = UserAvatar.objects.create(user=user, control_file_id=avatar_file.id)
+
+    rpc_avatar = user_service.get_user_avatar(user_id=user.id)
+
+    assert rpc_avatar
+    assert rpc_avatar.ident == avatar.ident
+    assert rpc_avatar.file_id == avatar.file_id
+    assert rpc_avatar.id == avatar.id
+    assert rpc_avatar.avatar_type == avatar.get_avatar_type_display()


### PR DESCRIPTION
Resubmission of #63716, without the usage. This is to ensure that a client-push of this change does not result in RPC errors being thrown in our application.

There is a follow-up PR that will consume this new RPC endpoint.
