### PR TITLE
feat(ddm): Escape tag glob patterns

### DIFF
--- a/tests/sentry/api/endpoints/test_project_metrics_visibility.py
+++ b/tests/sentry/api/endpoints/test_project_metrics_visibility.py
@@ -108,6 +108,22 @@ class ProjectMetricsVisibilityEndpointTestCase(APITestCase):
         assert response.data["blockedTags"] == []
         assert len(get_metrics_blocking_state([self.project])[self.project.id].metrics) == 0
 
+    def test_block_metric_tag_with_glob(self):
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            method="put",
+            operationType="blockTags",
+            metricMri="s:custom/user@none",
+            tags=["/*_project"],
+        )
+
+        assert response.status_code == 200
+        assert response.data["metricMri"] == "s:custom/user@none"
+        assert response.data["isBlocked"] is False
+        assert sorted(response.data["blockedTags"]) == ["/_project"]
+        assert len(get_metrics_blocking_state([self.project])[self.project.id].metrics) == 1
+
     @patch(
         "sentry.api.endpoints.project_metrics.ProjectMetricsVisibilityEndpoint.create_audit_entry"
     )


### PR DESCRIPTION
This PR escapes glob patterns in the form `*` from tags that are supplied to the blocking endpoint. This feature was requested by @jan-auer to protect Relay.

Closes: https://github.com/getsentry/sentry/issues/64157