### PR TITLE
feat(ddm): Return patched metric blocking state

### DIFF
--- a/src/sentry/api/endpoints/project_metrics.py
+++ b/src/sentry/api/endpoints/project_metrics.py
@@ -8,6 +8,8 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import ProjectEndpoint
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.metrics_blocking import MetricBlockingSerializer
 from sentry.exceptions import InvalidParams
 from sentry.models.project import Project
 from sentry.sentry_metrics.visibility import (
@@ -17,6 +19,7 @@ from sentry.sentry_metrics.visibility import (
     unblock_metric,
     unblock_tags_of_metric,
 )
+from sentry.sentry_metrics.visibility.metrics_blocking import MetricBlocking
 from sentry.snuba.metrics.naming_layer.mri import is_mri
 
 
@@ -50,22 +53,25 @@ class ProjectMetricsVisibilityEndpoint(ProjectEndpoint):
 
     def _handle_by_operation_type(
         self, request: Request, project: Project, metric_operation_type: MetricOperationType
-    ):
+    ) -> MetricBlocking:
         metric_mri = request.data.get("metricMri")
         if not is_mri(metric_mri):
             raise InvalidParams("You must supply a valid metric mri")
 
         metric_mri = cast(str, metric_mri)
+        patched_metrics = {}
         if metric_operation_type == MetricOperationType.BLOCK_METRIC:
-            block_metric(metric_mri, [project])
+            patched_metrics = block_metric(metric_mri, [project])
         elif metric_operation_type == MetricOperationType.UNBLOCK_METRIC:
-            unblock_metric(metric_mri, [project])
+            patched_metrics = unblock_metric(metric_mri, [project])
         elif metric_operation_type == MetricOperationType.BLOCK_TAGS:
             tags = request.data.get("tags") or []
-            block_tags_of_metric(metric_mri, set(tags), [project])
+            patched_metrics = block_tags_of_metric(metric_mri, set(tags), [project])
         elif metric_operation_type == MetricOperationType.UNBLOCK_TAGS:
             tags = request.data.get("tags") or []
-            unblock_tags_of_metric(metric_mri, set(tags), [project])
+            patched_metrics = unblock_tags_of_metric(metric_mri, set(tags), [project])
+
+        return patched_metrics[project.id]
 
     def put(self, request: Request, project: Project) -> Response:
         metric_operation_type = MetricOperationType.from_request(request)
@@ -75,7 +81,7 @@ class ProjectMetricsVisibilityEndpoint(ProjectEndpoint):
             )
 
         try:
-            self._handle_by_operation_type(request, project, metric_operation_type)
+            patched_metric = self._handle_by_operation_type(request, project, metric_operation_type)
         except MalformedBlockedMetricsPayloadError:
             # In case one metric fails to be inserted, we abort the entire insertion since the project options are
             # likely to be corrupted.
@@ -83,4 +89,6 @@ class ProjectMetricsVisibilityEndpoint(ProjectEndpoint):
                 {"detail": "The blocked metrics settings are corrupted, try again"}, status=500
             )
 
-        return Response(status=200)
+        return Response(
+            serialize(patched_metric, request.user, MetricBlockingSerializer()), status=200
+        )

--- a/src/sentry/api/endpoints/project_metrics.py
+++ b/src/sentry/api/endpoints/project_metrics.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional, Sequence, cast
+from typing import Mapping, Optional, Sequence, cast
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -59,7 +59,8 @@ class ProjectMetricsVisibilityEndpoint(ProjectEndpoint):
             raise InvalidParams("You must supply a valid metric mri")
 
         metric_mri = cast(str, metric_mri)
-        patched_metrics = {}
+        patched_metrics: Mapping[int, MetricBlocking] = {}
+
         if metric_operation_type == MetricOperationType.BLOCK_METRIC:
             patched_metrics = block_metric(metric_mri, [project])
         elif metric_operation_type == MetricOperationType.UNBLOCK_METRIC:

--- a/src/sentry/api/serializers/models/metrics_blocking.py
+++ b/src/sentry/api/serializers/models/metrics_blocking.py
@@ -1,0 +1,16 @@
+from sentry.api.serializers import Serializer
+
+
+class MetricBlockingSerializer(Serializer):
+    def __init__(self, *args, **kwargs):
+        Serializer.__init__(self, *args, **kwargs)
+
+    def get_attrs(self, item_list, user):
+        return {item: item.__dict__ for item in item_list}
+
+    def serialize(self, obj, attrs, user):
+        return {
+            "metricMri": attrs.get("metric_mri"),
+            "isBlocked": attrs.get("is_blocked"),
+            "blockedTags": list(attrs.get("blocked_tags") or set()),
+        }

