### PR TITLE
fix(self-hosted): Try dynamically setting CSRF_TRUSTED_ORIGINS

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -400,10 +400,11 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
     from sentry.app import env
     from sentry.runner.settings import get_sentry_conf
 
+    # Hacky workaround to dynamically set the CSRF_TRUSTED_ORIGINS for self hosted
     if settings.SENTRY_SELF_HOSTED:
         from sentry import options
 
-        settings.CSRF_TRUSTED_ORIGINS = options.get("system.url-prefix")
+        settings.CSRF_TRUSTED_ORIGINS = [options.get("system.url-prefix")]
 
     env.data["config"] = get_sentry_conf()
     env.data["start_date"] = timezone.now()

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -404,7 +404,9 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
     if settings.SENTRY_SELF_HOSTED:
         from sentry import options
 
-        settings.CSRF_TRUSTED_ORIGINS = [options.get("system.url-prefix")]
+        system_url_prefix = options.get("system.url-prefix")
+        if system_url_prefix:
+            settings.CSRF_TRUSTED_ORIGINS = [system_url_prefix]
 
     env.data["config"] = get_sentry_conf()
     env.data["start_date"] = timezone.now()

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -401,7 +401,7 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
     from sentry.runner.settings import get_sentry_conf
 
     # Hacky workaround to dynamically set the CSRF_TRUSTED_ORIGINS for self hosted
-    if settings.SENTRY_SELF_HOSTED:
+    if settings.SENTRY_SELF_HOSTED and not settings.CSRF_TRUSTED_ORIGINS:
         from sentry import options
 
         system_url_prefix = options.get("system.url-prefix")

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -400,6 +400,11 @@ def initialize_app(config: dict[str, Any], skip_service_validation: bool = False
     from sentry.app import env
     from sentry.runner.settings import get_sentry_conf
 
+    if settings.SENTRY_SELF_HOSTED:
+        from sentry import options
+
+        settings.CSRF_TRUSTED_ORIGINS = options.get("system.url-prefix")
+
     env.data["config"] = get_sentry_conf()
     env.data["start_date"] = timezone.now()
 


### PR DESCRIPTION
I think this should fix [this](https://github.com/getsentry/self-hosted/issues/2735), but not entirely sure.

Setting `CSRF_TRUSTED_ORIGINS` to the url prefix should fix this