### PR TITLE
fix(snuba): fix bug for serializing dict

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -975,11 +975,16 @@ def _bulk_snuba_query(
             raise UnexpectedResponseError(f"Could not decode JSON response: {response.data!r}")
 
         if response.status != 200:
+            error_query = snuba_param_list[index][0]
+            if isinstance(error_query, Request):
+                query_str = error_query.serialize()
+            else:
+                query_str = json.dumps(error_query)
             sentry_sdk.add_breadcrumb(
                 category="query_info",
                 level="info",
                 message="mql_query",
-                data={"mql": snuba_param_list[index][0].serialize()},
+                data={"mql": query_str},
             )
 
             if body.get("error"):


### PR DESCRIPTION
There was a bug causing error when trying to call serialize on a dict https://sentry.sentry.io/issues/4929526795/?notification_uuid=1baf6b5c-a73f-479c-95e7-151b1500a192&project=1&referrer=assigned_activity-slack

this is because the type of what we were calling serialize on could be MutableMapping or Request. I added a check to serialize if its a request, and call json dumps otherwise (MutableMapping)