### PR TITLE
fix(feedback): Only show URL when crash reports have a value, or its a feedback from the widget

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -49,11 +49,13 @@ export default function FeedbackItem({feedbackItem, eventData, tags}: Props) {
           </Blockquote>
         </Section>
 
-        <Section icon={<IconLink size="xs" />} title={t('URL')}>
-          <TextCopyInput size="sm">
-            {eventData?.tags ? (url ? url.value : t('URL not found')) : ''}
-          </TextCopyInput>
-        </Section>
+        {!crashReportId || (crashReportId && url) ? (
+          <Section icon={<IconLink size="xs" />} title={t('URL')}>
+            <TextCopyInput size="sm">
+              {eventData?.tags ? (url ? url.value : t('URL not found')) : ''}
+            </TextCopyInput>
+          </Section>
+        ) : null}
 
         {crashReportId && (
           <Section icon={<IconFire size="xs" />} title={t('Linked Error')}>


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/10179