### PR TITLE
ref(slack): Do not use mentions for suggested assignees

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -269,9 +269,7 @@ def get_suggested_assignees(
                 isinstance(current_assignee, RpcUser) and assignee.id == current_assignee.id
             ):
                 assignee_as_user = assignee.resolve()
-                assignee_texts.append(
-                    f"<mailto:{assignee_as_user.email}|{assignee_as_user.get_display_name()}>"
-                )
+                assignee_texts.append(assignee_as_user.get_display_name())
             elif assignee.actor_type == ActorType.TEAM and not (
                 isinstance(current_assignee, Team) and assignee.id == current_assignee.id
             ):

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -630,7 +630,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             users={self.user},
             group=group,
             event=event,
-            suggested_assignees=f"#{self.team.slug}, <mailto:{user2.email}|{user2.email}>",  # auto-assignee is not included in suggested
+            suggested_assignees=f"#{self.team.slug}, {user2.email}",  # auto-assignee is not included in suggested
             initial_assignee=self.user,
             suspect_commit=suspect_commit,
         )
@@ -649,7 +649,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             users={self.user},
             group=group,
             event=event,
-            suggested_assignees=f"#{self.team.slug}, <mailto:{user2.email}|{user2.name}>",
+            suggested_assignees=f"#{self.team.slug}, {user2.name}",
             initial_assignee=self.user,
             suspect_commit=suspect_commit,
         )


### PR DESCRIPTION
only use display name (name, then username, then email) for user who is a suggested assignee, as using mentions made the alerts noisier.