### PR TITLE
ref(open-pr-comment): pass repo_id when finding codemappings

### DIFF
--- a/src/sentry/tasks/integrations/github/open_pr_comment.py
+++ b/src/sentry/tasks/integrations/github/open_pr_comment.py
@@ -248,11 +248,15 @@ def get_pr_files(pr_files: List[Dict[str, str]]) -> List[PullRequestFile]:
 
 def get_projects_and_filenames_from_source_file(
     org_id: int,
+    repo_id: int,
     pr_filename: str,
 ) -> Tuple[Set[Project], Set[str]]:
     # fetch the code mappings in which the source_root is a substring at the start of pr_filename
     code_mappings = (
-        RepositoryProjectPathConfig.objects.filter(organization_id=org_id)
+        RepositoryProjectPathConfig.objects.filter(
+            organization_id=org_id,
+            repository_id=repo_id,
+        )
         .annotate(substring_match=StrIndex(Value(pr_filename), "source_root"))
         .filter(substring_match=1)
     )
@@ -480,7 +484,7 @@ def open_pr_comment_workflow(pr_id: int) -> None:
     # fetch issues related to the files
     for file in pullrequest_files:
         projects, sentry_filenames = get_projects_and_filenames_from_source_file(
-            org_id, file.filename
+            org_id, repo.id, file.filename
         )
         if not len(projects) or not len(sentry_filenames):
             continue

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -333,6 +333,53 @@ class TestGetFilenames(GithubCommentTestCase):
         assert project_list == set(projects)
         assert sentry_filenames == set(correct_filenames)
 
+    def test_get_projects_and_filenames_from_source_file_filters_repo(self):
+        projects = [self.create_project() for _ in range(3)]
+
+        source_stack_pairs = [
+            ("src/sentry", "sentry/"),
+            ("src/", ""),
+            ("src/sentry/", "sentry/"),
+        ]
+        for i, pair in enumerate(source_stack_pairs):
+            source_root, stack_root = pair
+            self.create_code_mapping(
+                project=projects[i],
+                repo=self.gh_repo,
+                source_root=source_root,
+                stack_root=stack_root,
+                default_branch="master",
+            )
+
+        # other codemapping in different repo, will not match
+        project = self.create_project()
+        repo = self.create_repo(
+            name="getsentry/santry",
+            provider="integrations:github",
+            integration_id=self.integration.id,
+            project=project,
+            url="https://github.com/getsentry/santry",
+        )
+        self.create_code_mapping(
+            project=project,
+            repo=repo,
+            source_root="",
+            stack_root="./",
+            default_branch="master",
+        )
+
+        filename = "src/sentry/tasks/integrations/github/open_pr_comment.py"
+        correct_filenames = [
+            "sentry//tasks/integrations/github/open_pr_comment.py",
+            "sentry/tasks/integrations/github/open_pr_comment.py",
+        ]
+
+        project_list, sentry_filenames = get_projects_and_filenames_from_source_file(
+            self.organization.id, self.gh_repo.id, filename
+        )
+        assert project_list == set(projects)
+        assert sentry_filenames == set(correct_filenames)
+
 
 @region_silo_test
 class TestGetCommentIssues(CreateEventTestCase):

--- a/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
+++ b/tests/sentry/tasks/integrations/github/test_open_pr_comment.py
@@ -328,7 +328,7 @@ class TestGetFilenames(GithubCommentTestCase):
         ]
 
         project_list, sentry_filenames = get_projects_and_filenames_from_source_file(
-            self.organization.id, filename
+            self.organization.id, self.gh_repo.id, filename
         )
         assert project_list == set(projects)
         assert sentry_filenames == set(correct_filenames)


### PR DESCRIPTION
We are having some cases where our Snuba query to fetch unhandled issues is too big ([example](https://sentry.sentry.io/issues/4929543284/)). This results in the error, and a comment is not made on an open PR.

The exact reason is because we are passing too many recent, unresolved issue ids into the query. If we backtrack from this reason, another reason is that we have too many projects in which we are fetching issues from.

If we backtrack even further, this could be happening because too many codemappings match when we are trying to go from the filename in Github to how the filename is represented in Sentry. We get projects from codemappings because each codemapping is associated with a project. A single codemapping is also mapped to a single repo -- and we have a repository from the webhook that kicks off an open PR comment.

tl;dr We can pass in the repository id into our search for matching codemappings. This makes the list of projects that we obtain from the matching codemappings more accurate, and should reduce the number of recent unresolved issues that we pass into the Snuba query.