### PR TITLE
feat(staff): Create user and staff permission class

### DIFF
--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -6,7 +6,7 @@ from typing_extensions import override
 
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.permissions import SentryPermission
+from sentry.api.permissions import SentryPermission, StaffPermissionMixin
 from sentry.auth.superuser import is_active_superuser
 from sentry.auth.system import is_system_auth
 from sentry.models.organization import OrganizationStatus
@@ -29,6 +29,15 @@ class UserPermission(SentryPermission):
         if is_active_superuser(request):
             return True
         return False
+
+
+class UserAndStaffPermission(StaffPermissionMixin, UserPermission):
+    """
+    Allows staff to access any endpoints this permission is used on. Note that
+    UserPermission already includes a check for Superuser
+    """
+
+    pass
 
 
 class OrganizationUserPermission(UserPermission):

--- a/tests/sentry/api/bases/test_user.py
+++ b/tests/sentry/api/bases/test_user.py
@@ -12,7 +12,7 @@ from sentry.api.bases.user import (
 )
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.auth.staff import is_active_staff
-from sentry.testutils.cases import DRFPermissionTestCase, TestCase
+from sentry.testutils.cases import DRFPermissionTestCase
 from sentry.testutils.silo import all_silo_test, control_silo_test, region_silo_test
 
 
@@ -71,7 +71,7 @@ class UserAndStaffPermissionTest(DRFPermissionTestCase):
         assert mock_is_active_staff.call_count == 1
 
 
-class BaseUserEndpointTest(TestCase):
+class BaseUserEndpointTest(DRFPermissionTestCase):
     endpoint: RegionSiloUserEndpoint | UserEndpoint = UserEndpoint()
 
     def test_retrieves_me_anonymous(self):

--- a/tests/sentry/api/bases/test_user.py
+++ b/tests/sentry/api/bases/test_user.py
@@ -71,7 +71,7 @@ class UserAndStaffPermissionTest(DRFPermissionTestCase):
         assert mock_is_active_staff.call_count == 1
 
 
-class BaseUserEndpointTest:
+class BaseUserEndpointTest(TestCase):
     endpoint: RegionSiloUserEndpoint | UserEndpoint = UserEndpoint()
 
     def test_retrieves_me_anonymous(self):
@@ -90,10 +90,10 @@ class BaseUserEndpointTest:
 
 
 @control_silo_test
-class UserEndpointTest(BaseUserEndpointTest, TestCase):
+class UserEndpointTest(BaseUserEndpointTest):
     endpoint = UserEndpoint()
 
 
 @region_silo_test
-class RegionSiloUserEndpointTest(BaseUserEndpointTest, TestCase):
+class RegionSiloUserEndpointTest(BaseUserEndpointTest):
     endpoint = RegionSiloUserEndpoint()

--- a/tests/sentry/api/bases/test_user.py
+++ b/tests/sentry/api/bases/test_user.py
@@ -1,44 +1,74 @@
 from __future__ import annotations
 
-import pytest
-from django.http import HttpRequest
-from rest_framework.request import Request
+from unittest.mock import patch
 
-from sentry.api.bases.user import RegionSiloUserEndpoint, UserEndpoint, UserPermission
+import pytest
+
+from sentry.api.bases.user import (
+    RegionSiloUserEndpoint,
+    UserAndStaffPermission,
+    UserEndpoint,
+    UserPermission,
+)
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.models.user import User
-from sentry.testutils.cases import TestCase
-from sentry.testutils.factories import Factories
+from sentry.auth.staff import is_active_staff
+from sentry.testutils.cases import DRFPermissionTestCase, TestCase
 from sentry.testutils.silo import all_silo_test, control_silo_test, region_silo_test
 
 
-def get_request(user: User | None = None) -> Request:
-    request = Request(HttpRequest())
-    request.method = "GET"
-    request.session = Factories.create_session()
-    if user is not None:
-        request.user = user
-    return request
+@all_silo_test
+class UserPermissionTest(DRFPermissionTestCase):
+    user_permission = UserPermission()
+
+    def setUp(self):
+        super().setUp()
+        self.normal_user = self.create_user()
+
+    def test_allows_none_user_as_anonymous(self):
+        assert self.user_permission.has_object_permission(self.make_request(), None, None)
+
+    def test_allows_current_user(self):
+        assert self.user_permission.has_object_permission(
+            self.make_request(self.normal_user), None, self.normal_user
+        )
+
+    def test_allows_active_superuser(self):
+        # The user passed in and the user on the request must be different to
+        # check superuser.
+        assert self.user_permission.has_object_permission(
+            self.superuser_request, None, self.normal_user
+        )
+
+    def test_rejects_active_staff(self):
+        # The user passed in and the user on the request must be different to
+        # check staff.
+        assert not self.user_permission.has_object_permission(
+            self.staff_request, None, self.normal_user
+        )
+
+    def test_rejects_user_as_anonymous(self):
+        assert not self.user_permission.has_object_permission(
+            self.make_request(), None, self.normal_user
+        )
+
+    def test_rejects_other_user(self):
+        other_user = self.create_user()
+        assert not self.user_permission.has_object_permission(
+            self.make_request(self.staff_user), None, other_user
+        )
 
 
 @all_silo_test
