### PR TITLE
ref(snuba): refactor _bulk_snuba_query method

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -789,7 +789,8 @@ def raw_query(
 
 SnubaQuery = Union[Request, MutableMapping[str, Any]]
 Translator = Callable[[Any], Any]
-SnubaQueryBody = tuple[SnubaQuery, Translator, Translator]
+RequestQueryBody = tuple[Request, Translator, Translator]
+LegacyQueryBody = tuple[MutableMapping[str, Any], Translator, Translator]
 ResultSet = list[Mapping[str, Any]]  # TODO: Would be nice to make this a concrete structure
 
 
@@ -868,7 +869,7 @@ def get_cache_key(query: SnubaQuery) -> str:
 
 
 def _apply_cache_and_build_results(
-    snuba_param_list: Sequence[SnubaQueryBody],
+    snuba_param_list: Sequence[LegacyQueryBody | RequestQueryBody],
     referrer: Optional[str] = None,
     use_cache: Optional[bool] = False,
 ) -> ResultSet:
@@ -884,7 +885,7 @@ def _apply_cache_and_build_results(
     if use_cache:
         cache_keys = [get_cache_key(query_params[0]) for _, query_params in query_param_list]
         cache_data = cache.get_many(cache_keys)
-        to_query: list[tuple[int, SnubaQueryBody, Optional[str]]] = []
+        to_query: list[tuple[int, LegacyQueryBody | RequestQueryBody, Optional[str]]] = []
         for (query_pos, query_params), cache_key in zip(query_param_list, cache_keys):
             cached_result = cache_data.get(cache_key)
             metric_tags = {"referrer": referrer} if referrer else None
@@ -911,7 +912,7 @@ def _apply_cache_and_build_results(
 
 
 def _bulk_snuba_query(
-    snuba_param_list: Sequence[SnubaQueryBody],
+    snuba_param_list: Sequence[LegacyQueryBody | RequestQueryBody],
     headers: Mapping[str, str],
 ) -> ResultSet:
     query_referrer = headers.get("referer", "<unknown>")
@@ -925,12 +926,6 @@ def _bulk_snuba_query(
         # but we still want to know a general sense of how referrers impact performance
         span.set_tag("query.referrer", query_referrer)
         sentry_sdk.set_tag("query.referrer", query_referrer)
-        # This is confusing because this function is overloaded right now with two cases:
-        # 1. A SnQL query of a legacy query (_legacy_snql_query)
-        # 2. A direct SnQL query using the new SDK (_snuba_query)
-        query_fn = _legacy_snql_query
-        if isinstance(snuba_param_list[0][0], Request):
-            query_fn = _snuba_query
 
         parent_api: str = "<missing>"
         with sentry_sdk.configure_scope() as scope:
@@ -940,7 +935,7 @@ def _bulk_snuba_query(
         if len(snuba_param_list) > 1:
             query_results = list(
                 _query_thread_pool.map(
-                    query_fn,
+                    _snuba_query,
                     [
                         (params, Hub(Hub.current), headers, parent_api)
                         for params in snuba_param_list
@@ -949,7 +944,9 @@ def _bulk_snuba_query(
             )
         else:
             # No need to submit to the thread pool if we're just performing a single query
-            query_results = [query_fn((snuba_param_list[0], Hub(Hub.current), headers, parent_api))]
+            query_results = [
+                _snuba_query((snuba_param_list[0], Hub(Hub.current), headers, parent_api))
+            ]
 
     results = []
     for index, item in enumerate(query_results):
@@ -1013,9 +1010,7 @@ RawResult = tuple[urllib3.response.HTTPResponse, Callable[[Any], Any], Callable[
 
 
 def _snql_query(
-    params: tuple[
-        tuple[SnubaQuery, Callable[[Any], Any], Callable[[Any], Any]], Hub, Mapping[str, str], str
-    ]
+    params: tuple[LegacyQueryBody | RequestQueryBody, Hub, Mapping[str, str], str]
 ) -> RawResult:
     # TODO: For backwards compatibility. Some modules in Sentry use this function directly (despite it being marked private).
     return _snuba_query(params)
@@ -1023,18 +1018,31 @@ def _snql_query(
 
 def _snuba_query(
     params: tuple[
-        tuple[SnubaQuery, Callable[[Any], Any], Callable[[Any], Any]],
+        LegacyQueryBody | RequestQueryBody,
         Hub,
         Mapping[str, str],
         str,
     ],
 ) -> RawResult:
     # Eventually we can get rid of this wrapper, but for now it's cleaner to unwrap
-    # the params here than in the calling function.
-    query_data, thread_hub, headers, parent_api = params
-    request, forward, reverse = query_data
+    # the params here than in the calling function. (bc of thread .map)
+    query_body, thread_hub, headers, parent_api = params
+    query, forward, reverse = query_body
+    if isinstance(query, Request):
+        request = query
+    else:  # legacy query
+        request = json_to_snql(query, query["dataset"])
+    return _request_query((request, forward, reverse), thread_hub, headers, parent_api)
+
+
+def _request_query(
+    body: RequestQueryBody,
+    thread_hub: Hub,
+    headers: Mapping[str, str],
+    parent_api: str,
+) -> RawResult:
+    request, forward, reverse = body
     request.parent_api = parent_api
-    assert isinstance(request, Request)
     try:
         referrer = headers.get("referer", "unknown")
         if SNUBA_INFO:
@@ -1051,22 +1059,6 @@ def _snuba_query(
         return _raw_snql_query(request, thread_hub, headers), forward, reverse
     except urllib3.exceptions.HTTPError as err:
         raise SnubaError(err)
-
-
-def _legacy_snql_query(params: tuple[SnubaQuery, Hub, Mapping[str, str], str, bool]) -> RawResult:
-    # Convert the JSON query to SnQL and run it
-    query_data, thread_hub, headers, parent_api = params
-    query_params, forward, reverse = query_data
-
-    try:
-        snql_entity = query_params["dataset"]
-        request = json_to_snql(query_params, snql_entity)
-        request.parent_api = parent_api
-        result = _raw_snql_query(request, Hub(thread_hub), headers)
-    except urllib3.exceptions.HTTPError as err:
-        raise SnubaError(err)
-
-    return result, forward, reverse
 
 
 def _raw_mql_query(


### PR DESCRIPTION
This PR is associated with [SNS-2588](https://getsentry.atlassian.net/browse/SNS-2588)

It is a refactoring of the structure of _bulk_snuba_query related to the input/output typing specifications. Previously the function could take in legacy and non-legacy queries and it would change a local function based on the type. The design was somewhat confusing, the two functions had different input specifications, and did not play nicely with mypy.

 In order to solve this I changed the design s.t. _bulk_snuba_query takes in legacy and non-legacy queries, and always sends them _snuba_query. Within _snuba_query it converts legacy queries to Request if necessary, and calls _request_query.


[SNS-2588]: https://getsentry.atlassian.net/browse/SNS-2588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