### PR TITLE
fix(functions): Unique examples should ignore processed profiles

### DIFF
--- a/src/sentry/search/events/datasets/profile_functions.py
+++ b/src/sentry/search/events/datasets/profile_functions.py
@@ -342,16 +342,30 @@ class ProfileFunctionsDatasetConfig(DatasetConfig):
                 SnQLFunction(
                     "unique_examples",
                     snql_aggregate=lambda args, alias: Function(
-                        "arrayMap",
+                        "arrayFilter",
                         [
-                            # TODO: should this transform be moved to snuba?
+                            # Filter out the profile ids for processed profiles
                             Lambda(
                                 ["x"],
                                 Function(
-                                    "replaceAll", [Function("toString", [Identifier("x")]), "-", ""]
+                                    "notEquals",
+                                    [Identifier("x"), uuid.UUID(int=0).hex],
                                 ),
                             ),
-                            Function("groupUniqArrayMerge(5)", [SnQLColumn("examples")]),
+                            Function(
+                                "arrayMap",
+                                [
+                                    # TODO: should this transform be moved to snuba?
+                                    Lambda(
+                                        ["x"],
+                                        Function(
+                                            "replaceAll",
+                                            [Function("toString", [Identifier("x")]), "-", ""],
+                                        ),
+                                    ),
+                                    Function("groupUniqArrayMerge(5)", [SnQLColumn("examples")]),
+                                ],
+                            ),
                         ],
                         alias,
                     ),

--- a/tests/sentry/profiles/test_flamegraph.py
+++ b/tests/sentry/profiles/test_flamegraph.py
@@ -48,6 +48,24 @@ class GetProfileWithFunctionTest(ProfilesSnubaTestCase):
             transaction=transaction,
         )
 
+        transaction = load_data("transaction", timestamp=before_now(minutes=10))
+        transaction["transaction"] = "foobar"
+        profile_context = transaction.setdefault("contexts", {}).setdefault("profile", {})
+        profile_context["profile_id"] = "00000000000000000000000000000000"
+        self.store_functions(
+            [
+                {
+                    "self_times_ns": [100 for _ in range(10)],
+                    "package": "foo",
+                    "function": "foo",
+                    "in_app": True,
+                },
+            ],
+            project=self.project,
+            timestamp=self.hour_ago,
+            transaction=transaction,
+        )
+
     def test_get_profile_with_function(self):
         profile_ids = get_profiles_with_function(
             self.organization.id,


### PR DESCRIPTION
With the change to process non indexed profiles, it's possible that we don't have any example profiles to link to anymore. Make sure to handle that case.