### PR TITLE
fix(snuba): try toIPv4, toIPv6

### DIFF
--- a/src/sentry/utils/eventuser.py
+++ b/src/sentry/utils/eventuser.py
@@ -55,7 +55,7 @@ KEYWORD_MAP = BidirectionalMapping(
     }
 )
 
-SNUBA_COLUMN_COALASCE = {"ip_address_v4": "IPv4StringToNum", "ip_address_v6": "IPv6StringToNum"}
+SNUBA_COLUMN_COALASCE = {"ip_address_v4": "toIPv4", "ip_address_v6": "toIPv6"}
 MAX_QUERY_TRIES = 5
 OVERFETCH_FACTOR = 10
 MAX_FETCH_SIZE = 10_000


### PR DESCRIPTION
A different attempt to https://github.com/getsentry/sentry/pull/63804 - test this https://fiddle.clickhouse.com/b420682f-8bf8-4bf1-8f03-84827a0561a5 seemed to work for the various ClickHouse versions.

Once we get to version ClickHouse 23.3+ I believe we should. be able to remove the `SNUBA_COLUMN_COALASCE` altogether (like in https://github.com/getsentry/sentry/pull/63804)