### PR TITLE
feat(metrics-extraction): Add spec hashes to logger

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -288,9 +288,7 @@ def _trim_if_above_limit(
                     len(specs_for_version),
                     widget_type,
                     project.slug,
-                    extra={
-                        specs=[spec[0] for spec in specs_for_version]
-                    }
+                    extra={"specs": [spec[0] for spec in specs_for_version]},
                 )
 
             return_specs += specs_for_version[:max_specs]

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -282,14 +282,15 @@ def _trim_if_above_limit(
         if len(specs_for_version) > max_specs:
             # Do not log for Sentry
             if project.organization.id != 1:
-                logger.error(
-                    "Spec version %s: Too many (%s) on demand metric %s for project %s",
-                    version,
-                    len(specs_for_version),
-                    widget_type,
-                    project.slug,
-                    extra={"specs": [spec[0] for spec in specs_for_version]},
-                )
+
+                with sentry_sdk.push_scope() as scope:
+                    scope.set_tag("project_id", project.id)
+                    scope.set_extra("specs", [spec[0] for spec in specs_for_version])
+                    sentry_sdk.capture_exception(
+                        Exception(
+                            f"Spec version {version}: Too many ({len(specs_for_version)}) on demand metric {widget_type} for org {project.organization.slug}"
+                        )
+                    )
 
             return_specs += specs_for_version[:max_specs]
         else:

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -288,6 +288,9 @@ def _trim_if_above_limit(
                     len(specs_for_version),
                     widget_type,
                     project.slug,
+                    extra={
+                        specs=[spec[0] for spec in specs_for_version]
+                    }
                 )
 
             return_specs += specs_for_version[:max_specs]

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -225,15 +225,19 @@ def test_get_metric_extraction_config_multiple_alerts_above_max_limit(
 
         config = get_metric_extraction_config(default_project)
 
-        assert config
+        with mock.patch("sentry_sdk.capture_exception") as capture_exception:
+            config = get_metric_extraction_config(default_project)
+            assert config
+
+            assert capture_exception.call_count == 1
+            exception = capture_exception.call_args.args[0]
+            assert (
+                exception.args[0]
+                == "Spec version 1: Too many (2) on demand metric alerts for org baz"
+            )
+
         # Since we have set a maximum of 1 we will not get 2
         assert len(config["metrics"]) == 1
-
-        out, _ = capfd.readouterr()
-        assert out.splitlines()[0].split(": ")[1:3] == [
-            "Spec version 1",
-            "Too many (2) on demand metric alerts for project bar",
-        ]
 
 
 @django_db_all
@@ -478,17 +482,19 @@ def test_get_metric_extraction_config_multiple_widgets_above_max_limit(
         create_widget(["count()"], "transaction.duration:>=1100", default_project)
         create_widget(["count()"], "transaction.duration:>=1000", default_project, "Dashboard 2")
 
-        config = get_metric_extraction_config(default_project)
+        with mock.patch("sentry_sdk.capture_exception") as capture_exception:
+            config = get_metric_extraction_config(default_project)
+            assert config
 
-        assert config
+            assert capture_exception.call_count == 1
+            exception = capture_exception.call_args.args[0]
+            assert (
+                exception.args[0]
+                == "Spec version 1: Too many (2) on demand metric widgets for org baz"
+            )
+
         # Since we have set a maximum of 1 we will not get 2
         assert len(config["metrics"]) == 1
-
-        out, _ = capfd.readouterr()
-        assert out.splitlines()[0].split(": ")[1:3] == [
-            "Spec version 1",
-            "Too many (2) on demand metric widgets for project bar",
-        ]
 
 
 @django_db_all
@@ -501,17 +507,19 @@ def test_get_metric_extraction_config_multiple_widgets_not_using_extended_specs(
         create_widget(["count()"], "transaction.duration:>=1100", default_project)
         create_widget(["count()"], "transaction.duration:>=1000", default_project, "Dashboard 2")
 
-        config = get_metric_extraction_config(default_project)
+        with mock.patch("sentry_sdk.capture_exception") as capture_exception:
+            config = get_metric_extraction_config(default_project)
+            assert config
 
-        assert config
+            assert capture_exception.call_count == 1
+            exception = capture_exception.call_args.args[0]
+            assert (
+                exception.args[0]
+                == "Spec version 1: Too many (2) on demand metric widgets for org baz"
+            )
+
         # Since we have set a maximum of 1 we will not get 2
         assert len(config["metrics"]) == 1
-
-        out, _ = capfd.readouterr()
-        assert out.splitlines()[0].split(": ")[1:3] == [
-            "Spec version 1",
-            "Too many (2) on demand metric widgets for project bar",
-        ]
 
 
 @django_db_all
@@ -526,17 +534,19 @@ def test_get_metric_extraction_config_multiple_widgets_above_extended_max_limit(
         create_widget(["count()"], "transaction.duration:>=1100", default_project)
         create_widget(["count()"], "transaction.duration:>=1000", default_project, "Dashboard 2")
 
-        config = get_metric_extraction_config(default_project)
+        with mock.patch("sentry_sdk.capture_exception") as capture_exception:
+            config = get_metric_extraction_config(default_project)
+            assert config
 
-        assert config
+            assert capture_exception.call_count == 1
+            exception = capture_exception.call_args.args[0]
+            assert (
+                exception.args[0]
+                == "Spec version 1: Too many (2) on demand metric widgets for org baz"
+            )
+
         # Since we have set a maximum of 1 we will not get 2
         assert len(config["metrics"]) == 1
-
-        out, _ = capfd.readouterr()
-        assert out.splitlines()[0].split(": ")[1:3] == [
-            "Spec version 1",
-            "Too many (2) on demand metric widgets for project bar",
-        ]
 
 
 @django_db_all


### PR DESCRIPTION
### Summary
This adds spec hashes when we have 'too many spec versions' error, specifically since the numbers don't -quite- match up (725 in build_config and 716 in the stateful extraction table) and I want to confirm which ones.
