### PR TITLE
ref(superuser): read or write helper

### DIFF
--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -21,6 +21,7 @@ from django.core.signing import BadSignature
 from django.utils import timezone as django_timezone
 from django.utils.crypto import constant_time_compare, get_random_string
 from rest_framework import serializers, status
+from rest_framework.request import Request
 
 from sentry import features
 from sentry.api.exceptions import SentryAPIException
@@ -85,7 +86,24 @@ def get_superuser_scopes(auth_state: RpcAuthState, user: Any):
     return superuser_scopes
 
 
-def is_active_superuser(request):
+def superuser_has_permission(request: Request):
+    if not is_active_superuser(request):
+        return False
+
+    if is_self_hosted():
+        return True
+
+    if features.has("auth:enterprise-superuser-read-write", actor=request.user):
+        if "superuser.write" in request.access.permissions:
+            return True
+
+        # superuser read-only can only hit GET and OPTIONS (pre-flight) requests
+        return request.method == "GET" or request.method == "OPTIONS"
+
+    return True
+
+
+def is_active_superuser(request: Request) -> bool:
     if is_system_auth(getattr(request, "auth", None)):
         return True
     su = getattr(request, "superuser", None) or Superuser(request)

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -18,6 +18,7 @@ from typing import Any, Tuple
 
 from django.conf import settings
 from django.core.signing import BadSignature
+from django.http import HttpRequest
 from django.utils import timezone as django_timezone
 from django.utils.crypto import constant_time_compare, get_random_string
 from rest_framework import serializers, status
@@ -86,7 +87,7 @@ def get_superuser_scopes(auth_state: RpcAuthState, user: Any):
     return superuser_scopes
 
 
-def superuser_has_permission(request: Request):
+def superuser_has_permission(request: HttpRequest | Request):
     if not is_active_superuser(request):
         return False
 
@@ -103,7 +104,7 @@ def superuser_has_permission(request: Request):
     return True
 
 
-def is_active_superuser(request: Request) -> bool:
+def is_active_superuser(request: HttpRequest | Request) -> bool:
     if is_system_auth(getattr(request, "auth", None)):
         return True
     su = getattr(request, "superuser", None) or Superuser(request)

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -87,7 +87,7 @@ def get_superuser_scopes(auth_state: RpcAuthState, user: Any):
     return superuser_scopes
 
 
-def superuser_has_permission(request: HttpRequest | Request):
+def superuser_has_permission(request: HttpRequest | Request) -> bool:
     if not is_active_superuser(request):
         return False
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -1771,7 +1771,7 @@ class Factories:
 
         auth_state = RpcAuthState(sso_state=sso_state, permissions=permissions)
         return RpcBackedAccess(
-            rpc_user_organization_context=RpcUserOrganizationContext(),
+            rpc_user_organization_context=org_context,
             auth_state=auth_state,
             scopes_upper_bound=scopes_upper_bound,
         )

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -9,7 +9,7 @@ from binascii import hexlify
 from datetime import datetime
 from hashlib import sha1
 from importlib import import_module
-from typing import Any, List, Mapping, Optional, Sequence
+from typing import Any, FrozenSet, List, Mapping, Optional, Sequence
 from unittest import mock
 from uuid import uuid4
 
@@ -23,6 +23,7 @@ from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.text import slugify
 
