### PR TITLE
chore: Stop checking organizations:session-replay-a11y-tab on the frontend

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -17,12 +17,8 @@ export enum TabKey {
 }
 
 function isReplayTab(tab: string, organization: Organization): tab is TabKey {
-  const hasA11yTab = organization.features.includes('session-replay-a11y-tab');
   const hasPerfTab = organization.features.includes('session-replay-trace-table');
 
-  if (tab === TabKey.A11Y) {
-    return hasA11yTab;
-  }
   if (tab === TabKey.PERF) {
     return hasPerfTab;
   }

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -16,9 +16,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
-  // The new Accessibility tab:
-  const hasA11yTab = organization.features.includes('session-replay-a11y-tab');
-
   // The new trace table inside Breadcrumb items:
   const hasTraceTable = organization.features.includes('session-replay-trace-table');
 
@@ -29,7 +26,7 @@ function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
     [TabKey.ERRORS]: t('Errors'),
     [TabKey.TRACE]: hasTraceTable ? null : t('Trace'),
     [TabKey.PERF]: null,
-    [TabKey.A11Y]: hasA11yTab ? (
+    [TabKey.A11Y]: (
       <Fragment>
         <Tooltip
           isHoverable
@@ -51,7 +48,7 @@ function getReplayTabs(organization: Organization): Record<TabKey, ReactNode> {
           title={t('This feature is available for early adopters and may change')}
         />
       </Fragment>
-    ) : null,
+    ),
     [TabKey.MEMORY]: t('Memory'),
     [TabKey.TAGS]: t('Tags'),
   };


### PR DESCRIPTION
This has been rolled out to everyone, so we can stop checking the feature flag on the frontend because it's always `true`

Enabled in flagr: https://flagr.getsentry.net/#/flags/476