### PR TITLE
feat(webvitals): Mocks inp data in webvital queries using fid data

### DIFF
--- a/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
@@ -198,6 +198,7 @@ export function PerformanceScoreBreakdownChart({transaction}: Props) {
           fid: storedScores.unweightedFid,
           cls: storedScores.unweightedCls,
           ttfb: storedScores.unweightedTtfb,
+          inp: storedScores.unweightedInp,
           total: storedScores.total,
         }
       : timeseriesData,

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
@@ -58,6 +58,7 @@ export const useProjectRawWebVitalsQuery = ({transaction, tag, dataset}: Props =
     referrer: 'api.performance.browser.web-vitals.project',
   });
   // Fake INP data with FID data
+  // TODO(edwardgou): Remove this once INP is queryable in discover
   if (result.data?.data[0]) {
     result.data.data[0]['count_web_vitals(measurements.inp, any)'] =
       result.data.data[0]['count_web_vitals(measurements.fid, any)'];

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsQuery.tsx
@@ -45,7 +45,7 @@ export const useProjectRawWebVitalsQuery = ({transaction, tag, dataset}: Props =
     pageFilters.selection
   );
 
-  return useDiscoverQuery({
+  const result = useDiscoverQuery({
     eventView: projectEventView,
     limit: 50,
     location,
@@ -57,4 +57,12 @@ export const useProjectRawWebVitalsQuery = ({transaction, tag, dataset}: Props =
     skipAbort: true,
     referrer: 'api.performance.browser.web-vitals.project',
   });
+  // Fake INP data with FID data
+  if (result.data?.data[0]) {
+    result.data.data[0]['count_web_vitals(measurements.inp, any)'] =
+      result.data.data[0]['count_web_vitals(measurements.fid, any)'];
+    result.data.data[0]['p75(measurements.inp)'] =
+      result.data.data[0]['p75(measurements.fid)'];
+  }
+  return result;
 };

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsTimeseriesQuery.tsx
@@ -21,6 +21,7 @@ export type WebVitalsScoreBreakdown = {
   cls: SeriesDataUnit[];
   fcp: SeriesDataUnit[];
   fid: SeriesDataUnit[];
+  inp: SeriesDataUnit[];
   lcp: SeriesDataUnit[];
   total: SeriesDataUnit[];
   ttfb: SeriesDataUnit[];
@@ -91,6 +92,7 @@ export const useProjectRawWebVitalsTimeseriesQuery = ({
     cls: [],
     ttfb: [],
     fid: [],
+    inp: [],
     total: [],
   };
 

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -79,6 +79,7 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
     count: SeriesDataUnit[];
     fcp: SeriesDataUnit[];
     fid: SeriesDataUnit[];
+    inp: SeriesDataUnit[];
     lcp: SeriesDataUnit[];
     ttfb: SeriesDataUnit[];
   } = {
@@ -87,6 +88,7 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
     cls: [],
     ttfb: [],
     fid: [],
+    inp: [],
     count: [],
   };
 
@@ -108,6 +110,9 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
       }
     });
   });
+
+  // Fake INP data with FID data
+  data.inp = data.fid;
 
   return {data, isLoading: result.isLoading};
 };

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useProjectRawWebVitalsValuesTimeseriesQuery.tsx
@@ -112,6 +112,7 @@ export const useProjectRawWebVitalsValuesTimeseriesQuery = ({
   });
 
   // Fake INP data with FID data
