### PR TITLE
chore(hybrid-cloud): Refactor tests for region by default

### DIFF
--- a/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
+++ b/tests/sentry/api/endpoints/test_event_ai_suggested_fix.py
@@ -1,13 +1,15 @@
 import time
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
+import responses
 from django.test.utils import override_settings
 from django.urls import reverse
 from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 
-from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba]
@@ -17,11 +19,6 @@ pytestmark = [requires_snuba]
 def openai_features():
     with override_settings(OPENAI_API_KEY="X"):
         yield
-
-
-@pytest.fixture(autouse=True)
-def auto_login(client, default_user):
-    assert client.login(username=default_user.username, password="admin")
 
 
 @pytest.fixture(autouse=True)
@@ -49,124 +46,123 @@ def openai_mock(monkeypatch):
     monkeypatch.setattr("sentry.api.endpoints.event_ai_suggested_fix.OpenAI", mock_openai)
 
 
-@pytest.fixture
-def test_event(default_project, factories):
-    event_data = {
-        "exception": {
-            "values": [
-                {
-                    "type": "ZeroDivisionError",
-                    "stacktrace": {"frames": [{"function": f} for f in ["a", "b"]]},
+@region_silo_test
+class EventAiSuggestedFixEndpointTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.event = self.store_event(
+            project_id=self.project.id,
+            data={
+                "exception": {
+                    "values": [
+                        {
+                            "type": "ZeroDivisionError",
+                            "stacktrace": {"frames": [{"function": "a"}, {"function": "b"}]},
+                        }
+                    ]
                 }
-            ]
+            },
+        )
+        self.path = reverse(
+            "sentry-api-0-event-ai-fix-suggest",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": self.project.slug,
+                "event_id": self.event.event_id,
+            },
+        )
+        self.login_as(self.user)
+
+    @responses.activate
+    def test_consent(self):
+        with patch(
+            "sentry.api.endpoints.event_ai_suggested_fix.get_openai_policy",
+            return_value="individual_consent",
+        ):
+            response = self.client.get(self.path)
+            assert response.status_code == 403
+            assert response.json() == {"restriction": "individual_consent"}
+            response = self.client.get(self.path + "?consent=yes")
+            assert response.status_code == 200
+            assert response.json() == {"suggestion": "AI generated response"}
+
+        with patch(
+            "sentry.api.endpoints.event_ai_suggested_fix.get_openai_policy",
+            return_value="subprocessor",
+        ):
+            response = self.client.get(self.path)
+            assert response.status_code == 403
+            assert response.json() == {"restriction": "subprocessor"}
+
+        with patch(
+            "sentry.api.endpoints.event_ai_suggested_fix.get_openai_policy",
+            return_value="pii_certification_required",
+        ):
+            response = self.client.get(self.path)
+            assert response.status_code == 403
+            assert response.json() == {"restriction": "pii_certification_required"}
+
+        with patch(
+            "sentry.api.endpoints.event_ai_suggested_fix.get_openai_policy",
+            return_value="allowed",
+        ):
+            response = self.client.get(self.path)
+            assert response.status_code == 200
+            assert response.json() == {"suggestion": "AI generated response"}
+
+    def test_describe_event_for_ai(self):
+        from sentry.api.endpoints.event_ai_suggested_fix import describe_event_for_ai
+
+        event_data = {
+            "exception": {
+                "values": [
+                    {
+                        "type": "ArithmeticError",
+                        "value": "division by zero",
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "function": "divide",
+                                    "filename": "math_operations.py",
+                                    "lineno": 27,
+                                    "context_line": "result = 1 / 0",
+                                    "pre_context": [
+                                        "def divide(x, y):",
+                                        "    # Attempt to divide by zero",
+                                    ],
+                                    "post_context": ["    return result", ""],
+                                    "in_app": True,
+                                },
+                                None,  # Edge case, just to make sure it doesn't break
+                                {
+                                    "function": "calculate",
+                                    "filename": "main.py",
+                                    "lineno": 15,
+                                    "context_line": "divide(10, 0)",
+                                    "pre_context": ["def calculate():", "    # Calculate division"],
+                                    "post_context": ["    print('Calculation complete')", ""],
+                                    "in_app": True,
+                                },
+                            ]
+                        },
+                    }
+                ]
+            }
         }
