### PR TITLE
fix(ai-autofix): Fix Ai Autofix stacktrace gathering

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -121,8 +121,7 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
         if not request.user.is_authenticated:
             raise PermissionDenied(detail="You must be authenticated to perform this action.")
 
-        # (request.user should've worked here, plus get_entries doesn't use it anyway...)
-        event_entries = self._get_event_entries(group, request.user)  # type: ignore
+        event_entries = self._get_event_entries(group, request.user)
 
         if event_entries is None:
             return self._respond_with_error(

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -121,17 +121,14 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
         if not request.user.is_authenticated:
             raise PermissionDenied(detail="You must be authenticated to perform this action.")
 
-        user = User.objects.get(id=request.user.id)  # type: ignore (user is authenticated)
-        event_entries = self._get_event_entries(group, user)
+        event_entries = self._get_event_entries(group, request.user)  # type: ignore (request.user should've worked here, plus get_entries doesn't use it anyway...)
 
         if event_entries is None:
             return self._respond_with_error(
                 group, metadata, "Cannot fix issues without an event.", 400
             )
 
-        if len(event_entries) == 0 or not any(
-            [exception.get("type") == "exception" for exception in event_entries]
-        ):
+        if not any([exception.get("type") == "exception" for exception in event_entries]):
             return self._respond_with_error(
                 group, metadata, "Cannot fix issues without a stacktrace.", 400
             )

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -122,15 +122,15 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
             raise PermissionDenied(detail="You must be authenticated to perform this action.")
 
         user = User.objects.get(id=request.user.id)  # type: ignore (user is authenticated)
-        event_exceptions = self._get_event_entries(group, user)
+        event_entries = self._get_event_entries(group, user)
 
-        if event_exceptions is None:
+        if event_entries is None:
             return self._respond_with_error(
                 group, metadata, "Cannot fix issues without an event.", 400
             )
 
-        if len(event_exceptions) == 0 or not any(
-            [exception.get("type") == "exception" for exception in event_exceptions]
+        if len(event_entries) == 0 or not any(
+            [exception.get("type") == "exception" for exception in event_entries]
         ):
             return self._respond_with_error(
                 group, metadata, "Cannot fix issues without a stacktrace.", 400
@@ -175,7 +175,7 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
 
         try:
             self._call_autofix(
-                group, base_commit.key, event_exceptions, data.get("additional_context", "")
+                group, base_commit.key, event_entries, data.get("additional_context", "")
             )
 
             # Mark the task as completed after TIMEOUT_SECONDS

--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -121,7 +121,8 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
         if not request.user.is_authenticated:
             raise PermissionDenied(detail="You must be authenticated to perform this action.")
 
-        event_entries = self._get_event_entries(group, request.user)  # type: ignore (request.user should've worked here, plus get_entries doesn't use it anyway...)
+        # (request.user should've worked here, plus get_entries doesn't use it anyway...)
+        event_entries = self._get_event_entries(group, request.user)  # type: ignore
 
         if event_entries is None:
             return self._respond_with_error(

--- a/tests/sentry/api/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/api/endpoints/test_group_ai_autofix.py
@@ -86,8 +86,8 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
             actual_group_arg = mock_call.call_args[0][0]
             assert actual_group_arg.id == group.id
 
-            exceptions_arg = mock_call.call_args[0][2]
-            assert dict(event.data.get("exception", {}).get("values", [])) == dict(exceptions_arg)
+            entries_arg = mock_call.call_args[0][2]
+            assert any([entry.get("type") == "exception" for entry in entries_arg])
 
         group = Group.objects.get(id=group.id)
 
@@ -159,7 +159,8 @@ class GroupAIAutofixEndpointTest(APITestCase, SnubaTestCase):
             data={
                 **data,
                 "release": release.version,
-                "exception": {"values": [{"type": "breadcrumbs", "data": {"values": []}}]},
+                "exception": None,
+                "stacktrace": None,
             },
             project_id=self.project.id,
         )


### PR DESCRIPTION
Use the `get_entries` from event serializer to get the event's entries instead of trying to get the exception values. This should make it match what the API will return.
