### PR TITLE
fix(replay-clip): Ensure fullscreen analytics event is captured for replay clips

### DIFF
--- a/static/app/components/events/eventReplay/replayClipPreview.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreview.tsx
@@ -1,7 +1,6 @@
 import type {ComponentProps} from 'react';
 import {useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
-import screenfull from 'screenfull';
 
 import {Alert} from 'sentry/components/alert';
 import {LinkButton} from 'sentry/components/button';
@@ -92,10 +91,6 @@ function ReplayPreviewPlayer({
   });
   const isFullscreen = useIsFullscreen();
 
-  // If the browser supports going fullscreen or not. iPhone Safari won't do
-  // it. https://caniuse.com/fullscreen
-  const showFullscreenButton = screenfull.isEnabled;
-
   const fullReplayUrl = {
     pathname: normalizeUrl(`/organizations/${organization.slug}/replays/${replayId}/`),
     query: {
@@ -136,9 +131,7 @@ function ReplayPreviewPlayer({
               <LinkButton size="sm" to={fullReplayUrl} {...fullReplayButtonProps}>
                 {t('See Full Replay')}
               </LinkButton>
-              {showFullscreenButton ? (
-                <ReplayFullscreenButton toggleFullscreen={toggleFullscreen} />
-              ) : null}
+              <ReplayFullscreenButton toggleFullscreen={toggleFullscreen} />
             </ButtonBar>
           </ButtonGrid>
         </ErrorBoundary>

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -1,28 +1,18 @@
 import {useCallback, useLayoutEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useResizeObserver} from '@react-aria/utils';
-import screenfull from 'screenfull';
 
 import {Button} from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {CompositeSelect} from 'sentry/components/compactSelect/composite';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {ReplayFullscreenButton} from 'sentry/components/replays/replayFullscreenButton';
 import ReplayPlayPauseButton from 'sentry/components/replays/replayPlayPauseButton';
 import TimeAndScrubberGrid from 'sentry/components/replays/timeAndScrubberGrid';
-import {
-  IconContract,
-  IconExpand,
-  IconNext,
-  IconRewind10,
-  IconSettings,
-} from 'sentry/icons';
+import {IconNext, IconRewind10, IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import {getNextReplayFrame} from 'sentry/utils/replays/getReplayEvent';
-import useOrganization from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
-import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
 
 const SECOND = 1000;
 
@@ -116,26 +106,8 @@ function ReplayControls({
   toggleFullscreen,
   speedOptions = [0.1, 0.25, 0.5, 1, 2, 4, 8, 16],
 }: Props) {
-  const user = useUser();
-  const organization = useOrganization();
   const barRef = useRef<HTMLDivElement>(null);
   const [isCompact, setIsCompact] = useState(false);
-  const isFullscreen = useIsFullscreen();
-  const {analyticsContext} = useReplayContext();
-
-  // If the browser supports going fullscreen or not. iPhone Safari won't do
-  // it. https://caniuse.com/fullscreen
-  const showFullscreenButton = screenfull.isEnabled;
-
-  const handleFullscreenToggle = useCallback(() => {
-    trackAnalytics('replay.toggle-fullscreen', {
-      organization,
-      context: analyticsContext,
-      user_email: user.email,
-      fullscreen: !isFullscreen,
-    });
-    toggleFullscreen();
-  }, [organization, analyticsContext, user.email, isFullscreen, toggleFullscreen]);
 
   const updateIsCompact = useCallback(() => {
     const {width} = barRef.current?.getBoundingClientRect() ?? {
@@ -158,15 +130,7 @@ function ReplayControls({
       </Container>
       <ButtonBar gap={1}>
         <ReplayOptionsMenu speedOptions={speedOptions} />
-        {showFullscreenButton ? (
-          <Button
-            size="sm"
-            title={isFullscreen ? t('Exit full screen') : t('Enter full screen')}
-            aria-label={isFullscreen ? t('Exit full screen') : t('Enter full screen')}
-            icon={isFullscreen ? <IconContract size="sm" /> : <IconExpand size="sm" />}
-            onClick={handleFullscreenToggle}
-          />
-        ) : null}
+        <ReplayFullscreenButton toggleFullscreen={toggleFullscreen} />
       </ButtonBar>
     </ButtonGrid>
   );

--- a/static/app/components/replays/replayFullscreenButton.tsx
+++ b/static/app/components/replays/replayFullscreenButton.tsx
@@ -1,6 +1,13 @@
+import {useCallback} from 'react';
+import screenfull from 'screenfull';
+
 import {Button} from 'sentry/components/button';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {IconContract, IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
 import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
 
 type Props = {
@@ -8,7 +15,28 @@ type Props = {
 };
 
 export function ReplayFullscreenButton({toggleFullscreen}: Props) {
+  const organization = useOrganization();
+  const user = useUser();
   const isFullscreen = useIsFullscreen();
+  const {analyticsContext} = useReplayContext();
+
+  const handleFullscreenToggle = useCallback(() => {
+    trackAnalytics('replay.toggle-fullscreen', {
+      organization,
+      context: analyticsContext,
+      user_email: user.email,
+      fullscreen: !isFullscreen,
+    });
+    toggleFullscreen();
+  }, [analyticsContext, isFullscreen, organization, toggleFullscreen, user.email]);
+
+  // If the browser supports going fullscreen or not. iPhone Safari won't do
+  // it. https://caniuse.com/fullscreen
+  const fullscreenSupported = screenfull.isEnabled;
+
+  if (!fullscreenSupported) {
+    return null;
+  }
 
   return (
     <Button
@@ -16,7 +44,7 @@ export function ReplayFullscreenButton({toggleFullscreen}: Props) {
       title={isFullscreen ? t('Exit full screen') : t('Enter full screen')}
       aria-label={isFullscreen ? t('Exit full screen') : t('Enter full screen')}
       icon={isFullscreen ? <IconContract size="sm" /> : <IconExpand size="sm" />}
-      onClick={toggleFullscreen}
+      onClick={handleFullscreenToggle}
     />
   );
 }


### PR DESCRIPTION
Moves the analytics logic into `ReplayFullscreenButton` so that it can be used in both replay details and replay clips. I actually added this common component earlier, but never updated the original player to import it (better late than never)