### PR TITLE
style(ui): align icon and integration name in issue tracker link

### DIFF
--- a/static/app/components/issueSyncListElement.tsx
+++ b/static/app/components/issueSyncListElement.tsx
@@ -103,8 +103,10 @@ function IssueSyncListElement({
             bodyClassName="issue-list-body"
             forceVisible={showHoverCard}
           >
-            {icon}
-            {link}
+            <Label>
+              {icon}
+              {link}
+            </Label>
           </StyledHovercard>
         )}
       </ClassNames>
@@ -154,5 +156,9 @@ const StyledHovercard = styled(Hovercard)`
     overflow-y: auto;
   }
 `;
+
+const Label = styled('div')`
+display: flex;
+align-items: center;`;
 
 export default IssueSyncListElement;


### PR DESCRIPTION
the icon & integration name was misaligned (used in both user feedback & issue details)

BEFORE:
<img width="269" alt="SCR-20240129-mdye" src="https://github.com/getsentry/sentry/assets/56095982/16c09371-79be-407f-90f3-55a0ceb01876">
<img width="483" alt="SCR-20240129-meeq" src="https://github.com/getsentry/sentry/assets/56095982/22cfebb8-04cb-4f24-9132-3420fb2014dc">


AFTER:
<img width="275" alt="SCR-20240129-mdza" src="https://github.com/getsentry/sentry/assets/56095982/c078255c-0288-4864-bb89-9c2dc5b77fb5">
<img width="395" alt="SCR-20240129-mfla" src="https://github.com/getsentry/sentry/assets/56095982/2c276724-8cb9-4b28-b5e6-7d397f9e38d1">

