### PR TITLE
fix(hc): Moves client call count check to precede request, removes deletion after throwing silo limits

### DIFF
--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -220,14 +220,6 @@ class RegionSiloClient(BaseSiloClient):
         if request_attempts > REQUEST_ATTEMPTS_LIMIT:
             raise SiloClientError(f"Request attempts limit reached for: {method} {path}")
 
-    def cleanup_request_attempts(self, hash: str | None) -> None:
-        if hash is None:
-            return
-
-        self.logger.info("silo_client.cleaning_request_attempts", extra={"request_hash": hash})
-        cache_key = self._get_hash_cache_key(hash=hash)
-        cache.delete(cache_key)
-
     def request(
         self,
         method: str,
@@ -258,5 +250,4 @@ class RegionSiloClient(BaseSiloClient):
             raw_response=raw_response,
         )
 
-        self.cleanup_request_attempts(hash=hash)
         return response

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -110,7 +110,6 @@ class ProcessControlOutboxTest(TestCase):
         parent_mock = mock.Mock()
         parent_mock.attach_mock(mock_cache.get, "cache_get")
         parent_mock.attach_mock(mock_cache.set, "cache_set")
-        parent_mock.attach_mock(mock_cache.delete, "cache_delete")
 
         request, outbox, cache_key = self.generate_outbox()
 
@@ -130,13 +129,11 @@ class ProcessControlOutboxTest(TestCase):
 
         assert mock_cache.get.call_count == 1
         assert mock_cache.set.call_count == 1
-        assert mock_cache.delete.call_count == 1
 
         # Assert order of cache method calls
         expected_calls = [
             mock.call.cache_get(cache_key),
             mock.call.cache_set(cache_key, 1, timeout=CACHE_TIMEOUT),
-            mock.call.cache_delete(cache_key),
         ]
         assert parent_mock.mock_calls == expected_calls
 
@@ -147,7 +144,6 @@ class ProcessControlOutboxTest(TestCase):
         parent_mock = mock.Mock()
         parent_mock.attach_mock(mock_cache.get, "cache_get")
         parent_mock.attach_mock(mock_cache.set, "cache_set")
-        parent_mock.attach_mock(mock_cache.delete, "cache_delete")
 
         request, outbox, cache_key = self.generate_outbox()
 
@@ -168,7 +164,6 @@ class ProcessControlOutboxTest(TestCase):
 
         assert mock_cache.get.call_count == 1
         assert mock_cache.set.call_count == 1
