### PR TITLE
fix(superuser): pass request.user into read-only superuser check

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -955,7 +955,7 @@ def from_request_org_and_scopes(
             org_member=member,
         )
 
-        superuser_scopes = get_superuser_scopes(auth_state, member)
+        superuser_scopes = get_superuser_scopes(auth_state, request.user)
 
         return ApiBackedOrganizationGlobalAccess(
             rpc_user_organization_context=rpc_user_org_context,
@@ -1045,7 +1045,7 @@ def from_request(
         )
         sso_state = auth_state.sso_state
 
-        superuser_scopes = get_superuser_scopes(auth_state, member)
+        superuser_scopes = get_superuser_scopes(auth_state, request.user)
 
         return OrganizationGlobalAccess(
             organization=organization,

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -26,7 +26,6 @@ from sentry import features
 from sentry.api.exceptions import SentryAPIException
 from sentry.auth.elevated_mode import ElevatedMode, InactiveReason
 from sentry.auth.system import is_system_auth
-from sentry.models.organizationmember import OrganizationMember
 from sentry.services.hybrid_cloud.auth.model import RpcAuthState
 from sentry.utils import json, metrics
 from sentry.utils.auth import has_completed_sso
@@ -74,11 +73,11 @@ SUPERUSER_SCOPES = settings.SENTRY_SCOPES.union({"org:superuser"})
 SUPERUSER_READONLY_SCOPES = settings.SENTRY_READONLY_SCOPES.union({"org:superuser"})
 
 
-def get_superuser_scopes(auth_state: RpcAuthState, member: Any | OrganizationMember | None):
+def get_superuser_scopes(auth_state: RpcAuthState, member: Any):
     superuser_scopes = SUPERUSER_SCOPES
     if (
         not is_self_hosted()
-        and features.has("auth:enterprise-superuser-read-write", member)
+        and features.has("auth:enterprise-superuser-read-write", actor=member)
         and "superuser.write" not in auth_state.permissions
     ):
         superuser_scopes = SUPERUSER_READONLY_SCOPES

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -73,11 +73,11 @@ SUPERUSER_SCOPES = settings.SENTRY_SCOPES.union({"org:superuser"})
 SUPERUSER_READONLY_SCOPES = settings.SENTRY_READONLY_SCOPES.union({"org:superuser"})
 
 
-def get_superuser_scopes(auth_state: RpcAuthState, member: Any):
+def get_superuser_scopes(auth_state: RpcAuthState, user: Any):
     superuser_scopes = SUPERUSER_SCOPES
     if (
         not is_self_hosted()
-        and features.has("auth:enterprise-superuser-read-write", actor=member)
+        and features.has("auth:enterprise-superuser-read-write", actor=user)
         and "superuser.write" not in auth_state.permissions
     ):
         superuser_scopes = SUPERUSER_READONLY_SCOPES

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -539,7 +539,7 @@ class FromRequestTest(AccessFactoryTestCase):
 
     def test_superuser_scopes(self):
         # superuser not in organization
-        request = self.make_request(user=self.superuser)
+        request = self.make_request(user=self.superuser, is_superuser=True)
 
         # needs org in request in order to assign any scopes
         result = self.from_request(request, self.org)

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -537,8 +537,7 @@ class FromRequestTest(AccessFactoryTestCase):
         result = self.from_request(request)
         assert result.has_permission("test.permission")
 
-    @patch("sentry.auth.access.is_active_superuser", return_value=True)
-    def test_superuser_scopes(self, mock_is_active_superuser):
+    def test_superuser_scopes(self):
         # superuser not in organization
         request = self.make_request(user=self.superuser)
 

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -557,10 +557,9 @@ class FromRequestTest(AccessFactoryTestCase):
 
     @with_feature("auth:enterprise-superuser-read-write")
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @patch("sentry.auth.access.is_active_superuser", return_value=True)
-    def test_superuser_readonly_scopes(self, mock_is_active_superuser):
+    def test_superuser_readonly_scopes(self):
         # superuser not in organization
-        request = self.make_request(user=self.superuser)
+        request = self.make_request(user=self.superuser, is_superuser=True)
 
         result = self.from_request(request, self.org)
         assert result.scopes == SUPERUSER_READONLY_SCOPES
@@ -573,13 +572,12 @@ class FromRequestTest(AccessFactoryTestCase):
 
     @with_feature("auth:enterprise-superuser-read-write")
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @patch("sentry.auth.access.is_active_superuser", return_value=True)
-    def test_superuser_write_scopes(self, mock_is_active_superuser):
+    def test_superuser_write_scopes(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             UserPermission.objects.create(user=self.superuser, permission="superuser.write")
 
         # superuser not in organization
-        request = self.make_request(user=self.superuser)
+        request = self.make_request(user=self.superuser, is_superuser=True)
 
         result = self.from_request(request, self.org)
         assert result.scopes == SUPERUSER_SCOPES
@@ -592,12 +590,11 @@ class FromRequestTest(AccessFactoryTestCase):
 
     @with_feature("auth:enterprise-superuser-read-write")
     @override_settings(SENTRY_SELF_HOSTED=False)
-    @patch("sentry.auth.access.is_active_superuser", return_value=True)
-    def test_superuser_in_organization_write_scopes(self, mock_is_active_superuser):
+    def test_superuser_in_organization_write_scopes(self):
         with assume_test_silo_mode(SiloMode.CONTROL):
             UserPermission.objects.create(user=self.superuser, permission="superuser.write")
 
-        request = self.make_request(user=self.superuser)
+        request = self.make_request(user=self.superuser, is_superuser=True)
 
         result = self.from_request(request, self.org)
         assert result.scopes == SUPERUSER_SCOPES


### PR DESCRIPTION
Previously I was passing `member` which in most cases was `None`, so the read-only scopes weren't being assigned. Using `request.user` should solve the problem.

For https://github.com/getsentry/team-enterprise/issues/39