### PR TITLE
ref(ddm): Refactor names in the api

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -220,7 +220,7 @@ def _build_metric_meta(
         unit=cast(MetricUnit, parsed_mri.unit),
         mri=parsed_mri.mri_string,
         operations=cast(Sequence[MetricOperationType], get_available_operations(parsed_mri)),
-        project_ids=project_ids,
+        projectIds=project_ids,
         blockingStatus=blocking_status,
     )
 

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -294,9 +294,8 @@ class MetricMeta(TypedDict):
     operations: Collection[MetricOperationType]
     unit: Optional[MetricUnit]
     mri: str
-    # TODO: change to camelcase.
-    project_ids: Sequence[int]
-    blockedForProjects: Optional[Sequence[BlockedMetric]]
+    projectIds: Sequence[int]
+    blockingStatus: Optional[Sequence[BlockedMetric]]
 
 
 class MetricMetaWithTagKeys(MetricMeta):

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -159,15 +159,15 @@ class OrganizationMetricsTest(OrganizationMetricsIntegrationTestCase):
 
         data = sorted(response.data, key=lambda d: d["mri"])
         assert data[0]["mri"] == "c:custom/clicks@none"
-        assert data[0]["project_ids"] == [project_1.id]
+        assert data[0]["projectIds"] == [project_1.id]
         assert data[0]["blockingStatus"] == []
         assert data[1]["mri"] == "d:custom/page_load@millisecond"
-        assert data[1]["project_ids"] == [project_2.id]
+        assert data[1]["projectIds"] == [project_2.id]
         assert data[1]["blockingStatus"] == [
             {"isBlocked": False, "blockedTags": ["release"], "projectId": project_2.id}
         ]
         assert data[2]["mri"] == "s:custom/user@none"
-        assert sorted(data[2]["project_ids"]) == sorted([project_1.id, project_2.id])
+        assert sorted(data[2]["projectIds"]) == sorted([project_1.id, project_2.id])
         assert data[2]["blockingStatus"] == [
             {"isBlocked": True, "blockedTags": [], "projectId": project_1.id}
         ]


### PR DESCRIPTION
This PR refactors the names in the `metrics/meta` API which are now honoring the camelcase standard.