### PR TITLE
chore(relay): Update default value from empty string to enabled

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -869,7 +869,7 @@ register("relay.span-usage-metric", default=False, flags=FLAG_AUTOMATOR_MODIFIAB
 #
 # Note: To fully enable the cardinality limiter the feature `organizations:relay-cardinality-limiter`
 # needs to be rolled out as well.
-register("relay.cardinality-limiter.mode", default=None, flags=FLAG_AUTOMATOR_MODIFIABLE)
+register("relay.cardinality-limiter.mode", default="enabled", flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 # Write new kafka headers in eventstream
 register("eventstream:kafka-headers", default=True, flags=FLAG_AUTOMATOR_MODIFIABLE)


### PR DESCRIPTION
Because of this code in the option manager: https://github.com/getsentry/sentry/blob/31aac1b9b0d24eda9c5aef67259bc24dedb94d95/src/sentry/options/manager.py#L375-L401

A `None` value in an option default yields an empty string. 

Use the same default value as Relay, to prevent serialization issues with an empty string.

Relay PR using the option: https://github.com/getsentry/relay/pull/3008