### PR TITLE
ref(ui): Move footer into OrganizationDetails

### DIFF
--- a/static/app/views/organizationDetails/body.tsx
+++ b/static/app/views/organizationDetails/body.tsx
@@ -1,9 +1,8 @@
-import {Fragment, useState} from 'react';
+import {useState} from 'react';
 
 import {Alert} from 'sentry/components/alert';
 import {Button} from 'sentry/components/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import Footer from 'sentry/components/footer';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t, tct} from 'sentry/locale';
 import AlertStore from 'sentry/stores/alertStore';
@@ -115,12 +114,7 @@ function OrganizationDetailsBody({children}: BodyProps) {
     return <DeletionInProgress organization={organization} />;
   }
 
-  return (
-    <Fragment>
-      <ErrorBoundary>{children}</ErrorBoundary>
-      <Footer />
-    </Fragment>
-  );
+  return <ErrorBoundary>{children}</ErrorBoundary>;
 }
 
 export default OrganizationDetailsBody;

--- a/static/app/views/organizationDetails/index.tsx
+++ b/static/app/views/organizationDetails/index.tsx
@@ -1,3 +1,4 @@
+import Footer from 'sentry/components/footer';
 import Sidebar from 'sentry/components/sidebar';
 import useRouteAnalyticsHookSetup from 'sentry/utils/routeAnalytics/useRouteAnalyticsHookSetup';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -17,6 +18,7 @@ function OrganizationDetails({children}: Props) {
     <OrganizationLayout>
       <Sidebar organization={organization ?? undefined} />
       <Body>{children}</Body>
+      <Footer />
     </OrganizationLayout>
   );
 }


### PR DESCRIPTION
This is another consistency change. The behavioral difference here is that the footer will now render on pages such as "organization pending deletion"