### PR TITLE
fix(prism): Selection background

### DIFF
--- a/static/app/styles/prism.tsx
+++ b/static/app/styles/prism.tsx
@@ -124,7 +124,8 @@ export const prismStyles = (theme: Theme) => css`
   }
 
   pre[class*='language-']::selection,
-  code[class*='language-']::selection {
+  code[class*='language-']::selection,
+  code[class*='language-'] *::selection {
     text-shadow: none;
     background: var(--prism-selected);
   }

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -158,7 +158,7 @@ const prismLight = {
 
 const prismDark = {
   '--prism-base': '#D6D0DC',
-  '--prism-selected': '#18121C',
+  '--prism-selected': '#393041',
   '--prism-inline-code': '#D6D0DC',
   '--prism-inline-code-background': '#18121C',
   '--prism-highlight-background': '#A8A2C31C',


### PR DESCRIPTION
### Problem

The selection color in prism's dark mode is only minimal darker than the code snippet's background and therefore not really visible.
Additionally it is not applied to sub-elements of the `<code/>` tag.

![Screenshot 2024-01-31 at 12 09 11](https://github.com/getsentry/sentry/assets/7033940/5881ad64-45af-4452-b593-f10096a59a41)

### Solution

Use a lighter color for the selection state and apply the style to all sub-elements.

![Screenshot 2024-01-31 at 12 03 08](https://github.com/getsentry/sentry/assets/7033940/fdc42fd5-6bc6-46ab-aa4b-fcd1f9f0a65a)

* closes https://github.com/getsentry/sentry/issues/64264
