### PR TITLE
fix(assignee-selector): improve el detection

### DIFF
--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -600,7 +600,7 @@ function isINPEntity(entry: PerformanceEntry): entry is INPPerformanceEntry {
   return entry.entryType === 'first-input';
 }
 
-function getNearestElementName(node: HTMLElement | undefined): string | undefined {
+function getNearestElementName(node: HTMLElement | undefined | null): string | undefined {
   if (!node) {
     return 'no-element';
   }

--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -602,22 +602,25 @@ function isINPEntity(entry: PerformanceEntry): entry is INPPerformanceEntry {
 
 function getNearestElementName(node: HTMLElement | undefined): string | undefined {
   if (!node) {
-    return 'unknown';
+    return 'no-element';
   }
 
   let current: HTMLElement | null = node;
   while (current && current !== document.body) {
     const elementName =
-      current.dataset?.testId ?? current.dataset?.component ?? current.dataset?.element;
+      current.dataset?.testId ??
+      current.dataset?.component ??
+      current.dataset?.element ??
+      current.id;
 
-    if (elementName !== undefined) {
+    if (elementName) {
       return elementName;
     }
 
     current = current.parentElement;
   }
 
-  return 'unknown';
+  return `${node.tagName.toLowerCase()}.${node.className ?? ''}`;
 }
 
 export function makeIssuesINPObserver(): PerformanceObserver | undefined {
@@ -636,10 +639,12 @@ export function makeIssuesINPObserver(): PerformanceObserver | undefined {
         if (entry.duration < 16) {
           return;
         }
+
+        const el = getNearestElementName(entry.target);
         Sentry.metrics.distribution('issues-stream.inp', entry.duration, {
           unit: 'millisecond',
           tags: {
-            element: getNearestElementName(entry.target),
+            element: el,
             entryType: entry.entryType,
             interaction: entry.name,
           },

--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -608,10 +608,7 @@ function getNearestElementName(node: HTMLElement | undefined): string | undefine
   let current: HTMLElement | null = node;
   while (current && current !== document.body) {
     const elementName =
-      current.dataset?.testId ??
-      current.dataset?.component ??
-      current.dataset?.element ??
-      current.id;
+      current.dataset?.testId ?? current.dataset?.component ?? current.dataset?.element;
 
     if (elementName) {
       return elementName;
@@ -640,11 +637,10 @@ export function makeIssuesINPObserver(): PerformanceObserver | undefined {
           return;
         }
 
-        const el = getNearestElementName(entry.target);
         Sentry.metrics.distribution('issues-stream.inp', entry.duration, {
           unit: 'millisecond',
           tags: {
-            element: el,
+            element: getNearestElementName(entry.target),
             entryType: entry.entryType,
             interaction: entry.name,
           },


### PR DESCRIPTION
We have a lot of `element: unknown` metrics which I cannot attribute to anywhere. This differentiates the case where we have no el target vs failing to infer nearest name by providing a tagname + classname fallback