### PR TITLE
ref(replay): Rewrite useReplayData to leverage useApiQuery 2/3

### DIFF
--- a/static/app/utils/api/useFetchParallelPages.spec.tsx
+++ b/static/app/utils/api/useFetchParallelPages.spec.tsx
@@ -1,0 +1,194 @@
+import type {ReactNode} from 'react';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import useFetchParallelPages from 'sentry/utils/api/useFetchParallelPages';
+import type {QueryClient} from 'sentry/utils/queryClient';
+import {QueryClientProvider} from 'sentry/utils/queryClient';
+
+function makeWrapper(queryClient: QueryClient) {
+  return function wrapper({children}: {children?: ReactNode}) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const MOCK_API_ENDPOINT = '/api/test/';
+function queryKeyFactory() {
+  return jest.fn().mockImplementation(query => [MOCK_API_ENDPOINT, {query}]);
+}
+
+describe('useFetchParallelPages', () => {
+  it('should not call the queryFn when enabled is false', () => {
+    MockApiClient.addMockResponse({
+      url: MOCK_API_ENDPOINT,
+      body: 'text result',
+    });
+    const getQueryKey = queryKeyFactory();
+
+    const {result} = reactHooks.renderHook(useFetchParallelPages, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps: {
+        enabled: false,
+        getQueryKey,
+        hits: 13,
+        perPage: 10,
+      },
+    });
+
+    expect(result.current.isFetching).toBeFalsy();
+    expect(getQueryKey).not.toHaveBeenCalled();
+  });
+
+  it('should call the queryFn zero times, when hits is 0', () => {
+    MockApiClient.addMockResponse({
+      url: MOCK_API_ENDPOINT,
+      body: 'text result',
+    });
+    const getQueryKey = queryKeyFactory();
+
+    const {result} = reactHooks.renderHook(useFetchParallelPages, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps: {
+        enabled: true,
+        getQueryKey,
+        hits: 0,
+        perPage: 10,
+      },
+    });
+
+    expect(result.current.isFetching).toBeFalsy();
+    expect(getQueryKey).not.toHaveBeenCalled();
+  });
+
+  it('should call the queryFn 1 times, when hits is less than the perPage size', async () => {
+    MockApiClient.addMockResponse({
+      url: MOCK_API_ENDPOINT,
+      body: 'text result',
+    });
+    const getQueryKey = queryKeyFactory();
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useFetchParallelPages, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps: {
+        enabled: true,
+        getQueryKey,
+        hits: 7,
+        perPage: 10,
+      },
+    });
+
+    expect(result.current.isFetching).toBeTruthy();
+    await waitForNextUpdate();
+    expect(result.current.isFetching).toBeFalsy();
+    expect(getQueryKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call the queryFn N times, depending on how many hits we expect', async () => {
+    MockApiClient.addMockResponse({
+      url: MOCK_API_ENDPOINT,
+      body: 'text result',
+    });
+    const getQueryKey = queryKeyFactory();
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useFetchParallelPages, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps: {
+        enabled: true,
+        getQueryKey,
+        hits: 21,
+        perPage: 10,
+      },
+    });
+
+    expect(result.current.isFetching).toBeTruthy();
+    await waitForNextUpdate();
+    expect(result.current.isFetching).toBeFalsy();
+    expect(getQueryKey).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return a list of all pages that have been resolved', async () => {
+    MockApiClient.addMockResponse({
+      url: MOCK_API_ENDPOINT,
+      body: 'results starting at 0',
+      match: [MockApiClient.matchQuery({cursor: '0:0:0', per_page: 10})],
+    });
+    MockApiClient.addMockResponse({
+      url: MOCK_API_ENDPOINT,
+      body: 'results starting at 10',
+      match: [MockApiClient.matchQuery({cursor: '0:10:0', per_page: 10})],
+    });
+    const getQueryKey = queryKeyFactory();
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useFetchParallelPages, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps: {
+        enabled: true,
+        getQueryKey,
+        hits: 13,
+        perPage: 10,
+      },
+    });
+
+    await waitForNextUpdate();
+    expect(result.current.isFetching).toBeFalsy();
+    expect(result.current.pages).toEqual([
+      'results starting at 0',
+      'results starting at 10',
+    ]);
+    expect(result.current.error).toEqual([]);
+  });
+
+  it('should reduce isError and isFetching', async () => {
+    MockApiClient.addMockResponse({
+      url: MOCK_API_ENDPOINT,
+      body: 'text result',
+    });
+    const getQueryKey = queryKeyFactory();
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useFetchParallelPages, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps: {
+        enabled: true,
+        getQueryKey,
+        hits: 13,
+        perPage: 10,
+      },
+    });
+
+    await waitForNextUpdate();
+    expect(result.current.isFetching).toBeFalsy();
+    expect(result.current.isError).toBeFalsy();
+  });
+
+  it('should return the final ResponseHeader that has been resolved', async () => {
+    MockApiClient.addMockResponse({
+      url: MOCK_API_ENDPOINT,
+      body: 'results starting at 0',
+      headers: {Link: 'next: 0:10:0'},
+      match: [MockApiClient.matchQuery({cursor: '0:0:0', per_page: 10})],
+    });
+    MockApiClient.addMockResponse({
+      url: MOCK_API_ENDPOINT,
+      body: 'results starting at 10',
+      headers: {Link: 'next: 0:20:0'},
+      match: [MockApiClient.matchQuery({cursor: '0:10:0', per_page: 10})],
+    });
+    const getQueryKey = queryKeyFactory();
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useFetchParallelPages, {
+      wrapper: makeWrapper(makeTestQueryClient()),
+      initialProps: {
+        enabled: true,
+        getQueryKey,
+        hits: 13,
+        perPage: 10,
+      },
+    });
+
+    await waitForNextUpdate();
+    expect(result.current.isFetching).toBeFalsy();
+    expect(result.current.getLastResponseHeader).toStrictEqual(expect.any(Function));
+    expect(result.current.getLastResponseHeader?.('Link')).toBe('next: 0:20:0');
+  });
+});

