### PR TITLE
fix(issues): Remove text from stacktrace link in frame

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -360,10 +360,9 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
             href={frame.sourceLink}
             openInNewTab
             hasInFrameFeature={hasInFrameFeature}
+            aria-label={t('GitHub')}
           >
-            <StyledIconWrapper aria-label={t('GitHub')}>
-              {getIntegrationIcon('github', 'sm')}
-            </StyledIconWrapper>
+            <StyledIconWrapper>{getIntegrationIcon('github', 'sm')}</StyledIconWrapper>
           </OpenInLink>
         </Tooltip>
       </StacktraceLinkWrapper>

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -361,7 +361,9 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
             openInNewTab
             hasInFrameFeature={hasInFrameFeature}
           >
-            <StyledIconWrapper>{getIntegrationIcon('github', 'sm')}</StyledIconWrapper>
+            <StyledIconWrapper aria-label={t('GitHub')}>
+              {getIntegrationIcon('github', 'sm')}
+            </StyledIconWrapper>
           </OpenInLink>
         </Tooltip>
       </StacktraceLinkWrapper>

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -354,15 +354,16 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
   ) {
     return (
       <StacktraceLinkWrapper hasInFrameFeature={hasInFrameFeature}>
-        <OpenInLink
-          onClick={e => onOpenLink(e, frame.sourceLink)}
-          href={frame.sourceLink}
-          openInNewTab
-          hasInFrameFeature={hasInFrameFeature}
-        >
-          <StyledIconWrapper>{getIntegrationIcon('github', 'sm')}</StyledIconWrapper>
-          {t('GitHub')}
-        </OpenInLink>
+        <Tooltip title={t('Open this line in GitHub')} skipWrapper>
+          <OpenInLink
+            onClick={e => onOpenLink(e, frame.sourceLink)}
+            href={frame.sourceLink}
+            openInNewTab
+            hasInFrameFeature={hasInFrameFeature}
+          >
+            <StyledIconWrapper>{getIntegrationIcon('github', 'sm')}</StyledIconWrapper>
+          </OpenInLink>
+        </Tooltip>
       </StacktraceLinkWrapper>
     );
   }
@@ -557,12 +558,11 @@ const StacktraceLinkWrapper = styled('div')<{
 
   ${p =>
     p.hasInFrameFeature
-      ? `
+      ? css`
       padding: ${space(0)} ${space(1)};
-      flex-wrap: wrap;
       gap: ${space(1)}
     `
-      : `
+      : css`
       background-color: ${p.theme.background};
       border-bottom: 1px solid ${p.theme.border};
       padding: ${space(0.25)} ${space(3)};
@@ -579,7 +579,7 @@ const FixMappingButton = styled(Button)<{
 
   ${p =>
     p.hasInFrameFeature
-      ? `
+      ? css`
       &:hover {
         color: ${p.theme.subText};
         text-decoration: underline;


### PR DESCRIPTION
removes text from in frame links like [this one](https://sentry.sentry.io/issues/3987454103/events/701f6f050e264c049f383a8913e1f2cf/) 
![image](https://github.com/getsentry/sentry/assets/1400464/a3b1690f-29f8-4d99-9a2c-359e33ababde)
