### PR TITLE
feat(replays): Use new icon for restart button

### DIFF
--- a/static/app/components/replays/replayPlayPauseButton.tsx
+++ b/static/app/components/replays/replayPlayPauseButton.tsx
@@ -1,7 +1,7 @@
 import type {BaseButtonProps} from 'sentry/components/button';
 import {Button} from 'sentry/components/button';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {IconPause, IconPlay, IconPrevious} from 'sentry/icons';
+import {IconPause, IconPlay, IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
 function ReplayPlayPauseButton(props: BaseButtonProps) {
@@ -10,7 +10,7 @@ function ReplayPlayPauseButton(props: BaseButtonProps) {
   return isFinished ? (
     <Button
       title={t('Restart Replay')}
-      icon={<IconPrevious size="md" />}
+      icon={<IconRefresh size="md" />}
       onClick={restart}
       aria-label={t('Restart Replay')}
       priority="primary"


### PR DESCRIPTION
Per @Jesse-Box, we should use IconRefresh for the restart replay button:

![CleanShot 2024-02-01 at 11 01 34](https://github.com/getsentry/sentry/assets/10888943/63c19ff3-51bd-4ae2-bd5e-e7051bfd7c09)
