### PR TITLE
ref(api): Delete unnecessary `start_transaction` call in `project_configs.py`

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2069,9 +2069,6 @@ SENTRY_SYMBOLICATE_EVENT_APM_SAMPLING = 0
 # Sample rate for the process_event task transactions
 SENTRY_PROCESS_EVENT_APM_SAMPLING = 0
 
-# sample rate for the relay projectconfig endpoint
-SENTRY_RELAY_ENDPOINT_APM_SAMPLING = 0
-
 # sample rate for relay's cache invalidation task
 SENTRY_RELAY_TASK_APM_SAMPLING = 0
 


### PR DESCRIPTION
This PR also removes the `_sample_apm` function, which was only used in the deleted `start_transaction` call from `project_configs.py`. Additionally, the PR deletes the `SENTRY_RELAY_ENDPOINT_APM_SAMPLING` constant, which was only used in the `_sample_apm` function.

Ref #63590