### PR TITLE
build: replace eslint-typescript with biome linter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,38 +26,17 @@ module.exports = {
     tick: true,
     jest: true,
   },
-  parserOptions: {
-    project: true,
-    tsConfigRootDir: __dirname,
-  },
   rules: {
     'react-hooks/exhaustive-deps': [
       'warn',
       {additionalHooks: ADDITIONAL_HOOKS_TO_CHECK_DEPS_FOR},
     ],
     ...(!isRelaxed && !isCi ? strictRulesNotCi : {}),
-    // TODO(@anonrig): Move this to eslint-config-sentry-app
-    '@typescript-eslint/consistent-type-imports': [
-      'error',
-      {fixStyle: 'separate-type-imports', prefer: 'type-imports'},
-    ],
-    '@typescript-eslint/consistent-type-exports': ['error'],
   },
   // JSON file formatting is handled by Biome. ESLint should not be linting
   // and formatting these files.
   ignorePatterns: ['*.json'],
   overrides: [
-    {
-      // Benchmarks are not compiled with the same tsconfig as the rest of the
-      // app, so we need to disable some rules.
-      files: ['static/app/**/*.benchmark.ts'],
-      parserOptions: {
-        project: false,
-      },
-      rules: {
-        '@typescript-eslint/consistent-type-exports': 'off',
-      },
-    },
     {
       files: ['tests/js/**/*.{ts,js}'],
       extends: ['plugin:testing-library/react', 'sentry-app/strict'],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,11 @@
       "program": "${workspaceRoot}/.venv/bin/sentry",
       "args": ["devserver"],
       "cwd": "${workspaceRoot}",
-      "debugOptions": ["WaitOnAbnormalExit", "WaitOnNormalExit", "RedirectOutput"]
+      "debugOptions": [
+        "WaitOnAbnormalExit",
+        "WaitOnNormalExit",
+        "RedirectOutput"
+      ]
     },
     {
       "name": "sentry backend debug",

--- a/babel.config.ts
+++ b/babel.config.ts
@@ -1,6 +1,6 @@
 /* eslint-env node */
 
-import {TransformOptions} from '@babel/core';
+import type {TransformOptions} from '@babel/core';
 
 const config: TransformOptions = {
   presets: [

--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,14 @@
     "enabled": false
   },
   "linter": {
-    "enabled": false
+    "enabled": true,
+    "rules": {
+      "recommended": false,
+      "nursery": {
+        "useExportType": "error",
+        "useImportType": "error"
+      }
+    }
   },
   "files": {
     "ignoreUnknown": true,
@@ -47,6 +54,10 @@
   "json": {
     "formatter": {
       "enabled": true
+    },
+    "parser": {
+      "allowComments": true,
+      "allowTrailingCommas": true
     }
   }
 }

--- a/build-utils/integration-docs-fetch-plugin.ts
+++ b/build-utils/integration-docs-fetch-plugin.ts
@@ -7,7 +7,7 @@ import https from 'https';
 import path from 'path';
 import url from 'url';
 
-import webpack from 'webpack';
+import type webpack from 'webpack';
 
 const INTEGRATIONS_DOC_URL =
   process.env.INTEGRATION_DOCS_URL || 'https://docs.sentry.io/_platforms/';

--- a/build-utils/last-built-plugin.ts
+++ b/build-utils/last-built-plugin.ts
@@ -4,7 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import webpack from 'webpack';
+import type webpack from 'webpack';
 
 type Options = {
   basePath: string;

--- a/build-utils/sentry-instrumentation.ts
+++ b/build-utils/sentry-instrumentation.ts
@@ -7,7 +7,7 @@ import os from 'os';
 
 import type Sentry from '@sentry/node';
 import type {Transaction} from '@sentry/types';
-import webpack from 'webpack';
+import type webpack from 'webpack';
 
 const {
   NODE_ENV,

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -114,7 +114,7 @@
     "plugins": [
       // The styled plugin provides language server autocompletion for styled
       // component template strings
-      {"name": "@styled/typescript-styled-plugin"}
+      { "name": "@styled/typescript-styled-plugin" }
     ]
   },
   "include": ["../static/app", "../tests/js", "../fixtures/js-stubs"],

--- a/static/app/components/alerts/onDemandMetricAlert.tsx
+++ b/static/app/components/alerts/onDemandMetricAlert.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type React from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';

--- a/static/app/components/dropdownAutoComplete/index.tsx
+++ b/static/app/components/dropdownAutoComplete/index.tsx
@@ -1,4 +1,5 @@
-import React, {useCallback, useState} from 'react';
+import type React from 'react';
+import {useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 
 import type {MenuProps} from './menu';

--- a/static/app/components/events/eventStatisticalDetector/transactionsDeltaProvider.tsx
+++ b/static/app/components/events/eventStatisticalDetector/transactionsDeltaProvider.tsx
@@ -1,4 +1,5 @@
-import React, {createContext, useContext} from 'react';
+import type React from 'react';
+import {createContext, useContext} from 'react';
 
 import {RELATIVE_DAYS_WINDOW} from 'sentry/components/events/eventStatisticalDetector/consts';
 import type {Event, Project} from 'sentry/types';

--- a/static/app/components/events/interfaces/crashContent/exception/actionableItems.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/actionableItems.tsx
@@ -1,4 +1,5 @@
-import React, {Fragment, useEffect, useMemo, useState} from 'react';
+import type React from 'react';
+import {Fragment, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import startCase from 'lodash/startCase';
 import moment from 'moment';

--- a/static/app/components/profiling/flamegraph/deprecatedAggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/deprecatedAggregateFlamegraph.tsx
@@ -1,5 +1,6 @@
 import type {ReactElement} from 'react';
-import React, {Fragment, useEffect, useLayoutEffect, useMemo, useState} from 'react';
+import type React from 'react';
+import {Fragment, useEffect, useLayoutEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import type {mat3} from 'gl-matrix';

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
@@ -1,4 +1,5 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import type React from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';

--- a/static/app/utils/performance/contexts/pageAlert.tsx
+++ b/static/app/utils/performance/contexts/pageAlert.tsx
@@ -1,4 +1,5 @@
-import React, {createContext, Fragment, useContext, useState} from 'react';
+import type React from 'react';
+import {createContext, Fragment, useContext, useState} from 'react';
 import type {Theme} from '@emotion/react';
 
 import {Alert} from 'sentry/components/alert';

--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -3,11 +3,7 @@ import {Fragment, Profiler, useEffect, useRef} from 'react';
 import type {IdleTransaction} from '@sentry/core';
 import {captureMessage, setExtra, setTag} from '@sentry/react';
 import * as Sentry from '@sentry/react';
-import {
-  type MeasurementUnit,
-  type Transaction,
-  type TransactionEvent,
-} from '@sentry/types';
+import type {MeasurementUnit, Transaction, TransactionEvent} from '@sentry/types';
 import {
   _browserPerformanceTimeOriginMode,
   browserPerformanceTimeOrigin,

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsHoverWrapper.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsHoverWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type React from 'react';
 import styled from '@emotion/styled';
 
 import CircleIndicator from 'sentry/components/circleIndicator';

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -14,7 +14,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import TerserPlugin from 'terser-webpack-plugin';
 import webpack from 'webpack';
-import {Configuration as DevServerConfig} from 'webpack-dev-server';
+import type {Configuration as DevServerConfig} from 'webpack-dev-server';
 import WebpackHookPlugin from 'webpack-hook-plugin';
 import FixStyleOnlyEntriesPlugin from 'webpack-remove-empty-scripts';
 


### PR DESCRIPTION
There's good news, and there is bad news.

**Bad news:** I should have done a better job on researching Biome. It appears so that, with Biome v1.5.0, they added typescript-eslint rules, which got merged into Biome `main` at Jan 4, 2024.

**Good news:** Moving to Biome for these 2 rules and enabling the linter, speeds up the linter, since we don't have to parse those files anymore, and actually finds bugs!

My motivation is to tackle the typescript-eslint related issues where the file that's triggered through a `pre-commit-hook` isn't included in the proper tsconfig `include` property. Such error is:

```
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
```

----------

**Bonus:** Biome still takes less than a second:

```
$ biome check .
Checked 5117 file(s) in 788ms
```