### PR TITLE
feat(ai-autofix): Implement a new step-based autofix 

### DIFF
--- a/src/sentry/api/endpoints/seer_rpc.py
+++ b/src/sentry/api/endpoints/seer_rpc.py
@@ -110,7 +110,7 @@ class SeerRpcServiceEndpoint(Endpoint):
             raise RpcResolutionException(f"Unknown method {method_name}")
         # As seer is a single service, we just directly expose the methods instead of services.
         method = seer_method_registry[method_name]
-        return method(**arguments)
+        return method(**arguments)  # type: ignore
 
     def post(self, request: Request, method_name: str) -> Response:
         if not self._is_authorized(request):

--- a/src/sentry/tasks/ai_autofix.py
+++ b/src/sentry/tasks/ai_autofix.py
@@ -16,11 +16,20 @@ def ai_autofix_check_for_timeout(group_id: int, created_at: str):
     autofix_data = metadata.get("autofix", {})
     # created_at is checked to make sure that the correct run is being marked as completed
     if autofix_data.get("status") == "PROCESSING" and autofix_data.get("createdAt") == created_at:
+        steps = autofix_data.get("steps", [])
+
+        for step in steps:
+            if step.get("status") == "PROCESSING":
+                step["status"] = "ERROR"
+            if step.get("status") == "PENDING":
+                step["status"] = "CANCELLED"
+
         metadata["autofix"] = {
             **autofix_data,
             "fix": None,
-            "status": "COMPLETED",
+            "status": "ERROR",
             "completedAt": datetime.now().isoformat(),
+            "steps": steps,
         }
         group.data["metadata"] = metadata
         group.save()

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from sentry.models.group import Group
 from sentry.testutils.cases import APITestCase, SnubaTestCase
@@ -60,6 +60,7 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
             data={
                 **data,
                 "release": release.version,
+                "exception": {"values": [{"type": "exception", "data": {"values": []}}]},
             },
             project_id=self.project.id,
         )
@@ -71,25 +72,120 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         url = f"/api/0/issues/{group.id}/ai-autofix/"
         self.login_as(user=self.user)
-        with patch("sentry.api.endpoints.group_ai_autofix.requests.post") as mock_post:
+        with patch(
+            "sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix"
+        ) as mock_call:
             response = self.client.post(url, data={"additional_context": "Yes"}, format="json")
-            mock_post.assert_called_once()
-            mock_post.assert_called_with(
-                "http://127.0.0.1:9091/v0/automation/autofix",
-                json={
-                    "additional_context": "Yes",
-                    "base_commit_sha": "1234",
-                    "issue": {
-                        "events": [{"entries": []}],
-                        "id": group.id,
-                        "title": group.title,
-                    },
-                },
-                headers={"content-type": "application/json;charset=utf-8"},
+            mock_call.assert_called_with(
+                ANY,
+                "1234",
+                ANY,
+                "Yes",
             )
+
+            actual_group_arg = mock_call.call_args[0][0]
+            assert actual_group_arg.id == group.id
+
+            exceptions_arg = mock_call.call_args[0][2]
+            assert dict(event.data.get("exception", {}).get("values", [])) == dict(exceptions_arg)
 
         group = Group.objects.get(id=group.id)
 
         assert response.status_code == 202
         assert "autofix" in group.data["metadata"]
         assert group.data["metadata"]["autofix"]["status"] == "PROCESSING"
+
+    def test_ai_autofix_with_invalid_repo(self):
+        release = self.create_release(project=self.project, version="1.0.0")
+
+        # Creating a repository with a name that is not 'getsentry/sentry'
+        invalid_repo = self.create_repo(
+            project=self.project, name="invalid/repo", provider="integrations:github"
+        )
+        invalid_repo.save()
+
+        self.create_commit(project=self.project, release=release, key="1234", repo=invalid_repo)
+
+        data = load_data("python", timestamp=before_now(minutes=1))
+        event = self.store_event(
+            data={
+                **data,
+                "release": release.version,
+                "exception": {"values": [{"type": "exception", "data": {"values": []}}]},
+            },
+            project_id=self.project.id,
+        )
+
+        group = event.group
+
+        assert group is not None
+        group.save()
+
+        url = f"/api/0/issues/{group.id}/ai-autofix/"
+        self.login_as(user=self.user)
+
+        with patch(
+            "sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix"
+        ) as mock_call:
+            response = self.client.post(url, data={"additional_context": "Yes"}, format="json")
+            mock_call.assert_not_called()
+
+        group = Group.objects.get(id=group.id)
+
+        error_msg = "No valid base commit found for release; only getsentry/sentry repo is supported right now."
+
+        assert response.status_code == 400  # Expecting a Bad Request response for invalid repo
+        assert response.data["detail"] == error_msg
+
+        assert "autofix" in group.data["metadata"]
+        assert group.data["metadata"]["autofix"]["status"] == "ERROR"
+        assert group.data["metadata"]["autofix"]["error_message"] == error_msg
+        assert group.data["metadata"]["autofix"]["steps"] == []
+
+    def test_ai_autofix_without_stacktrace(self):
+        release = self.create_release(project=self.project, version="1.0.0")
+
+        # Creating a repository with a valid name 'getsentry/sentry'
+        valid_repo = self.create_repo(
+            project=self.project, name="getsentry/sentry", provider="integrations:github"
+        )
+        valid_repo.save()
+
+        self.create_commit(project=self.project, release=release, key="1234", repo=valid_repo)
+
+        data = load_data("python", timestamp=before_now(minutes=1))
+
+        event = self.store_event(
+            data={
+                **data,
+                "release": release.version,
+                "exception": {"values": [{"type": "breadcrumbs", "data": {"values": []}}]},
+            },
+            project_id=self.project.id,
+        )
+
+        group = event.group
+
+        assert group is not None
+        group.save()
+
+        url = f"/api/0/issues/{group.id}/ai-autofix/"
+        self.login_as(user=self.user)
+
+        with patch(
+            "sentry.api.endpoints.group_ai_autofix.GroupAiAutofixEndpoint._call_autofix"
+        ) as mock_call:
+            response = self.client.post(url, data={"additional_context": "Yes"}, format="json")
+            mock_call.assert_not_called()
+
+        group = Group.objects.get(id=group.id)
+
+        error_msg = "Cannot fix issues without a stacktrace."
+
+        assert response.status_code == 400  # Expecting a Bad Request response for invalid repo
+        assert response.data["detail"] == error_msg
+
+        assert "autofix" in group.data["metadata"]
+        assert group.data["metadata"]["autofix"]["status"] == "ERROR"
+        assert group.data["metadata"]["autofix"]["error_message"] == error_msg
+        assert group.data["metadata"]["autofix"]["steps"] == []


### PR DESCRIPTION
- Update call to seer autofix with better checks for the issue/event before sending (still locked to getsentry/sentry repo)
- Receive step-based autofix status in real time from seer service

**tested e2e locally with frontend and seer service**


Frontend UI for reference of what this looks like:
<img width="919" alt="Screenshot 2024-01-30 at 1 00 03 PM" src="https://github.com/getsentry/sentry/assets/30991498/c49b04fe-4e07-4ae7-8d29-192485b7eadc">
