### PR TITLE
chore: Stop checking organizations:session-replay-accessibility-issues

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1847,8 +1847,6 @@ SENTRY_FEATURES: dict[str, bool | None] = {
     "organizations:session-replay": False,
     # Enable the Replay Details > Accessibility tab
     "organizations:session-replay-a11y-tab": False,
-    # Enable the accessibility issues endpoint
-    "organizations:session-replay-accessibility-issues": False,
     # Enable core Session Replay SDK for recording onError events on sentry.io
     "organizations:session-replay-count-query-optimize": False,
     # Enable canvas recording

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -246,7 +246,6 @@ default_manager.add("organizations:sdk-crash-detection", OrganizationFeature, Fe
 default_manager.add("organizations:sentry-functions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL)
 default_manager.add("organizations:sentry-pride-logo-footer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-a11y-tab", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
-default_manager.add("organizations:session-replay-accessibility-issues", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-count-query-optimize", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-enable-canvas-replayer", OrganizationFeature, FeatureHandlerStrategy.REMOTE)
 default_manager.add("organizations:session-replay-enable-canvas", OrganizationFeature, FeatureHandlerStrategy.REMOTE)

--- a/src/sentry/replays/endpoints/project_replay_accessibility_issues.py
+++ b/src/sentry/replays/endpoints/project_replay_accessibility_issues.py
@@ -54,14 +54,6 @@ class ProjectReplayAccessibilityIssuesEndpoint(ProjectEndpoint):
         ):
             return Response(status=404)
 
-        if not features.has(
-            "organizations:session-replay-accessibility-issues",
-            project.organization,
-            actor=request.user,
-        ):
-            metrics.incr("session-replay-accessibility-issues-flag-disabled")
-            return Response(status=404)
-
         if options.get("organizations:session-replay-accessibility-issues-enabled") is False:
             metrics.incr("session-replay-accessibility-issues-option-disabled")
             return Response(status=404)

--- a/tests/sentry/replays/test_project_replay_accessibility_issues.py
+++ b/tests/sentry/replays/test_project_replay_accessibility_issues.py
@@ -10,7 +10,6 @@ from sentry.testutils.silo import region_silo_test
 
 REPLAYS_FEATURES = {
     "organizations:session-replay": True,
-    "organizations:session-replay-accessibility-issues": True,
 }
 
 


### PR DESCRIPTION
This is enabled for everyone in flagr. 

There's a similar option called `organizations:session-replay-accessibility-issues-enabled` which i didn't touch in here.

In flagr: https://flagr.getsentry.net/#/flags/496