### PR TITLE
feat(issue-priority): Set a default priority for each group type

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2394,9 +2394,6 @@ def _send_occurrence_to_platform(jobs: Sequence[Job], projects: ProjectsMapping)
 
         performance_problems = job["performance_problems"]
         for problem in performance_problems:
-            priority = get_default_priority_for_group_type(
-                group_type=problem.type, level=job["level"]
-            )
             occurrence = IssueOccurrence(
                 id=uuid.uuid4().hex,
                 resource_id=None,
@@ -2411,7 +2408,7 @@ def _send_occurrence_to_platform(jobs: Sequence[Job], projects: ProjectsMapping)
                 evidence_display=problem.evidence_display,
                 detection_time=event.datetime,
                 level=job["level"],
-                initial_issue_priority=priority,
+                initial_issue_priority=problem.type.default_priority,
             )
 
             produce_occurrence_to_kafka(payload_type=PayloadType.OCCURRENCE, occurrence=occurrence)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -66,7 +66,6 @@ from sentry.grouping.result import CalculatedHashes
 from sentry.ingest.inbound_filters import FilterStatKeys
 from sentry.issues.grouptype import GroupCategory
 from sentry.issues.issue_occurrence import IssueOccurrence
-from sentry.issues.priority import PriorityLevel, get_default_priority_for_group_type
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.killswitches import killswitch_matches_context
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL, convert_crashreport_count
@@ -109,7 +108,7 @@ from sentry.tasks.process_buffer import buffer_incr
 from sentry.tasks.relay import schedule_invalidate_project_config
 from sentry.tsdb.base import TSDBModel
 from sentry.types.activity import ActivityType
-from sentry.types.group import GroupSubStatus
+from sentry.types.group import GroupSubStatus, PriorityLevel
 from sentry.usage_accountant import record
 from sentry.utils import json, metrics
 from sentry.utils.cache import cache_key_for_event

--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -12,7 +12,6 @@ from sentry.eventstore.models import Event
 from sentry.issues.grouptype import FeedbackGroup
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.json_schemas import EVENT_PAYLOAD_SCHEMA, LEGACY_EVENT_PAYLOAD_SCHEMA
-from sentry.issues.priority import get_default_priority_for_group_type
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.models.project import Project
 from sentry.signals import first_feedback_received, first_new_feedback_received
@@ -135,7 +134,6 @@ def create_feedback_issue(event, project_id, source: FeedbackCreationSource):
     event["event_id"] = event.get("event_id") or uuid4().hex
     evidence_data, evidence_display = make_evidence(event["contexts"]["feedback"], source)
     level = event.get("level", "info")
-    priority = get_default_priority_for_group_type(group_type=FeedbackGroup, level=level)
     occurrence = IssueOccurrence(
         id=uuid4().hex,
         event_id=event.get("event_id") or uuid4().hex,
@@ -152,7 +150,7 @@ def create_feedback_issue(event, project_id, source: FeedbackCreationSource):
         detection_time=ensure_aware(datetime.fromtimestamp(event["timestamp"])),
         culprit="user",  # TODO: fill in culprit correctly -- URL or paramaterized route/tx name?
         level=level,
-        initial_issue_priority=priority,
+        initial_issue_priority=FeedbackGroup.default_priority,
     )
     now = datetime.now()
 

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -12,6 +12,7 @@ from sentry import features
 from sentry.features.base import OrganizationFeature
 from sentry.ratelimits.sliding_windows import Quota
 from sentry.utils import metrics
+from sentry.types.group import PriorityLevel
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
@@ -116,6 +117,7 @@ class GroupType:
     description: str
     category: int
     noise_config: Optional[NoiseConfig] = None
+    default_priority: int = PriorityLevel.MEDIUM
     # If True this group type should be released everywhere. If False, fall back to features to
     # decide if this is released.
     released: bool = False
@@ -217,6 +219,7 @@ class ErrorGroupType(GroupType):
     slug = "error"
     description = "Error"
     category = GroupCategory.ERROR.value
+    default_priority = PriorityLevel.MEDIUM
     released = True
 
 
