### PR TITLE
experiment(replays): Use default JSON decoder

### DIFF
--- a/src/sentry/replays/usecases/ingest/__init__.py
+++ b/src/sentry/replays/usecases/ingest/__init__.py
@@ -196,7 +196,7 @@ def recording_post_processor(
     try:
         with metrics.timer("replays.usecases.ingest.decompress_and_parse"):
             decompressed_segment = decompress(segment_bytes)
-            parsed_segment_data = json.loads(decompressed_segment, use_rapid_json=True)
+            parsed_segment_data = json.loads(decompressed_segment)
             _report_size_metrics(len(segment_bytes), len(decompressed_segment))
 
         # Emit DOM search metadata to Clickhouse.


### PR DESCRIPTION
We're seeing a lot of "The surrogate pair in string is invalid" errors.  This root cause seems to be rapidjson.  The increase in errors might be attributable to our new canvas changes.  Switching to the simplejson default decoder might allow us to parse these JSON messages.

Related to: https://github.com/Tencent/rapidjson/issues/2259
