### PR TITLE
fix(functions): groupUniqArray call must match ClickHouse definition

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict
 
+import sentry_sdk
 from django.http import HttpResponse
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
@@ -68,6 +69,7 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
 
         span_group = request.query_params.get("spans.group", None)
         if span_group is not None:
+            sentry_sdk.set_tag("dataset", "spans")
             profile_ids = get_profile_ids_with_spans(
                 organization.id,
                 project_ids[0],
@@ -75,6 +77,7 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
                 span_group,
             )
         elif request.query_params.get("fingerprint"):
+            sentry_sdk.set_tag("dataset", "functions")
             function_fingerprint = int(request.query_params["fingerprint"])
             profile_ids = get_profiles_with_function(
                 organization.id,
@@ -84,6 +87,7 @@ class OrganizationProfilingFlamegraphEndpoint(OrganizationProfilingBaseEndpoint)
                 request.GET.get("query", ""),
             )
         else:
+            sentry_sdk.set_tag("dataset", "profiles")
             profile_ids = get_profile_ids(params, request.query_params.get("query", None))
 
         kwargs: Dict[str, Any] = {

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -139,6 +139,7 @@ def get_profiles_with_function(
         query=" ".join(cond for cond in conditions if cond),
         params=params,
         limit=100,
+        orderby=["-timestamp"],
         referrer=Referrer.API_PROFILING_FUNCTION_SCOPED_FLAMEGRAPH.value,
         auto_aggregations=True,
         use_aggregate_conditions=True,

--- a/src/sentry/profiles/flamegraph.py
+++ b/src/sentry/profiles/flamegraph.py
@@ -135,14 +135,29 @@ def get_profiles_with_function(
     conditions = [query, f"fingerprint:{function_fingerprint}"]
 
     result = functions.query(
-        selected_columns=["unique_examples(100)"],
+        selected_columns=["timestamp", "unique_examples()"],
         query=" ".join(cond for cond in conditions if cond),
         params=params,
-        limit=1,
+        limit=100,
         referrer=Referrer.API_PROFILING_FUNCTION_SCOPED_FLAMEGRAPH.value,
         auto_aggregations=True,
         use_aggregate_conditions=True,
         transform_alias_to_input_format=True,
     )
 
-    return {"profile_ids": result["data"][0]["unique_examples(100)"]}
+    def extract_profile_ids() -> List[str]:
+        max_profiles = options.get("profiling.flamegraph.profile-set.size")
+        profile_ids = []
+
+        for i in range(5):
+            for row in result["data"]:
+                examples = row["unique_examples()"]
+                if i < len(examples):
+                    profile_ids.append(examples[i])
+
+                    if len(profile_ids) >= max_profiles:
+                        return profile_ids
+
+        return profile_ids
+
+    return {"profile_ids": extract_profile_ids()}

--- a/src/sentry/search/events/datasets/profile_functions.py
+++ b/src/sentry/search/events/datasets/profile_functions.py
@@ -18,7 +18,6 @@ from sentry.search.events.datasets.base import DatasetConfig
 from sentry.search.events.fields import (
     ColumnArg,
     Combinator,
-    IntArg,
     InvalidFunctionArgument,
     NumberRange,
     NumericColumn,
@@ -342,9 +341,6 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                 ),
                 SnQLFunction(
                     "unique_examples",
-                    optional_args=[
-                        with_default(5, IntArg("count", negative=False)),
-                    ],
                     snql_aggregate=lambda args, alias: Function(
                         "arrayMap",
                         [
@@ -355,9 +351,7 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                                     "replaceAll", [Function("toString", [Identifier("x")]), "-", ""]
                                 ),
                             ),
-                            Function(
-                                f"groupUniqArrayMerge({args['count']})", [SnQLColumn("examples")]
-                            ),
+                            Function("groupUniqArrayMerge(5)", [SnQLColumn("examples")]),
                         ],
                         alias,
                     ),

--- a/tests/sentry/profiles/test_flamegraph.py
+++ b/tests/sentry/profiles/test_flamegraph.py
@@ -17,7 +17,7 @@ class GetProfileWithFunctionTest(ProfilesSnubaTestCase):
             minute=0, second=0, microsecond=0, tzinfo=timezone.utc
         )
 
-        for _ in range(3):
+        for i in range(3):
             self.store_functions(
                 [
                     {
@@ -28,7 +28,7 @@ class GetProfileWithFunctionTest(ProfilesSnubaTestCase):
                     },
                 ],
                 project=self.project,
-                timestamp=self.hour_ago,
+                timestamp=self.hour_ago - timedelta(hours=i),
             )
 
         transaction = load_data("transaction", timestamp=before_now(minutes=10))


### PR DESCRIPTION
In newer versions of ClickHouse, the uses of `groupUniqArrayMerge` must match the underlying definition in the table. Since it uses `groupUniqArrayState(5)`, we must use `groupUniqArrayMerge(5)` and not allow other sizes.