+  // TODO(edwardgou): Remove this once INP is queryable in discover
   data.inp = data.fid;
 
   return {data, isLoading: result.isLoading};

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawSamplesWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawSamplesWebVitalsQuery.tsx
@@ -134,6 +134,8 @@ export const useTransactionRawSamplesWebVitalsQuery = ({
               lcpScore: lcpScore ?? 0,
               ttfbScore: ttfbScore ?? 0,
               fidScore: fidScore ?? 0,
+              // Fake INP data using FID data
+              inpScore: fidScore ?? 0,
             };
           })
       : [];

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawSamplesWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawSamplesWebVitalsQuery.tsx
@@ -135,6 +135,7 @@ export const useTransactionRawSamplesWebVitalsQuery = ({
               ttfbScore: ttfbScore ?? 0,
               fidScore: fidScore ?? 0,
               // Fake INP data using FID data
+              // TODO(edwardgou): Remove this once INP is queryable in discover
               inpScore: fidScore ?? 0,
             };
           })

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawWebVitalsQuery.tsx
@@ -86,6 +86,7 @@ export const useTransactionRawWebVitalsQuery = ({
             'p75(measurements.cls)': row['p75(measurements.cls)'] as number,
             'p75(measurements.ttfb)': row['p75(measurements.ttfb)'] as number,
             'p75(measurements.fid)': row['p75(measurements.fid)'] as number,
+            'p75(measurements.inp)': row['p75(measurements.fid)'] as number,
             'count()': row['count()'] as number,
             'count_web_vitals(measurements.lcp, any)': row[
               'count_web_vitals(measurements.lcp, any)'
@@ -114,6 +115,8 @@ export const useTransactionRawWebVitalsQuery = ({
               lcpScore: lcpScore ?? 0,
               ttfbScore: ttfbScore ?? 0,
               fidScore: fidScore ?? 0,
+              // Fake INP data using FID data
+              inpScore: fidScore ?? 0,
             };
           })
       : [];

--- a/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawWebVitalsQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/rawWebVitalsQueries/useTransactionRawWebVitalsQuery.tsx
@@ -116,6 +116,7 @@ export const useTransactionRawWebVitalsQuery = ({
               ttfbScore: ttfbScore ?? 0,
               fidScore: fidScore ?? 0,
               // Fake INP data using FID data
+              // TODO(edwardgou): Remove this once INP is queryable in discover
               inpScore: fidScore ?? 0,
             };
           })

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -77,14 +77,19 @@ export const useProjectWebVitalsScoresQuery = ({
     referrer: 'api.performance.browser.web-vitals.project-scores',
   });
 
-  if (result.status === 'success' && result.data) {
+  if (
+    result.status === 'success' &&
+    result.data?.data?.[0]?.['avg(measurements.score.weight.fid)'] &&
+    result.data?.data?.[0]?.['count_scores(measurements.score.fid)'] &&
+    result.data?.data?.[0]?.['performance_score(measurements.score.fid)']
+  ) {
     // Fake INP data with FID data
     result.data.data[0]['avg(measurements.score.weight.inp)'] =
-      result.data?.data[0]['avg(measurements.score.weight.fid)'];
+      result.data.data[0]['avg(measurements.score.weight.fid)'];
     result.data.data[0]['count_scores(measurements.score.inp)'] =
-      result.data?.data[0]['count_scores(measurements.score.fid)'];
+      result.data.data[0]['count_scores(measurements.score.fid)'];
     result.data.data[0]['performance_score(measurements.score.inp)'] =
-      result.data?.data[0]['performance_score(measurements.score.fid)'];
+      result.data.data[0]['performance_score(measurements.score.fid)'];
   }
   return result;
 };

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -84,6 +84,7 @@ export const useProjectWebVitalsScoresQuery = ({
     result.data?.data?.[0]?.['performance_score(measurements.score.fid)']
   ) {
     // Fake INP data with FID data
+    // TODO(edwardgou): Remove this once INP is queryable in discover
     result.data.data[0]['avg(measurements.score.weight.inp)'] =
       result.data.data[0]['avg(measurements.score.weight.fid)'];
     result.data.data[0]['count_scores(measurements.score.inp)'] =

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresQuery.tsx
@@ -63,7 +63,7 @@ export const useProjectWebVitalsScoresQuery = ({
     pageFilters.selection
   );
 
-  return useDiscoverQuery({
+  const result = useDiscoverQuery({
     eventView: projectEventView,
     limit: 50,
     location,
@@ -76,4 +76,15 @@ export const useProjectWebVitalsScoresQuery = ({
     skipAbort: true,
     referrer: 'api.performance.browser.web-vitals.project-scores',
   });
+
+  if (result.status === 'success' && result.data) {
+    // Fake INP data with FID data
+    result.data.data[0]['avg(measurements.score.weight.inp)'] =
+      result.data?.data[0]['avg(measurements.score.weight.fid)'];
+    result.data.data[0]['count_scores(measurements.score.inp)'] =
+      result.data?.data[0]['count_scores(measurements.score.fid)'];
+    result.data.data[0]['performance_score(measurements.score.inp)'] =
+      result.data?.data[0]['performance_score(measurements.score.fid)'];
+  }
+  return result;
 };

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
@@ -134,6 +134,7 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
   );
 
   // Fake INP data with FID data
+  // TODO(edwardgou): Remove this once INP is queryable in discover
   data.inp = data.fid;
   data.unweightedInp = data.unweightedFid;
   return {data, isLoading: result.isLoading};

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useProjectWebVitalsScoresTimeseriesQuery.tsx
@@ -22,6 +22,7 @@ export type UnweightedWebVitalsScoreBreakdown = {
   unweightedCls: SeriesDataUnit[];
   unweightedFcp: SeriesDataUnit[];
   unweightedFid: SeriesDataUnit[];
+  unweightedInp: SeriesDataUnit[];
   unweightedLcp: SeriesDataUnit[];
   unweightedTtfb: SeriesDataUnit[];
 };
@@ -96,10 +97,12 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
     cls: [],
     ttfb: [],
     fid: [],
+    inp: [],
     total: [],
     unweightedCls: [],
     unweightedFcp: [],
     unweightedFid: [],
+    unweightedInp: [],
     unweightedLcp: [],
     unweightedTtfb: [],
   };
@@ -130,5 +133,8 @@ export const useProjectWebVitalsScoresTimeseriesQuery = ({
     }
   );
 
+  // Fake INP data with FID data
+  data.inp = data.fid;
+  data.unweightedInp = data.unweightedFid;
   return {data, isLoading: result.isLoading};
 };

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -99,6 +99,8 @@ export const useTransactionWebVitalsScoresQuery = ({
             'p75(measurements.cls)': row['p75(measurements.cls)'] as number,
             'p75(measurements.ttfb)': row['p75(measurements.ttfb)'] as number,
             'p75(measurements.fid)': row['p75(measurements.fid)'] as number,
+            // Fake INP data using FID data
+            'p75(measurements.inp)': row['p75(measurements.fid)'] as number,
             'count()': row['count()'] as number,
             'count_scores(measurements.score.lcp)': row[
               'count_scores(measurements.score.lcp)'
@@ -115,12 +117,16 @@ export const useTransactionWebVitalsScoresQuery = ({
             'count_scores(measurements.score.fid)': row[
               'count_scores(measurements.score.fid)'
             ] as number,
+            'count_scores(measurements.score.inp)': row[
+              'count_scores(measurements.score.fid)'
+            ] as number,
             totalScore: totalScore ?? 0,
             clsScore: clsScore ?? 0,
             fcpScore: fcpScore ?? 0,
             lcpScore: lcpScore ?? 0,
             ttfbScore: ttfbScore ?? 0,
             fidScore: fidScore ?? 0,
+            inpScore: fidScore ?? 0,
             opportunity: row[
               `opportunity_score(measurements.score.${opportunityWebVital})`
             ] as number,

--- a/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/performance/browser/webVitals/utils/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -100,6 +100,7 @@ export const useTransactionWebVitalsScoresQuery = ({
             'p75(measurements.ttfb)': row['p75(measurements.ttfb)'] as number,
             'p75(measurements.fid)': row['p75(measurements.fid)'] as number,
             // Fake INP data using FID data
+            // TODO(edwardgou): Remove this once INP is queryable in discover
             'p75(measurements.inp)': row['p75(measurements.fid)'] as number,
             'count()': row['count()'] as number,
             'count_scores(measurements.score.lcp)': row[
@@ -126,6 +127,8 @@ export const useTransactionWebVitalsScoresQuery = ({
             lcpScore: lcpScore ?? 0,
             ttfbScore: ttfbScore ?? 0,
             fidScore: fidScore ?? 0,
+            // Fake INP data using FID data
+            // TODO(edwardgou): Remove this once INP is queryable in discover
             inpScore: fidScore ?? 0,
             opportunity: row[
               `opportunity_score(measurements.score.${opportunityWebVital})`


### PR DESCRIPTION
Updates most query hooks used in the Web Vitals module to also substitute INP fields using FID data. This is to enable UI development of INP in the Web Vitals module while supporting sdk and relay changes are in progress.