### PR TITLE
chore(open-pr-comments): populate file extensions column

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -439,6 +439,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
         patch_parsers = BETA_PATCH_PARSERS
 
     # fetch issues related to the files
+    file_extensions = set()  # tracks the different file extensions in the comment
     for file in pullrequest_files:
         projects, sentry_filenames = get_projects_and_filenames_from_source_file(
             org_id, file.filename
@@ -470,6 +471,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
             continue
 
         top_issues_per_file.append(top_issues)
+        file_extensions.add(file_extension)
 
         issue_table_contents[file.filename] = get_issue_table_contents(top_issues)
 
@@ -518,6 +520,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
             issue_list=issue_id_list,
             comment_type=CommentType.OPEN_PR,
             metrics_base=OPEN_PR_METRICS_BASE,
+            file_extensions=list(file_extensions),
         )
     except ApiError as e:
         if e.json:

--- a/src/sentry/tasks/integrations/github/utils.py
+++ b/src/sentry/tasks/integrations/github/utils.py
@@ -44,6 +44,7 @@ def create_or_update_comment(
     issue_list: List[int],
     metrics_base: str,
     comment_type: int = CommentType.MERGED_PR,
+    file_extensions: List[str] | None = None,  # only passed in for open PR comments
 ):
     pr_comment_query = PullRequestComment.objects.filter(
         pull_request__id=pullrequest_id, comment_type=comment_type
@@ -64,6 +65,7 @@ def create_or_update_comment(
             updated_at=current_time,
             group_ids=issue_list,
             comment_type=comment_type,
+            file_extensions=file_extensions,
         )
         metrics.incr(metrics_base.format(key="comment_created"))
     else:

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -799,8 +799,11 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
 
         pull_request_comment_query = PullRequestComment.objects.all()
         assert len(pull_request_comment_query) == 1
-        assert pull_request_comment_query[0].external_id == 1
-        assert pull_request_comment_query[0].comment_type == CommentType.OPEN_PR
+
+        pr_comment = pull_request_comment_query[0]
+        assert pr_comment.external_id == 1
+        assert pr_comment.comment_type == CommentType.OPEN_PR
+        assert pr_comment.file_extensions == ["py"]
         mock_metrics.incr.assert_called_with("github_open_pr_comment.comment_created")
 
     @responses.activate
@@ -832,6 +835,7 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
             updated_at=now,
             group_ids=[0, 1],
             comment_type=CommentType.OPEN_PR,
+            file_extensions=["py"],
         )
 
         responses.add(

--- a/tests/sentry/tasks/integrations/github/test_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_pr_comment.py
@@ -367,8 +367,11 @@ class TestCommentWorkflow(GithubCommentTestCase):
         )
         pull_request_comment_query = PullRequestComment.objects.all()
         assert len(pull_request_comment_query) == 1
-        assert pull_request_comment_query[0].external_id == 1
-        assert pull_request_comment_query[0].comment_type == CommentType.MERGED_PR
+
+        pr_comment = pull_request_comment_query[0]
+        assert pr_comment.external_id == 1
+        assert pr_comment.comment_type == CommentType.MERGED_PR
+        assert pr_comment.file_extensions is None
         mock_metrics.incr.assert_called_with("github_pr_comment.comment_created")
 
     @patch("sentry.tasks.integrations.github.pr_comment.get_top_5_issues_by_count")


### PR DESCRIPTION
Requires #63975

Populates the `file_extensions` column in the `PullRequestComment` for open PR comments. This is so that we can track how many comments we make for each language since we only have Python and Javascript (soon).