### PR TITLE
ref(replay): Tweak timeline to make all pixels activate on hover, and rm dead code

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {CSSProperties, useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import Panel from 'sentry/components/panels/panel';
@@ -16,9 +16,11 @@ import {divide} from 'sentry/components/replays/utils';
 import toPercent from 'sentry/utils/number/toPercent';
 import {useDimensions} from 'sentry/utils/useDimensions';
 
-type Props = {};
+type Props = {
+  style?: CSSProperties;
+};
 
-function ReplayTimeline({}: Props) {
+function ReplayTimeline({style}: Props) {
   const {replay, currentTime, timelineScale, startTimeOffsetMs, durationMs} =
     useReplayContext();
 
@@ -31,24 +33,16 @@ function ReplayTimeline({}: Props) {
   const stackedRef = useRef<HTMLDivElement>(null);
   const {width} = useDimensions<HTMLDivElement>({elementRef: stackedRef});
 
-  if (!replay) {
-    return <Placeholder height="20px" />;
-  }
+  const translate = useCallback(() => {
+    const percentComplete = divide(currentTime - startTimeOffsetMs, durationMs);
+    // timeline is in the middle
+    const initialTranslate = 0.5 / timelineScale;
 
-  const startTimestampMs = replay.getReplay().started_at.getTime() + startTimeOffsetMs;
-  const chapterFrames = replay.getChapterFrames();
-
-  // timeline is in the middle
-  const initialTranslate = 0.5 / timelineScale;
-  const percentComplete = divide(currentTime - startTimeOffsetMs, durationMs);
-
-  const starting = percentComplete < initialTranslate;
-  const ending = percentComplete + initialTranslate > 1;
-
-  const translate = () => {
+    const starting = percentComplete < initialTranslate;
     if (starting) {
       return 0;
     }
+    const ending = percentComplete + initialTranslate > 1;
     if (ending) {
       return initialTranslate - (1 - initialTranslate);
     }
@@ -56,38 +50,55 @@ function ReplayTimeline({}: Props) {
       initialTranslate -
       (currentTime - startTimeOffsetMs > durationMs ? 1 : percentComplete)
     );
-  };
+  }, [currentTime, durationMs, startTimeOffsetMs, timelineScale]);
+
+  if (!replay) {
+    return <Placeholder style={style} height="20px" />;
+  }
+
+  const startTimestampMs = replay.getReplay().started_at.getTime() + startTimeOffsetMs;
+  const chapterFrames = replay.getChapterFrames();
 
   return (
-    <VisiblePanel ref={panelRef} {...mouseTrackingProps}>
-      <Stacked
-        style={{
-          width: `${toPercent(timelineScale)}`,
-          transform: `translate(${toPercent(translate())}, 0%)`,
-        }}
-        ref={stackedRef}
-      >
-        <MinorGridlines durationMs={durationMs} width={width} />
-        <MajorGridlines durationMs={durationMs} width={width} />
-        <TimelineScrubber />
-        <TimelineEventsContainer>
-          <ReplayTimelineEvents
-            durationMs={durationMs}
-            frames={chapterFrames}
-            startTimestampMs={startTimestampMs}
-            width={width}
-            startTimeOffsetMs={startTimeOffsetMs}
-          />
-        </TimelineEventsContainer>
-      </Stacked>
-    </VisiblePanel>
+    <MouseArea ref={panelRef} style={style} {...mouseTrackingProps}>
+      <VisiblePanel>
+        <Stacked
+          style={{
+            width: `${toPercent(timelineScale)}`,
+            transform: `translate(${toPercent(translate())}, 0%)`,
+          }}
+          ref={stackedRef}
+        >
+          <MinorGridlines durationMs={durationMs} width={width} />
+          <MajorGridlines durationMs={durationMs} width={width} />
+          <TimelineScrubber />
+          <TimelineEventsContainer>
+            <ReplayTimelineEvents
+              durationMs={durationMs}
+              frames={chapterFrames}
+              startTimestampMs={startTimestampMs}
+              width={width}
+              startTimeOffsetMs={startTimeOffsetMs}
+            />
+          </TimelineEventsContainer>
+        </Stacked>
+      </VisiblePanel>
+    </MouseArea>
   );
 }
 
+const MouseArea = styled('div')`
+  display: flex;
+  justify-self: stretch;
+  align-self: stretch;
+  align-items: center;
+  cursor: pointer;
+`;
+
 const VisiblePanel = styled(Panel)`
+  flex-grow: 1;
   margin: 0;
   border: 0;
-  overflow: hidden;
   background: ${p => p.theme.translucentInnerBorder};
 `;
 

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -1,6 +1,5 @@
-import {useCallback, useLayoutEffect, useRef, useState} from 'react';
+import {useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
-import {useResizeObserver} from '@react-aria/utils';
 import screenfull from 'screenfull';
 
 import {Button} from 'sentry/components/button';
@@ -25,8 +24,6 @@ import {useUser} from 'sentry/utils/useUser';
 import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
 
 const SECOND = 1000;
-
-const COMPACT_WIDTH_BREAKPOINT = 500;
 
 interface Props {
   toggleFullscreen: () => void;
@@ -119,7 +116,6 @@ function ReplayControls({
   const user = useUser();
   const organization = useOrganization();
   const barRef = useRef<HTMLDivElement>(null);
-  const [isCompact, setIsCompact] = useState(false);
   const isFullscreen = useIsFullscreen();
 
   // If the browser supports going fullscreen or not. iPhone Safari won't do
@@ -135,24 +131,11 @@ function ReplayControls({
     toggleFullscreen();
   }, [user.email, isFullscreen, organization, toggleFullscreen]);
 
-  const updateIsCompact = useCallback(() => {
-    const {width} = barRef.current?.getBoundingClientRect() ?? {
-      width: COMPACT_WIDTH_BREAKPOINT,
-    };
-    setIsCompact(width < COMPACT_WIDTH_BREAKPOINT);
-  }, []);
-
-  useResizeObserver({
-    ref: barRef,
-    onResize: updateIsCompact,
-  });
-  useLayoutEffect(() => updateIsCompact, [updateIsCompact]);
-
   return (
-    <ButtonGrid ref={barRef} isCompact={isCompact}>
+    <ButtonGrid ref={barRef}>
       <ReplayPlayPauseBar />
       <Container>
-        <TimeAndScrubberGrid isCompact={isCompact} showZoom />
+        <TimeAndScrubberGrid showZoom />
       </Container>
       <ButtonBar gap={1}>
         <ReplayOptionsMenu speedOptions={speedOptions} />
@@ -170,12 +153,11 @@ function ReplayControls({
   );
 }
 
-const ButtonGrid = styled('div')<{isCompact: boolean}>`
+const ButtonGrid = styled('div')`
   display: flex;
   gap: 0 ${space(2)};
   flex-direction: row;
   justify-content: space-between;
-  ${p => (p.isCompact ? `flex-wrap: wrap;` : '')}
 `;
 
 const Container = styled('div')`

--- a/static/app/components/replays/timeAndScrubberGrid.tsx
+++ b/static/app/components/replays/timeAndScrubberGrid.tsx
@@ -13,7 +13,6 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 
 type TimeAndScrubberGridProps = {
-  isCompact?: boolean;
   showZoom?: boolean;
 };
 
@@ -49,22 +48,17 @@ function TimelineSizeBar() {
   );
 }
 
-function TimeAndScrubberGrid({
-  isCompact = false,
-  showZoom = false,
-}: TimeAndScrubberGridProps) {
+function TimeAndScrubberGrid({showZoom = false}: TimeAndScrubberGridProps) {
   const {currentTime, startTimeOffsetMs, durationMs} = useReplayContext();
   const elem = useRef<HTMLDivElement>(null);
   const mouseTrackingProps = useScrubberMouseTracking({elem});
 
   return (
-    <Grid id="replay-timeline-player" isCompact={isCompact}>
+    <Grid id="replay-timeline-player">
       <Time style={{gridArea: 'currentTime'}}>
         {formatTime(currentTime - startTimeOffsetMs)}
       </Time>
-      <div style={{gridArea: 'timeline'}}>
-        <ReplayTimeline />
-      </div>
+      <ReplayTimeline style={{gridArea: 'timeline'}} />
       <div style={{gridArea: 'timelineSize', fontVariantNumeric: 'tabular-nums'}}>
         {showZoom ? <TimelineSizeBar /> : null}
       </div>
@@ -78,7 +72,7 @@ function TimeAndScrubberGrid({
   );
 }
 
-const Grid = styled('div')<{isCompact: boolean}>`
+const Grid = styled('div')`
   width: 100%;
   display: grid;
   grid-template-areas:
@@ -86,15 +80,7 @@ const Grid = styled('div')<{isCompact: boolean}>`
     'currentTime scrubber duration';
   grid-column-gap: ${space(1)};
   grid-template-columns: max-content auto max-content;
-  align-items: center;
-  ${p =>
-    p.isCompact
-      ? `
-        order: -1;
-        min-width: 100%;
-        margin-top: -8px;
-      `
-      : ''}
+  align-items: stretch;
 `;
 
 const StyledScrubber = styled('div')`


### PR DESCRIPTION
This PR removes some dead code related to `isCompact`. Turns out that there's no difference anymore, just some padding change is all that was actually being applied to the UI.

Also, i refactored the Timeline basically moving a naked `<div>` into replayTimeline.tsx and named it `MouseArea`. It's got some CSS added so it's full-height, and has mouse-tracking applied. The child is still `<VisiblePanel>` which has the background. the result is that all the pixels between the seeker bar (the purple circles between "00:00" and "05:59" in the screen shot) and the Timeline are clickable.

| | Wide |
| --- | --- |
| Before | ![before - wide](https://github.com/getsentry/sentry/assets/187460/446ccbbc-f804-483b-84e7-cbf56ee8e8d2)
| After | ![after - wide](https://github.com/getsentry/sentry/assets/187460/a9cde9b6-d0e8-4300-8df3-c7060dda0a8d)


| | Narrow |
| --- | --- |
| Before | ![before - narrow](https://github.com/getsentry/sentry/assets/187460/f9685e34-9826-45d2-a188-d35e2783d30f)
| After | ![after - narrow](https://github.com/getsentry/sentry/assets/187460/6d827bed-f467-44ea-b4bf-2b1348c8157e)



Fixes https://github.com/getsentry/team-replay/issues/276