### PR TITLE
feat(issue-details): Add URL and breadcrumbs sidebar to issue replay when in fullscreen mode

### DIFF
--- a/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
@@ -4,7 +4,7 @@ import {RRWebInitFrameEventsFixture} from 'sentry-fixture/replay/rrweb';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render as baseRender, screen} from 'sentry-test/reactTestingLibrary';
+import {render as baseRender, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import useReplayReader from 'sentry/utils/replays/hooks/useReplayReader';
 import ReplayReader from 'sentry/utils/replays/replayReader';
@@ -25,16 +25,6 @@ const mockReplayId = '761104e184c64d439ee1014b72b4d83b';
 const mockEventTimestampMs = new Date('2022-09-22T16:59:41Z').getTime();
 
 const mockButtonHref = `/organizations/${mockOrgSlug}/replays/761104e184c64d439ee1014b72b4d83b/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&t=52&t_main=errors`;
-
-// Mock screenfull library
-jest.mock('screenfull', () => ({
-  enabled: true,
-  isFullscreen: false,
-  request: jest.fn(),
-  exit: jest.fn(),
-  on: jest.fn(),
-  off: jest.fn(),
-}));
 
 // Get replay data with the mocked replay reader params
 const mockReplay = ReplayReader.factory({
@@ -96,7 +86,24 @@ const render: typeof baseRender = children => {
   );
 };
 
-describe('ReplayPreview', () => {
+const mockIsFullscreen = jest.fn();
+
+jest.mock('screenfull', () => ({
+  enabled: true,
+  get isFullscreen() {
+    return mockIsFullscreen();
+  },
+  request: jest.fn(),
+  exit: jest.fn(),
+  on: jest.fn(),
+  off: jest.fn(),
+}));
+
+describe('ReplayClipPreview', () => {
+  beforeEach(() => {
+    mockIsFullscreen.mockReturnValue(false);
+  });
+
   it('Should render a placeholder when is fetching the replay data', () => {
     // Change the mocked hook to return a loading state
     mockUseReplayReader.mockImplementationOnce(() => {
@@ -184,5 +191,34 @@ describe('ReplayPreview', () => {
       'href',
       mockButtonHref
     );
+  });
+
+  it('Display URL and breadcrumbs in fullscreen mode', async () => {
+    mockIsFullscreen.mockReturnValue(true);
+
+    render(
+      <ReplayClipPreview
+        orgSlug={mockOrgSlug}
+        replaySlug={mockReplaySlug}
+        eventTimestampMs={mockEventTimestampMs}
+      />
+    );
+
+    // Should have URL bar
+    expect(screen.getByRole('textbox', {name: 'Current URL'})).toHaveValue(
+      'http://localhost:3000/'
+    );
+
+    // Breadcrumbs sidebar should be open
+    expect(screen.getByTestId('replay-details-breadcrumbs-tab')).toBeInTheDocument();
+
+    // Should filter out breadcrumbs that aren't part of the clip
+    expect(screen.getByText('No breadcrumbs recorded')).toBeInTheDocument();
+
+    // Can close the breadcrumbs sidebar
+    await userEvent.click(screen.getByRole('button', {name: 'Collapse Sidebar'}));
+    expect(
+      screen.queryByTestId('replay-details-breadcrumbs-tab')
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -1,9 +1,9 @@
-import {ComponentProps, Fragment, useMemo, useRef} from 'react';
+import {ComponentProps, Fragment, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import screenfull from 'screenfull';
 
 import {Alert} from 'sentry/components/alert';
-import {Button, LinkButton} from 'sentry/components/button';
+import {LinkButton} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import Placeholder from 'sentry/components/placeholder';
@@ -13,11 +13,14 @@ import {
   Provider as ReplayContextProvider,
   useReplayContext,
 } from 'sentry/components/replays/replayContext';
+import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
+import {ReplayFullscreenButton} from 'sentry/components/replays/replayFullscreenButton';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import ReplayPlayPauseButton from 'sentry/components/replays/replayPlayPauseButton';
 import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
+import {ReplaySidebarToggleButton} from 'sentry/components/replays/replaySidebarToggleButton';
 import TimeAndScrubberGrid from 'sentry/components/replays/timeAndScrubberGrid';
-import {IconContract, IconDelete, IconExpand} from 'sentry/icons';
+import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
@@ -30,6 +33,8 @@ import {useRoutes} from 'sentry/utils/useRoutes';
 import useFullscreen from 'sentry/utils/window/useFullscreen';
 import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
+import BrowserOSIcons from 'sentry/views/replays/detail/browserOSIcons';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import {ReplayRecord} from 'sentry/views/replays/types';
 
@@ -77,6 +82,7 @@ function ReplayPreviewPlayer({
 }) {
   const routes = useRoutes();
   const organization = useOrganization();
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const isFullscreen = useIsFullscreen();
   const {currentTime} = useReplayContext();
 
@@ -95,9 +101,24 @@ function ReplayPreviewPlayer({
 
   return (
     <Fragment>
-      <StaticPanel>
-        <ReplayPlayer />
-      </StaticPanel>
+      <PlayerBreadcrumbContainer>
+        <PlayerContextContainer>
+          {isFullscreen ? (
+            <ContextContainer>
+              <ReplayCurrentUrl />
+              <BrowserOSIcons />
+              <ReplaySidebarToggleButton
+                isOpen={isSidebarOpen}
+                setIsOpen={setIsSidebarOpen}
+              />
+            </ContextContainer>
+          ) : null}
+          <StaticPanel>
+            <ReplayPlayer />
+          </StaticPanel>
+        </PlayerContextContainer>
+        {isFullscreen && isSidebarOpen ? <Breadcrumbs /> : null}
+      </PlayerBreadcrumbContainer>
       <ErrorBoundary mini>
         <ButtonGrid>
           <ReplayPlayPauseButton />
@@ -105,20 +126,11 @@ function ReplayPreviewPlayer({
             <TimeAndScrubberGrid />
           </Container>
           <ButtonBar gap={1}>
-            <LinkButton size="sm" to={fullReplayUrl}>
+            <LinkButton size="sm" to={fullReplayUrl} {...fullReplayButtonProps}>
               {t('See Full Replay')}
             </LinkButton>
             {showFullscreenButton ? (
-              <Button
-                size="sm"
-                title={isFullscreen ? t('Exit full screen') : t('Enter full screen')}
-                aria-label={isFullscreen ? t('Exit full screen') : t('Enter full screen')}
-                icon={
-                  isFullscreen ? <IconContract size="sm" /> : <IconExpand size="sm" />
-                }
-                onClick={toggleFullscreen}
-                {...fullReplayButtonProps}
-              />
+              <ReplayFullscreenButton toggleFullscreen={toggleFullscreen} />
             ) : null}
           </ButtonBar>
         </ButtonGrid>
@@ -218,11 +230,33 @@ function ReplayClipPreview({
   );
 }
 
+const PlayerBreadcrumbContainer = styled(FluidHeight)`
+  position: relative;
+  height: 100%;
+`;
+
 const PlayerContainer = styled(FluidHeight)`
   position: relative;
   background: ${p => p.theme.background};
   gap: ${space(1)};
   max-height: 448px;
+
+  :fullscreen {
+    padding: ${space(1)};
+
+    ${PlayerBreadcrumbContainer} {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      height: 100%;
+      gap: ${space(1)};
+    }
+  }
+`;
+
+const PlayerContextContainer = styled(FluidHeight)`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1)};
 `;
 
 const StaticPanel = styled(FluidHeight)`
@@ -247,6 +281,14 @@ const Container = styled('div')`
   flex-direction: column;
   flex: 1 1;
   justify-content: center;
+`;
+
+const ContextContainer = styled('div')`
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-columns: 1fr max-content max-content;
+  align-items: center;
+  gap: ${space(1)};
 `;
 
 export default ReplayClipPreview;

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -67,7 +67,7 @@ function BreadcrumbItem({
 }: Props) {
   const {color, description, projectSlug, title, icon, timestampMs} =
     getCrumbOrFrameData(frame);
-  const {replay} = useReplayContext();
+  const {replay, startTimeOffsetMs} = useReplayContext();
 
   const forceSpan = 'category' in frame && FRAMES_WITH_BUTTONS.includes(frame.category);
 
@@ -89,7 +89,7 @@ function BreadcrumbItem({
           {onClick ? (
             <TimestampButton
               startTimestampMs={startTimestampMs}
-              timestampMs={timestampMs}
+              timestampMs={timestampMs - startTimeOffsetMs}
             />
           ) : null}
         </TitleContainer>
@@ -116,7 +116,7 @@ function BreadcrumbItem({
           <div>
             <OpenReplayComparisonButton
               replay={replay}
-              leftTimestamp={frame.offsetMs}
+              leftTimestamp={frame.offsetMs - startTimeOffsetMs}
               rightTimestamp={
                 (frame.data.mutations.next.timestamp as number) -
                 (replay?.getReplay().started_at.getTime() ?? 0)

--- a/static/app/components/replays/replayCurrentUrl.tsx
+++ b/static/app/components/replays/replayCurrentUrl.tsx
@@ -29,7 +29,7 @@ function ReplayCurrentUrl() {
 
   if (!replay || !url) {
     return (
-      <TextCopyInput size="sm" disabled>
+      <TextCopyInput aria-label="Current URL" size="sm" disabled>
         {''}
       </TextCopyInput>
     );
@@ -57,12 +57,18 @@ function ReplayCurrentUrl() {
         )}
         isHoverable
       >
-        <TextCopyInput size="sm">{url}</TextCopyInput>
+        <TextCopyInput aria-label="Current URL" size="sm">
+          {url}
+        </TextCopyInput>
       </Tooltip>
     );
   }
 
-  return <TextCopyInput size="sm">{url}</TextCopyInput>;
+  return (
+    <TextCopyInput aria-label="Current URL" size="sm">
+      {url}
+    </TextCopyInput>
+  );
 }
 
 export default ReplayCurrentUrl;

--- a/static/app/components/replays/replayCurrentUrl.tsx
+++ b/static/app/components/replays/replayCurrentUrl.tsx
@@ -6,7 +6,7 @@ import Link from 'sentry/components/links/link';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import TextCopyInput from 'sentry/components/textCopyInput';
 import {Tooltip} from 'sentry/components/tooltip';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import getCurrentUrl from 'sentry/utils/replays/getCurrentUrl';
 import useProjects from 'sentry/utils/useProjects';
 
@@ -29,7 +29,7 @@ function ReplayCurrentUrl() {
 
   if (!replay || !url) {
     return (
-      <TextCopyInput aria-label="Current URL" size="sm" disabled>
+      <TextCopyInput aria-label={t('Current URL')} size="sm" disabled>
         {''}
       </TextCopyInput>
     );
@@ -57,7 +57,7 @@ function ReplayCurrentUrl() {
         )}
         isHoverable
       >
-        <TextCopyInput aria-label="Current URL" size="sm">
+        <TextCopyInput aria-label={t('Current URL')} size="sm">
           {url}
         </TextCopyInput>
       </Tooltip>
@@ -65,7 +65,7 @@ function ReplayCurrentUrl() {
   }
 
   return (
-    <TextCopyInput aria-label="Current URL" size="sm">
+    <TextCopyInput aria-label={t('Current URL')} size="sm">
       {url}
     </TextCopyInput>
   );

--- a/static/app/components/replays/replayFullscreenButton.tsx
+++ b/static/app/components/replays/replayFullscreenButton.tsx
@@ -3,11 +3,11 @@ import {IconContract, IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
 
-type ReplayFullscreenButtonProps = {
+type Props = {
   toggleFullscreen: () => void;
 };
 
-export function ReplayFullscreenButton({toggleFullscreen}: ReplayFullscreenButtonProps) {
+export function ReplayFullscreenButton({toggleFullscreen}: Props) {
   const isFullscreen = useIsFullscreen();
 
   return (

--- a/static/app/components/replays/replayFullscreenButton.tsx
+++ b/static/app/components/replays/replayFullscreenButton.tsx
@@ -1,0 +1,22 @@
+import {Button} from 'sentry/components/button';
+import {IconContract, IconExpand} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
+
+type ReplayFullscreenButtonProps = {
+  toggleFullscreen: () => void;
+};
+
+export function ReplayFullscreenButton({toggleFullscreen}: ReplayFullscreenButtonProps) {
+  const isFullscreen = useIsFullscreen();
+
+  return (
+    <Button
+      size="sm"
+      title={isFullscreen ? t('Exit full screen') : t('Enter full screen')}
+      aria-label={isFullscreen ? t('Exit full screen') : t('Enter full screen')}
+      icon={isFullscreen ? <IconContract size="sm" /> : <IconExpand size="sm" />}
+      onClick={toggleFullscreen}
+    />
+  );
+}

--- a/static/app/components/replays/replaySidebarToggleButton.tsx
+++ b/static/app/components/replays/replaySidebarToggleButton.tsx
@@ -1,0 +1,23 @@
+import {Button} from 'sentry/components/button';
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+type ReplaySidebarToggleButtonProps = {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+};
+
+export function ReplaySidebarToggleButton({
+  isOpen,
+  setIsOpen,
+}: ReplaySidebarToggleButtonProps) {
+  return (
+    <Button
+      size="sm"
+      onClick={() => setIsOpen(!isOpen)}
+      icon={<IconChevron direction={isOpen ? 'right' : 'left'} />}
+    >
+      {isOpen ? t('Collapse Sidebar') : t('Open Sidebar')}
+    </Button>
+  );
+}

--- a/static/app/components/replays/replaySidebarToggleButton.tsx
+++ b/static/app/components/replays/replaySidebarToggleButton.tsx
@@ -2,15 +2,12 @@ import {Button} from 'sentry/components/button';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
-type ReplaySidebarToggleButtonProps = {
+type Props = {
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
 };
 
-export function ReplaySidebarToggleButton({
-  isOpen,
-  setIsOpen,
-}: ReplaySidebarToggleButtonProps) {
+export function ReplaySidebarToggleButton({isOpen, setIsOpen}: Props) {
   return (
     <Button
       size="sm"

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -1,14 +1,12 @@
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {Button} from 'sentry/components/button';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import ReplayController from 'sentry/components/replays/replayController';
 import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
-import {IconChevron} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {ReplaySidebarToggleButton} from 'sentry/components/replays/replaySidebarToggleButton';
 import {space} from 'sentry/styles/space';
 import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
 import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
@@ -34,13 +32,10 @@ function ReplayView({toggleFullscreen}: Props) {
             <ReplayCurrentUrl />
             <BrowserOSIcons />
             {isFullscreen ? (
-              <Button
-                size="sm"
-                onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-                icon={<IconChevron direction={isSidebarOpen ? 'right' : 'left'} />}
-              >
-                {isSidebarOpen ? t('Collapse Sidebar') : t('Open Sidebar')}
-              </Button>
+              <ReplaySidebarToggleButton
+                isOpen={isSidebarOpen}
+                setIsOpen={setIsSidebarOpen}
+              />
             ) : null}
           </ContextContainer>
           {!isFetching && replay?.hasProcessingErrors() ? (

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -57,13 +57,17 @@ function Breadcrumbs() {
 
   const startTimestampMs =
     replay?.getReplay()?.started_at?.getTime() ?? 0 + startTimeOffsetMs;
-  const frames = replay
-    ?.getChapterFrames()
-    .filter(
-      frame =>
-        frame.offsetMs >= startTimeOffsetMs &&
-        frame.offsetMs <= startTimeOffsetMs + durationMs
-    );
+  const allFrames = replay?.getChapterFrames();
+
+  const frames = useMemo(
+    () =>
+      allFrames?.filter(
+        frame =>
+          frame.offsetMs >= startTimeOffsetMs &&
+          frame.offsetMs <= startTimeOffsetMs + durationMs
+      ),
+    [allFrames, durationMs, startTimeOffsetMs]
+  );
 
   const [scrollToRow, setScrollToRow] = useState<undefined | number>(undefined);
 

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -46,7 +46,7 @@ const cellMeasurer = {
 
 function Breadcrumbs() {
   const {dismiss, isDismissed} = useDismissAlert({key: LOCAL_STORAGE_KEY});
-  const {currentTime, replay} = useReplayContext();
+  const {currentTime, replay, startTimeOffsetMs, durationMs} = useReplayContext();
   const organization = useOrganization();
   const hasPerfTab = organization.features.includes('session-replay-trace-table');
 
@@ -55,8 +55,15 @@ function Breadcrumbs() {
     useExtractedDomNodes({replay});
   const {data: frameToTrace, isFetching: isFetchingTraces} = useReplayPerfData({replay});
 
-  const startTimestampMs = replay?.getReplay()?.started_at?.getTime() ?? 0;
-  const frames = replay?.getChapterFrames();
+  const startTimestampMs =
+    replay?.getReplay()?.started_at?.getTime() ?? 0 + startTimeOffsetMs;
+  const frames = replay
+    ?.getChapterFrames()
+    .filter(
+      frame =>
+        frame.offsetMs >= startTimeOffsetMs &&
+        frame.offsetMs <= startTimeOffsetMs + durationMs
+    );
 
   const [scrollToRow, setScrollToRow] = useState<undefined | number>(undefined);
 


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/issues/63157

Adds the URL bar and breadcrumbs sidebar to the fullscreen view. While doing so, extracted the fullscreen and sidebar toggle buttons into new common components.

The only replay-side changes aside from that is some filtering in the breadcrumbs to ensure that the `clipWindow` is applied to those items.

![CleanShot 2024-01-25 at 16 22 30](https://github.com/getsentry/sentry/assets/10888943/9c202102-66c6-470a-b8f1-dfc99cf5a37d)
