### PR TITLE
fix(open-pr-comments): skip renamed files

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -206,7 +206,11 @@ def safe_for_comment(
     for file in pr_files:
         filename = file["filename"]
         # don't count the file if it was added or is not a Python file
-        if file["status"] == "added" or filename.split(".")[-1] not in patch_parsers:
+        if (
+            file["status"] == "added"
+            or file["status"] == "renamed"
+            or filename.split(".")[-1] not in patch_parsers
+        ):
             continue
 
         changed_file_count += 1

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -102,6 +102,7 @@ class TestSafeForComment(GithubCommentTestCase):
             {"filename": "bar.js", "changes": 100, "status": "modified"},
             {"filename": "baz.py", "changes": 100, "status": "added"},
             {"filename": "bee.py", "changes": 100, "status": "deleted"},
+            {"filename": "boo.py", "changes": 0, "status": "renamed"},
         ]
         responses.add(
             responses.GET,
@@ -124,6 +125,7 @@ class TestSafeForComment(GithubCommentTestCase):
             {"filename": "bar.js", "changes": 100, "status": "modified"},
             {"filename": "baz.py", "changes": 100, "status": "added"},
             {"filename": "bee.py", "changes": 100, "status": "deleted"},
+            {"filename": "boo.js", "changes": 0, "status": "renamed"},
         ]
         responses.add(
             responses.GET,


### PR DESCRIPTION
Courtesy of an open PR comment! https://github.com/getsentry/sentry/pull/64080#issuecomment-1915330003

This error is happening because renamed files do not have a `patch` since no lines are modified, but we are still trying to fetch the `patch` from the dictionary representing the file. This is preventing us from possibly commenting on open PRs that contain some renamed files. We should skip these entirely.

Fixes [SENTRY-2D2J](https://sentry.sentry.io/issues/4817645187/)