### PR TITLE
feat(replay-clip): Add render context info to analytics events

### DIFF
--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -76,6 +76,7 @@ function EventReplayContent({
   const eventTimestampMs = timeOfEvent ? Math.floor(new Date(timeOfEvent).getTime()) : 0;
 
   const commonProps = {
+    analyticsContext: 'issue_details',
     replaySlug: replayId,
     orgSlug: organization.slug,
     eventTimestampMs,

--- a/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.spec.tsx
@@ -110,6 +110,13 @@ describe('ReplayClipPreview', () => {
     });
   });
 
+  const defaultProps = {
+    analyticsContext: '',
+    orgSlug: mockOrgSlug,
+    replaySlug: mockReplaySlug,
+    eventTimestampMs: mockEventTimestampMs,
+  };
+
   it('Should render a placeholder when is fetching the replay data', () => {
     // Change the mocked hook to return a loading state
     mockUseReplayReader.mockImplementationOnce(() => {
@@ -126,13 +133,7 @@ describe('ReplayClipPreview', () => {
       };
     });
 
-    render(
-      <ReplayClipPreview
-        orgSlug={mockOrgSlug}
-        replaySlug={mockReplaySlug}
-        eventTimestampMs={mockEventTimestampMs}
-      />
-    );
+    render(<ReplayClipPreview {...defaultProps} />);
 
     expect(screen.getByTestId('replay-loading-placeholder')).toBeInTheDocument();
   });
@@ -153,25 +154,13 @@ describe('ReplayClipPreview', () => {
       };
     });
 
-    render(
-      <ReplayClipPreview
-        orgSlug={mockOrgSlug}
-        replaySlug={mockReplaySlug}
-        eventTimestampMs={mockEventTimestampMs}
-      />
-    );
+    render(<ReplayClipPreview {...defaultProps} />);
 
     expect(screen.getByTestId('replay-error')).toBeVisible();
   });
 
   it('Should have the correct time range', () => {
-    render(
-      <ReplayClipPreview
-        orgSlug={mockOrgSlug}
-        replaySlug={mockReplaySlug}
-        eventTimestampMs={mockEventTimestampMs}
-      />
-    );
+    render(<ReplayClipPreview {...defaultProps} />);
 
     // Should be two sliders, one for the scrubber and one for timeline
     const sliders = screen.getAllByRole('slider', {name: 'Seek slider'});
@@ -185,13 +174,7 @@ describe('ReplayClipPreview', () => {
   });
 
   it('Should link to the full replay correctly', () => {
-    render(
-      <ReplayClipPreview
-        orgSlug={mockOrgSlug}
-        replaySlug={mockReplaySlug}
-        eventTimestampMs={mockEventTimestampMs}
-      />
-    );
+    render(<ReplayClipPreview {...defaultProps} />);
 
     expect(screen.getByRole('button', {name: 'See Full Replay'})).toHaveAttribute(
       'href',
@@ -202,13 +185,7 @@ describe('ReplayClipPreview', () => {
   it('Display URL and breadcrumbs in fullscreen mode', async () => {
     mockIsFullscreen.mockReturnValue(true);
 
-    render(
-      <ReplayClipPreview
-        orgSlug={mockOrgSlug}
-        replaySlug={mockReplaySlug}
-        eventTimestampMs={mockEventTimestampMs}
-      />
-    );
+    render(<ReplayClipPreview {...defaultProps} />);
 
     // Should have URL bar
     expect(screen.getByRole('textbox', {name: 'Current URL'})).toHaveValue(

--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -41,6 +41,7 @@ import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
 type Props = {
+  analyticsContext: string;
   eventTimestampMs: number;
   orgSlug: string;
   replaySlug: string;
@@ -142,6 +143,7 @@ function ReplayPreviewPlayer({
 }
 
 function ReplayClipPreview({
+  analyticsContext,
   eventTimestampMs,
   orgSlug,
   replaySlug,
@@ -216,6 +218,7 @@ function ReplayClipPreview({
       replay={replay}
       initialTimeOffsetMs={offset}
       clipWindow={clipWindow}
+      analyticsContext={analyticsContext}
     >
       <PlayerContainer data-test-id="player-container" ref={fullscreenRef}>
         {replay?.hasProcessingErrors() ? (

--- a/static/app/components/events/eventReplay/replayPreview.spec.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.spec.tsx
@@ -96,6 +96,13 @@ const render: typeof baseRender = children => {
   );
 };
 
+const defaultProps = {
+  analyticsContext: '',
+  orgSlug: mockOrgSlug,
+  replaySlug: mockReplaySlug,
+  eventTimestampMs: mockEventTimestampMs,
+};
+
 describe('ReplayPreview', () => {
   it('Should render a placeholder when is fetching the replay data', () => {
     // Change the mocked hook to return a loading state
@@ -113,13 +120,7 @@ describe('ReplayPreview', () => {
       };
     });
 
-    render(
-      <ReplayPreview
-        orgSlug={mockOrgSlug}
-        replaySlug={mockReplaySlug}
-        eventTimestampMs={mockEventTimestampMs}
-      />
-    );
+    render(<ReplayPreview {...defaultProps} />);
 
     expect(screen.getByTestId('replay-loading-placeholder')).toBeInTheDocument();
   });
@@ -140,38 +141,20 @@ describe('ReplayPreview', () => {
       };
     });
 
-    render(
-      <ReplayPreview
-        orgSlug={mockOrgSlug}
-        replaySlug={mockReplaySlug}
-        eventTimestampMs={mockEventTimestampMs}
-      />
-    );
+    render(<ReplayPreview {...defaultProps} />);
 
     expect(screen.getByTestId('replay-error')).toBeVisible();
   });
 
   it('Should render details button when there is a replay', () => {
-    render(
-      <ReplayPreview
-        orgSlug={mockOrgSlug}
-        replaySlug={mockReplaySlug}
-        eventTimestampMs={mockEventTimestampMs}
-      />
-    );
+    render(<ReplayPreview {...defaultProps} />);
 
     const detailButton = screen.getByLabelText('Open Replay');
     expect(detailButton).toHaveAttribute('href', mockButtonHref);
   });
 
   it('Should render all its elements correctly', () => {
-    render(
-      <ReplayPreview
-        orgSlug={mockOrgSlug}
-        replaySlug={mockReplaySlug}
-        eventTimestampMs={mockEventTimestampMs}
-      />
-    );
+    render(<ReplayPreview {...defaultProps} />);
 
     // Expect replay view to be rendered
     expect(screen.getByTestId('player-container')).toBeInTheDocument();

--- a/static/app/components/events/eventReplay/replayPreview.tsx
+++ b/static/app/components/events/eventReplay/replayPreview.tsx
@@ -24,6 +24,7 @@ import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
 type Props = {
+  analyticsContext: string;
   eventTimestampMs: number;
   orgSlug: string;
   replaySlug: string;
@@ -54,6 +55,7 @@ function getReplayAnalyticsStatus({
 }
 
 function ReplayPreview({
+  analyticsContext,
   fullReplayButtonProps,
   eventTimestampMs,
   focusTab,
@@ -118,6 +120,7 @@ function ReplayPreview({
       isFetching={fetching}
       replay={replay}
       initialTimeOffsetMs={{offsetMs: initialTimeOffsetMs}}
+      analyticsContext={analyticsContext}
     >
       <PlayerContainer data-test-id="player-container">
         {replay?.hasProcessingErrors() ? (

--- a/static/app/components/feedback/feedbackItem/replaySection.tsx
+++ b/static/app/components/feedback/feedbackItem/replaySection.tsx
@@ -18,6 +18,7 @@ export default function ReplaySection({eventTimestampMs, organization, replayId}
 
   return (
     <LazyLoad
+      analyticsContext="feedback"
       component={replayPreview}
       eventTimestampMs={eventTimestampMs}
       focusTab={TabKey.BREADCRUMBS}

--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -103,6 +103,7 @@ export default function ReplayComparisonModal({
             }}
           >
             <ReplayContextProvider
+              analyticsContext="replay_comparison_modal_left"
               isFetching={fetching}
               replay={replay}
               initialTimeOffsetMs={{offsetMs: startOffset}}
@@ -116,6 +117,7 @@ export default function ReplayComparisonModal({
               </ComparisonSideWrapper>
             </ReplayContextProvider>
             <ReplayContextProvider
+              analyticsContext="replay_comparison_modal_right"
               isFetching={fetching}
               replay={replay}
               initialTimeOffsetMs={{offsetMs: rightTimestamp + 1}}

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -33,6 +33,11 @@ type HighlightCallbacks = ReturnType<typeof useReplayHighlighting>;
 // Instead only expose methods that wrap `Replayer` and manage state.
 interface ReplayPlayerContextProps extends HighlightCallbacks {
   /**
+   * The context in which the replay is being viewed.
+   */
+  analyticsContext: string;
+
+  /**
    * The time, in milliseconds, where the user focus is.
    * The user focus can be reported by any collaborating object, usually on
    * hover.
@@ -156,6 +161,7 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
 }
 
 const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
+  analyticsContext: '',
   clearAllHighlights: () => {},
   currentHoverTime: undefined,
   currentTime: 0,
@@ -184,6 +190,12 @@ const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
 });
 
 type Props = {
+  /**
+   * The context in which the replay is being viewed.
+   * Attached to certain analytics events.
+   */
+  analyticsContext: string;
+
   children: React.ReactNode;
 
   /**
@@ -267,6 +279,7 @@ function useClipWindow({
 }
 
 export function Provider({
+  analyticsContext,
   children,
   clipWindow,
   initialTimeOffsetMs,
@@ -532,9 +545,10 @@ export function Provider({
         organization,
         user_email: user.email,
         play,
+        context: analyticsContext,
       });
     },
-    [getCurrentTime, user.email, organization]
+    [organization, user.email, analyticsContext, getCurrentTime]
   );
 
   useEffect(() => {
@@ -604,6 +618,7 @@ export function Provider({
   return (
     <ReplayPlayerContext.Provider
       value={{
+        analyticsContext,
         clearAllHighlights,
         currentHoverTime,
         currentTime,

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -121,6 +121,7 @@ function ReplayControls({
   const barRef = useRef<HTMLDivElement>(null);
   const [isCompact, setIsCompact] = useState(false);
   const isFullscreen = useIsFullscreen();
+  const {analyticsContext} = useReplayContext();
 
   // If the browser supports going fullscreen or not. iPhone Safari won't do
   // it. https://caniuse.com/fullscreen
@@ -129,11 +130,12 @@ function ReplayControls({
   const handleFullscreenToggle = useCallback(() => {
     trackAnalytics('replay.toggle-fullscreen', {
       organization,
+      context: analyticsContext,
       user_email: user.email,
       fullscreen: !isFullscreen,
     });
     toggleFullscreen();
-  }, [user.email, isFullscreen, organization, toggleFullscreen]);
+  }, [organization, analyticsContext, user.email, isFullscreen, toggleFullscreen]);
 
   const updateIsCompact = useCallback(() => {
     const {width} = barRef.current?.getBoundingClientRect() ?? {

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -28,6 +28,8 @@ function useVideoSizeLogger({
 }) {
   const organization = useOrganization();
   const [didLog, setDidLog] = useState<boolean>(false);
+  const {analyticsContext} = useReplayContext();
+
   useEffect(() => {
     if (didLog || (videoDimensions.width === 0 && videoDimensions.height === 0)) {
       return;
@@ -48,10 +50,11 @@ function useVideoSizeLogger({
     trackAnalytics('replay.render-player', {
       organization,
       aspect_ratio,
+      context: analyticsContext,
       scale_bucket,
     });
     setDidLog(true);
-  }, [organization, windowDimensions, videoDimensions, didLog]);
+  }, [organization, windowDimensions, videoDimensions, didLog, analyticsContext]);
 }
 
 function BasePlayerRoot({className, isPreview = false}: Props) {

--- a/static/app/utils/analytics/replayAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/replayAnalyticsEvents.tsx
@@ -77,6 +77,7 @@ export type ReplayEventParameters = {
   };
   'replay.list-view-setup-sidebar': {};
   'replay.play-pause': {
+    context: string;
     play: boolean;
     user_email: string;
   };
@@ -93,6 +94,7 @@ export type ReplayEventParameters = {
   };
   'replay.render-player': {
     aspect_ratio: 'portrait' | 'landscape';
+    context: string;
     // What scale is the video as a percent, bucketed into ranges of 10% increments
     // example:
     //  - The video is shown at 25% the normal size
@@ -104,6 +106,7 @@ export type ReplayEventParameters = {
     search_keys: string;
   };
   'replay.toggle-fullscreen': {
+    context: string;
     fullscreen: boolean;
     user_email: string;
   };

--- a/static/app/views/replays/detail/tagPanel/index.spec.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.spec.tsx
@@ -23,7 +23,7 @@ const mockReplay = ReplayReader.factory({
 
 const renderComponent = (replay: ReplayReader | null) => {
   return render(
-    <ReplayContextProvider isFetching={false} replay={replay}>
+    <ReplayContextProvider analyticsContext="" isFetching={false} replay={replay}>
       <TagPanel />
     </ReplayContextProvider>
   );

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -145,6 +145,7 @@ function ReplayDetails({params: {replaySlug}}: Props) {
 
   return (
     <ReplayContextProvider
+      analyticsContext="replay_details"
       isFetching={fetching}
       replay={replay}
       initialTimeOffsetMs={initialTimeOffsetMs}


### PR DESCRIPTION
Closes https://github.com/getsentry/getsentry/issues/12760

Adds `analyticsContext` to the replay context. That data can be added to certain analytics events so we can tell the difference between a play on the issue details page vs replay details. 

This attaches the data to render, play, and fullscreen events which should be enough for now. The values are `issue_details`, `replay_details`, and `feedback`.

One other option would be to provide a modified `trackAnalytics` function that would automatically provide the context in the data, but that would be a bit more complex and I'm not sure it's necessary. But open to suggestions if anyone doesn't agree with this approach.  