### PR TITLE
feat(replay): Never disable the "Run Accessibility" button inside Replay Details

### DIFF
--- a/static/app/views/replays/detail/accessibility/accessibilityRefetchBanner.tsx
+++ b/static/app/views/replays/detail/accessibility/accessibilityRefetchBanner.tsx
@@ -55,12 +55,7 @@ export default function AccessibilityRefetchBanner({initialOffsetMs, refetch}: P
             ),
           })}
         </Flex>
-        <Button
-          size="xs"
-          priority="primary"
-          onClick={handleClickRefetch}
-          disabled={currentTime === lastOffsetMs}
-        >
+        <Button size="xs" priority="primary" onClick={handleClickRefetch}>
           {isPlaying
             ? tct('Pause and run validation for [now]', {now})
             : tct('Run validation for [now]', {now})}


### PR DESCRIPTION
When the button is disabled it's hard to tell why. Instead lets just make the button always available. People can click it & see the table of data refresh, they'll be able to understand better what's happening.

Fixes https://github.com/getsentry/sentry/issues/63854