### PR TITLE
fix(trace): Facets not loading for traces

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -609,13 +609,15 @@ def get_facets(
             offset=cursor - 1 if fetch_projects and cursor > 0 else cursor,
             turbo=sample,
         )
+        non_sample_columns = [
+            key_name_builder.resolve_column("trace"),
+            key_name_builder.resolve_column("id"),
+        ]
         for condition in key_name_builder.where:
-            if condition.lhs == key_name_builder.resolve_column("trace"):
-                key_name_builder.turbo = False
-                break
-            elif condition.lhs == key_name_builder.resolve_column("id"):
-                key_name_builder.turbo = False
-                break
+            if isinstance(condition, Condition):
+                if condition.lhs in non_sample_columns:
+                    key_name_builder.turbo = False
+                    break
         key_names = key_name_builder.run_query(referrer)
         # Sampling keys for multi-project results as we don't need accuracy
         # with that much data.

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -8,8 +8,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import sentry_sdk
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
-from snuba_sdk.conditions import Condition, Op
-from snuba_sdk.function import Function
+from snuba_sdk import Condition, Function, Op
 from typing_extensions import NotRequired, TypedDict
 
 from sentry.discover.arithmetic import categorize_columns
@@ -610,6 +609,13 @@ def get_facets(
             offset=cursor - 1 if fetch_projects and cursor > 0 else cursor,
             turbo=sample,
         )
+        for condition in key_name_builder.where:
+            if condition.lhs == key_name_builder.resolve_column("trace"):
+                key_name_builder.turbo = False
+                break
+            elif condition.lhs == key_name_builder.resolve_column("id"):
+                key_name_builder.turbo = False
+                break
         key_names = key_name_builder.run_query(referrer)
         # Sampling keys for multi-project results as we don't need accuracy
         # with that much data.


### PR DESCRIPTION
- Because we're turboing even with a trace filter we're not finding any tags. In these cases we want to turn sample off since trace is indexed and should already be pretty fast
- While we're here adding id since this applies there too