### PR TITLE
ref: Remove `transaction_start` from Pipeline Advancer

### DIFF
--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -8,7 +8,6 @@ from sentry.api.utils import generate_organization_url
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.utils.http import absolute_uri, create_redirect_url
-from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
 
 # The request doesn't contain the pipeline type (pipeline information is stored
@@ -33,7 +32,6 @@ class PipelineAdvancerView(BaseView):
 
     csrf_protect = False
 
-    @transaction_start("PipelineAdvancerView")
     def handle(self, request: Request, provider_id: str) -> HttpResponseBase:
         pipeline = None
 


### PR DESCRIPTION
Using `transaction_start` is unnecessary here, since this is a route handler already auto-instrumented by the Django integration. The auto-instrumented transactions can be viewed [here](https://sentry.sentry.io/performance/?isDefaultQuery=false&metricSearchSetting=metricsOnly&project=1&query=transaction%3A%22%2Fextensions%2F%7Bprovider_id%7D%2Fsetup%2F%22&statsPeriod=1h).

ref #63951

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
