### PR TITLE
feat(feedback): Emit outcome on user-feedback creation

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import jsonschema
 
+from sentry.constants import DataCategory
 from sentry.eventstore.models import Event
 from sentry.issues.grouptype import FeedbackGroup
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
@@ -17,6 +18,7 @@ from sentry.models.project import Project
 from sentry.signals import first_feedback_received, first_new_feedback_received
 from sentry.utils import metrics
 from sentry.utils.dates import ensure_aware
+from sentry.utils.outcomes import Outcome, track_outcome
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)
@@ -132,6 +134,7 @@ def create_feedback_issue(event, project_id, source: FeedbackCreationSource):
     # Note that some of the fields below like title and subtitle
     # are not used by the feedback UI, but are required.
     event["event_id"] = event.get("event_id") or uuid4().hex
+    detection_time = ensure_aware(datetime.fromtimestamp(event["timestamp"]))
     evidence_data, evidence_display = make_evidence(event["contexts"]["feedback"], source)
     occurrence = IssueOccurrence(
         id=uuid4().hex,
@@ -146,7 +149,7 @@ def create_feedback_issue(event, project_id, source: FeedbackCreationSource):
         evidence_data=evidence_data,
         evidence_display=evidence_display,
         type=FeedbackGroup,
-        detection_time=ensure_aware(datetime.fromtimestamp(event["timestamp"])),
+        detection_time=detection_time,
         culprit="user",  # TODO: fill in culprit correctly -- URL or paramaterized route/tx name?
         level=event.get("level", "info"),
     )
@@ -180,6 +183,18 @@ def create_feedback_issue(event, project_id, source: FeedbackCreationSource):
 
     produce_occurrence_to_kafka(
         payload_type=PayloadType.OCCURRENCE, occurrence=occurrence, event_data=event_fixed
+    )
+
+    track_outcome(
+        org_id=project.organization_id,
+        project_id=project_id,
+        key_id=None,
+        outcome=Outcome.ACCEPTED,
+        reason=None,
+        timestamp=detection_time,
+        event_id=event["event_id"],
+        category=DataCategory.USER_REPORT_V2,
+        quantity=1,
     )
 
 


### PR DESCRIPTION
Emits an accepted outcome on issue create.  I did not emit a failed outcome for unreal events or failures to deserialize.  The protocol should be enforced in Relay.  Failure to deserialize in Sentry should be a logged exception which requires developer intervention.