### PR TITLE
feat(profiling): add metric to count unsampled profiles processed 

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -79,6 +79,12 @@ def process_profile_task(
 
     assert profile is not None
 
+    if not sampled:
+        metrics.incr(
+            "process_profile.unsampled_profiles",
+            tags={"platform": profile["platform"]},
+        )
+
     organization = Organization.objects.get_from_cache(id=profile["organization_id"])
 
     sentry_sdk.set_tag("organization", organization.id)


### PR DESCRIPTION
Adding this to make sure we can track new unsampled profiles being processed and collect some stats.

We probably won't need to keep this metric in the future so we might remove it at some point. 