### PR TITLE
ref: use upstream BigAutoField as base for BoundedBigAutoField

### DIFF
--- a/src/sentry/db/models/fields/bounded.py
+++ b/src/sentry/db/models/fields/bounded.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from django.conf import settings
 from django.db import models
-from django.db.backends.base.base import BaseDatabaseWrapper
 from django.utils.translation import gettext_lazy as _
 
 __all__ = (
@@ -60,19 +59,13 @@ if settings.SENTRY_USE_BIG_INTS:
                 assert value <= self.MAX_VALUE
             return super().get_prep_value(value)
 
-    class BoundedBigAutoField(models.AutoField):
+    class BoundedBigAutoField(models.BigAutoField):
         description = _("Big Integer")
 
         MAX_VALUE = 9223372036854775807
 
-        def db_type(self, connection: BaseDatabaseWrapper) -> str:
-            return "bigserial"
-
-        def get_related_db_type(self, connection: BaseDatabaseWrapper) -> str | None:
-            return BoundedBigIntegerField().db_type(connection)
-
         def get_internal_type(self) -> str:
-            return "BigIntegerField"
+            return "BigAutoField"
 
         def get_prep_value(self, value: int) -> int:
             if value:

--- a/src/sentry/db/models/fields/foreignkey.py
+++ b/src/sentry/db/models/fields/foreignkey.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 from django.db import models
-from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.models import ForeignKey
 
 __all__ = ("FlexibleForeignKey",)
@@ -13,10 +12,3 @@ class FlexibleForeignKey(ForeignKey):
     def __init__(self, *args: Any, **kwargs: Any):
         kwargs.setdefault("on_delete", models.CASCADE)
         super().__init__(*args, **kwargs)
-
-    def db_type(self, connection: BaseDatabaseWrapper) -> str | None:
-        # This is required to support BigAutoField (or anything similar)
-        rel_field = self.target_field
-        if hasattr(rel_field, "get_related_db_type"):
-            return rel_field.get_related_db_type(connection)
-        return super().db_type(connection)


### PR DESCRIPTION
looks like this has been a thing since django 1.10 -- cleans this up a bit!

<!-- Describe your PR here. -->