### PR TITLE
feat(staff): Create staff mixin and organization/staff permission class

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -92,10 +92,12 @@ class OrganizationPermission(SentryPermission):
         return is_member_disabled_from_limit(request, organization)
 
 
-class OrganizationAndStaffPermission(OrganizationPermission):
+class StaffPermissionMixin:
     """
-    Staff requires this permission because it has no scopes attached to it. We
-    use this permission on _admin endpoints that require Organization permissions.
+    Endpoints that should be accessible by staff require this mixin because
+    staff does not give any scopes. The child class attached to this mixin
+    should inherit from another Parent permission class. See
+    'OrganizationAndStaffPermission' for an example of this.
     """
 
     def has_permission(self, request, *args, **kwargs):
@@ -103,6 +105,10 @@ class OrganizationAndStaffPermission(OrganizationPermission):
 
     def has_object_permission(self, request, *args, **kwargs):
         return super().has_object_permission(request, *args, **kwargs) or is_active_staff(request)
+
+
+class OrganizationAndStaffPermission(StaffPermissionMixin, OrganizationPermission):
+    pass
 
 
 class OrganizationAuditPermission(OrganizationPermission):

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -13,9 +13,8 @@ from rest_framework.request import Request
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
-from sentry.api.permissions import SentryPermission
+from sentry.api.permissions import SentryPermission, StaffPermissionMixin
 from sentry.api.utils import get_date_range_from_params, is_member_disabled_from_limit
-from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import ALL_ACCESS_PROJECT_ID, ALL_ACCESS_PROJECTS_SLUG, ObjectStatus
 from sentry.exceptions import InvalidParams
@@ -90,21 +89,6 @@ class OrganizationPermission(SentryPermission):
         organization: Organization | RpcOrganization | RpcUserOrganizationContext,
     ) -> bool:
         return is_member_disabled_from_limit(request, organization)
-
-
-class StaffPermissionMixin:
-    """
-    Endpoints that should be accessible by staff require this mixin because
-    staff does not give any scopes. The child class attached to this mixin
-    should inherit from another Parent permission class. See
-    'OrganizationAndStaffPermission' for an example of this.
-    """
-
-    def has_permission(self, request, *args, **kwargs):
-        return super().has_permission(request, *args, **kwargs) or is_active_staff(request)
-
-    def has_object_permission(self, request, *args, **kwargs):
-        return super().has_object_permission(request, *args, **kwargs) or is_active_staff(request)
 
 
 class OrganizationAndStaffPermission(StaffPermissionMixin, OrganizationPermission):

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -45,16 +45,40 @@ class NoPermission(BasePermission):
 
 
 class SuperuserPermission(BasePermission):
+    """
+    This permission class is used for endpoints that should ONLY be accessible
+    by superuser.
+    """
+
     def has_permission(self, request: Request, view: object) -> bool:
         return is_active_superuser(request)
 
 
 class StaffPermission(BasePermission):
+    """
+    This permission class is used for endpoints that should ONLY be accessible
+    by staff.
+    """
+
     def has_permission(self, request: Request, view: object) -> bool:
         return is_active_staff(request)
 
 
-# XXX(schew2381): This is a temporary permission that does NOT perform an OR
+class StaffPermissionMixin:
+    """
+    Sentry endpoints that should be accessible by staff but have an existing permission
+    class (that is not StaffPermission) require this mixin because staff does not give
+    any scopes. See 'OrganizationAndStaffPermission' for an example of this.
+    """
+
+    def has_permission(self, request, *args, **kwargs):
+        return super().has_permission(request, *args, **kwargs) or is_active_staff(request)
+
+    def has_object_permission(self, request, *args, **kwargs):
+        return super().has_object_permission(request, *args, **kwargs) or is_active_staff(request)
+
+
+# NOTE(schew2381): This is a temporary permission that does NOT perform an OR
 # between SuperuserPermission and StaffPermission. Instead, it uses StaffPermission
 # if the feature flag is enabled, and otherwise uses SuperuserPermission. We
 # need this to handle the transition for endpoints that will only be accessible to

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -10,7 +10,12 @@ from django.test import RequestFactory
 from django.utils import timezone
 from rest_framework.exceptions import PermissionDenied
 
