### PR TITLE
feat(browser-starifish): make page alerts dismissible

### DIFF
--- a/static/app/utils/performance/contexts/pageAlert.tsx
+++ b/static/app/utils/performance/contexts/pageAlert.tsx
@@ -7,10 +7,14 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 
 type PageAlertType = keyof Theme['alert'];
 
+export enum DismissId {
+  RESOURCE_SIZE_ALERT,
+}
+
 export type PageAlertOptions = {
   message: React.ReactNode | undefined;
   type: PageAlertType;
-  dismissId?: string;
+  dismissId?: DismissId;
 };
 
 const localStorageKey = 'sentry:page-alert';

--- a/static/app/utils/performance/contexts/pageAlert.tsx
+++ b/static/app/utils/performance/contexts/pageAlert.tsx
@@ -2,15 +2,23 @@ import React, {createContext, Fragment, useContext, useState} from 'react';
 import {Theme} from '@emotion/react';
 
 import {Alert} from 'sentry/components/alert';
+import {IconClose} from 'sentry/icons';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 
 type PageAlertType = keyof Theme['alert'];
 
 export type PageAlertOptions = {
   message: React.ReactNode | undefined;
   type: PageAlertType;
+  dismissId?: string;
 };
 
-type PageAlertSetter = (message: React.ReactNode | undefined) => void;
+const localStorageKey = 'sentry:page-alert';
+
+type PageAlertSetter = (
+  message: React.ReactNode | undefined,
+  options?: Pick<PageAlertOptions, 'dismissId'>
+) => void;
 
 const pageErrorContext = createContext<{
   setPageError: PageAlertSetter;
@@ -31,23 +39,23 @@ const pageErrorContext = createContext<{
 export function PageAlertProvider({children}: {children: React.ReactNode}) {
   const [pageAlert, setPageAlert] = useState<PageAlertOptions | undefined>();
 
-  const setPageInfo: PageAlertSetter = message => {
-    setPageAlert({message, type: 'info'});
+  const setPageInfo: PageAlertSetter = (message, options) => {
+    setPageAlert({message, type: 'info', ...options});
   };
-  const setPageMuted: PageAlertSetter = message => {
-    setPageAlert({message, type: 'muted'});
-  };
-
-  const setPageSuccess: PageAlertSetter = message => {
-    setPageAlert({message, type: 'success'});
+  const setPageMuted: PageAlertSetter = (message, options) => {
+    setPageAlert({message, type: 'muted', ...options});
   };
 
-  const setPageWarning: PageAlertSetter = message => {
-    setPageAlert({message, type: 'warning'});
+  const setPageSuccess: PageAlertSetter = (message, options) => {
+    setPageAlert({message, type: 'success', ...options});
   };
 
-  const setPageError: PageAlertSetter = message => {
-    setPageAlert({message, type: 'error'});
+  const setPageWarning: PageAlertSetter = (message, options) => {
+    setPageAlert({message, type: 'warning', ...options});
+  };
+
+  const setPageError: PageAlertSetter = (message, options) => {
+    setPageAlert({message, type: 'error', ...options});
   };
 
   return (
@@ -68,15 +76,36 @@ export function PageAlertProvider({children}: {children: React.ReactNode}) {
 
 export function PageAlert() {
   const {pageAlert} = useContext(pageErrorContext);
+  const [dismissedAlerts, setDismissedAlerts] = useLocalStorageState<string[]>(
+    localStorageKey,
+    []
+  );
+
   if (!pageAlert || !pageAlert.message) {
     return null;
   }
 
-  const isStringError = typeof pageAlert === 'string';
-  const message = isStringError ? pageAlert : pageAlert.message;
+  const {message, dismissId} = pageAlert;
+
+  if (dismissId && dismissedAlerts.includes(dismissId)) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    if (!dismissId || dismissedAlerts.includes(dismissId)) {
+      return;
+    }
+    const prev = new Set(dismissedAlerts);
+    setDismissedAlerts([...prev, dismissId]);
+  };
 
   return (
-    <Alert type={pageAlert.type} data-test-id="page-error-alert" showIcon>
+    <Alert
+      type={pageAlert.type}
+      data-test-id="page-error-alert"
+      showIcon
+      trailingItems={dismissId && <IconClose size="sm" onClick={handleDismiss} />}
+    >
       <Fragment>{message}</Fragment>
     </Alert>
   );

--- a/static/app/views/performance/browser/resources/resourceView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceView/resourceTable.tsx
@@ -107,7 +107,7 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
       for (const row of tableData) {
         const encodedSize = row[`avg(${HTTP_RESPONSE_CONTENT_LENGTH})`];
         if (encodedSize >= 2147483647) {
-          setPageInfo(RESOURCE_SIZE_ALERT);
+          setPageInfo(RESOURCE_SIZE_ALERT, {dismissId: 'resource-size-alert'});
           break;
         }
       }

--- a/static/app/views/performance/browser/resources/resourceView/resourceTable.tsx
+++ b/static/app/views/performance/browser/resources/resourceView/resourceTable.tsx
@@ -12,7 +12,7 @@ import Pagination, {CursorHandler} from 'sentry/components/pagination';
 import {IconImage} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
+import {DismissId, usePageAlert} from 'sentry/utils/performance/contexts/pageAlert';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {RESOURCE_THROUGHPUT_UNIT} from 'sentry/views/performance/browser/resources';
@@ -107,7 +107,7 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
       for (const row of tableData) {
         const encodedSize = row[`avg(${HTTP_RESPONSE_CONTENT_LENGTH})`];
         if (encodedSize >= 2147483647) {
-          setPageInfo(RESOURCE_SIZE_ALERT, {dismissId: 'resource-size-alert'});
+          setPageInfo(RESOURCE_SIZE_ALERT, {dismissId: DismissId.RESOURCE_SIZE_ALERT});
           break;
         }
       }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/64099

And more changes post #61881 

1. This adds a `dismissId` property to pageAlert options. When set, the id is used to uniquely identify a dismissible alert so that it can maintain in its dismissed state post reload via localstorage.

2. Implements the alert to the resource SDK alert
<img width="791" alt="image" src="https://github.com/getsentry/sentry/assets/44422760/031d60eb-86a1-426f-a7a1-01bf3d059604">
 