-    }
-    return factories.store_event(data=event_data, project_id=default_project.id)
-
-
-@pytest.fixture
-def openai_policy():
-    from sentry.api.endpoints.event_ai_suggested_fix import openai_policy_check
-
-    data = {"result": "allowed"}
-
-    def policy(sender, **kwargs):
-        return data["result"]
-
-    try:
-        openai_policy_check.connect(policy)
-        yield data
-    finally:
-        openai_policy_check.disconnect(policy)
-
-
-@django_db_all
-def test_consent(client, monkeypatch, default_user, default_project, test_event, openai_policy):
-    path = reverse(
-        "sentry-api-0-event-ai-fix-suggest",
-        kwargs={
-            "organization_slug": default_project.organization.slug,
-            "project_slug": default_project.slug,
-            "event_id": test_event.event_id,
-        },
-    )
-
-    openai_policy["result"] = "individual_consent"
-    response = client.get(path)
-    assert response.status_code == 403
-    assert response.json() == {"restriction": "individual_consent"}
-    response = client.get(path + "?consent=yes")
-    assert response.status_code == 200
-    assert response.json() == {"suggestion": "AI generated response"}
-
-    openai_policy["result"] = "subprocessor"
-    response = client.get(path)
-    assert response.status_code == 403
-    assert response.json() == {"restriction": "subprocessor"}
-
-    openai_policy["result"] = "pii_certification_required"
-    response = client.get(path)
-    assert response.status_code == 403
-    assert response.json() == {"restriction": "pii_certification_required"}
-
-    openai_policy["result"] = "allowed"
-    response = client.get(path)
-    assert response.status_code == 200
-    assert response.json() == {"suggestion": "AI generated response"}
-
-
-@django_db_all
-def test_describe_event_for_ai(client, default_project, test_event, openai_policy):
-    from sentry.api.endpoints.event_ai_suggested_fix import describe_event_for_ai
-
-    event_data = {
-        "exception": {
-            "values": [
-                {
-                    "type": "ArithmeticError",
-                    "value": "division by zero",
-                    "stacktrace": {
-                        "frames": [
-                            {
-                                "function": "divide",
-                                "filename": "math_operations.py",
-                                "lineno": 27,
-                                "context_line": "result = 1 / 0",
-                                "pre_context": [
-                                    "def divide(x, y):",
-                                    "    # Attempt to divide by zero",
-                                ],
-                                "post_context": ["    return result", ""],
-                                "in_app": True,
-                            },
-                            None,  # Edge case, just to make sure it doesn't break
-                            {
-                                "function": "calculate",
-                                "filename": "main.py",
-                                "lineno": 15,
-                                "context_line": "divide(10, 0)",
-                                "pre_context": ["def calculate():", "    # Calculate division"],
-                                "post_context": ["    print('Calculation complete')", ""],
-                                "in_app": True,
-                            },
-                        ]
-                    },
-                }
-            ]
-        }
-    }
-    exceptions = describe_event_for_ai(event=event_data, model="gpt-3.5-turbo")
-    assert len(exceptions.get("exceptions", [])) == 1, "Should have one exception in the event data"
-    exception = exceptions["exceptions"][0]
-    assert exception["type"] == "ArithmeticError", "Exception type should be 'ArithmeticError'"
-    assert (
-        exception["message"] == "division by zero"
-    ), "Exception message should be 'division by zero'"
-    assert "stacktrace" in exception, "Exception should have a stacktrace"
-    assert len(exception["stacktrace"]) == 2, "Stacktrace should have two frames"
-    assert (
-        exception["stacktrace"][0]["func"] == "calculate"
-    ), "First frame function should be 'calculate'"
-    assert (
-        exception["stacktrace"][1]["func"] == "divide"
-    ), "Second frame function should be 'divide'"
+        exceptions = describe_event_for_ai(event=event_data, model="gpt-3.5-turbo")
+        assert (
+            len(exceptions.get("exceptions", [])) == 1
+        ), "Should have one exception in the event data"
+        exception = exceptions["exceptions"][0]
+        assert exception["type"] == "ArithmeticError", "Exception type should be 'ArithmeticError'"
+        assert (
+            exception["message"] == "division by zero"
+        ), "Exception message should be 'division by zero'"
+        assert "stacktrace" in exception, "Exception should have a stacktrace"
+        assert len(exception["stacktrace"]) == 2, "Stacktrace should have two frames"
+        assert (
+            exception["stacktrace"][0]["func"] == "calculate"
+        ), "First frame function should be 'calculate'"
+        assert (
+            exception["stacktrace"][1]["func"] == "divide"
+        ), "Second frame function should be 'divide'"

