### PR TITLE
Revert "feat(traces): Parallelize indexed span query (#63960)"

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -1,5 +1,4 @@
 import logging
-import math
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
@@ -50,15 +49,6 @@ from sentry.utils.validators import INVALID_ID_DETAILS, is_event_id
 
 logger: logging.Logger = logging.getLogger(__name__)
 MAX_TRACE_SIZE: int = 100
-MAX_PARALLEL_QUERIES: int = 3
-
-
-def chunk(input, chunk_size):
-    output = []
-    for i in range(0, len(input), chunk_size):
-        output.append(input[i : i + chunk_size])
-
-    return output
 
 
 _T = TypeVar("_T")
@@ -515,7 +505,7 @@ def augment_transactions_with_spans(
     issue_occurrences = []
     occurrence_spans = set()
     error_spans = {e["trace.span"] for e in errors if e["trace.span"]}
-    projects = {e["project.id"] for e in errors if e["trace.span"]}
+    projects = set()
 
     for transaction in transactions:
         transaction["occurrence_spans"] = []
@@ -554,7 +544,6 @@ def augment_transactions_with_spans(
                 ]
             )
 
-    projects = list(projects)
     for problem in issue_occurrences:
         occurrence_spans = occurrence_spans.union(set(problem.evidence_data["offender_span_ids"]))
 
@@ -568,41 +557,24 @@ def augment_transactions_with_spans(
     # Fetch parent span ids of segment spans and their corresponding
     # transaction id so we can link parent/child transactions in
     # a trace.
+    spans_params = params.copy()
+    spans_params["project_objects"] = [p for p in params["project_objects"] if p.id in projects]
+    spans_params["project_id"] = list(projects.union(set(problem_project_map.keys())))
 
-    def build_query(chunked_project_ids):
-        spans_params = params.copy()
-        spans_params["project_objects"] = [
-            p for p in params["project_objects"] if p.id in chunked_project_ids
-        ]
-        spans_params["project_id"] = chunked_project_ids
-        return SpansIndexedQueryBuilder(
-            Dataset.SpansIndexed,
-            spans_params,
-            # Send all span IDs since we can't match them back to the right project ID.
-            query=f"trace:{trace_id} span_id:[{','.join(query_spans)}]",
-            selected_columns=[
-                "transaction.id",
-                "span_id",
-                "timestamp",
-            ],
-            orderby=["timestamp", "id"],
-            limit=10000,
-        )
+    parents_results = SpansIndexedQueryBuilder(
+        Dataset.SpansIndexed,
+        spans_params,
+        query=f"trace:{trace_id} span_id:[{','.join(query_spans)}]",
+        selected_columns=[
+            "transaction.id",
+            "span_id",
+            "timestamp",
+        ],
+        orderby=["timestamp", "id"],
+        limit=10000,
+    ).run_query(referrer=Referrer.API_TRACE_VIEW_GET_PARENTS.value)
 
-    chunk_size = math.ceil(len(projects) / MAX_PARALLEL_QUERIES)
-    spans_queries = [
-        build_query(chunked_projects) for chunked_projects in chunk(projects, chunk_size)
-    ]
-    parents_results = bulk_snql_query(
-        [query.get_snql_query() for query in spans_queries],
-        referrer=Referrer.API_TRACE_VIEW_GET_PARENTS.value,
-    )
-
-    parent_map = {}
-    for result in parents_results:
-        for parent in result["data"]:
-            parent_map[parent["span_id"]] = parent
-
+    parent_map = {parent["span_id"]: parent for parent in parents_results["data"]}
     for transaction in transactions:
         # For a given transaction, if parent span id exists in the tranaction (so this is
         # not a root span), see if the indexed spans data can tell us what the parent

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -7,7 +7,6 @@ from django.urls import NoReverseMatch, reverse
 
 from sentry import options
 from sentry.issues.grouptype import NoiseConfig, PerformanceFileIOMainThreadGroupType
-from sentry.search.events.builder.spans_indexed import SpansIndexedQueryBuilder
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
@@ -1526,45 +1525,27 @@ class OrganizationEventsTraceEndpointTestUsingSpans(OrganizationEventsTraceEndpo
 
         assert response.status_code == 400, response.content
 
-    def test_indexed_spans_only_query_required_projects(self):
+    @mock.patch("sentry.api.endpoints.organization_events_trace.SpansIndexedQueryBuilder")
+    def test_indexed_spans_only_query_required_projects(self, mock_query_builder):
         # Add a few more projects to the org
         self.create_project(organization=self.organization)
         self.create_project(organization=self.organization)
 
         self.load_trace()
         with self.feature(self.FEATURES):
-            with mock.patch(
-                "sentry.api.endpoints.organization_events_trace.SpansIndexedQueryBuilder",
-                wraps=SpansIndexedQueryBuilder,
-            ) as mock_query_builder:
-                response = self.client_get(
-                    data={"project": -1},
-                )
+            response = self.client_get(
+                data={"project": -1},
+            )
 
-                assert mock_query_builder.call_count == 2
+        assert sorted(
+            [self.project.id, self.gen1_project.id, self.gen2_project.id, self.gen3_project.id]
+        ) == sorted(mock_query_builder.mock_calls[0].args[1]["project_id"])
 
-                projects_to_be_queried = {
-                    self.project.id,
-                    self.gen1_project.id,
-                    self.gen2_project.id,
-                    self.gen3_project.id,
-                }
+        assert sorted(
+            [self.project.id, self.gen1_project.id, self.gen2_project.id, self.gen3_project.id]
+        ) == sorted([p.id for p in mock_query_builder.mock_calls[0].args[1]["project_objects"]])
 
-                assert set(mock_query_builder.call_args_list[0].args[1]["project_id"]).issubset(
-                    projects_to_be_queried
-                )
-                assert {
-                    p.id for p in mock_query_builder.call_args_list[0].args[1]["project_objects"]
-                }.issubset(projects_to_be_queried)
-
-                assert set(mock_query_builder.call_args_list[1].args[1]["project_id"]).issubset(
-                    projects_to_be_queried
-                )
-                assert {
-                    p.id for p in mock_query_builder.call_args_list[1].args[1]["project_objects"]
-                }.issubset(projects_to_be_queried)
-
-            assert response.status_code == 200, response.content
+        assert response.status_code == 200, response.content
 
 
 @region_silo_test


### PR DESCRIPTION
This reverts commit a8edd87c6ee021a780340e28b72bcf3090671db5.
- Temporarily reverting this, its causing the endpoint to timeout now -- but we're unsure if this was always the case or not and its only happening in prod