### PR TITLE
fix(api): don't rely on list tokens exposing value

### DIFF
--- a/static/app/views/releases/list/releasesPromo.tsx
+++ b/static/app/views/releases/list/releasesPromo.tsx
@@ -149,7 +149,7 @@ const ReleasesPromo = ({organization, project}: Props) => {
     });
   }, [organization, project.id]);
 
-  const fetchToken = async sentryAppSlug => {
+  const generateAndSetNewToken = async (sentryAppSlug: string) => {
     const newToken = await generateToken(sentryAppSlug);
     return setToken(newToken);
   };
@@ -251,7 +251,7 @@ sentry-cli releases finalize "$VERSION"`,
                 alignMenu="left"
                 onSelect={({label, value}) => {
                   selectItem({label, value});
-                  fetchToken(value.slug);
+                  generateAndSetNewToken(value.slug);
                 }}
                 itemSize="small"
                 searchPlaceholder={t('Select Internal Integration')}
@@ -279,7 +279,7 @@ sentry-cli releases finalize "$VERSION"`,
                                   label,
                                   value,
                                 });
-                                fetchToken(value.slug);
+                                generateAndSetNewToken(value.slug);
                                 trackQuickstartCreatedIntegration(integration);
                               },
                               onCancel: () => {

--- a/static/app/views/releases/list/releasesPromo.tsx
+++ b/static/app/views/releases/list/releasesPromo.tsx
@@ -21,7 +21,12 @@ import {Tooltip} from 'sentry/components/tooltip';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {Organization, Project, SentryApp} from 'sentry/types';
+import type {
+  NewInternalAppApiToken,
+  Organization,
+  Project,
+  SentryApp,
+} from 'sentry/types';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useApi from 'sentry/utils/useApi';
 import useApiRequests from 'sentry/utils/useApiRequests';
@@ -102,7 +107,7 @@ const ReleasesPromo = ({organization, project}: Props) => {
     ],
   });
   const api = useApi();
-  const [token, setToken] = useState(null);
+  const [token, setToken] = useState<string | null>(null);
   const [integrations, setIntegrations] = useState<SentryApp[]>([]);
   const [selectedItem, selectItem] = useState<Pick<Item, 'label' | 'value'> | null>(null);
 
@@ -145,16 +150,12 @@ const ReleasesPromo = ({organization, project}: Props) => {
   }, [organization, project.id]);
 
   const fetchToken = async sentryAppSlug => {
-    const tokens = await api.requestPromise(`/sentry-apps/${sentryAppSlug}/api-tokens/`);
-    if (!tokens.length) {
-      const newToken = await generateToken(sentryAppSlug);
-      return setToken(newToken);
-    }
-    return setToken(tokens[0].token);
+    const newToken = await generateToken(sentryAppSlug);
+    return setToken(newToken);
   };
 
   const generateToken = async (sentryAppSlug: string) => {
-    const newToken = await api.requestPromise(
+    const newToken: NewInternalAppApiToken = await api.requestPromise(
       `/sentry-apps/${sentryAppSlug}/api-tokens/`,
       {
         method: 'POST',


### PR DESCRIPTION
We are relying on the list endpoint to be exposing the API tokens, but this is not the direction we want to be going in. If the feature requires the token value for easy copy/paste of the snippet, use the generation feature to create a new token instead of forcing the list to constantly show the value.


https://github.com/getsentry/sentry/assets/5581484/d1e1dbb0-0a23-45d1-ad02-c714333edb35



Resolves: https://github.com/getsentry/team-enterprise/issues/21
