### PR TITLE
fix(browser-starfish): use tags instead of data for Sentry.captureexception

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -133,12 +133,12 @@ function SampleImagesChartPanelBody(props: {
             const url = new URL(resource[SPAN_DESCRIPTION], resource[RAW_DOMAIN]);
             src = url.href;
           } catch {
-            Sentry.captureException(new Error('Invalid URL'), {
-              tags: {
-                [SPAN_DESCRIPTION]: resource[SPAN_DESCRIPTION],
-                [RAW_DOMAIN]: resource[RAW_DOMAIN],
-              },
+            Sentry.setContext('resource', {
+              src,
+              description: resource[SPAN_DESCRIPTION],
+              rawDomain: resource[RAW_DOMAIN],
             });
+            Sentry.captureException(new Error('Invalid URL'));
           }
         }
 

--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.tsx
@@ -134,7 +134,7 @@ function SampleImagesChartPanelBody(props: {
             src = url.href;
           } catch {
             Sentry.captureException(new Error('Invalid URL'), {
-              data: {
+              tags: {
                 [SPAN_DESCRIPTION]: resource[SPAN_DESCRIPTION],
                 [RAW_DOMAIN]: resource[RAW_DOMAIN],
               },


### PR DESCRIPTION
@AbhiPrasad made a good point here, that we should be using the `tags` property instead of data when capturing exceptions 
https://github.com/getsentry/sentry/pull/63680#discussion_r1468123562

This PR makes the appropriate changes