### PR TITLE
ref: match django naming for get_related_db_type

### DIFF
--- a/src/sentry/db/models/fields/bounded.py
+++ b/src/sentry/db/models/fields/bounded.py
@@ -68,7 +68,7 @@ if settings.SENTRY_USE_BIG_INTS:
         def db_type(self, connection: BaseDatabaseWrapper) -> str:
             return "bigserial"
 
-        def get_related_db_type(self, connection: BaseDatabaseWrapper) -> str | None:
+        def rel_db_type(self, connection: BaseDatabaseWrapper) -> str | None:
             return BoundedBigIntegerField().db_type(connection)
 
         def get_internal_type(self) -> str:

--- a/src/sentry/db/models/fields/foreignkey.py
+++ b/src/sentry/db/models/fields/foreignkey.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 from django.db import models
-from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import ForeignKey
 
 __all__ = ("FlexibleForeignKey",)
@@ -13,10 +12,3 @@ class FlexibleForeignKey(ForeignKey):
     def __init__(self, *args: Any, **kwargs: Any):
         kwargs.setdefault("on_delete", models.CASCADE)
         super().__init__(*args, **kwargs)
-
-    def db_type(self, connection: BaseDatabaseWrapper) -> str | None:
-        # This is required to support BigAutoField (or anything similar)
-        rel_field = self.target_field
-        if hasattr(rel_field, "get_related_db_type"):
-            return rel_field.get_related_db_type(connection)
-        return super().db_type(connection)


### PR DESCRIPTION
apparently been a thing since django 1.10 -- our version of this is causing problems in django 5.x

#64374 is probably a better alternative

<!-- Describe your PR here. -->