### PR TITLE
fix(relay): Increase project config build time limit

### DIFF
--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 @instrumented_task(
     name="sentry.tasks.relay.build_project_config",
     queue="relay_config",
-    soft_time_limit=5,
-    time_limit=10,  # Extra 5 seconds to remove the debounce key.
+    soft_time_limit=10,
+    time_limit=15,  # Extra 5 seconds to remove the debounce key.
     expires=30,  # Relay stops waiting for this anyway.
 )
 def build_project_config(public_key=None, **kwargs):


### PR DESCRIPTION
There has been an increase in projects failing to compute their project config in time. If this happens multiple times for the same project, it can lead to event loss. See [POP-RELAY-2Z6](https://sentry.my.sentry.io/organizations/sentry/issues/531560/).

Seems to be caused by on-demand metrics calculations, see for example [this event](https://sentry.sentry.io/performance/trace/4e211ae99343479b8a1a283b93e6ad48).

For now, we can increase the Celery timeout, but ideally we also try to optimize the code that causes the slowdown.

Fixes [SENTRY-VCS](https://sentry.sentry.io/issues/3389239864/).