### PR TITLE
chore(linting): update flake8-logging to 1.5.0 to include a fix

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -55,7 +55,7 @@ fido2==0.9.2
 filelock==3.7.0
 flake8==6.1.0
 flake8-bugbear==22.10.27
-flake8-logging==1.4.0
+flake8-logging==1.5.0
 google-api-core==2.15.0
 google-auth==2.25.2
 google-cloud-bigtable==2.22.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,7 +24,7 @@ pre-commit>=3.3
 black>=22.10.0
 flake8>=6.1
 flake8-bugbear>=22.10
-flake8-logging>=1.4
+flake8-logging>=1.5
 pyupgrade>=3.2.3
 isort>=5.10.1
 


### PR DESCRIPTION
Bumping flake8-logging to 1.5.0 to include fix for 
```python
KeyError "Attempt to overwrite 'message' in LogRecord"
```

Changelog: https://github.com/adamchainz/flake8-logging/blob/main/CHANGELOG.rst#150-2024-01-23
Fix: https://github.com/adamchainz/flake8-logging/pull/77
