### PR TITLE
ref: revert json instrumentation

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -4,7 +4,7 @@ import {extraErrorDataIntegration} from '@sentry/integrations';
 import * as Sentry from '@sentry/react';
 import {BrowserTracing} from '@sentry/react';
 import {_browserPerformanceTimeOriginMode} from '@sentry/utils';
-import {Event, IntegrationFn} from '@sentry/types';
+import type {Event} from '@sentry/types';
 
 import {SENTRY_RELEASE_VERSION, SPA_DSN} from 'sentry/constants';
 import {Config} from 'sentry/types';
@@ -67,7 +67,6 @@ function getSentryIntegrations(routes?: Function) {
       },
     }),
     new Sentry.BrowserProfilingIntegration(),
-    JSONSerializationIntegration(),
   ];
 
   return integrations;
@@ -309,49 +308,3 @@ export function addEndpointTagToRequestError(event: Event): void {
     event.tags = {...event.tags, endpoint: messageMatch[1]};
   }
 }
-
-/**
- * Custom Sentry integration to instrument JSON.stringify
- * and JSON.parse with spans.
- */
-const JSONSerializationIntegration = (() => {
-  let patched = false;
-  return {
-    name: 'JSONSerialization',
-    setupOnce(): void {
-      if (patched) {
-        return;
-      }
-
-      JSON.stringify = new Proxy(JSON.stringify, {
-        apply(target, thisArg, args) {
-          // Only attach JSON serialization spans to transactions for now
-          const activeSpan = Sentry.getActiveSpan();
-          if (!activeSpan) {
-            return target.apply(thisArg, args);
-          }
-
-          return Sentry.startSpan({op: 'serialize', name: 'JSON.stringify'}, () =>
-            target.apply(thisArg, args)
-          );
-        },
-      });
-
-      JSON.parse = new Proxy(JSON.parse, {
-        apply(target, thisArg, args) {
-          // Only attach JSON serialization spans to transactions for now
-          const activeSpan = Sentry.getActiveSpan();
-          if (!activeSpan) {
-            return target.apply(thisArg, args);
-          }
-
-          return Sentry.startSpan({op: 'parse', name: 'JSON.parse'}, () =>
-            target.apply(thisArg, args)
-          );
-        },
-      });
-
-      patched = true;
-    },
-  };
-}) satisfies IntegrationFn;


### PR DESCRIPTION
Reverts JSON.parse and JSON.serialize instrumentation as it is something that replay heavily uses. Even if the instrumentation has small overhead (not entirely sure), it can still quickly become non negligible due to the amount of ops performed