### PR TITLE
ref(tsc): Convert LogFileViewer from AsyncComponent to FC and useApiQuery

### DIFF
--- a/static/app/components/events/attachmentViewers/logFileViewer.tsx
+++ b/static/app/components/events/attachmentViewers/logFileViewer.tsx
@@ -1,40 +1,40 @@
 import styled from '@emotion/styled';
 import Ansi from 'ansi-to-react';
 
-import DeprecatedAsyncComponent from 'sentry/components/deprecatedAsyncComponent';
 import PreviewPanelItem from 'sentry/components/events/attachmentViewers/previewPanelItem';
 import {
   getAttachmentUrl,
   ViewerProps,
 } from 'sentry/components/events/attachmentViewers/utils';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {useApiQuery} from 'sentry/utils/queryClient';
 
-type Props = ViewerProps & DeprecatedAsyncComponent['props'];
+function LogFileViewer(props: ViewerProps) {
+  const {data, isLoading, isError} = useApiQuery<string>(
+    [getAttachmentUrl(props), {headers: {Accept: '*/*; charset=utf-8'}}],
+    {
+      staleTime: Infinity,
+    }
+  );
 
-type State = DeprecatedAsyncComponent['state'];
-
-class LogFileViewer extends DeprecatedAsyncComponent<Props, State> {
-  getEndpoints(): ReturnType<DeprecatedAsyncComponent['getEndpoints']> {
-    return [
-      [
-        'attachmentText',
-        getAttachmentUrl(this.props),
-        {headers: {Accept: '*/*; charset=utf-8'}},
-      ],
-    ];
+  if (isError) {
+    return <LoadingError message={t('Failed to download attachment.')} />;
   }
 
-  renderBody() {
-    const {attachmentText} = this.state;
-
-    return !attachmentText ? null : (
-      <PreviewPanelItem>
-        <CodeWrapper>
-          <SentryStyleAnsi useClasses>{attachmentText}</SentryStyleAnsi>
-        </CodeWrapper>
-      </PreviewPanelItem>
-    );
+  if (isLoading) {
+    return <LoadingIndicator />;
   }
+
+  return data ? (
+    <PreviewPanelItem>
+      <CodeWrapper>
+        <SentryStyleAnsi useClasses>{data}</SentryStyleAnsi>
+      </CodeWrapper>
+    </PreviewPanelItem>
+  ) : null;
 }
 
 export default LogFileViewer;

--- a/static/app/components/events/eventAttachments.spec.tsx
+++ b/static/app/components/events/eventAttachments.spec.tsx
@@ -151,7 +151,7 @@ describe('EventAttachments', function () {
 
     await userEvent.click(screen.getByRole('button', {name: /preview/i}));
 
-    expect(screen.getByText('file contents')).toBeInTheDocument();
+    expect(await screen.findByText('file contents')).toBeInTheDocument();
   });
 
   it('can delete attachments', async function () {


### PR DESCRIPTION
Ref https://github.com/getsentry/frontend-tsc/issues/2

Here's a simple one. It's shown when previewing plain text attachments on the issue event details.