### PR TITLE
ref(slack): Don't add tags and context to non-error issues notifications

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -568,23 +568,27 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if self.actions:
             blocks.append(self.get_markdown_block(action_text))
 
-        # build tags block
-        tags = get_tags(event_for_tags, self.tags)
-        if tags:
-            blocks.append(self.get_tags_block(tags))
+        if self.group.issue_category == GroupCategory.ERROR:
+            # XXX(CEO): in the short term we're not adding these to non-error issues (e.g. crons)
+            # since they don't make sense, but in the future we'll read some config from the grouptype
 
-        # add event count, user count, substate, first seen
-        context = {
-            "Events": get_group_global_count(self.group),
-            "Users Affected": self.group.count_users_seen(),
-            "State": SUBSTATUS_TO_STR.get(self.group.substatus, "").replace("_", " ").title(),
-            "First Seen": time_since(self.group.first_seen),
-        }
-        context_text = ""
-        for k, v in context.items():
-            if k and v:
-                context_text += f"{k}: *{v}*   "
-        blocks.append(self.get_context_block(context_text[:-3]))
+            # build tags block
+            tags = get_tags(event_for_tags, self.tags)
+            if tags:
+                blocks.append(self.get_tags_block(tags))
+
+            # add event count, user count, substate, first seen
+            context = {
+                "Events": get_group_global_count(self.group),
+                "Users Affected": self.group.count_users_seen(),
+                "State": SUBSTATUS_TO_STR.get(self.group.substatus, "").replace("_", " ").title(),
+                "First Seen": time_since(self.group.first_seen),
+            }
+            context_text = ""
+            for k, v in context.items():
+                if k and v:
+                    context_text += f"{k}: *{v}*   "
+            blocks.append(self.get_context_block(context_text[:-3]))
 
         # build actions
         actions = []

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2822,7 +2822,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
             == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
         )
         assert (
-            blocks[5]["elements"][0]["text"]
+            blocks[3]["elements"][0]["text"]
             == f"{project_slug} | production | <http://testserver/settings/account/notifications/{alert_type}/?referrer={referrer}-user&notification_uuid={notification_uuid}|Notification Settings>"
         )
 


### PR DESCRIPTION
As a short term solution, we're removing tags and context (users affected, error count, etc.) from non-error issues as the teams have requested that they either be removed or be customized. We have plans in the future to allow these to be more customizable, but in order to release all the Slack changes to customers in the near future, we're removing the aforementioned sections so the alerts will make sense.