### PR TITLE
ref: Remove `transaction_start` from Slack integration

### DIFF
--- a/src/sentry/integrations/slack/views/link_identity.py
+++ b/src/sentry/integrations/slack/views/link_identity.py
@@ -10,7 +10,6 @@ from sentry.notifications.notificationcontroller import NotificationController
 from sentry.notifications.notifications.integration_nudge import IntegrationNudgeNotification
 from sentry.types.integrations import ExternalProviderEnum, ExternalProviders
 from sentry.utils.signing import unsign
-from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView, control_silo_view
 from sentry.web.helpers import render_to_response
 
@@ -41,7 +40,6 @@ class SlackLinkIdentityView(BaseView):
     Django view for linking user to slack account. Creates an entry on Identity table.
     """
 
-    @transaction_start("SlackLinkIdentityView")
     @method_decorator(never_cache)
     def handle(self, request: Request, signed_params: str) -> HttpResponse:
         try:

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -20,7 +20,6 @@ from sentry.services.hybrid_cloud.integration import RpcIntegration, integration
 from sentry.services.hybrid_cloud.notifications import notifications_service
 from sentry.types.integrations import ExternalProviderEnum, ExternalProviders
 from sentry.utils.signing import unsign
-from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView, region_silo_view
 from sentry.web.helpers import render_to_response
 
@@ -69,7 +68,6 @@ class SlackLinkTeamView(BaseView):
     Django view for linking team to slack channel. Creates an entry on ExternalActor table.
     """
 
-    @transaction_start("SlackLinkTeamView")
     @method_decorator(never_cache)
     def handle(self, request: Request, signed_params: str) -> HttpResponseBase:
         if request.method not in ALLOWED_METHODS:

--- a/src/sentry/integrations/slack/views/unlink_identity.py
+++ b/src/sentry/integrations/slack/views/unlink_identity.py
@@ -8,7 +8,6 @@ from sentry.integrations.utils import get_identity_or_404
 from sentry.models.identity import Identity
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.signing import unsign
-from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView, control_silo_view
 from sentry.web.helpers import render_to_response
 
@@ -37,7 +36,6 @@ class SlackUnlinkIdentityView(BaseView):
     Django view for unlinking user from slack account. Deletes from Identity table.
     """
 
-    @transaction_start("SlackUnlinkIdentityView")
     @method_decorator(never_cache)
     def handle(self, request: Request, signed_params: str) -> HttpResponse:
         try:

--- a/src/sentry/integrations/slack/views/unlink_identity.py
+++ b/src/sentry/integrations/slack/views/unlink_identity.py
@@ -1,8 +1,7 @@
 from django.core.signing import BadSignature, SignatureExpired
 from django.db import IntegrityError
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpRequest, HttpResponse
 from django.utils.decorators import method_decorator
-from rest_framework.request import Request
 
 from sentry.integrations.utils import get_identity_or_404
 from sentry.models.identity import Identity
@@ -37,7 +36,7 @@ class SlackUnlinkIdentityView(BaseView):
     """
 
     @method_decorator(never_cache)
-    def handle(self, request: Request, signed_params: str) -> HttpResponse:
+    def handle(self, request: HttpRequest, signed_params: str) -> HttpResponse:
         try:
             params = unsign(signed_params)
         except (SignatureExpired, BadSignature):

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -12,7 +12,6 @@ from sentry.services.hybrid_cloud.identity import identity_service
 from sentry.services.hybrid_cloud.integration import integration_service
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils.signing import unsign
-from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView, region_silo_view
 from sentry.web.helpers import render_to_response
 
@@ -52,7 +51,6 @@ class SlackUnlinkTeamView(BaseView):
     Django view for unlinking team from slack channel. Deletes from ExternalActor table.
     """
 
-    @transaction_start("SlackUnlinkIdentityView")
     @method_decorator(never_cache)
     def handle(self, request: Request, signed_params: str) -> HttpResponse:
         if request.method not in ALLOWED_METHODS:

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -38,7 +38,6 @@ from sentry.services.hybrid_cloud.user import RpcUser
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.types.integrations import ExternalProviderEnum
 from sentry.utils import json
-from sentry.web.decorators import transaction_start
 
 from ..utils import logger
 
@@ -732,7 +731,6 @@ class SlackActionEndpoint(Endpoint):
             if "name" in action_data
         ]
 
-    @transaction_start("SlackActionEndpoint")
     def post(self, request: Request) -> Response:
         try:
             slack_request = self.slack_request_class(request)

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -22,7 +22,6 @@ from sentry.services.hybrid_cloud.organization import organization_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import json
 from sentry.utils.urls import parse_link
-from sentry.web.decorators import transaction_start
 
 from ..utils import logger
 from .base import SlackDMEndpoint
@@ -202,7 +201,6 @@ class SlackEventEndpoint(SlackDMEndpoint):
         return True
 
     # TODO(dcramer): implement app_uninstalled and tokens_revoked
-    @transaction_start("SlackEventEndpoint")
     def post(self, request: Request) -> Response:
         try:
             slack_request = self.slack_request_class(request)

--- a/src/sentry/integrations/slack/webhooks/options_load.py
+++ b/src/sentry/integrations/slack/webhooks/options_load.py
@@ -16,7 +16,6 @@ from sentry.integrations.slack.requests.base import SlackRequestError
 from sentry.integrations.slack.requests.options_load import SlackOptionsLoadRequest
 from sentry.models.group import Group
 from sentry.utils import json
-from sentry.web.decorators import transaction_start
 
 from ..utils import logger
 
@@ -78,7 +77,6 @@ class SlackOptionsLoadEndpoint(Endpoint):
         return option_groups
 
     # XXX(isabella): atm this endpoint is used only for the assignment dropdown on issue alerts
-    @transaction_start("SlackOptionsLoadEndpoint")
     def post(self, request: Request) -> Response:
         try:
             slack_request = self.slack_request_class(request)


### PR DESCRIPTION
The `transaction_start` decorator is unnecessary here, and it causes undefined behavior, since all of the functions it is decorating are endpoints which are auto-instrumented by the Django integration. The auto-instrumented transactions can all be viewed [here](https://sentry.sentry.io/performance/?isDefaultQuery=false&metricSearchSetting=metricsOnly&project=1&query=%2Fextensions%2Fslack&statsPeriod=14d).

ref #63951