### PR TITLE
fix(api): Cleanup delete code for auth tokens

### DIFF
--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -66,12 +66,7 @@ class ApiTokensEndpoint(Endpoint):
                 "application"
             )
         )
-        """
-        TODO:
-        - when the delete endpoint no longer requires the full token value, update this to stop including token
-        - update the endpoint to use pagination instead of unbounded return
-        """
-        return Response(serialize(token_list, request.user))
+        return Response(serialize(token_list, request.user, include_token=False))
 
     @method_decorator(never_cache)
     def post(self, request: Request) -> Response:

--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -42,7 +42,7 @@ class ApiTokensEndpoint(Endpoint):
         """
         Gets the user id to use for the request, based on what the current state of the request is.
         If the request is made by a superuser, then they are allowed to act on behalf of other user's data.
-        Therefore, when GET or DELETE endpoints are invoked by the superuser, they can use another user id.
+        Therefore, when GET or DELETE endpoints are invoked by the superuser, we may utilize a provided user_id.
 
         The user_id to use comes from the GET or BODY parameter based on the request type.
         For GET endpoints, the GET dict is used.

--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.conf import settings
 from django.db import router, transaction
 from django.utils.decorators import method_decorator
@@ -35,11 +37,29 @@ class ApiTokensEndpoint(Endpoint):
     authentication_classes = (SessionNoAuthTokenAuthentication,)
     permission_classes = (IsAuthenticated,)
 
-    @method_decorator(never_cache)
-    def get(self, request: Request) -> Response:
+    @classmethod
+    def _get_appropriate_user_id(cls, request: Request) -> str:
+        """
+        Gets the user id to use for the request, based on what the current state of the request is.
+        If the request is made by a superuser, then they are allowed to act on behalf of other user's data.
+        Therefore, when GET or DELETE endpoints are invoked by the superuser, they can use another user id.
+
+        The user_id to use comes from the GET or BODY parameter based on the request type.
+        For GET endpoints, the GET dict is used.
+        For all others, the DATA dict is used.
+        """
+        # Get the user id for the user that made the current request as a baseline default
         user_id = request.user.id
         if is_active_superuser(request):
-            user_id = request.GET.get("userId", user_id)
+            datastore = request.GET if request.GET else request.data
+            # If a userId override is not found, use the id for the user who made the request
+            user_id = datastore.get("userId", user_id)
+
+        return user_id
+
+    @method_decorator(never_cache)
+    def get(self, request: Request) -> Response:
+        user_id = self._get_appropriate_user_id(request=request)
 
         token_list = list(
             ApiToken.objects.filter(application__isnull=True, user_id=user_id).select_related(
@@ -83,27 +103,21 @@ class ApiTokensEndpoint(Endpoint):
 
     @method_decorator(never_cache)
     def delete(self, request: Request):
-        user_id = request.user.id
-        if is_active_superuser(request):
-            user_id = request.data.get("userId", user_id)
-        # TODO: we should not be requiring full token value in the delete endpoint, and should instead be using the id
-        token = request.data.get("token", None)
+        user_id = self._get_appropriate_user_id(request=request)
         token_id = request.data.get("tokenId", None)
         # Account for token_id being 0, which can be considered valid
-        if not token and token_id is None:
-            return Response({"token": token, "tokenId": token_id}, status=400)
+        if token_id is None:
+            return Response({"tokenId": token_id}, status=400)
 
         with outbox_context(transaction.atomic(router.db_for_write(ApiToken)), flush=False):
-            if token:
-                for token in ApiToken.objects.filter(
-                    user_id=user_id, token=token, application__isnull=True
-                ):
-                    token.delete()
-            else:
-                token_to_delete = ApiToken.objects.get(
-                    id=token_id, application__isnull=True, user_id=user_id
-                )
-                token_to_delete.delete()
+            token_to_delete: Optional[ApiToken] = ApiToken.objects.filter(
+                id=token_id, application__isnull=True, user_id=user_id
+            ).first()
+
+            if token_to_delete is None:
+                return Response({"tokenId": token_id, "userId": user_id}, status=400)
+
+            token_to_delete.delete()
 
         analytics.record("api_token.deleted", user_id=request.user.id)
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/__init__.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/__init__.py
@@ -10,10 +10,7 @@ from .installation.external_issue.index import SentryAppInstallationExternalIssu
 from .installation.external_requests import SentryAppInstallationExternalRequestsEndpoint
 from .installation.index import SentryAppInstallationsEndpoint
 from .interaction import SentryAppInteractionEndpoint
-from .internal_app_token.details import (
-    NewSentryInternalAppTokenDetailsEndpoint,
-    SentryInternalAppTokenDetailsEndpoint,
-)
+from .internal_app_token.details import SentryInternalAppTokenDetailsEndpoint
 from .internal_app_token.index import SentryInternalAppTokensEndpoint
 from .organization_sentry_apps import OrganizationSentryAppsEndpoint
 from .publish_request import SentryAppPublishRequestEndpoint
@@ -41,6 +38,5 @@ __all__ = (
     "SentryAppsStatsEndpoint",
     "SentryAppStatsEndpoint",
     "SentryInternalAppTokenDetailsEndpoint",
-    "NewSentryInternalAppTokenDetailsEndpoint",
     "SentryInternalAppTokensEndpoint",
 )

--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
@@ -16,7 +16,6 @@ from sentry.models.apitoken import ApiToken
 from sentry.models.integrations.sentry_app_installation_token import SentryAppInstallationToken
 
 
-# TODO: this endpoint should be deprecated in favor of the new version below, as this endpoint exposes the secret token
 @control_silo_endpoint
 class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
     owner = ApiOwner.INTEGRATIONS
@@ -25,13 +24,13 @@ class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
     }
     permission_classes = (SentryInternalAppTokenPermission,)
 
-    def convert_args(self, request: Request, sentry_app_slug, api_token, *args, **kwargs):
+    def convert_args(self, request: Request, sentry_app_slug, api_token_id, *args, **kwargs):
         # get the sentry_app from the SentryAppBaseEndpoint class
         (args, kwargs) = super().convert_args(request, sentry_app_slug, *args, **kwargs)
 
         try:
-            kwargs["api_token"] = ApiToken.objects.get(token=api_token)
-        except ApiToken.DoesNotExist:
+            kwargs["api_token"] = ApiToken.objects.get(id=api_token_id)
+        except (ApiToken.DoesNotExist, ValueError):
             raise Http404
 
         return (args, kwargs)
@@ -71,28 +70,3 @@ class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
         )
 
         return Response(status=204)
-
-
-# TODO: when the above endpoint is deprecated, simply move the convert method.
-# This endpoint handler utilizes the id instead.
-@control_silo_endpoint
-class NewSentryInternalAppTokenDetailsEndpoint(SentryInternalAppTokenDetailsEndpoint):
-    owner = ApiOwner.INTEGRATIONS
-    publish_status = {
-        "DELETE": ApiPublishStatus.EXPERIMENTAL,
-    }
-
-    # The api_token is actually the id of the api token, but needs the same signature of the parent class method
-    def convert_args(self, request: Request, sentry_app_slug, api_token, *args, **kwargs):
-        try:
-            api_token_obj = ApiToken.objects.get(id=api_token)
-        except ApiToken.DoesNotExist:
-            raise Http404
-
-        # We are doing the super call AFTER getting the api token because the parent class still needs the token
-        # Once the token passing is deprecated, we can change the order to be similar to the parent
-        (args, kwargs) = super().convert_args(
-            request, sentry_app_slug, api_token_obj.token, *args, **kwargs
-        )
-
-        return (args, kwargs)

--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/details.py
@@ -20,7 +20,7 @@ from sentry.models.integrations.sentry_app_installation_token import SentryAppIn
 class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
     owner = ApiOwner.INTEGRATIONS
     publish_status = {
-        "DELETE": ApiPublishStatus.UNKNOWN,
+        "DELETE": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (SentryInternalAppTokenPermission,)
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/index.py
@@ -34,7 +34,8 @@ class SentryInternalAppTokensEndpoint(SentryAppBaseEndpoint):
         attrs = {"application": None}
 
         token_list = [
-            ApiTokenSerializer().serialize(token, attrs, request.user) for token in tokens
+            ApiTokenSerializer().serialize(token, attrs, request.user, include_token=False)
+            for token in tokens
         ]
 
         if not sentry_app.show_auth_info(request.access):

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -243,7 +243,6 @@ from .endpoints.integrations import (
     OrganizationPluginsEndpoint,
 )
 from .endpoints.integrations.sentry_apps import (
-    NewSentryInternalAppTokenDetailsEndpoint,
     OrganizationSentryAppComponentsEndpoint,
     OrganizationSentryAppsEndpoint,
     SentryAppAuthorizationsEndpoint,
@@ -2761,15 +2760,8 @@ SENTRY_APP_URLS = [
         SentryInternalAppTokensEndpoint.as_view(),
         name="sentry-api-0-sentry-internal-app-tokens",
     ),
-    # The order of the next 2 urls matters. We want to let the numeric id handler try to match the regex first,
-    # before moving to alphanumeric which is a catch-all.
     re_path(
-        r"^(?P<sentry_app_slug>[^\/]+)/api-tokens/(?P<api_token>\d+)/$",
-        NewSentryInternalAppTokenDetailsEndpoint.as_view(),
-        name="sentry-api-0-sentry-internal-app-token-details",
-    ),
-    re_path(
-        r"^(?P<sentry_app_slug>[^\/]+)/api-tokens/(?P<api_token>\w+)/$",
+        r"^(?P<sentry_app_slug>[^\/]+)/api-tokens/(?P<api_token_id>[^\/]+)/$",
         SentryInternalAppTokenDetailsEndpoint.as_view(),
         name="sentry-api-0-sentry-internal-app-token-details",
     ),

--- a/tests/sentry/api/endpoints/test_api_tokens.py
+++ b/tests/sentry/api/endpoints/test_api_tokens.py
@@ -127,7 +127,7 @@ class ApiTokensSuperUserTest(APITestCase):
         response = self.client.get(self.url, {"userId": self.user.id})
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
-        assert response.data[0]["token"] == user_token.token
+        assert response.data[0]["id"] == str(user_token.id)
 
     def test_get_as_su_implicit_userid(self):
         super_user = self.create_user(is_superuser=True)
@@ -138,8 +138,8 @@ class ApiTokensSuperUserTest(APITestCase):
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
-        assert response.data[0]["token"] != user_token.token
-        assert response.data[0]["token"] == superuser_token.token
+        assert response.data[0]["id"] != str(user_token.id)
+        assert response.data[0]["id"] == str(superuser_token.id)
 
     def test_get_as_user(self):
         super_user = self.create_user(is_superuser=True)
@@ -149,7 +149,7 @@ class ApiTokensSuperUserTest(APITestCase):
         response = self.client.get(self.url, {"userId": self.user.id})
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
-        assert response.data[0]["token"] == su_token.token
+        assert response.data[0]["id"] == str(su_token.id)
 
     def test_delete_as_su(self):
         super_user = self.create_user(is_superuser=True)

--- a/tests/sentry/api/endpoints/test_api_tokens.py
+++ b/tests/sentry/api/endpoints/test_api_tokens.py
@@ -8,23 +8,26 @@ from sentry.testutils.silo import control_silo_test
 
 @control_silo_test
 class ApiTokensListTest(APITestCase):
-    def test_simple(self):
-        ApiToken.objects.create(user=self.user)
-        ApiToken.objects.create(user=self.user)
+    def setUp(self) -> None:
+        super().setUp()
+        for _ in range(2):
+            ApiToken.objects.create(user=self.user)
 
+    def test_simple(self):
         self.login_as(self.user)
+
         url = reverse("sentry-api-0-api-tokens")
         response = self.client.get(url)
+
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
 
     def test_never_cache(self):
-        ApiToken.objects.create(user=self.user)
-        ApiToken.objects.create(user=self.user)
-
         self.login_as(self.user)
+
         url = reverse("sentry-api-0-api-tokens")
         response = self.client.get(url)
+
         assert response.status_code == 200, response.content
         assert (
             response.get("cache-control")
@@ -88,7 +91,7 @@ class ApiTokensDeleteTest(APITestCase):
         token = ApiToken.objects.create(user=self.user)
         self.login_as(self.user)
         url = reverse("sentry-api-0-api-tokens")
-        response = self.client.delete(url, data={"token": token.token})
+        response = self.client.delete(url, data={"tokenId": token.id})
         assert response.status_code == 204
         assert not ApiToken.objects.filter(id=token.id).exists()
 
@@ -96,20 +99,12 @@ class ApiTokensDeleteTest(APITestCase):
         token = ApiToken.objects.create(user=self.user)
         self.login_as(self.user)
         url = reverse("sentry-api-0-api-tokens")
-        response = self.client.delete(url, data={"token": token.token})
+        response = self.client.delete(url, data={"tokenId": token.id})
         assert response.status_code == 204
         assert (
             response.get("cache-control")
             == "max-age=0, no-cache, no-store, must-revalidate, private"
         )
-
-    def test_with_id(self) -> None:
-        token = ApiToken.objects.create(user=self.user)
-        self.login_as(self.user)
-        url = reverse("sentry-api-0-api-tokens")
-        response = self.client.delete(url, data={"tokenId": token.id})
-        assert response.status_code == 204
-        assert not ApiToken.objects.filter(id=token.id).exists()
 
     def test_returns_400_when_no_token_param_is_sent(self) -> None:
         token = ApiToken.objects.create(user=self.user)
@@ -161,7 +156,7 @@ class ApiTokensSuperUserTest(APITestCase):
         user_token = ApiToken.objects.create(user=self.user)
         self.login_as(super_user, superuser=True)
 
-        response = self.client.delete(self.url, {"userId": self.user.id, "token": user_token.token})
+        response = self.client.delete(self.url, {"userId": self.user.id, "tokenId": user_token.id})
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert not ApiToken.objects.filter(id=user_token.id).exists()
 
@@ -171,12 +166,13 @@ class ApiTokensSuperUserTest(APITestCase):
         su_token = ApiToken.objects.create(user=super_user)
         self.login_as(super_user, superuser=True)
 
-        response = self.client.delete(self.url, {"token": user_token.token})
-        assert response.status_code == status.HTTP_204_NO_CONTENT
+        response = self.client.delete(self.url, {"tokenId": user_token.id})
+        # The superusers' id will be used since no override is sent, and because it does not exist, it is a bad request
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert ApiToken.objects.filter(id=user_token.id).exists()
         assert ApiToken.objects.filter(id=su_token.id).exists()
 
-        response = self.client.delete(self.url, {"token": su_token.token})
+        response = self.client.delete(self.url, {"tokenId": su_token.id})
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert ApiToken.objects.filter(id=user_token.id).exists()
         assert not ApiToken.objects.filter(id=su_token.id).exists()
@@ -187,7 +183,7 @@ class ApiTokensSuperUserTest(APITestCase):
         su_token = ApiToken.objects.create(user=super_user)
         self.login_as(super_user)
         # Fails trying to delete the user's token, since we're not an active superuser
-        response = self.client.delete(self.url, {"userId": self.user.id, "token": user_token.token})
-        assert response.status_code == status.HTTP_204_NO_CONTENT
+        response = self.client.delete(self.url, {"userId": self.user.id, "tokenId": user_token.id})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert ApiToken.objects.filter(id=user_token.id).exists()
         assert ApiToken.objects.filter(id=su_token.id).exists()

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
@@ -20,7 +20,7 @@ class SentryInternalAppTokenCreationTest(APITestCase):
 
         self.url = reverse(
             "sentry-api-0-sentry-internal-app-token-details",
-            args=[self.internal_sentry_app.slug, self.api_token.token],
+            args=[self.internal_sentry_app.slug, self.api_token.id],
         )
 
     def test_delete_token(self):
@@ -47,7 +47,7 @@ class SentryInternalAppTokenCreationTest(APITestCase):
 
         url = reverse(
             "sentry-api-0-sentry-internal-app-token-details",
-            args=[self.internal_sentry_app.slug, api_token.token],
+            args=[self.internal_sentry_app.slug, api_token.id],
         )
 
         self.login_as(user=self.user)
@@ -63,7 +63,7 @@ class SentryInternalAppTokenCreationTest(APITestCase):
 
         url = reverse(
             "sentry-api-0-sentry-internal-app-token-details",
-            args=[install.sentry_app.slug, install.api_token.token],
+            args=[install.sentry_app.slug, install.api_token.id],
         )
 
         self.login_as(user=self.user)
@@ -76,7 +76,7 @@ class SentryInternalAppTokenCreationTest(APITestCase):
 
         url = reverse(
             "sentry-api-0-sentry-internal-app-token-details",
-            args=["not_a_slug", self.api_token.token],
+            args=["not_a_slug", self.api_token.id],
         )
 
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
@@ -88,7 +88,6 @@ class GetSentryInternalAppTokenTest(SentryInternalAppTokenTest):
         assert len(response_content) == 1
 
         assert response_content[0]["id"] == str(token.id)
-        assert response_content[0]["token"] == token.token
 
     def no_access_for_members(self):
         user = self.create_user(email="meep@example.com")


### PR DESCRIPTION
We were allowing deletes to still be done by tokens, along with ids, such that we can support blue/green deployments with the FE. Now that we've migrated the FE code off of relying on token deletion through the token values, we can remove the support for deleting tokens by value, and only keep the id logic. We can also stop sending the token values through the get endpoints as we don't rely on them.

Resolves: https://github.com/getsentry/team-enterprise/issues/21

Transactions showing endpoint usage: https://sentry.sentry.io/performance/summary/?environment=prod&project=1&query=http.method%3ADELETE&referrer=performance-transaction-summary&statsPeriod=14d&transaction=%2Fapi%2F0%2Fsentry-apps%2F%7Bsentry_app_slug%7D%2Fapi-tokens%2F%7Bapi_token%7D%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29
