### PR TITLE
fix(dashboards): add to dashboards not working consistently

### DIFF
--- a/static/app/views/dashboards/view.tsx
+++ b/static/app/views/dashboards/view.tsx
@@ -56,9 +56,9 @@ function ViewEditDashboard(props: Props) {
 
   useEffect(() => {
     const constructedWidget = constructWidgetFromQuery(location.query);
-    setNewWidget(constructedWidget);
     // Clean up url after constructing widget from query string, only allow GHS params
     if (constructedWidget) {
+      setNewWidget(constructedWidget);
       setDashboardInitialState(DashboardState.EDIT);
       browserHistory.replace({
         pathname: location.pathname,


### PR DESCRIPTION
Fixes #64170 

It seems like `setNewWidget` would be called correctly, the query parms for the new widget would be removed as expected. But then that caused `setNewWidget` to be called again and set to `undefined`. 

This PR ensure `setNewWidget` can never be set to undefined in this flow.