### PR TITLE
ref(github-pr-comments): cap suspect commit issues list to 1000

### DIFF
--- a/src/sentry/tasks/integrations/github/pr_comment.py
+++ b/src/sentry/tasks/integrations/github/pr_comment.py
@@ -137,6 +137,9 @@ def github_comment_workflow(pullrequest_id: int, project_id: int):
 
     gh_repo_id, pr_key, org_id, issue_list = pr_to_issue_query(pullrequest_id)[0]
 
+    # cap to 1000 issues in which the merge commit is the suspect commit
+    issue_list = issue_list[:1000]
+
     try:
         organization = Organization.objects.get_from_cache(id=org_id)
     except Organization.DoesNotExist:


### PR DESCRIPTION
We have an issue [here](https://sentry.sentry.io/issues/4929850579/) where for a select few cases, the Snuba query used for merged PR comments (suspect issue comments) is erroring out. The Snuba query is used to fetch the top 5 issues by count that are caused by the suspect commit.

The error is happening because we are passing too many issue ids into the Snuba query. For merged PR comments, we fetch all of the issues in which the merge commit of the PR is the suspect commit for the issue. For the merge commits in which this is erroring, there are are 50k+(!) issues being passed into the Snuba query.

I'm introducing a cap here to cap the number of issues fetched for the suspect commit to 1000. The issues are ordered from most to least recent. If a single PR's merge commit is suspected of causing more than 1000 issues, then either somebody really messed up or we have grouping problems we should address.