### PR TITLE
ref: fix test which joined on already-deleted object

### DIFF
--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1220,13 +1220,13 @@ class DeleteAlertRuleTriggerTest(TestCase):
         )
         trigger_id = trigger.id
         assert AlertRuleTriggerExclusion.objects.filter(
-            alert_rule_trigger=trigger, query_subscription__project=self.project
+            alert_rule_trigger=trigger_id, query_subscription__project=self.project
         ).exists()
         delete_alert_rule_trigger(trigger)
 
         assert not AlertRuleTrigger.objects.filter(id=trigger_id).exists()
         assert not AlertRuleTriggerExclusion.objects.filter(
-            alert_rule_trigger=trigger, query_subscription__project=self.project
+            alert_rule_trigger=trigger_id, query_subscription__project=self.project
         ).exists()
 
 


### PR DESCRIPTION
this join will always fail so the test was not asserting anything

django 4 makes this a warning, django 5 makes this fatal

<!-- Describe your PR here. -->