### PR TITLE
fix(hybrid-cloud): Check enforce_rate_limit early

### DIFF
--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -96,28 +96,27 @@ class RatelimitMiddleware:
                 )
                 if rate_limit_cond:
                     request.will_be_rate_limited = True
-                    if enforce_rate_limit:
-                        logger.info(
-                            "sentry.api.rate-limit.exceeded",
-                            extra={
-                                "key": request.rate_limit_key,
-                                "url": request.build_absolute_uri(),
-                                "limit": request.rate_limit_metadata.limit,
-                                "window": request.rate_limit_metadata.window,
-                            },
-                        )
-                        response = HttpResponse(
-                            json.dumps(
-                                DEFAULT_ERROR_MESSAGE.format(
-                                    limit=request.rate_limit_metadata.limit,
-                                    window=request.rate_limit_metadata.window,
-                                )
-                            ),
-                            status=429,
-                        )
-                        return apply_cors_headers(
-                            request=request, response=response, allowed_methods=[request.method]
-                        )
+                    logger.info(
+                        "sentry.api.rate-limit.exceeded",
+                        extra={
+                            "key": request.rate_limit_key,
+                            "url": request.build_absolute_uri(),
+                            "limit": request.rate_limit_metadata.limit,
+                            "window": request.rate_limit_metadata.window,
+                        },
+                    )
+                    response = HttpResponse(
+                        json.dumps(
+                            DEFAULT_ERROR_MESSAGE.format(
+                                limit=request.rate_limit_metadata.limit,
+                                window=request.rate_limit_metadata.window,
+                            )
+                        ),
+                        status=429,
+                    )
+                    return apply_cors_headers(
+                        request=request, response=response, allowed_methods=[request.method]
+                    )
             except Exception:
                 logging.exception(
                     "Error during rate limiting, failing open. THIS SHOULD NOT HAPPEN"

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -58,6 +58,10 @@ class RatelimitMiddleware:
                 if not view_class:
                     return None
 
+                enforce_rate_limit = getattr(view_class, "enforce_rate_limit", False)
+                if enforce_rate_limit is False:
+                    return None
+
                 rate_limit_config = get_rate_limit_config(
                     view_class, view_args, {**view_kwargs, "request": request}
                 )
@@ -92,7 +96,6 @@ class RatelimitMiddleware:
                 )
                 if rate_limit_cond:
                     request.will_be_rate_limited = True
-                    enforce_rate_limit = getattr(view_class, "enforce_rate_limit", False)
                     if enforce_rate_limit:
                         logger.info(
                             "sentry.api.rate-limit.exceeded",

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -35,10 +35,19 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
         return RequestFactory()
 
     class TestEndpoint(Endpoint):
+        enforce_rate_limit = True
+
+        def get(self):
+            return Response({"ok": True})
+
+    class TestEndpointNoRateLimits(Endpoint):
+        enforce_rate_limit = False
+
         def get(self):
             return Response({"ok": True})
 
     _test_endpoint = TestEndpoint.as_view()
+    _test_endpoint_no_rate_limits = TestEndpointNoRateLimits.as_view()
 
     def populate_sentry_app_request(self, request):
         install = self.create_sentry_app_installation(organization=self.organization)
@@ -248,6 +257,15 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
             == "ip:default:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
         )
 
+    def test_enforce_rate_limit_is_false(self):
+        request = self.factory.get("/")
+        with freeze_time("2000-01-01"):
+            self.middleware.process_view(request, self._test_endpoint_no_rate_limits, [], {})
+            assert request.will_be_rate_limited is False
+            assert request.rate_limit_category is None
+            assert hasattr(request, "rate_limit_key") is False
+            assert hasattr(request, "rate_limit_metadata") is False
+
 
 @override_settings(SENTRY_SELF_HOSTED=False)
 class TestGetRateLimitValue(TestCase):
@@ -380,7 +398,6 @@ urlpatterns = [
     ROOT_URLCONF="tests.sentry.middleware.test_ratelimit_middleware", SENTRY_SELF_HOSTED=False
 )
 class TestRatelimitHeader(APITestCase):
-
     endpoint = "ratelimit-header-endpoint"
 
     def test_header_counts(self):

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -259,12 +259,11 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
 
     def test_enforce_rate_limit_is_false(self):
         request = self.factory.get("/")
-        with freeze_time("2000-01-01"):
-            self.middleware.process_view(request, self._test_endpoint_no_rate_limits, [], {})
-            assert request.will_be_rate_limited is False
-            assert request.rate_limit_category is None
-            assert hasattr(request, "rate_limit_key") is False
-            assert hasattr(request, "rate_limit_metadata") is False
+        self.middleware.process_view(request, self._test_endpoint_no_rate_limits, [], {})
+        assert request.will_be_rate_limited is False
+        assert request.rate_limit_category is None
+        assert hasattr(request, "rate_limit_key") is False
+        assert hasattr(request, "rate_limit_metadata") is False
 
 
 @override_settings(SENTRY_SELF_HOSTED=False)


### PR DESCRIPTION
Check `enforce_rate_limit` on a view class early, and if it is either not defined or `False`, we bail out early.