### PR TITLE
chore(hybridcloud) Handle ConnectionError when retries fail

### DIFF
--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -599,9 +599,11 @@ class _RemoteSiloCall:
             headers["Baggage"] = baggage
         try:
             return http.post(url, headers=headers, data=data, timeout=settings.RPC_TIMEOUT)
-        except requests.ConnectionError as e:
+        except requests.exceptions.ConnectionError as e:
             raise self._remote_exception("RPC Connection failed") from e
-        except requests.Timeout as e:
+        except requests.exceptions.RetryError as e:
+            raise self._remote_exception("RPC failed, max retries reached.") from e
+        except requests.exceptions.Timeout as e:
             raise self._remote_exception(f"Timeout of {settings.RPC_TIMEOUT} exceeded") from e
 
 

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -599,6 +599,8 @@ class _RemoteSiloCall:
             headers["Baggage"] = baggage
         try:
             return http.post(url, headers=headers, data=data, timeout=settings.RPC_TIMEOUT)
+        except requests.ConnectionError as e:
+            raise self._remote_exception("RPC Connection failed") from e
         except requests.Timeout as e:
             raise self._remote_exception(f"Timeout of {settings.RPC_TIMEOUT} exceeded") from e
 


### PR DESCRIPTION
Handle ConnectionError from requests when retries fail. Converting to a RpcRemoteException will give us better grouping than ConnectionError would.
