### PR TITLE
 fix(hybrid-cloud): Fix RPC call with invalid parameters with test fix

### DIFF
--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -221,10 +221,11 @@ class ApiInviteHelper:
 
         if self.member_already_exists:
             self.handle_member_already_exists()
-            organization_service.delete_organization_member(
-                organization_member_id=self.invite_context.invite_organization_member_id,
-                organization_id=self.invite_context.organization.id,
-            )
+            if self.invite_context.invite_organization_member_id is not None:
+                organization_service.delete_organization_member(
+                    organization_member_id=self.invite_context.invite_organization_member_id,
+                    organization_id=self.invite_context.organization.id,
+                )
             return None
 
         try:

--- a/tests/sentry/api/test_invite_helper.py
+++ b/tests/sentry/api/test_invite_helper.py
@@ -69,7 +69,8 @@ class ApiInviteHelperTest(TestCase):
         assert invite_context is not None
 
         helper = ApiInviteHelper(self.request, invite_context, None)
-        helper.accept_invite()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            helper.accept_invite()
         invite_context = organization_service.get_invite_by_id(
             organization_member_id=om.id, organization_id=om.organization_id
         )
@@ -80,7 +81,8 @@ class ApiInviteHelperTest(TestCase):
         # Without this member_id, don't delete the organization member
         invite_context.invite_organization_member_id = None
         helper = ApiInviteHelper(self.request, invite_context, None)
-        helper.accept_invite()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            helper.accept_invite()
         om = OrganizationMember.objects.get(id=self.member.id)
         assert om.email is None
         assert om.user_id == self.user.id
@@ -88,7 +90,8 @@ class ApiInviteHelperTest(TestCase):
         # With the member_id, ensure it's deleted
         invite_context.invite_organization_member_id = member_id
         helper = ApiInviteHelper(self.request, invite_context, None)
-        helper.accept_invite()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            helper.accept_invite()
         with pytest.raises(OrganizationMember.DoesNotExist):
             OrganizationMember.objects.get(id=self.member.id)
 

--- a/tests/sentry/api/test_invite_helper.py
+++ b/tests/sentry/api/test_invite_helper.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 from django.http import HttpRequest
 
 from sentry.api.invite_helper import ApiInviteHelper
@@ -55,6 +56,41 @@ class ApiInviteHelperTest(TestCase):
         om = OrganizationMember.objects.get(id=self.member.id)
         assert om.email is None
         assert om.user_id == self.user.id
+
+    @patch("sentry.api.invite_helper.create_audit_entry")
+    @patch("sentry.api.invite_helper.RpcOrganizationMember.get_audit_log_metadata")
+    def test_accept_invite_already_exists(self, get_audit, create_audit):
+        om = OrganizationMember.objects.get(id=self.member.id)
+        assert om.email == self.member.email
+
+        invite_context = organization_service.get_invite_by_id(
+            organization_member_id=om.id, organization_id=om.organization_id
+        )
+        assert invite_context is not None
+
+        helper = ApiInviteHelper(self.request, invite_context, None)
+        helper.accept_invite()
+        invite_context = organization_service.get_invite_by_id(
+            organization_member_id=om.id, organization_id=om.organization_id
+        )
+        assert invite_context is not None
+        member_id = invite_context.invite_organization_member_id
+        assert member_id is not None
+
+        # Without this member_id, don't delete the organization member
+        invite_context.invite_organization_member_id = None
+        helper = ApiInviteHelper(self.request, invite_context, None)
+        helper.accept_invite()
+        om = OrganizationMember.objects.get(id=self.member.id)
+        assert om.email is None
+        assert om.user_id == self.user.id
+
+        # With the member_id, ensure it's deleted
+        invite_context.invite_organization_member_id = member_id
+        helper = ApiInviteHelper(self.request, invite_context, None)
+        helper.accept_invite()
+        with pytest.raises(OrganizationMember.DoesNotExist):
+            OrganizationMember.objects.get(id=self.member.id)
 
     @patch("sentry.api.invite_helper.create_audit_entry")
     @patch("sentry.api.invite_helper.RpcOrganizationMember.get_audit_log_metadata")


### PR DESCRIPTION
Repeat of https://github.com/getsentry/sentry/pull/63434, which was stale when merged, and had a failing test. Added the text fix.