### PR TITLE
fix(issue-details): Fix hitbox for resources link 

### DIFF
--- a/static/app/components/events/interfaces/performance/resources.tsx
+++ b/static/app/components/events/interfaces/performance/resources.tsx
@@ -63,6 +63,7 @@ const LinkSection = styled('div')`
   a {
     display: flex;
     align-items: center;
+    width: max-content;
   }
 
   svg {


### PR DESCRIPTION
this pr fixes the hitbox for the resources links on the issue details page. previously, it was the entire width of the component

closes https://github.com/getsentry/sentry/issues/64104