### PR TITLE
chore(replay/issues): make show details button style consistent for replay section

### DIFF
--- a/static/app/components/events/eventReplay/replayInlineOnboardingPanelBackend.tsx
+++ b/static/app/components/events/eventReplay/replayInlineOnboardingPanelBackend.tsx
@@ -34,9 +34,9 @@ export default function ReplayInlineOnboardingPanelBackend({
   return (
     <EventReplaySection
       actions={
-        <Button borderless onClick={() => setIsHidden(!isHidden)}>
+        <ToggleButton priority="link" onClick={() => setIsHidden(!isHidden)}>
           {isHidden ? t('Show Details') : t('Hide Details')}
-        </Button>
+        </ToggleButton>
       }
     >
       {isHidden ? null : (
@@ -71,4 +71,13 @@ export default function ReplayInlineOnboardingPanelBackend({
 const PurpleText = styled('span')`
   color: ${p => p.theme.purple300};
   font-weight: bold;
+`;
+
+const ToggleButton = styled(Button)`
+  font-weight: 700;
+  color: ${p => p.theme.subText};
+  &:hover,
+  &:focus {
+    color: ${p => p.theme.textColor};
+  }
 `;


### PR DESCRIPTION
- make the replay CTA show/hide details button style consistent with the rest of the issue details page
- tbh this should just be a component because it's copy pasted a lot throughout issues

https://github.com/getsentry/sentry/assets/56095982/ee7b7255-c507-4f44-9b3d-00c5384f4e62