-from sentry.api.bases.organization import NoProjects, OrganizationEndpoint, OrganizationPermission
+from sentry.api.bases.organization import (
+    NoProjects,
+    OrganizationAndStaffPermission,
+    OrganizationEndpoint,
+    OrganizationPermission,
+)
 from sentry.api.exceptions import (
     MemberDisabledOverLimit,
     ResourceDoesNotExist,
@@ -21,6 +26,7 @@ from sentry.api.exceptions import (
 from sentry.api.utils import MAX_STATS_PERIOD
 from sentry.auth.access import NoAccess, from_request
 from sentry.auth.authenticators.totp import TotpInterface
+from sentry.auth.staff import is_active_staff
 from sentry.constants import ALL_ACCESS_PROJECTS_SLUG
 from sentry.models.apikey import ApiKey
 from sentry.models.authidentity import AuthIdentity
@@ -41,12 +47,22 @@ class MockSuperUser:
         return True
 
 
-class OrganizationPermissionBase(TestCase):
+class PermissionBaseTestCase(TestCase):
     def setUp(self):
         self.org = self.create_organization()
+        # default to the organization permission class
+        self.permission_cls = OrganizationPermission
         super().setUp()
 
-    def has_object_perm(self, method, obj, auth=None, user=None, is_superuser=None) -> bool:
+    def has_object_perm(
+        self,
+        method,
+        obj,
+        auth=None,
+        user=None,
+        is_superuser=None,
+        is_staff=None,
+    ) -> bool:
         result_with_org_rpc = None
         result_with_org_context_rpc = None
         if isinstance(obj, Organization):
@@ -55,17 +71,18 @@ class OrganizationPermissionBase(TestCase):
             )
             assert organization_context is not None
             result_with_org_context_rpc = self.has_object_perm(
-                method, organization_context, auth, user, is_superuser
+                method, organization_context, auth, user, is_superuser, is_staff
             )
             result_with_org_rpc = self.has_object_perm(
-                method, organization_context.organization, auth, user, is_superuser
+                method, organization_context.organization, auth, user, is_superuser, is_staff
             )
-        perm = OrganizationPermission()
+        perm = self.permission_cls()
         if user is not None:
             user = user_service.get_user(user.id)  # Replace with region silo APIUser
-        request = self.make_request(user=user, auth=auth, method=method)
-        if is_superuser:
-            request.superuser.set_logged_in(request.user)
+
+        request = self.make_request(
+            user=user, auth=auth, method=method, is_superuser=is_superuser, is_staff=is_staff
+        )
         result_with_obj = perm.has_permission(
             request=request, view=None
         ) and perm.has_object_permission(request=request, view=None, organization=obj)
@@ -75,7 +92,7 @@ class OrganizationPermissionBase(TestCase):
 
 
 @region_silo_test
-class OrganizationPermissionTest(OrganizationPermissionBase):
+class OrganizationPermissionTest(PermissionBaseTestCase):
     def org_require_2fa(self):
         self.org.update(flags=F("flags").bitor(Organization.flags.require_2fa))
         assert self.org.flags.require_2fa.is_set is True
@@ -199,6 +216,28 @@ class OrganizationPermissionTest(OrganizationPermissionBase):
             assert self.has_object_perm("GET", self.org, user=user)
         with pytest.raises(SsoRequired):
             assert not self.has_object_perm("POST", self.org, user=user)
+
+
+class OrganizationAndStaffPermissionTest(PermissionBaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.permission_cls = OrganizationAndStaffPermission
+
+    def test_regular_user(self):
+        user = self.create_user()
+        assert not self.has_object_perm("GET", self.org, user=user)
+
+    def test_superuser(self):
+        user = self.create_user(is_superuser=True)
+        assert self.has_object_perm("GET", self.org, user=user, is_superuser=True)
+
+    @mock.patch("sentry.api.bases.organization.is_active_staff", wraps=is_active_staff)
+    def test_staff(self, mock_is_active_staff):
+        user = self.create_user(is_staff=True)
+
+        assert self.has_object_perm("GET", self.org, user=user, is_staff=True)
+        # ensure we fail the scope check and call is_active_staff
+        assert mock_is_active_staff.call_count == 3
 
 
 class BaseOrganizationEndpointTest(TestCase):

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -231,7 +231,7 @@ class OrganizationAndStaffPermissionTest(PermissionBaseTestCase):
         user = self.create_user(is_superuser=True)
         assert self.has_object_perm("GET", self.org, user=user, is_superuser=True)
 
-    @mock.patch("sentry.api.bases.organization.is_active_staff", wraps=is_active_staff)
+    @mock.patch("sentry.api.permissions.is_active_staff", wraps=is_active_staff)
     def test_staff(self, mock_is_active_staff):
         user = self.create_user(is_staff=True)
 


### PR DESCRIPTION
We need to have many existing permission classes accessible by staff.
Using a mixin allows us to easily attach it to all the permission classes, and avoids having to create many extra classes for the permission classes that are only used for 1 endpoint and inherit from one of the core base permissions (like team, project, org)

Also create the `OrganizationAndStaffPermission` class to see the mixin in action.

Closes https://github.com/getsentry/team-enterprise/issues/55