--- a/static/app/utils/api/useFetchParallelPages.tsx
+++ b/static/app/utils/api/useFetchParallelPages.tsx
@@ -1,0 +1,170 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+import {defined} from 'sentry/utils';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import {fetchDataQuery, useQueryClient} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+
+interface Props {
+  /**
+   * Whether or not to start fetched when the hook is mounted
+   */
+  enabled: boolean;
+
+  /**
+   * Generate the queryKey to use, given the pagination params
+   */
+  getQueryKey: (pagination: {cursor: string; per_page: number}) => ApiQueryKey;
+
+  /**
+   * The total number of records within the dataset
+   *
+   * This, combined with `perPage`, determines the number of fetches to make
+   */
+  hits: number;
+
+  /**
+   * The size of each page to fetch
+   *
+   * This, combined with `hits`, determines the number of fetches to make
+   */
+  perPage: number;
+}
+
+interface ResponsePage<Data> {
+  data: undefined | Data;
+  error: unknown;
+  getResponseHeader: ((header: string) => string | null) | undefined;
+  isError: boolean;
+  isFetching: boolean;
+}
+
+interface State<Data> {
+  error: unknown;
+  getLastResponseHeader: ((header: string) => string | null) | undefined;
+  isError: boolean;
+  isFetching: boolean;
+  pages: Data[];
+}
+
+/**
+ * A query hook to fetch a fixed number of list pages all at once.
+ *
+ * See also: `useFetchSequentialPages()`
+ *
+ * <WARNING>
+ *   Using this hook might not be a good idea!
+ *   Pagination is a good strategy to limit the amount of data that a server
+ *   needs to fetch at a given time, it also limits the amount of data that the
+ *   browser needs to hold in memory. Loading all data with this hook could
+ *   cause rate-limiting, memory exhaustion, slow rendering, and other problems.
+ *
+ *   Before implementing a sequential-fetch you should first think about
+ *   building new api endpoints that return just the data you need (in a
+ *   paginated way), or look at the feature design itself and make adjustments.
+ * </WARNING>
+ *
+ * EXAMPLE: You want to fetch 100 items to show in a list, but the max-page-size
+ * is set to only 50.
+ *   In the well-behaved case this might seem fine, but in the pathological
+ *   case (in the extreme) there could be too many users to do this safely!
+ * Knowing that you have to make
+ *
+ * | Request        | Waterfall     |
+ * | -------------- | ------------- |
+ * | ?cursor=0:0:0  | ==========    |
+ * | ?cursor=0:50:0 | =======       |
+ * |                | ^      ^  ^   |
+ * |                | t=0    t=1    |
+ * |                |           t=2 |
+ *
+ * At t=0 the hook will return `data=Array(0)` because no records are fetched yet.
+ * - Both requests will start at the same time, but are not guaranteed to end at
+ *   the same time, or in order.
+ * - If the network saturated with many requests (which can happen during
+ *   pageload) then some requests might still need to wait before starting.
+ * - Each response (in this case 2) will cause a re-render.
+ * - Responses will return out of order (in this case items 50 to 100 return
+ *   before items 0 to 50) which could cause layout shift.
+ */
+export default function useFetchParallelPages<Data>({
+  enabled,
+  hits,
+  getQueryKey,
+  perPage,
+}: Props): State<Data> {
+  const api = useApi({persistInFlight: true});
+  const queryClient = useQueryClient();
+
+  const responsePages = useRef<Map<string, ResponsePage<Data>>>(new Map());
+  const [state, setState] = useState<State<Data>>({
+    pages: [],
+    error: undefined,
+    getLastResponseHeader: undefined,
+    isError: false,
+    isFetching: true,
+  });
+
+  const fetch = useCallback(
+    async function () {
+      const pages = Math.ceil(hits / perPage);
+      const cursors = new Array(pages).fill(0).map((_, i) => `0:${perPage * i}:0`);
+
+      await Promise.allSettled(
+        cursors.map(async cursor => {
+          try {
+            responsePages.current.set(cursor, {
+              data: undefined,
+              error: undefined,
+              getResponseHeader: undefined,
+              isError: false,
+              isFetching: true,
+            });
+
+            const [data, , resp] = await queryClient.fetchQuery({
+              queryKey: getQueryKey({cursor, per_page: perPage}),
+              queryFn: fetchDataQuery(api),
+              staleTime: Infinity,
+            });
+
+            responsePages.current.set(cursor, {
+              data,
+              error: undefined,
+              getResponseHeader: resp?.getResponseHeader,
+              isError: false,
+              isFetching: false,
+            });
+          } catch (error) {
+            responsePages.current.set(cursor, {
+              data: undefined,
+              error,
+              getResponseHeader: undefined,
+              isError: true,
+              isFetching: false,
+            });
+          } finally {
+            const values = Array.from(responsePages.current.values());
+            setState({
+              pages: values.map(value => value.data).filter(defined),
+              error: values.map(value => value.error),
+              getLastResponseHeader: values.slice(-1)[0]?.getResponseHeader,
+              isError: values.map(value => value.isError).some(Boolean),
+              isFetching: values.map(value => value.isFetching).every(Boolean),
+            });
+          }
+        })
+      );
+    },
+    [api, hits, getQueryKey, perPage, queryClient]
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    fetch();
+  }, [enabled, fetch]);
+
+  return state;
+}

