### PR TITLE
ref(superuser): switch SentryAppsPermissions to use superuser_has_permission

### DIFF
--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -87,8 +87,7 @@ class SentryAppsPermission(SentryPermission):
 
         self.determine_access(request, context)
 
-        # TODO(cathy): replace with superuser_has_permission
-        if is_active_superuser(request):
+        if superuser_has_permission(request):
             return True
 
         # User must be a part of the Org they're trying to create the app in.
@@ -278,8 +277,7 @@ class SentryAppInstallationsPermission(SentryPermission):
 
         self.determine_access(request, organization)
 
-        # TODO(cathy): replace with superuser_has_permission
-        if is_active_superuser(request):
+        if superuser_has_permission(request):
             return True
 
         organizations = (

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -12,7 +12,6 @@ from sentry.api.bases.sentryapps import (
     SentryAppPermission,
     add_integration_platform_metric_tag,
 )
-from sentry.auth.superuser import Superuser
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -12,6 +12,7 @@ from sentry.api.bases.sentryapps import (
     SentryAppPermission,
     add_integration_platform_metric_tag,
 )
+from sentry.auth.superuser import Superuser
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -1,6 +1,9 @@
+from django.test import override_settings
+
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
 from sentry.slug.errors import DEFAULT_SLUG_ERROR_MESSAGE
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test
 
 
@@ -62,6 +65,24 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
             }
         ]
 
+        # also works for SaaS
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            response = self.get_success_response(self.org.slug, status_code=200)
+            response = self.get_success_response(self.super_org.slug, status_code=200)
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    @with_feature("auth:enterprise-superuser-read-write")
+    def test_superuser_read_and_write_sees_all_installs(self):
+        # test SaaS only
+        self.login_as(user=self.superuser, superuser=True)
+        self.get_success_response(self.org.slug, status_code=200)
+        self.get_success_response(self.super_org.slug, status_code=200)
+
+        self.add_user_permission(self.superuser, "superuser.write")
+
+        self.get_success_response(self.org.slug, status_code=200)
+        self.get_success_response(self.super_org.slug, status_code=200)
+
     def test_users_only_sees_installs_on_their_org(self):
         self.login_as(user=self.user)
         response = self.get_success_response(self.org.slug, status_code=200)
@@ -106,6 +127,32 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
         }
 
         assert expected.items() <= response.data.items()
+
+    def test_install_superuser(self):
+        self.login_as(user=self.superuser, superuser=True)
+        app = self.create_sentry_app(name="Sample", organization=self.org)
+        self.get_success_response(self.org.slug, slug=app.slug, status_code=200)
+
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            app = self.create_sentry_app(name="Sample 2", organization=self.org, published=True)
+            self.get_success_response(self.org.slug, slug=app.slug, status_code=200)
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    @with_feature("auth:enterprise-superuser-read-write")
+    def test_install_superuser_read(self):
+        self.login_as(user=self.superuser, superuser=True)
+
+        app = self.create_sentry_app(name="Sample", organization=self.org)
+        self.get_error_response(self.org.slug, slug=app.slug, status_code=404)
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    @with_feature("auth:enterprise-superuser-read-write")
+    def test_install_superuser_write(self):
+        self.login_as(user=self.superuser, superuser=True)
+        self.add_user_permission(self.superuser, "superuser.write")
+
+        app = self.create_sentry_app(name="Sample", organization=self.org)
+        self.get_success_response(self.org.slug, slug=app.slug, status_code=200)
 
     def test_members_cannot_install_apps(self):
         user = self.create_user("bar@example.com")

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -4,6 +4,7 @@ import re
 from typing import Any, Mapping
 from unittest.mock import patch
 
+from django.test import override_settings
 from django.urls import reverse
 from rest_framework.response import Response
 
@@ -170,6 +171,17 @@ class SuperUserGetSentryAppsTest(SentryAppsTest):
         assert self.unpublished_app.uuid in response_uuids
         assert self.unowned_unpublished_app.uuid in response_uuids
 
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            self.get_success_response()
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    @with_feature("auth:enterprise-superuser-read-write")
+    def test_superuser_read_write_sees_all_apps(self):
+        self.get_success_response()
+
+        self.add_user_permission(self.superuser, "superuser.write")
+        self.get_success_response()
+
     def test_superusers_filter_on_internal_apps(self):
         self.set_up_internal_app()
         new_org = self.create_organization()
@@ -313,6 +325,20 @@ class SuperUserPostSentryAppsTest(SentryAppsTest):
     def test_superuser_can_create_with_popularity(self):
         response = self.get_success_response(**self.get_data(popularity=POPULARITY))
         assert {"popularity": POPULARITY}.items() <= json.loads(response.content).items()
+
+        with self.settings(SENTRY_SELF_HOSTED=False):
+            self.get_success_response(**self.get_data(popularity=25, name="myApp 2"))
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    @with_feature("auth:enterprise-superuser-read-write")
+    def test_superuser_read_cannot_create(self):
+        self.get_error_response(**self.get_data(name="POPULARITY"))
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    @with_feature("auth:enterprise-superuser-read-write")
+    def test_superuser_read_can_create(self):
+        self.add_user_permission(self.superuser, "superuser.write")
+        self.get_success_response(**self.get_data(popularity=POPULARITY))
 
 
 @control_silo_test


### PR DESCRIPTION
Replace `is_active_superuser` calls in `SentryAppsPermission` and `SentryAppInstallationsPermission` with `superuser_has_permission`. Note that these are different permissions from #64317.

`SentryAppsPermission` is used by `SentryAppsBaseEndpoint`, which is subclassed by: 
- `SentryAppsEndpoint`
- `SentryAppsStatsEndpoint` (GET only)

`SentryAppsInstallationsPermission` is used by `SentryAppInstallationsBaseEndpoint`, which is subclassed by:
- `SentryAppInstallationsEndpoint`

For https://github.com/getsentry/team-enterprise/issues/40