### PR TITLE
ref(slack): Use SlackIssuesMessageBuilder directly

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -669,33 +669,3 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             block_id=json.dumps(block_id),
             skip_fallback=self.skip_fallback,
         )
-
-
-def build_group_attachment(
-    group: Group,
-    event: GroupEvent | None = None,
-    tags: set[str] | None = None,
-    identity: RpcIdentity | None = None,
-    actions: Sequence[MessageAction] | None = None,
-    rules: list[Rule] | None = None,
-    link_to_event: bool = False,
-    issue_details: bool = False,
-    is_unfurl: bool = False,
-    notification_uuid: str | None = None,
-    notes: str | None = None,
-    commits: Sequence[Mapping[str, Any]] | None = None,
-) -> Union[SlackBlock, SlackAttachment]:
-
-    return SlackIssuesMessageBuilder(
-        group,
-        event,
-        tags,
-        identity,
-        actions,
-        rules,
-        link_to_event,
-        issue_details,
-        is_unfurl=is_unfurl,
-        notes=notes,
-        commits=commits,
-    ).build(notification_uuid=notification_uuid)

--- a/src/sentry/integrations/slack/unfurl/issues.py
+++ b/src/sentry/integrations/slack/unfurl/issues.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from django.http.request import HttpRequest
 
 from sentry import eventstore
-from sentry.integrations.slack.message_builder.issues import build_group_attachment
+from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.models.group import Group
 from sentry.models.integrations.integration import Integration
 from sentry.models.project import Project
@@ -62,9 +62,9 @@ def unfurl_issues(
                 if event_id
                 else None
             )
-            out[link.url] = build_group_attachment(
-                group_by_id[issue_id], event=event, link_to_event=True, is_unfurl=True
-            )
+            out[link.url] = SlackIssuesMessageBuilder(
+                group=group_by_id[issue_id], event=event, link_to_event=True, is_unfurl=True
+            ).build()
     return out
 
 


### PR DESCRIPTION
Use `SlackIssuesMessageBuilder` directly and consistently - we had a mix of using it directly and using `build_group_attachment` and I don't see a good reason for it.