--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -96,13 +96,13 @@ describe('useReplayData', () => {
       },
     });
 
+    // First we get the replay record
     await waitForNextUpdate();
-
     expect(result.current).toEqual({
       attachments: expect.any(Array),
       errors: expect.any(Array),
       fetchError: undefined,
-      fetching: false,
+      fetching: true, // more data may still be fetching
       onRetry: expect.any(Function),
       projectSlug: project.slug,
       replayRecord: expectedReplay,

--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -97,6 +97,7 @@ describe('useReplayData', () => {
     });
 
     await waitForNextUpdate();
+
     expect(result.current).toEqual({
       attachments: expect.any(Array),
       errors: expect.any(Array),

--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -96,13 +96,12 @@ describe('useReplayData', () => {
       },
     });
 
-    // First we get the replay record
     await waitForNextUpdate();
     expect(result.current).toEqual({
       attachments: expect.any(Array),
       errors: expect.any(Array),
       fetchError: undefined,
-      fetching: true, // more data may still be fetching
+      fetching: false,
       onRetry: expect.any(Function),
       projectSlug: project.slug,
       replayRecord: expectedReplay,


### PR DESCRIPTION
Rewriting useReplayData, part 2

This replaces the attachment fetching with the `useFetchParallelPages` helper, resulting in a smaller `useReplayData.tsx` file that has less of the state management stuff in it. Also, all the fetched data lives in the queryCache, so re-visits to the same replay are faster (for instance, if someone were on issue details and clicked-through to a replay).

Follows: https://github.com/getsentry/sentry/pull/63455
It's a slice of: https://github.com/getsentry/sentry/pull/62109