-class UserPermissionTest(TestCase):
-    user_permission = UserPermission()
-
-    def test_allows_none_user_as_anonymous(self):
-        assert self.user_permission.has_object_permission(get_request(), None, None)
-
-    def test_allows_current_user(self):
-        user = Factories.create_user()
-        assert self.user_permission.has_object_permission(get_request(user), None, user)
-
-    def test_rejects_user_as_anonymous(self):
-        user = Factories.create_user()
-        assert not self.user_permission.has_object_permission(get_request(), None, user)
-
-    def test_rejects_other_user(self):
-        user, other = Factories.create_user(), Factories.create_user()
-        assert not self.user_permission.has_object_permission(get_request(user), None, other)
+class UserAndStaffPermissionTest(DRFPermissionTestCase):
+    @patch("sentry.api.permissions.is_active_staff", wraps=is_active_staff)
+    def test_allows_active_staff(self, mock_is_active_staff):
+        # The user passed in and the user on the request must be different to
+        # check staff.
+        assert UserAndStaffPermission().has_object_permission(
+            self.staff_request, None, self.create_user()
+        )
+        # Ensure we failed the UserPermission check and check is_active_staff
+        assert mock_is_active_staff.call_count == 1
 
 
 class BaseUserEndpointTest:
@@ -46,16 +76,16 @@ class BaseUserEndpointTest:
 
     def test_retrieves_me_anonymous(self):
         with pytest.raises(ResourceDoesNotExist):
-            self.endpoint.convert_args(get_request(), user_id="me")
+            self.endpoint.convert_args(self.make_request(), user_id="me")
 
     def test_retrieves_me(self):
-        user = Factories.create_user()
-        args, kwargs = self.endpoint.convert_args(get_request(user), user_id="me")
+        user = self.create_user()
+        _, kwargs = self.endpoint.convert_args(self.make_request(user), user_id="me")
         assert kwargs["user"].id == user.id
 
     def test_retrieves_user_id(self):
-        user = Factories.create_user()
-        args, kwargs = self.endpoint.convert_args(get_request(user), user_id=user.id)
+        user = self.create_user()
+        _, kwargs = self.endpoint.convert_args(self.make_request(user), user_id=user.id)
         assert kwargs["user"].id == user.id
 
 

--- a/tests/sentry/api/test_permissions.py
+++ b/tests/sentry/api/test_permissions.py
@@ -1,42 +1,36 @@
-from rest_framework.request import Request
-
 from sentry.api.permissions import (
     StaffPermission,
     SuperuserOrStaffFeatureFlaggedPermission,
     SuperuserPermission,
 )
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import DRFPermissionTestCase
 from sentry.testutils.helpers import with_feature
 
 
-class PermissionsTest(TestCase):
-    def setUp(self):
-        self.superuser_request: Request = self.make_request(user=self.user, is_superuser=True)  # type: ignore
-        self.staff_request: Request = self.make_request(user=self.user, is_staff=True)  # type: ignore
+class PermissionsTest(DRFPermissionTestCase):
+    superuser_permission = SuperuserPermission()
+    staff_permission = StaffPermission()
+    superuser_staff_flagged_permission = SuperuserOrStaffFeatureFlaggedPermission()
 
     def test_superuser_permission(self):
-        assert SuperuserPermission().has_permission(self.superuser_request, None)
+        assert self.superuser_permission.has_permission(self.superuser_request, None)
 
     def test_staff_permission(self):
-        assert StaffPermission().has_permission(self.staff_request, None)
+        assert self.staff_permission.has_permission(self.staff_request, None)
 
     @with_feature("auth:enterprise-staff-cookie")
     def test_superuser_or_staff_feature_flagged_permission_active_flag(self):
         # With active superuser
-        assert not SuperuserOrStaffFeatureFlaggedPermission().has_permission(
+        assert not self.superuser_staff_flagged_permission.has_permission(
             self.superuser_request, None
         )
 
         # With active staff
-        assert SuperuserOrStaffFeatureFlaggedPermission().has_permission(self.staff_request, None)
+        assert self.superuser_staff_flagged_permission.has_permission(self.staff_request, None)
 
     def test_superuser_or_staff_feature_flagged_permission_inactive_flag(self):
         # With active staff
-        assert not SuperuserOrStaffFeatureFlaggedPermission().has_permission(
-            self.staff_request, None
-        )
+        assert not self.superuser_staff_flagged_permission.has_permission(self.staff_request, None)
 
         # With active superuser
-        assert SuperuserOrStaffFeatureFlaggedPermission().has_permission(
-            self.superuser_request, None
-        )
+        assert self.superuser_staff_flagged_permission.has_permission(self.superuser_request, None)


### PR DESCRIPTION
Create `UserAndStaffPermission` that lets admin access user endpoints.

User endpoints are quite confusing b/c there are endpoints that are:
1. Only used in frontend - I think these exist, but need to do more digging
2. Only used in admin - e.g. All user permission endpoints (the model, not the actual permission class) 
3. Used in both - e.g. removing authenticators
It seems like I will have individually identify them and assign the appropriate permission class.

Also refactored the permissions tests by creating a `DRFPermissionTestCase` that I can easily use for future permission class tests for diff resources