### PR TITLE
feat(metrics-extraction): Set limit to unique specs

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -242,6 +242,8 @@ def _get_widget_metric_specs(
                     metrics.incr("on_demand_metrics.widget_query.high_cardinality", sample_rate=1.0)
                     ignored_widget_ids[widget_query.widget.id] = True
 
+    sentry_sdk.set_context("ignored_widget_ids", ignored_widget_ids)
+
     metrics.incr("on_demand_metrics.widget_query_specs.pre_trim", amount=total_spec_count)
     specs = _trim_disabled_widgets(ignored_widget_ids, specs_for_widget)
     metrics.incr("on_demand_metrics.widget_query_specs.post_disabled_trim", amount=len(specs))
@@ -275,10 +277,11 @@ def _trim_if_above_limit(
     return_specs = []
     specs_per_version: dict[int, list[HashedMetricSpec]] = {}
     for hash, spec, spec_version in specs:
-        specs_per_version.setdefault(spec_version.version, [])
-        specs_per_version[spec_version.version].append((hash, spec, spec_version))
+        specs_per_version.setdefault(spec_version.version, {})
+        specs_per_version[spec_version.version][hash] = (hash, spec, spec_version)
 
-    for version, specs_for_version in specs_per_version.items():
+    for version, _specs_for_version in specs_per_version.items():
+        specs_for_version = _specs_for_version.values()
         if len(specs_for_version) > max_specs:
             with sentry_sdk.push_scope() as scope:
                 scope.set_tag("project_id", project.id)
@@ -289,9 +292,9 @@ def _trim_if_above_limit(
                     )
                 )
 
-            return_specs += specs_for_version[:max_specs]
+            return_specs += list(specs_for_version)[:max_specs]
         else:
-            return_specs += specs_for_version
+            return_specs += list(specs_for_version)
 
     return return_specs
 

--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -242,8 +242,6 @@ def _get_widget_metric_specs(
                     metrics.incr("on_demand_metrics.widget_query.high_cardinality", sample_rate=1.0)
                     ignored_widget_ids[widget_query.widget.id] = True
 
-    sentry_sdk.set_context("ignored_widget_ids", ignored_widget_ids)
-
     metrics.incr("on_demand_metrics.widget_query_specs.pre_trim", amount=total_spec_count)
     specs = _trim_disabled_widgets(ignored_widget_ids, specs_for_widget)
     metrics.incr("on_demand_metrics.widget_query_specs.post_disabled_trim", amount=len(specs))
@@ -275,7 +273,7 @@ def _trim_if_above_limit(
 ) -> list[HashedMetricSpec]:
     """Trim specs per version if above max limit"""
     return_specs = []
-    specs_per_version: dict[int, list[HashedMetricSpec]] = {}
+    specs_per_version: dict[int, dict[str, HashedMetricSpec]] = {}
     for hash, spec, spec_version in specs:
         specs_per_version.setdefault(spec_version.version, {})
         specs_per_version[spec_version.version][hash] = (hash, spec, spec_version)

--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -604,6 +604,22 @@ def test_get_metric_extraction_config_multiple_widgets_above_max_limit(
 
 
 @django_db_all
+@override_options({"on_demand.max_widget_specs": 1})
+def test_get_metric_extraction_config_multiple_widgets_not_above_max_limit_identical_hashes(
+    default_project: Project,
+) -> None:
+    with Feature({ON_DEMAND_METRICS_WIDGETS: True}):
+        create_widget(["count()"], "transaction.duration:>=1000", default_project)
+        create_widget(["count()"], "transaction.duration:>=1000", default_project, "Dashboard 2")
+
+        with mock.patch("sentry_sdk.capture_exception") as capture_exception:
+            config = get_metric_extraction_config(default_project)
+            assert config
+
+            assert capture_exception.call_count == 0
+
+
+@django_db_all
 @override_options({"on_demand.max_widget_specs": 1, "on_demand.extended_max_widget_specs": 0})
 def test_get_metric_extraction_config_multiple_widgets_not_using_extended_specs(
     default_project: Project,


### PR DESCRIPTION
### Summary
We want to limit unique specs, since later once the specs go through 'merge' with alert specs they are de-duped anyway. This results in a far lower number of specs compared to our current limit (likely in the 500 range).
