### PR TITLE
feat(feedback): Remove feedback widget from feedback page

### DIFF
--- a/static/app/views/feedback/index.tsx
+++ b/static/app/views/feedback/index.tsx
@@ -2,7 +2,6 @@ import type {RouteComponentProps} from 'react-router';
 
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
-import FloatingFeedbackWidget from 'sentry/components/feedback/widget/floatingFeedbackWidget';
 import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import {t} from 'sentry/locale';
@@ -21,10 +20,7 @@ export default function FeedbackContainer({children}: Props) {
       organization={organization}
       renderDisabled={NoAccess}
     >
-      <NoProjectMessage organization={organization}>
-        <FloatingFeedbackWidget />
-        {children}
-      </NoProjectMessage>
+      <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
     </Feature>
   );
 }


### PR DESCRIPTION
Remove feedback widget from the feedback page as we're just getting a multitude of support inquiries, that could go through our Support agents instead of the product eng team directly to triage, investigate, respond back to, etc. 

Closes https://github.com/getsentry/team-replay/issues/369
