### PR TITLE
test(hc): Have validate_silo_mode look at configurable default mode

### DIFF
--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -16,6 +16,7 @@ from django.conf import settings
 from sentry_sdk import Hub
 
 from sentry.runner.importer import install_plugin_apps
+from sentry.silo import SiloMode
 from sentry.testutils.region import TestEnvRegionDirectory
 from sentry.testutils.silo import monkey_patch_single_process_silo_mode_state
 from sentry.types import region
@@ -50,6 +51,11 @@ def configure_split_db() -> None:
 
 
 def _configure_test_env_regions() -> None:
+    # This value is checked by validate_silo_mode and should remain stable at all times.
+    settings.DEFAULT_SILO_MODE_FOR_TEST_CASES = SiloMode.MONOLITH
+
+    # But this one is subject to ephemeral changes via override_settings, etc.
+    settings.SILO_MODE = settings.DEFAULT_SILO_MODE_FOR_TEST_CASES
 
     # Assign a random name on every test run, as a reminder that test setup and
     # assertions should not depend on this value. If you need to test behavior that

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -50,12 +50,11 @@ def configure_split_db() -> None:
     settings.DATABASE_ROUTERS = ("sentry.db.router.SiloRouter",)
 
 
-def _configure_test_env_regions() -> None:
-    # This value is checked by validate_silo_mode and should remain stable at all times.
-    settings.DEFAULT_SILO_MODE_FOR_TEST_CASES = SiloMode.MONOLITH
+DEFAULT_SILO_MODE_FOR_TEST_CASES = SiloMode.MONOLITH
 
-    # But this one is subject to ephemeral changes via override_settings, etc.
-    settings.SILO_MODE = settings.DEFAULT_SILO_MODE_FOR_TEST_CASES
+
+def _configure_test_env_regions() -> None:
+    settings.SILO_MODE = DEFAULT_SILO_MODE_FOR_TEST_CASES
 
     # Assign a random name on every test run, as a reminder that test setup and
     # assertions should not depend on this value. If you need to test behavior that

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,10 @@ from typing import MutableMapping
 import psutil
 import pytest
 import responses
-from django.conf import settings
 from django.db import connections
 
 from sentry.silo import SiloMode
+from sentry.testutils.pytest.sentry import DEFAULT_SILO_MODE_FOR_TEST_CASES
 
 pytest_plugins = ["sentry.testutils.pytest"]
 
@@ -112,7 +112,7 @@ def validate_silo_mode():
     # during tests.  It depends upon `override_settings` using the correct contextmanager behaviors and correct
     # thread handling in acceptance tests.  If you hit one of these, it's possible either that cleanup logic has
     # a bug, or you may be using a contextmanager incorrectly.  Let us know and we can help!
-    expected = settings.DEFAULT_SILO_MODE_FOR_TEST_CASES
+    expected = DEFAULT_SILO_MODE_FOR_TEST_CASES
     message = (
         f"Possible test leak bug!  SiloMode was not reset to {expected} between tests.  "
         "Please read the comment for validate_silo_mode() in tests/conftest.py."


### PR DESCRIPTION
This will make it easier to swap the default mode from monolith to region in the future without breaking `validate_silo_mode`.