### PR TITLE
ref(grouping): Move all grouping logic into  `_save_aggregate`

### DIFF
--- a/tests/sentry/event_manager/test_save_aggregate.py
+++ b/tests/sentry/event_manager/test_save_aggregate.py
@@ -1,6 +1,7 @@
 import contextlib
 import time
 from threading import Thread
+from unittest.mock import patch
 
 import pytest
 from django.db import router, transaction
@@ -67,18 +68,25 @@ def test_group_creation_race(monkeypatch, default_project, is_race_free):
                 tree_labels=[],
             )
 
-            ret = _save_aggregate(
-                evt,
-                hashes=hashes,
-                release=None,
-                metadata={},
-                received_timestamp=0,
-                migrate_off_hierarchical=False,
-                **group_creation_kwargs,
-            )
+            with patch(
+                "sentry.event_manager.get_hash_values",
+                return_value=(hashes, hashes, hashes),
+            ):
+                with patch(
+                    "sentry.event_manager._get_group_creation_kwargs",
+                    return_value=group_creation_kwargs,
+                ):
+                    with patch("sentry.event_manager._materialize_metadata_many"):
+                        ret = _save_aggregate(
+                            evt,
+                            job={"event_metadata": {}},
+                            release=None,
+                            received_timestamp=0,
+                            metric_tags={},
+                        )
 
-            assert ret is not None
-            return_values.append(ret)
+                        assert ret is not None
+                        return_values.append(ret)
         finally:
             transaction.get_connection(router.db_for_write(GroupHash)).close()
 


### PR DESCRIPTION
Currently, the logic in `save_error_events` looks roughly like this:

```
`save_error_events`
	do first batch of non-grouping stuff
	get hash values
	get value for hierarchical grouping
	update some metadata
	pass hash values, hierarchical grouping value, and metadata to `_save_aggregate`
	do second batch of non-grouping stuff
	update grouping config
```

As it happens, though, the only place the hash values and hierarchical grouping value are used is in `_save_aggregate`, and updating the grouping config is independent of the second batch of non-grouping stuff. As for the metadata, it's added to the event rather than returned, so as long as that happens before `_save_aggregate` is finished, we're good. This means that all four tasks can safely be moved into `_save_aggregate`. This PR does just that.

(The advantage of moving them is that then all grouping code in `event_manager` is contained in just one function - `_save_aggregate` - which will make further refactoring easier. It will also make it easier to feature-flag the new logic.)

Note that in order to move the code, the signature of `_save_aggregate` had to be changed. Fortunately, other than in tests, it's only called in one place (in `save_error_events`), so this shouldn't cause any problems. 