### PR TITLE
chore(open-pr-comments): emit analytic event when comment is created

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -53,6 +53,7 @@ from .missing_members_nudge import *  # noqa: F401,F403
 from .monitor_mark_failed import *  # noqa: F401,F403
 from .notifications_settings_updated import *  # noqa: F401,F403
 from .onboarding_continuation_sent import *  # noqa: F401,F403
+from .open_pr_comment import *  # noqa: F401,F403
 from .org_auth_token_created import *  # noqa: F401,F403
 from .org_auth_token_deleted import *  # noqa: F401,F403
 from .organization_created import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/open_pr_comment.py
+++ b/src/sentry/analytics/events/open_pr_comment.py
@@ -1,0 +1,15 @@
+from sentry import analytics
+
+
+class OpenPRCommentCreatedEvent(analytics.Event):
+    type = "open_pr_comment.created"
+
+    attributes = (
+        analytics.Attribute("comment_id"),
+        analytics.Attribute("org_id"),
+        analytics.Attribute("pr_id"),
+        analytics.Attribute("language"),
+    )
+
+
+analytics.register(OpenPRCommentCreatedEvent)

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -517,7 +517,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
         for extension in file_extensions
         if extension in EXTENSION_LANGUAGE_MAP
     ]
-    language = languages[0] if len(languages) else ""
+    language = languages[0] if len(languages) else "not found"
 
     try:
         create_or_update_comment(

--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -21,8 +21,8 @@ from snuba_sdk import (
 )
 from snuba_sdk import Request as SnubaRequest
 
-from bin.extension_language_map import EXTENSION_LANGUAGE_MAP
 from sentry import features
+from sentry.constants import EXTENSION_LANGUAGE_MAP
 from sentry.integrations.github.client import GitHubAppsClient
 from sentry.models.group import Group, GroupStatus
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig

--- a/src/sentry/tasks/integrations/github/utils.py
+++ b/src/sentry/tasks/integrations/github/utils.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from django.utils import timezone
 
+from sentry import analytics
 from sentry.integrations.github.client import GitHubAppsClient
 from sentry.models.pullrequest import CommentType, PullRequestComment
 from sentry.models.repository import Repository
@@ -44,6 +45,7 @@ def create_or_update_comment(
     issue_list: List[int],
     metrics_base: str,
     comment_type: int = CommentType.MERGED_PR,
+    language: str | None = "",
 ):
     pr_comment_query = PullRequestComment.objects.filter(
         pull_request__id=pullrequest_id, comment_type=comment_type
@@ -57,7 +59,7 @@ def create_or_update_comment(
         )
 
         current_time = timezone.now()
-        PullRequestComment.objects.create(
+        comment = PullRequestComment.objects.create(
             external_id=resp.body["id"],
             pull_request_id=pullrequest_id,
             created_at=current_time,
@@ -66,6 +68,15 @@ def create_or_update_comment(
             comment_type=comment_type,
         )
         metrics.incr(metrics_base.format(key="comment_created"))
+
+        if comment_type == CommentType.OPEN_PR:
+            analytics.record(
+                "open_pr_comment.created",
+                comment_id=comment.id,
+                org_id=repo.organization_id,
+                pr_id=pullrequest_id,
+                language=language,
+            )
     else:
         resp = client.update_comment(
             repo=repo.name, comment_id=pr_comment.external_id, data={"body": comment_body}

--- a/src/sentry/tasks/integrations/github/utils.py
+++ b/src/sentry/tasks/integrations/github/utils.py
@@ -45,7 +45,7 @@ def create_or_update_comment(
     issue_list: List[int],
     metrics_base: str,
     comment_type: int = CommentType.MERGED_PR,
-    language: str | None = "",
+    language: str | None = "not found",
 ):
     pr_comment_query = PullRequestComment.objects.filter(
         pull_request__id=pullrequest_id, comment_type=comment_type

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -763,8 +763,10 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         self.groups.reverse()
 
     @responses.activate
+    @patch("sentry.analytics.record")
     def test_comment_workflow(
         self,
+        mock_analytics,
         mock_metrics,
         mock_safe_for_comment,
         mock_issues,
@@ -799,13 +801,24 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
 
         pull_request_comment_query = PullRequestComment.objects.all()
         assert len(pull_request_comment_query) == 1
-        assert pull_request_comment_query[0].external_id == 1
-        assert pull_request_comment_query[0].comment_type == CommentType.OPEN_PR
+        comment = pull_request_comment_query[0]
+        assert comment.external_id == 1
+        assert comment.comment_type == CommentType.OPEN_PR
+
         mock_metrics.incr.assert_called_with("github_open_pr_comment.comment_created")
+        mock_analytics.assert_any_call(
+            "open_pr_comment.created",
+            comment_id=comment.id,
+            org_id=self.organization.id,
+            pr_id=comment.pull_request.id,
+            language="python",
+        )
 
     @responses.activate
+    @patch("sentry.analytics.record")
     def test_comment_workflow_comment_exists(
         self,
+        mock_analytics,
         mock_metrics,
         mock_safe_for_comment,
         mock_issues,
@@ -849,13 +862,17 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
         assert pr_comment.external_id == 1
         assert pr_comment.comment_type == CommentType.OPEN_PR
         assert pr_comment.created_at != pr_comment.updated_at
-        mock_metrics.incr.assert_called_with("github_open_pr_comment.comment_updated")
 
+        mock_metrics.incr.assert_called_with("github_open_pr_comment.comment_updated")
+        assert not mock_analytics.called
+
+    @patch("sentry.analytics.record")
     @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
     @responses.activate
     def test_comment_workflow_early_return(
         self,
         mock_metrics,
+        mock_analytics,
         _,
         mock_safe_for_comment,
         mock_issues,
@@ -902,13 +919,17 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
 
         pull_request_comment_query = PullRequestComment.objects.all()
         assert len(pull_request_comment_query) == 0
-        mock_metrics.incr.assert_called_with("github_open_pr_comment.no_issues")
 
+        mock_metrics.incr.assert_called_with("github_open_pr_comment.no_issues")
+        assert not mock_analytics.called
+
+    @patch("sentry.analytics.record")
     @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
     @responses.activate
     def test_comment_workflow_api_error(
         self,
         mock_metrics,
+        mock_analytics,
         _,
         mock_safe_for_comment,
         mock_issues,
@@ -974,9 +995,11 @@ class TestOpenPRCommentWorkflow(IntegrationTestCase, CreateEventTestCase):
 
         # does not raise ApiError for rate limited error
         open_pr_comment_workflow(pr_3.id)
+
         mock_metrics.incr.assert_called_with(
             "github_open_pr_comment.error", tags={"type": "rate_limited_error"}
         )
+        assert not mock_analytics.called
 
     @patch("sentry.tasks.integrations.github.open_pr_comment.metrics")
     def test_comment_workflow_missing_pr(


### PR DESCRIPTION
Due to a mix in how customers send data from multiple SDKs into a project or have multiple code mappings, it's not very easy to query the numbers for how many open PR comments we are making per language.

Rather than add a column (#63975) we can emit an analytic event to track the language in the comment. We can just send one language even if the PR has multiple to make it easier to query in Amplitude.