### PR TITLE
fix(perf): Improve sidebar accordion active state III

### DIFF
--- a/static/app/components/sidebar/sidebarAccordion.tsx
+++ b/static/app/components/sidebar/sidebarAccordion.tsx
@@ -93,7 +93,11 @@ function findChildElementsInTree(
     }
 
     const currentComponentName: string =
-      typeof child.type === 'string' ? child.type : child.type.name;
+      typeof child.type === 'string'
+        ? child.type
+        : 'displayName' in child.type
+          ? (child.type.displayName as string) // `.displayName` is added by `babel-plugin-add-react-displayname` in production builds
+          : child.type.name; // `.name` is available in development builds
 
     if (currentComponentName === componentName) {
       found.push(child);


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/63449. Use `displayName` if available. `.name` will be incorrect in production builds, but `displayName` is guaranteed by Babel.
