### PR TITLE
chore(ts): Fix a few sample unchecked index access errors

### DIFF
--- a/static/app/components/autoComplete.spec.tsx
+++ b/static/app/components/autoComplete.spec.tsx
@@ -15,7 +15,7 @@ const items = [
   {
     name: 'Orange',
   },
-];
+] as const;
 
 /**
  * For every render, we push all injected params into `autoCompleteState`, we probably want to

--- a/static/app/components/collapsible.spec.tsx
+++ b/static/app/components/collapsible.spec.tsx
@@ -10,7 +10,7 @@ describe('Collapsible', function () {
     render(<Collapsible>{items}</Collapsible>);
 
     expect(screen.getAllByText(/Item/)).toHaveLength(5);
-    expect(screen.getAllByText(/Item/)[2].innerHTML).toBe('Item 3');
+    expect(screen.getAllByText(/Item/)[2]!.innerHTML).toBe('Item 3');
 
     expect(screen.getByLabelText('Show 2 hidden items')).toBeInTheDocument();
     expect(screen.queryByLabelText('Collapse')).not.toBeInTheDocument();

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -669,6 +669,9 @@ export const extractSpanURLString = (span: Span, baseURL?: string): URL | null =
   }
 
   const [_method, _url] = (span?.description ?? '').split(' ', 2);
+  if (!_url) {
+    return null;
+  }
 
   return safeURL(_url, baseURL) ?? null;
 };

--- a/static/app/constants/chartPalette.tsx
+++ b/static/app/constants/chartPalette.tsx
@@ -176,4 +176,4 @@ export const CHART_PALETTE = [
     '#f4aa27',
     '#f2b712',
   ],
-] as string[][];
+] as const;

--- a/static/app/constants/chartPalette.tsx
+++ b/static/app/constants/chartPalette.tsx
@@ -176,4 +176,4 @@ export const CHART_PALETTE = [
     '#f4aa27',
     '#f2b712',
   ],
-] as const;
+] as string[][];

--- a/static/app/types/utils.tsx
+++ b/static/app/types/utils.tsx
@@ -23,3 +23,14 @@ export type DeepPartial<T> = T extends object
       [P in keyof T]?: DeepPartial<T[P]>;
     }
   : T;
+
+// https://github.com/microsoft/TypeScript/pull/40002
+export type FixedTuple<T, N extends number> = N extends N
+  ? number extends N
+    ? T[]
+    : _TupleOf<T, N, []> // eslint-disable-line @typescript-eslint/ban-types
+  : never;
+
+type _TupleOf<T, N extends number, R extends unknown[]> = R['length'] extends N
+  ? R
+  : _TupleOf<T, N, [T, ...R]>;

--- a/static/app/utils/profiling/gl/utils.spec.tsx
+++ b/static/app/utils/profiling/gl/utils.spec.tsx
@@ -46,6 +46,8 @@ describe('getContext', () => {
   });
 });
 
+import type {FixedTuple} from 'sentry/types/utils';
+
 describe('upperBound', () => {
   it.each([
     [[], 5, 0],
@@ -63,7 +65,12 @@ describe('upperBound', () => {
   });
 
   it('finds the upper bound frame outside of view', () => {
-    const frames = new Array(10).fill(1).map((_, i) => ({start: i, end: i + 1}));
+    const frames = new Array(10)
+      .fill(1)
+      .map((_, i) => ({start: i, end: i + 1})) as FixedTuple<
+      {end: number; start: number},
+      10
+    >;
     const view = new Rect(4, 0, 2, 0);
 
     expect(upperBound(view.right, frames)).toBe(6);
@@ -89,7 +96,12 @@ describe('lowerBound', () => {
   });
 
   it('finds the lower bound frame outside of view', () => {
-    const frames = new Array(10).fill(1).map((_, i) => ({start: i, end: i + 1}));
+    const frames = new Array(10)
+      .fill(1)
+      .map((_, i) => ({start: i, end: i + 1})) as FixedTuple<
+      {end: number; start: number},
+      10
+    >;
     const view = new Rect(4, 0, 2, 0);
 
     expect(lowerBound(view.left, frames)).toBe(3);


### PR DESCRIPTION
First case study of fixing unchecked indexed access for https://github.com/getsentry/frontend-tsc/issues/26. I found what I think are good examples of the kinds of fixes we expect to make, which are:

1. Adding `!` in specs to quickly skip the check when it's obvious
2. Adding manual early returns when data is not what we expect
3. Fixed tuples! When we know that something is a tuple of N element rather than an array, we can annotate correctly
4. `as const` for arrays of simple constant values, so TypeScript knows how many elements exist

I'm fine to either merge this, or just keep this as a discussion point for which of the fixes are appropriate.

## Changes

- Allow unchecked index access in spec

- Add `FixedTuple` utility types
    
    Allows for quick fixed size tuple definitions.
    
    e.g., `FixedTuple<string, 6>` is equivalent to [string, string, string,
    string, string, string];

- Annotate fixture data as fixed tuples

- Add manual undefined check

- Type a test fixture as constant
    
    This way index access on it will succeed since TypeScript knows how many
    elements are in it
