### PR TITLE
ref(slack): Get commits from context if possible

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -278,7 +278,7 @@ def get_suggested_assignees(
     return []
 
 
-def get_suspect_commit_block(
+def get_suspect_commit_text(
     project: Project, event: GroupEvent, commits: Sequence[Mapping[str, Any]] | None = None
 ) -> SlackBlock:
     """Build up the suspect commit text for the given event"""

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -626,7 +626,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         # add suspect commit info
         if event_for_tags:
-            suspect_commit_text = get_suspect_commit_block(project, event_for_tags, self.commits)
+            suspect_commit_text = get_suspect_commit_text(project, event_for_tags, self.commits)
             if suspect_commit_text:
                 blocks.append(self.get_context_block(suspect_commit_text))
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -44,6 +44,7 @@ from sentry.models.rule import Rule
 from sentry.models.team import Team
 from sentry.models.user import User
 from sentry.notifications.notifications.base import ProjectNotification
+from sentry.notifications.utils import get_commits
 from sentry.notifications.utils.actions import MessageAction
 from sentry.notifications.utils.participants import (
     dedupe_suggested_assignees,
@@ -55,7 +56,6 @@ from sentry.services.hybrid_cloud.user.model import RpcUser
 from sentry.types.group import SUBSTATUS_TO_STR
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
-from sentry.utils.committers import get_serialized_event_file_committers
 
 STATUSES = {"resolved": "resolved", "ignored": "ignored", "unresolved": "re-opened"}
 logger = logging.getLogger(__name__)
@@ -278,58 +278,46 @@ def get_suggested_assignees(
     return []
 
 
-def get_suspect_commit_block(project: Project, event: GroupEvent):
-    """Build up the suspect commit info for the given event"""
-    author = None
-    commit_id = None
-    commit_link = None
-    pr_link = None
-    pr_date = None
-    committers = None
-    repo_base = None
+def get_suspect_commit_block(
+    project: Project, event: GroupEvent, commits: Sequence[Mapping[str, Any]] | None = None
+) -> SlackBlock:
+    """Build up the suspect commit text for the given event"""
 
-    try:
-        committers = get_serialized_event_file_committers(project, event)
-    except (Release.DoesNotExist, Commit.DoesNotExist):
-        logger.info("Skipping suspect committers because release does not exist.")
-    except Exception:
-        logger.exception("Could not get suspect committers. Continuing execution.")
-    if not committers:
+    # commits is passed from context when the rule initially fires
+    # we may not have that data if the message is being built after an action is taken, for example
+    if not commits:
+        commits = get_commits(project, event)
+    if not commits:
         return None
 
-    if committers:
-        committer = committers[0]
-        author = committer.get("author", {})
-        commits = committer.get("commits")
-        if commits:
-            commit_id = commits[0].get("id")
-            pull_request = commits[0].get("pullRequest")
-            if pull_request:
-                pr_title = pull_request.get("title")
-                pr_link = pull_request.get("externalUrl")
-                repo_base = pull_request.get("repository", {}).get("url")
-                pr_date = pull_request.get("dateCreated")
-                pr_id = pull_request.get("id")
-                if pr_date:
-                    pr_date = time_since(pr_date)
+    commit = commits[0]  # get the most recent commit
+    suspect_commit_text = "Suspect Commit: "
+    pull_request = commit.get("pull_request")
+    author = commit.get("author")
+    commit_id = commit.get("id")
+    if not author and not commit_id:
+        return None
 
-    if author and commit_id:
-        author_display = (
-            author.get("name") if author.get("name") is not None else author.get("email")
-        )
-
-        suspect_commit_text = "Suspect Commit: "
+    author_display = author.get("name") if author.get("name") is not None else author.get("email")
+    if pull_request:
+        repo_base = pull_request.get("repository", {}).get("url")
         if repo_base:
             commit_link = f"<{repo_base}/commits/{commit_id}|{commit_id[0:6]}>"
             suspect_commit_text += f"{commit_link} by {author_display}"
-        else:
-            suspect_commit_text += f"{commit_id} by {author_display}"
-        if pull_request:
+
+        pr_date = pull_request.get("dateCreated")
+        if pr_date:
+            pr_date = time_since(pr_date)
+        pr_id = pull_request.get("id")
+        pr_title = pull_request.get("title")
+        pr_link = pull_request.get("externalUrl")
+        if pr_date and pr_id and pr_title and pr_link:
             suspect_commit_text += (
                 f" {pr_date} \n'{pr_title} (#{pr_id})' <{pr_link}|View Pull Request>"
             )
-        return suspect_commit_text
-    return None
+    else:
+        suspect_commit_text += f"{commit_id} by {author_display}"
+    return suspect_commit_text
 
 
 def get_action_text(text: str, actions: Sequence[Any], identity: RpcIdentity) -> str:
@@ -460,6 +448,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         is_unfurl: bool = False,
         skip_fallback: bool = False,
         notes: str | None = None,
+        commits: Sequence[Mapping[str, Any]] | None = None,
     ) -> None:
         super().__init__()
         self.group = group
@@ -475,6 +464,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self.is_unfurl = is_unfurl
         self.skip_fallback = skip_fallback
         self.notes = notes
+        self.commits = commits
 
     @property
     def escape_text(self) -> bool:
@@ -636,7 +626,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
 
         # add suspect commit info
         if event_for_tags:
-            suspect_commit_text = get_suspect_commit_block(project, event_for_tags)
+            suspect_commit_text = get_suspect_commit_block(project, event_for_tags, self.commits)
             if suspect_commit_text:
                 blocks.append(self.get_context_block(suspect_commit_text))
 
@@ -693,6 +683,7 @@ def build_group_attachment(
     is_unfurl: bool = False,
     notification_uuid: str | None = None,
     notes: str | None = None,
+    commits: Sequence[Mapping[str, Any]] | None = None,
 ) -> Union[SlackBlock, SlackAttachment]:
 
     return SlackIssuesMessageBuilder(
@@ -706,4 +697,5 @@ def build_group_attachment(
         issue_details,
         is_unfurl=is_unfurl,
         notes=notes,
+        commits=commits,
     ).build(notification_uuid=notification_uuid)

--- a/src/sentry/integrations/slack/message_builder/notifications/issues.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/issues.py
@@ -30,4 +30,5 @@ class IssueNotificationMessageBuilder(SlackNotificationsMessageBuilder):
             issue_details=True,
             notification=self.notification,
             recipient=self.recipient,
+            commits=self.context.get("commits", None),
         ).build()

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -265,7 +265,9 @@ def get_commits(project: Project, event: Event) -> Sequence[Mapping[str, Any]]:
                     if commit.get("pullRequest"):
                         commit_data["pull_request"] = commit["pullRequest"]
                     commits[commit["id"]] = commit_data
-    return sorted(commits.values())
+    # TODO(nisanthan): Once Commit Context is GA, no need to sort by "score"
+    # commits from Commit Context dont have a "score" key
+    return sorted(commits.values(), key=lambda x: float(x.get("score", 0)), reverse=True)
 
 
 @region_silo_function

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -262,11 +262,10 @@ def get_commits(project: Project, event: Event) -> Sequence[Mapping[str, Any]]:
                     commit_data["subject"] = (
                         commit_data["message"].split("\n", 1)[0] if commit_data["message"] else ""
                     )
+                    if commit.get("pullRequest"):
+                        commit_data["pull_request"] = commit["pullRequest"]
                     commits[commit["id"]] = commit_data
-
-    # TODO(nisanthan): Once Commit Context is GA, no need to sort by "score"
-    # commits from Commit Context dont have a "score" key
-    return sorted(commits.values(), key=lambda x: float(x.get("score", 0)), reverse=True)
+    return sorted(commits.values())
 
 
 @region_silo_function

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -159,7 +159,7 @@ def build_test_message_blocks(
         blocks.append(suggested_assignees_section)
 
     if suspect_commit and event:
-        suspect_commit_text = get_suspect_commit_text(project, event)
+        suspect_commit_text = get_suspect_commit_text(project, event.for_group(group))
         suspect_commit_section = {
             "type": "context",
             "elements": [{"type": "mrkdwn", "text": suspect_commit_text}],

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -18,7 +18,7 @@ from sentry.integrations.slack.message_builder.issues import (
     format_release_tag,
     get_option_groups,
     get_option_groups_block_kit,
-    get_suspect_commit_block,
+    get_suspect_commit_text,
     time_since,
 )
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
@@ -159,7 +159,7 @@ def build_test_message_blocks(
         blocks.append(suggested_assignees_section)
 
     if suspect_commit and event:
-        suspect_commit_text = get_suspect_commit_block(project, event)
+        suspect_commit_text = get_suspect_commit_text(project, event)
         suspect_commit_section = {
             "type": "context",
             "elements": [{"type": "mrkdwn", "text": suspect_commit_text}],

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -18,6 +18,7 @@ from sentry.integrations.slack.message_builder.issues import (
     format_release_tag,
     get_option_groups,
     get_option_groups_block_kit,
+    get_suspect_commit_block,
     time_since,
 )
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
@@ -157,28 +158,8 @@ def build_test_message_blocks(
         }
         blocks.append(suggested_assignees_section)
 
-    if suspect_commit:
-        suspect_commit_text = "Suspect Commit: "
-        if suspect_commit.get("repo_base"):
-            commit_link = f"<{suspect_commit['repo_base']}/commits/{suspect_commit['commit_id']}|{suspect_commit['commit_id'][0:6]}>"
-            suspect_commit_text += f"{commit_link}"
-        else:
-            suspect_commit_text += f"{suspect_commit['commit_id']}"
-        suspect_commit_name = (
-            suspect_commit["author_name"]
-            if suspect_commit.get("author_name")
-            else suspect_commit["author_email"]
-        )
-        suspect_commit_text += f" by {suspect_commit_name}"
-
-        if suspect_commit.get("time_since"):
-            suspect_commit_text += f" {suspect_commit['time_since']}"
-
-        if suspect_commit.get("pr_link") and suspect_commit.get("pr_id"):
-            pr_link = f"<{suspect_commit['pr_link']}|View Pull Request>"
-            pr_title_text = f"'{suspect_commit['pr_title']} (#{suspect_commit['pr_id']})'"
-
-            suspect_commit_text += f" \n{pr_title_text} {pr_link}"
+    if suspect_commit and event:
+        suspect_commit_text = get_suspect_commit_block(project, event)
         suspect_commit_section = {
             "type": "context",
             "elements": [{"type": "mrkdwn", "text": suspect_commit_text}],
@@ -526,16 +507,26 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             type=GroupOwnerType.SUSPECT_COMMIT.value,
             context={"commitId": self.commit.id},
         )
+
         suspect_commit = {
             "commit_id": self.commit.key,
-            "author_email": commit_author.email,
-            "time_since": "Just now",
-            "pr_title": pull_request.title,
-            "pr_link": mock_external_url.return_value,
-            "pr_id": pull_request.key,
-            "repo_base": self.repo.url,
+            "author": {
+                "email": commit_author.email,
+                "name": commit_author.name,
+            },
+            "pull_request": {
+                "dateCreated": pull_request.date_added,
+                "title": pull_request.title,
+                "externalUrl": mock_external_url.return_value,
+                "id": pull_request.key,
+                "repository": {
+                    "url": self.repo.url,
+                },
+            },
         }
+
         commits = get_commits(self.project, event)
+
         assert SlackIssuesMessageBuilder(
             group,
             event.for_group(group),

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -34,6 +34,7 @@ from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.models.team import Team
 from sentry.models.user import User
+from sentry.notifications.utils import get_commits
 from sentry.notifications.utils.actions import MessageAction
 from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema
 from sentry.services.hybrid_cloud.actor import RpcActor
@@ -534,8 +535,11 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             "pr_id": pull_request.key,
             "repo_base": self.repo.url,
         }
+        commits = get_commits(self.project, event)
         assert SlackIssuesMessageBuilder(
-            group, event.for_group(group)
+            group,
+            event.for_group(group),
+            commits=commits,
         ).build() == build_test_message_blocks(
             teams={self.team},
             users={self.user},


### PR DESCRIPTION
I realized that when the rule first fires, we already get the commit data and add it to context [here](https://github.com/getsentry/sentry/blob/master/src/sentry/notifications/notifications/rules.py#L172), but we didn't pass it to the Slack message builder. This adds the pull request data we need to the commit context, passes commits to the message builder if available, and builds the suspect commit block from that data. If we don't have it (like after an action is taken), we call `get_commits` for that data. This also cleans up the test data to just call `get_suspect_commit_block` instead of recreating it.