### PR TITLE
fix(issues): remove unnecessary query

### DIFF
--- a/src/sentry/tasks/auto_ongoing_issues.py
+++ b/src/sentry/tasks/auto_ongoing_issues.py
@@ -129,8 +129,6 @@ def schedule_auto_transition_issues_new_to_ongoing(
         "first_seen_lte": first_seen_lte,
         "first_seen_lte_datetime": first_seen_lte_datetime,
     }
-    if base_queryset:
-        logger_extra["issue_first_seen"] = base_queryset[0].first_seen
     logger.info(
         "auto_transition_issues_new_to_ongoing started",
         extra=logger_extra,

--- a/tests/sentry/tasks/test_auto_ongoing_issues.py
+++ b/tests/sentry/tasks/test_auto_ongoing_issues.py
@@ -262,7 +262,6 @@ class ScheduleAutoNewOngoingIssuesTest(TestCase):
             extra={
                 "first_seen_lte": 1688582400,
                 "first_seen_lte_datetime": datetime(2023, 7, 5, 18, 40, tzinfo=timezone.utc),
-                "issue_first_seen": datetime(2023, 7, 5, 17, 40, tzinfo=timezone.utc),
             },
         )
 


### PR DESCRIPTION
Taking out this piece of logging data to make sure the query isn't timing out.