### PR TITLE
fix(browser-starfish): remap resource fields in discover

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -124,6 +124,10 @@ SPAN_COLUMN_MAP = {
     "environment": "sentry_tags[environment]",
     "device.class": "sentry_tags[device.class]",
     "category": "sentry_tags[category]",
+    "resource.render_blocking_status": "sentry_tags[resource.render_blocking_status]",
+    "http.response_content_length": "sentry_tags[http.response_content_length]",
+    "http.decoded_response_content_length": "sentry_tags[http.decoded_response_content_length]",
+    "http.response_transfer_size": "sentry_tags[http.response_transfer_size]",
 }
 
 SPAN_COLUMN_MAP.update(


### PR DESCRIPTION
Map fields used in the resource module to query for `sentry_tags` instead of `tags`.