### PR TITLE
ref(replay): Rewrite useReplayData to leverage useApiQuery 3/3

### DIFF
--- a/static/app/utils/api/useFetchParallelPages.spec.tsx
+++ b/static/app/utils/api/useFetchParallelPages.spec.tsx
@@ -40,6 +40,39 @@ describe('useFetchParallelPages', () => {
     expect(getQueryKey).not.toHaveBeenCalled();
   });
 
+  it('should immediately switch to isFetching=true when the prop is changed', async () => {
+    MockApiClient.addMockResponse({
+      url: MOCK_API_ENDPOINT,
+      body: 'text result',
+    });
+    const getQueryKey = queryKeyFactory();
+
+    const {result, rerender, waitForNextUpdate} = reactHooks.renderHook(
+      useFetchParallelPages,
+      {
+        wrapper: makeWrapper(makeTestQueryClient()),
+        initialProps: {
+          enabled: false,
+          getQueryKey,
+          hits: 13,
+          perPage: 10,
+        },
+      }
+    );
+
+    expect(result.current.isFetching).toBeFalsy();
+    expect(getQueryKey).not.toHaveBeenCalled();
+
+    rerender({enabled: true, getQueryKey, hits: 13, perPage: 10});
+
+    expect(result.current.isFetching).toBeTruthy();
+    expect(getQueryKey).toHaveBeenCalled();
+
+    await waitForNextUpdate();
+
+    expect(result.current.isFetching).toBeFalsy();
+  });
+
   it('should call the queryFn zero times, when hits is 0', () => {
     MockApiClient.addMockResponse({
       url: MOCK_API_ENDPOINT,

--- a/static/app/utils/api/useFetchParallelPages.tsx
+++ b/static/app/utils/api/useFetchParallelPages.tsx
@@ -103,12 +103,13 @@ export default function useFetchParallelPages<Data>({
     [pages, perPage]
   );
 
+  const willFetch = enabled && Boolean(cursors.length);
   const [state, setState] = useState<State<Data>>({
     pages: [],
     error: undefined,
     getLastResponseHeader: undefined,
     isError: false,
-    isFetching: enabled && Boolean(cursors.length),
+    isFetching: willFetch,
   });
 
   const fetch = useCallback(
@@ -162,12 +163,17 @@ export default function useFetchParallelPages<Data>({
   );
 
   useEffect(() => {
-    if (!enabled) {
+    if (!willFetch) {
       return;
     }
 
+    setState(prev => ({
+      ...prev,
+      isFetching: true,
+    }));
+
     fetch();
-  }, [enabled, fetch]);
+  }, [willFetch, fetch]);
 
   return state;
 }

--- a/static/app/utils/api/useFetchSequentialPages.tsx
+++ b/static/app/utils/api/useFetchSequentialPages.tsx
@@ -7,7 +7,7 @@ import useApi from 'sentry/utils/useApi';
 
 interface Props {
   /**
-   * Whether or not to start fetched when the hook is mounted
+   * Whether or not to start fetching when the hook is mounted
    */
   enabled: boolean;
 
@@ -150,7 +150,7 @@ export default function useFetchSequentialPages<Data>({
         setState({
           pages: values.map(value => value.data).filter(defined),
           error: values.map(value => value.error),
-          getLastResponseHeader: values.slice(-1)[0]?.getResponseHeader,
+          getLastResponseHeader: values.at(-1)?.getResponseHeader,
           isError: values.map(value => value.isError).some(Boolean),
           isFetching: values.map(value => value.isFetching).every(Boolean),
         });

--- a/static/app/utils/api/useFetchSequentialPages.tsx
+++ b/static/app/utils/api/useFetchSequentialPages.tsx
@@ -1,0 +1,176 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+import {defined} from 'sentry/utils';
+import parseLinkHeader, {type ParsedHeader} from 'sentry/utils/parseLinkHeader';
+import {type ApiQueryKey, fetchDataQuery, useQueryClient} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+
+interface Props {
+  /**
+   * Whether or not to start fetched when the hook is mounted
+   */
+  enabled: boolean;
+
+  /**
+   * Generate the queryKey to use, given the pagination params
+   * If `undefined` is returned iteration will not continue
+   */
+  getQueryKey: (pagination: {
+    cursor: string;
+    per_page: number;
+  }) => undefined | ApiQueryKey;
+
+  /**
+   * You must set the page size to be used.
+   *
+   * This will be passed back as an argument into getQueryKey
+   */
+  perPage: number;
+
+  /**
+   * The initial cursor to use when fetching.
+   *
+   * Default: `0:0:0`
+   */
+  initialCursor?: undefined | string;
+}
+
+interface ResponsePage<Data> {
+  data: undefined | Data;
+  error: unknown;
+  getResponseHeader: ((header: string) => string | null) | undefined;
+  isError: boolean;
+  isFetching: boolean;
+}
+
+interface State<Data> {
+  error: unknown;
+  getLastResponseHeader: ((header: string) => string | null) | undefined;
+  isError: boolean;
+  isFetching: boolean;
+  pages: Data[];
+}
+
+/**
+ * A query hook that fetches multiple pages of data from the same endpoint, one-by-one.
+ *
+ * See also: `useFetchParallelPages()`
+ *
+ * `useFetchSequentialPages` is an iterator for fetch calls. It makes it possible
+ * to fetch ALL data from an api endpoint.
+ *
+ * <WARNING>
+ *   Using this hook might not be a good idea!
+ *   Pagination is a good stratergy to limit the amount of data that a server
+ *   needs to fetch at a given time, it also limits the amount of data that the
+ *   browser needs to hold in memory. Loading all data with this hook could
+ *   cause rate-limiting, memory exhaustion, slow rendering, and other problems.
+ *
+ *   Before implementing a sequential-fetch you should first think about
+ *   building new api endpoints that return just the data you need (in a
+ *   paginated way), or look at the feature design itself and make adjustments.
+ * </WARNING>
+ *
+ * EXAMPLE: you want to make a request for all user's within a project...
+ *   In the well-behaved case this might seem fine, but in the pathological
+ *   case (in the extreme) there could be too many users to do this safely!
+ * If there are 64 users in the project, but the max page-size is only 50, then
+ * you can expect two calls to be made. The network waterfall would look like:
+ *
+ * | Request        | Waterfall           |
+ * | -------------- | ------------------- |
+ * | ?cursor=0:0:0  | ========            |
+ * | ?cursor=0:50:0 |         ========    |
+ * |                | ^       ^       ^   |
+ * |                | t=0     t=1     t=2 |
+ *
+ * At t=0 the hook will return `data=Array(0)` because no records are fetched yet.
+ * At t=1 the hook will return `data=Array(50)` and will has `isFetching=true`
+ * Finally at t=2 all data will be fetched and combined: `data=Array(64)`
+ */
+export default function useFetchSequentialPages<Data>({
+  enabled,
+  getQueryKey,
+  initialCursor,
+  perPage,
+}: Props): State<Data> {
+  const api = useApi({persistInFlight: true});
+  const queryClient = useQueryClient();
+
+  const responsePages = useRef<Map<string, ResponsePage<Data>>>(new Map());
+  const [state, setState] = useState<State<Data>>({
+    pages: [],
+    error: undefined,
+    getLastResponseHeader: undefined,
+    isError: false,
+    isFetching: enabled,
+  });
+
+  const fetch = useCallback(
+    async function recursiveFetch() {
+      let parsedHeader: ParsedHeader = {
+        cursor: initialCursor ?? '0:0:0',
+        href: '',
+        results: true,
+      };
+      try {
+        while (parsedHeader.results) {
+          const cursor = parsedHeader.cursor;
+          const queryKey = getQueryKey({cursor, per_page: perPage});
+          if (!queryKey) {
+            break;
+          }
+          const [data, , resp] = await queryClient.fetchQuery({
+            queryKey,
+            queryFn: fetchDataQuery(api),
+            staleTime: Infinity,
+          });
+
+          responsePages.current.set(cursor, {
+            data,
+            error: undefined,
+            getResponseHeader: resp?.getResponseHeader,
+            isError: false,
+            isFetching: false,
+          });
+
+          const pageLinks = resp?.getResponseHeader('Link') ?? null;
+          parsedHeader = parseLinkHeader(pageLinks)?.next;
+        }
+      } catch (error) {
+        responsePages.current.set(parsedHeader.cursor, {
+          data: undefined,
+          error,
+          getResponseHeader: undefined,
+          isError: true,
+          isFetching: false,
+        });
+      } finally {
+        const values = Array.from(responsePages.current.values());
+        setState({
+          pages: values.map(value => value.data).filter(defined),
+          error: values.map(value => value.error),
+          getLastResponseHeader: values.slice(-1)[0]?.getResponseHeader,
+          isError: values.map(value => value.isError).some(Boolean),
+          isFetching: values.map(value => value.isFetching).every(Boolean),
+        });
+      }
+    },
+    [api, initialCursor, getQueryKey, perPage, queryClient]
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    setState(prev => ({
+      ...prev,
+      isFetching: true,
+    }));
+
+    fetch();
+  }, [enabled, fetch]);
+
+  return state;
+}


### PR DESCRIPTION
Rewriting useReplayData, part 3

This replaces the error fetching with the useFetchParallelPages & new useFetchSequentialPages helpers, resulting in a smaller useReplayData.tsx file that has less of the state management stuff in it.
The two helpers work in tandem, first to fetch all the known front-end errors in parallel, then if there are more backend errors, we page through them one by one. We're trying to load everything possible upfront for the page to work, which isn't great in terms of overfetching... but it makes the page itself easier to build & maintain because everything is just there. 

As before, all the fetched data lives in the queryCache, so re-visits to the same replay are faster (for instance, if someone were on issue details and clicked-through to a replay).

Follows: https://github.com/getsentry/sentry/pull/63455
Follows: https://github.com/getsentry/sentry/pull/64234
It's a slice of: https://github.com/getsentry/sentry/pull/62109