### PR TITLE
chore(dashbaords): move inline edit out of experimental

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -42,7 +42,7 @@ import {
   isEquationAlias,
 } from 'sentry/utils/discover/fields';
 import {isSupportedDisplayType} from 'sentry/utils/metrics';
-import {hasDDMExperimentalFeature} from 'sentry/utils/metrics/features';
+import {hasDDMFeature} from 'sentry/utils/metrics/features';
 import {parseField, parseMRI} from 'sentry/utils/metrics/mri';
 import {createOnDemandFilterWarning} from 'sentry/utils/onDemandMetrics';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
@@ -965,7 +965,7 @@ function WidgetViewerModal(props: Props) {
                 chartZoomOptions={chartZoomOptions}
               />
             ) : widget.widgetType === WidgetType.METRICS &&
-              hasDDMExperimentalFeature(organization) &&
+              hasDDMFeature(organization) &&
               isSupportedDisplayType(widget.displayType) ? (
               <MetricWidgetChartContainer widget={widget} selection={selection} />
             ) : (

--- a/static/app/views/dashboards/addWidget.tsx
+++ b/static/app/views/dashboards/addWidget.tsx
@@ -12,7 +12,7 @@ import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {hasDDMExperimentalFeature, hasDDMFeature} from 'sentry/utils/metrics/features';
+import {hasDDMFeature} from 'sentry/utils/metrics/features';
 import useOrganization from 'sentry/utils/useOrganization';
 import {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
 
@@ -62,7 +62,7 @@ function AddWidget({onAddWidget}: Props) {
         duration: 0.25,
       }}
     >
-      {hasDDMExperimentalFeature(organization) ? (
+      {hasDDMFeature(organization) ? (
         <InnerWrapper>
           <AddWidgetButton
             onAddWidget={onAddWidget}

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -13,7 +13,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {hasDDMExperimentalFeature} from 'sentry/utils/metrics/features';
+import {hasDDMFeature} from 'sentry/utils/metrics/features';
 import useOrganization from 'sentry/utils/useOrganization';
 import {AddWidgetButton} from 'sentry/views/dashboards/addWidget';
 import {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
@@ -171,7 +171,7 @@ function Controls({
                 })}
                 disabled={!widgetLimitReached}
               >
-                {hasDDMExperimentalFeature(organization) ? (
+                {hasDDMFeature(organization) ? (
                   <AddWidgetButton
                     onAddWidget={onAddWidget}
                     aria-label="Add Widget"

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -23,7 +23,7 @@ import {t} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import {space} from 'sentry/styles/space';
 import type {Organization, PageFilters} from 'sentry/types';
-import {hasDDMExperimentalFeature} from 'sentry/utils/metrics/features';
+import {hasDDMFeature} from 'sentry/utils/metrics/features';
 import theme from 'sentry/utils/theme';
 import withApi from 'sentry/utils/withApi';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
@@ -314,10 +314,7 @@ class Dashboard extends Component<Props, State> {
 
     const widget = this.props.dashboard.widgets[index];
 
-    if (
-      widget.widgetType === WidgetType.METRICS &&
-      hasDDMExperimentalFeature(organization)
-    ) {
+    if (widget.widgetType === WidgetType.METRICS && hasDDMFeature(organization)) {
       this.handleStartEditMetricWidget(index);
       return;
     }
@@ -551,7 +548,7 @@ class Dashboard extends Component<Props, State> {
     const canModifyLayout = !isMobile && isEditingDashboard;
 
     const displayInlineAddWidget =
-      hasDDMExperimentalFeature(organization) &&
+      hasDDMFeature(organization) &&
       isValidLayout({...this.addWidgetLayout, i: ADD_WIDGET_BUTTON_DRAG_ID});
 
     return (

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -26,7 +26,7 @@ import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import {isSupportedDisplayType} from 'sentry/utils/metrics';
-import {hasDDMExperimentalFeature} from 'sentry/utils/metrics/features';
+import {hasDDMFeature} from 'sentry/utils/metrics/features';
 import {ExtractedMetricsTag} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {
   MEPConsumer,
@@ -269,10 +269,7 @@ class WidgetCard extends Component<Props, State> {
     );
 
     if (widget.widgetType === WidgetType.METRICS) {
-      if (
-        hasDDMExperimentalFeature(organization) &&
-        isSupportedDisplayType(widget.displayType)
-      ) {
+      if (hasDDMFeature(organization) && isSupportedDisplayType(widget.displayType)) {
         return (
           <MetricWidgetCard
             index={this.props.index}

--- a/static/app/views/ddm/useChartGroup.tsx
+++ b/static/app/views/ddm/useChartGroup.tsx
@@ -1,0 +1,8 @@
+import {useLayoutEffect} from 'react';
+import * as echarts from 'echarts/core';
+
+export function useChartGroup(groupName: string, deps?: React.DependencyList) {
+  useLayoutEffect(() => {
+    echarts.connect(groupName);
+  }, [groupName, deps]);
+}


### PR DESCRIPTION
moves DDM dashboard features outside of experimental flag and enables them for alpha users