### PR TITLE
fix(security): deny fetching internal app tokens by auth token

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/internal_app_token/index.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.authentication import SessionNoAuthTokenAuthentication
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppBaseEndpoint, SentryInternalAppTokenPermission
 from sentry.api.endpoints.integrations.sentry_apps.details import (
@@ -24,6 +25,7 @@ class SentryInternalAppTokensEndpoint(SentryAppBaseEndpoint):
         "GET": ApiPublishStatus.UNKNOWN,
         "POST": ApiPublishStatus.UNKNOWN,
     }
+    authentication_classes = (SessionNoAuthTokenAuthentication,)
     permission_classes = (SentryInternalAppTokenPermission,)
 
     def get(self, request: Request, sentry_app) -> Response:

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
@@ -114,3 +114,13 @@ class GetSentryInternalAppTokenTest(SentryInternalAppTokenTest):
 
         assert response_content[0]["token"] == MASKED_VALUE
         assert response_content[0]["refreshToken"] == MASKED_VALUE
+
+    def test_deny_token_access(self):
+        self.login_as(self.user)
+        token = ApiToken.objects.create(user=self.user, scope_list=["org:write"])
+
+        sentry_app = self.create_internal_integration(name="OtherInternal", organization=self.org)
+
+        url = reverse("sentry-api-0-sentry-internal-app-tokens", args=[sentry_app.slug])
+        response = self.client.get(url, format="json", HTTP_AUTHORIZATION=f"Bearer {token.token}")
+        assert response.status_code == 403, response.content


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/53850
Internal app tokens should be accessible only via UI not auth tokens.