### PR TITLE
ref: re-enable warning about unsaved models in filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ filterwarnings = [
 
     # TODO: after upgrading to django 4.x
     "ignore:'index_together' is deprecated. Use 'Meta.indexes' in.*",
-    "ignore:Passing unsaved model instances to related filters is deprecated.",
 
     # a bunch of google packages use legacy namespace packages
     "ignore:pkg_resources is deprecated as an API",


### PR DESCRIPTION
fatal in django 5

HC and I fixed the rest of these in other patches

<!-- Describe your PR here. -->