### PR TITLE
feat(issue-details): Fix replay clip analytics for full replay link

### DIFF
--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -85,7 +85,7 @@ function EventReplayContent({
             replaySlug={replayId}
             orgSlug={organization.slug}
             eventTimestampMs={eventTimestampMs}
-            buttonProps={{
+            fullReplayButtonProps={{
               analyticsEventKey: 'issue_details.open_replay_details_clicked',
               analyticsEventName: 'Issue Details: Open Replay Details Clicked',
               analyticsParams: {

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -27,8 +27,8 @@ type Props = {
   eventTimestampMs: number;
   orgSlug: string;
   replaySlug: string;
-  buttonProps?: Partial<ComponentProps<typeof LinkButton>>;
   focusTab?: TabKey;
+  fullReplayButtonProps?: Partial<ComponentProps<typeof LinkButton>>;
 };
 
 function getReplayAnalyticsStatus({
@@ -54,7 +54,7 @@ function getReplayAnalyticsStatus({
 }
 
 function ReplayPreview({
-  buttonProps,
+  fullReplayButtonProps,
   eventTimestampMs,
   focusTab,
   orgSlug,
@@ -130,7 +130,7 @@ function ReplayPreview({
 
             <CTAOverlay>
               <LinkButton
-                {...buttonProps}
+                {...fullReplayButtonProps}
                 icon={<IconPlay />}
                 priority="primary"
                 to={fullReplayUrl}

--- a/static/app/components/feedback/feedbackItem/replaySection.tsx
+++ b/static/app/components/feedback/feedbackItem/replaySection.tsx
@@ -23,7 +23,7 @@ export default function ReplaySection({eventTimestampMs, organization, replayId}
       focusTab={TabKey.BREADCRUMBS}
       orgSlug={organization.slug}
       replaySlug={replayId}
-      buttonProps={{
+      fullReplayButtonProps={{
         analyticsEventKey: 'feedback_details.open_replay_details_clicked',
         analyticsEventName: 'Feedback Details: Open Replay Details Clicked',
         analyticsParams: {


### PR DESCRIPTION
Renamed the replay clip preview to have a more descriptive prop name `fullReplayButtonProps`, but never renamed it in the parent that was rendering it which meant that the analytics event wasn't coming through. Since it was being loaded dynamically it wasn't a TS error. Renaming both now to be the more descriptive name.