### PR TITLE
chore(hybridcloud) Add service/method tags to RPC requests

### DIFF
--- a/src/sentry/api/endpoints/internal/rpc.py
+++ b/src/sentry/api/endpoints/internal/rpc.py
@@ -4,7 +4,7 @@ import pydantic
 from rest_framework.exceptions import NotFound, ParseError, PermissionDenied, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry_sdk import capture_exception
+from sentry_sdk import capture_exception, configure_scope
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -34,10 +34,13 @@ class InternalRpcServiceEndpoint(Endpoint):
         return False
 
     def post(self, request: Request, service_name: str, method_name: str) -> Response:
+        with configure_scope() as scope:
+            scope.set_tag("rpc_service", service_name)
+            scope.set_tag("rpc_method", method_name)
+
         if not self._is_authorized(request):
             raise PermissionDenied
 
-        metadata = request.data.get("meta")  # noqa
         try:
             arguments: Dict[str, Any] = request.data["args"]
         except KeyError as e:


### PR DESCRIPTION
Set service/method tags on rpc requests so that we can slice data by rpc service/method
