### PR TITLE
ref(superuser): switch SentryAppPermissions to use superuser_has_permission

### DIFF
--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -14,7 +14,7 @@ from sentry.api.authentication import ClientIdSecretAuthentication
 from sentry.api.base import Endpoint
 from sentry.api.bases.integration import PARANOID_GET
 from sentry.api.permissions import SentryPermission
-from sentry.auth.superuser import is_active_superuser
+from sentry.auth.superuser import is_active_superuser, superuser_has_permission
 from sentry.coreapi import APIError
 from sentry.middleware.stats import add_request_metric_tags
 from sentry.models.integrations.sentry_app import SentryApp
@@ -87,6 +87,7 @@ class SentryAppsPermission(SentryPermission):
 
         self.determine_access(request, context)
 
+        # TODO(cathy): replace with superuser_has_permission
         if is_active_superuser(request):
             return True
 
@@ -202,7 +203,7 @@ class SentryAppPermission(SentryPermission):
         )
         self.determine_access(request, owner_app)
 
-        if is_active_superuser(request):
+        if superuser_has_permission(request):
             return True
 
         organizations = (
@@ -277,6 +278,7 @@ class SentryAppInstallationsPermission(SentryPermission):
 
         self.determine_access(request, organization)
 
+        # TODO(cathy): replace with superuser_has_permission
         if is_active_superuser(request):
             return True
 
@@ -341,7 +343,7 @@ class SentryAppInstallationPermission(SentryPermission):
 
         self.determine_access(request, installation.organization_id)
 
-        if is_active_superuser(request):
+        if superuser_has_permission(request):
             return True
 
         # if user is an app, make sure it's for that same app

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -94,10 +94,10 @@ def superuser_has_permission(request: HttpRequest | Request) -> bool:
     Superuser read-only is restricted to GET and OPTIONS requests.
     These checks do not affect self-hosted.
     """
-    if is_self_hosted():
-        return True
-
     if is_active_superuser(request):
+        if is_self_hosted():
+            return True
+
         if features.has("auth:enterprise-superuser-read-write", actor=request.user):
             if request.access.has_permission("superuser.write"):
                 return True

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -58,7 +58,6 @@ class SentryAppPermissionTest(TestCase):
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_has_permission_read_only(self):
         request = self.make_request(user=self.superuser, method="GET", is_superuser=True)
-        request.access = self.create_request_access()
 
         assert self.permission.has_object_permission(request, None, self.sentry_app)
 
@@ -146,7 +145,6 @@ class SentryAppInstallationPermissionTest(TestCase):
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_has_permission_read_only(self):
         request = self.make_request(user=self.superuser, method="GET", is_superuser=True)
-        request.access = self.create_request_access()
 
         assert self.permission.has_object_permission(request, None, self.installation)
 

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from django.http import Http404
+from django.test.utils import override_settings
 
 from sentry.api.bases.sentryapps import (
     SentryAppBaseEndpoint,
@@ -11,7 +12,9 @@ from sentry.api.bases.sentryapps import (
     SentryAppPermission,
     add_integration_platform_metric_tag,
 )
+from sentry.auth.superuser import Superuser
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test
 
 
@@ -25,6 +28,8 @@ class SentryAppPermissionTest(TestCase):
         self.sentry_app = self.create_sentry_app(name="foo", organization=self.org)
 
         self.request = self.make_request(user=self.user, method="GET")
+
+        self.superuser = self.create_user(is_superuser=True)
 
     def test_request_user_is_app_owner_succeeds(self):
         assert self.permission.has_object_permission(self.request, None, self.sentry_app)
@@ -41,6 +46,45 @@ class SentryAppPermissionTest(TestCase):
         token = ApiToken.objects.create(user=self.user, scope_list=["event:read", "org:read"])
         self.request = self.make_request(user=None, auth=token, method="GET")
         assert self.permission.has_permission(self.request, None)
+
+    def test_superuser_has_permission(self):
+        request = self.make_request(user=self.superuser, method="GET")
+        request.superuser = Superuser(request)
+        request.superuser.set_logged_in(request.user)
+
+        assert self.permission.has_object_permission(request, None, self.sentry_app)
+
+        request.method = "POST"
+        assert self.permission.has_object_permission(request, None, self.sentry_app)
+
+    @with_feature("auth:enterprise-superuser-read-write")
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    def test_superuser_has_permission_read_only(self):
+        request = self.make_request(user=self.superuser, method="GET")
+        request.superuser = Superuser(request)
+        request.superuser.set_logged_in(request.user)
+
+        assert self.permission.has_object_permission(request, None, self.sentry_app)
+
+        request.method = "POST"
+
+        with pytest.raises(Http404):
+            self.permission.has_object_permission(request, None, self.sentry_app)
+
+    @with_feature("auth:enterprise-superuser-read-write")
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    def test_superuser_has_permission_write(self):
+        request = self.make_request(user=self.superuser, method="GET")
+        request.superuser = Superuser(request)
+        request.superuser.set_logged_in(request.user)
+        request.access = self.create_request_access(permissions=["superuser.write"])
+
+        assert self.permission.has_object_permission(request, None, self.sentry_app)
+
+        request.method = "POST"
+
+        with pytest.raises(Http404):
+            self.permission.has_object_permission(request, None, self.sentry_app)
 
 
 @control_silo_test
@@ -81,6 +125,8 @@ class SentryAppInstallationPermissionTest(TestCase):
 
         self.request = self.make_request(user=self.user, method="GET")
 
+        self.superuser = self.create_user(is_superuser=True)
+
     def test_missing_request_user(self):
         self.request.user = None
 
@@ -94,6 +140,45 @@ class SentryAppInstallationPermissionTest(TestCase):
     def test_request_user_not_in_organization(self):
         with pytest.raises(Http404):
             self.permission.has_object_permission(self.request, None, self.installation)
+
+    def test_superuser_has_permission(self):
+        request = self.make_request(user=self.superuser, method="GET")
+        request.superuser = Superuser(request)
+        request.superuser.set_logged_in(request.user)
+
+        assert self.permission.has_object_permission(request, None, self.sentry_app)
+
+        request.method = "POST"
+        assert self.permission.has_object_permission(request, None, self.sentry_app)
+
+    @with_feature("auth:enterprise-superuser-read-write")
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    def test_superuser_has_permission_read_only(self):
+        request = self.make_request(user=self.superuser, method="GET")
+        request.superuser = Superuser(request)
+        request.superuser.set_logged_in(request.user)
+
+        assert self.permission.has_object_permission(request, None, self.sentry_app)
+
+        request.method = "POST"
+
+        with pytest.raises(Http404):
+            self.permission.has_object_permission(request, None, self.sentry_app)
+
+    @with_feature("auth:enterprise-superuser-read-write")
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    def test_superuser_has_permission_write(self):
+        request = self.make_request(user=self.superuser, method="GET")
+        request.superuser = Superuser(request)
+        request.superuser.set_logged_in(request.user)
+        request.access = self.create_request_access(permissions=["superuser.write"])
+
+        assert self.permission.has_object_permission(request, None, self.sentry_app)
+
+        request.method = "POST"
+
+        with pytest.raises(Http404):
+            self.permission.has_object_permission(request, None, self.sentry_app)
 
 
 @control_silo_test

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -12,7 +12,6 @@ from sentry.api.bases.sentryapps import (
     SentryAppPermission,
     add_integration_platform_metric_tag,
 )
-from sentry.auth.superuser import Superuser
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test
@@ -48,9 +47,7 @@ class SentryAppPermissionTest(TestCase):
         assert self.permission.has_permission(self.request, None)
 
     def test_superuser_has_permission(self):
-        request = self.make_request(user=self.superuser, method="GET")
-        request.superuser = Superuser(request)
-        request.superuser.set_logged_in(request.user)
+        request = self.make_request(user=self.superuser, method="GET", is_superuser=True)
 
         assert self.permission.has_object_permission(request, None, self.sentry_app)
 
@@ -60,9 +57,8 @@ class SentryAppPermissionTest(TestCase):
     @with_feature("auth:enterprise-superuser-read-write")
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_has_permission_read_only(self):
-        request = self.make_request(user=self.superuser, method="GET")
-        request.superuser = Superuser(request)
-        request.superuser.set_logged_in(request.user)
+        request = self.make_request(user=self.superuser, method="GET", is_superuser=True)
+        request.access = self.create_request_access()
 
         assert self.permission.has_object_permission(request, None, self.sentry_app)
 
@@ -74,17 +70,14 @@ class SentryAppPermissionTest(TestCase):
     @with_feature("auth:enterprise-superuser-read-write")
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_has_permission_write(self):
-        request = self.make_request(user=self.superuser, method="GET")
-        request.superuser = Superuser(request)
-        request.superuser.set_logged_in(request.user)
-        request.access = self.create_request_access(permissions=["superuser.write"])
+        self.add_user_permission(self.superuser, "superuser.write")
+        request = self.make_request(user=self.superuser, method="GET", is_superuser=True)
 
         assert self.permission.has_object_permission(request, None, self.sentry_app)
 
         request.method = "POST"
 
-        with pytest.raises(Http404):
-            self.permission.has_object_permission(request, None, self.sentry_app)
+        self.permission.has_object_permission(request, None, self.sentry_app)
 
 
 @control_silo_test
@@ -142,9 +135,7 @@ class SentryAppInstallationPermissionTest(TestCase):
             self.permission.has_object_permission(self.request, None, self.installation)
 
     def test_superuser_has_permission(self):
-        request = self.make_request(user=self.superuser, method="GET")
-        request.superuser = Superuser(request)
-        request.superuser.set_logged_in(request.user)
+        request = self.make_request(user=self.superuser, method="GET", is_superuser=True)
 
         assert self.permission.has_object_permission(request, None, self.installation)
 
@@ -154,9 +145,8 @@ class SentryAppInstallationPermissionTest(TestCase):
     @with_feature("auth:enterprise-superuser-read-write")
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_has_permission_read_only(self):
-        request = self.make_request(user=self.superuser, method="GET")
-        request.superuser = Superuser(request)
-        request.superuser.set_logged_in(request.user)
+        request = self.make_request(user=self.superuser, method="GET", is_superuser=True)
+        request.access = self.create_request_access()
 
         assert self.permission.has_object_permission(request, None, self.installation)
 
@@ -168,17 +158,14 @@ class SentryAppInstallationPermissionTest(TestCase):
     @with_feature("auth:enterprise-superuser-read-write")
     @override_settings(SENTRY_SELF_HOSTED=False)
     def test_superuser_has_permission_write(self):
-        request = self.make_request(user=self.superuser, method="GET")
-        request.superuser = Superuser(request)
-        request.superuser.set_logged_in(request.user)
-        request.access = self.create_request_access(permissions=["superuser.write"])
+        self.add_user_permission(self.superuser, "superuser.write")
+        request = self.make_request(user=self.superuser, method="GET", is_superuser=True)
 
         assert self.permission.has_object_permission(request, None, self.installation)
 
         request.method = "POST"
 
-        with pytest.raises(Http404):
-            self.permission.has_object_permission(request, None, self.installation)
+        self.permission.has_object_permission(request, None, self.installation)
 
 
 @control_silo_test

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -146,10 +146,10 @@ class SentryAppInstallationPermissionTest(TestCase):
         request.superuser = Superuser(request)
         request.superuser.set_logged_in(request.user)
 
-        assert self.permission.has_object_permission(request, None, self.sentry_app)
+        assert self.permission.has_object_permission(request, None, self.installation)
 
         request.method = "POST"
-        assert self.permission.has_object_permission(request, None, self.sentry_app)
+        assert self.permission.has_object_permission(request, None, self.installation)
 
     @with_feature("auth:enterprise-superuser-read-write")
     @override_settings(SENTRY_SELF_HOSTED=False)
@@ -158,12 +158,12 @@ class SentryAppInstallationPermissionTest(TestCase):
         request.superuser = Superuser(request)
         request.superuser.set_logged_in(request.user)
 
-        assert self.permission.has_object_permission(request, None, self.sentry_app)
+        assert self.permission.has_object_permission(request, None, self.installation)
 
         request.method = "POST"
 
         with pytest.raises(Http404):
-            self.permission.has_object_permission(request, None, self.sentry_app)
+            self.permission.has_object_permission(request, None, self.installation)
 
     @with_feature("auth:enterprise-superuser-read-write")
     @override_settings(SENTRY_SELF_HOSTED=False)
@@ -173,12 +173,12 @@ class SentryAppInstallationPermissionTest(TestCase):
         request.superuser.set_logged_in(request.user)
         request.access = self.create_request_access(permissions=["superuser.write"])
 
-        assert self.permission.has_object_permission(request, None, self.sentry_app)
+        assert self.permission.has_object_permission(request, None, self.installation)
 
         request.method = "POST"
 
         with pytest.raises(Http404):
-            self.permission.has_object_permission(request, None, self.sentry_app)
+            self.permission.has_object_permission(request, None, self.installation)
 
 
 @control_silo_test


### PR DESCRIPTION
Requires #64108

Replace `is_active_superuser` calls in `SentryAppPermission` and `SentryAppInstallationPermission` with `superuser_has_permission`.

For https://github.com/getsentry/team-enterprise/issues/40