### PR TITLE
fix(js): Remove withOrganization from demoModeGate

### DIFF
--- a/static/app/components/acl/demoModeGate.tsx
+++ b/static/app/components/acl/demoModeGate.tsx
@@ -1,13 +1,7 @@
 import ConfigStore from 'sentry/stores/configStore';
-import type {Organization} from 'sentry/types';
-import withOrganization from 'sentry/utils/withOrganization';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type Props = {
-  /**
-   * Current Organization
-   */
-  organization: Organization;
-
   /**
    * Children can be a node or a function as child.
    */
@@ -21,16 +15,16 @@ type Props = {
 /**
  * Component to handle demo mode switches
  */
-function DemoModeGate(props: Props) {
-  const {organization, children, demoComponent = null} = props;
+function DemoModeGate({children, demoComponent}: Props) {
+  const organization = useOrganization({allowNull: true});
 
   if (organization?.orgRole === 'member' && ConfigStore.get('demoMode')) {
     if (typeof demoComponent === 'function') {
       return demoComponent({children});
     }
-    return demoComponent;
+    return demoComponent ?? null;
   }
   return children;
 }
 
-export default withOrganization(DemoModeGate);
+export default DemoModeGate;

--- a/static/app/components/sidebar/sidebarDropdown/index.spec.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.spec.tsx
@@ -26,7 +26,7 @@ function renderDropdown(props: any = {}) {
       org={organization}
       {...props}
     />,
-    {context: routerContext}
+    {context: routerContext, organization}
   );
 }
 
@@ -34,9 +34,11 @@ describe('SidebarDropdown', function () {
   it('renders', function () {
     renderDropdown();
   });
+
   it('renders without org links', function () {
     renderDropdown({hideOrgLinks: true});
   });
+
   it('renders open sidebar', async function () {
     const config = ConfigFixture({
       singleOrganization: false,
@@ -45,6 +47,7 @@ describe('SidebarDropdown', function () {
     await userEvent.click(screen.getByTestId('sidebar-dropdown'));
     expect(screen.getByText('Switch organization')).toBeInTheDocument();
   });
+
   it('sandbox/demo mode render open sidebar', async function () {
     ConfigStore.set('demoMode', true);
     const config = ConfigFixture({singleOrganization: false});


### PR DESCRIPTION
This can be used in contexts where the organization is no set. The types did not correctly reflect this.