### PR TITLE
feat(ddm): Return span id of the transaction

### DIFF
--- a/src/sentry/api/serializers/models/metrics_correlations.py
+++ b/src/sentry/api/serializers/models/metrics_correlations.py
@@ -43,6 +43,7 @@ class MetricCorrelationsSerializer(Serializer):
         return {
             "projectId": segment_payload.get("project_id"),
             "transactionId": segment_payload.get("segment_id"),
+            "transactionSpanId": segment_payload.get("segment_span_id"),
             "traceId": segment_payload.get("trace_id"),
             "profileId": segment_payload.get("profile_id"),
             "segmentName": segment_payload.get("segment_name"),

--- a/src/sentry/sentry_metrics/querying/metadata/metrics_correlations.py
+++ b/src/sentry/sentry_metrics/querying/metadata/metrics_correlations.py
@@ -109,6 +109,7 @@ class Segment:
     project_id: int
     trace_id: str
     segment_id: str
+    segment_span_id: str
     segment_name: str
     profile_id: Optional[str]
     spans_number: int
@@ -513,6 +514,12 @@ def _get_segments_aggregates_query(
                 [Column("span_id"), Function("equals", [Column("is_segment"), 0])],
                 alias="spans_number",
             ),
+            # Returns the span id of the transaction.
+            Function(
+                "anyIf",
+                [Column("span_id"), Function("equals", [Column("is_segment"), 1])],
+                alias="transaction_span_id",
+            ),
             # Returns the duration of the transaction.
             Function(
                 "sumIf",
@@ -621,6 +628,7 @@ def _get_segments(
             project_id=row["project_id"],
             # For now, we still use the old transaction_id.
             segment_id=row["transaction_id"],
+            segment_span_id=row["transaction_span_id"],
             trace_id=row["trace_id"],
             profile_id=row["profile_id"],
             segment_name=row["segment_name"],

--- a/tests/sentry/api/endpoints/test_organization_ddm_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_ddm_meta.py
@@ -338,11 +338,13 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
         transaction_id = uuid.uuid4().hex
         trace_id = uuid.uuid4().hex
 
+        segment_span_id = "56230207e8e4a6ab"
         self.store_segment(
             project_id=self.project.id,
             timestamp=before_now(minutes=5),
             trace_id=trace_id,
             transaction_id=transaction_id,
+            span_id=segment_span_id,
             duration=30,
         )
         span_id_1 = "98230207e6e4a6ad"
@@ -387,6 +389,7 @@ class OrganizationDDMEndpointTest(APITestCase, BaseSpansTestCase):
         metric_spans = response.data["metricSpans"]
         assert len(metric_spans) == 1
         assert metric_spans[0]["transactionId"] == transaction_id
+        assert metric_spans[0]["transactionSpanId"] == segment_span_id
         assert metric_spans[0]["duration"] == 30
         assert metric_spans[0]["spansNumber"] == 3
         assert sorted(metric_spans[0]["metricSummaries"], key=lambda value: value["min"]) == [


### PR DESCRIPTION
This PR returns an additional field, named `transactionSpanId` which contains the id of the span that is also a transaction.