### PR TITLE
chore(issue-stream):Remove issue stream performance feature flag from back end

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -491,13 +491,7 @@ class GroupSerializerBase(Serializer, ABC):
     def _get_group_snuba_stats(
         self, item_list: Sequence[Group], seen_stats: Optional[Mapping[Group, SeenStats]]
     ):
-        if (
-            self._collapse("unhandled")
-            and len(item_list) > 0
-            and features.has(
-                "organizations:issue-stream-performance", item_list[0].project.organization
-            )
-        ):
+        if self._collapse("unhandled") and len(item_list) > 0:
             return None
         start = self._get_start_from_seen_stats(seen_stats)
         unhandled = {}

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Mapping, MutableMapping, Optional, Sequence
 from django.utils import timezone
 from rest_framework.request import Request
 
-from sentry import features, release_health, tsdb
+from sentry import release_health, tsdb
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.external_issue import ExternalIssueSerializer
 from sentry.api.serializers.models.group import (
@@ -279,9 +279,7 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                 attrs = {item: seen_stats.get(item, {}) for item in item_list}
             else:
                 attrs = {item: {} for item in item_list}
-            if len(item_list) > 0 and features.has(
-                "organizations:issue-stream-performance", item_list[0].project.organization
-            ):
+            if len(item_list) > 0:
                 unhandled_stats = self._get_group_snuba_stats(item_list, seen_stats)
 
                 if unhandled_stats is not None:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1632,8 +1632,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     # sentry at the moment.
     "organizations:issue-search-use-cdc-primary": False,
     "organizations:issue-search-use-cdc-secondary": False,
-    # Enable issue stream performance improvements
-    "organizations:issue-stream-performance": False,
     # Enable issue stream performance improvements (cache)
     "organizations:issue-stream-performance-cache": False,
     # Enable issue similarity embeddings

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -133,7 +133,6 @@ default_manager.add("organizations:issue-search-group-attributes-side-query", Or
 default_manager.add("organizations:issue-search-use-cdc-primary", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-search-use-cdc-secondary", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issue-stream-performance-cache", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:issue-stream-performance", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issues-similarity-embeddings", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:issues-trace-timeline", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:large-debug-files", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -49,7 +49,6 @@ from sentry.silo import SiloMode
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, freeze_time, iso_format
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus
@@ -2046,7 +2045,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert len(response.data) == 1
         assert int(response.data[0]["id"]) == event.group.id
 
-    @with_feature("organizations:issue-stream-performance")
     def test_collapse_unhandled(self):
         event = self.store_event(
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},

--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -2,7 +2,7 @@ import uuid
 
 from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.testutils.cases import APITestCase, SnubaTestCase
-from sentry.testutils.helpers import parse_link_header, with_feature
+from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
@@ -68,7 +68,6 @@ class GroupListTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert "filtered" in response_data[0]
         assert "isUnhandled" not in response_data[0]
 
-    @with_feature("organizations:issue-stream-performance")
     def test_unhandled(self):
         self.store_event(
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},


### PR DESCRIPTION
this pr removes references to the issue stream performance feature flag from the front end. Merge after https://github.com/getsentry/sentry/pull/64293

closes https://github.com/getsentry/sentry/issues/64289