### PR TITLE
feat(replay): Show "Feedback Opened" breadcrumb

### DIFF
--- a/static/app/components/feedback/useCurrentFeedbackId.tsx
+++ b/static/app/components/feedback/useCurrentFeedbackId.tsx
@@ -1,11 +1,41 @@
+import {useEffect} from 'react';
+
 import decodeFeedbackSlug from 'sentry/components/feedback/decodeFeedbackSlug';
+import type {Event} from 'sentry/types';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {decodeScalar} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 
 export default function useCurrentFeedbackId() {
-  const {feedbackSlug} = useLocationQuery({
+  const organization = useOrganization();
+  const navigate = useNavigate();
+
+  const {eventId, feedbackSlug, projectSlug} = useLocationQuery({
     fields: {
+      eventId: decodeScalar,
       feedbackSlug: val => decodeFeedbackSlug(val).feedbackId ?? '',
+      projectSlug: decodeScalar,
     },
   });
+
+  const {data: event} = useApiQuery<Event>(
+    [`/projects/${organization.slug}/${projectSlug}/events/${eventId}/`],
+    {
+      staleTime: Infinity,
+      enabled: Boolean(eventId) && Boolean(projectSlug),
+    }
+  );
+
+  useEffect(() => {
+    if (projectSlug && event?.groupID) {
+      navigate(
+        `/organizations/${organization.slug}/feedback/?feedbackSlug=${projectSlug}:${event.groupID}`,
+        {replace: true}
+      );
+    }
+  }, [navigate, organization.slug, projectSlug, event]);
+
   return feedbackSlug;
 }

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -8,6 +8,7 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Link from 'sentry/components/links/link';
 import ObjectInspector from 'sentry/components/objectInspector';
 import PanelItem from 'sentry/components/panels/panelItem';
+import OpenFeedbackButton from 'sentry/components/replays/breadcrumbs/openFeedbackButton';
 import {OpenReplayComparisonButton} from 'sentry/components/replays/breadcrumbs/openReplayComparisonButton';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {useReplayGroupContext} from 'sentry/components/replays/replayGroupContext';
@@ -27,7 +28,7 @@ import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 
 type MouseCallback = (frame: ReplayFrame, e: React.MouseEvent<HTMLElement>) => void;
 
-const FRAMES_WITH_BUTTONS = ['replay.hydrate-error'];
+const FRAMES_WITH_BUTTONS = ['replay.hydrate-error', 'sentry.feedback'];
 
 interface Props {
   extraction: Extraction | undefined;
@@ -41,18 +42,12 @@ interface Props {
   ) => void;
   onMouseEnter: MouseCallback;
   onMouseLeave: MouseCallback;
+  projectSlug: string | undefined;
   startTimestampMs: number;
   traces: ReplayTraceRow | undefined;
   className?: string;
   expandPaths?: string[];
   style?: CSSProperties;
-}
-
-function getCrumbOrFrameData(frame: ReplayFrame) {
-  return {
-    ...getFrameDetails(frame),
-    timestampMs: frame.timestampMs,
-  };
 }
 
 function BreadcrumbItem({
@@ -65,11 +60,12 @@ function BreadcrumbItem({
   onInspectorExpanded,
   onMouseEnter,
   onMouseLeave,
+  projectSlug,
   startTimestampMs,
   style,
   traces,
 }: Props) {
-  const {color, description, title, icon, timestampMs} = getCrumbOrFrameData(frame);
+  const {color, description, title, icon} = getFrameDetails(frame);
   const {replay} = useReplayContext();
 
   const forceSpan = 'category' in frame && FRAMES_WITH_BUTTONS.includes(frame.category);
@@ -96,12 +92,13 @@ function BreadcrumbItem({
           {onClick ? (
             <TimestampButton
               startTimestampMs={startTimestampMs}
-              timestampMs={timestampMs}
+              timestampMs={frame.timestampMs}
             />
           ) : null}
         </TitleContainer>
 
-        {typeof description === 'string' || isValidElement(description) ? (
+        {typeof description === 'string' ||
+        (description !== undefined && isValidElement(description)) ? (
           <Description title={description} showOnlyOnOverflow isHoverable>
             {description}
           </Description>
@@ -128,6 +125,15 @@ function BreadcrumbItem({
                 (frame.data.mutations.next.timestamp as number) -
                 (replay?.getReplay().started_at.getTime() ?? 0)
               }
+            />
+          </div>
+        ) : null}
+
+        {projectSlug && 'data' in frame && frame.data && 'feedbackId' in frame.data ? (
+          <div>
+            <OpenFeedbackButton
+              projectSlug={projectSlug}
+              eventId={frame.data.feedbackId}
             />
           </div>
         ) : null}

--- a/static/app/components/replays/breadcrumbs/openFeedbackButton.tsx
+++ b/static/app/components/replays/breadcrumbs/openFeedbackButton.tsx
@@ -1,0 +1,33 @@
+import {LinkButton} from 'sentry/components/button';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+
+interface Props {
+  eventId: string;
+  projectSlug: string;
+  className?: string;
+}
+
+export default function OpenFeedbackButton({className, eventId, projectSlug}: Props) {
+  const organization = useOrganization();
+
+  return (
+    <LinkButton
+      className={className}
+      to={{
+        pathname: normalizeUrl(`/organizations/${organization.slug}/feedback/`),
+        query: {
+          projectSlug,
+          eventId,
+        },
+      }}
+      role="button"
+      size="xs"
+      analyticsEventKey="replay.details-feedback-opened"
+      analyticsEventName="Replay Details Feedback Opened"
+    >
+      {t('Open Feedback')}
+    </LinkButton>
+  );
+}

--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -15,11 +15,13 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {divide} from 'sentry/components/replays/utils';
 import toPercent from 'sentry/utils/number/toPercent';
 import {useDimensions} from 'sentry/utils/useDimensions';
+import useProjectFromId from 'sentry/utils/useProjectFromId';
 
-type Props = {};
-
-function ReplayTimeline({}: Props) {
+export default function ReplayTimeline() {
   const {replay, currentTime, timelineScale} = useReplayContext();
+  const projectSlug = useProjectFromId({
+    project_id: replay?.getReplay().project_id,
+  })?.slug;
 
   const panelRef = useRef<HTMLDivElement>(null);
   const mouseTrackingProps = useTimelineScrubberMouseTracking(
@@ -71,6 +73,7 @@ function ReplayTimeline({}: Props) {
           <ReplayTimelineEvents
             durationMs={durationMs}
             frames={chapterFrames}
+            projectSlug={projectSlug}
             startTimestampMs={startTimestampMs}
             width={width}
           />
@@ -91,5 +94,3 @@ const TimelineEventsContainer = styled('div')`
   padding-top: 10px;
   padding-bottom: 10px;
 `;
-
-export default ReplayTimeline;

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -19,15 +19,17 @@ const NODE_SIZES = [8, 12, 16];
 interface Props {
   durationMs: number;
   frames: ReplayFrame[];
+  projectSlug: string | undefined;
   startTimestampMs: number;
   width: number;
   className?: string;
 }
 
-function ReplayTimelineEvents({
+export default function ReplayTimelineEvents({
   className,
   durationMs,
   frames,
+  projectSlug,
   startTimestampMs,
   width,
 }: Props) {
@@ -43,6 +45,7 @@ function ReplayTimelineEvents({
           <Event
             frames={colFrames}
             markerWidth={markerWidth}
+            projectSlug={projectSlug}
             startTimestampMs={startTimestampMs}
           />
         </EventColumn>
@@ -66,10 +69,12 @@ const EventColumn = styled(Timeline.Col)<{column: number}>`
 function Event({
   frames,
   markerWidth,
+  projectSlug,
   startTimestampMs,
 }: {
   frames: ReplayFrame[];
   markerWidth: number;
+  projectSlug: string | undefined;
   startTimestampMs: number;
 }) {
   const theme = useTheme();
@@ -87,6 +92,7 @@ function Event({
       }}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      projectSlug={projectSlug}
       startTimestampMs={startTimestampMs}
       traces={undefined}
       onDimensionChange={() => {}}
@@ -211,5 +217,3 @@ const TooltipWrapper = styled('div')`
   max-height: 80vh;
   overflow: auto;
 `;
-
-export default ReplayTimelineEvents;

--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -5,6 +5,7 @@ import FeatureBadge from 'sentry/components/featureBadge';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {Tooltip} from 'sentry/components/tooltip';
 import {
+  IconChat,
   IconCursorArrow,
   IconFire,
   IconFix,
@@ -267,6 +268,13 @@ const MAPPER_FOR_FRAME: Record<string, (frame) => Details> = {
     tabKey: TabKey.NETWORK,
     title: 'Paint',
     icon: <IconInfo size="xs" />,
+  }),
+  'sentry.feedback': () => ({
+    color: 'blue300',
+    description: '',
+    tabKey: TabKey.BREADCRUMBS,
+    title: 'User Feedback Submitted',
+    icon: <IconChat size="xs" />,
   }),
   'resource.css': frame => ({
     color: 'gray300',

--- a/static/app/utils/replays/hydrateFrames.tsx
+++ b/static/app/utils/replays/hydrateFrames.tsx
@@ -22,6 +22,10 @@ export default function hydrateFrames(attachments: unknown[]) {
       return;
     }
     if (isBreadcrumbFrameEvent(attachment)) {
+      if (attachment.data.payload.category === 'sentry.feedback') {
+        // @ts-expect-error In SDK <= 7.100.0 we were incorrectly setting the timestamp
+        attachment.data.payload.timestamp = attachment.data.timestamp;
+      }
       breadcrumbFrames.push(attachment.data.payload);
     } else if (isSpanFrameEvent(attachment)) {
       spanFrames.push(attachment.data.payload);

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -388,9 +388,12 @@ export default class ReplayReader {
       [
         ...this.getPerfFrames(),
         ...this._sortedBreadcrumbFrames.filter(frame =>
-          ['replay.init', 'replay.mutations', 'replay.hydrate-error'].includes(
-            frame.category
-          )
+          [
+            'replay.hydrate-error',
+            'replay.init',
+            'replay.mutations',
+            'sentry.feedback',
+          ].includes(frame.category)
         ),
         ...this._errors,
       ].sort(sortFrames),

--- a/static/app/utils/replays/types.tsx
+++ b/static/app/utils/replays/types.tsx
@@ -189,6 +189,7 @@ export type MultiClickFrame = HydratedBreadcrumb<'ui.multiClick'>;
 export type MutationFrame = HydratedBreadcrumb<'replay.mutations'>;
 export type NavFrame = HydratedBreadcrumb<'navigation'>;
 export type SlowClickFrame = HydratedBreadcrumb<'ui.slowClickDetected'>;
+export type FeedbackOpenedFrame = HydratedBreadcrumb<'sentry.feedback'>;
 
 // This list must match each of the categories used in `HydratedBreadcrumb` above
 // and any app-specific types that we hydrate (ie: replay.init).
@@ -197,6 +198,7 @@ export const BreadcrumbCategories = [
   'navigation',
   'replay.init',
   'replay.mutations',
+  'sentry.feedback',
   'ui.blur',
   'ui.click',
   'ui.focus',

--- a/static/app/utils/useProjectFromId.tsx
+++ b/static/app/utils/useProjectFromId.tsx
@@ -1,0 +1,13 @@
+import useProjects from 'sentry/utils/useProjects';
+
+interface Props {
+  project_id: string | undefined;
+}
+
+export default function useProjectFromId({project_id}: Props) {
+  const {projects} = useProjects();
+  if (project_id) {
+    return projects.find(p => p.id === project_id) ?? undefined;
+  }
+  return undefined;
+}

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbRow.tsx
@@ -22,6 +22,7 @@ interface Props {
     expandedState: Record<string, boolean>,
     event: MouseEvent<HTMLDivElement>
   ) => void;
+  projectSlug: string | undefined;
   startTimestampMs: number;
   style: CSSProperties;
   traces: ReplayTraceRow | undefined;
@@ -29,14 +30,15 @@ interface Props {
   expandPaths?: string[];
 }
 
-function BreadcrumbRow({
+export default function BreadcrumbRow({
   expandPaths,
-  frame,
   extraction,
+  frame,
   index,
   onClick,
   onDimensionChange,
   onInspectorExpanded,
+  projectSlug,
   startTimestampMs,
   style,
   traces,
@@ -75,6 +77,7 @@ function BreadcrumbRow({
         onClick={onClick}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
+        projectSlug={projectSlug}
         startTimestampMs={startTimestampMs}
         expandPaths={expandPaths}
         onDimensionChange={handleDimensionChange}
@@ -89,5 +92,3 @@ const StyledTimeBorder = styled('div')`
   border-top: 1px solid transparent;
   border-bottom: 1px solid transparent;
 `;
-
-export default BreadcrumbRow;

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -10,6 +10,7 @@ import {t} from 'sentry/locale';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import useExtractedDomNodes from 'sentry/utils/replays/hooks/useExtractedDomNodes';
 import useOrganization from 'sentry/utils/useOrganization';
+import useProjectFromId from 'sentry/utils/useProjectFromId';
 import useVirtualizedInspector from 'sentry/views/replays/detail//useVirtualizedInspector';
 import BreadcrumbFilters from 'sentry/views/replays/detail/breadcrumbs/breadcrumbFilters';
 import BreadcrumbRow from 'sentry/views/replays/detail/breadcrumbs/breadcrumbRow';
@@ -34,6 +35,10 @@ function Breadcrumbs() {
   const {currentTime, replay} = useReplayContext();
   const organization = useOrganization();
   const hasPerfTab = organization.features.includes('session-replay-trace-table');
+
+  const projectSlug = useProjectFromId({
+    project_id: replay?.getReplay().project_id,
+  })?.slug;
 
   const {onClickTimestamp} = useCrumbHandlers();
   const {data: frameToExtraction, isFetching: isFetchingExtractions} =
@@ -104,6 +109,7 @@ function Breadcrumbs() {
           frame={item}
           extraction={frameToExtraction?.get(item)}
           traces={hasPerfTab ? frameToTrace?.get(item) : undefined}
+          projectSlug={projectSlug}
           startTimestampMs={startTimestampMs}
           style={style}
           expandPaths={Array.from(expandPathsRef.current?.get(index) || [])}

--- a/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
@@ -29,6 +29,7 @@ type Return = {
 
 const TYPE_TO_LABEL: Record<string, string> = {
   start: 'Replay Start',
+  feedback: 'User Feedback',
   replay: 'Replay',
   issue: 'Issue',
   console: 'Console',
@@ -51,6 +52,7 @@ const TYPE_TO_LABEL: Record<string, string> = {
 const OPORCATEGORY_TO_TYPE: Record<string, keyof typeof TYPE_TO_LABEL> = {
   'replay.init': 'start',
   'replay.mutations': 'replay',
+  'sentry.feedback': 'feedback',
   issue: 'issue',
   console: 'console',
   navigation: 'nav',


### PR DESCRIPTION
New breadkcrumb type renders in the replay details list:
![SCR-20240206-lqhl](https://github.com/getsentry/sentry/assets/187460/a04e28e1-7519-487b-bbf3-1a53c87dd066)

The button will go to the feedback page (with a redirect because we need the groupid).

filters for the breadcrumbs work well, look like this:
![SCR-20240206-lrjs](https://github.com/getsentry/sentry/assets/187460/73ceda59-1a96-4d25-bf8d-6bf6d93f7fc9)


Here is the example replay that I was experimenting with: https://sentry.dev.getsentry.net:7999/replays/402c0be4e829465f8dc5d5c001f84816/?f_b_type=feedback&project=11276&query=&referrer=%2Freplays%2F&statsPeriod=90d&t_main=breadcrumbs&yAxis=count%28%29

I 'created' it by:
- logging into prod
- go to the replays list, notice that a replay started for my session (open a new window to try again if sampling got you down)
- go to crons or somewhere, and submit a feedback


Fixes https://github.com/getsentry/sentry/issues/63791