-        assert mock_cache.delete.call_count == 0
 
         # Assert order of cache method calls
         expected_calls = [
@@ -204,7 +199,6 @@ class ProcessControlOutboxTest(TestCase):
             parent_mock = mock.Mock()
             parent_mock.attach_mock(mock_cache.get, "cache_get")
             parent_mock.attach_mock(mock_cache.set, "cache_set")
-            parent_mock.attach_mock(mock_cache.delete, "cache_delete")
 
             if num_of_request_attempts == REQUEST_ATTEMPTS_LIMIT:
                 with mock.patch("sentry_sdk.capture_exception") as capture_exception:
@@ -226,7 +220,6 @@ class ProcessControlOutboxTest(TestCase):
 
                 assert mock_cache.get.call_count == 1
                 assert mock_cache.set.call_count == 1
-                assert mock_cache.delete.call_count == 0
 
                 # Assert order of cache method calls
                 expected_calls = [
@@ -251,7 +244,6 @@ class ProcessControlOutboxTest(TestCase):
 
                 assert mock_cache.get.call_count == 1
                 assert mock_cache.set.call_count == 1
-                assert mock_cache.delete.call_count == 0
 
                 # Assert order of cache method calls
                 expected_calls = [
@@ -292,7 +284,6 @@ class ProcessControlOutboxTest(TestCase):
             parent_mock = mock.Mock()
             parent_mock.attach_mock(mock_cache.get, "cache_get")
             parent_mock.attach_mock(mock_cache.set, "cache_set")
-            parent_mock.attach_mock(mock_cache.delete, "cache_delete")
 
             if num_of_request_attempts == (REQUEST_ATTEMPTS_LIMIT - 1):
                 with mock.patch("sentry_sdk.capture_exception") as capture_exception:
@@ -308,13 +299,11 @@ class ProcessControlOutboxTest(TestCase):
 
                 assert mock_cache.get.call_count == 1
                 assert mock_cache.set.call_count == 1
-                assert mock_cache.delete.call_count == 1
 
                 # Assert order of cache method calls
                 expected_calls = [
                     mock.call.cache_get(cache_key),
                     mock.call.cache_set(cache_key, 10, timeout=CACHE_TIMEOUT),
-                    mock.call.cache_delete(cache_key),
                 ]
                 assert parent_mock.mock_calls == expected_calls
                 return
@@ -334,7 +323,6 @@ class ProcessControlOutboxTest(TestCase):
 
                 assert mock_cache.get.call_count == 1
                 assert mock_cache.set.call_count == 1
-                assert mock_cache.delete.call_count == 0
 
                 # Assert order of cache method calls
                 expected_calls = [
@@ -386,7 +374,6 @@ class ProcessControlOutboxTest(TestCase):
             parent_mock = mock.Mock()
             parent_mock.attach_mock(mock_cache.get, "cache_get")
             parent_mock.attach_mock(mock_cache.set, "cache_set")
-            parent_mock.attach_mock(mock_cache.delete, "cache_delete")
 
             with mock.patch("sentry_sdk.capture_exception") as capture_exception:
                 # Does not raise on ApiHostError exceptions
@@ -412,7 +399,6 @@ class ProcessControlOutboxTest(TestCase):
 
                 assert mock_cache.get.call_count == 1
                 assert mock_cache.set.call_count == 1
-                assert mock_cache.delete.call_count == 0
 
                 # Assert order of cache method calls
                 expected_calls = [
@@ -441,7 +427,6 @@ class ProcessControlOutboxTest(TestCase):
             parent_mock = mock.Mock()
             parent_mock.attach_mock(mock_cache.get, "cache_get")
             parent_mock.attach_mock(mock_cache.set, "cache_set")
-            parent_mock.attach_mock(mock_cache.delete, "cache_delete")
 
             expected_exception: Type[Exception] = ApiTimeoutError
             if api_host_error == ApiConnectionResetError:
@@ -463,7 +448,6 @@ class ProcessControlOutboxTest(TestCase):
 
             assert mock_cache.get.call_count == 1
             assert mock_cache.set.call_count == 1
-            assert mock_cache.delete.call_count == 0
 
             # Assert order of cache method calls
             expected_calls = [
@@ -478,7 +462,6 @@ class ProcessControlOutboxTest(TestCase):
         parent_mock = mock.Mock()
         parent_mock.attach_mock(mock_cache.get, "cache_get")
         parent_mock.attach_mock(mock_cache.set, "cache_set")
-        parent_mock.attach_mock(mock_cache.delete, "cache_delete")
 
         request, outbox, cache_key = self.generate_outbox()
 
@@ -501,7 +484,6 @@ class ProcessControlOutboxTest(TestCase):
 
             assert mock_cache.get.call_count == 1
             assert mock_cache.set.call_count == 1
-            assert mock_cache.delete.call_count == 0
 
             # Assert order of cache method calls
             expected_calls = [
@@ -516,7 +498,6 @@ class ProcessControlOutboxTest(TestCase):
         parent_mock = mock.Mock()
         parent_mock.attach_mock(mock_cache.get, "cache_get")
         parent_mock.attach_mock(mock_cache.set, "cache_set")
-        parent_mock.attach_mock(mock_cache.delete, "cache_delete")
 
         request, outbox, cache_key = self.generate_outbox()
 
@@ -544,7 +525,6 @@ class ProcessControlOutboxTest(TestCase):
 
             assert mock_cache.get.call_count == 1
             assert mock_cache.set.call_count == 1
-            assert mock_cache.delete.call_count == 0
 
             # Assert order of cache method calls
             expected_calls = [

--- a/tests/sentry/receivers/outbox/test_control.py
+++ b/tests/sentry/receivers/outbox/test_control.py
@@ -128,12 +128,14 @@ class ProcessControlOutboxTest(TestCase):
 
         assert mock_response.call_count == 1
 
-        assert mock_cache.get.call_count == 0
-        assert mock_cache.set.call_count == 0
+        assert mock_cache.get.call_count == 1
+        assert mock_cache.set.call_count == 1
         assert mock_cache.delete.call_count == 1
 
         # Assert order of cache method calls
         expected_calls = [
+            mock.call.cache_get(cache_key),
+            mock.call.cache_set(cache_key, 1, timeout=CACHE_TIMEOUT),
             mock.call.cache_delete(cache_key),
         ]
         assert parent_mock.mock_calls == expected_calls
@@ -212,7 +214,7 @@ class ProcessControlOutboxTest(TestCase):
                         shard_identifier=outbox.shard_identifier,
                         object_identifier=outbox.object_identifier,
                     )
-                    assert len(responses.calls) == 1
+                    assert len(responses.calls) == 0
 
                     assert capture_exception.call_count == 1
                     exception = capture_exception.call_args.args[0]
@@ -223,13 +225,13 @@ class ProcessControlOutboxTest(TestCase):
                     )
 
                 assert mock_cache.get.call_count == 1
-                assert mock_cache.set.call_count == 0
-                assert mock_cache.delete.call_count == 1
+                assert mock_cache.set.call_count == 1
+                assert mock_cache.delete.call_count == 0
 
                 # Assert order of cache method calls
                 expected_calls = [
                     mock.call.cache_get(cache_key),
-                    mock.call.cache_delete(cache_key),
+                    mock.call.cache_set(cache_key, 11, timeout=CACHE_TIMEOUT),
                 ]
                 assert parent_mock.mock_calls == expected_calls
                 return
@@ -304,12 +306,14 @@ class ProcessControlOutboxTest(TestCase):
 
                     assert capture_exception.call_count == 0
 
-                assert mock_cache.get.call_count == 0
-                assert mock_cache.set.call_count == 0
+                assert mock_cache.get.call_count == 1
+                assert mock_cache.set.call_count == 1
                 assert mock_cache.delete.call_count == 1
 
                 # Assert order of cache method calls
                 expected_calls = [
+                    mock.call.cache_get(cache_key),
+                    mock.call.cache_set(cache_key, 10, timeout=CACHE_TIMEOUT),
                     mock.call.cache_delete(cache_key),
                 ]
                 assert parent_mock.mock_calls == expected_calls


### PR DESCRIPTION
Fixes an issue where clearing the call count cache after raising a silo limit error can cause outboxes to get stuck.

The current implementation will attempt to handle consecutive webhook timeouts by trying the request 10 times before clearing the call count and finally raising a silo error, but another bug with the outbox implementation causes the message to never be dropped. This causes the outbox to be reprocessed with a call count of 0 on the subsequent shard process, repeating the cycle.

By moving the call count check to precede the request, it will require an additional outbox shard processing iteration to discard the message, but will also ensure that we skip any potentially costly requests. This sidesteps the outbox issue and ensures discards are done with low latency which should allow the outbox implementation to clear these stuck messages.

This also removes the request count cache cleanup after exceeding the the max limit, ensuring that any failed outbox discards will attempt another discard on the subsequent shard drain.
