### PR TITLE
feat(issue-details): Apply initial design feedback to replay player

### DIFF
--- a/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
@@ -24,7 +24,7 @@ const mockReplayId = '761104e184c64d439ee1014b72b4d83b';
 
 const mockEventTimestampMs = new Date('2022-09-22T16:59:41Z').getTime();
 
-const mockButtonHref = `/organizations/${mockOrgSlug}/replays/761104e184c64d439ee1014b72b4d83b/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&t=52&t_main=errors`;
+const mockButtonHref = `/organizations/${mockOrgSlug}/replays/761104e184c64d439ee1014b72b4d83b/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&t=57&t_main=errors`;
 
 // Get replay data with the mocked replay reader params
 const mockReplay = ReplayReader.factory({
@@ -170,9 +170,9 @@ describe('ReplayClipPreview', () => {
     // Should be two sliders, one for the scrubber and one for timeline
     const sliders = screen.getAllByRole('slider', {name: 'Seek slider'});
 
-    // Replay should start at 52000ms because event happened at 62000ms
-    expect(sliders[0]).toHaveValue('52000');
-    expect(sliders[0]).toHaveAttribute('min', '52000');
+    // Replay should start at 57000ms because event happened at 62000ms
+    expect(sliders[0]).toHaveValue('57000');
+    expect(sliders[0]).toHaveAttribute('min', '57000');
 
     // End of range should be 5 seconds after at 67000ms
     expect(sliders[0]).toHaveAttribute('max', '67000');

--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -1,4 +1,4 @@
-import {ComponentProps, Fragment, useMemo, useRef, useState} from 'react';
+import {ComponentProps, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import screenfull from 'screenfull';
 
@@ -6,6 +6,7 @@ import {Alert} from 'sentry/components/alert';
 import {LinkButton} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import Panel from 'sentry/components/panels/panel';
 import Placeholder from 'sentry/components/placeholder';
 import {Flex} from 'sentry/components/profiling/flex';
 import MissingReplayAlert from 'sentry/components/replays/alerts/missingReplayAlert';
@@ -46,7 +47,7 @@ type Props = {
   fullReplayButtonProps?: Partial<ComponentProps<typeof LinkButton>>;
 };
 
-const CLIP_DURATION_BEFORE_EVENT = 10_000;
+const CLIP_DURATION_BEFORE_EVENT = 5_000;
 const CLIP_DURATION_AFTER_EVENT = 5_000;
 
 function getReplayAnalyticsStatus({
@@ -100,7 +101,7 @@ function ReplayPreviewPlayer({
   };
 
   return (
-    <Fragment>
+    <PlayerPanel>
       <PlayerBreadcrumbContainer>
         <PlayerContextContainer>
           {isFullscreen ? (
@@ -121,7 +122,7 @@ function ReplayPreviewPlayer({
       </PlayerBreadcrumbContainer>
       <ErrorBoundary mini>
         <ButtonGrid>
-          <ReplayPlayPauseButton />
+          <ReplayPlayPauseButton priority="default" />
           <Container>
             <TimeAndScrubberGrid />
           </Container>
@@ -135,7 +136,7 @@ function ReplayPreviewPlayer({
           </ButtonBar>
         </ButtonGrid>
       </ErrorBoundary>
-    </Fragment>
+    </PlayerPanel>
   );
 }
 
@@ -230,9 +231,19 @@ function ReplayClipPreview({
   );
 }
 
+const PlayerPanel = styled(Panel)`
+  padding: ${space(3)} ${space(3)} ${space(1.5)};
+  margin: 0;
+  display: flex;
+  gap: ${space(1)};
+  flex-direction: column;
+  flex-grow: 1;
+  overflow: hidden;
+  height: 100%;
+`;
+
 const PlayerBreadcrumbContainer = styled(FluidHeight)`
   position: relative;
-  height: 100%;
 `;
 
 const PlayerContainer = styled(FluidHeight)`

--- a/static/app/components/replays/replayPlayPauseButton.tsx
+++ b/static/app/components/replays/replayPlayPauseButton.tsx
@@ -1,9 +1,9 @@
-import {Button} from 'sentry/components/button';
+import {BaseButtonProps, Button} from 'sentry/components/button';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {IconPause, IconPlay, IconPrevious} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
-function ReplayPlayPauseButton() {
+function ReplayPlayPauseButton(props: BaseButtonProps) {
   const {isFinished, isPlaying, restart, togglePlayPause} = useReplayContext();
 
   return isFinished ? (
@@ -13,6 +13,7 @@ function ReplayPlayPauseButton() {
       onClick={restart}
       aria-label={t('Restart Replay')}
       priority="primary"
+      {...props}
     />
   ) : (
     <Button
@@ -21,6 +22,7 @@ function ReplayPlayPauseButton() {
       onClick={() => togglePlayPause(!isPlaying)}
       aria-label={isPlaying ? t('Pause') : t('Play')}
       priority="primary"
+      {...props}
     />
   );
 }


### PR DESCRIPTION
Changes:

- Put the player into a panel to more clearly define the replay area
- Change the play button priority to default because playing the replay is not the primary action on this page
- Change the pre-error duration to 5 seconds (10 felt too long)

Before:

![CleanShot 2024-01-26 at 10 06 42](https://github.com/getsentry/sentry/assets/10888943/f3233cc4-7f75-4857-940f-731044834c40)

After:

![CleanShot 2024-01-26 at 10 06 48](https://github.com/getsentry/sentry/assets/10888943/107193c1-631d-4410-aafd-6d720a0e5532)
