### PR TITLE
ref(api): Make processing team endpoints private

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -48,8 +48,8 @@ class GzipChunk(BytesIO):
 @region_silo_endpoint
 class ChunkUploadEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.OWNERS_NATIVE
     permission_classes = (OrganizationReleasePermission,)

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -360,7 +360,7 @@ class DebugFilesEndpoint(ProjectEndpoint):
 class UnknownDebugFilesEndpoint(ProjectEndpoint):
     owner = ApiOwner.OWNERS_NATIVE
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
 
@@ -374,7 +374,7 @@ class UnknownDebugFilesEndpoint(ProjectEndpoint):
 class AssociateDSymFilesEndpoint(ProjectEndpoint):
     owner = ApiOwner.OWNERS_NATIVE
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
 
@@ -387,7 +387,7 @@ class AssociateDSymFilesEndpoint(ProjectEndpoint):
 class DifAssembleEndpoint(ProjectEndpoint):
     owner = ApiOwner.OWNERS_NATIVE
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
 

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -180,9 +180,9 @@ class ProguardArtifactReleasesEndpoint(ProjectEndpoint):
 class DebugFilesEndpoint(ProjectEndpoint):
     owner = ApiOwner.OWNERS_NATIVE
     publish_status = {
-        "DELETE": ApiPublishStatus.PRIVATE,
-        "GET": ApiPublishStatus.PRIVATE,
-        "POST": ApiPublishStatus.PRIVATE,
+        "DELETE": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.UNKNOWN,
     }
     permission_classes = (ProjectReleasePermission,)
 

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -180,9 +180,9 @@ class ProguardArtifactReleasesEndpoint(ProjectEndpoint):
 class DebugFilesEndpoint(ProjectEndpoint):
     owner = ApiOwner.OWNERS_NATIVE
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
-        "GET": ApiPublishStatus.UNKNOWN,
-        "POST": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
 

--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -16,7 +16,7 @@ from sentry.utils.safe import get_path
 class EventAppleCrashReportEndpoint(ProjectEndpoint):
     owner = ApiOwner.OWNERS_NATIVE
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, project, event_id) -> HttpResponseBase:

--- a/src/sentry/api/endpoints/event_reprocessable.py
+++ b/src/sentry/api/endpoints/event_reprocessable.py
@@ -14,7 +14,7 @@ from sentry.reprocessing2 import CannotReprocess, pull_event_data
 class EventReprocessableEndpoint(ProjectEndpoint):
     owner = ApiOwner.OWNERS_PROCESSING
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
     def get(self, request: Request, project, event_id) -> Response:

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -86,7 +86,7 @@ class AppStoreConnectCredentialsSerializer(serializers.Serializer):
 @region_silo_endpoint
 class AppStoreConnectAppsEndpoint(ProjectEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     """Retrieves available applications with provided credentials.
 
@@ -205,7 +205,7 @@ class AppStoreCreateCredentialsSerializer(serializers.Serializer):
 @region_silo_endpoint
 class AppStoreConnectCreateCredentialsEndpoint(ProjectEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     """Returns all the App Store Connect symbol source settings ready to be saved.
 
@@ -283,7 +283,7 @@ class AppStoreUpdateCredentialsSerializer(serializers.Serializer):
 @region_silo_endpoint
 class AppStoreConnectUpdateCredentialsEndpoint(ProjectEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     """Updates a subset of the existing credentials.
 
@@ -349,7 +349,7 @@ class AppStoreConnectUpdateCredentialsEndpoint(ProjectEndpoint):
 @region_silo_endpoint
 class AppStoreConnectRefreshEndpoint(ProjectEndpoint):
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     """Triggers an immediate check for new App Store Connect builds.
 
@@ -403,7 +403,7 @@ class AppStoreConnectRefreshEndpoint(ProjectEndpoint):
 @region_silo_endpoint
 class AppStoreConnectStatusEndpoint(ProjectEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.UNKNOWN,
+        "GET": ApiPublishStatus.PRIVATE,
     }
     """Returns a summary of the project's App Store Connect configuration
     and builds.

--- a/src/sentry/api/endpoints/project_reprocessing.py
+++ b/src/sentry/api/endpoints/project_reprocessing.py
@@ -12,7 +12,7 @@ from sentry.reprocessing import trigger_reprocessing
 class ProjectReprocessingEndpoint(ProjectEndpoint):
     owner = ApiOwner.OWNERS_PROCESSING
     publish_status = {
-        "POST": ApiPublishStatus.UNKNOWN,
+        "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (ProjectReleasePermission,)
 


### PR DESCRIPTION
This makes the endpoints private that the processing team doesn't think should be public.