### PR TITLE
chore(hybridcloud) Consolidate RPC tags

### DIFF
--- a/src/sentry/api/endpoints/internal/rpc.py
+++ b/src/sentry/api/endpoints/internal/rpc.py
@@ -35,9 +35,7 @@ class InternalRpcServiceEndpoint(Endpoint):
 
     def post(self, request: Request, service_name: str, method_name: str) -> Response:
         with configure_scope() as scope:
-            scope.set_tag("rpc_service", service_name)
-            scope.set_tag("rpc_method", method_name)
-
+            scope.set_tag("rpc_method", f"{service_name}.{method_name}")
         if not self._is_authorized(request):
             raise PermissionDenied
 

--- a/src/sentry/services/hybrid_cloud/rpc.py
+++ b/src/sentry/services/hybrid_cloud/rpc.py
@@ -533,8 +533,7 @@ class _RemoteSiloCall:
 
     def _raise_from_response_status_error(self, response: requests.Response) -> NoReturn:
         with sentry_sdk.configure_scope() as scope:
-            scope.set_tag("rpc_service", self.service_name)
-            scope.set_tag("rpc_method", self.method_name)
+            scope.set_tag("rpc_method", f"{self.service_name}.{self.method_name}")
             scope.set_tag("rpc_status_code", response.status_code)
 
         if in_test_environment():


### PR DESCRIPTION
Instead of having service + method, we only need one tag, as RPC methods are isolated from each other and there isn't useful scenario where we only use one tag.

I'll update grouping rules once this lands.