### PR TITLE
ref(slack): Fix post action text

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -553,12 +553,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         # build up the blocks for newer issue alert formatting #
 
         # build title block
-        if text:
-            text = text.lstrip(" ")
-            if self.actions:
-                text += "\n" + action_text
-        if not text:
-            text = action_text
         title_text = f"<{title_link}|*{escape_slack_text(title)}*>"
 
         if self.group.issue_category == GroupCategory.ERROR:
@@ -574,8 +568,15 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if title_emoji:
             title_text = f"{title_emoji} {title_text}"
         blocks = [self.get_markdown_block(title_text)]
+
+        # build up text block
         if text:
+            text = text.lstrip(" ")
             blocks.append(self.get_rich_text_preformatted_block(text))
+
+        # build up actions text
+        if self.actions:
+            blocks.append(self.get_markdown_block(action_text))
 
         # build tags block
         tags = get_tags(event_for_tags, self.tags)

--- a/tests/sentry/integrations/slack/webhooks/actions/test_status.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_status.py
@@ -40,6 +40,7 @@ pytestmark = [requires_snuba]
 class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
     def setUp(self):
         super().setUp()
+        self.notification_text = "Identity not found."
         self.event_data = {
             "event_id": "a" * 32,
             "message": "IntegrationError",
@@ -48,7 +49,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
                 "values": [
                     {
                         "type": "IntegrationError",
-                        "value": "Identity not found.",
+                        "value": self.notification_text,
                     }
                 ]
             },
@@ -61,7 +62,7 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
                     "ts": 1681409875,
                     "color": "E03E2F",
                     "fallback": "[node] IntegrationError: Identity not found.",
-                    "text": "Identity not found.",
+                    "text": self.notification_text,
                     "title": "IntegrationError",
                     "footer": "NODE-F via <http://localhost:8000/organizations/sentry/alerts/rules/node/3/details/|New Issue in #critical channel>",
                     "mrkdwn_in": ["text"],
@@ -74,7 +75,6 @@ class StatusActionTest(BaseEventTest, HybridCloudTestMixin):
         )
         assert event.group
         self.group = Group.objects.get(id=event.group.id)
-        self.notification_text = self.event_data["exception"]["values"][0]["value"]
 
     def get_original_message_block_kit(self, group_id):
         return {


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/63996 I accidentally made the action text a preformatted block too which doesn't look very good. This fixes that and cleans up the tests in the file so that we can ensure the post-action notification contains both the error text and the action text, both formatted as expected
<img width="611" alt="Screenshot 2024-01-29 at 5 43 26 PM" src="https://github.com/getsentry/sentry/assets/29959063/2dec9d57-8292-40b7-9f7f-b3cf2af61899">


