### PR TITLE
ref(snuba): add typing to utils/snuba.py (SNS-2588)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -510,7 +510,6 @@ module = [
     "sentry.tsdb.dummy",
     "sentry.tsdb.inmemory",
     "sentry.tsdb.redis",
-    "sentry.tsdb.snuba",
     "sentry.types.integrations",
     "sentry.utils.audit",
     "sentry.utils.auth",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -510,7 +510,7 @@ module = [
     "sentry.tsdb.dummy",
     "sentry.tsdb.inmemory",
     "sentry.tsdb.redis",
-"sentry.tsdb.snuba",
+    "sentry.tsdb.snuba",
     "sentry.types.integrations",
     "sentry.utils.audit",
     "sentry.utils.auth",
@@ -646,6 +646,6 @@ module = [
     "src.sentry.snuba.metrics.extraction",
     "tests.sentry.tasks.test_on_demand_metrics",
     "tests.sentry.relay.config.test_metric_extraction",
-    ]
+]
 disallow_untyped_defs = true
 # end: stronger typing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -510,6 +510,7 @@ module = [
     "sentry.tsdb.dummy",
     "sentry.tsdb.inmemory",
     "sentry.tsdb.redis",
+"sentry.tsdb.snuba",
     "sentry.types.integrations",
     "sentry.utils.audit",
     "sentry.utils.auth",
@@ -529,7 +530,6 @@ module = [
     "sentry.utils.sentry_apps.webhooks",
     "sentry.utils.services",
     "sentry.utils.snowflake",
-    "sentry.utils.snuba",
     "sentry.utils.suspect_resolutions.get_suspect_resolutions",
     "sentry.utils.suspect_resolutions_releases.get_suspect_resolutions_releases",
     "sentry.web.client_config",
@@ -646,6 +646,6 @@ module = [
     "src.sentry.snuba.metrics.extraction",
     "tests.sentry.tasks.test_on_demand_metrics",
     "tests.sentry.relay.config.test_metric_extraction",
-]
+    ]
 disallow_untyped_defs = true
 # end: stronger typing

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -428,9 +428,9 @@ def to_naive_timestamp(value):
     return (value - epoch_naive).total_seconds()
 
 
-def to_start_of_hour(dt: datetime) -> datetime:
+def to_start_of_hour(dt: datetime) -> str:
     """This is a function that mimics toStartOfHour from Clickhouse"""
-    return dt.replace(minute=0, second=0, microsecond=0)
+    return dt.replace(minute=0, second=0, microsecond=0).isoformat()
 
 
 def get_snuba_column_name(name, dataset=Dataset.Events):

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from hashlib import sha1
-from typing import Any, Callable, Mapping, MutableMapping, Optional, Sequence, Union
+from typing import Any, Union
 from urllib.parse import urlparse
 
 import sentry_sdk
@@ -1152,7 +1152,7 @@ def query(
 
 
 def nest_groups(
-    data: MutableMapping[Any, Any], groups: Optional[list[str]], aggregate_cols: list[str]
+    data: MutableMapping[Any, Any], groups: list[str] | None, aggregate_cols: list[str]
 ) -> MutableMapping[Any, Any] | None:
     """
     Build a nested mapping from query response rows. Each group column

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -6,7 +6,7 @@ import os
 import re
 import time
 from collections import namedtuple
-from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Collection, Mapping, MutableMapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from copy import deepcopy
@@ -1174,7 +1174,7 @@ def nest_groups(
 
 
 def resolve_column(dataset) -> Callable:
-    def _resolve_column(col: Any) -> Any:
+    def _resolve_column(col):
         if col is None:
             return col
         if isinstance(col, int) or isinstance(col, float):
@@ -1330,7 +1330,7 @@ def aliased_query_params(
     having=None,
     dataset=None,
     orderby=None,
-    condition_resolver=None,
+    condition_resolver: Callable | None = None,
     **kwargs,
 ) -> Mapping[str, Any]:
     if dataset is None:
@@ -1352,9 +1352,7 @@ def aliased_query_params(
 
     if conditions:
         if condition_resolver:
-            column_resolver: Callable[[Any], Callable] = functools.partial(
-                condition_resolver, dataset=dataset
-            )
+            column_resolver: Callable = functools.partial(condition_resolver, dataset=dataset)
         else:
             column_resolver = resolve_func
         resolved_conditions = resolve_conditions(conditions, column_resolver)
@@ -1576,7 +1574,7 @@ def get_related_project_ids(column, ids):
     return []
 
 
-def shrink_time_window(issues, start: datetime) -> datetime:
+def shrink_time_window(issues: Collection | None, start: datetime) -> datetime:
     """\
     If a single issue is passed in, shrink the `start` parameter to be briefly before
     the `first_seen` in order to hopefully eliminate a large percentage of rows scanned.

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -524,7 +524,7 @@ def infer_project_ids_from_related_models(filter_keys: Mapping[str, Sequence[int
 
 def get_query_params_to_update_for_projects(
     query_params: SnubaQueryParams, with_org: bool = False
-) -> tuple[int, MutableMapping[str, Any]]:
+) -> tuple[int, dict[str, Any]]:
     """
     Get the project ID and query params that need to be updated for project
     based datasets, before we send the query to Snuba.
@@ -551,7 +551,7 @@ def get_query_params_to_update_for_projects(
 
     organization_id = get_organization_id_from_project_ids(project_ids)
 
-    params: MutableMapping[str, Any] = {"project": project_ids}
+    params: dict[str, Any] = {"project": project_ids}
     if with_org:
         params["organization"] = organization_id
 
@@ -1152,8 +1152,10 @@ def query(
 
 
 def nest_groups(
-    data: MutableMapping[Any, Any], groups: list[str] | None, aggregate_cols: list[str]
-) -> MutableMapping[Any, Any] | None:
+    data: Sequence[MutableMapping],
+    groups: Sequence[str] | None,
+    aggregate_cols: Sequence[str],
+) -> dict | Any:
     """
     Build a nested mapping from query response rows. Each group column
     gives a new level of nesting and the leaf result is the aggregate
@@ -1214,7 +1216,7 @@ def resolve_column(dataset) -> Callable:
     return _resolve_column
 
 
-def resolve_condition(cond: list, column_resolver: Callable[[Any], Any]) -> Sequence[Any]:
+def resolve_condition(cond: list, column_resolver: Callable[[Any], Any]) -> list:
     """
     When conditions have been parsed by the api.event_search module
     we can end up with conditions that are not valid on the current dataset
@@ -1304,8 +1306,8 @@ def _aliased_query_impl(**kwargs):
 
 
 def resolve_conditions(
-    conditions: Sequence[Any] | None, column_resolver: Callable[[Any], Any]
-) -> Sequence[Any] | None:
+    conditions: Sequence | None, column_resolver: Callable[[Any], Any]
+) -> list | None:
     if conditions is None:
         return conditions
 
@@ -1332,7 +1334,7 @@ def aliased_query_params(
     orderby=None,
     condition_resolver: Callable | None = None,
     **kwargs,
-) -> Mapping[str, Any]:
+) -> dict[str, Any]:
     if dataset is None:
         raise ValueError("A dataset is required, and is no longer automatically detected.")
 


### PR DESCRIPTION
This pr is associated with [SNS-2588](https://getsentry.atlassian.net/browse/SNS-2588)

The goal of this pr is to fully type utils/snuba.py up to the standard deemed in the codebase's pyproject.toml, and remove it from the do-not-typecheck list.

* most of the changes are adding type annotation to functions signatures and some local variables.
* there were a few cases where I needed to slightly rewrite lines to equivalent logic, to help with typing
* break variables out when they are being re-assigned multiple types
* a few asserts were added, that should be guaranteed to pass, for mypy

[SNS-2588]: https://getsentry.atlassian.net/browse/SNS-2588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