--- a/tests/sentry/api/endpoints/test_event_reprocessable.py
+++ b/tests/sentry/api/endpoints/test_event_reprocessable.py
@@ -1,38 +1,26 @@
-import pytest
-
-from sentry.silo import SiloMode
-from sentry.testutils.helpers import Feature
+from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
+from sentry.testutils.silo import region_silo_test
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba]
 
 
-@pytest.fixture(autouse=True)
-def reprocessing_feature(monkeypatch):
-    with Feature({"organizations:reprocessing-v2": True}):
-        yield
-
-
-@assume_test_silo_mode(SiloMode.CONTROL)
-@pytest.fixture(autouse=True)
-def auto_login(settings, client, default_user):
-    assert client.login(username=default_user.username, password="admin")
-
-
-@django_db_all
 @region_silo_test
-def test_simple(client, factories, default_project):
-    min_ago = iso_format(before_now(minutes=1))
-    event1 = factories.store_event(
-        data={"fingerprint": ["group1"], "timestamp": min_ago}, project_id=default_project.id
-    )
+class EventReprocessableEndpointTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
 
-    path = f"/api/0/projects/{event1.project.organization.slug}/{event1.project.slug}/events/{event1.event_id}/reprocessable/"
+    def test_simple(self):
+        min_ago = iso_format(before_now(minutes=1))
+        event1 = self.store_event(
+            data={"fingerprint": ["group1"], "timestamp": min_ago}, project_id=self.project.id
+        )
 
-    response = client.get(path, format="json")
-    assert response.status_code == 200
-    assert not response.data["reprocessable"]
-    assert response.data["reason"] == "unprocessed_event.not_found"
+        path = f"/api/0/projects/{event1.project.organization.slug}/{event1.project.slug}/events/{event1.event_id}/reprocessable/"
+        with self.feature("organizations:reprocessing-v2"):
+            response = self.client.get(path, format="json")
+            assert response.status_code == 200
+            assert not response.data["reprocessable"]
+            assert response.data["reason"] == "unprocessed_event.not_found"

--- a/tests/sentry_plugins/heroku/test_plugin.py
+++ b/tests/sentry_plugins/heroku/test_plugin.py
@@ -16,12 +16,13 @@ from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.releaseheadcommit import ReleaseHeadCommit
 from sentry.models.repository import Repository
-from sentry.models.user import User
 from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 from sentry_plugins.heroku.plugin import HerokuReleaseHook
 
 
+@region_silo_test
 class SetRefsTest(TestCase):
     """
     tests that when finish_release is called on a release hook,
@@ -55,7 +56,7 @@ class SetRefsTest(TestCase):
                 "author_email": "katie@example.com",
             },
         ]
-        user = User.objects.create(email="stebe@sentry.io")
+        user = self.create_user(email="stebe@sentry.io")
         repo = Repository.objects.create(
             organization_id=project.organization_id, name=project.name, provider="dummy"
         )
@@ -125,6 +126,7 @@ class SetRefsTest(TestCase):
         )
 
 
+@region_silo_test
 class HookHandleTest(TestCase):
     @pytest.fixture(autouse=True)
     def patch_is_valid_signature(self):


### PR DESCRIPTION
This PR has two tests that I largely refactored to conform to the `EndpointNameTest(APITestCase)` convention. This let us remove some fixtures and add a decorator that will apply to future added tests (if region-by-default isn't in before more are added)