### PR TITLE
fix(hc): Pin sentry-js-sdk-loader to the US region

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3982,6 +3982,7 @@ REGION_PINNED_URL_NAMES = {
     # Backwards compatibility for US customers.
     # New usage of these is region scoped.
     "sentry-error-page-embed",
+    "sentry-js-sdk-loader",
     "sentry-release-hook",
     "sentry-api-0-organizations",
     "sentry-api-0-projects",


### PR DESCRIPTION
This endpoint can't be proxied since it's only parameterized by public key. New requests will use the region domain but for existing usage without a region domain, we need to pin to the US region.