### PR TITLE
chore(mypy): Add .mpy_cache to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ import-graph.txt
 import-graph.dot
 bin/rrweb-output
 model-manifest.json
+.mypy_cache


### PR DESCRIPTION
Biome is formatting this directory and doesn't know how to use the gitignore within the subdirectory.

this is what mine looked like
![image](https://github.com/getsentry/sentry/assets/1400464/173b4f19-1876-476f-86b2-04f5f82e57fb)
