### PR TITLE
ref: Remove `start_transaction` from `deobfuscation_template`

### DIFF
--- a/src/sentry/lang/java/utils.py
+++ b/src/sentry/lang/java/utils.py
@@ -94,6 +94,7 @@ def _deobfuscate_view_hierarchy(event_data: dict[str, Any], project: Project, vi
                     windows_to_deobfuscate.extend(children)
 
 
+@sentry_sdk.trace
 def deobfuscation_template(data, map_type, deobfuscation_fn):
     """
     Template for operations involved in deobfuscating view hierarchies.
@@ -108,28 +109,27 @@ def deobfuscation_template(data, map_type, deobfuscation_fn):
     if not any(attachment.type == "event.view_hierarchy" for attachment in attachments):
         return
 
-    with sentry_sdk.start_transaction(name=f"{map_type}.deobfuscate_view_hierarchy", sampled=True):
-        new_attachments = []
-        for attachment in attachments:
-            if attachment.type == "event.view_hierarchy":
-                view_hierarchy = json.loads(attachment_cache.get_data(attachment))
-                deobfuscation_fn(data, project, view_hierarchy)
+    new_attachments = []
+    for attachment in attachments:
+        if attachment.type == "event.view_hierarchy":
+            view_hierarchy = json.loads(attachment_cache.get_data(attachment))
+            deobfuscation_fn(data, project, view_hierarchy)
 
-                # Reupload to cache as a unchunked data
-                new_attachments.append(
-                    CachedAttachment(
-                        type=attachment.type,
-                        id=attachment.id,
-                        name=attachment.name,
-                        content_type=attachment.content_type,
-                        data=json.dumps_htmlsafe(view_hierarchy).encode(),
-                        chunks=None,
-                    )
+            # Reupload to cache as a unchunked data
+            new_attachments.append(
+                CachedAttachment(
+                    type=attachment.type,
+                    id=attachment.id,
+                    name=attachment.name,
+                    content_type=attachment.content_type,
+                    data=json.dumps_htmlsafe(view_hierarchy).encode(),
+                    chunks=None,
                 )
-            else:
-                new_attachments.append(attachment)
+            )
+        else:
+            new_attachments.append(attachment)
 
-        attachment_cache.set(cache_key, attachments=new_attachments, timeout=CACHE_TIMEOUT)
+    attachment_cache.set(cache_key, attachments=new_attachments, timeout=CACHE_TIMEOUT)
 
 
 def deobfuscate_view_hierarchy(data):


### PR DESCRIPTION
This `start_transaction` call causes undefined behavior because it runs inside a Celery task, which already has a transaction automatically created for it by the Sentry SDK's Celery integration. We can observe this by checking the [proguard.deobfuscate_view_hierarchy](https://sentry.sentry.io/performance/summary/?project=1&query=&referrer=performance-transaction-summary&statsPeriod=24h&transaction=proguard.deobfuscate_view_hierarchy&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29) transaction, generated by this `start_transaction` call, in Sentry. Since no occurrences of the other transaction which could be generated by this call, dart_symbols.deobfuscate_view_hierarchy, have been noted in the [last 30 days](https://sentry.sentry.io/performance/?isDefaultQuery=false&metricSearchSetting=metricsOnly&project=1&query=deobfuscate_view_hierarchy&referrer=performance-transaction-summary&statsPeriod=30d&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29) (querying the past 90 days times out), it seems reasonable to assume that the only transaction this call generates in practice is proguard.deobfuscate_view_hierarchy. If we check the proguard.deobfuscate_view_hierarchy transaction's tags in Sentry, we notice that approximately 100% of the transaction events have the `task_name` tag set to `sentry.tasks.store.process_event`, indicating the events occur within the `sentry.tasks.store.process_event` Celery task, and are therefore already auto-instrumented in the [sentry.tasks.store.process_event](https://sentry.sentry.io/performance/summary/?project=1&query=&referrer=performance-transaction-summary&statsPeriod=24h&transaction=sentry.tasks.store.process_event&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29) transaction.

Starting a transaction within a transaction has undefined behavior, so we need to remove this `start_transaction` call. I have instead replaced it with a `sentry_sdk.trace` decorator, which will create a span for the function. Although we will lose the distinction between when this function is called for proguard versus for dart_symbols (the `trace` decorator does not support passing a parameter to specify a different span name; it always takes the function's name), losing the distinction is likely okay because the function is, in practice, only ever called for proguard.

ref #63590