### PR TITLE
ref(sdk-crashes): Make allowlist nonoptional

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -75,7 +75,7 @@ class SDKCrashDetection:
         organization_allowlist = sdk_crash_detector.config.organization_allowlist
 
         if (
-            organization_allowlist is not None
+            len(organization_allowlist) > 0
             and event.project.organization_id not in organization_allowlist
         ):
             return None

--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection_config.py
@@ -38,8 +38,8 @@ class SDKCrashDetectionConfig:
     project_id: int
     """The percentage of events to sample. 0.0 = 0%, 0.5 = 50% 1.0 = 100%."""
     sample_rate: float
-    """The organization allowlist to detect crashes for. If None, all organizations are allowed."""
-    organization_allowlist: Optional[list[int]]
+    """The organization allowlist to detect crashes for. If empty, all organizations are allowed. Use the sample_rate to disable the SDK crash detection for all organizations."""
+    organization_allowlist: list[int]
     """The SDK names to detect crashes for. For example, ["sentry.cocoa", "sentry.cocoa.react-native"]."""
     sdk_names: Sequence[str]
     """The minimum SDK version to detect crashes for. For example, "8.2.0"."""
@@ -55,7 +55,7 @@ class SDKCrashDetectionConfig:
 class SDKCrashDetectionOptions(TypedDict):
     project_id: int
     sample_rate: float
-    organization_allowlist: Optional[list[int]]
+    organization_allowlist: list[int]
 
 
 def build_sdk_crash_detection_configs() -> Sequence[SDKCrashDetectionConfig]:
@@ -167,7 +167,7 @@ def _get_options(
     if not sample_rate:
         return None
 
-    organization_allowlist: Optional[list[int]] = None
+    organization_allowlist: list[int] = []
     if has_organization_allowlist:
         organization_allowlist = options.get(f"{options_prefix}.organization_allowlist")
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1817,7 +1817,7 @@ class SDKCrashMonitoringTestMixin(BasePostProgressGroupMixin):
         assert cocoa_config.sdk_name == SdkName.Cocoa
         assert cocoa_config.project_id == 1234
         assert cocoa_config.sample_rate == 1.0
-        assert cocoa_config.organization_allowlist is None
+        assert cocoa_config.organization_allowlist == []
 
         react_native_config = args["configs"][1]
         assert react_native_config.sdk_name == SdkName.ReactNative

--- a/tests/sentry/utils/sdk_crashes/test_build_sdk_crash_detection_configs.py
+++ b/tests/sentry/utils/sdk_crashes/test_build_sdk_crash_detection_configs.py
@@ -23,7 +23,7 @@ def test_build_sdk_crash_detection_configs():
     assert cocoa_config.sdk_name == SdkName.Cocoa
     assert cocoa_config.project_id == 1
     assert cocoa_config.sample_rate == 0.1
-    assert cocoa_config.organization_allowlist is None
+    assert cocoa_config.organization_allowlist == []
 
     react_native_config = configs[1]
     assert react_native_config.sdk_name == SdkName.ReactNative


### PR DESCRIPTION
The allowlist option for RN can't be None, as it is defined as a sequence, [see GH actions](https://github.com/getsentry/sentry-options-automator/actions/runs/7651413445/job/20849155404?pr=626). Therefore, we change it to nonoptional. When the list is empty, all organizations are allowed. You can use the sample rate instead to turn off the detection for an SDK.

