### PR TITLE
ref(slack): remove use of mentions for suggested assignees

### DIFF
--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -29,7 +29,6 @@ from sentry.issues.grouptype import (
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
-from sentry.models.identity import Identity, IdentityStatus
 from sentry.models.projectownership import ProjectOwnership
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
@@ -593,7 +592,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             name="home-repo",
             integration_id=self.integration.id,
         )
-        user2 = self.create_user(name="Scooby Doo")
+        user2 = self.create_user()
         self.create_member(teams=[self.team], user=user2, organization=self.organization)
 
         commit = self.create_commit(
@@ -617,7 +616,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         suspect_commit = {
             "commit_id": commit.key,
             "author_email": commit.author.email,
-            "author_name": commit.author.name,
         }
         expected_blocks = build_test_message_blocks(
             teams={self.team},
@@ -628,30 +626,26 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             initial_assignee=self.user,
             suspect_commit=suspect_commit,
         )
-
-        # suggested user without slack identity linked, with display name
-        expected_blocks["blocks"][4]["elements"][0][
-            "text"
-        ] = f"Suggested Assignees: #{self.team.slug}, <mailto:{user2.email}|{user2.name}>"
-
         assert (
             SlackIssuesMessageBuilder(group, event.for_group(group), tags={"foo"}).build()
             == expected_blocks
         )
 
-        # suggested user with slack identity linked
+        # suggested user with name
         with assume_test_silo_mode(SiloMode.CONTROL):
-            self.idp = self.create_identity_provider(type="slack", external_id="TXXXXXXX2")
-            self.identity = Identity.objects.create(
-                external_id="UXXXXXXX2",
-                idp=self.idp,
-                user=user2,
-                status=IdentityStatus.VALID,
-                scopes=[],
-            )
-        expected_blocks["blocks"][4]["elements"][0][
-            "text"
-        ] = f"Suggested Assignees: #{self.team.slug}, <@{self.identity.external_id}>"
+            user2.update(name="Scooby Doo")
+        commit.author.update(name=user2.name)
+        suspect_commit["author_name"] = commit.author.name
+        expected_blocks = build_test_message_blocks(
+            teams={self.team},
+            users={self.user},
+            group=group,
+            event=event,
+            suggested_assignees=f"#{self.team.slug}, <mailto:{user2.email}|{user2.name}>",  # auto-assignee is not included in suggested
+            initial_assignee=self.user,
+            suspect_commit=suspect_commit,
+        )
+
         assert (
             SlackIssuesMessageBuilder(group, event.for_group(group), tags={"foo"}).build()
             == expected_blocks


### PR DESCRIPTION
<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
