### PR TITLE
ref: handle invalid timezone set to empty string

### DIFF
--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -127,7 +127,7 @@ class AlertRuleNotification(ProjectNotification):
             user_tz = get_option_from_list(user_options, key="timezone", default="UTC")
             try:
                 tz = zoneinfo.ZoneInfo(user_tz)
-            except zoneinfo.ZoneInfoNotFoundError:
+            except (ValueError, zoneinfo.ZoneInfoNotFoundError):
                 pass
         return {
             **super().get_recipient_context(recipient, extra_context),


### PR DESCRIPTION
seems ZoneInfo sometimes raises an alternative exception

resolves https://sentry.sentry.io/issues/4924796224

<!-- Describe your PR here. -->