### PR TITLE
test: remove unnecessary imports

### DIFF
--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -1,7 +1,4 @@
 /* eslint-env node */
-/* eslint import/no-nodejs-modules:0 */
-import {TextDecoder, TextEncoder} from 'util';
-
 import type {ReactElement} from 'react';
 import {configure as configureRtl} from '@testing-library/react'; // eslint-disable-line no-restricted-imports
 import MockDate from 'mockdate';


### PR DESCRIPTION
TextEncoder and TextDecoder are global classes. There is no need to import them from Node.js `util`