### PR TITLE
feat(feedback): Add option to manage organization denylist

### DIFF
--- a/src/sentry/feedback/usecases/create_feedback.py
+++ b/src/sentry/feedback/usecases/create_feedback.py
@@ -127,7 +127,8 @@ def should_filter_feedback(event, project_id, source: FeedbackCreationSource):
 
 def create_feedback_issue(event, project_id, organization_id, source: FeedbackCreationSource):
     # If the organization exists in the organization denylist reject the feedback event.
-    if organization_id is None or organization_id in options.get("feedback.organizations.denylist"):
+    if organization_id in options.get("feedback.organizations.denylist"):
+        metrics.incr("feedback.rejected", tags={"referrer": source.value}, sample_rate=1.0)
         return None
 
     if should_filter_feedback(event, project_id, source):

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -170,6 +170,7 @@ def process_event(message: IngestMessage, project: Project) -> None:
                 start_time=start_time,
                 event_id=event_id,
                 project_id=project_id,
+                organization_id=project.organization_id,
             )
     else:
         # Preprocess this event, which spawns either process_event or

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -384,6 +384,14 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# User Feedback Options
+register(
+    "feedback.organizations.denylist",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Analytics
 register("analytics.backend", default="noop", flags=FLAG_NOSTORE)
 register("analytics.options", default={}, flags=FLAG_NOSTORE)

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -878,9 +878,12 @@ def save_event_feedback(
     start_time: Optional[int] = None,
     event_id: Optional[str] = None,
     project_id: Optional[int] = None,
+    organization_id: Optional[int] = None,
     **kwargs: Any,
 ) -> None:
-    create_feedback_issue(data, project_id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+    create_feedback_issue(
+        data, project_id, organization_id, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE
+    )
 
 
 @instrumented_task(

--- a/tests/sentry/feedback/usecases/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/test_create_feedback.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from sentry import options
 from sentry.feedback.usecases.create_feedback import (
     FeedbackCreationSource,
     create_feedback_issue,
@@ -246,6 +247,110 @@ def test_create_feedback_filters_unreal(default_project, mock_produce_occurrence
         "breadcrumbs": [],
         "platform": "javascript",
     }
-    create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
+    create_feedback_issue(
+        event,
+        default_project,
+        default_project.organization_id,
+        FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE,
+    )
 
     assert mock_produce_occurrence_to_kafka.call_count == 0
+
+
+@django_db_all
+def test_denylist_prevents_feedback_creation(default_project, mock_produce_occurrence_to_kafka):
+    event = {
+        "project_id": 1,
+        "request": {
+            "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            "headers": {
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+            },
+        },
+        "event_id": "56b08cf7852c42cbb95e4a6998c66ad6",
+        "timestamp": 1698255009.574,
+        "received": "2021-10-24T22:23:29.574000+00:00",
+        "environment": "prod",
+        "release": "frontend@daf1316f209d961443664cd6eb4231ca154db502",
+        "sdk": {
+            "integrations": [
+                "InboundFilters",
+                "FunctionToString",
+                "TryCatch",
+                "Breadcrumbs",
+                "GlobalHandlers",
+                "LinkedErrors",
+                "Dedupe",
+                "HttpContext",
+                "ExtraErrorData",
+                "BrowserTracing",
+                "BrowserProfilingIntegration",
+            ],
+            "name": "sentry.javascript.react",
+            "version": "7.75.0",
+        },
+        "tags": {
+            "transaction": "/feedback/",
+            "sentry_version": "23.11.0.dev0",
+            "isCustomerDomain": "yes",
+            "customerDomain.organizationUrl": "https://sentry.sentry.io",
+            "customerDomain.sentryUrl": "https://sentry.io",
+            "customerDomain.subdomain": "sentry",
+            "organization": "1",
+            "organization.slug": "sentry",
+            "plan": "am2_business_ent_auf",
+            "plan.name": "Business",
+            "plan.max_members": "null",
+            "plan.total_members": "414",
+            "plan.tier": "am2",
+            "timeOrigin.mode": "navigationStart",
+        },
+        "user": {
+            "ip_address": "72.164.175.154",
+            "email": "josh.ferge@sentry.io",
+            "id": 880461,
+            "isStaff": False,
+            "name": "Josh Ferge",
+        },
+        "contexts": {
+            "feedback": {
+                "contact_email": "josh.ferge@sentry.io",
+                "name": "Josh Ferge",
+                "message": "josh ferge testing again!",
+                "replay_id": "3d621c61593c4ff9b43f8490a78ae18e",
+                "url": "https://sentry.sentry.io/feedback/?statsPeriod=14d",
+            },
+            "trace": {
+                "op": "navigation",
+                "span_id": "9ffadde1100e4d55",
+                "tags": {
+                    "routing.instrumentation": "react-router-v3",
+                    "from": "/issues/(searches/:searchId/)",
+                },
+                "trace_id": "8e51f44000d34b8d871cea7f0c3e394c",
+            },
+            "organization": {"id": "1", "slug": "sentry"},
+        },
+        "breadcrumbs": [],
+        "platform": "javascript",
+    }
+
+    # Deny the organization access!
+    options.set("feedback.organizations.denylist", [default_project.organization_id])
+    create_feedback_issue(
+        event,
+        default_project,
+        default_project.organization_id,
+        FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE,
+    )
+    assert mock_produce_occurrence_to_kafka.call_count == 0
+
+    # Allow the organization to access.
+    options.set("feedback.organizations.denylist", [])
+    create_feedback_issue(
+        event,
+        default_project,
+        default_project.organization_id,
+        FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE,
+    )
+    assert mock_produce_occurrence_to_kafka.call_count == 1


### PR DESCRIPTION
Adds the option `feedback.organizations.denylist` which contains a list of blocked organization-ids.