### PR TITLE
ref(issues): Make auto-transition task batch size smaller

### DIFF
--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 TRANSITION_AFTER_DAYS = 7
 ITERATOR_CHUNK = 100
-CHILD_TASK_COUNT = 250
+CHILD_TASK_COUNT = 10
 
 
 def log_error_if_queue_has_items(func):


### PR DESCRIPTION
Currently, there is a bug where new issues have not been auto-transitioning to ongoing after 7 days (see #63726 for more information). We started receiving Celery timeout errors having to do with this task around the same time we started seeing the bug, so we believe that is stopping the tasks entirely. 