--- a/tests/sentry/api/endpoints/test_project_metrics_visibility.py
+++ b/tests/sentry/api/endpoints/test_project_metrics_visibility.py
@@ -41,6 +41,9 @@ class ProjectMetricsVisibilityEndpointTestCase(APITestCase):
         )
 
         assert response.status_code == 200
+        assert response.data["metricMri"] == "s:custom/user@none"
+        assert response.data["isBlocked"] is True
+        assert response.data["blockedTags"] == []
         assert len(get_metrics_blocking_state([self.project])[self.project.id].metrics) == 1
 
         response = self.get_success_response(
@@ -52,6 +55,9 @@ class ProjectMetricsVisibilityEndpointTestCase(APITestCase):
         )
 
         assert response.status_code == 200
+        assert response.data["metricMri"] == "s:custom/user@none"
+        assert response.data["isBlocked"] is False
+        assert response.data["blockedTags"] == []
         assert len(get_metrics_blocking_state([self.project])[self.project.id].metrics) == 0
 
     def test_block_metric_tag(self):
@@ -65,6 +71,9 @@ class ProjectMetricsVisibilityEndpointTestCase(APITestCase):
         )
 
         assert response.status_code == 200
+        assert response.data["metricMri"] == "s:custom/user@none"
+        assert response.data["isBlocked"] is False
+        assert sorted(response.data["blockedTags"]) == ["release", "transaction"]
         assert len(get_metrics_blocking_state([self.project])[self.project.id].metrics) == 1
 
         response = self.get_success_response(
@@ -77,6 +86,9 @@ class ProjectMetricsVisibilityEndpointTestCase(APITestCase):
         )
 
         assert response.status_code == 200
+        assert response.data["metricMri"] == "s:custom/user@none"
+        assert response.data["isBlocked"] is False
+        assert response.data["blockedTags"] == ["release"]
         assert len(get_metrics_blocking_state([self.project])[self.project.id].metrics) == 1
 
         response = self.get_success_response(
@@ -89,4 +101,7 @@ class ProjectMetricsVisibilityEndpointTestCase(APITestCase):
         )
 
         assert response.status_code == 200
+        assert response.data["metricMri"] == "s:custom/user@none"
+        assert response.data["isBlocked"] is False
+        assert response.data["blockedTags"] == []
         assert len(get_metrics_blocking_state([self.project])[self.project.id].metrics) == 0

--- a/tests/sentry/sentry_metrics/querying/visibility/test_metrics_blocking.py
+++ b/tests/sentry/sentry_metrics/querying/visibility/test_metrics_blocking.py
@@ -102,6 +102,31 @@ def test_apply_multiple_operations(default_project):
 
 
 @django_db_all
+def test_returns_patched_state(default_project):
+    mri = "c:custom/page_click@none"
+
+    metric_blocking = block_metric(mri, [default_project])[default_project.id]
+    assert metric_blocking == MetricBlocking(metric_mri=mri, is_blocked=True, blocked_tags=set())
+
+    metric_blocking = block_tags_of_metric(mri, {"release", "transaction"}, [default_project])[
+        default_project.id
+    ]
+    assert metric_blocking == MetricBlocking(
+        metric_mri=mri, is_blocked=True, blocked_tags={"release", "transaction"}
+    )
+
+    metric_blocking = unblock_metric(mri, [default_project])[default_project.id]
+    assert metric_blocking == MetricBlocking(
+        metric_mri=mri, is_blocked=False, blocked_tags={"release", "transaction"}
+    )
+
+    metric_blocking = unblock_tags_of_metric(mri, {"release", "transaction"}, [default_project])[
+        default_project.id
+    ]
+    assert metric_blocking == MetricBlocking(metric_mri=mri, is_blocked=False, blocked_tags=set())
+
+
+@django_db_all
 def test_get_metrics_blocking_state(default_project):
     mri_1 = "c:custom/page_click@none"
     mri_2 = "g:custom/page_load@millisecond"


### PR DESCRIPTION
This PR returns the patched state for the blocked/unblocked metric in order for the frontend to know the actual state of the metric.