### PR TITLE
ref: Removed `start_transaction` from `appstore_connect.py`

### DIFF
--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -137,8 +137,7 @@ def _get_appstore_json(
             full_url = ""
         full_url += url
         logger.debug("GET %s", full_url)
-        with sentry_sdk.start_transaction(op="http", description="AppStoreConnect request"):
-            response = session.get(full_url, headers=headers, timeout=REQUEST_TIMEOUT)
+        response = session.get(full_url, headers=headers, timeout=REQUEST_TIMEOUT)
         if not response.ok:
             err_info = {
                 "url": full_url,


### PR DESCRIPTION
This `start_transaction` call is unnecessary for a few reasons, and it causes undefined behavior.

The primary reason that the call is unnecessary and the reason why it causes undefined behavior is because the call is always made from within an auto-instrumented transaction. The `start_transaction` call occurs within the `_get_appstore_json` function. Tracing back, we see that the `_get_appstore_json` function is called only from `_get_appstore_info_paged`, which can be called either from  `get_apps` or `get_build_info`. `get_apps` is called only from the `AppStoreConnectStatusEndpoint`, which should be auto-instrumented by the Django integration. `get_build_info` is called only by `appconnect.py`'s `list_builds` function, which is called by `app_store_connect.py`'s `inner_dsym_download` function which is called by the `dsym_download` Celery task, which should also be auto-instrumented.

Second, this `start_transaction` call was originally [changed from a `start_span` call in order to have a "searchable transaction"](https://github.com/getsentry/sentry/pull/29724#discussion_r741939673). However, because the transaction is created without a `name` (it only has a `description`), it is actually showing in Sentry as an [\<unlabeled transaction\>](https://sentry.sentry.io/performance/summary/?project=1&query=&referrer=performance-transaction-summary&statsPeriod=1h&transaction=%3Cunlabeled+transaction%3E&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29).

Finally, there is no need even to have a `start_span` here, since the SDK's `StdlibIntegration` should automatically start a span for any GET request.

ref GH-63590