### PR TITLE
ref: delete after audit log data so self information is captured

### DIFF
--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -633,8 +633,6 @@ class OrganizationMember(ReplicatedRegionModel):
         if self.invite_status == InviteStatus.APPROVED.value:
             return
 
-        self.delete()
-
         create_audit_entry_from_user(
             user_to_approve,
             api_key,
@@ -644,6 +642,8 @@ class OrganizationMember(ReplicatedRegionModel):
             data=self.get_audit_log_data(),
             event=audit_log.get_event_id("INVITE_REQUEST_REMOVE"),
         )
+
+        self.delete()
 
     def get_allowed_org_roles_to_invite(self):
         """


### PR DESCRIPTION
currently the model is being deleted and then looked up in a join after resulting in no data

django 4 makes this a warning, django 5 makes this fatal

<!-- Describe your PR here. -->