### PR TITLE
ref: handle another case where urlsplit gets an invalid host

### DIFF
--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -9,7 +9,7 @@ from hashlib import sha1
 from io import BytesIO
 from tempfile import TemporaryDirectory
 from typing import IO, ClassVar, Optional, Tuple
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urlunsplit
 
 import sentry_sdk
 from django.core.files.base import File as FileObj
@@ -34,6 +34,7 @@ from sentry.models.release import Release
 from sentry.utils import json, metrics
 from sentry.utils.db import atomic_transaction
 from sentry.utils.hashlib import sha1_text
+from sentry.utils.urls import urlsplit_best_effort
 from sentry.utils.zip import safe_extract_zip
 
 logger = logging.getLogger(__name__)
@@ -135,7 +136,7 @@ class ReleaseFile(Model):
         * (optional) full url without scheme and netloc or querystring
         """
         # Always ignore the fragment
-        scheme, netloc, path, query, _ = urlsplit(url)
+        scheme, netloc, path, query = urlsplit_best_effort(url)
 
         uri_without_fragment = (scheme, netloc, path, query, "")
         uri_relative = ("", "", path, query, "")

--- a/tests/sentry/models/test_releasefile.py
+++ b/tests/sentry/models/test_releasefile.py
@@ -24,33 +24,43 @@ from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 
 
-@region_silo_test
-class ReleaseFileTestCase(TestCase):
-    def test_normalize(self):
-        n = ReleaseFile.normalize
-
-        assert n("http://example.com") == ["http://example.com", "~"]
-        assert n("http://example.com/foo.js") == ["http://example.com/foo.js", "~/foo.js"]
-        assert n("http://example.com/foo.js?bar") == [
+@pytest.mark.parametrize(
+    ("s", "expected"),
+    (
+        ("http://example.com", ["http://example.com", "~"]),
+        ("http://example.com/foo.js", ["http://example.com/foo.js", "~/foo.js"]),
+        (
             "http://example.com/foo.js?bar",
-            "http://example.com/foo.js",
-            "~/foo.js?bar",
-            "~/foo.js",
-        ]
-        assert n("/foo.js") == ["/foo.js", "~/foo.js"]
-
-        assert n("http://example.com/foo.js?bar#baz") == [
-            "http://example.com/foo.js?bar",
-            "http://example.com/foo.js",
-            "~/foo.js?bar",
-            "~/foo.js",
-        ]
-
+            [
+                "http://example.com/foo.js?bar",
+                "http://example.com/foo.js",
+                "~/foo.js?bar",
+                "~/foo.js",
+            ],
+        ),
+        ("/foo.js", ["/foo.js", "~/foo.js"]),
+        (
+            "http://example.com/foo.js?bar#baz",
+            [
+                "http://example.com/foo.js?bar",
+                "http://example.com/foo.js",
+                "~/foo.js?bar",
+                "~/foo.js",
+            ],
+        ),
         # This is the current behavior, but seems weird to me.
         # unclear if we actually experience this case in the real
         # world, but worth documenting the behavior
-        assert n("foo.js") == ["foo.js", "~foo.js"]
+        ("foo.js", ["foo.js", "~foo.js"]),
+        pytest.param("app://[native_code]", ["app://[native_code]", "~"], id="invalid hostname"),
+    ),
+)
+def test_normalize(s, expected):
+    assert ReleaseFile.normalize(s) == expected
 
+
+@region_silo_test
+class ReleaseFileTestCase(TestCase):
     def test_count_artifacts(self):
         assert self.release.count_artifacts() == 0
         for count in (3, 1, None, 0):


### PR DESCRIPTION
fixes a regression in python 3.11

resolves https://sentry.sentry.io/issues/4924339873

<!-- Describe your PR here. -->