### PR TITLE
feat(issues/feedback): allow `sentryAppIssues` to be expanded

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -23,6 +23,7 @@ from sentry.api.helpers.group_index import (
 from sentry.api.serializers import GroupSerializer, GroupSerializerSnuba, serialize
 from sentry.api.serializers.models.external_issue import ExternalIssueSerializer
 from sentry.api.serializers.models.group_stream import get_actions, get_available_issue_plugins
+from sentry.api.serializers.models.platformexternalissue import PlatformExternalIssueSerializer
 from sentry.api.serializers.models.plugin import PluginSerializer
 from sentry.api.serializers.models.team import TeamSerializer
 from sentry.issues.constants import get_issue_tsdb_group_model
@@ -36,6 +37,7 @@ from sentry.models.groupowner import get_owner_details
 from sentry.models.groupseen import GroupSeen
 from sentry.models.groupsubscription import GroupSubscriptionManager
 from sentry.models.integrations.external_issue import ExternalIssue
+from sentry.models.platformexternalissue import PlatformExternalIssue
 from sentry.models.team import Team
 from sentry.models.userreport import UserReport
 from sentry.plugins.base import plugins
@@ -225,6 +227,13 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                     serializer=ExternalIssueSerializer(),
                 )
                 data.update({"integrationIssues": integration_issues})
+
+            if "sentryAppIssues" in expand:
+                external_issues = PlatformExternalIssue.objects.filter(group_id=group.id)
+                sentry_app_issues = serialize(
+                    list(external_issues), request, serializer=PlatformExternalIssueSerializer()
+                )
+                data.update({"sentryAppIssues": sentry_app_issues})
 
             data.update(
                 {

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -19,6 +19,7 @@ from sentry.api.serializers.models.group import (
     SeenStats,
     snuba_tsdb,
 )
+from sentry.api.serializers.models.platformexternalissue import PlatformExternalIssueSerializer
 from sentry.api.serializers.models.plugin import is_plugin_deprecated
 from sentry.constants import StatsPeriod
 from sentry.issues.grouptype import GroupCategory
@@ -28,6 +29,7 @@ from sentry.models.groupinbox import get_inbox_details
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupowner import get_owner_details
 from sentry.models.integrations.external_issue import ExternalIssue
+from sentry.models.platformexternalissue import PlatformExternalIssue
 from sentry.snuba.dataset import Dataset
 from sentry.tsdb.base import TSDBModel
 from sentry.utils import metrics
@@ -385,6 +387,14 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                 )
                 attrs[item].update({"integrationIssues": integration_issues})
 
+        if self._expand("sentryAppIssues"):
+            for item in item_list:
+                external_issues = PlatformExternalIssue.objects.filter(group_id=item.id)
+                sentry_app_issues = serialize(
+                    list(external_issues), request, serializer=PlatformExternalIssueSerializer()
+                )
+                attrs[item].update({"sentryAppIssues": sentry_app_issues})
+
         return attrs
 
     def serialize(
@@ -439,6 +449,9 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
 
         if self._expand("integrationIssues"):
             result["integrationIssues"] = attrs["integrationIssues"]
+
+        if self._expand("sentryAppIssues"):
+            result["sentryAppIssues"] = attrs["sentryAppIssues"]
 
         return result
 


### PR DESCRIPTION
closes https://github.com/getsentry/sentry/issues/62594

- the serializer already existed; all I needed to do was allow the issue endpoint to expand `sentryAppIssues` and call the serializer