### PR TITLE
build: update `@types/node` to latest version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,6 @@
 /* eslint-env node */
 /* eslint import/no-nodejs-modules:0 */
 
-const process = require('process');
-
 const isRelaxed = !!process.env.SENTRY_ESLINT_RELAXED;
 const isCi = !!process.env.CI;
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,7 +1,7 @@
 /* eslint-env node */
 /* eslint import/no-nodejs-modules:0 */
-import path from 'path';
-import process from 'process';
+import path from 'node:path';
+import process from 'node:process';
 
 import type {Config} from '@jest/types';
 

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.4.3",
-    "@types/node": "^18.14.0",
+    "@types/node": "^20.11.7",
     "babel-gettext-extractor": "^4.1.3",
     "babel-jest": "^29.6.2",
     "babel-plugin-dynamic-import-node": "^2.3.3",

--- a/scripts/build-js-loader.ts
+++ b/scripts/build-js-loader.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 /* eslint import/no-nodejs-modules:0 */
 
-import fs from 'fs';
+import fs from 'node:fs';
 
 import {minify} from 'terser';
 import * as ts from 'typescript';

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,8 +1,8 @@
 /* eslint-env node */
 /* eslint import/no-nodejs-modules:0 */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import {WebpackReactSourcemapsPlugin} from '@acemarke/react-prod-sourcemaps';
 import browserslist from 'browserslist';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3342,17 +3342,12 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@*", "@types/node@>=10.0.0":
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@^20.11.7":
   version "20.11.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.7.tgz#cb49aedd758c978c30806d0c38b520ed2a3df6e0"
   integrity sha512-GPmeN1C3XAyV5uybAf4cMLWT9fDWcmQhZVtMFu7OR32WjrqGG+Wnk2V1d0bmtUyE/Zy1QJ9BxyiTih9z8Oks8A==
   dependencies:
     undici-types "~5.26.4"
-
-"@types/node@^18.14.0":
-  version "18.14.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.0.tgz#94c47b9217bbac49d4a67a967fdcdeed89ebb7d0"
-  integrity sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
Updates `@types/node` to reduce the amount of packages we have to install, and updates all Node.js module imports to use `node:` prefix to differentiate if it's a Node.js module or not, that is supported since Node v16.

Closes https://github.com/getsentry/sentry/pull/63982