### PR TITLE
feat(metrics-extraction): Set spec limit with stateful extraction

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -182,7 +182,7 @@ def _get_alert_metric_specs(
                     specs.append(spec)
 
     max_alert_specs = options.get("on_demand.max_alert_specs") or _MAX_ON_DEMAND_ALERTS
-    (specs,) = _trim_if_above_limit(specs, max_alert_specs, project, "alerts")
+    (specs, _) = _trim_if_above_limit(specs, max_alert_specs, project, "alerts")
 
     return specs
 
@@ -316,20 +316,20 @@ def _trim_if_above_limit(
 
 def _update_state_with_spec_limit(
     trimmed_specs: Sequence[HashedMetricSpec],
-    widget_query_for_spec_hash: dict[HashedMetricSpec, DashboardWidgetQuery],
+    widget_query_for_spec_hash: dict[str, DashboardWidgetQuery],
 ) -> None:
     """We don't want to picked randomly last-visited widgets to exclude for specs, since we ideally want the extracted specs to be stable.
     This sets the extracted state to disabled for specs over the limit. With stateful extraction that means that we will pick a consistent set of specs
     under the limit and not have churn.
     """
 
-    widget_queries: dict[int, set()] = {}
+    widget_queries: dict[int, set] = {}
 
     for spec in trimmed_specs:
-        spec_hash, spec_version, _ = spec
+        spec_hash, _, spec_version = spec
         widget_query = widget_query_for_spec_hash[spec_hash]
         if widget_query:
-            widget_queries.setdefault(spec_version.version, [])
+            widget_queries.setdefault(spec_version.version, set())
             widget_queries[spec_version.version].add(widget_query)
 
     for (version, widget_query_set) in widget_queries.items():

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -12,7 +12,11 @@ from sentry import features, options
 from sentry.api.endpoints.project_transaction_threshold import DEFAULT_THRESHOLD
 from sentry.api.utils import get_date_range_from_params
 from sentry.incidents.models import AlertRule, AlertRuleStatus
-from sentry.models.dashboard_widget import DashboardWidgetQuery, DashboardWidgetTypes
+from sentry.models.dashboard_widget import (
+    DashboardWidgetQuery,
+    DashboardWidgetQueryOnDemand,
+    DashboardWidgetTypes,
+)
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.transaction_threshold import (
@@ -38,6 +42,8 @@ from sentry.snuba.models import SnubaQuery
 from sentry.snuba.referrer import Referrer
 from sentry.utils import json, metrics
 from sentry.utils.cache import cache
+
+OnDemandExtractionState = DashboardWidgetQueryOnDemand.OnDemandExtractionState
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +182,7 @@ def _get_alert_metric_specs(
                     specs.append(spec)
 
     max_alert_specs = options.get("on_demand.max_alert_specs") or _MAX_ON_DEMAND_ALERTS
-    specs = _trim_if_above_limit(specs, max_alert_specs, project, "alerts")
+    (specs,) = _trim_if_above_limit(specs, max_alert_specs, project, "alerts")
 
     return specs
 
@@ -195,10 +201,14 @@ def _get_widget_metric_specs(
     )
 
     # fetch all queries of all on demand metrics widgets of this organization
-    widget_queries = DashboardWidgetQuery.objects.filter(
-        widget__dashboard__organization=project.organization,
-        widget__widget_type=DashboardWidgetTypes.DISCOVER,
-    ).prefetch_related("dashboardwidgetqueryondemand_set", "widget")
+    widget_queries = (
+        DashboardWidgetQuery.objects.filter(
+            widget__dashboard__organization=project.organization,
+            widget__widget_type=DashboardWidgetTypes.DISCOVER,
+        )
+        .prefetch_related("dashboardwidgetqueryondemand_set", "widget")
+        .order_by("-widget__dashboard__last_visited", "widget__order")
+    )
 
     metrics.incr(
         "on_demand_metrics.widgets_to_process", amount=len(widget_queries), sample_rate=1.0
@@ -206,6 +216,7 @@ def _get_widget_metric_specs(
 
     ignored_widget_ids: dict[int, bool] = {}
     specs_for_widget: dict[int, list[HashedMetricSpec]] = defaultdict(list)
+    widget_query_for_spec_hash: dict[str, DashboardWidgetQuery] = {}
     specs: list[HashedMetricSpec] = []
 
     total_spec_count = 0
@@ -221,6 +232,8 @@ def _get_widget_metric_specs(
 
             total_spec_count += 1
             specs_for_widget[widget_query.widget.id] += widget_specs
+            for spec in widget_specs:
+                widget_query_for_spec_hash[spec[0]] = widget_query
 
             can_widget_query_use_stateful_extraction = _can_widget_query_use_stateful_extraction(
                 widget_query, widget_specs
@@ -246,8 +259,9 @@ def _get_widget_metric_specs(
     specs = _trim_disabled_widgets(ignored_widget_ids, specs_for_widget)
     metrics.incr("on_demand_metrics.widget_query_specs.post_disabled_trim", amount=len(specs))
     max_widget_specs = get_max_widget_specs(project.organization)
-    specs = _trim_if_above_limit(specs, max_widget_specs, project, "widgets")
+    (specs, trimmed_specs) = _trim_if_above_limit(specs, max_widget_specs, project, "widgets")
 
+    _update_state_with_spec_limit(trimmed_specs, widget_query_for_spec_hash)
     metrics.incr("on_demand_metrics.widget_query_specs", amount=len(specs))
     return specs
 
@@ -270,10 +284,12 @@ def _trim_if_above_limit(
     max_specs: int,
     project: Project,
     widget_type: str,
-) -> list[HashedMetricSpec]:
-    """Trim specs per version if above max limit"""
+) -> tuple[list[HashedMetricSpec], list[HashedMetricSpec]]:
+    """Trim specs per version if above max limit, returns the accepted specs and the trimmed specs in a tuple"""
     return_specs = []
+    trimmed_specs = []
     specs_per_version: dict[int, dict[str, HashedMetricSpec]] = {}
+
     for hash, spec, spec_version in specs:
         specs_per_version.setdefault(spec_version.version, {})
         specs_per_version[spec_version.version][hash] = (hash, spec, spec_version)
@@ -291,10 +307,38 @@ def _trim_if_above_limit(
                 )
 
             return_specs += list(specs_for_version)[:max_specs]
+            trimmed_specs += list(specs_for_version)[max_specs:]
         else:
             return_specs += list(specs_for_version)
 
-    return return_specs
+    return return_specs, trimmed_specs
+
+
+def _update_state_with_spec_limit(
+    trimmed_specs: Sequence[HashedMetricSpec],
+    widget_query_for_spec_hash: dict[HashedMetricSpec, DashboardWidgetQuery],
+) -> None:
+    """We don't want to picked randomly last-visited widgets to exclude for specs, since we ideally want the extracted specs to be stable.
+    This sets the extracted state to disabled for specs over the limit. With stateful extraction that means that we will pick a consistent set of specs
+    under the limit and not have churn.
+    """
+
+    widget_queries: dict[int, set()] = {}
+
+    for spec in trimmed_specs:
+        spec_hash, spec_version, _ = spec
+        widget_query = widget_query_for_spec_hash[spec_hash]
+        if widget_query:
+            widget_queries.setdefault(spec_version.version, [])
+            widget_queries[spec_version.version].add(widget_query)
+
+    for (version, widget_query_set) in widget_queries.items():
+        for widget_query in widget_query_set:
+            widget_query.dashboardwidgetqueryondemand_set.filter(spec_version=version).update(
+                extraction_state=OnDemandExtractionState.DISABLED_SPEC_LIMIT
+            )
+
+    return None
 
 
 @metrics.wraps("on_demand_metrics._merge_metric_specs")
@@ -466,7 +510,7 @@ def _can_widget_query_use_stateful_extraction(
 
 
 def _widget_query_stateful_extraction_enabled(widget_query: DashboardWidgetQuery) -> bool:
-    """Separate from the check on whether to use stateful extraction in the first place,
+    """Separate from the check on whether to use stateful extracion in the first place,
     this assumes stateful extraction can be used, and returns the enabled state."""
 
     stateful_extraction_version = OnDemandMetricSpecVersioning.get_default_spec_version().version

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -1,7 +1,9 @@
+from datetime import timedelta
 from typing import Optional, Sequence
 from unittest import mock
 
 import pytest
+from django.utils import timezone
 
 from sentry.incidents.models import AlertRule
 from sentry.models.dashboard import Dashboard
@@ -621,6 +623,54 @@ def test_get_metric_extraction_config_multiple_widgets_not_above_max_limit_ident
             assert config
 
             assert capture_exception.call_count == 0
+
+
+@django_db_all
+@override_options({"on_demand.max_widget_specs": 4, "on_demand_metrics.check_widgets.enable": True})
+def test_get_metric_extraction_config_multiple_widgets_above_max_limit_ordered_specs(
+    default_project: Project,
+) -> None:
+    with Feature({ON_DEMAND_METRICS_WIDGETS: True}):
+        create_widget(["count()"], "transaction.duration:>=1000", default_project, "Dashboard 1")
+        create_widget(["count()"], "transaction.duration:>=1100", default_project, "Dashboard 2")
+        widget_query = create_widget(
+            ["count()"], "transaction.duration:>=1200", default_project, "Dashboard 3"
+        )
+        create_widget(["count()"], "transaction.duration:>=1300", default_project, "Dashboard 4")
+        create_widget(["count()"], "transaction.duration:>=1400", default_project, "Dashboard 5")
+
+        widget_query.widget.dashboard.last_visited = timezone.now() - timedelta(days=1)
+        widget_query.widget.dashboard.save()
+
+        process_widget_specs([widget_query.id])
+
+        config = get_metric_extraction_config(default_project)
+
+        assert config
+        assert len(config["metrics"]) == 4
+
+        duration_conditions = [spec["condition"]["value"] for spec in config["metrics"]]
+
+        assert duration_conditions == [
+            1400.0,
+            1300.0,
+            1100.0,
+            1000.0,
+        ]  # We only exclude the oldest spec (1200.0 duration)
+
+        with mock.patch("sentry_sdk.capture_exception") as capture_exception:
+            assert capture_exception.call_count == 2
+            exception = capture_exception.call_args.args[0]
+            assert (
+                exception.args[0]
+                == "Spec version 1: Too many (5) on demand metric widgets for org baz"
+            )
+
+        # Check that state was correctly updated.
+        on_demand_entries = widget_query.dashboardwidgetqueryondemand_set.all()
+        assert [entry.extraction_state for entry in on_demand_entries] == [
+            "disabled:spec-limit"
+        ]  # Only see the one entry disabled
 
 
 @django_db_all

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -1543,18 +1543,9 @@ def test_get_metric_extraction_config_with_unicode_character(default_project: Pr
         create_widget(["count()"], "user.name:Armén", default_project)
         create_widget(["count()"], "user.name:Kevan", default_project, title="Dashboard Foo")
         config = get_metric_extraction_config(default_project)
+
         assert config
         assert config["metrics"] == [
-            {
-                "category": "transaction",
-                "condition": {"name": "event.tags.user.name", "op": "eq", "value": "Armén"},
-                "field": None,
-                "mri": "c:transactions/on_demand@none",
-                "tags": [
-                    {"key": "query_hash", "value": "d3e07bdf"},
-                    {"key": "environment", "field": "event.environment"},
-                ],
-            },
             {
                 "category": "transaction",
                 "condition": {"name": "event.tags.user.name", "op": "eq", "value": "Kevan"},
@@ -1571,7 +1562,7 @@ def test_get_metric_extraction_config_with_unicode_character(default_project: Pr
                 "field": None,
                 "mri": "c:transactions/on_demand@none",
                 "tags": [
-                    {"key": "query_hash", "value": "c57cc340"},
+                    {"key": "query_hash", "value": "d3e07bdf"},
                     {"key": "environment", "field": "event.environment"},
                 ],
             },
@@ -1582,6 +1573,16 @@ def test_get_metric_extraction_config_with_unicode_character(default_project: Pr
                 "mri": "c:transactions/on_demand@none",
                 "tags": [
                     {"key": "query_hash", "value": "762b5dae"},
+                    {"key": "environment", "field": "event.environment"},
+                ],
+            },
+            {
+                "category": "transaction",
+                "condition": {"name": "event.tags.user.name", "op": "eq", "value": "Armén"},
+                "field": None,
+                "mri": "c:transactions/on_demand@none",
+                "tags": [
+                    {"key": "query_hash", "value": "c57cc340"},
                     {"key": "environment", "field": "event.environment"},
                 ],
             },


### PR DESCRIPTION
### Summary

This re-arranges widgets to exclude only the least recently visited widget, and in the case that you're over your limit it'll mark down which ones were excluded in the extraction state table. This way once we've passed the org one time we should fill out the spec-limit and maintain a stable set of specs across time moving forward.
