### PR TITLE
ref(feedback): expand `sentryAppIssues`  instead of endpoint call

### DIFF
--- a/static/app/components/feedback/list/useHasLinkedIssues.tsx
+++ b/static/app/components/feedback/list/useHasLinkedIssues.tsx
@@ -1,7 +1,5 @@
 import {ExternalIssueComponent} from 'sentry/components/group/externalIssuesList/types';
-import useFetchSentryAppData from 'sentry/components/group/externalIssuesList/useFetchSentryAppData';
 import useIssueTrackingFilter from 'sentry/components/group/externalIssuesList/useIssueTrackingFilter';
-import ExternalIssueStore from 'sentry/stores/externalIssueStore';
 import SentryAppInstallationStore from 'sentry/stores/sentryAppInstallationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Group, Project} from 'sentry/types';
@@ -17,10 +15,8 @@ type Props = {
 
 export default function useExternalIssueData({group, event, project}: Props) {
   const organization = useOrganization();
-  useFetchSentryAppData({group, organization}); // TODO: add this info onto the group directly
   const issueTrackingFilter = useIssueTrackingFilter();
   const components = useSentryAppComponentsStore({componentType: 'issue-link'});
-  const externalIssues = useLegacyStore(ExternalIssueStore);
   const sentryAppInstallations = useLegacyStore(SentryAppInstallationStore);
 
   const renderSentryAppIssues = (): ExternalIssueComponent[] => {
@@ -35,7 +31,9 @@ export default function useExternalIssueData({group, event, project}: Props) {
           return null;
         }
 
-        const issue = (externalIssues || []).find(i => i.serviceType === sentryApp.slug);
+        const issue = (group.sentryAppIssues || []).find(
+          i => i.serviceType === sentryApp.slug
+        );
 
         return {
           type: 'sentry-app-issue',

--- a/static/app/components/feedback/useFeedbackListQueryKey.tsx
+++ b/static/app/components/feedback/useFeedbackListQueryKey.tsx
@@ -93,6 +93,7 @@ export default function useFeedbackListQueryKey({
                 'pluginActions', // Gives us plugin actions available
                 'pluginIssues', // Gives us plugin issues available
                 'integrationIssues', // Gives us integration issues available
+                'sentryAppIssues', // Gives us Sentry app issues available
               ],
           shortIdLookup: 0,
           query: `issue.category:feedback status:${mailbox} ${fixedQueryView.query}`,

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -4,7 +4,13 @@ import type {FieldKind} from 'sentry/utils/fields';
 
 import type {Actor, TimeseriesValue} from './core';
 import type {Event, EventMetadata, EventOrGroupType, Level} from './event';
-import type {Commit, ExternalIssue, PullRequest, Repository} from './integrations';
+import type {
+  Commit,
+  ExternalIssue,
+  PlatformExternalIssue,
+  PullRequest,
+  Repository,
+} from './integrations';
 import type {Team} from './organization';
 import type {PlatformKey, Project} from './project';
 import type {AvatarUser, User} from './user';
@@ -733,6 +739,7 @@ export interface BaseGroup {
   integrationIssues?: ExternalIssue[];
   latestEvent?: Event;
   owners?: SuggestedOwner[] | null;
+  sentryAppIssues?: PlatformExternalIssue[];
   substatus?: GroupSubstatus | null;
 }
 


### PR DESCRIPTION
Getting rid of the last extra endpoint call for the feedback list! Now our issue tracker signals are only doing 1 call, and that's to the overall issues list endpoint. Uses the changes in https://github.com/getsentry/sentry/pull/63905

Same behavior as before:

https://github.com/getsentry/sentry/assets/56095982/c323b9f3-d46e-4dac-81fc-9e3e1f4724e9

