### PR TITLE
Call `Enhancements.dumps` only once

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -152,7 +152,7 @@ class Enhancements:
         # The extra fingerprint mostly makes sense during test execution when two different group configs
         # can share the same set of rules and bases
         stacktrace_fingerprint = _generate_stacktrace_fingerprint(
-            match_frames, exception_data, f"{extra_fingerprint}.{self.dumps()}", platform
+            match_frames, exception_data, extra_fingerprint, platform
         )
         # The most expensive part of creating groups is applying the rules to frames (next code block)
         cache_key = f"stacktrace_hash.{stacktrace_fingerprint}"

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -327,10 +327,11 @@ def normalize_stacktraces_for_grouping(
     # If a grouping config is available, run grouping enhancers
     if grouping_config is not None:
         with sentry_sdk.start_span(op=op, description="apply_modifications_to_frame"):
+            extra_fingerprint = f"{grouping_config.id}.{grouping_config.enhancements.dumps()}"
             for frames, stacktrace_container in zip(stacktrace_frames, stacktrace_containers):
                 # This call has a caching mechanism when the same stacktrace and rules are used
                 grouping_config.enhancements.apply_modifications_to_frame(
-                    frames, platform, stacktrace_container, extra_fingerprint=grouping_config.id
+                    frames, platform, stacktrace_container, extra_fingerprint=extra_fingerprint
                 )
 
     # normalize `in_app` values, noting and storing the event's mix of in-app and system frames, so
@@ -591,7 +592,6 @@ def process_stacktraces(data, make_processors=None, set_raw_stacktrace=True):
     # Build a new processing task
     processing_task = get_stacktrace_processing_task(infos, processors)
     try:
-
         # Preprocess step
         for processor in processing_task.iter_processors():
             with sentry_sdk.start_span(


### PR DESCRIPTION
Previously, it was being called for every stacktrace, now we only call it once per grouping invocation.

The `extra_fingerprint` argument was only used in a single place: formatting it into a string together with `Enhancements.dumps()` inside of `apply_modifications_to_frame`.

This just moved this string formatting out of `apply_modifications_to_frame` and into the caller. This code is loop-invariant, so moving it out of the function and out of the loop is sound.