### PR TITLE
ref(slack): Use rich text preformatted block

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/block.py
+++ b/src/sentry/integrations/slack/message_builder/base/block.py
@@ -40,6 +40,19 @@ class BlockSlackMessageBuilder(SlackMessageBuilder, ABC):
         }
 
     @staticmethod
+    def get_rich_text_preformatted_block(text: str) -> SlackBlock:
+        return {
+            "type": "rich_text",
+            "elements": [
+                {
+                    "type": "rich_text_preformatted",
+                    "elements": [{"type": "text", "text": text}],
+                    "border": 0,
+                }
+            ],
+        }
+
+    @staticmethod
     def get_tags_block(tags) -> SlackBlock:
         text = ""
         for tag in tags:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -554,12 +554,12 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         # build title block
         if text:
-            text = f"```{text.lstrip(' ')}```"
+            text = text.lstrip(" ")
             if self.actions:
                 text += "\n" + action_text
         if not text:
             text = action_text
-        title_text = f"<{title_link}|*{escape_slack_text(title)}*>  \n{text}"
+        title_text = f"<{title_link}|*{escape_slack_text(title)}*>"
 
         if self.group.issue_category == GroupCategory.ERROR:
             level_text = None
@@ -573,8 +573,10 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         if title_emoji:
             title_text = f"{title_emoji} {title_text}"
-
         blocks = [self.get_markdown_block(title_text)]
+        if text:
+            blocks.append(self.get_rich_text_preformatted_block(text))
+
         # build tags block
         tags = get_tags(event_for_tags, self.tags)
         if tags:
@@ -633,9 +635,10 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             )  # get rid of comma at the end
 
         # add suspect commit info
-        suspect_commit_text = get_suspect_commit_block(project, event_for_tags)
-        if suspect_commit_text:
-            blocks.append(self.get_context_block(suspect_commit_text))
+        if event_for_tags:
+            suspect_commit_text = get_suspect_commit_block(project, event_for_tags)
+            if suspect_commit_text:
+                blocks.append(self.get_context_block(suspect_commit_text))
 
         # add notes
         if self.notes:

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2799,9 +2799,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
         issue_link = f"http://testserver/organizations/{org_slug}/issues/{group.id}/?referrer={referrer}&notification_uuid={notification_uuid}"
         if issue_link_extra_params is not None:
             issue_link += issue_link_extra_params
