### PR TITLE
chore(api): Remove mocks from API helper invite tests

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -49,6 +49,7 @@ from sentry.models.actor import Actor
 from sentry.models.apikey import ApiKey
 from sentry.models.apitoken import ApiToken
 from sentry.models.artifactbundle import ArtifactBundle
+from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.avatars.doc_integration_avatar import DocIntegrationAvatar
 from sentry.models.commit import Commit
@@ -390,6 +391,11 @@ class Factories:
     @assume_test_silo_mode(SiloMode.CONTROL)
     def create_auth_provider(**kwargs):
         return AuthProvider.objects.create(**kwargs)
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CONTROL)
+    def create_auth_identity(**kwargs):
+        return AuthIdentity.objects.create(**kwargs)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -49,6 +49,7 @@ from sentry.models.actor import Actor
 from sentry.models.apikey import ApiKey
 from sentry.models.apitoken import ApiToken
 from sentry.models.artifactbundle import ArtifactBundle
+from sentry.models.authprovider import AuthProvider
 from sentry.models.avatars.doc_integration_avatar import DocIntegrationAvatar
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
@@ -384,6 +385,11 @@ class Factories:
         return ApiKey.objects.create(
             organization_id=organization.id if organization else None, scope_list=scope_list
         )
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CONTROL)
+    def create_auth_provider(**kwargs):
+        return AuthProvider.objects.create(**kwargs)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -133,6 +133,9 @@ class Fixtures:
     def create_auth_provider(self, *args, **kwargs):
         return Factories.create_auth_provider(*args, **kwargs)
 
+    def create_auth_identity(self, *args, **kwargs):
+        return Factories.create_auth_identity(*args, **kwargs)
+
     def create_user_auth_token(self, *args, **kwargs):
         return Factories.create_user_auth_token(*args, **kwargs)
 

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -130,6 +130,9 @@ class Fixtures:
     def create_api_key(self, *args, **kwargs):
         return Factories.create_api_key(*args, **kwargs)
 
+    def create_auth_provider(self, *args, **kwargs):
+        return Factories.create_auth_provider(*args, **kwargs)
+
     def create_user_auth_token(self, *args, **kwargs):
         return Factories.create_user_auth_token(*args, **kwargs)
 

--- a/tests/sentry/api/test_invite_helper.py
+++ b/tests/sentry/api/test_invite_helper.py
@@ -4,7 +4,6 @@ import pytest
 from django.http import HttpRequest
 
 from sentry.api.invite_helper import ApiInviteHelper
-from sentry.models.authprovider import AuthProvider
 from sentry.models.organizationmember import OrganizationMember
 from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.signals import receivers_raise_on_send
@@ -27,8 +26,9 @@ class ApiInviteHelperTest(TestCase):
             organization=self.org,
             teams=[self.team],
         )
-        self.auth_provider_inst = AuthProvider(
-            provider="Friendly IdP", organization_id=self.organization.id
+        self.auth_provider = self.create_auth_provider(
+            organization_id=self.organization.id,
+            provider="Friendly IdP",
         )
 
         self.request = HttpRequest()
@@ -99,8 +99,8 @@ class ApiInviteHelperTest(TestCase):
     @patch("sentry.api.invite_helper.RpcOrganizationMember.get_audit_log_metadata")
     @patch("sentry.api.invite_helper.AuthProvider.objects")
     def test_accept_invite_with_SSO(self, mock_provider, get_audit, create_audit):
-        self.auth_provider_inst.flags.allow_unlinked = True
-        mock_provider.get.return_value = self.auth_provider_inst
+        self.auth_provider.flags.allow_unlinked = True
+        mock_provider.get.return_value = self.auth_provider
 
         om = OrganizationMember.objects.get(id=self.member.id)
         assert om.email == self.member.email
@@ -127,8 +127,8 @@ class ApiInviteHelperTest(TestCase):
     @patch("sentry.api.invite_helper.RpcOrganizationMember.get_audit_log_metadata")
     @patch("sentry.api.invite_helper.AuthProvider.objects")
     def test_accept_invite_with_required_SSO(self, mock_provider, get_audit, create_audit):
-        self.auth_provider_inst.flags.allow_unlinked = False
-        mock_provider.get.return_value = self.auth_provider_inst
+        self.auth_provider.flags.allow_unlinked = False
+        mock_provider.get.return_value = self.auth_provider
 
         om = OrganizationMember.objects.get(id=self.member.id)
         assert om.email == self.member.email
@@ -158,8 +158,8 @@ class ApiInviteHelperTest(TestCase):
     def test_accept_invite_with_required_SSO_with_identity(
         self, mock_identity, mock_provider, get_audit, create_audit
     ):
-        self.auth_provider_inst.flags.allow_unlinked = False
-        mock_provider.get.return_value = self.auth_provider_inst
+        self.auth_provider.flags.allow_unlinked = False
+        mock_provider.get.return_value = self.auth_provider
         mock_identity.exists.return_value = True
 
         om = OrganizationMember.objects.get(id=self.member.id)


### PR DESCRIPTION
These had quite a few mocks that made the test coverage look a bit suspect. I've removed the mocks so we run more real code, and refactored the tests since there was quite a bit of repetition. It might be redundant but I also added tests to make sure double-accepting invites has the same behaviour even if the org has required/optional SSO, but I can remove those if we'd like.