### PR TITLE
feat(crons): Add click flag to run monitor consumer in parallel

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -81,6 +81,31 @@ def ingest_replay_recordings_buffered_options() -> List[click.Option]:
     return options
 
 
+def ingest_monitors_options() -> List[click.Option]:
+    """Return a list of ingest-monitors options."""
+    options = [
+        click.Option(
+            ["--parallel", "parallel"],
+            type=bool,
+            default=False,
+            help="Process monitor check-ins in parallel.",
+        ),
+        click.Option(
+            ["--max-batch-size", "max_batch_size"],
+            type=int,
+            default=500,
+            help="Maximum number of check-ins to batch before processing in parallel.",
+        ),
+        click.Option(
+            ["--max-batch-time", "max_batch_time"],
+            type=int,
+            default=10,
+            help="Maximum time spent batching check-ins to batch before processing in parallel.",
+        ),
+    ]
+    return options
+
+
 _METRICS_INDEXER_OPTIONS = [
     click.Option(["--input-block-size"], type=int, default=None),
     click.Option(["--output-block-size"], type=int, default=None),
@@ -160,6 +185,7 @@ KAFKA_CONSUMERS: Mapping[str, ConsumerDefinition] = {
     "ingest-monitors": {
         "topic": settings.KAFKA_INGEST_MONITORS,
         "strategy_factory": "sentry.monitors.consumers.monitor_consumer.StoreMonitorCheckInStrategyFactory",
+        "click_options": ingest_monitors_options(),
     },
     "billing-metrics-consumer": {
         "topic": settings.KAFKA_SNUBA_GENERIC_METRICS,

--- a/src/sentry/monitors/consumers/monitor_consumer.py
+++ b/src/sentry/monitors/consumers/monitor_consumer.py
@@ -865,8 +865,28 @@ class StoreMonitorCheckInStrategyFactory(ProcessingStrategyFactory[KafkaPayload]
     Does the consumer process unrelated check-ins in parallel?
     """
 
-    def __init__(self, parallel=False) -> None:
-        self.parallel = parallel
+    max_batch_size = 500
+    """
+    How many messages will be batched at once when in parallel mode.
+    """
+
+    max_batch_time = 10
+    """
+    The maximum time in seconds to accumulate a bach of check-ins.
+    """
+
+    def __init__(
+        self,
+        parallel=None,
+        max_batch_size=None,
+        max_batch_time=None,
+    ) -> None:
+        if parallel is not None:
+            self.parallel = parallel
+        if max_batch_size is not None:
+            self.max_batch_size = max_batch_size
+        if max_batch_time is not None:
+            self.max_batch_time = max_batch_time
 
     def create_paralell_worker(self, commit: Commit) -> ProcessingStrategy[KafkaPayload]:
         batch_processor = RunTask(
@@ -874,8 +894,8 @@ class StoreMonitorCheckInStrategyFactory(ProcessingStrategyFactory[KafkaPayload]
             next_step=CommitOffsets(commit),
         )
         return BatchStep(
-            max_batch_size=500,
-            max_batch_time=10,
+            max_batch_size=self.max_batch_size,
+            max_batch_time=self.max_batch_time,
             next_step=batch_processor,
         )
 


### PR DESCRIPTION
Adds a `--parallel` flag (and a few other configuration flags for batch sizing).

Will follow up with a change to the k8s config so we can test this in production.

see #60292 for details on how the parallelism works.