### PR TITLE
ref: Remove `start_transaction` from `OrganizationIntegrationSetupView`

### DIFF
--- a/src/sentry/web/frontend/organization_integration_setup.py
+++ b/src/sentry/web/frontend/organization_integration_setup.py
@@ -1,5 +1,6 @@
 import logging
 
+import sentry_sdk
 from django.http import Http404
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
@@ -19,6 +20,10 @@ class OrganizationIntegrationSetupView(ControlSiloOrganizationView):
     csrf_protect = False
 
     def handle(self, request: Request, organization, provider_id) -> HttpResponseBase:
+        with sentry_sdk.configure_scope() as scope:
+            scope.transaction.op = "integration.setup"
+            scope.transaction.name = f"integration.{provider_id}"
+
         pipeline = IntegrationPipeline(
             request=request, organization=organization, provider_key=provider_id
         )

--- a/src/sentry/web/frontend/organization_integration_setup.py
+++ b/src/sentry/web/frontend/organization_integration_setup.py
@@ -4,6 +4,7 @@ import sentry_sdk
 from django.http import Http404
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
+from sentry_sdk.tracing import TRANSACTION_SOURCE_VIEW
 
 from sentry import features
 from sentry.features.exceptions import FeatureNotRegistered
@@ -21,9 +22,7 @@ class OrganizationIntegrationSetupView(ControlSiloOrganizationView):
 
     def handle(self, request: Request, organization, provider_id) -> HttpResponseBase:
         with sentry_sdk.configure_scope() as scope:
-            scope.set_transaction_name(
-                f"integration.{provider_id}", source="OrganizationIntegrationSetupView"
-            )
+            scope.set_transaction_name(f"integration.{provider_id}", source=TRANSACTION_SOURCE_VIEW)
 
         pipeline = IntegrationPipeline(
             request=request, organization=organization, provider_key=provider_id

--- a/src/sentry/web/frontend/organization_integration_setup.py
+++ b/src/sentry/web/frontend/organization_integration_setup.py
@@ -1,6 +1,5 @@
 import logging
 
-import sentry_sdk
 from django.http import Http404
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
@@ -20,46 +19,30 @@ class OrganizationIntegrationSetupView(ControlSiloOrganizationView):
     csrf_protect = False
 
     def handle(self, request: Request, organization, provider_id) -> HttpResponseBase:
-        try:
-            with sentry_sdk.configure_scope() as scope:
-                parent_span_id = scope.span.span_id
-                trace_id = scope.span.trace_id
-        except AttributeError:
-            parent_span_id = None
-            trace_id = None
+        pipeline = IntegrationPipeline(
+            request=request, organization=organization, provider_key=provider_id
+        )
 
-        with sentry_sdk.start_transaction(
-            op="integration.setup",
-            name=f"integration.{provider_id}",
-            parent_span_id=parent_span_id,
-            trace_id=trace_id,
-            sampled=True,
-        ):
-            pipeline = IntegrationPipeline(
-                request=request, organization=organization, provider_key=provider_id
+        is_feature_enabled = {}
+        for feature in pipeline.provider.features:
+            feature_flag_name = "organizations:integrations-%s" % feature.value
+            try:
+                features.get(feature_flag_name, None)
+                is_feature_enabled[feature_flag_name] = features.has(
+                    feature_flag_name, organization
+                )
+            except FeatureNotRegistered:
+                is_feature_enabled[feature_flag_name] = True
+
+        if not any(is_feature_enabled.values()):
+            return pipeline.render_warning(
+                "At least one feature from this list has to be enabled in order to setup the integration:\n%s"
+                % "\n".join(is_feature_enabled)
             )
 
-            is_feature_enabled = {}
-            for feature in pipeline.provider.features:
-                feature_flag_name = "organizations:integrations-%s" % feature.value
-                try:
-                    features.get(feature_flag_name, None)
-                    is_feature_enabled[feature_flag_name] = features.has(
-                        feature_flag_name, organization
-                    )
-                except FeatureNotRegistered:
-                    is_feature_enabled[feature_flag_name] = True
+        if not pipeline.provider.can_add:
+            raise Http404
 
-            if not any(is_feature_enabled.values()):
-                return pipeline.render_warning(
-                    "At least one feature from this list has to be enabled in order to setup the integration:\n%s"
-                    % "\n".join(is_feature_enabled)
-                )
+        pipeline.initialize()
 
-            if not pipeline.provider.can_add:
-                raise Http404
-
-            pipeline.initialize()
-
-            response = pipeline.current_step()
-        return response
+        return pipeline.current_step()

--- a/src/sentry/web/frontend/organization_integration_setup.py
+++ b/src/sentry/web/frontend/organization_integration_setup.py
@@ -21,8 +21,9 @@ class OrganizationIntegrationSetupView(ControlSiloOrganizationView):
 
     def handle(self, request: Request, organization, provider_id) -> HttpResponseBase:
         with sentry_sdk.configure_scope() as scope:
-            scope.transaction.op = "integration.setup"
-            scope.transaction.name = f"integration.{provider_id}"
+            scope.set_transaction_name(
+                f"integration.{provider_id}", source="OrganizationIntegrationSetupView"
+            )
 
         pipeline = IntegrationPipeline(
             request=request, organization=organization, provider_key=provider_id


### PR DESCRIPTION
This `start_transaction` call is unnecessary and causes undefined behavior. Since the `start_transaction` call occurs within an endpoint, a transaction is already automatically started by the Django integration. The auto-instrumented transaction can be viewed [here](https://sentry.sentry.io/performance/?isDefaultQuery=false&metricSearchSetting=metricsOnly&project=1&query=transaction%3A%22%2Forganizations%2F%7Borganization_slug%7D%2Fintegrations%2F%7Bprovider_id%7D%2Fsetup%2F%22&statsPeriod=24h).

Instead, to preserve the different transaction names for each integration, we now set the transaction name on the auto-instrumented transaction instead of creating a new transaction.

ref GH-63590
