### PR TITLE
fix(replays): Vertically center replay timeline breadcrumbs

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -139,7 +139,12 @@ function Event({
 
   return (
     <IconPosition style={{marginLeft: `${markerWidth / 2}px`}}>
-      <IconNodeTooltip title={title} overlayStyle={overlayStyle} isHoverable>
+      <Tooltip
+        title={title}
+        overlayStyle={overlayStyle}
+        containerDisplayMode="grid"
+        isHoverable
+      >
         <IconNode
           colors={sortedUniqueColors}
           frameCount={frameCount}
@@ -149,16 +154,10 @@ function Event({
             }
           }}
         />
-      </IconNodeTooltip>
+      </Tooltip>
     </IconPosition>
   );
 }
-
-const IconNodeTooltip = styled(Tooltip)`
-  display: grid;
-  justify-items: center;
-  align-items: center;
-`;
 
 const IconPosition = styled('div')`
   position: absolute;


### PR DESCRIPTION
Not sure when this regressed, but noticed that the timeline wasn't centering things properly anymore 

Before:

![CleanShot 2024-01-30 at 14 29 29](https://github.com/getsentry/sentry/assets/10888943/6cdcb1dc-1f33-43eb-a280-a01969b37a23)

After:

![CleanShot 2024-01-30 at 14 28 40](https://github.com/getsentry/sentry/assets/10888943/588e4482-603c-4d31-af99-34834a48d9dd)