-        assert (
-            blocks[1]["text"]["text"] == f":chart_with_upwards_trend: <{issue_link}|*N+1 Query*>"
-        )
+        assert blocks[1]["text"]["text"] == f":chart_with_upwards_trend: <{issue_link}|*N+1 Query*>"
         assert (
             blocks[2]["elements"][0]["elements"][0]["text"]
             == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2800,11 +2800,14 @@ class SlackActivityNotificationTest(ActivityTestCase):
         if issue_link_extra_params is not None:
             issue_link += issue_link_extra_params
         assert (
-            blocks[1]["text"]["text"]
-            == f":chart_with_upwards_trend: <{issue_link}|*N+1 Query*>  \n```db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21```"
+            blocks[1]["text"]["text"] == f":chart_with_upwards_trend: <{issue_link}|*N+1 Query*>"
         )
         assert (
-            blocks[4]["elements"][0]["text"]
+            blocks[2]["elements"][0]["elements"][0]["text"]
+            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+        )
+        assert (
+            blocks[5]["elements"][0]["text"]
             == f"{project_slug} | production | <http://testserver/settings/account/notifications/{alert_type}/?referrer={referrer}-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 
@@ -2835,10 +2838,14 @@ class SlackActivityNotificationTest(ActivityTestCase):
             issue_link += issue_link_extra_params
         assert (
             blocks[1]["text"]["text"]
-            == f":exclamation: <{issue_link}|*{TEST_ISSUE_OCCURRENCE.issue_title}*>  \n```{TEST_ISSUE_OCCURRENCE.evidence_display[0].value}```"
+            == f":exclamation: <{issue_link}|*{TEST_ISSUE_OCCURRENCE.issue_title}*>"
         )
         assert (
-            blocks[4]["elements"][0]["text"]
+            blocks[2]["elements"][0]["elements"][0]["text"]
+            == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
+        )
+        assert (
+            blocks[5]["elements"][0]["text"]
             == f"{project_slug} | <http://testserver/settings/account/notifications/{alert_type}/?referrer={referrer}-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -144,7 +144,7 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
+            == f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
         )
         assert (
             blocks[3]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -115,7 +115,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={self.rule.id}&alert_type=issue|*Hello world*>  \n"
+            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={self.rule.id}&alert_type=issue|*Hello world*>"
         )
         assert (
             blocks[4]["elements"][0]["text"]
@@ -350,7 +350,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
+            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
         )
         assert (
             blocks[4]["elements"][0]["text"]
@@ -458,7 +458,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment={environment.name}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
+            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment={environment.name}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
         )
         assert (
             blocks[4]["elements"][0]["text"]
@@ -651,7 +651,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
+            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
         )
         assert blocks[5]["elements"][0]["text"] == f"Suggested Assignees: #{self.team.slug}"
         assert (
@@ -983,7 +983,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":exclamation: <http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
+            == f":exclamation: <http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
         )
         assert (
             blocks[5]["elements"][0]["text"]
@@ -1245,7 +1245,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>  \n"
+            == f":exclamation: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
         )
         assert (
             blocks[4]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -59,7 +59,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         assert blocks[0]["text"]["text"] == fallback_text
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert blocks[1]["text"]["text"] == (
-            f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
+            f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
         )
         assert blocks[3]["elements"][0]["text"] == (
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"
@@ -105,7 +105,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert blocks[1]["text"]["text"] == (
-            f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
+            f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
         )
         assert blocks[3]["elements"][0]["text"] == (
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -67,9 +67,8 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert blocks[0]["text"]["text"] == fallback_text
         assert (
             blocks[1]["text"]["text"]
-            == f":exclamation: <{issue_link}/?referrer=resolved_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
+            == f":exclamation: <{issue_link}/?referrer=resolved_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
         )
-        # import pdb; pdb.set_trace()
         assert (
             blocks[3]["elements"][0]["text"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user&notification_uuid={notification_uuid}|Notification Settings>"

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -64,7 +64,7 @@ class SlackResolvedInReleaseNotificationTest(
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_release_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
+            == f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_release_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
         )
         assert (
             blocks[3]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -58,7 +58,7 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         assert blocks[0]["text"]["text"] == fallback_text
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert blocks[1]["text"]["text"] == (
-            f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n"
+            f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
         )
         assert (
             blocks[3]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -75,7 +75,7 @@ def build_test_message_blocks(
         if link_to_event:
             title_link += f"/events/{event.event_id}"
     title_link += "/?referrer=slack"
-    title_text = f":exclamation: <{title_link}|*{formatted_title}*>  \n"
+    title_text = f":exclamation: <{title_link}|*{formatted_title}*>"
 
     blocks: list[dict[str, Any]] = [
         {
@@ -755,7 +755,11 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         for section in blocks["blocks"]:
             if section["type"] == "text":
                 assert occurrence.issue_title in section["text"]["text"]
-        assert occurrence.evidence_display[0].value in blocks["blocks"][0]["text"]["text"]
+
+        assert (
+            occurrence.evidence_display[0].value
+            in blocks["blocks"][1]["elements"][0]["elements"][0]["text"]
+        )
         assert blocks["text"] == f"[{self.project.slug}] {occurrence.issue_title}"
 
     def test_build_error_issue_fallback_text(self):
@@ -795,7 +799,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         assert "N+1 Query" in blocks["blocks"][0]["text"]["text"]
         assert (
             "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-            in blocks["blocks"][0]["text"]["text"]
+            in blocks["blocks"][1]["elements"][0]["elements"][0]["text"]
         )
         assert blocks["text"] == f"[{self.project.slug}] N+1 Query"
 
@@ -827,7 +831,10 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         )
         ret = SlackIssuesMessageBuilder(group, None).build()
         assert isinstance(ret, dict)
-        assert "&lt;https://example.com/|*Click Here*&gt;" in ret["blocks"][0]["text"]["text"]
+        assert (
+            "&lt;https://example.com/|*Click Here*&gt;"
+            in ret["blocks"][1]["elements"][0]["elements"][0]["text"]
+        )
 
 
 class BuildGroupAttachmentReplaysTest(TestCase):
@@ -885,7 +892,7 @@ class BuildGroupAttachmentReplaysTest(TestCase):
         assert isinstance(blocks, dict)
         assert (
             f"\n\n<http://testserver/organizations/baz/issues/{event.group.id}/replays/?referrer=slack|View Replays>"
-            in blocks["blocks"][0]["text"]["text"]
+            in blocks["blocks"][1]["elements"][0]["elements"][0]["text"]
         )
 
 

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -279,7 +279,7 @@ class UnfurlTest(TestCase):
         unfurls = link_handlers[LinkType.ISSUES].fn(self.request, self.integration, links)
         assert (
             "&amp;lt;https://example.com/|*Click Here*&amp;gt;"
-            in unfurls[links[0].url]["blocks"][0]["text"]["text"]
+            in unfurls[links[0].url]["blocks"][1]["elements"][0]["elements"][0]["text"]
         )
 
     def test_unfurl_metric_alert(self):

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -1303,7 +1303,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        )
 
     @responses.activate
     def test_resolve_issue_in_current_release_block_kit_through_unfurl(self):
@@ -1326,7 +1328,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        )
 
     @responses.activate
     def test_resolve_in_next_release_block_kit(self):

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -284,8 +284,8 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             assert self.group.get_status() == GroupStatus.IGNORED
             assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
             # XXX(CEO): it's kind of odd to code format this but would be tricky to avoid
-            expect_status = f"```Identity not found.```\n*Issue archived by <@{self.external_id}>*"
-            assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
+            expect_status = f"Identity not found.\n*Issue archived by <@{self.external_id}>*"
+            assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == expect_status
 
     @responses.activate
     def test_archive_issue_backwards_compat_block_kit(self):
@@ -316,7 +316,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             assert self.group.substatus == GroupSubStatus.UNTIL_ESCALATING
 
             expect_status = f"*Issue archived by <@{self.external_id}>*"
-            assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
+            assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+                expect_status
+            )
 
     @responses.activate
     def test_archive_issue_until_escalating_block_kit(self):
@@ -330,7 +332,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == expect_status
 
     @responses.activate
     def test_archive_issue_until_escalating_block_kit_through_unfurl(self):
@@ -347,7 +349,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == expect_status
 
     @responses.activate
     def test_archive_issue_until_condition_met_block_kit(self):
@@ -363,7 +365,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == expect_status
 
     @responses.activate
     def test_archive_issue_until_condition_met_block_kit_through_unfurl(self):
@@ -382,7 +384,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == expect_status
 
     @responses.activate
     def test_archive_issue_forever_block_kit(self):
@@ -396,7 +398,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == expect_status
 
     @responses.activate
     def test_archive_issue_forever_block_kit_through_unfurl(self):
@@ -411,7 +413,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == expect_status
 
     def test_archive_issue_with_additional_user_auth(self):
         """
@@ -443,7 +445,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             assert resp.status_code == 200, resp.content
             assert self.group.get_status() == GroupStatus.IGNORED
             assert self.group.substatus == GroupSubStatus.FOREVER
-            assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
+            assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"] == expect_status
 
     @responses.activate
     def test_archive_issue_with_additional_user_auth_block_kit(self):
@@ -466,7 +468,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == expect_status
 
     @responses.activate
     def test_archive_issue_with_additional_user_auth_block_kit_through_unfurl(self):
@@ -489,7 +491,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"] == expect_status
 
     def test_unarchive_issue_block_kit(self):
         event = self.store_event(
@@ -516,7 +518,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert self.group.substatus == GroupSubStatus.NEW  # the issue is less than 7 days old
 
         expect_status = f"*Issue re-opened by <@{self.external_id}>*"
-        assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(expect_status)
 
     def test_unarchive_issue_block_kit_through_unfurl(self):
         event = self.store_event(
@@ -544,7 +546,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert self.group.substatus == GroupSubStatus.NEW  # the issue is less than 7 days old
 
         expect_status = f"*Issue re-opened by <@{self.external_id}>*"
-        assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(expect_status)
 
     def test_assign_issue(self):
         user2 = self.create_user(is_superuser=False)
@@ -599,7 +601,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
                 "integration": ActivityIntegration.SLACK.value,
             }
             expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
-            assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
+            assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+                expect_status
+            ), resp.data["text"]
 
     def test_assign_issue_block_kit(self):
         user2 = self.create_user(is_superuser=False)
@@ -616,7 +620,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
 
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
-        assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        ), resp.data["text"]
 
         # Assign to team
         status_action = self.get_assign_status_action("team", self.team.slug, self.team.id)
@@ -637,7 +643,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         }
 
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
-        assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        ), resp.data["text"]
 
     def test_assign_issue_block_kit_through_unfurl(self):
         user2 = self.create_user(is_superuser=False)
@@ -654,7 +662,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
 
         expect_status = f"*Issue assigned to {user2.get_display_name()} by <@{self.external_id}>*"
-        assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        ), resp.data["text"]
 
         # Assign to team
         status_action = self.get_assign_status_action("team", self.team.slug, self.team.id)
@@ -673,7 +683,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         }
 
         expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.external_id}>*"
-        assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        ), resp.data["text"]
 
     def test_assign_issue_where_team_not_in_project(self):
         user2 = self.create_user(is_superuser=False)
@@ -770,7 +782,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             resp = self.post_webhook(action_data=[status_action])
             assert resp.status_code == 200, resp.content
             assert GroupAssignee.objects.filter(group=self.group, user_id=user2.id).exists()
-            assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
+            assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+                expect_status
+            ), resp.data["text"]
 
     def test_assign_issue_user_has_identity_block_kit(self):
         user2 = self.create_user(is_superuser=False)
@@ -794,7 +808,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = (
             f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.external_id}>*"
         )
-        assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        ), resp.data["text"]
 
     def test_assign_issue_user_has_identity_block_kit_through_unfurl(self):
         user2 = self.create_user(is_superuser=False)
@@ -817,7 +833,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = (
             f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.external_id}>*"
         )
-        assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        ), resp.data["text"]
 
     def test_response_differs_on_bot_message(self):
         status_action = {"name": "status", "value": "ignored:archived_forever", "type": "button"}
@@ -900,7 +918,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue archived by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        )
 
     def test_assign_user_with_multiple_identities(self):
         org2 = self.create_organization(owner=None)
@@ -937,7 +957,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
             resp = self.post_webhook(action_data=[status_action])
             assert resp.status_code == 200, resp.content
             assert GroupAssignee.objects.filter(group=self.group, user_id=self.user.id).exists()
-            assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
+            assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+                expect_status
+            ), resp.data["text"]
 
     def test_assign_user_with_multiple_identities_block_kit(self):
         org2 = self.create_organization(owner=None)
@@ -966,7 +988,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
             assignee=self.external_id
         )
-        assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        ), resp.data["text"]
 
     def test_assign_user_with_multiple_identities_block_kit_through_unfurl(self):
         org2 = self.create_organization(owner=None)
@@ -994,7 +1018,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         expect_status = "*Issue assigned to <@{assignee}> by <@{assignee}>*".format(
             assignee=self.external_id
         )
-        assert resp.data["blocks"][0]["text"]["text"].endswith(expect_status), resp.data["text"]
+        assert resp.data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        ), resp.data["text"]
 
     @responses.activate
     def test_resolve_issue(self):
@@ -1100,7 +1126,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        )
 
     @responses.activate
     def test_resolve_issue_block_kit(self):
@@ -1114,7 +1142,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        )
 
     @responses.activate
     def test_resolve_issue_block_kit_through_unfurl(self):
@@ -1129,7 +1159,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        )
 
     @responses.activate
     def test_resolve_issue_in_next_release(self):
@@ -1247,7 +1279,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
 
             update_data = json.loads(responses.calls[1].request.body)
             expect_status = f"*Issue resolved by <@{self.external_id}>*"
-            assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+            assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+                expect_status
+            )
 
     @responses.activate
     def test_resolve_issue_in_current_release_block_kit(self):
@@ -1313,7 +1347,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        )
 
     @responses.activate
     def test_resolve_in_next_release_block_kit_through_unfurl(self):
@@ -1335,7 +1371,9 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         update_data = json.loads(responses.calls[1].request.body)
 
         expect_status = f"*Issue resolved by <@{self.external_id}>*"
-        assert update_data["blocks"][0]["text"]["text"].endswith(expect_status)
+        assert update_data["blocks"][1]["elements"][0]["elements"][0]["text"].endswith(
+            expect_status
+        )
 
     def test_permission_denied(self):
         user2 = self.create_user(is_superuser=False)

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -283,10 +283,10 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         assert blocks[0]["text"]["text"] == fallback_text
 
         assert event1.group
-        event1_alert_title = f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{event1.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event1.group.title}*>  \n"
+        event1_alert_title = f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{event1.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event1.group.title}*>"
 
         assert event2.group
-        event2_alert_title = f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{event2.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event2.group.title}*>  \n"
+        event2_alert_title = f":exclamation: <http://testserver/organizations/{self.organization.slug}/issues/{event2.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event2.group.title}*>"
 
         # digest order not definitive
         try:


### PR DESCRIPTION
The title and text is getting funky on iOS mobile, so this is an attempt to fix that by using a [rich text preformatted block](https://api.slack.com/reference/block-kit/blocks#rich_text_preformatted). It looks fine in the browser, app, and Android phones.

<img width="628" alt="Screenshot 2024-01-26 at 3 39 12 PM" src="https://github.com/getsentry/sentry/assets/29959063/4c17c04c-b49d-4ad5-925b-beb16a68aa10">
