### PR TITLE
build: improve formatting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,9 @@ module.exports = {
       {fixStyle: 'separate-type-imports', prefer: 'type-imports'},
     ],
   },
+  // JSON file formatting is handled by Biome. ESLint should not be linting
+  // and formatting these files.
+  ignorePatterns: ['*.json'],
   overrides: [
     {
       files: ['tests/js/**/*.{ts,js}'],

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -84,9 +84,7 @@ jobs:
         env:
           # Run relax config on main branch (and stricter config for changed files)
           SENTRY_ESLINT_RELAXED: 1
-        run: |
-          yarn lint
-          yarn lint:css
+        run: yarn lint
 
       # Otherwise... only lint modified files
       # Note `eslint --fix` will not fail when it auto fixes files
@@ -99,6 +97,10 @@ jobs:
         if: github.ref != 'refs/heads/master' && needs.files-changed.outputs.frontend_components_modified_lintable == 'true'
         run: |
           yarn stylelint ${{ needs.files-changed.outputs.frontend_components_modified_lintable_files }}
+
+      - name: biome
+        if: github.ref != 'refs/heads/master' && needs.files-changed.outputs.frontend_components_modified_lintable == 'true'
+        run: yarn biome check . --apply
 
       # Check (and error) for dirty working tree for forks
       # Reason being we need a different token to auto commit changes and

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -123,7 +123,7 @@ repos:
     hooks:
       - id: prettier
         name: prettier (yaml, markdown)
-        types: [yaml, markdown]
+        types_or: [yaml, markdown]
         # https://pre-commit.com/#regular-expressions
         exclude: |
           (?x)^($^

--- a/biome.json
+++ b/biome.json
@@ -3,7 +3,8 @@
   "vcs": {
     "enabled": true,
     "clientKind": "git",
-    "useIgnoreFile": true
+    "useIgnoreFile": true,
+    "defaultBranch": "master"
   },
   "organizeImports": {
     "enabled": false

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "test-debug": "node --inspect-brk scripts/test.js --runInBand",
     "test-precommit": "yarn test-wrap --bail --findRelatedTests -u",
     "test-staged": "yarn test-wrap --findRelatedTests $(git diff --name-only --cached)",
-    "lint": "yarn lint:biome && yarn lint:prettier && yarn lint:js",
+    "lint": "yarn lint:biome && yarn lint:prettier && yarn lint:js && yarn lint:css",
     "lint:js": "eslint static/app tests/js --ext .js,.jsx,.ts,.tsx",
     "lint:css": "stylelint 'static/app/**/*.[jt]sx'",
     "lint:biome": "biome check .",


### PR DESCRIPTION
We don't need to install Biome twice. This change proposes using the local biome installation for pre-commit hooks.