### PR TITLE
feat(priority): Update group serializer to return priority

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -66,7 +66,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.tagstore.snuba.backend import fix_tag_value_data
 from sentry.tagstore.types import GroupTagValue
 from sentry.tsdb.snuba import SnubaTSDB
-from sentry.types.group import SUBSTATUS_TO_STR, PriorityLevel
+from sentry.types.group import PRIORITY_LEVEL_TO_STR, SUBSTATUS_TO_STR
 from sentry.utils.cache import cache
 from sentry.utils.json import JSONData
 from sentry.utils.safe import safe_execute
@@ -364,7 +364,7 @@ class GroupSerializerBase(Serializer, ABC):
         }
 
         if features.has("projects:issue-priority", obj.project, actor=None):
-            priority_label = self._get_priority(obj.priority) if obj.priority is not None else None
+            priority_label = PRIORITY_LEVEL_TO_STR[obj.priority] if obj.priority else None
             group_dict["priority"] = priority_label
 
         # This attribute is currently feature gated
@@ -396,15 +396,6 @@ class GroupSerializerBase(Serializer, ABC):
         if self.collapse is None:
             return False
         return key in self.collapse
-
-    def _get_priority(self, priority: int) -> str:
-        if priority == PriorityLevel.HIGH:
-            priority_label = "high"
-        elif priority == PriorityLevel.LOW:
-            priority_label = "low"
-        else:
-            priority_label = "medium"
-        return priority_label
 
     def _get_status(self, attrs: MutableMapping[str, Any], obj: Group):
         status = obj.status

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -364,7 +364,7 @@ class GroupSerializerBase(Serializer, ABC):
         }
 
         if features.has("projects:issue-priority", obj.project, actor=None):
-            priority_label = self._get_priority(obj) if obj.priority is not None else None
+            priority_label = self._get_priority(obj.priority) if obj.priority is not None else None
             group_dict["priority"] = priority_label
 
         # This attribute is currently feature gated
@@ -397,8 +397,7 @@ class GroupSerializerBase(Serializer, ABC):
             return False
         return key in self.collapse
 
-    def _get_priority(self, obj: Group) -> str:
-        priority = obj.priority
+    def _get_priority(self, priority: int) -> str:
         if priority == PriorityLevel.HIGH:
             priority_label = "high"
         elif priority == PriorityLevel.LOW:

--- a/src/sentry/types/group.py
+++ b/src/sentry/types/group.py
@@ -71,3 +71,10 @@ class PriorityLevel:
     LOW = 25
     MEDIUM = 50
     HIGH = 75
+
+
+PRIORITY_LEVEL_TO_STR: dict[int, str] = {
+    PriorityLevel.LOW: "low",
+    PriorityLevel.MEDIUM: "medium",
+    PriorityLevel.HIGH: "high",
+}

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -47,6 +47,12 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         result = serialize(group, outside_user, serializer=GroupSerializerSnuba())
         assert result["permalink"] is None
 
+    def test_priority_no_ff(self):
+        outside_user = self.create_user()
+        group = self.create_group()
+        result = serialize(group, outside_user, serializer=GroupSerializerSnuba())
+        assert "priority" not in result
+
     @with_feature("projects:issue-priority")
     def test_priority_high(self):
         outside_user = self.create_user()

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -21,6 +21,7 @@ from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, SnubaT
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.performance_issues.store_transaction import PerfIssueTransactionTestMixin
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.types.group import PriorityLevel
 from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 
@@ -44,6 +45,19 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         group = self.create_group()
         result = serialize(group, outside_user, serializer=GroupSerializerSnuba())
         assert result["permalink"] is None
+
+    def test_priority_high(self):
+        outside_user = self.create_user()
+        group = self.create_group()
+        group.priority = PriorityLevel.HIGH
+        result = serialize(group, outside_user, serializer=GroupSerializerSnuba())
+        assert result["priority"] == "high"
+
+    def test_priority_default(self):
+        outside_user = self.create_user()
+        group = self.create_group()
+        result = serialize(group, outside_user, serializer=GroupSerializerSnuba())
+        assert result["priority"] == "low"
 
     def test_is_ignored_with_expired_snooze(self):
         now = django_timezone.now()

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -56,16 +56,14 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
     @with_feature("projects:issue-priority")
     def test_priority_high(self):
         outside_user = self.create_user()
-        group = self.create_group()
-        group.priority = PriorityLevel.HIGH
+        group = self.create_group(priority=PriorityLevel.HIGH)
         result = serialize(group, outside_user, serializer=GroupSerializerSnuba())
         assert result["priority"] == "high"
 
     @with_feature("projects:issue-priority")
     def test_priority_medium(self):
         outside_user = self.create_user()
-        group = self.create_group()
-        group.priority = PriorityLevel.MEDIUM
+        group = self.create_group(priority=PriorityLevel.MEDIUM)
         result = serialize(group, outside_user, serializer=GroupSerializerSnuba())
         assert result["priority"] == "medium"
 


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/63266

Serializer updated to return priority. The serialized value is a string (high/ medium / low) and not the raw number value.