### PR TITLE
feat(grouping): Add `suppress-unnecessary-secondary-hash` flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1555,6 +1555,8 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # Enable experimental new version of stacktrace component where additional
     # data related to grouping is shown on each frame
     "organizations:grouping-stacktrace-ui": False,
+    # Enable only calculating a secondary hash when needed
+    "organizations:grouping-suppress-unnecessary-secondary-hash": False,
     # Enable tweaks to group title in relation to hierarchical grouping.
     "organizations:grouping-title-ui": False,
     # Enable experimental new version of Merged Issues where sub-hashes are shown

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -108,6 +108,7 @@ default_manager.add("organizations:gitlab-disable-on-broken", OrganizationFeatur
 default_manager.add("organizations:group-chunk-load-errors", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:grouping-built-in-fingerprint-rules", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:grouping-stacktrace-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
+default_manager.add("organizations:grouping-suppress-unnecessary-secondary-hash", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:grouping-title-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:grouping-tree-ui", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:higher-ownership-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)


### PR DESCRIPTION
This adds a new feature flag, `organizations:suppress-unnecessary-secondary-hash`, which will be used to feature-gate the new, optimized transition hash calculation process. The complementary handler is added in https://github.com/getsentry/getsentry/pull/12753.