### PR TITLE
ref(slack): Account for different commit URL formats

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -58,14 +58,12 @@ from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 
 STATUSES = {"resolved": "resolved", "ignored": "ignored", "unresolved": "re-opened"}
-PROVIDER_TO_COMMIT_LINK_URL_FORMAT = {
+SUPPORTED_PROVIDER_TO_COMMIT_URL = {
     "github": "{base_url}/commit/{commit_id}",
     "integrations:github": "{base_url}/commit/{commit_id}",
     "integrations:github_enterprise": "{base_url}/commit/{commit_id}",
-    "visualstudio": "{base_url}/commit/{commit_id}",  # TODO: buggy
     "integrations:vsts": "{base_url}/commit/{commit_id}",
-    "gitlab": "{base_url}/commit/{commit_id}",  # TODO: buggy
-    "integrations:gitlab": "{base_url}/commit/{commit_id}",  # TODO: buggy
+    "integrations:gitlab": "{base_url}/commit/{commit_id}",
     "bitbucket": "{base_url}/commits/{commit_id}",
     "integrations:bitbucket": "{base_url}/commits/{commit_id}",
 }
@@ -315,8 +313,8 @@ def get_suspect_commit_text(
         repo = pull_request.get("repository", {})
         repo_base = repo.get("url")
         provider = repo.get("provider", {}).get("id")
-        if repo_base and provider in PROVIDER_TO_COMMIT_LINK_URL_FORMAT:
-            commit_link = f"<{PROVIDER_TO_COMMIT_LINK_URL_FORMAT[provider].format(base_url=repo_base, commit_id=commit_id)}|{commit_id[:6]}>"
+        if repo_base and provider in SUPPORTED_PROVIDER_TO_COMMIT_URL:
+            commit_link = f"<{SUPPORTED_PROVIDER_TO_COMMIT_URL[provider].format(base_url=repo_base, commit_id=commit_id)}|{commit_id[:6]}>"
             suspect_commit_text += f"{commit_link} by {author_display}"
         else:  # for unsupported providers
             suspect_commit_text += f"{commit_id[:6]} by {author_display}"

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -58,6 +58,18 @@ from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 
 STATUSES = {"resolved": "resolved", "ignored": "ignored", "unresolved": "re-opened"}
+PROVIDER_TO_COMMIT_LINK_URL_FORMAT = {
+    "github": "{base_url}/commit/{commit_id}",
+    "integrations:github": "{base_url}/commit/{commit_id}",
+    "integrations:github_enterprise": "{base_url}/commit/{commit_id}",
+    "visualstudio": "{base_url}/commit/{commit_id}",
+    "integrations:vsts": "{base_url}/commit/{commit_id}",
+    "gitlab": "{base_url}/commit/{commit_id}",
+    "integrations:gitlab": "{base_url}/commit/{commit_id}",
+    "bitbucket": "{base_url}/commits/{commit_id}",
+    "integrations:bitbucket": "{base_url}/commits/{commit_id}",
+}
+
 logger = logging.getLogger(__name__)
 
 
@@ -300,9 +312,11 @@ def get_suspect_commit_text(
 
     author_display = author.get("name") if author.get("name") is not None else author.get("email")
     if pull_request:
-        repo_base = pull_request.get("repository", {}).get("url")
-        if repo_base:
-            commit_link = f"<{repo_base}/commit/{commit_id}|{commit_id[0:6]}>"
+        repo = pull_request.get("repository", {})
+        repo_base = repo.get("url")
+        provider = repo.get("provider", {}).get("name")
+        if repo_base and provider in PROVIDER_TO_COMMIT_LINK_URL_FORMAT:
+            commit_link = f"<{PROVIDER_TO_COMMIT_LINK_URL_FORMAT[provider].format(base_url=repo_base, commit_id=commit_id)}|{commit_id[:6]}>"
             suspect_commit_text += f"{commit_link} by {author_display}"
 
         pr_date = pull_request.get("dateCreated")

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -318,6 +318,8 @@ def get_suspect_commit_text(
         if repo_base and provider in PROVIDER_TO_COMMIT_LINK_URL_FORMAT:
             commit_link = f"<{PROVIDER_TO_COMMIT_LINK_URL_FORMAT[provider].format(base_url=repo_base, commit_id=commit_id)}|{commit_id[:6]}>"
             suspect_commit_text += f"{commit_link} by {author_display}"
+        else:  # for unsupported providers
+            suspect_commit_text += f"{commit_id} by {author_display}"
 
         pr_date = pull_request.get("dateCreated")
         if pr_date:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -58,15 +58,15 @@ from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 
 STATUSES = {"resolved": "resolved", "ignored": "ignored", "unresolved": "re-opened"}
-SUPPORTED_PROVIDER_TO_COMMIT_URL = {
-    "github": "{base_url}/commit/{commit_id}",
-    "integrations:github": "{base_url}/commit/{commit_id}",
-    "integrations:github_enterprise": "{base_url}/commit/{commit_id}",
-    "integrations:vsts": "{base_url}/commit/{commit_id}",
-    "integrations:gitlab": "{base_url}/commit/{commit_id}",
-    "bitbucket": "{base_url}/commits/{commit_id}",
-    "integrations:bitbucket": "{base_url}/commits/{commit_id}",
-}
+SUPPORTED_COMMIT_PROVIDERS = (
+    "github",
+    "integrations:github",
+    "integrations:github_enterprise",
+    "integrations:vsts",
+    "integrations:gitlab",
+    "bitbucket",
+    "integrations:bitbucket",
+)
 
 logger = logging.getLogger(__name__)
 
@@ -313,8 +313,12 @@ def get_suspect_commit_text(
         repo = pull_request.get("repository", {})
         repo_base = repo.get("url")
         provider = repo.get("provider", {}).get("id")
-        if repo_base and provider in SUPPORTED_PROVIDER_TO_COMMIT_URL:
-            commit_link = f"<{SUPPORTED_PROVIDER_TO_COMMIT_URL[provider].format(base_url=repo_base, commit_id=commit_id)}|{commit_id[:6]}>"
+        if repo_base and provider in SUPPORTED_COMMIT_PROVIDERS:
+            if "bitbucket" in provider:
+                commit_link = f"<{repo_base}/commits/{commit_id}"
+            else:
+                commit_link = f"<{repo_base}/commit/{commit_id}"
+            commit_link += f"|{commit_id[:6]}>"
             suspect_commit_text += f"{commit_link} by {author_display}"
         else:  # for unsupported providers
             suspect_commit_text += f"{commit_id[:6]} by {author_display}"

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -62,10 +62,10 @@ PROVIDER_TO_COMMIT_LINK_URL_FORMAT = {
     "github": "{base_url}/commit/{commit_id}",
     "integrations:github": "{base_url}/commit/{commit_id}",
     "integrations:github_enterprise": "{base_url}/commit/{commit_id}",
-    "visualstudio": "{base_url}/commit/{commit_id}",
+    "visualstudio": "{base_url}/commit/{commit_id}",  # TODO: buggy
     "integrations:vsts": "{base_url}/commit/{commit_id}",
-    "gitlab": "{base_url}/commit/{commit_id}",
-    "integrations:gitlab": "{base_url}/commit/{commit_id}",
+    "gitlab": "{base_url}/commit/{commit_id}",  # TODO: buggy
+    "integrations:gitlab": "{base_url}/commit/{commit_id}",  # TODO: buggy
     "bitbucket": "{base_url}/commits/{commit_id}",
     "integrations:bitbucket": "{base_url}/commits/{commit_id}",
 }
@@ -314,12 +314,12 @@ def get_suspect_commit_text(
     if pull_request:
         repo = pull_request.get("repository", {})
         repo_base = repo.get("url")
-        provider = repo.get("provider", {}).get("name")
+        provider = repo.get("provider", {}).get("id")
         if repo_base and provider in PROVIDER_TO_COMMIT_LINK_URL_FORMAT:
             commit_link = f"<{PROVIDER_TO_COMMIT_LINK_URL_FORMAT[provider].format(base_url=repo_base, commit_id=commit_id)}|{commit_id[:6]}>"
             suspect_commit_text += f"{commit_link} by {author_display}"
         else:  # for unsupported providers
-            suspect_commit_text += f"{commit_id} by {author_display}"
+            suspect_commit_text += f"{commit_id[:6]} by {author_display}"
 
         pr_date = pull_request.get("dateCreated")
         if pr_date:
@@ -332,7 +332,7 @@ def get_suspect_commit_text(
                 f" {pr_date} \n'{pr_title} (#{pr_id})' <{pr_link}|View Pull Request>"
             )
     else:
-        suspect_commit_text += f"{commit_id} by {author_display}"
+        suspect_commit_text += f"{commit_id[:6]} by {author_display}"
     return suspect_commit_text
 
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -542,7 +542,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
 
     @patch(
         "sentry.api.serializers.models.pullrequest.PullRequestSerializer._external_url",
-        return_value="https://github.com/meowmeow/cats/pull/1",
+        return_value="https://unknown.com/meowmeow/cats/pull/1",
     )
     @with_feature("organizations:slack-block-kit")
     def test_issue_alert_with_suspect_commits_unknown_provider(self, mock_external_url):
@@ -553,7 +553,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             organization_id=self.organization.id,
             name="example",
             integration_id=self.integration.id,
-            url="http://www.github.com/meowmeow/cats",
+            url="http://www.unknown.com/meowmeow/cats",
         )
         commit_author = self.create_commit_author(project=self.project, user=self.user)
         self.commit = self.create_commit(

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -536,6 +536,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             name="example",
             integration_id=self.integration.id,
             url="http://www.unknown.com/meowmeow/cats",
+            provider="dummy",
         )
         commit_author = self.create_commit_author(project=self.project, user=self.user)
         self.commit = self.create_commit(

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -467,6 +467,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             name="example",
             integration_id=self.integration.id,
             url="http://www.github.com/meowmeow/cats",
+            provider="github",
         )
         commit_author = self.create_commit_author(project=self.project, user=self.user)
         self.commit = self.create_commit(
@@ -612,6 +613,8 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             "commit_id": commit.key,
             "author_email": commit.author.email,
         }
+
+        commits = get_commits(self.project, event)
         expected_blocks = build_test_message_blocks(
             teams={self.team},
             users={self.user},
@@ -622,7 +625,9 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             suspect_commit=suspect_commit,
         )
         assert (
-            SlackIssuesMessageBuilder(group, event.for_group(group), tags={"foo"}).build()
+            SlackIssuesMessageBuilder(
+                group, event.for_group(group), tags={"foo"}, commits=commits
+            ).build()
             == expected_blocks
         )
 
@@ -640,8 +645,11 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
             initial_assignee=self.user,
             suspect_commit=suspect_commit,
         )
+        commits = get_commits(self.project, event)
         assert (
-            SlackIssuesMessageBuilder(group, event.for_group(group), tags={"foo"}).build()
+            SlackIssuesMessageBuilder(
+                group, event.for_group(group), tags={"foo"}, commits=commits
+            ).build()
             == expected_blocks
         )
 
@@ -832,6 +840,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         )
 
 
+@region_silo_test
 class BuildGroupAttachmentReplaysTest(TestCase):
     @patch("sentry.models.group.Group.has_replays")
     def test_build_replay_issue(self, has_replays):


### PR DESCRIPTION
Different providers have different commit URL formats, so this PR makes sure we render the correct commit URL in Slack issue alerts with suspect commits depending on the provider the commit is tied to.