### PR TITLE
fix(crons): Reset cursor on search

### DIFF
--- a/static/app/components/modals/bulkEditMonitorsModal.tsx
+++ b/static/app/components/modals/bulkEditMonitorsModal.tsx
@@ -46,6 +46,11 @@ export function BulkEditMonitorsModal({Header, Body, Footer, closeModal}: Props)
     return !!selectedMonitors.find(m => m.slug === monitor.slug);
   };
 
+  const handleSearch = (query: string) => {
+    setSearchQuery(query);
+    setCursor(undefined);
+  };
+
   const handleToggleMonitor = (monitor: Monitor) => {
     const checked = isMonitorSelected(monitor);
     if (!checked) {
@@ -134,7 +139,7 @@ export function BulkEditMonitorsModal({Header, Body, Footer, closeModal}: Props)
             size="sm"
             placeholder={t('Search Monitors')}
             query={searchQuery}
-            onSearch={setSearchQuery}
+            onSearch={handleSearch}
           />
         </Actions>
         <StyledPanelTable headers={headers} stickyHeaders>


### PR DESCRIPTION
Need to reset the cursor here, or else if you

1. Page to the second or higher page of results
2. Enter a search query

You will receive the second page of results for that search query (which may show no results)