### PR TITLE
feat(issues): Adjust trace timeline grouping

### DIFF
--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
@@ -28,9 +28,9 @@ export function TraceTimeline({event}: TraceTimelineProps) {
     return null;
   }
 
-  if (isError || (!isLoading && !data)) {
+  if (isError || (!isLoading && data.length === 0)) {
     // display placeholder to reduce layout shift
-    return <div style={{height: 20}} />;
+    return <div style={{height: 45}} />;
   }
 
   return (

--- a/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
+++ b/static/app/views/issueDetails/traceTimeline/traceTimeline.tsx
@@ -22,13 +22,13 @@ export function TraceTimeline({event}: TraceTimelineProps) {
   const timelineRef = useRef<HTMLDivElement>(null);
   const {width} = useDimensions({elementRef: timelineRef});
   const hasFeature = hasTraceTimelineFeature(organization, user);
-  const {isError, isLoading} = useTraceTimelineEvents({event}, hasFeature);
+  const {isError, isLoading, data} = useTraceTimelineEvents({event}, hasFeature);
 
   if (!hasFeature) {
     return null;
   }
 
-  if (isError) {
+  if (isError || (!isLoading && !data)) {
     // display placeholder to reduce layout shift
     return <div style={{height: 20}} />;
   }

--- a/static/app/views/issueDetails/traceTimeline/utils.spec.tsx
+++ b/static/app/views/issueDetails/traceTimeline/utils.spec.tsx
@@ -1,0 +1,26 @@
+import {getChunkTimeRange} from './utils';
+
+describe('getChunkTimeRange', () => {
+  const start = 1000000000; // Easier to understand timestamp
+  const chunkDurationMs = 500000; // Half a minute
+  it('should return correct timestamps for the first chunk', () => {
+    const chunkIndex = 0;
+    expect(getChunkTimeRange(start, chunkIndex, chunkDurationMs)).toEqual([
+      1000000000, 1000500001,
+    ]);
+  });
+
+  it('should return correct timestamps for a chunk in the middle', () => {
+    const chunkIndex = 2;
+    expect(getChunkTimeRange(start, chunkIndex, chunkDurationMs)).toEqual([
+      1001000000, 1001500001,
+    ]);
+  });
+
+  it('should return correct timestamps for the last chunk', () => {
+    const chunkIndex = 10; // Assume 10 chunks total
+    expect(getChunkTimeRange(start, chunkIndex, chunkDurationMs)).toEqual([
+      1005000000, 1005500001,
+    ]);
+  });
+});

--- a/static/app/views/issueDetails/traceTimeline/utils.tsx
+++ b/static/app/views/issueDetails/traceTimeline/utils.tsx
@@ -30,6 +30,24 @@ export function getEventsByColumn(
   return eventsByColumn;
 }
 
+export function getChunkTimeRange(
+  startTimestamp: number,
+  chunkIndex: number,
+  chunkDurationMs: number
+): [number, number] {
+  // Calculate the absolute start time of the chunk in milliseconds
+  const chunkStartMs = chunkIndex * chunkDurationMs;
+
+  // Add the chunk start time to the overall start timestamp
+  const chunkStartTimestamp = startTimestamp + chunkStartMs;
+
+  // Calculate the end timestamp by adding the chunk duration
+  const chunkEndTimestamp = chunkStartTimestamp + chunkDurationMs;
+
+  // Round up and down to the nearest second
+  return [Math.floor(chunkStartTimestamp), Math.floor(chunkEndTimestamp) + 1];
+}
+
 export function hasTraceTimelineFeature(
   organization: Organization | null,
   user: User | undefined


### PR DESCRIPTION
- fixes some of the math that was over rendering items in the same sub grid
- prevents rendering of a timeline with zero items

[example event](https://sentry.sentry.io/issues/4808560416/events/8ed20d163c1247c78df00916b084ae45/) before

![Screenshot 2024-01-30 at 5 42 45 PM](https://github.com/getsentry/sentry/assets/1400464/87dc28ea-bdc2-4686-8439-60cfaa816bc7)

after - more dots which is correct
![Screenshot 2024-01-30 at 5 43 15 PM](https://github.com/getsentry/sentry/assets/1400464/132aa4bd-7dac-4bc5-af51-fd51479f5dcf)
