### PR TITLE
feat(feedback): Add comments icon to feedback list items

### DIFF
--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -14,7 +14,7 @@ import {Flex} from 'sentry/components/profiling/flex';
 import TextOverflow from 'sentry/components/textOverflow';
 import TimeSince from 'sentry/components/timeSince';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconCircleFill, IconFatal, IconPlay} from 'sentry/icons';
+import {IconChat, IconCircleFill, IconFatal, IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
@@ -54,6 +54,7 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
     const hasReplayId = feedbackHasReplay(feedbackItem.id);
 
     const isCrashReport = feedbackItem.metadata.source === 'crash_report_embed_form';
+    const hasComments = feedbackItem.numComments > 0;
     const theme = isOpen || config.theme === 'dark' ? darkTheme : lightTheme;
 
     return (
@@ -124,6 +125,12 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
 
               <Row justify="flex-end" gap={space(1)}>
                 <IssueTrackingSignals group={feedbackItem as unknown as Group} />
+
+                {hasComments && (
+                  <Tooltip title={t('Linked Replay')} containerDisplayMode="flex">
+                    <IconChat color="gray500" size="sm" />
+                  </Tooltip>
+                )}
 
                 {isCrashReport && (
                   <Tooltip title={t('Linked Error')} containerDisplayMode="flex">


### PR DESCRIPTION
The icon sits to the right of the issue-tracker stuff, but right of crash-reports & errors & replays.

I was thinking that the stuff on the right is more constant (assuming automatic assignment), and since icons are all right aligned I would go left of it, so the icons "grow" into the row as comments & external issues are created.

![SCR-20240125-ozbk](https://github.com/getsentry/sentry/assets/187460/4d3740b2-2882-4f68-a191-64367adedfcc)


Fixes https://github.com/getsentry/sentry/issues/63204