### PR TITLE
feat(ddm-performance): Format metrics summary

### DIFF
--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -121,7 +121,10 @@ function EventEntries({
       {!isShare && <EventAttachments event={event} projectSlug={projectSlug} />}
       <EventSdk sdk={event.sdk} meta={event._meta?.sdk} />
       {event.type === EventOrGroupType.TRANSACTION && event._metrics_summary && (
-        <CustomMetricsEventData metricsSummary={event._metrics_summary} />
+        <CustomMetricsEventData
+          metricsSummary={event._metrics_summary}
+          startTimestamp={event.startTimestamp}
+        />
       )}
       {!isShare && event.groupID && (
         <EventGroupingInfo

--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -11,6 +11,7 @@ import {
   Entry,
   EntryType,
   Event,
+  EventOrGroupType,
   Group,
   Organization,
   Project,
@@ -18,6 +19,7 @@ import {
 } from 'sentry/types';
 import {isNotSharedOrganization} from 'sentry/types/utils';
 import {objectIsEmpty} from 'sentry/utils';
+import {CustomMetricsEventData} from 'sentry/views/ddm/customMetricsEventData';
 
 import {EventContexts} from './contexts';
 import {EventDevice} from './device';
@@ -118,6 +120,9 @@ function EventEntries({
       {!isShare && <EventViewHierarchy event={event} project={project} />}
       {!isShare && <EventAttachments event={event} projectSlug={projectSlug} />}
       <EventSdk sdk={event.sdk} meta={event._meta?.sdk} />
+      {event.type === EventOrGroupType.TRANSACTION && event._metrics_summary && (
+        <CustomMetricsEventData metricsSummary={event._metrics_summary} />
+      )}
       {!isShare && event.groupID && (
         <EventGroupingInfo
           projectSlug={projectSlug}

--- a/static/app/components/events/interfaces/keyValueList/index.tsx
+++ b/static/app/components/events/interfaces/keyValueList/index.tsx
@@ -133,6 +133,7 @@ const ValueWithButtonContainer = styled('div')`
   background: ${p => p.theme.bodyBackground};
   padding: ${space(1)} 10px;
   margin: ${space(0.25)} 0;
+  border-radius: ${p => p.theme.borderRadius};
   pre {
     padding: 0 !important;
     margin: 0 !important;

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -40,6 +40,7 @@ import {
 } from 'sentry/utils/performance/quickTrace/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
+import {CustomMetricsEventData} from 'sentry/views/ddm/customMetricsEventData';
 import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {getPerformanceDuration} from 'sentry/views/performance/utils';
@@ -558,6 +559,9 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
               ))}
             </tbody>
           </table>
+          {span._metrics_summary ? (
+            <CustomMetricsEventData metricsSummary={span._metrics_summary} />
+          ) : null}
         </SpanDetails>
       </Fragment>
     );

--- a/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/newTraceDetailsSpanDetails.tsx
@@ -560,7 +560,10 @@ function NewTraceDetailsSpanDetail(props: SpanDetailProps) {
             </tbody>
           </table>
           {span._metrics_summary ? (
-            <CustomMetricsEventData metricsSummary={span._metrics_summary} />
+            <CustomMetricsEventData
+              metricsSummary={span._metrics_summary}
+              startTimestamp={span.start_timestamp}
+            />
           ) : null}
         </SpanDetails>
       </Fragment>

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -582,7 +582,10 @@ function SpanDetail(props: Props) {
             </tbody>
           </table>
           {span._metrics_summary && (
-            <CustomMetricsEventData metricsSummary={span._metrics_summary} />
+            <CustomMetricsEventData
+              metricsSummary={span._metrics_summary}
+              startTimestamp={span.start_timestamp}
+            />
           )}
         </SpanDetails>
       </Fragment>

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -44,6 +44,7 @@ import {
 } from 'sentry/utils/performance/quickTrace/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
+import {CustomMetricsEventData} from 'sentry/views/ddm/customMetricsEventData';
 import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {getPerformanceDuration} from 'sentry/views/performance/utils';
@@ -580,6 +581,9 @@ function SpanDetail(props: Props) {
               ))}
             </tbody>
           </table>
+          {span._metrics_summary && (
+            <CustomMetricsEventData metricsSummary={span._metrics_summary} />
+          )}
         </SpanDetails>
       </Fragment>
     );

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -1,3 +1,4 @@
+import {MRI} from 'sentry/types/metrics';
 import type {Fuse} from 'sentry/utils/fuzzySearch';
 
 import {SpanBarProps} from './spanBar';
@@ -29,6 +30,18 @@ interface SpanDatabaseAttributes {
   'db.user'?: string;
 }
 
+export interface MetricsSummaryItem {
+  count: number | null;
+  max: number | null;
+  min: number | null;
+  sum: number | null;
+  tags: Record<string, string> | null;
+}
+
+export interface MetricsSummary {
+  [mri: MRI]: MetricsSummaryItem[];
+}
+
 export type RawSpanType = {
   data: SpanSourceCodeAttributes & SpanDatabaseAttributes & Record<string, any>;
   span_id: string;
@@ -36,6 +49,7 @@ export type RawSpanType = {
   // this is essentially end_timestamp
   timestamp: number;
   trace_id: string;
+  _metrics_summary?: MetricsSummary;
   description?: string;
   exclusive_time?: number;
   hash?: string;
@@ -78,6 +92,7 @@ export const rawSpanKeys: Set<keyof RawSpanType> = new Set([
   'tags',
   'hash',
   'exclusive_time',
+  '_metrics_summary',
 ]);
 
 export type OrphanSpanType = RawSpanType & {

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -1,5 +1,6 @@
 import type {
   AggregateSpanType,
+  MetricsSummary,
   RawSpanType,
   TraceContextType,
 } from 'sentry/components/events/interfaces/spans/types';
@@ -815,6 +816,7 @@ export interface EventTransaction
   )[];
   startTimestamp: number;
   type: EventOrGroupType.TRANSACTION;
+  _metrics_summary?: MetricsSummary;
   perfProblem?: PerformanceDetectorData;
 }
 

--- a/static/app/utils/metrics/index.tsx
+++ b/static/app/utils/metrics/index.tsx
@@ -24,6 +24,7 @@ import {
   MetricsApiRequestQuery,
   MetricsApiRequestQueryOptions,
   MetricsGroup,
+  MetricsOperation,
   MetricType,
   MRI,
   UseCase,
@@ -319,6 +320,20 @@ const metricTypeToReadable: Record<MetricType, string> = {
   s: t('set'),
   e: t('derived'),
 };
+
+export function getDefaultMetricOp(mri: MRI): MetricsOperation {
+  const parsedMRI = parseMRI(mri);
+  switch (parsedMRI?.type) {
+    case 'd':
+    case 'g':
+      return 'avg';
+    case 's':
+      return 'count_unique';
+    case 'c':
+    default:
+      return 'sum';
+  }
+}
 
 // Converts from "c" to "counter"
 export function getReadableMetricType(type?: string) {

--- a/static/app/views/ddm/customMetricsEventData.spec.tsx
+++ b/static/app/views/ddm/customMetricsEventData.spec.tsx
@@ -21,16 +21,22 @@ describe('CustomMetricsEventData', () => {
       ],
     };
     const {container} = render(
-      <CustomMetricsEventData metricsSummary={metricsSummary} />
+      <CustomMetricsEventData
+        metricsSummary={metricsSummary}
+        startTimestamp={1706189398.176}
+      />
     );
     expect(container).toBeEmptyDOMElement();
   });
 
   it('renders empty (no data)', () => {
     const organization = OrganizationFixture({features: ['ddm-ui']});
-    const {container} = render(<CustomMetricsEventData metricsSummary={{}} />, {
-      organization,
-    });
+    const {container} = render(
+      <CustomMetricsEventData metricsSummary={{}} startTimestamp={1706189398.176} />,
+      {
+        organization,
+      }
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -50,9 +56,15 @@ describe('CustomMetricsEventData', () => {
       ],
     };
 
-    render(<CustomMetricsEventData metricsSummary={metricsSummary} />, {
-      organization,
-    });
+    render(
+      <CustomMetricsEventData
+        metricsSummary={metricsSummary}
+        startTimestamp={1706189398.176}
+      />,
+      {
+        organization,
+      }
+    );
 
     expect(screen.getByText('Emitted Metrics')).toBeInTheDocument();
 
@@ -89,9 +101,15 @@ describe('CustomMetricsEventData', () => {
       ],
     };
 
-    render(<CustomMetricsEventData metricsSummary={metricsSummary} />, {
-      organization,
-    });
+    render(
+      <CustomMetricsEventData
+        metricsSummary={metricsSummary}
+        startTimestamp={1706189398.176}
+      />,
+      {
+        organization,
+      }
+    );
 
     expect(screen.getByText('Emitted Metrics')).toBeInTheDocument();
 
@@ -101,7 +119,6 @@ describe('CustomMetricsEventData', () => {
 
     expect(screen.getByText('Stats')).toBeInTheDocument();
     expect(screen.getByText(/Type: distribution/)).toBeInTheDocument();
-    expect(screen.getByText(/Count: 1/)).toBeInTheDocument();
     expect(screen.getByText(/Value: 2s/)).toBeInTheDocument();
 
     expect(screen.getByText('Tags')).toBeInTheDocument();
@@ -125,9 +142,15 @@ describe('CustomMetricsEventData', () => {
       ],
     };
 
-    render(<CustomMetricsEventData metricsSummary={metricsSummary} />, {
-      organization,
-    });
+    render(
+      <CustomMetricsEventData
+        metricsSummary={metricsSummary}
+        startTimestamp={1706189398.176}
+      />,
+      {
+        organization,
+      }
+    );
 
     expect(screen.getByText('Emitted Metrics')).toBeInTheDocument();
 
@@ -158,9 +181,15 @@ describe('CustomMetricsEventData', () => {
       ],
     };
 
-    render(<CustomMetricsEventData metricsSummary={metricsSummary} />, {
-      organization,
-    });
+    render(
+      <CustomMetricsEventData
+        metricsSummary={metricsSummary}
+        startTimestamp={1706189398.176}
+      />,
+      {
+        organization,
+      }
+    );
 
     expect(screen.getByText('Emitted Metrics')).toBeInTheDocument();
 
@@ -189,9 +218,15 @@ describe('CustomMetricsEventData', () => {
       ],
     };
 
-    render(<CustomMetricsEventData metricsSummary={metricsSummary} />, {
-      organization,
-    });
+    render(
+      <CustomMetricsEventData
+        metricsSummary={metricsSummary}
+        startTimestamp={1706189398.176}
+      />,
+      {
+        organization,
+      }
+    );
 
     expect(screen.getByText('Emitted Metrics')).toBeInTheDocument();
 
@@ -240,9 +275,15 @@ describe('CustomMetricsEventData', () => {
       ],
     };
 
-    render(<CustomMetricsEventData metricsSummary={metricsSummary} />, {
-      organization,
-    });
+    render(
+      <CustomMetricsEventData
+        metricsSummary={metricsSummary}
+        startTimestamp={1706189398.176}
+      />,
+      {
+        organization,
+      }
+    );
 
     expect(screen.getByText('Emitted Metrics')).toBeInTheDocument();
 

--- a/static/app/views/ddm/customMetricsEventData.spec.tsx
+++ b/static/app/views/ddm/customMetricsEventData.spec.tsx
@@ -1,0 +1,253 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {MetricsSummary} from 'sentry/components/events/interfaces/spans/types';
+import {CustomMetricsEventData} from 'sentry/views/ddm/customMetricsEventData';
+
+describe('CustomMetricsEventData', () => {
+  it('renders empty (no feature flag)', () => {
+    const metricsSummary: MetricsSummary = {
+      'd:custom/my.metric@second': [
+        {
+          count: 2,
+          min: 1,
+          max: 2,
+          sum: 3,
+          tags: {
+            foo: 'bar',
+          },
+        },
+      ],
+    };
+    const {container} = render(
+      <CustomMetricsEventData metricsSummary={metricsSummary} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders empty (no data)', () => {
+    const organization = OrganizationFixture({features: ['ddm-ui']});
+    const {container} = render(<CustomMetricsEventData metricsSummary={{}} />, {
+      organization,
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders (all information)', () => {
+    const organization = OrganizationFixture({features: ['ddm-ui']});
+    const metricsSummary: MetricsSummary = {
+      'd:custom/my.metric@second': [
+        {
+          count: 2,
+          min: 1,
+          max: 2,
+          sum: 3,
+          tags: {
+            foo: 'bar',
+          },
+        },
+      ],
+    };
+
+    render(<CustomMetricsEventData metricsSummary={metricsSummary} />, {
+      organization,
+    });
+
+    expect(screen.getByText('Emitted Metrics')).toBeInTheDocument();
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('my.metric')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open in Metrics'})).toBeInTheDocument();
+
+    expect(screen.getByText('Stats')).toBeInTheDocument();
+    expect(screen.getByText(/Type: distribution/)).toBeInTheDocument();
+    expect(screen.getByText(/Count: 2/)).toBeInTheDocument();
+    expect(screen.getByText(/Min: 1s/)).toBeInTheDocument();
+    expect(screen.getByText(/Max: 2s/)).toBeInTheDocument();
+    expect(screen.getByText(/Sum: 3s/)).toBeInTheDocument();
+    expect(screen.getByText(/Avg: 1\.5s/)).toBeInTheDocument();
+
+    expect(screen.getByText('Tags')).toBeInTheDocument();
+    expect(screen.getByText('foo')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'bar'})).toBeInTheDocument();
+  });
+
+  it('renders (count === 1)', () => {
+    const organization = OrganizationFixture({features: ['ddm-ui']});
+    const metricsSummary: MetricsSummary = {
+      'd:custom/my.metric@second': [
+        {
+          count: 1,
+          min: 2,
+          max: 2,
+          sum: 2,
+          tags: {
+            foo: 'bar',
+          },
+        },
+      ],
+    };
+
+    render(<CustomMetricsEventData metricsSummary={metricsSummary} />, {
+      organization,
+    });
+
+    expect(screen.getByText('Emitted Metrics')).toBeInTheDocument();
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('my.metric')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open in Metrics'})).toBeInTheDocument();
+
+    expect(screen.getByText('Stats')).toBeInTheDocument();
+    expect(screen.getByText(/Type: distribution/)).toBeInTheDocument();
+    expect(screen.getByText(/Count: 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Value: 2s/)).toBeInTheDocument();
+
+    expect(screen.getByText('Tags')).toBeInTheDocument();
+    expect(screen.getByText('foo')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'bar'})).toBeInTheDocument();
+  });
+
+  it('renders (counter metric)', () => {
+    const organization = OrganizationFixture({features: ['ddm-ui']});
+    const metricsSummary: MetricsSummary = {
+      'c:custom/my.metric@second': [
+        {
+          count: 1,
+          min: 1,
+          max: 1,
+          sum: 1,
+          tags: {
+            foo: 'bar',
+          },
+        },
+      ],
+    };
+
+    render(<CustomMetricsEventData metricsSummary={metricsSummary} />, {
+      organization,
+    });
+
+    expect(screen.getByText('Emitted Metrics')).toBeInTheDocument();
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('my.metric')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open in Metrics'})).toBeInTheDocument();
+
+    expect(screen.getByText('Stats')).toBeInTheDocument();
+    expect(screen.getByText(/Type: counter/)).toBeInTheDocument();
+    expect(screen.getByText(/Count: 1/)).toBeInTheDocument();
+
+    expect(screen.getByText('Tags')).toBeInTheDocument();
+    expect(screen.getByText('foo')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'bar'})).toBeInTheDocument();
+  });
+
+  it('renders (no tags)', () => {
+    const organization = OrganizationFixture({features: ['ddm-ui']});
+    const metricsSummary: MetricsSummary = {
+      'c:custom/my.metric@second': [
+        {
+          count: 1,
+          min: 1,
+          max: 1,
+          sum: 1,
+          tags: null,
+        },
+      ],
+    };
+
+    render(<CustomMetricsEventData metricsSummary={metricsSummary} />, {
+      organization,
+    });
+
+    expect(screen.getByText('Emitted Metrics')).toBeInTheDocument();
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('my.metric')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open in Metrics'})).toBeInTheDocument();
+
+    expect(screen.getByText('Stats')).toBeInTheDocument();
+    expect(screen.getByText(/Type: counter/)).toBeInTheDocument();
+    expect(screen.getByText(/Count: 1/)).toBeInTheDocument();
+
+    expect(screen.queryByText('Tags')).not.toBeInTheDocument();
+  });
+
+  it('renders (empty tags)', () => {
+    const organization = OrganizationFixture({features: ['ddm-ui']});
+    const metricsSummary: MetricsSummary = {
+      'c:custom/my.metric@second': [
+        {
+          count: 1,
+          min: 1,
+          max: 1,
+          sum: 1,
+          tags: {},
+        },
+      ],
+    };
+
+    render(<CustomMetricsEventData metricsSummary={metricsSummary} />, {
+      organization,
+    });
+
+    expect(screen.getByText('Emitted Metrics')).toBeInTheDocument();
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('my.metric')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open in Metrics'})).toBeInTheDocument();
+
+    expect(screen.getByText('Stats')).toBeInTheDocument();
+    expect(screen.getByText(/Type: counter/)).toBeInTheDocument();
+    expect(screen.getByText(/Count: 1/)).toBeInTheDocument();
+
+    expect(screen.queryByText('Tags')).not.toBeInTheDocument();
+  });
+
+  it('renders (multiple)', () => {
+    const organization = OrganizationFixture({features: ['ddm-ui']});
+    const metricsSummary: MetricsSummary = {
+      'd:custom/my.distribution@second': [
+        {
+          count: 2,
+          min: 1,
+          max: 2,
+          sum: 3,
+          tags: {
+            foo: 'bar',
+          },
+        },
+        {
+          count: 1,
+          min: 1,
+          max: 1,
+          sum: 1,
+          tags: null,
+        },
+      ],
+      'c:custom/my.counter@second': [
+        {
+          count: 2,
+          min: 1,
+          max: 2,
+          sum: 3,
+          tags: {
+            foo: 'bar',
+          },
+        },
+      ],
+    };
+
+    render(<CustomMetricsEventData metricsSummary={metricsSummary} />, {
+      organization,
+    });
+
+    expect(screen.getByText('Emitted Metrics')).toBeInTheDocument();
+
+    expect(screen.getAllByText('Name')).toHaveLength(3);
+    expect(screen.getAllByText('my.distribution')).toHaveLength(2);
+    expect(screen.getAllByText('my.counter')).toHaveLength(1);
+  });
+});

--- a/static/app/views/ddm/customMetricsEventData.tsx
+++ b/static/app/views/ddm/customMetricsEventData.tsx
@@ -1,0 +1,206 @@
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {LinkButton} from 'sentry/components/button';
+import {EventDataSection} from 'sentry/components/events/eventDataSection';
+import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
+import {
+  MetricsSummary,
+  MetricsSummaryItem,
+} from 'sentry/components/events/interfaces/spans/types';
+import Link from 'sentry/components/links/link';
+import Pill from 'sentry/components/pill';
+import Pills from 'sentry/components/pills';
+import TextOverflow from 'sentry/components/textOverflow';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {MRI, Organization} from 'sentry/types';
+import {
+  formatMetricUsingUnit,
+  getDdmUrl,
+  getDefaultMetricOp,
+  getReadableMetricType,
+  MetricDisplayType,
+} from 'sentry/utils/metrics';
+import {hasDDMFeature} from 'sentry/utils/metrics/features';
+import {formatMRI, parseMRI} from 'sentry/utils/metrics/mri';
+import useOrganization from 'sentry/utils/useOrganization';
+
+function flattenMetricsSummary(
+  metricsSummary: MetricsSummary
+): {item: MetricsSummaryItem; key: string; mri: MRI}[] {
+  return Object.entries(metricsSummary).flatMap(([mri, items]) =>
+    items.map((item, index) => ({item, mri, key: `${mri}${index}`}))
+  );
+}
+
+export function CustomMetricsEventData({
+  metricsSummary,
+}: {
+  metricsSummary: MetricsSummary;
+}) {
+  const organization = useOrganization();
+  const metricsSummaryEntries = flattenMetricsSummary(metricsSummary);
+
+  if (!hasDDMFeature(organization) || metricsSummaryEntries.length === 0) {
+    return null;
+  }
+
+  return (
+    <EventDataSection type="custom-metrics" title={t('Emitted Metrics')}>
+      {metricsSummaryEntries.map(({mri, item, key}) => {
+        return (
+          <Fragment key={key}>
+            <KeyValueList
+              shouldSort={false}
+              data={[
+                {
+                  key: 'name',
+                  subject: t('Name'),
+                  value: <TextOverflow>{formatMRI(mri)}</TextOverflow>,
+                  actionButton: (
+                    <LinkButton
+                      size="xs"
+                      to={getDdmUrl(organization.slug, {
+                        widgets: [
+                          {
+                            mri,
+                            displayType: MetricDisplayType.LINE,
+                            op: getDefaultMetricOp(mri),
+                          },
+                        ],
+                      })}
+                    >
+                      {t('Open in Metrics')}
+                    </LinkButton>
+                  ),
+                },
+                {
+                  key: 'stats',
+                  subject: t('Stats'),
+                  value: <MetricStats item={item} mri={mri} />,
+                },
+                item.tags && Object.keys(item.tags).length > 0
+                  ? {
+                      key: 'tags',
+                      subject: t('Tags'),
+                      value: (
+                        <Tags tags={item.tags} organization={organization} mri={mri} />
+                      ),
+                    }
+                  : null,
+              ].filter((row): row is Exclude<typeof row, null> => Boolean(row))}
+            />
+          </Fragment>
+        );
+      })}
+    </EventDataSection>
+  );
+}
+
+function MetricStats({mri, item}: {item: MetricsSummaryItem; mri: MRI}) {
+  const parsedMRI = parseMRI(mri);
+  const unit = parsedMRI?.unit ?? 'none';
+  const type = parsedMRI?.type ?? 'c';
+
+  const typeLine = t(`Type: %s`, getReadableMetricType(type));
+  // We use formatMetricUsingUnit with unit 'none' to ensure uniform number formatting
+  const countLine = t(`Count: %s`, formatMetricUsingUnit(item.count, 'none'));
+
+  const baseStats = (
+    <Fragment>
+      {typeLine}
+      <br />
+      {countLine}
+    </Fragment>
+  );
+
+  // For counters the other stats offer little value, so we only show type and count
+  if (type === 'c' || !item.count) {
+    return <pre>{baseStats}</pre>;
+  }
+
+  // If there is only one value, min, max, avg and sum are all the same
+  if (item.count <= 1) {
+    return (
+      <pre>
+        {baseStats}
+        <br />
+        {t('Value: %s', formatMetricUsingUnit(item.sum, unit))}
+      </pre>
+    );
+  }
+
+  return (
+    <pre>
+      {baseStats}
+      <br />
+      {t('Sum: %s', formatMetricUsingUnit(item.sum, unit))}
+      <br />
+      {t('Min: %s', formatMetricUsingUnit(item.min, unit))}
+      <br />
+      {t('Max: %s', formatMetricUsingUnit(item.max, unit))}
+      <br />
+      {t(
+        'Avg: %s',
+        formatMetricUsingUnit(item.sum && item.count && item.sum / item.count, unit)
+      )}
+    </pre>
+  );
+}
+
+function Tags({
+  tags,
+  organization,
+  mri,
+}: {
+  mri: MRI;
+  organization: Organization;
+  tags: Record<string, string>;
+}) {
+  const [showingAll, setShowingAll] = useState(false);
+
+  const renderedTags = Object.entries(tags).slice(0, showingAll ? undefined : 5);
+  const renderText = showingAll ? t('Show less') : t('Show more') + '...';
+
+  return (
+    <StyledPills>
+      {renderedTags.map(([tagKey, tagValue]) => (
+        <Pill key={tagKey} name={tagKey}>
+          <Link
+            to={getDdmUrl(organization.slug, {
+              widgets: [
+                {
+                  mri,
+                  displayType: MetricDisplayType.LINE,
+                  op: getDefaultMetricOp(mri),
+                  query: `${tagKey}:"${tagValue}"`,
+                },
+              ],
+            })}
+          >
+            <StyledTextOverflow>{tagValue}</StyledTextOverflow>
+          </Link>
+        </Pill>
+      ))}
+      {Object.entries(tags).length > 5 && (
+        <ShowMore onClick={() => setShowingAll(prev => !prev)}>{renderText}</ShowMore>
+      )}
+    </StyledPills>
+  );
+}
+
+const StyledTextOverflow = styled(TextOverflow)`
+  max-width: 300px;
+`;
+
+const StyledPills = styled(Pills)`
+  padding-top: ${space(1)};
+`;
+
+const ShowMore = styled('a')`
+  white-space: nowrap;
+  align-self: center;
+  margin-bottom: ${space(1)};
+  padding: ${space(0.5)} ${space(0.5)};
+`;

--- a/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
+++ b/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
@@ -62,6 +62,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {isCustomMeasurement} from 'sentry/views/dashboards/utils';
+import {CustomMetricsEventData} from 'sentry/views/ddm/customMetricsEventData';
 import {ProfileGroupProvider} from 'sentry/views/profiling/profileGroupProvider';
 import {ProfileContext, ProfilesProvider} from 'sentry/views/profiling/profilesProvider';
 import DetailPanel from 'sentry/views/starfish/components/detailPanel';
@@ -461,6 +462,9 @@ function EventDetails({detail, organization, location}: EventDetailProps) {
       )}
       <EventExtraData event={detail.event} />
       <EventSdk sdk={detail.event.sdk} meta={detail.event._meta?.sdk} />
+      {detail.event._metrics_summary ? (
+        <CustomMetricsEventData metricsSummary={detail.event._metrics_summary} />
+      ) : null}
       <BreadCrumbsSection event={detail.event} organization={organization} />
       {projectSlug && <EventAttachments event={detail.event} projectSlug={projectSlug} />}
       {project && <EventViewHierarchy event={detail.event} project={project} />}

--- a/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
+++ b/static/app/views/performance/traceDetails/traceViewDetailPanel.tsx
@@ -463,7 +463,10 @@ function EventDetails({detail, organization, location}: EventDetailProps) {
       <EventExtraData event={detail.event} />
       <EventSdk sdk={detail.event.sdk} meta={detail.event._meta?.sdk} />
       {detail.event._metrics_summary ? (
-        <CustomMetricsEventData metricsSummary={detail.event._metrics_summary} />
+        <CustomMetricsEventData
+          metricsSummary={detail.event._metrics_summary}
+          startTimestamp={detail.event.startTimestamp}
+        />
       ) : null}
       <BreadCrumbsSection event={detail.event} organization={organization} />
       {projectSlug && <EventAttachments event={detail.event} projectSlug={projectSlug} />}


### PR DESCRIPTION
Format metrics summary when showing transaction / span details.
Render metrics summary in transaction details.

![Screenshot 2024-01-25 at 11 22 39](https://github.com/getsentry/sentry/assets/7033940/bc7d5cd7-8aa8-4c5e-b854-03eda15be984)

- https://github.com/getsentry/sentry/issues/62931
- https://github.com/getsentry/sentry/issues/63578