### PR TITLE
feat(replay): Allow clicking on the circles in the replay timeline

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -112,6 +112,8 @@ function Event({
     }
   `;
 
+  const firstFrame = frames.at(0);
+
   // We want to show the full variety of colors available.
   const uniqueColors = uniq(frames.map(frame => getFrameDetails(frame).color));
 
@@ -141,7 +143,9 @@ function Event({
           colors={sortedUniqueColors}
           frameCount={frameCount}
           onClick={() => {
-            onClickTimestamp(frames.at(0)!);
+            if (firstFrame) {
+              onClickTimestamp(firstFrame);
+            }
           }}
         />
       </IconNodeTooltip>

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -137,7 +137,13 @@ function Event({
   return (
     <IconPosition style={{marginLeft: `${markerWidth / 2}px`}}>
       <IconNodeTooltip title={title} overlayStyle={overlayStyle} isHoverable>
-        <IconNode colors={sortedUniqueColors} frameCount={frameCount} />
+        <IconNode
+          colors={sortedUniqueColors}
+          frameCount={frameCount}
+          onClick={() => {
+            onClickTimestamp(frames.at(0)!);
+          }}
+        />
       </IconNodeTooltip>
     </IconPosition>
   );
@@ -190,7 +196,9 @@ const getBackgroundGradient = ({
     );`;
 };
 
-const IconNode = styled('div')<{colors: Color[]; frameCount: number}>`
+const IconNode = styled('button')<{colors: Color[]; frameCount: number}>`
+  padding: 0;
+  border: none;
   grid-column: 1;
   grid-row: 1;
   width: ${p => NODE_SIZES[p.frameCount - 1]}px;


### PR DESCRIPTION
Before these red/purple/green circles were not clickable.... now they are! Clicking will take to you the timestamp of the first event in the bunch. You can still click on events that are listed in the hovercard too for the same result.

![SCR-20240125-nldg](https://github.com/getsentry/sentry/assets/187460/063aedc1-b6c9-4b9a-9ef1-87b940d3b924)


Fixes https://github.com/getsentry/sentry/issues/62641