### PR TITLE
chore(migrations) Remove 'changed migration' task

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -33,19 +33,6 @@ jobs:
           token: ${{ github.token }}
           filters: .github/file-filters.yml
 
-  modified-migration:
-    name: check if modified migration
-    runs-on: ubuntu-22.04
-    timeout-minutes: 4
-    needs: did-migration-change
-    if: needs.did-migration-change.outputs.modified == 'true'
-
-    steps:
-      - name: Failure because of modified migration
-        run: |
-          echo "If you have a valid reason to modify a migration please get approval"
-          echo "from @getsentry/owners-migrations." && exit 1
-
   sql:
     name: Generate SQL
     runs-on: ubuntu-22.04


### PR DESCRIPTION
We don't require admin approval to merge modified migrations, this check gives misleading advice and isn't part of our process anymore.
