### PR TITLE
build: use macos m1 machines

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   bootstrap-script:
     name: bootstrap
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
       - name: Run bootstrap scripts


### PR DESCRIPTION
It's a lot faster since macOS 14 is now based on M1 machines.