### PR TITLE
fix(webvitals): Update web vitals ring and chart to be more responsive

### DIFF
--- a/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
+++ b/static/app/views/performance/browser/webVitals/components/performanceScoreBreakdownChart.tsx
@@ -300,6 +300,7 @@ const ChartContainer = styled('div')`
   border: 1px solid ${p => p.theme.gray200};
   border-radius: ${p => p.theme.borderRadius};
   position: relative;
+  min-width: 320px;
 `;
 
 const PerformanceScoreLabel = styled('div')`

--- a/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
+++ b/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
@@ -92,7 +92,7 @@ export function PerformanceScoreChart({
             projectScore={projectScore}
             text={score}
             width={220}
-            height={190}
+            height={200}
             ringBackgroundColors={ringBackgroundColors}
             ringSegmentColors={ringSegmentColors}
             weights={weights}
@@ -116,6 +116,7 @@ const Flex = styled('div')`
   width: 100%;
   gap: ${space(1)};
   margin-top: ${space(1)};
+  flex-wrap: wrap;
 `;
 
 const PerformanceScoreLabelContainer = styled('div')`
@@ -139,7 +140,6 @@ const PerformanceScoreSubtext = styled('div')`
   width: 100%;
   font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.gray300};
-  margin-bottom: ${space(1)};
 `;
 
 const StyledQuestionTooltip = styled(QuestionTooltip)`

--- a/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
+++ b/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
@@ -127,6 +127,9 @@ const PerformanceScoreLabelContainer = styled('div')`
   display: flex;
   align-items: center;
   flex-direction: column;
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
+    flex-grow: 1;
+  }
 `;
 
 const PerformanceScoreLabel = styled('div')`
@@ -134,6 +137,7 @@ const PerformanceScoreLabel = styled('div')`
   font-size: ${p => p.theme.fontSizeLarge};
   color: ${p => p.theme.textColor};
   font-weight: bold;
+  margin-bottom: ${space(1)};
 `;
 
 const PerformanceScoreSubtext = styled('div')`

--- a/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
+++ b/static/app/views/performance/browser/webVitals/performanceScoreChart.tsx
@@ -137,13 +137,13 @@ const PerformanceScoreLabel = styled('div')`
   font-size: ${p => p.theme.fontSizeLarge};
   color: ${p => p.theme.textColor};
   font-weight: bold;
-  margin-bottom: ${space(1)};
 `;
 
 const PerformanceScoreSubtext = styled('div')`
   width: 100%;
   font-size: ${p => p.theme.fontSizeSmall};
   color: ${p => p.theme.gray300};
+  margin-bottom: ${space(1)};
 `;
 
 const StyledQuestionTooltip = styled(QuestionTooltip)`


### PR DESCRIPTION
Update performance score ring and breakdown charts to wrap on mobile screen sizes.
Also adds a bit more height to the performance score ring to prevent potential label overflowing issue.