### PR TITLE
ref(slack): Format tags differently, release to use description and be a link

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -44,7 +44,7 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         for tag in tags:
             title = tag["title"]
             value = tag["value"]
-            text += f"`{title}: {value}`  "
+            text += f"{title}: `{value}`  "
         return {
             "type": "section",
             "text": {"type": "mrkdwn", "text": text},

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -143,7 +143,7 @@ def build_tag_fields(
     return fields
 
 
-def format_release_tag(value: str, event: GroupEvent):
+def format_release_tag(value: str, event: GroupEvent | Group):
     """Format the release tag using the short version and make it a link"""
     path = f"/releases/{value}/"
     url = event.project.organization.absolute_url(path)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping, Sequence, Union
 from django.utils import timezone
 from django.utils.timesince import timesince
 from django.utils.translation import gettext as _
+from sentry_relay.processing import parse_release
 
 from sentry import features, tagstore
 from sentry.api.endpoints.group_details import get_group_global_count
@@ -142,6 +143,14 @@ def build_tag_fields(
     return fields
 
 
+def format_release_tag(value: str, event: GroupEvent):
+    """Format the release tag using the short version and make it a link"""
+    path = f"/releases/{value}/"
+    url = event.project.organization.absolute_url(path)
+    release_description = parse_release(value).get("description")
+    return f"<{url}|{release_description}>"
+
+
 def get_tags(
     event_for_tags: Any,
     tags: set[str] | None = None,
@@ -163,8 +172,9 @@ def get_tags(
             std_key = tagstore.backend.get_standardized_key(key)
             if std_key not in tags:
                 continue
-
             labeled_value = tagstore.backend.get_tag_value_label(key, value)
+            if std_key == "release":
+                labeled_value = format_release_tag(labeled_value, event_for_tags)
             fields.append(
                 {
                     "title": std_key,


### PR DESCRIPTION
Format tags to be like:
* environment: `prod`

Instead of:
* `environment: prod`

and specifically for release tags, use the shorter version and make it a link to the release (even though it's code formatted and isn't super obvious it's clickable)

<img width="670" alt="Screenshot 2024-01-25 at 11 37 18 AM" src="https://github.com/getsentry/sentry/assets/29959063/06696f8c-1ee4-4fa1-af38-3e365d05cc84">
<img width="682" alt="Screenshot 2024-01-25 at 11 37 23 AM" src="https://github.com/getsentry/sentry/assets/29959063/b289da6b-b81a-4393-9ba8-49c2ac1b2717">
