### PR TITLE
fix(snuba): fix mql string in stack trace (SNS-2585)

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -979,10 +979,12 @@ def _bulk_snuba_query(
 
         if response.status != 200:
             if use_mql:
-                error_request = snuba_param_list[index][0]
-                error_request = (
-                    error_request.serialize_mql()
-                )  # never used, only for sentry visibility
+                sentry_sdk.add_breadcrumb(
+                    category="query_info",
+                    level="info",
+                    message="mql_query",
+                    data={"mql": snuba_param_list[index][0].serialize_mql()},
+                )
 
             if body.get("error"):
                 error = body["error"]


### PR DESCRIPTION
This PR is associated with [SNS-2585](https://getsentry.atlassian.net/browse/SNS-2585)

The first [PR #63456](https://github.com/getsentry/sentry/pull/63456) failed to make the mql string show up in the stack trace. It was determined that this is due to the sdk arbitrarily dropping local variable when there are too many. This PR is a fix that should get the mql string to show up by adding it to the breadcrumbs.

[SNS-2585]: https://getsentry.atlassian.net/browse/SNS-2585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