### PR TITLE
ref(proj-config): Remove span attributes

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -682,7 +682,6 @@ def _get_project_config(
             ]
         }
 
-    config["spanAttributes"] = project.get_option("sentry:span_attributes")
     with Hub.current.start_span(op="get_filter_settings"):
         if filter_settings := get_filter_settings(project):
             config["filterSettings"] = filter_settings

--- a/tests/relay_integration/test_integration.py
+++ b/tests/relay_integration/test_integration.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 import pytest
 
 from sentry.models.eventattachment import EventAttachment
-from sentry.spans.grouping.utils import hash_values
 from sentry.tasks.relay import invalidate_project_config
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format, timestamp_format
@@ -220,21 +219,6 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
         event = self.post_and_retrieve_event(event_data)
         raw_event = event.get_raw_data()
 
-        exclusive_times = [
-            pytest.approx(50, abs=2),
-            pytest.approx(0, abs=2),
-            pytest.approx(200, abs=2),
-            pytest.approx(0, abs=2),
-            pytest.approx(200, abs=2),
-        ]
-        for actual, expected, exclusive_time in zip(
-            raw_event["spans"], event_data["spans"], exclusive_times
-        ):
-            assert actual == dict(
-                expected,
-                exclusive_time=exclusive_time,
-                hash=hash_values([expected["description"]]),
-            )
         assert raw_event["breakdowns"] == {
             "span_ops": {
                 "ops.browser": {"unit": "millisecond", "value": pytest.approx(200, abs=2)},

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/full_config/REGION.pysnap
@@ -1,6 +1,4 @@
 ---
-created: '2024-01-24T14:07:55.778589Z'
-creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 config:
@@ -121,8 +119,6 @@ config:
         - '@ip'
         - '@mac'
         type: multiple
-  spanAttributes:
-  - exclusive-time
   trustedRelays: []
 disabled: false
 slug: bar

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -546,16 +546,6 @@ def test_project_config_satisfaction_thresholds(
 
 @django_db_all
 @region_silo_test
-def test_project_config_with_span_attributes(default_project, insta_snapshot):
-    # The span attributes config is not set with the flag turnd off
-    project_cfg = get_project_config(default_project, full_config=True)
-    cfg = project_cfg.to_dict()
-    _validate_project_config(cfg["config"])
-    insta_snapshot(cfg["config"]["spanAttributes"])
-
-
-@django_db_all
-@region_silo_test
 @pytest.mark.parametrize("feature_flag", (False, True), ids=("feature_disabled", "feature_enabled"))
 @pytest.mark.parametrize(
     "killswitch", (False, True), ids=("killswitch_disabled", "killswitch_enabled")


### PR DESCRIPTION
Relay PR: https://github.com/getsentry/relay/pull/3038.

Removes the unused `spanAttributes` in project configs.