### PR TITLE
fix(metrics-extraction): Fix # relations for stateful extraction

### DIFF
--- a/tests/sentry/relay/config/test_metric_extraction.py
+++ b/tests/sentry/relay/config/test_metric_extraction.py
@@ -1447,8 +1447,9 @@ def test_stateful_get_metric_extraction_config_enabled_with_multiple_versions(
         extraction_row_default = next(
             filter(lambda row: row.spec_version == 1, on_demand_entries), None
         )
-        extraction_row_default.extraction_state = "disabled:manual"
-        extraction_row_default.save()
+        if extraction_row_default:
+            extraction_row_default.extraction_state = "disabled:manual"
+            extraction_row_default.save()
 
         config = get_metric_extraction_config(default_project)
 


### PR DESCRIPTION
### Summary
This fixes some errors currently escalating due to us releasing a new spec version and creating new rows. This change has stateful extraction solely base it's decision on the default (lowest available) spec version. Technically we want stateful extraction to be per-version and separate, but the state decision won't change with the current two version so it's something we can put off until after LA.

Fixes SENTRY-2B58 SENTRY-2HP0


