### PR TITLE
ref(js): Move Sidebar component to OrganizationDetails

### DIFF
--- a/static/app/views/organizationDetails/index.tsx
+++ b/static/app/views/organizationDetails/index.tsx
@@ -2,6 +2,8 @@ import useRouteAnalyticsHookSetup from 'sentry/utils/routeAnalytics/useRouteAnal
 import OrganizationLayout from 'sentry/views/organizationLayout';
 
 import Body from './body';
+import useOrganization from 'sentry/utils/useOrganization';
+import Sidebar from 'sentry/components/sidebar';
 
 interface Props {
   children: React.ReactNode;
@@ -9,9 +11,11 @@ interface Props {
 
 function OrganizationDetails({children}: Props) {
   useRouteAnalyticsHookSetup();
+  const organization = useOrganization({allowNull: true});
 
   return (
-    <OrganizationLayout includeSidebar>
+    <OrganizationLayout>
+      <Sidebar organization={organization ?? undefined} />
       <Body>{children}</Body>
     </OrganizationLayout>
   );

--- a/static/app/views/organizationDetails/index.tsx
+++ b/static/app/views/organizationDetails/index.tsx
@@ -1,9 +1,9 @@
+import Sidebar from 'sentry/components/sidebar';
 import useRouteAnalyticsHookSetup from 'sentry/utils/routeAnalytics/useRouteAnalyticsHookSetup';
+import useOrganization from 'sentry/utils/useOrganization';
 import OrganizationLayout from 'sentry/views/organizationLayout';
 
 import Body from './body';
-import useOrganization from 'sentry/utils/useOrganization';
-import Sidebar from 'sentry/components/sidebar';
 
 interface Props {
   children: React.ReactNode;


### PR DESCRIPTION
Trying to break up this component so that I can give these better names. The `OrganizationLayout` component's real responsibility is to make sure the organization is loaded before rendering children. Ideally we can rename it to something better and have the `OrganizationDetails` be renamed to `OrganizationLayout`