### PR TITLE
ref: remove unused lock arg in Synchronized.__init__

### DIFF
--- a/src/sentry/consumers/synchronized.py
+++ b/src/sentry/consumers/synchronized.py
@@ -38,12 +38,9 @@ class Synchronized(Generic[T]):
     (replacing) the value.
     """
 
-    def __init__(self, value: T, lock: Optional[Lock] = None) -> None:
-        if lock is None:
-            lock = Lock()
-
+    def __init__(self, value: T) -> None:
         self.__value = value
-        self.__lock = lock
+        self.__lock = Lock()
 
     # TODO: For future use, it might make sense to expose the other lock
     # arguments on `get` and `set`, such as `timeout`, `block`, etc.


### PR DESCRIPTION
when enforcing PEP 604 this argument becomes `Lock | None`

turns out `Lock` is not a real type but a function so it crashes

alternatively I thought about adding `from __future__ import annotations`, but this is simpler

<!-- Describe your PR here. -->