### PR TITLE
ref: Removed `ProjectRuleActionsEndpoint` `transaction_start` decorator

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -11,7 +11,6 @@ from sentry.models.rule import Rule
 from sentry.rules.processor import RuleProcessor
 from sentry.utils.safe import safe_execute
 from sentry.utils.samples import create_sample_event
-from sentry.web.decorators import transaction_start
 
 
 @region_silo_endpoint
@@ -23,7 +22,6 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
 
     permission_classes = (ProjectAlertRulePermission,)
 
-    @transaction_start("ProjectRuleActionsEndpoint")
     def post(self, request: Request, project) -> Response:
         """
         Creates a dummy event/group and activates the actions given by request body


### PR DESCRIPTION
Using `transaction_start` in the `ProjectRuleActionsEndpoint` is unnecessary and causes undefined behavior, since this endpoint is already auto-instrumented, as it is a Django endpoint. The auto-instrumented transaction can be viewed [here](https://sentry.sentry.io/performance/summary/?project=1&query=http.method%3APOST&referrer=performance-transaction-summary&statsPeriod=1h&transaction=%2Fapi%2F0%2Fprojects%2F%7Borganization_slug%7D%2F%7Bproject_slug%7D%2Frule-actions%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29).

ref #63951