### PR TITLE
fix(webvitals): fix meter width regression

### DIFF
--- a/static/app/views/performance/browser/webVitals/components/webVitalMeters.tsx
+++ b/static/app/views/performance/browser/webVitals/components/webVitalMeters.tsx
@@ -214,7 +214,7 @@ const MeterBarFooterContainer = styled('div')<{status: string}>`
 
 const NoValueContainer = styled('span')`
   color: ${p => p.theme.gray300};
-  font-size: ${p => p.theme.fontSizeExtraLarge};
+  font-size: ${p => p.theme.headerFontSize};
 `;
 
 function NoValue() {
@@ -223,6 +223,7 @@ function NoValue() {
 
 const StyledTooltip = styled(Tooltip)`
   display: block;
+  width: 100%;
 `;
 
 const StyledQuestionTooltip = styled(QuestionTooltip)`


### PR DESCRIPTION
Fixes a regression in web vitals meter components not rendering with correct width.