### PR TITLE
ref(open-pr-comments): include affected users in javascript comments

### DIFF
--- a/src/sentry/tasks/integrations/github/language_parsers.py
+++ b/src/sentry/tasks/integrations/github/language_parsers.py
@@ -42,6 +42,8 @@ class LanguageParser(ABC):
 
 
 class PythonParser(LanguageParser):
+    issue_row_template = "| **`{function_name}`** | [**{title}**]({url}) {subtitle} <br> `Event Count:` **{event_count}** |"
+
     @staticmethod
     def extract_functions_from_patch(patch: str) -> Set[str]:
         r"""
@@ -97,6 +99,8 @@ class PythonParser(LanguageParser):
 
 
 class JavascriptParser(LanguageParser):
+    issue_row_template = "| **`{function_name}`** | [**{title}**]({url}) {subtitle} <br> `Event Count:` **{event_count}** `Affected Users:` **{affected_users}** |"
+
     @staticmethod
     def extract_functions_from_patch(patch: str) -> Set[str]:
         r"""


### PR DESCRIPTION
For Javascript comments we want to include the number of affected users because frontend errors affect users and developers often care about that.

Example comment

## 🔍 Existing Issues For Review
Your pull request is modifying functions with the following pre-existing issues:
📄 File: **tests/sentry/tasks/integrations/github/test_open_pr_comment.js**

| Function | Unhandled Issue |
| :------- | :----- |
| **`function_0`** | [**file1 0**](http://testserver/organizations/baz/issues/0/?referrer=github-open-pr-bot) subtitle0 <br> `Event Count:` **5k** `Affected Users:` **5k** |
| **`function_1`** | [**file1 1**](http://testserver/organizations/baz/issues/1/?referrer=github-open-pr-bot) subtitle1 <br> `Event Count:` **4k** `Affected Users:` **4k** |
| **`function_2`** | [**file1 2**](http://testserver/organizations/baz/issues/2/?referrer=github-open-pr-bot) subtitle2 <br> `Event Count:` **3k** `Affected Users:` **3k** |
| **`function_3`** | [**file1 3**](http://testserver/organizations/baz/issues/3/?referrer=github-open-pr-bot) subtitle3 <br> `Event Count:` **2k** `Affected Users:` **2k** |
| **`function_4`** | [**file1 4**](http://testserver/organizations/baz/issues/4/?referrer=github-open-pr-bot) subtitle4 <br> `Event Count:` **1k** `Affected Users:` **1k** |

<details>
<summary><b>📄 File: tests/sentry/tasks/integrations/github/test_pr_comment.js (Click to Expand)</b></summary>

| Function | Unhandled Issue |
| :------- | :----- |
| **`function_0`** | [**SoftTimeLimitExceeded 0**](http://testserver/organizations/baz/issues/5/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **20k** `Affected Users:` **20k** |
| **`function_1`** | [**SoftTimeLimitExceeded 1**](http://testserver/organizations/baz/issues/6/?referrer=github-open-pr-bot) sentry.tasks.low_priority... <br> `Event Count:` **10k** `Affected Users:` **10k** |

</details>
---

<sub>Did you find this useful? React with a 👍 or 👎</sub>

For https://github.com/getsentry/team-enterprise/issues/41