### PR TITLE
ref: Remove `transaction_start` from MSTeams integration

### DIFF
--- a/src/sentry/integrations/msteams/link_identity.py
+++ b/src/sentry/integrations/msteams/link_identity.py
@@ -10,7 +10,6 @@ from sentry.models.identity import Identity
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
-from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView, control_silo_view
 from sentry.web.helpers import render_to_response
 
@@ -34,7 +33,6 @@ def build_linking_url(integration, organization, teams_user_id, team_id, tenant_
 
 @control_silo_view
 class MsTeamsLinkIdentityView(BaseView):
-    @transaction_start("MsTeamsLinkIdentityView")
     @method_decorator(never_cache)
     def handle(self, request: Request, signed_params) -> HttpResponse:
         try:

--- a/src/sentry/integrations/msteams/unlink_identity.py
+++ b/src/sentry/integrations/msteams/unlink_identity.py
@@ -1,9 +1,8 @@
 from django.core.signing import BadSignature, SignatureExpired
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
-from rest_framework.request import Request
 
 from sentry.models.identity import Identity
 from sentry.utils.http import absolute_uri
@@ -32,7 +31,7 @@ def build_unlinking_url(conversation_id, service_url, teams_user_id):
 @control_silo_view
 class MsTeamsUnlinkIdentityView(BaseView):
     @method_decorator(never_cache)
-    def handle(self, request: Request, signed_params) -> HttpResponse:
+    def handle(self, request: HttpRequest, signed_params) -> HttpResponse:
         try:
             params = unsign(signed_params)
         except (SignatureExpired, BadSignature):

--- a/src/sentry/integrations/msteams/unlink_identity.py
+++ b/src/sentry/integrations/msteams/unlink_identity.py
@@ -8,7 +8,6 @@ from rest_framework.request import Request
 from sentry.models.identity import Identity
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
-from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView, control_silo_view
 from sentry.web.helpers import render_to_response
 
@@ -32,7 +31,6 @@ def build_unlinking_url(conversation_id, service_url, teams_user_id):
 
 @control_silo_view
 class MsTeamsUnlinkIdentityView(BaseView):
-    @transaction_start("MsTeamsUnlinkIdentityView")
     @method_decorator(never_cache)
     def handle(self, request: Request, signed_params) -> HttpResponse:
         try:

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -26,7 +26,6 @@ from sentry.silo import SiloMode
 from sentry.utils import json, jwt
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.signing import sign
-from sentry.web.decorators import transaction_start
 
 from .card_builder.block import AdaptiveCard
 from .card_builder.help import (
@@ -199,7 +198,6 @@ class MsTeamsWebhookEndpoint(Endpoint, MsTeamsWebhookMixin):
     def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         return super().dispatch(request, *args, **kwargs)
 
-    @transaction_start("MsTeamsWebhookEndpoint")
     def post(self, request: HttpRequest) -> HttpResponse:
         # verify_signature will raise the exception corresponding to the error
         self.verify_webhook_request(request)


### PR DESCRIPTION
Using `transaction_start` in the MSTeams integration routes is unnecessary and causes undefined behavior. All the routes in this integration are already automatically instrumented by the Django integration, and the auto-instrumented transactions can be viewed [here](https://sentry.sentry.io/performance/?isDefaultQuery=false&metricSearchSetting=metricsOnly&project=1&query=%2Fextensions%2Fmsteams%2F%2A&statsPeriod=24h).

ref #63951