### PR TITLE
chore(support): Change type for onClick for SidebarMenuItemLink

### DIFF
--- a/static/app/components/sidebar/sidebarMenuItemLink.tsx
+++ b/static/app/components/sidebar/sidebarMenuItemLink.tsx
@@ -11,7 +11,7 @@ type Props = {
   /**
    * It is raised when the user clicks on the element - optional
    */
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent) => void;
   /**
    * specifies whether to open the linked document in a new tab
    */


### PR DESCRIPTION
this pr changes the type for onClick for SidebarMenuItemLink so that https://github.com/getsentry/getsentry/pull/12765 can use it. 