### PR TITLE
fix(crons): Fix monitor env status indicator for muted monitors

### DIFF
--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -97,6 +97,7 @@ export function TimelineTableRow({
             label: isMuted ? t('Unmute Environment') : t('Mute Environment'),
             details: monitor.isMuted ? t('Monitor is muted') : undefined,
             key: 'mute',
+            disabled: monitor.isMuted,
             onAction: () => onToggleMuteEnvironment(env, !isMuted),
           }),
         ]

--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -95,7 +95,7 @@ export function TimelineTableRow({
       ? [
           (env: string, isMuted: boolean) => ({
             label: isMuted ? t('Unmute Environment') : t('Mute Environment'),
-            details: monitor.isMuted ? 'Monitor is muted' : undefined,
+            details: monitor.isMuted ? t('Monitor is muted') : undefined,
             key: 'mute',
             onAction: () => onToggleMuteEnvironment(env, !isMuted),
           }),

--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -8,7 +8,7 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import Tag from 'sentry/components/tag';
 import {Tooltip} from 'sentry/components/tooltip';
-import {IconEllipsis} from 'sentry/icons';
+import {IconEllipsis, IconUnsubscribed} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {fadeIn} from 'sentry/styles/animations';
 import {space} from 'sentry/styles/space';
@@ -65,7 +65,10 @@ export function TimelineTableRow({
     <DetailsArea>
       <DetailsLink to={`/organizations/${organization.slug}/crons/${monitor.slug}/`}>
         <DetailsHeadline>
-          <Name>{monitor.name}</Name>
+          <Name>
+            {monitor.name}
+            {monitor.isMuted && <StyledIconUnsubscribed color="subText" size="xs" />}
+          </Name>
           {isDisabled && <Tag>{t('Disabled')}</Tag>}
         </DetailsHeadline>
         <Schedule>{scheduleAsText(monitor.config)}</Schedule>
@@ -92,6 +95,7 @@ export function TimelineTableRow({
       ? [
           (env: string, isMuted: boolean) => ({
             label: isMuted ? t('Unmute Environment') : t('Mute Environment'),
+            details: monitor.isMuted ? 'Monitor is muted' : undefined,
             key: 'mute',
             onAction: () => onToggleMuteEnvironment(env, !isMuted),
           }),
@@ -128,7 +132,7 @@ export function TimelineTableRow({
       {monitorDetails}
       <MonitorEnvContainer>
         {environments.map(({name, status, isMuted}) => {
-          const envStatus = monitor.isMuted || isMuted ? MonitorStatus.DISABLED : status;
+          const envStatus = isMuted ? MonitorStatus.DISABLED : status;
           const {label, icon} = statusIconColorMap[envStatus];
           return (
             <EnvRow key={name}>
@@ -223,6 +227,10 @@ const Name = styled('h3')`
   font-size: ${p => p.theme.fontSizeLarge};
   margin-bottom: ${space(0.25)};
   word-break: break-word;
+`;
+
+const StyledIconUnsubscribed = styled(IconUnsubscribed)`
+  margin-left: ${space(0.5)};
 `;
 
 const Schedule = styled('small')`

--- a/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
+++ b/static/app/views/monitors/components/overviewTimeline/timelineTableRow.tsx
@@ -94,7 +94,10 @@ export function TimelineTableRow({
     ...(onToggleMuteEnvironment
       ? [
           (env: string, isMuted: boolean) => ({
-            label: isMuted ? t('Unmute Environment') : t('Mute Environment'),
+            label:
+              isMuted && !monitor.isMuted
+                ? t('Unmute Environment')
+                : t('Mute Environment'),
             details: monitor.isMuted ? t('Monitor is muted') : undefined,
             key: 'mute',
             disabled: monitor.isMuted,


### PR DESCRIPTION
Previously `monitor.isMuted` would translate to us showing a muted status on all monitor environments. This was before we had individual mute actions on each environment. Now that we can mute monitor environments and the overarching monitor itself, we should clearly distinguish them.

- Adds a muted icon to the right of the monitor name
- Accurately shows monitor environment status (even if monitor is muted)
- Notify user that overarching monitor is already muted when performing mute actions on the monitor environment

<img width="585" alt="image" src="https://github.com/getsentry/sentry/assets/9372512/f88b1b9c-e47e-4703-bcdc-eb77518ee308">
