### PR TITLE
fix(ui) Fix webpack local proxy hitting CSRF issues

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -675,6 +675,7 @@ if (IS_UI_DEV_ONLY) {
         headers: {
           Referer: 'https://sentry.io/',
           'Document-Policy': 'js-profiling',
+          origin: 'https://sentry.io',
         },
         cookieDomainRewrite: {'.sentry.io': 'localhost'},
         router: ({hostname}) => {
@@ -696,6 +697,7 @@ if (IS_UI_DEV_ONLY) {
         headers: {
           Referer: 'https://sentry.io/',
           'Document-Policy': 'js-profiling',
+          origin: 'https://sentry.io',
         },
         cookieDomainRewrite: {'.sentry.io': 'localhost'},
         pathRewrite: {


### PR DESCRIPTION
New Django is applying more restrictive hostname checking that is resulting in all update operations failing with CSRF errors.

Rewrite the origin header to one that saas expects instead of using what devserver normally would.