+from sentry.auth.access import RpcBackedAccess
 from sentry.constants import SentryAppInstallationStatus, SentryAppStatus
 from sentry.event_manager import EventManager
 from sentry.incidents.logic import (
@@ -120,8 +121,10 @@ from sentry.sentry_apps.installations import (
     SentryAppInstallationTokenCreator,
 )
 from sentry.services.hybrid_cloud.app.serial import serialize_sentry_app_installation
+from sentry.services.hybrid_cloud.auth.model import RpcAuthState, RpcMemberSsoState
 from sentry.services.hybrid_cloud.hook import hook_service
 from sentry.services.hybrid_cloud.organization import RpcOrganization
+from sentry.services.hybrid_cloud.organization.model import RpcUserOrganizationContext
 from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.signals import project_created
 from sentry.silo import SiloMode
@@ -1751,3 +1754,24 @@ class Factories:
     @assume_test_silo_mode(SiloMode.REGION)
     def snooze_rule(**kwargs):
         return RuleSnooze.objects.create(**kwargs)
+
+    @staticmethod
+    def create_request_access(
+        sso_state: Optional[RpcMemberSsoState] = None,
+        permissions: Optional[List] = None,
+        org_context: Optional[RpcUserOrganizationContext] = None,
+        scopes_upper_bound: Optional[FrozenSet] = frozenset(),
+    ) -> RpcBackedAccess:
+        if not sso_state:
+            sso_state = RpcMemberSsoState()
+        if not permissions:
+            permissions = []
+        if not org_context:
+            org_context = RpcUserOrganizationContext()
+
+        auth_state = RpcAuthState(sso_state=sso_state, permissions=permissions)
+        return RpcBackedAccess(
+            rpc_user_organization_context=RpcUserOrganizationContext(),
+            auth_state=auth_state,
+            scopes_upper_bound=scopes_upper_bound,
+        )

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -533,6 +533,9 @@ class Fixtures:
     def snooze_rule(self, *args, **kwargs):
         return Factories.snooze_rule(*args, **kwargs)
 
+    def create_request_access(self, *args, **kwargs):
+        return Factories.create_request_access(*args, **kwargs)
+
     @pytest.fixture(autouse=True)
     def _init_insta_snapshot(self, insta_snapshot):
         self.insta_snapshot = insta_snapshot

--- a/tests/sentry/auth/test_superuser.py
+++ b/tests/sentry/auth/test_superuser.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.core import signing
 from django.utils import timezone as django_timezone
 
+from sentry.auth.access import RpcBackedAccess
 from sentry.auth.superuser import (
     COOKIE_DOMAIN,
     COOKIE_HTTPONLY,
@@ -17,18 +18,25 @@ from sentry.auth.superuser import (
     IDLE_MAX_AGE,
     MAX_AGE,
     SESSION_KEY,
+    SUPERUSER_READONLY_SCOPES,
+    SUPERUSER_SCOPES,
     EmptySuperuserAccessForm,
     Superuser,
     SuperuserAccessFormInvalidJson,
     SuperuserAccessSerializer,
+    get_superuser_scopes,
     is_active_superuser,
+    superuser_has_permission,
 )
 from sentry.auth.system import SystemToken
 from sentry.middleware.placeholder import placeholder_get_response
 from sentry.middleware.superuser import SuperuserMiddleware
 from sentry.models.user import User
+from sentry.services.hybrid_cloud.auth.model import RpcAuthState, RpcMemberSsoState
+from sentry.services.hybrid_cloud.organization.model import RpcUserOrganizationContext
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
 from sentry.utils.auth import mark_sso_complete
@@ -61,11 +69,12 @@ class SuperuserTestCase(TestCase):
         uid=UNSET,
         session_data=True,
         user=None,
+        method=None,
     ):
         if user is None:
             user = self.create_user("foo@example.com", is_superuser=True)
         current_datetime = self.current_datetime
-        request = self.make_request(user=user)
+        request = self.make_request(user=user, method=method)
         if cookie_token is not None:
             request.COOKIES[COOKIE_NAME] = signing.get_cookie_signer(
                 salt=COOKIE_NAME + COOKIE_SALT
@@ -466,3 +475,113 @@ class SuperuserTestCase(TestCase):
             json.dumps(serialized_data.errors)
             == '{"superuserReason":["Ensure this field has no more than 128 characters."]}'
         )
+
+    def test_superuser_scopes(self):
+        user = self.create_user(is_superuser=True)
+
+        auth_state = RpcAuthState(sso_state=RpcMemberSsoState(), permissions=[])
+        auth_state_with_write = RpcAuthState(
+            sso_state=RpcMemberSsoState(), permissions=["superuser.write"]
+        )
+
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            assert get_superuser_scopes(auth_state, user) == SUPERUSER_SCOPES
+            assert get_superuser_scopes(auth_state_with_write, user) == SUPERUSER_SCOPES
+
+            # test scope separation
+            with self.feature("auth:enterprise-superuser-read-write"):
+                assert get_superuser_scopes(auth_state, user) == SUPERUSER_READONLY_SCOPES
+                assert get_superuser_scopes(auth_state_with_write, user) == SUPERUSER_SCOPES
+
+    def test_superuser_scopes_self_hosted(self):
+        # self hosted always has superuser write scopes
+
+        user = self.create_user(is_superuser=True)
+
+        auth_state = RpcAuthState(sso_state=RpcMemberSsoState(), permissions=[])
+        auth_state_with_write = RpcAuthState(
+            sso_state=RpcMemberSsoState(), permissions=["superuser.write"]
+        )
+
+        assert get_superuser_scopes(auth_state, user) == SUPERUSER_SCOPES
+        assert get_superuser_scopes(auth_state_with_write, user) == SUPERUSER_SCOPES
+
+        with self.feature("auth:enterprise-superuser-read-write"):
+            assert get_superuser_scopes(auth_state, user) == SUPERUSER_SCOPES
+            assert get_superuser_scopes(auth_state_with_write, user) == SUPERUSER_SCOPES
+
+    def test_superuser_has_permission(self):
+        request = self.build_request()
+
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            assert not superuser_has_permission(request)
+
+            # logging in gives permission
+            request.superuser = Superuser(request)
+            request.superuser._is_active = True
+            assert superuser_has_permission(request)
+
+    def test_superuser_has_permission_self_hosted(self):
+        request = self.build_request()
+
+        request.superuser = Superuser(request)
+        request.superuser._is_active = True
+
+        assert superuser_has_permission(request)
+
+    @with_feature("auth:enterprise-superuser-read-write")
+    def test_superuser_has_permission_read_write_get(self):
+        request = self.build_request(method="GET")
+
+        request.superuser = Superuser(request)
+        request.superuser._is_active = True
+
+        auth_state = RpcAuthState(sso_state=RpcMemberSsoState(), permissions=[])
+        auth_state_with_write = RpcAuthState(
+            sso_state=RpcMemberSsoState(), permissions=["superuser.write"]
+        )
+
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            # all superusers have permission to hit GET
+            request.access = RpcBackedAccess(
+                rpc_user_organization_context=RpcUserOrganizationContext(),
+                auth_state=auth_state,
+                scopes_upper_bound=frozenset(),
+            )
+            assert superuser_has_permission(request)
+
+            request.access = RpcBackedAccess(
+                rpc_user_organization_context=RpcUserOrganizationContext(),
+                auth_state=auth_state_with_write,
+                scopes_upper_bound=frozenset(),
+            )
+            assert superuser_has_permission(request)
+
+    @with_feature("auth:enterprise-superuser-read-write")
+    def test_superuser_has_permission_read_write_post(self):
+        request = self.build_request(method="POST")
+
+        request.superuser = Superuser(request)
+        request.superuser._is_active = True
+
+        auth_state = RpcAuthState(sso_state=RpcMemberSsoState(), permissions=[])
+        auth_state_with_write = RpcAuthState(
+            sso_state=RpcMemberSsoState(), permissions=["superuser.write"]
+        )
+
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            # superuser without superuser.write does not have permission
+            request.access = RpcBackedAccess(
+                rpc_user_organization_context=RpcUserOrganizationContext(),
+                auth_state=auth_state,
+                scopes_upper_bound=frozenset(),
+            )
+            assert not superuser_has_permission(request)
+
+            # superuser with superuser.write has permission
+            request.access = RpcBackedAccess(
+                rpc_user_organization_context=RpcUserOrganizationContext(),
+                auth_state=auth_state_with_write,
+                scopes_upper_bound=frozenset(),
+            )
+            assert superuser_has_permission(request)


### PR DESCRIPTION
Adds a `superuser_has_permission()` helper function that will replace `is_active_superuser()` calls within APIs.

We are separating superuser into superuser read-only and superuser write. Within APIs, we are often calling `is_active_superuser()` to give all superusers access to all request methods in a class. We want to only allow superuser read-only to make `GET` and `OPTIONS` requests.

Superuser read vs write separation will not apply to self-hosted.