### PR TITLE
fix(browser-starfish): fix relative image raw_domain incorrect

### DIFF
--- a/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.spec.tsx
+++ b/static/app/views/performance/browser/resources/resourceSummaryPage/sampleImages.spec.tsx
@@ -43,10 +43,10 @@ describe('SampleImages', function () {
       render(<SampleImages groupId="group123" projectId={2} />);
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('loading-indicator'));
 
-      expect(screen.queryByTestId('sample-image')).toHaveAttribute(
-        'src',
-        'https://cdn.com/image.png'
-      );
+      const sampleImages = screen.queryAllByTestId('sample-image');
+
+      expect(sampleImages[0]).toHaveAttribute('src', 'https://cdn.com/image.png');
+      expect(sampleImages[1]).toHaveAttribute('src', 'https://cdn.com/image2.png');
     });
   });
 
@@ -119,6 +119,14 @@ const setupMockRequests = (
           [SPAN_DESCRIPTION]: 'https://cdn.com/image.png',
           'any(id)': 'anyId123',
           [RAW_DOMAIN]: '',
+        },
+        {
+          [SPAN_GROUP]: 'group123',
+          [`measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`]: 1234,
+          project: 'javascript',
+          [SPAN_DESCRIPTION]: '/image2.png',
+          'any(id)': 'anyId123',
+          [RAW_DOMAIN]: 'https://cdn.com',
         },
       ],
     },

--- a/static/app/views/performance/browser/resources/utils/useIndexedResourceQuery.ts
+++ b/static/app/views/performance/browser/resources/utils/useIndexedResourceQuery.ts
@@ -68,7 +68,7 @@ export const useIndexedResourcesQuery = ({
       project: row.project as string,
       'transaction.id': row['transaction.id'] as string,
       [SPAN_DESCRIPTION]: row[SPAN_DESCRIPTION]?.toString(),
-      [RAW_DOMAIN]: row[RAW_DOMAIN][0]?.toString(),
+      [RAW_DOMAIN]: row[RAW_DOMAIN]?.toString(),
       'measurements.http.response_content_length': row[
         `measurements.${HTTP_RESPONSE_CONTENT_LENGTH}`
       ] as number,


### PR DESCRIPTION
We were doing `RAW_DOMAIN[0]` which would actually just return the first character of the domain as raw domain is a string. The reason why we were indexing 0 is because domain returns an array while raw_domain returns a string.
I've tested the full flow of relative images after this change and it works well!