### PR TITLE
chore(hc): Adds request attempt counter logging to silo client, outbox receiver

### DIFF
--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -109,9 +109,13 @@ def process_async_webhooks(
             "integration_proxy.control.process_async_webhooks",
             tags={"destination_region": region.name},
         ):
+            request_prefix_hash = sha1(
+                f"{shard_identifier}{object_identifier}".encode()
+            ).hexdigest()
             logging_context["region"] = region.name
             logging_context["request_method"] = webhook_payload.method
             logging_context["proxy_path"] = webhook_payload.path
+            logging_context["request_hash"] = request_prefix_hash
 
             logger.info(
                 "integration_proxy.issuing_proxy_request",
@@ -125,7 +129,7 @@ def process_async_webhooks(
                 # We need to send the body as raw bytes to avoid interfering with webhook signatures
                 data=webhook_payload.body.encode("utf-8"),
                 json=False,
-                prefix_hash=sha1(f"{shard_identifier}{object_identifier}".encode()).hexdigest(),
+                prefix_hash=request_prefix_hash,
             )
         logger.info(
             "webhook_proxy.complete",

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ipaddress
+import logging
 import socket
 from hashlib import sha1
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, Set
@@ -204,6 +205,16 @@ class RegionSiloClient(BaseSiloClient):
         if not isinstance(request_attempts, int):
             request_attempts = 0
 
+        logging.info(
+            "silo_client.check_request_attempts",
+            extra={
+                "path": path,
+                "method": method,
+                "request_hash": hash,
+                "request_attempts": request_attempts,
+                "configured_attempt_limit": REQUEST_ATTEMPTS_LIMIT,
+            },
+        )
         if request_attempts < REQUEST_ATTEMPTS_LIMIT:
             request_attempts += 1
             cache.set(cache_key, request_attempts, timeout=CACHE_TIMEOUT)
@@ -214,6 +225,8 @@ class RegionSiloClient(BaseSiloClient):
     def cleanup_request_attempts(self, hash: str | None) -> None:
         if hash is None:
             return
+
+        logging.info("silo_client.cleaning_request_attempts", extra={"request_hash": hash})
         cache_key = self._get_hash_cache_key(hash=hash)
         cache.delete(cache_key)
 


### PR DESCRIPTION
Adds additional logging to check whether our request attempt counter is correctly tracking each request.

This will log the prefix hash of each request going through the client to make log querying by hash possible.
