### PR TITLE
ref: Remove `transaction_start` from `ProjectRulePreviewEndpoint`

### DIFF
--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -14,7 +14,6 @@ from sentry.api.serializers.rest_framework.rule import RulePreviewSerializer
 from sentry.models.group import Group
 from sentry.models.groupinbox import get_inbox_details
 from sentry.rules.history.preview import preview
-from sentry.web.decorators import transaction_start
 
 
 @region_silo_endpoint
@@ -27,7 +26,6 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
     permission_classes = (ProjectAlertRulePermission,)
 
     # a post endpoint because it's too hard to pass a list of objects from the frontend
-    @transaction_start("ProjectRulePreviewEndpoint")
     def post(self, request: Request, project) -> Response:
         """
         Get a list of alert triggers in past 2 weeks for given rules


### PR DESCRIPTION
The `transaction_start` decorator is unnecessary here, and it causes undefined behavior, because the `ProjectRulePreviewEndpoint` is already auto-instrumented by the Django integration. The auto-instrumented transaction can be viewed [here](https://sentry.sentry.io/performance/summary/?project=1&query=http.method%3APOST&referrer=performance-transaction-summary&statsPeriod=1h&transaction=%2Fapi%2F0%2Fprojects%2F%7Borganization_slug%7D%2F%7Bproject_slug%7D%2Frules%2Fpreview%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29).

ref #63951
