### PR TITLE
chore: Stop checking organizations:session-replay-a11y-tab on the backend

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1845,8 +1845,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:sentry-pride-logo-footer": False,
     # Enable core Session Replay backend APIs
     "organizations:session-replay": False,
-    # Enable the Replay Details > Accessibility tab
-    "organizations:session-replay-a11y-tab": False,
     # Enable the accessibility issues endpoint
     "organizations:session-replay-accessibility-issues": False,
     # Enable core Session Replay SDK for recording onError events on sentry.io

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -245,7 +245,6 @@ default_manager.add("organizations:scim-team-roles", OrganizationFeature, Featur
 default_manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:sentry-functions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:sentry-pride-logo-footer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:session-replay-a11y-tab", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-accessibility-issues", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-count-query-optimize", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-enable-canvas-replayer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)


### PR DESCRIPTION
Enabled in flagr: https://flagr.getsentry.net/#/flags/476

Depends on https://github.com/getsentry/sentry/pull/64304 being deployed