### PR TITLE
fix(metrics-extraction): Fix process_widget_specs unique check

### DIFF
--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -252,15 +252,7 @@ def _get_widget_on_demand_specs(
         return []
 
     widget_specs = convert_widget_query_to_metric(project_for_query, widget_query, True)
-
-    unique_specs = []
-    hashes = set()
-    for hashed_metric_spec in widget_specs:
-        if hashed_metric_spec[0] not in hashes:
-            unique_specs.append(hashed_metric_spec)
-            hashes.add(hashed_metric_spec[0])
-
-    return unique_specs
+    return widget_specs
 
 
 def _set_widget_on_demand_state(

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -258,7 +258,7 @@ def _get_widget_on_demand_specs(
         specs_per_version.setdefault(spec_version.version, {})
         specs_per_version[spec_version.version][hash] = (hash, spec, spec_version)
 
-    specs = []
+    specs: list[HashedMetricSpec] = []
     for _, _specs_for_version in specs_per_version.items():
         specs += _specs_for_version.values()
 

--- a/src/sentry/tasks/on_demand_metrics.py
+++ b/src/sentry/tasks/on_demand_metrics.py
@@ -252,7 +252,17 @@ def _get_widget_on_demand_specs(
         return []
 
     widget_specs = convert_widget_query_to_metric(project_for_query, widget_query, True)
-    return widget_specs
+
+    specs_per_version: dict[int, dict[str, HashedMetricSpec]] = {}
+    for hash, spec, spec_version in widget_specs:
+        specs_per_version.setdefault(spec_version.version, {})
+        specs_per_version[spec_version.version][hash] = (hash, spec, spec_version)
+
+    specs = []
+    for _, _specs_for_version in specs_per_version.items():
+        specs += _specs_for_version.values()
+
+    return specs
 
 
 def _set_widget_on_demand_state(


### PR DESCRIPTION
### Summary
This was doing a non-versioning unique check, which was causing collision when a widget query had 'environment' in it's tag, and was not outputting the correct number of specs for version 2. Added a test from a production use case
