### PR TITLE
ref: upgrade cssutils to avoid warning in 3.11

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -35,7 +35,7 @@ coverage==6.3.3
 croniter==1.3.10
 cryptography==41.0.7
 cssselect==1.0.3
-cssutils==2.4.0
+cssutils==2.9.0
 datadog==0.44.0
 distlib==0.3.4
 distro==1.8.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -29,7 +29,7 @@ confluent-kafka==2.1.1
 croniter==1.3.10
 cryptography==41.0.7
 cssselect==1.0.3
-cssutils==2.4.0
+cssutils==2.9.0
 datadog==0.44.0
 distro==1.8.0
 django==4.2.8


### PR DESCRIPTION
fixes this warning:

```
/Users/asottile/workspace/sentry/.venv/lib/python3.11/site-packages/encutils/__init__.py:55: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
  import cgi
```

<!-- Describe your PR here. -->