### PR TITLE
fix(celery): Stop reporting metrics directly after worker init

### DIFF
--- a/src/sentry/celery.py
+++ b/src/sentry/celery.py
@@ -112,11 +112,6 @@ class SentryCelery(Celery):
     task_cls = SentryTask
 
 
-@signals.worker_process_init.connect
-def record_worker_init(*args, **kwargs):
-    metrics.incr("jobs.process.start")
-
-
 app = SentryCelery("sentry")
 app.config_from_object(settings)
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)


### PR DESCRIPTION
reverts https://github.com/getsentry/sentry/pull/62795

We think this causes SIGABRT, and there's a clear correlation between
the deploy where that PR went out vs the errors appearing.

I don't really understand why this would break but the metric is only
nice-to-have anyway
