### PR TITLE
chore(app-start): Add app_start_type to metrics indexer

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -180,6 +180,7 @@ SHARED_TAG_STRINGS = {
     "group": PREFIX + 263,
     # Resource span
     "file_extension": PREFIX + 264,
+    "app_start_type": PREFIX + 265,  # Mobile app start type
     # GENERAL/MISC (don't have a category)
     "": PREFIX + 1000,
 }


### PR DESCRIPTION
Adds the `app_start_type` tag, as is necessary for https://github.com/getsentry/relay/pull/3027