### PR TITLE
build: enable `@typescript-eslint/consistent-type-exports` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,10 @@ module.exports = {
     tick: true,
     jest: true,
   },
+  parserOptions: {
+    project: true,
+    tsConfigRootDir: __dirname,
+  },
   rules: {
     'react-hooks/exhaustive-deps': [
       'warn',
@@ -37,8 +41,20 @@ module.exports = {
       'error',
       {fixStyle: 'separate-type-imports', prefer: 'type-imports'},
     ],
+    '@typescript-eslint/consistent-type-exports': ['error'],
   },
   overrides: [
+    {
+      // Benchmarks are not compiled with the same tsconfig as the rest of the
+      // app, so we need to disable some rules.
+      files: ['static/app/**/*.benchmark.ts'],
+      parserOptions: {
+        project: false,
+      },
+      rules: {
+        '@typescript-eslint/consistent-type-exports': 'off',
+      },
+    },
     {
       files: ['tests/js/**/*.{ts,js}'],
       extends: ['plugin:testing-library/react', 'sentry-app/strict'],

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -594,13 +594,5 @@ const Icon = styled('span')<IconProps>`
 
 const LinkButton = Button as React.ComponentType<LinkButtonProps>;
 
-export {
-  Button,
-  ButtonProps,
-  BaseButtonProps,
-  LinkButton,
-  LinkButtonProps,
-  // Also export these styled components so we can use them as selectors
-  StyledButton,
-  ButtonLabel,
-};
+export type {ButtonProps, BaseButtonProps, LinkButtonProps};
+export {Button, LinkButton, StyledButton, ButtonLabel};

--- a/static/app/components/overlayArrow.tsx
+++ b/static/app/components/overlayArrow.tsx
@@ -110,4 +110,5 @@ const SVG = styled('svg')<{background: ColorOrAlias; border: ColorOrAlias}>`
   }
 `;
 
-export {OverlayArrow, OverlayArrowProps};
+export type {OverlayArrowProps};
+export {OverlayArrow};

--- a/static/app/components/search/index.tsx
+++ b/static/app/components/search/index.tsx
@@ -211,7 +211,8 @@ function Search({
   );
 }
 
-export {Search, SearchProps};
+export type {SearchProps};
+export {Search};
 
 const SearchWrapper = styled('div')`
   position: relative;

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -2114,7 +2114,8 @@ class SmartSearchBarContainer extends Component<Props, ContainerState> {
 
 export default withApi(withSentryRouter(withOrganization(SmartSearchBarContainer)));
 
-export {SmartSearchBar, Props as SmartSearchBarProps};
+export type {Props as SmartSearchBarProps};
+export {SmartSearchBar};
 
 const Container = styled('div')<{inputHasFocus: boolean}>`
   min-height: ${p => p.theme.form.md.height}px;

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -80,4 +80,5 @@ const TooltipContent = styled(Overlay)`
   text-align: center;
 `;
 
-export {Tooltip, TooltipProps};
+export type {TooltipProps};
+export {Tooltip};

--- a/static/app/utils/routeAnalytics/withRouteAnalytics.tsx
+++ b/static/app/utils/routeAnalytics/withRouteAnalytics.tsx
@@ -22,4 +22,4 @@ const withRouteAnalytics = <P extends WithRouteAnalyticsProps>(
 };
 
 export default withRouteAnalytics;
-export {WithRouteAnalyticsProps};
+export type {WithRouteAnalyticsProps};

--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -309,4 +309,5 @@ const Container = styled('span')<{containerDisplayMode: React.CSSProperties['dis
   max-width: 100%;
 `;
 
-export {useHoverOverlay, UseHoverOverlayProps};
+export type {UseHoverOverlayProps};
+export {useHoverOverlay};

--- a/static/app/views/dashboards/widgetBuilder/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/index.tsx
@@ -27,5 +27,5 @@ function WidgetBuilderContainer(props: WidgetBuilderProps) {
   );
 }
 
-export {WidgetBuilderProps};
+export type {WidgetBuilderProps};
 export default WidgetBuilderContainer;

--- a/static/app/views/monitors/components/statusToggleButton.tsx
+++ b/static/app/views/monitors/components/statusToggleButton.tsx
@@ -49,4 +49,5 @@ const StatusToggleButton = HookOrDefault({
   defaultComponent: SimpleStatusToggle,
 });
 
-export {StatusToggleButton, StatusToggleButtonProps};
+export type {StatusToggleButtonProps};
+export {StatusToggleButton};


### PR DESCRIPTION
Enables the remaining rule for consistent type exports. After merging this, we'll make sure both imports and exports use proper syntax to define types.