### PR TITLE
fix(apps): validate if the app exists and is published before installation

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
@@ -48,9 +48,9 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
 
         # only published or owned apps are allowed to be installed
         app = SentryApp.objects.filter(slug=slug).first()
-        if not app:
-            return Response(status=404)
-        if not app.status == SentryAppStatus.PUBLISHED and app.owner_id != organization.id:
+        if app is None or (
+            app.status != SentryAppStatus.PUBLISHED and app.owner_id != organization.id
+        ):
             return Response(status=404)
 
         try:

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
@@ -46,9 +46,10 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
 
         slug = serializer.validated_data.get("slug")
 
-        # only published apps are allowed to be installed
-        app = SentryApp.objects.filter(slug=slug, status=SentryAppStatus.PUBLISHED)
-        if not app:
+        # only published or owned apps are allowed to be installed
+        app_published = SentryApp.objects.filter(slug=slug, status=SentryAppStatus.PUBLISHED)
+        app_owned = SentryApp.objects.filter(slug=slug, owner_id=organization.id)
+        if not app_published and not app_owned:
             return Response(status=404)
 
         try:

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
@@ -9,7 +9,8 @@ from sentry.api.bases import SentryAppInstallationsBaseEndpoint
 from sentry.api.fields.sentry_slug import SentrySerializerSlugField
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.constants import SENTRY_APP_SLUG_MAX_LENGTH
+from sentry.constants import SENTRY_APP_SLUG_MAX_LENGTH, SentryAppStatus
+from sentry.models.integrations.sentry_app import SentryApp
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.sentry_apps.installations import SentryAppInstallationCreator
 
@@ -43,9 +44,15 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
-        # check for an exiting installation and return that if it exists
         slug = serializer.validated_data.get("slug")
+
+        # only published apps are allowed to be installed
+        app = SentryApp.objects.filter(slug=slug, status=SentryAppStatus.PUBLISHED)
+        if not app:
+            return Response(status=404)
+
         try:
+            # check for an exiting installation and return that if it exists
             install = SentryAppInstallation.objects.get(
                 sentry_app__slug=slug, organization_id=organization.id
             )

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
@@ -47,9 +47,10 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
         slug = serializer.validated_data.get("slug")
 
         # only published or owned apps are allowed to be installed
-        app_published = SentryApp.objects.filter(slug=slug, status=SentryAppStatus.PUBLISHED)
-        app_owned = SentryApp.objects.filter(slug=slug, owner_id=organization.id)
-        if not app_published and not app_owned:
+        app = SentryApp.objects.filter(slug=slug).first()
+        if not app:
+            return Response(status=404)
+        if not app.status == SentryAppStatus.PUBLISHED and app.owner_id != organization.id:
             return Response(status=404)
 
         try:

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -127,3 +127,19 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
         self.login_as(user=self.user)
         response = self.get_error_response(self.org.slug, slug="1234", status_code=400)
         assert response.data["slug"][0] == DEFAULT_SLUG_ERROR_MESSAGE
+
+    def test_cannot_install_nonexistent_app(self):
+        self.login_as(user=self.user)
+        self.get_error_response(self.org.slug, slug="nonexistent", status_code=404)
+
+    def test_cannot_install_unpublished_unowned_app(self):
+        self.login_as(user=self.user)
+        org2 = self.create_organization()
+        app2 = self.create_sentry_app(name="Unpublished", organization=org2)
+        self.get_error_response(self.org.slug, slug=app2.slug, status_code=404)
+
+    def test_cannot_install_other_org_internal_app(self):
+        self.login_as(user=self.user)
+        org2 = self.create_organization()
+        internal_app = self.create_internal_integration(name="Internal App", organization=org2)
+        self.get_error_response(self.org.slug, slug=internal_app.slug, status_code=404)


### PR DESCRIPTION
* fixes [HTTP 500 on SentryApp.DoesNotExist](https://sentry.sentry.io/issues/4914934320/?project=1), now responds with empty 404
* disallows installation of other org's unpublished sentry apps
* disallows installation of other org's internal integration as a sentry app