@@ -232,6 +235,7 @@ class PerformanceSlowDBQueryGroupType(PerformanceGroupTypeDefaults, GroupType):
     description = "Slow DB Query"
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=100)
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -241,6 +245,7 @@ class PerformanceRenderBlockingAssetSpanGroupType(PerformanceGroupTypeDefaults, 
     slug = "performance_render_blocking_asset_span"
     description = "Large Render Blocking Asset"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -250,6 +255,7 @@ class PerformanceNPlusOneGroupType(PerformanceGroupTypeDefaults, GroupType):
     slug = "performance_n_plus_one_db_queries"
     description = "N+1 Query"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -260,6 +266,7 @@ class PerformanceConsecutiveDBQueriesGroupType(PerformanceGroupTypeDefaults, Gro
     description = "Consecutive DB Queries"
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=15)
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -269,6 +276,7 @@ class PerformanceFileIOMainThreadGroupType(PerformanceGroupTypeDefaults, GroupTy
     slug = "performance_file_io_main_thread"
     description = "File IO on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -279,6 +287,7 @@ class PerformanceConsecutiveHTTPQueriesGroupType(PerformanceGroupTypeDefaults, G
     description = "Consecutive HTTP"
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=5)
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -288,6 +297,7 @@ class PerformanceNPlusOneAPICallsGroupType(GroupType):
     slug = "performance_n_plus_one_api_calls"
     description = "N+1 API Call"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -297,6 +307,7 @@ class PerformanceMNPlusOneDBQueriesGroupType(PerformanceGroupTypeDefaults, Group
     slug = "performance_m_n_plus_one_db_queries"
     description = "MN+1 Query"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -307,6 +318,7 @@ class PerformanceUncompressedAssetsGroupType(PerformanceGroupTypeDefaults, Group
     description = "Uncompressed Asset"
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=100)
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -316,6 +328,7 @@ class PerformanceDBMainThreadGroupType(PerformanceGroupTypeDefaults, GroupType):
     slug = "performance_db_main_thread"
     description = "DB on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -325,6 +338,7 @@ class PerformanceLargeHTTPPayloadGroupType(PerformanceGroupTypeDefaults, GroupTy
     slug = "performance_large_http_payload"
     description = "Large HTTP payload"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
     released = True
 
 
@@ -335,6 +349,7 @@ class PerformanceHTTPOverheadGroupType(PerformanceGroupTypeDefaults, GroupType):
     description = "HTTP/1.1 Overhead"
     noise_config = NoiseConfig(ignore_limit=20)
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 # experimental
@@ -346,6 +361,7 @@ class PerformanceDurationRegressionGroupType(GroupType):
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
     enable_escalation_detection = False
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -356,6 +372,7 @@ class PerformanceP95EndpointRegressionGroupType(GroupType):
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
     enable_escalation_detection = False
+    default_priority = PriorityLevel.MEDIUM
     released = True
 
 
@@ -366,6 +383,7 @@ class ProfileFileIOGroupType(GroupType):
     slug = "profile_file_io_main_thread"
     description = "File I/O on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -374,6 +392,7 @@ class ProfileImageDecodeGroupType(GroupType):
     slug = "profile_image_decode_main_thread"
     description = "Image Decoding on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -382,6 +401,7 @@ class ProfileJSONDecodeType(GroupType):
     slug = "profile_json_decode_main_thread"
     description = "JSON Decoding on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -390,6 +410,7 @@ class ProfileCoreDataExperimentalType(GroupType):
     slug = "profile_core_data_main_exp"
     description = "Core Data on Main Thread"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 # 2005 was ProfileRegexExperimentalType
@@ -401,6 +422,7 @@ class ProfileViewIsSlowExperimentalType(GroupType):
     slug = "profile_view_is_slow_experimental"
     description = "View Render/Layout/Update is slow"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -410,6 +432,7 @@ class ProfileRegexType(GroupType):
     description = "Regex on Main Thread"
     category = GroupCategory.PERFORMANCE.value
     released = True
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -418,6 +441,7 @@ class ProfileFrameDropExperimentalType(GroupType):
     slug = "profile_frame_drop_experimental"
     description = "Frame Drop"
     category = GroupCategory.PERFORMANCE.value
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -428,6 +452,7 @@ class ProfileFrameDropType(GroupType):
     category = GroupCategory.PERFORMANCE.value
     noise_config = NoiseConfig(ignore_limit=2000)
     released = True
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -437,6 +462,7 @@ class ProfileFunctionRegressionExperimentalType(GroupType):
     description = "Function Duration Regression (Experimental)"
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
+    default_priority = PriorityLevel.LOW
 
 
 @dataclass(frozen=True)
@@ -447,6 +473,7 @@ class ProfileFunctionRegressionType(GroupType):
     category = GroupCategory.PERFORMANCE.value
     enable_auto_resolve = False
     released = True
+    default_priority = PriorityLevel.MEDIUM
 
 
 @dataclass(frozen=True)
@@ -457,6 +484,7 @@ class MonitorCheckInFailure(GroupType):
     category = GroupCategory.CRON.value
     released = True
     creation_quota = Quota(3600, 60, 60_000)  # 60,000 per hour, sliding window of 60 seconds
+    default_priority = PriorityLevel.HIGH
 
 
 @dataclass(frozen=True)
@@ -467,6 +495,7 @@ class MonitorCheckInTimeout(GroupType):
     category = GroupCategory.CRON.value
     released = True
     creation_quota = Quota(3600, 60, 60_000)  # 60,000 per hour, sliding window of 60 seconds
+    default_priority = PriorityLevel.HIGH
 
 
 @dataclass(frozen=True)
@@ -477,6 +506,7 @@ class MonitorCheckInMissed(GroupType):
     category = GroupCategory.CRON.value
     released = True
     creation_quota = Quota(3600, 60, 60_000)  # 60,000 per hour, sliding window of 60 seconds
+    default_priority = PriorityLevel.HIGH
 
 
 @dataclass(frozen=True)
@@ -486,6 +516,7 @@ class ReplayDeadClickType(GroupType):
     slug = "replay_click_dead"
     description = "Dead Click Detected"
     category = GroupCategory.REPLAY.value
+    default_priority = PriorityLevel.MEDIUM
 
 
 @dataclass(frozen=True)
@@ -494,6 +525,7 @@ class ReplayRageClickType(GroupType):
     slug = "replay_click_rage"
     description = "Rage Click Detected"
     category = GroupCategory.REPLAY.value
+    default_priority = PriorityLevel.MEDIUM
 
 
 @dataclass(frozen=True)
@@ -503,6 +535,7 @@ class FeedbackGroup(GroupType):
     description = "Feedback"
     category = GroupCategory.FEEDBACK.value
     creation_quota = Quota(3600, 60, 1000)  # 1000 per hour, sliding window of 60 seconds
+    default_priority = PriorityLevel.MEDIUM
 
 
 @metrics.wraps("noise_reduction.should_create_group", sample_rate=1.0)

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -11,8 +11,8 @@ import sentry_sdk
 from sentry import features
 from sentry.features.base import OrganizationFeature
 from sentry.ratelimits.sliding_windows import Quota
-from sentry.utils import metrics
 from sentry.types.group import PriorityLevel
+from sentry.utils import metrics
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -114,7 +114,6 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                 "type": payload["type"],
                 "detection_time": payload["detection_time"],
                 "level": payload.get("level", DEFAULT_LEVEL),
-                "initial_issue_priority": payload.get("initial_issue_priority"),
             }
 
             process_occurrence_data(occurrence_data)
@@ -124,6 +123,12 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
 
             if payload.get("culprit"):
                 occurrence_data["culprit"] = payload["culprit"]
+
+            if payload.get("initial_issue_priority"):
+                occurrence_data["initial_issue_priority"] = payload["initial_issue_priority"]
+            else:
+                group_type = get_group_type_by_type_id(occurrence_data["type"])
+                occurrence_data["initial_issue_priority"] = group_type.default_priority
 
             if "event" in payload:
                 event_payload = payload["event"]

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -13,7 +13,6 @@ from sentry.issues.grouptype import (
     MonitorCheckInMissed,
     MonitorCheckInTimeout,
 )
-from sentry.issues.priority import get_default_priority_for_group_type
 from sentry.models.organization import Organization
 from sentry.monitors.constants import SUBTITLE_DATETIME_FORMAT, TIMEOUT
 from sentry.monitors.models import (
@@ -274,9 +273,6 @@ def create_issue_platform_occurrence(
     if last_successful_checkin:
         last_successful_checkin_timestamp = last_successful_checkin.date_added.isoformat()
 
-    priority = get_default_priority_for_group_type(
-        group_type=occurrence_data["group_type"], level=occurrence_data["level"]
-    )
     occurrence = IssueOccurrence(
         id=uuid.uuid4().hex,
         resource_id=None,
@@ -305,7 +301,7 @@ def create_issue_platform_occurrence(
         culprit=occurrence_data["reason"],
         detection_time=current_timestamp,
         level=occurrence_data["level"],
-        initial_issue_priority=priority,
+        initial_issue_priority=occurrence_data["group_type"].default_priority,
     )
 
     if failed_checkin.trace_id:

--- a/src/sentry/monitors/logic/mark_failed.py
+++ b/src/sentry/monitors/logic/mark_failed.py
@@ -13,6 +13,7 @@ from sentry.issues.grouptype import (
     MonitorCheckInMissed,
     MonitorCheckInTimeout,
 )
+from sentry.issues.priority import get_default_priority_for_group_type
 from sentry.models.organization import Organization
 from sentry.monitors.constants import SUBTITLE_DATETIME_FORMAT, TIMEOUT
 from sentry.monitors.models import (
@@ -273,6 +274,9 @@ def create_issue_platform_occurrence(
     if last_successful_checkin:
         last_successful_checkin_timestamp = last_successful_checkin.date_added.isoformat()
 
+    priority = get_default_priority_for_group_type(
+        group_type=occurrence_data["group_type"], level=occurrence_data["level"]
+    )
     occurrence = IssueOccurrence(
         id=uuid.uuid4().hex,
         resource_id=None,
@@ -301,6 +305,7 @@ def create_issue_platform_occurrence(
         culprit=occurrence_data["reason"],
         detection_time=current_timestamp,
         level=occurrence_data["level"],
+        initial_issue_priority=priority,
     )
 
     if failed_checkin.trace_id:

--- a/src/sentry/replays/usecases/issue.py
+++ b/src/sentry/replays/usecases/issue.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Sequence, Type
 
 from sentry.issues.grouptype import GroupType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
+from sentry.issues.priority import get_default_priority_for_group_type
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 
 
@@ -26,6 +27,7 @@ def new_issue_occurrence(
     event_id = uuid.uuid4().hex
     extra_event_data["event_id"] = event_id
 
+    priority = get_default_priority_for_group_type(group_type=issue_type, level=level)
     occurrence = IssueOccurrence(
         id=uuid.uuid4().hex,
         project_id=project_id,
@@ -40,6 +42,7 @@ def new_issue_occurrence(
         detection_time=timestamp,
         culprit=culprit,
         level=level,
+        initial_issue_priority=priority,
     )
 
     event_data = {

--- a/src/sentry/replays/usecases/issue.py
+++ b/src/sentry/replays/usecases/issue.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional, Sequence, Type
 
 from sentry.issues.grouptype import GroupType
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
-from sentry.issues.priority import get_default_priority_for_group_type
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 
 
@@ -27,7 +26,6 @@ def new_issue_occurrence(
     event_id = uuid.uuid4().hex
     extra_event_data["event_id"] = event_id
 
-    priority = get_default_priority_for_group_type(group_type=issue_type, level=level)
     occurrence = IssueOccurrence(
         id=uuid.uuid4().hex,
         project_id=project_id,
@@ -42,7 +40,7 @@ def new_issue_occurrence(
         detection_time=timestamp,
         culprit=culprit,
         level=level,
-        initial_issue_priority=priority,
+        initial_issue_priority=issue_type.default_priority,
     )
 
     event_data = {

--- a/src/sentry/statistical_detectors/issue_platform_adapter.py
+++ b/src/sentry/statistical_detectors/issue_platform_adapter.py
@@ -9,7 +9,7 @@ from sentry.issues.grouptype import (
     PerformanceP95EndpointRegressionGroupType,
 )
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
-from sentry.issues.priority import PriorityLevel
+from sentry.types.group import PriorityLevel
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.seer.utils import BreakpointData
 from sentry.utils import metrics
@@ -66,9 +66,7 @@ def send_regression_to_platform(regression: BreakpointData, released: bool):
         ],
         detection_time=current_timestamp,
         level="info",
-        priority=PriorityLevel.MEDIUM
-        if issue_type == PerformanceP95EndpointRegressionGroupType
-        else PriorityLevel.LOW,
+        initial_issue_priority=issue_type.default_priority,
     )
 
     event_data = {

--- a/src/sentry/statistical_detectors/issue_platform_adapter.py
+++ b/src/sentry/statistical_detectors/issue_platform_adapter.py
@@ -9,9 +9,9 @@ from sentry.issues.grouptype import (
     PerformanceP95EndpointRegressionGroupType,
 )
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
-from sentry.types.group import PriorityLevel
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.seer.utils import BreakpointData
+from sentry.types.group import PriorityLevel
 from sentry.utils import metrics
 
 

--- a/src/sentry/statistical_detectors/issue_platform_adapter.py
+++ b/src/sentry/statistical_detectors/issue_platform_adapter.py
@@ -9,6 +9,7 @@ from sentry.issues.grouptype import (
     PerformanceP95EndpointRegressionGroupType,
 )
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
+from sentry.issues.priority import PriorityLevel
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.seer.utils import BreakpointData
 from sentry.utils import metrics
@@ -65,6 +66,9 @@ def send_regression_to_platform(regression: BreakpointData, released: bool):
         ],
         detection_time=current_timestamp,
         level="info",
+        priority=PriorityLevel.MEDIUM
+        if issue_type == PerformanceP95EndpointRegressionGroupType
+        else PriorityLevel.LOW,
     )
 
     event_data = {

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -11,12 +11,12 @@ from sentry.issues.grouptype import (
     ProfileFileIOGroupType,
 )
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
-from sentry.types.group import PriorityLevel
 from sentry.models.group import Group
 from sentry.models.team import Team
 from sentry.models.user import User
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.services.hybrid_cloud.user import RpcUser
+from sentry.types.group import PriorityLevel
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.dates import ensure_aware
 

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -11,6 +11,7 @@ from sentry.issues.grouptype import (
     ProfileFileIOGroupType,
 )
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
+from sentry.types.group import PriorityLevel
 from sentry.models.group import Group
 from sentry.models.team import Team
 from sentry.models.user import User

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -100,7 +100,7 @@ TEST_ISSUE_OCCURRENCE = IssueOccurrence(
     ensure_aware(datetime.now()),
     "info",
     "/api/123/",
-    initial_issue_priority=PriorityLevel.MEDIUM,
+    initial_issue_priority=PriorityLevel.LOW,
 )
 TEST_PERF_ISSUE_OCCURRENCE = IssueOccurrence(
     uuid.uuid4().hex,
@@ -122,7 +122,7 @@ TEST_PERF_ISSUE_OCCURRENCE = IssueOccurrence(
     ensure_aware(datetime.now()),
     "info",
     "/api/123/",
-    initial_issue_priority=PriorityLevel.MEDIUM,
+    initial_issue_priority=PriorityLevel.LOW,
 )
 
 SAMPLE_TO_OCCURRENCE_MAP = {
@@ -165,7 +165,7 @@ SAMPLE_TO_OCCURRENCE_MAP = {
         ensure_aware(datetime.now()),
         "info",
         "/books/",
-        initial_issue_priority=PriorityLevel.MEDIUM,
+        initial_issue_priority=PriorityLevel.LOW,
     ),
     "transaction-n-plus-one": IssueOccurrence(
         uuid.uuid4().hex,
@@ -202,7 +202,7 @@ SAMPLE_TO_OCCURRENCE_MAP = {
         ensure_aware(datetime.now()),
         "info",
         "/books/",
-        initial_issue_priority=PriorityLevel.MEDIUM,
+        initial_issue_priority=PriorityLevel.LOW,
     ),
     "transaction-render-blocking-asset": IssueOccurrence(
         uuid.uuid4().hex,
@@ -230,6 +230,6 @@ SAMPLE_TO_OCCURRENCE_MAP = {
         ensure_aware(datetime.now()),
         "info",
         "/render-blocking-asset/",
-        initial_issue_priority=PriorityLevel.MEDIUM,
+        initial_issue_priority=PriorityLevel.LOW,
     ),
 }

--- a/src/sentry/types/group.py
+++ b/src/sentry/types/group.py
@@ -1,3 +1,4 @@
+from enum import IntEnum
 from typing import Mapping
 
 
@@ -65,3 +66,9 @@ GROUP_SUBSTATUS_TO_GROUP_HISTORY_STATUS = {
     GroupSubStatus.FOREVER: "archived_forever",
     GroupSubStatus.UNTIL_CONDITION_MET: "archived_until_condition_met",
 }
+
+
+class PriorityLevel(IntEnum):
+    LOW = 25
+    MEDIUM = 50
+    HIGH = 75

--- a/tests/sentry/event_manager/test_priority.py
+++ b/tests/sentry/event_manager/test_priority.py
@@ -4,11 +4,11 @@ import logging
 from unittest.mock import MagicMock, patch
 
 from sentry.event_manager import EventManager
-from sentry.issues.priority import PriorityLevel
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
+from sentry.types.group import PriorityLevel
 from tests.sentry.event_manager.test_severity import make_event
 
 pytestmark = [requires_snuba]

--- a/tests/sentry/issues/test_priority.py
+++ b/tests/sentry/issues/test_priority.py
@@ -4,7 +4,6 @@ from sentry.issues.priority import (
     PRIORITY_LEVEL_TO_STR,
     PRIORITY_TO_GROUP_HISTORY_STATUS,
     PriorityChangeReason,
-    PriorityLevel,
     auto_update_priority,
 )
 from sentry.models.activity import Activity
@@ -14,6 +13,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import apply_feature_flag_on_cls
 from sentry.types.activity import ActivityType
+from sentry.types.group import PriorityLevel
 
 
 @apply_feature_flag_on_cls("projects:issue-priority")

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -13,10 +13,10 @@ from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.issues.ingest import process_occurrence_data, save_issue_occurrence
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence, IssueOccurrenceData
 from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
-from sentry.issues.priority import PriorityLevel
 from sentry.models.group import Group
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.helpers.datetime import iso_format
+from sentry.types.group import PriorityLevel
 
 
 class OccurrenceTestMixin:

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -19,6 +19,7 @@ from sentry.digests.notifications import build_digest, event_to_record
 from sentry.event_manager import EventManager, get_event_type
 from sentry.issues.grouptype import MonitorCheckInFailure
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
+from sentry.issues.priority import PriorityLevel
 from sentry.mail import build_subject_prefix, mail_adapter
 from sentry.models.activity import Activity
 from sentry.models.grouprelease import GroupRelease
@@ -324,6 +325,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             ensure_aware(datetime.now()),
             "info",
             "/api/123",
+            initial_issue_priority=PriorityLevel.HIGH,
         )
         occurrence.save()
         event.occurrence = occurrence
@@ -376,6 +378,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             ensure_aware(datetime.now()),
             "info",
             "/api/123",
+            initial_issue_priority=PriorityLevel.HIGH,
         )
         occurrence.save()
         event.occurrence = occurrence

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -19,7 +19,6 @@ from sentry.digests.notifications import build_digest, event_to_record
 from sentry.event_manager import EventManager, get_event_type
 from sentry.issues.grouptype import MonitorCheckInFailure
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
-from sentry.issues.priority import PriorityLevel
 from sentry.mail import build_subject_prefix, mail_adapter
 from sentry.models.activity import Activity
 from sentry.models.grouprelease import GroupRelease
@@ -50,7 +49,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
-from sentry.types.group import GroupSubStatus
+from sentry.types.group import GroupSubStatus, PriorityLevel
 from sentry.types.rules import RuleFuture
 from sentry.utils.dates import ensure_aware
 from sentry.utils.email import MessageBuilder, get_email_addresses

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -29,7 +29,6 @@ from sentry.issues.grouptype import (
     ProfileFileIOGroupType,
 )
 from sentry.issues.ingest import save_issue_occurrence
-from sentry.issues.priority import PriorityLevel
 from sentry.models.activity import Activity, ActivityIntegration
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
@@ -72,7 +71,7 @@ from sentry.testutils.performance_issues.store_transaction import PerfIssueTrans
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
-from sentry.types.group import GroupSubStatus
+from sentry.types.group import GroupSubStatus, PriorityLevel
 from sentry.utils import json
 from sentry.utils.cache import cache
 from sentry.utils.sdk_crashes.sdk_crash_detection_config import SdkName

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -7,7 +7,6 @@ from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializerSnuba
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType, ProfileFileIOGroupType
-from sentry.issues.priority import PriorityLevel
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.grouplink import GroupLink
@@ -23,6 +22,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.performance_issues.store_transaction import PerfIssueTransactionTestMixin
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.types.group import PriorityLevel
 from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 


### PR DESCRIPTION
Sets the `initial_issue_priority` field for existing calls to create IssueOccurrence objects, based on the group type since this field will be marked as required soon. 

Followup to https://github.com/getsentry/sentry/pull/64131