### PR TITLE
ref(grouping): Pre-`_save_aggregate`-consolidation fixes

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1367,7 +1367,7 @@ def _save_aggregate(
     metadata: dict[str, Any],
     received_timestamp: Union[int, float],
     migrate_off_hierarchical: Optional[bool] = False,
-    **kwargs: Any,
+    **group_creation_kwargs: Any,
 ) -> Optional[GroupInfo]:
     project = event.project
 
@@ -1406,12 +1406,12 @@ def _save_aggregate(
     #
     # Additionally the `last_received` key is set for group metadata, later in
     # _save_aggregate
-    kwargs["data"] = materialize_metadata(
+    group_creation_kwargs["data"] = materialize_metadata(
         event.data,
         get_event_type(event.data),
         metadata,
     )
-    kwargs["data"]["last_received"] = received_timestamp
+    group_creation_kwargs["data"]["last_received"] = received_timestamp
 
     if existing_grouphash is None:
         if killswitch_matches_context(
@@ -1455,7 +1455,7 @@ def _save_aggregate(
                 root_hierarchical_grouphash = None
 
             if existing_grouphash is None:
-                group = _create_group(project, event, **kwargs)
+                group = _create_group(project, event, **group_creation_kwargs)
 
                 if (
                     features.has("projects:first-event-severity-calculation", event.project)
@@ -1570,7 +1570,7 @@ def _save_aggregate(
     is_regression = _process_existing_aggregate(
         group=group,
         event=event,
-        incoming_group_values=kwargs,
+        incoming_group_values=group_creation_kwargs,
         release=release,
     )
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -525,8 +525,6 @@ class EventManager:
 
         group_creation_kwargs = _get_group_creation_kwargs(job)
 
-        group_creation_kwargs["culprit"] = job["culprit"]
-
         # Load attachments first, but persist them at the very last after
         # posting to eventstream to make sure all counters and eventstream are
         # incremented for sure. Also wait for grouping to remove attachments
@@ -960,6 +958,7 @@ def _get_group_creation_kwargs(job: Union[Job, PerformanceJob]) -> dict[str, Any
         "last_seen": job["event"].datetime,
         "first_seen": job["event"].datetime,
         "active_at": job["event"].datetime,
+        "culprit": job["culprit"],
     }
 
     if job["release"]:

--- a/tests/sentry/event_manager/test_hierarchical_hashes.py
+++ b/tests/sentry/event_manager/test_hierarchical_hashes.py
@@ -23,57 +23,59 @@ def fast_save(default_project, task_runner):
             uuid.uuid4().hex,
             data=data,
         )
+        group_creation_kwargs = {"level": 10, "culprit": ""}
+        hashes = CalculatedHashes(
+            hashes=["a" * 32, "b" * 32],
+            hierarchical_hashes=["c" * 32, "d" * 32, "e" * 32, last_frame * 32],
+            tree_labels=[
+                [
+                    {
+                        "function": "foo",
+                        "package": "",
+                        "is_sentinel": False,
+                        "is_prefix": False,
+                        "datapath": "",
+                    }
+                ],
+                [
+                    {
+                        "function": "bar",
+                        "package": "",
+                        "is_sentinel": False,
+                        "is_prefix": False,
+                        "datapath": "",
+                    }
+                ],
+                [
+                    {
+                        "function": "baz",
+                        "package": "",
+                        "is_sentinel": False,
+                        "is_prefix": False,
+                        "datapath": "",
+                    }
+                ],
+                [
+                    {
+                        "function": "bam",
+                        "package": "",
+                        "is_sentinel": False,
+                        "is_prefix": False,
+                        "datapath": "",
+                    }
+                ],
+            ],
+        )
 
         with task_runner():
             return _save_aggregate(
                 evt,
-                hashes=CalculatedHashes(
-                    hashes=["a" * 32, "b" * 32],
-                    hierarchical_hashes=["c" * 32, "d" * 32, "e" * 32, last_frame * 32],
-                    tree_labels=[
-                        [
-                            {
-                                "function": "foo",
-                                "package": "",
-                                "is_sentinel": False,
-                                "is_prefix": False,
-                                "datapath": "",
-                            }
-                        ],
-                        [
-                            {
-                                "function": "bar",
-                                "package": "",
-                                "is_sentinel": False,
-                                "is_prefix": False,
-                                "datapath": "",
-                            }
-                        ],
-                        [
-                            {
-                                "function": "baz",
-                                "package": "",
-                                "is_sentinel": False,
-                                "is_prefix": False,
-                                "datapath": "",
-                            }
-                        ],
-                        [
-                            {
-                                "function": "bam",
-                                "package": "",
-                                "is_sentinel": False,
-                                "is_prefix": False,
-                                "datapath": "",
-                            }
-                        ],
-                    ],
-                ),
+                hashes=hashes,
                 release=None,
                 metadata={},
                 received_timestamp=0,
-                level=10,
-                culprit="",
+                migrate_off_hierarchical=False,
+                **group_creation_kwargs,
             )
 
     return inner

--- a/tests/sentry/event_manager/test_save_aggregate.py
+++ b/tests/sentry/event_manager/test_save_aggregate.py
@@ -60,19 +60,23 @@ def test_group_creation_race(monkeypatch, default_project, is_race_free):
                 "89aeed6a472e4c5fb992d14df4d7e1b6",
                 data=data,
             )
+            group_creation_kwargs = {"level": 10, "culprit": ""}
+            hashes = CalculatedHashes(
+                hashes=["a" * 32, "b" * 32],
+                hierarchical_hashes=[],
+                tree_labels=[],
+            )
+
             ret = _save_aggregate(
                 evt,
-                hashes=CalculatedHashes(
-                    hashes=["a" * 32, "b" * 32],
-                    hierarchical_hashes=[],
-                    tree_labels=[],
-                ),
+                hashes=hashes,
                 release=None,
                 metadata={},
                 received_timestamp=0,
-                level=10,
-                culprit="",
+                migrate_off_hierarchical=False,
+                **group_creation_kwargs,
             )
+
             assert ret is not None
             return_values.append(ret)
         finally:

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -515,11 +515,17 @@ def test_apply_new_fingerprinting_rules(
 
     assert is_group_finished(event1.group_id)
 
-    # Events should now be in different groups:
+    # Events should now be in different groups
     event1 = eventstore.backend.get_event_by_id(default_project.id, event_id1)
     event2 = eventstore.backend.get_event_by_id(default_project.id, event_id2)
+    # Both events end up with new group ids because the entire group is reprocessed, so even though
+    # nothing has changed for event2, it's still put into a new group
     assert event1.group.id != original_issue_id
+    assert event2.group.id != original_issue_id
     assert event1.group.id != event2.group.id
+    # The group `message` value is taken from the `search_message` attribute, which is basically
+    # just all the event's `metadata` entries shoved together (so that they can all be searhed on -
+    # hence the name). Thus group1 includes both the event's message and its title.
     assert event1.group.message == "hello world 1 HW1"
     assert event2.group.message == "hello world 2"
 


### PR DESCRIPTION
This is a handful of small fixes preparing for https://github.com/getsentry/sentry/pull/63805, to make it easier to review. Specifically:

- Adding `culprit` to `group_creation_kwargs` is moved into `get_group_creation_kwargs`.
- In `_save_aggregate`, `kwargs` is renamed to `group_creation_kwargs`.
- In both `test_hierarchical_hashes.py` and `test_save_aggregate.py`, the hashes and extra kwargs passed to `_save_aggregate` have been pulled out in to variables. For #reasons, in order to accept this change, `mypy` insisted I explicitly pass `migrate_off_hierarchical=False` as well, even though there's a default, and the default is `False`. One PR from now it will be a moot point, though, so sure, why not?
- In `test_hierarchical_hashes.py`, two helper functions have been renamed for clarity. This has nothing really to do with the upcoming PR except that in debugging said PR, I had to change the names for myself in order to make the tests easier to understand, and figured I might as well improve the names for everyone. The same applies to the comments which are updated in `test_reprocessing2.py`.