### PR TITLE
ref: remove sentry.db.postgres.operations

### DIFF
--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -3,6 +3,7 @@ import psycopg2 as Database
 # Some of these imports are unused, but they are inherited from other engines
 # and should be available as part of the backend ``base.py`` namespace.
 from django.db.backends.postgresql.base import DatabaseWrapper as DjangoDatabaseWrapper
+from django.db.backends.postgresql.operations import DatabaseOperations
 
 from sentry.utils.strings import strip_lone_surrogates
 
@@ -13,11 +14,9 @@ from .decorators import (
     capture_transaction_exceptions,
     more_better_error_messages,
 )
-from .operations import DatabaseOperations
+from .schema import DatabaseSchemaEditorProxy
 
 __all__ = ("DatabaseWrapper",)
-
-from .schema import DatabaseSchemaEditorProxy
 
 
 def remove_null(value):

--- a/src/sentry/db/postgres/operations.py
+++ b/src/sentry/db/postgres/operations.py
@@ -1,7 +1,0 @@
-from django.db.backends.postgresql.operations import DatabaseOperations as DjangoDatabaseOperations
-
-
-class DatabaseOperations(DjangoDatabaseOperations):
-    # Remove HOST() lookups for GenericIPAddressField
-    def field_cast_sql(self, db_type, internal_type):
-        return "%s"


### PR DESCRIPTION
this has been unused since django 1.8 and is now causing errors in django 5 due to overriding a deprecated method

this was originally used to work around a bug in django 1.6 related to `HOST(...)`
<!-- Describe your PR here. -->