### PR TITLE
chore(ai/ml): use SEER_AUTOFIX_URL

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -120,7 +120,7 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
 
         try:
             requests.post(
-                f"{settings.AI_AUTOFIX_URL}/v0/automation/autofix",
+                f"{settings.SEER_AUTOFIX_URL}/v0/automation/autofix",
                 json={
                     "base_commit_sha": base_commit.key,
                     "issue": {

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3727,7 +3727,7 @@ SEVERITY_DETECTION_URL = ANOMALY_DETECTION_URL
 SEVERITY_DETECTION_TIMEOUT = 0.3  # 300 milliseconds
 SEVERITY_DETECTION_RETRIES = 1
 
-AI_AUTOFIX_URL = SEVERITY_DETECTION_URL
+SEER_AUTOFIX_URL = ANOMALY_DETECTION_URL  # In local development this is the same as ANOMALY_DETECTION_URL, for prod check getsentry.
 
 # This is the URL to the profiling service
 SENTRY_VROOM = os.getenv("VROOM", "http://127.0.0.1:8085")

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3719,7 +3719,7 @@ if int(PG_VERSION.split(".", maxsplit=1)[0]) < 12:
     # constraints instead of setting the column to not null.
     ZERO_DOWNTIME_MIGRATIONS_USE_NOT_NULL = False
 
-ANOMALY_DETECTION_URL = "127.0.0.1:9091"
+ANOMALY_DETECTION_URL = "http://127.0.0.1:9091"
 ANOMALY_DETECTION_TIMEOUT = 30
 
 # TODO: Once this moves to its own service, this URL will need to be updated

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -75,7 +75,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
             response = self.client.post(url, data={"additional_context": "Yes"}, format="json")
             mock_post.assert_called_once()
             mock_post.assert_called_with(
-                "127.0.0.1:9091/v0/automation/autofix",
+                "http://127.0.0.1:9091/v0/automation/autofix",
                 json={
                     "additional_context": "Yes",
                     "base_commit_sha": "1234",


### PR DESCRIPTION
Points autofix to a special deployment of seer, the url for saas will be set in getsentry, otherwise by default it will be same URL as normal seer.