### PR TITLE
ref: replace deprecated get_storage_class with import_string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ filterwarnings = [
     "ignore:'index_together' is deprecated. Use 'Meta.indexes' in.*",
     "ignore:Passing unsaved model instances to related filters is deprecated.",
     "ignore:The django.utils.timezone.utc alias is deprecated.*",
-    "ignore:django.core.files.storage.get_storage_class is deprecated in favor of using django.core.files.storage.storages.",
 
     # a bunch of google packages use legacy namespace packages
     "ignore:pkg_resources is deprecated as an API",

--- a/src/sentry/models/files/utils.py
+++ b/src/sentry/models/files/utils.py
@@ -7,12 +7,12 @@ from datetime import timedelta
 from hashlib import sha1
 
 from django.conf import settings
-from django.core.files.storage import get_storage_class
 from django.utils import timezone
 
 from sentry import options
 from sentry.locks import locks
 from sentry.utils import redis
+from sentry.utils.imports import import_string
 from sentry.utils.retries import TimedRetryPolicy
 
 ONE_DAY = 60 * 60 * 24
@@ -133,7 +133,7 @@ def get_storage(config=None):
     except KeyError:
         pass
 
-    storage = get_storage_class(backend)
+    storage = import_string(backend)
     return storage(**options)
 
 
@@ -152,7 +152,7 @@ def get_relocation_storage(config=None):
     except KeyError:
         pass
 
-    storage = get_storage_class(backend)
+    storage = import_string(backend)
     return storage(**relocation)
 
 


### PR DESCRIPTION
we're not actually using the django STORAGES for this so `get_storage_class` was wrong all along

the warning is new in django 4, but this change is compatible with django 3

<!-- Describe your PR here. -->