### PR TITLE
ref(feedback): show skull icon if feedback is from user report

### DIFF
--- a/static/app/components/feedback/list/feedbackListItem.tsx
+++ b/static/app/components/feedback/list/feedbackListItem.tsx
@@ -54,6 +54,7 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
     const hasReplayId = feedbackHasReplay(feedbackItem.id);
 
     const isCrashReport = feedbackItem.metadata.source === 'crash_report_embed_form';
+    const isUserReportWithError = feedbackItem.metadata.source === 'user_report_envelope';
     const hasComments = feedbackItem.numComments > 0;
     const theme = isOpen || config.theme === 'dark' ? darkTheme : lightTheme;
 
@@ -132,7 +133,7 @@ const FeedbackListItem = forwardRef<HTMLDivElement, Props>(
                   </Tooltip>
                 )}
 
-                {isCrashReport && (
+                {(isCrashReport || isUserReportWithError) && (
                   <Tooltip title={t('Linked Error')} containerDisplayMode="flex">
                     <IconFatal color="red400" size="xs" />
                   </Tooltip>


### PR DESCRIPTION
Previously, to display a skull icon in the feedback list, we were only checking for source = `crash_report_embed_form` (aka the crash report modal), but weren't checking if the source was `user_report_envelope`. Confirmed with @JoshFerge that user reports _should_ always have a linked error.

fixes https://github.com/getsentry/team-replay/issues/321