### PR TITLE
feat(feedback): add manual mark as spam button

### DIFF
--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -117,6 +117,10 @@ export type OpenConfirmOptions = {
    * Used to render a message instead of using the static `message` prop.
    */
   renderMessage?: (renderProps: ConfirmMessageRenderProps) => React.ReactNode;
+  /**
+   * Show the message without bold formatting
+   */
+  withoutBold?: boolean;
 };
 
 interface Props extends OpenConfirmOptions {
@@ -218,6 +222,7 @@ type ModalProps = ModalRenderProps &
     | 'onCancel'
     | 'disableConfirmButton'
     | 'onRender'
+    | 'withoutBold'
   >;
 
 type ModalState = {
@@ -270,7 +275,7 @@ class ConfirmModal extends Component<ModalProps, ModalState> {
   };
 
   get confirmMessage() {
-    const {message, renderMessage} = this.props;
+    const {message, renderMessage, withoutBold} = this.props;
 
     if (typeof renderMessage === 'function') {
       return renderMessage({
@@ -283,7 +288,7 @@ class ConfirmModal extends Component<ModalProps, ModalState> {
       });
     }
 
-    if (isValidElement(message)) {
+    if (isValidElement(message) || withoutBold) {
       return message;
     }
 

--- a/static/app/components/feedback/decodeMailbox.ts
+++ b/static/app/components/feedback/decodeMailbox.ts
@@ -1,6 +1,6 @@
 import {decodeScalar} from 'sentry/utils/queryString';
 
-type Mailbox = 'unresolved' | 'resolved';
+type Mailbox = 'unresolved' | 'resolved' | 'ignored';
 
 export default function decodeMailbox(
   value: string | string[] | undefined | null
@@ -9,7 +9,9 @@ export default function decodeMailbox(
     case 'resolved':
       return 'resolved';
     case 'archived':
-      return 'resolved';
+    case 'ignored':
+    case 'spam':
+      return 'ignored';
     default:
       return 'unresolved';
   }

--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -31,6 +31,7 @@ export default function FeedbackActions({
   style,
 }: Props) {
   const organization = useOrganization();
+  const hasSpamFeature = organization.features.includes('user-feedback-spam-filter-ui');
 
   const {markAsRead, resolve} = useMutateFeedback({
     feedbackIds: [feedbackItem.id],
@@ -47,6 +48,7 @@ export default function FeedbackActions({
   };
 
   const isResolved = feedbackItem.status === 'resolved';
+  const isSpam = feedbackItem.status === 'ignored';
 
   return (
     <Flex gap={space(0.5)} align="center" className={className} style={style}>
@@ -62,6 +64,18 @@ export default function FeedbackActions({
       >
         {feedbackItem.hasSeen ? t('Mark Unread') : t('Mark Read')}
       </Button>
+      {hasSpamFeature && (
+        <Button
+          priority="default"
+          onClick={() => {
+            addLoadingMessage(t('Updating feedback...'));
+            const newStatus = isSpam ? GroupStatus.UNRESOLVED : GroupStatus.IGNORED;
+            resolve(newStatus, mutationOptions);
+          }}
+        >
+          {isSpam ? t('Move to Inbox') : t('Mark as Spam')}
+        </Button>
+      )}
       <Button
         priority={isResolved ? 'danger' : 'primary'}
         onClick={() => {

--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -47,8 +47,9 @@ export default function FeedbackActions({
     },
   };
 
-  const isResolved = feedbackItem.status === 'resolved';
-  const isSpam = feedbackItem.status === 'ignored';
+  // reuse the issues ignored category for spam feedbacks
+  const isResolved = feedbackItem.status === GroupStatus.RESOLVED;
+  const isSpam = feedbackItem.status === GroupStatus.IGNORED;
 
   return (
     <Flex gap={space(0.5)} align="center" className={className} style={style}>

--- a/static/app/components/feedback/list/feedbackListBulkSelection.tsx
+++ b/static/app/components/feedback/list/feedbackListBulkSelection.tsx
@@ -9,6 +9,7 @@ import {IconEllipsis} from 'sentry/icons/iconEllipsis';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {GroupStatus} from 'sentry/types';
+import useOrganization from 'sentry/utils/useOrganization';
 
 interface Props
   extends Pick<
@@ -24,13 +25,19 @@ export default function FeedbackListBulkSelection({
   selectedIds,
   deselectAll,
 }: Props) {
+  const organization = useOrganization();
+  const hasSpamFeature = organization.features.includes('user-feedback-spam-filter-ui');
+
   const {onToggleResovled, onMarkAsRead, onMarkUnread} = useBulkEditFeedbacks({
     selectedIds,
     deselectAll,
   });
 
-  const newMailbox =
+  const newMailboxResolve =
     mailbox === 'resolved' ? GroupStatus.UNRESOLVED : GroupStatus.RESOLVED;
+
+  const newMailboxSpam =
+    mailbox === 'ignored' ? GroupStatus.UNRESOLVED : GroupStatus.IGNORED;
 
   return (
     <Flex gap={space(1)} align="center" justify="space-between" flex="1 0 auto">
@@ -43,10 +50,24 @@ export default function FeedbackListBulkSelection({
       </span>
       <Flex gap={space(1)} justify="flex-end">
         <ErrorBoundary mini>
-          <Button onClick={() => onToggleResovled(newMailbox)}>
+          <Button onClick={() => onToggleResovled({newMailbox: newMailboxResolve})}>
             {mailbox === 'resolved' ? t('Unresolve') : t('Resolve')}
           </Button>
         </ErrorBoundary>
+        {hasSpamFeature && (
+          <ErrorBoundary mini>
+            <Button
+              onClick={() =>
+                onToggleResovled({
+                  newMailbox: newMailboxSpam,
+                  moveToInbox: mailbox === 'ignored',
+                })
+              }
+            >
+              {mailbox === 'ignored' ? t('Move to inbox') : t('Mark as Spam')}
+            </Button>
+          </ErrorBoundary>
+        )}
         <ErrorBoundary mini>
           <DropdownMenu
             position="bottom-end"

--- a/static/app/components/feedback/list/feedbackListBulkSelection.tsx
+++ b/static/app/components/feedback/list/feedbackListBulkSelection.tsx
@@ -36,6 +36,7 @@ export default function FeedbackListBulkSelection({
   const newMailboxResolve =
     mailbox === 'resolved' ? GroupStatus.UNRESOLVED : GroupStatus.RESOLVED;
 
+  // reuse the issues ignored category for spam feedbacks
   const newMailboxSpam =
     mailbox === 'ignored' ? GroupStatus.UNRESOLVED : GroupStatus.IGNORED;
 

--- a/static/app/components/feedback/list/mailboxPicker.tsx
+++ b/static/app/components/feedback/list/mailboxPicker.tsx
@@ -11,9 +11,16 @@ interface Props {
   value: Mailbox;
 }
 
+const items = [
+  {key: 'unresolved', label: t('Inbox')},
+  {key: 'resolved', label: t('Resolved')},
+  {key: 'ignored', label: t('Spam')},
+];
+
 export default function MailboxPicker({onChange, value}: Props) {
   const organization = useOrganization();
   const hasSpamFeature = organization.features.includes('user-feedback-spam-filter-ui');
+  const children = hasSpamFeature ? items : items.filter(i => i.key !== 'ignored');
   return (
     <Flex justify="flex-end" flex="1 0 auto">
       <SegmentedControl
@@ -22,11 +29,9 @@ export default function MailboxPicker({onChange, value}: Props) {
         value={value}
         onChange={onChange}
       >
-        <SegmentedControl.Item key="unresolved">{t('Inbox')}</SegmentedControl.Item>
-        <SegmentedControl.Item key="resolved">{t('Resolved')}</SegmentedControl.Item>
-        <SegmentedControl.Item key="ignored" disabled={!hasSpamFeature}>
-          {t('Spam')}
-        </SegmentedControl.Item>
+        {children.map(c => (
+          <SegmentedControl.Item key={c.key}>{c.label}</SegmentedControl.Item>
+        ))}
       </SegmentedControl>
     </Flex>
   );

--- a/static/app/components/feedback/list/mailboxPicker.tsx
+++ b/static/app/components/feedback/list/mailboxPicker.tsx
@@ -2,6 +2,7 @@ import type decodeMailbox from 'sentry/components/feedback/decodeMailbox';
 import {Flex} from 'sentry/components/profiling/flex';
 import {SegmentedControl} from 'sentry/components/segmentedControl';
 import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type Mailbox = ReturnType<typeof decodeMailbox>;
 
@@ -11,6 +12,8 @@ interface Props {
 }
 
 export default function MailboxPicker({onChange, value}: Props) {
+  const organization = useOrganization();
+  const hasSpamFeature = organization.features.includes('user-feedback-spam-filter-ui');
   return (
     <Flex justify="flex-end" flex="1 0 auto">
       <SegmentedControl
@@ -21,6 +24,9 @@ export default function MailboxPicker({onChange, value}: Props) {
       >
         <SegmentedControl.Item key="unresolved">{t('Inbox')}</SegmentedControl.Item>
         <SegmentedControl.Item key="resolved">{t('Resolved')}</SegmentedControl.Item>
+        <SegmentedControl.Item key="ignored" disabled={!hasSpamFeature}>
+          {t('Spam')}
+        </SegmentedControl.Item>
       </SegmentedControl>
     </Flex>
   );

--- a/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
+++ b/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
@@ -12,9 +12,16 @@ import {t, tct} from 'sentry/locale';
 import type {GroupStatus} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 
-const statusToText: Record<string, string> = {
+const statusToButtonLabel: Record<string, string> = {
   resolved: 'Resolve',
   unresolved: 'Unresolve',
+  ignored: 'Mark as Spam',
+};
+
+const statusToText: Record<string, string> = {
+  resolved: 'resolved',
+  unresolved: 'unresolved',
+  ignored: 'spam',
 };
 
 interface Props
@@ -31,7 +38,7 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
   });
 
   const onToggleResovled = useCallback(
-    (newMailbox: GroupStatus) => {
+    ({newMailbox, moveToInbox}: {newMailbox: GroupStatus; moveToInbox?: boolean}) => {
       openConfirmModal({
         bypass: Array.isArray(selectedIds) && selectedIds.length === 1,
         onConfirm: () => {
@@ -46,10 +53,14 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
             },
           });
         },
-        message: tct('Are you sure you want to [status] these feedbacks?', {
-          status: statusToText[newMailbox].toLowerCase(),
-        }),
-        confirmText: statusToText[newMailbox],
+        message: moveToInbox
+          ? tct('Are you sure you want to move these feedbacks to the inbox?', {})
+          : tct('Are you sure you want to mark these feedbacks as [status]?', {
+              status: statusToText[newMailbox],
+            }),
+        confirmText: moveToInbox
+          ? t('Move to Inbox')
+          : tct('[confirm]', {confirm: statusToButtonLabel[newMailbox]}),
       });
     },
     [deselectAll, resolve, selectedIds]

--- a/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
+++ b/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
@@ -13,9 +13,9 @@ import type {GroupStatus} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 
 const statusToButtonLabel: Record<string, string> = {
-  resolved: 'Resolve',
-  unresolved: 'Unresolve',
-  ignored: 'Mark as Spam',
+  resolved: t('Resolve'),
+  unresolved: t('Unresolve'),
+  ignored: t('Mark as Spam'),
 };
 
 const statusToText: Record<string, string> = {

--- a/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
+++ b/static/app/components/feedback/list/useBulkEditFeedbacks.tsx
@@ -54,13 +54,12 @@ export default function useBulkEditFeedbacks({deselectAll, selectedIds}: Props) 
           });
         },
         message: moveToInbox
-          ? tct('Are you sure you want to move these feedbacks to the inbox?', {})
+          ? t('Are you sure you want to move these feedbacks to the inbox?')
           : tct('Are you sure you want to mark these feedbacks as [status]?', {
               status: statusToText[newMailbox],
             }),
-        confirmText: moveToInbox
-          ? t('Move to Inbox')
-          : tct('[confirm]', {confirm: statusToButtonLabel[newMailbox]}),
+        confirmText: moveToInbox ? t('Move to Inbox') : statusToButtonLabel[newMailbox],
+        withoutBold: true,
       });
     },
     [deselectAll, resolve, selectedIds]


### PR DESCRIPTION
- Closes https://github.com/getsentry/sentry/issues/64097
- Design/button placement can be iterated on cc @Jesse-Box 

The buttons look like this:
- If you're in the inbox: `RESOLVE` or `MARK AS SPAM`
- If you're in resolved: `UNRESOLVE` or `MARK AS SPAM`
- If you're in spam: `RESOLVE` or `MOVE TO INBOX` (aka unresolve)


Single feedback edit:

https://github.com/getsentry/sentry/assets/56095982/29e04665-8a3f-4517-94f5-41dd8d268fc6


Bulk edit:

https://github.com/getsentry/sentry/assets/56095982/d38346a8-2261-488b-840f-ebae81860ef9


Orgs without the feature flag will not have the spam option shown in the mailbox:

<img width="427" alt="SCR-20240129-nvpq" src="https://github.com/getsentry/sentry/assets/56095982/49da6f14-f2b9-408f-a102-e3a7b4e5e7ac">
