### PR TITLE
fix(flamegraph-preview): Increase missing instrumentation preview height

### DIFF
--- a/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
+++ b/static/app/components/events/interfaces/spans/gapSpanDetails.tsx
@@ -284,7 +284,7 @@ const Image = styled('img')`
 `;
 
 const FlamegraphContainer = styled('div')`
-  height: 300px;
+  height: 310px;
   margin-top: ${space(1)};
   margin-bottom: ${space(1)};
 `;


### PR DESCRIPTION
A fixed height of 300px is a multiple of the 20px bar height meaning if there are additional frames not shown, it's not immediately obvious. This increases the height to something that is not a multiple of the bar height so that we have a small amount of the next frame shown in the preview to prompt users to open the full flamegraph.