### PR TITLE
fix(metrics-extraction): Killswitch should assume low cardinality

### DIFF
--- a/src/sentry/relay/config/metric_extraction.py
+++ b/src/sentry/relay/config/metric_extraction.py
@@ -564,7 +564,7 @@ def _is_widget_query_low_cardinality(widget_query: DashboardWidgetQuery, project
 
     query_killswitch = options.get("on_demand.max_widget_cardinality.killswitch")
     if query_killswitch:
-        return False
+        return True
 
     # No columns or only errors means no high-cardinality tags.
     if not widget_query.columns or "event.type:error" in widget_query.conditions:


### PR DESCRIPTION
### Summary
The killswitch is for the code going out to check cardinality, not to stop ingestion all together. At some point this function was reversed to be a check for low cardinality and it's likely this bool wasn't flipped
