### PR TITLE
ref(open-pr-comment): squash issues with the same title and culprit

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -305,60 +305,93 @@ def get_top_5_issues_by_count_for_file(
 
     multi_if = language_parser.generate_multi_if(function_names)
 
+    # fetch the count of events for each group_id
+    subquery = (
+        Query(Entity("events"))
+        .set_select(
+            [
+                Column("title"),
+                Column("culprit"),
+                Column("group_id"),
+                Function("count", [], "event_count"),
+                Function(
+                    "multiIf",
+                    multi_if,
+                    "function_name",
+                ),
+            ]
+        )
+        .set_groupby(
+            [
+                Column("title"),
+                Column("culprit"),
+                Column("group_id"),
+                Column("exception_frames.function"),
+            ]
+        )
+        .set_where(
+            [
+                Condition(Column("project_id"), Op.IN, project_ids),
+                Condition(Column("group_id"), Op.IN, group_ids),
+                Condition(Column("timestamp"), Op.GTE, datetime.now() - timedelta(days=14)),
+                Condition(Column("timestamp"), Op.LT, datetime.now()),
+                # NOTE: ideally this would follow suspect commit logic
+                BooleanCondition(
+                    BooleanOp.OR,
+                    [
+                        BooleanCondition(
+                            BooleanOp.AND,
+                            [
+                                Condition(
+                                    Function(
+                                        "arrayElement",
+                                        (Column("exception_frames.filename"), i),
+                                    ),
+                                    Op.IN,
+                                    sentry_filenames,
+                                ),
+                                language_parser.generate_function_name_conditions(
+                                    function_names, i
+                                ),
+                            ],
+                        )
+                        for i in range(-STACKFRAME_COUNT, 0)  # first n frames
+                    ],
+                ),
+                Condition(Function("notHandled", []), Op.EQ, 1),
+            ]
+        )
+        .set_orderby([OrderBy(Column("event_count"), Direction.DESC)])
+    )
+
+    # filter on the subquery to squash group_ids with the same title and culprit
+    # return the group_id with the greatest count of events
     request = SnubaRequest(
         dataset=Dataset.Events.value,
         app_id="default",
         tenant_ids={"organization_id": projects[0].organization_id},
         query=(
-            Query(Entity("events"))
+            Query(subquery)
             .set_select(
                 [
-                    Column("group_id"),
-                    Function("count", [], "event_count"),
+                    Column("function_name"),
                     Function(
-                        "multiIf",
-                        multi_if,
-                        "function_name",
+                        "arrayElement",
+                        (Function("groupArray", [Column("group_id")]), 1),
+                        "group_id",
+                    ),
+                    Function(
+                        "arrayElement",
+                        (Function("groupArray", [Column("event_count")]), 1),
+                        "event_count",
                     ),
                 ]
             )
             .set_groupby(
                 [
-                    Column("group_id"),
-                    Column("exception_stacks.mechanism_handled"),
-                    Column("exception_frames.function"),
-                ]
-            )
-            .set_where(
-                [
-                    Condition(Column("project_id"), Op.IN, project_ids),
-                    Condition(Column("group_id"), Op.IN, group_ids),
-                    Condition(Column("timestamp"), Op.GTE, datetime.now() - timedelta(days=14)),
-                    Condition(Column("timestamp"), Op.LT, datetime.now()),
-                    # NOTE: ideally this would follow suspect commit logic
-                    BooleanCondition(
-                        BooleanOp.OR,
-                        [
-                            BooleanCondition(
-                                BooleanOp.AND,
-                                [
-                                    Condition(
-                                        Function(
-                                            "arrayElement",
-                                            (Column("exception_frames.filename"), i),
-                                        ),
-                                        Op.IN,
-                                        sentry_filenames,
-                                    ),
-                                    language_parser.generate_function_name_conditions(
-                                        function_names, i
-                                    ),
-                                ],
-                            )
-                            for i in range(-STACKFRAME_COUNT, 0)  # first n frames
-                        ],
-                    ),
-                    Condition(Function("notHandled", []), Op.EQ, 1),
+                    Column("title"),
+                    Column("culprit"),
+                    Column("function_name"),
                 ]
             )
             .set_orderby([OrderBy(Column("event_count"), Direction.DESC)])


### PR DESCRIPTION
There are some known grouping issues in Javascript, so before we LA we want to address the fact that we do not want to comment issues that have the same title + culprit multiple times.

For instance, [JAVASCRIPT-2QQ6](https://sentry.sentry.io/issues/4886784186/) and [JAVASCRIPT-2QYE](https://sentry.sentry.io/issues/4923114971/) have the same title ("TypeError: Cannot read properties of null (reading 'slug')") and culprit ("storeConfig.updateOrganization(app/stores/releaseStore)") but are listed as separate issues.

Without this PR, they would appear in an open PR comment like this, since they are two different issues:

| Function | Unhandled Issue |
| :------- | :----- |
| **`storeConfig.updateOrganization`** | [**TypeError: Cannot read properties of null (reading 'slug')**](https://sentry.sentry.io/issues/4886784186/) storeConfig.updateOrganization(app/stores/releaseStore) <br> `Event Count:` **15k** `Affected Users:` **41** |
| **`storeConfig.updateOrganization`** | [**TypeError: Cannot read properties of null (reading 'slug')**](https://sentry.sentry.io/issues/4923114971/) storeConfig.updateOrganization(app/stores/releaseStore) <br> `Event Count:` **5k** `Affected Users:` **0** |

In this PR, we squash issues with the same title and culprit and only return the issue with the greatest number of events. So the two issues above would become:

| Function | Unhandled Issue |
| :------- | :----- |
| **`storeConfig.updateOrganization`** | [**TypeError: Cannot read properties of null (reading 'slug')**](https://sentry.sentry.io/issues/4886784186/) storeConfig.updateOrganization(app/stores/releaseStore) <br> `Event Count:` **15k** `Affected Users:` **41** |

This is done by using the old query as a subquery and grouping issues with the same title + culprit as one issue, and selecting the `group_id` and `event_count` of duplicate issues with the greatest `event_count`.

Basic query outline
```
MATCH {
MATCH (events) SELECT group_id, project_id, count() AS `event_count`, arrayElement(exception_frames.function, -1) AS `function_name` BY title, culprit, group_id, project_id, exception_frames.function WHERE project_id IN array(project_id) AND timestamp >= toDateTime(start_time) AND timestamp < toDateTime(end_time) ORDER BY event_count DESC
}
SELECT function_name, arrayElement(groupArray(group_id), 1) AS group_id, arrayElement(groupArray(event_count),1) AS event_count BY title, culprit, function_name WHERE project_id IN array(project_id) ORDER BY event_count DESC LIMIT 5
```