### PR TITLE
feat(mobile-starfish): Replace release labels with R1, R2

### DIFF
--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -79,7 +79,7 @@ export function ReleaseSelector({selectorKey, selectorValue, triggerLabelPrefix}
       }}
       triggerLabel={
         <span>
-          <strong>{triggerLabelPrefix}:</strong>{' '}
+          {triggerLabelPrefix}:&nbsp;
           <ReleaseLabelContainer>{triggerLabelContent}</ReleaseLabelContainer>
         </span>
       }
@@ -182,4 +182,5 @@ const DetailsContainer = styled('div')`
 
 const ReleaseLabelContainer = styled('span')`
   display: inline;
+  font-weight: normal;
 `;

--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -21,9 +21,9 @@ import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/center
 
 type Props = {
   selectorKey: string;
-  triggerLabelPrefix: string;
   selectorName?: string;
   selectorValue?: string;
+  triggerLabelPrefix?: string;
 };
 
 export function ReleaseSelector({selectorKey, selectorValue, triggerLabelPrefix}: Props) {
@@ -78,10 +78,14 @@ export function ReleaseSelector({selectorKey, selectorValue, triggerLabelPrefix}
         title: selectorValue,
       }}
       triggerLabel={
-        <span>
-          {triggerLabelPrefix}:&nbsp;
-          <ReleaseLabelContainer>{triggerLabelContent}</ReleaseLabelContainer>
-        </span>
+        triggerLabelPrefix ? (
+          <span>
+            {triggerLabelPrefix}:&nbsp;
+            <ReleaseLabelContainer>{triggerLabelContent}</ReleaseLabelContainer>
+          </span>
+        ) : (
+          triggerLabelContent
+        )
       }
       menuTitle={t('Filter Release')}
       loading={isLoading}

--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -19,6 +19,9 @@ import {
 } from 'sentry/views/starfish/queries/useReleases';
 import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 
+export const PRIMARY_RELEASE_ALIAS = 'R1';
+export const SECONDARY_RELEASE_ALIAS = 'R2';
+
 type Props = {
   selectorKey: string;
   selectorName?: string;
@@ -76,17 +79,9 @@ export function ReleaseSelector({selectorKey, selectorValue, triggerLabelPrefix}
       triggerProps={{
         icon: <IconReleases />,
         title: selectorValue,
+        prefix: triggerLabelPrefix,
       }}
-      triggerLabel={
-        triggerLabelPrefix ? (
-          <span>
-            {triggerLabelPrefix}:&nbsp;
-            <ReleaseLabelContainer>{triggerLabelContent}</ReleaseLabelContainer>
-          </span>
-        ) : (
-          triggerLabelContent
-        )
-      }
+      triggerLabel={triggerLabelContent}
       menuTitle={t('Filter Release')}
       loading={isLoading}
       searchable
@@ -148,14 +143,14 @@ export function ReleaseComparisonSelector() {
         selectorValue={primaryRelease}
         selectorName={t('Release 1')}
         key="primaryRelease"
-        triggerLabelPrefix="R1"
+        triggerLabelPrefix={PRIMARY_RELEASE_ALIAS}
       />
       <ReleaseSelector
         selectorKey="secondaryRelease"
         selectorName={t('Release 2')}
         selectorValue={secondaryRelease}
         key="secondaryRelease"
-        triggerLabelPrefix="R2"
+        triggerLabelPrefix={SECONDARY_RELEASE_ALIAS}
       />
     </StyledPageSelector>
   );
@@ -182,9 +177,4 @@ const DetailsContainer = styled('div')`
   justify-content: space-between;
   gap: ${space(1)};
   min-width: 200px;
-`;
-
-const ReleaseLabelContainer = styled('span')`
-  display: inline;
-  font-weight: normal;
 `;

--- a/static/app/views/starfish/components/releaseSelector.tsx
+++ b/static/app/views/starfish/components/releaseSelector.tsx
@@ -21,11 +21,12 @@ import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/center
 
 type Props = {
   selectorKey: string;
+  triggerLabelPrefix: string;
   selectorName?: string;
   selectorValue?: string;
 };
 
-export function ReleaseSelector({selectorKey, selectorValue}: Props) {
+export function ReleaseSelector({selectorKey, selectorValue, triggerLabelPrefix}: Props) {
   const [searchTerm, setSearchTerm] = useState<string | undefined>(undefined);
   const {data, isLoading} = useReleases(searchTerm);
   const {primaryRelease, secondaryRelease} = useReleaseSelection();
@@ -66,6 +67,10 @@ export function ReleaseSelector({selectorKey, selectorValue}: Props) {
       options.push(option);
     });
 
+  const triggerLabelContent = selectorValue
+    ? formatVersionAndCenterTruncate(selectorValue, 16)
+    : selectorValue;
+
   return (
     <StyledCompactSelect
       triggerProps={{
@@ -73,7 +78,10 @@ export function ReleaseSelector({selectorKey, selectorValue}: Props) {
         title: selectorValue,
       }}
       triggerLabel={
-        selectorValue ? formatVersionAndCenterTruncate(selectorValue, 16) : selectorValue
+        <span>
+          <strong>{triggerLabelPrefix}:</strong>{' '}
+          <ReleaseLabelContainer>{triggerLabelContent}</ReleaseLabelContainer>
+        </span>
       }
       menuTitle={t('Filter Release')}
       loading={isLoading}
@@ -136,12 +144,14 @@ export function ReleaseComparisonSelector() {
         selectorValue={primaryRelease}
         selectorName={t('Release 1')}
         key="primaryRelease"
+        triggerLabelPrefix="R1"
       />
       <ReleaseSelector
         selectorKey="secondaryRelease"
         selectorName={t('Release 2')}
         selectorValue={secondaryRelease}
         key="secondaryRelease"
+        triggerLabelPrefix="R2"
       />
     </StyledPageSelector>
   );
@@ -168,4 +178,8 @@ const DetailsContainer = styled('div')`
   justify-content: space-between;
   gap: ${space(1)};
   min-width: 200px;
+`;
+
+const ReleaseLabelContainer = styled('span')`
+  display: inline;
 `;

--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.spec.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.spec.tsx
@@ -4,6 +4,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {EventSamples} from 'sentry/views/starfish/views/appStartup/screenSummary/eventSamples';
 import {
   MobileCursors,
@@ -11,6 +12,7 @@ import {
 } from 'sentry/views/starfish/views/screens/constants';
 
 jest.mock('sentry/utils/usePageFilters');
+jest.mock('sentry/views/starfish/queries/useReleases');
 
 describe('ScreenLoadEventSamples', function () {
   const organization = OrganizationFixture();
@@ -33,6 +35,26 @@ describe('ScreenLoadEventSamples', function () {
         environments: [],
         projects: [parseInt(project.id, 10)],
       },
+    });
+    jest.mocked(useReleaseSelection).mockReturnValue({
+      primaryRelease: 'com.example.vu.android@2.10.5',
+      isLoading: false,
+      secondaryRelease: 'com.example.vu.android@2.10.3+42',
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/`,
+      body: [
+        {
+          id: 970136705,
+          version: 'com.example.vu.android@2.10.5',
+          dateCreated: '2023-12-19T21:37:53.895495Z',
+        },
+        {
+          id: 969902997,
+          version: 'com.example.vu.android@2.10.3+42',
+          dateCreated: '2023-12-19T18:04:06.953025Z',
+        },
+      ],
     });
     mockEventsRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
@@ -73,9 +95,7 @@ describe('ScreenLoadEventSamples', function () {
     );
 
     // Check that headers are set properly
-    expect(
-      screen.getByRole('columnheader', {name: 'Event ID (2.10.5)'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Event ID (R1)'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Profile'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Start Type'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Duration'})).toBeInTheDocument();

--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
@@ -7,6 +7,10 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {
+  PRIMARY_RELEASE_ALIAS,
+  SECONDARY_RELEASE_ALIAS,
+} from 'sentry/views/starfish/components/releaseSelector';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {EventSamplesTable} from 'sentry/views/starfish/views/screens/screenLoadSpans/eventSamplesTable';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
@@ -60,7 +64,10 @@ export function EventSamples({
   const sort = fromSorts(decodeScalar(location.query[sortKey]))[0] ?? DEFAULT_SORT;
 
   const columnNameMap = {
-    'transaction.id': t('Event ID (%s)', release === primaryRelease ? 'R1' : 'R2'),
+    'transaction.id': t(
+      'Event ID (%s)',
+      release === primaryRelease ? PRIMARY_RELEASE_ALIAS : SECONDARY_RELEASE_ALIAS
+    ),
     profile_id: t('Profile'),
     'span.description': t('Start Type'),
     'span.duration': t('Duration'),

--- a/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/eventSamples.tsx
@@ -7,7 +7,7 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {EventSamplesTable} from 'sentry/views/starfish/views/screens/screenLoadSpans/eventSamplesTable';
 import {useTableQuery} from 'sentry/views/starfish/views/screens/screensTable';
 
@@ -33,6 +33,7 @@ export function EventSamples({
 }: Props) {
   const location = useLocation();
   const {selection} = usePageFilters();
+  const {primaryRelease} = useReleaseSelection();
   const cursor = decodeScalar(location.query?.[cursorName]);
 
   const searchQuery = new MutableSearch([
@@ -59,7 +60,7 @@ export function EventSamples({
   const sort = fromSorts(decodeScalar(location.query[sortKey]))[0] ?? DEFAULT_SORT;
 
   const columnNameMap = {
-    'transaction.id': t('Event ID (%s)', formatVersionAndCenterTruncate(release)),
+    'transaction.id': t('Event ID (%s)', release === primaryRelease ? 'R1' : 'R2'),
     profile_id: t('Profile'),
     'span.description': t('Start Type'),
     'span.duration': t('Duration'),

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.spec.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.spec.tsx
@@ -110,10 +110,10 @@ describe('Screen Summary', function () {
       });
 
       const blocks = [
-        {header: 'Cold Start (2.10.5)', value: '1.00s'},
-        {header: 'Cold Start (2.10.… (42))', value: '2.00s'},
-        {header: 'Warm Start (2.10.5)', value: '5.00s'},
-        {header: 'Warm Start (2.10.… (42))', value: '6.00s'},
+        {header: 'Cold Start (R1)', value: '1.00s'},
+        {header: 'Cold Start (R2)', value: '2.00s'},
+        {header: 'Warm Start (R1)', value: '5.00s'},
+        {header: 'Warm Start (R2)', value: '6.00s'},
         {header: 'Count', value: '50'},
       ];
 

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -17,9 +17,12 @@ import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pa
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
-import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
+import {
+  PRIMARY_RELEASE_ALIAS,
+  ReleaseComparisonSelector,
+  SECONDARY_RELEASE_ALIAS,
+} from 'sentry/views/starfish/components/releaseSelector';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {EventSamples} from 'sentry/views/starfish/views/appStartup/screenSummary/eventSamples';
 import {SpanOperationTable} from 'sentry/views/starfish/views/appStartup/screenSummary/spanOperationTable';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
@@ -79,9 +82,6 @@ function ScreenSummary() {
     },
   ];
 
-  const truncatedPrimary = formatVersionAndCenterTruncate(primaryRelease ?? '', 10);
-  const truncatedSecondary = formatVersionAndCenterTruncate(secondaryRelease ?? '', 10);
-
   return (
     <SentryDocumentTitle title={transactionName} orgSlug={organization.slug}>
       <Layout.Page>
@@ -122,7 +122,7 @@ function ScreenSummary() {
                     blocks={[
                       {
                         type: 'duration',
-                        title: t('Cold Start (R1)', truncatedPrimary),
+                        title: t('Cold Start (%s)', PRIMARY_RELEASE_ALIAS),
                         dataKey: data => {
                           const matchingRow = data?.find(
                             row => row['span.op'] === 'app.start.cold'
@@ -136,7 +136,7 @@ function ScreenSummary() {
                       },
                       {
                         type: 'duration',
-                        title: t('Cold Start (R2)', truncatedSecondary),
+                        title: t('Cold Start (%s)', SECONDARY_RELEASE_ALIAS),
                         dataKey: data => {
                           const matchingRow = data?.find(
                             row => row['span.op'] === 'app.start.cold'
@@ -150,7 +150,7 @@ function ScreenSummary() {
                       },
                       {
                         type: 'duration',
-                        title: t('Warm Start (R1)', truncatedPrimary),
+                        title: t('Warm Start (%s)', PRIMARY_RELEASE_ALIAS),
                         dataKey: data => {
                           const matchingRow = data?.find(
                             row => row['span.op'] === 'app.start.warm'
@@ -164,7 +164,7 @@ function ScreenSummary() {
                       },
                       {
                         type: 'duration',
-                        title: t('Warm Start (R2)', truncatedSecondary),
+                        title: t('Warm Start (%s)', SECONDARY_RELEASE_ALIAS),
                         dataKey: data => {
                           const matchingRow = data?.find(
                             row => row['span.op'] === 'app.start.warm'

--- a/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/index.tsx
@@ -122,7 +122,7 @@ function ScreenSummary() {
                     blocks={[
                       {
                         type: 'duration',
-                        title: t('Cold Start (%s)', truncatedPrimary),
+                        title: t('Cold Start (R1)', truncatedPrimary),
                         dataKey: data => {
                           const matchingRow = data?.find(
                             row => row['span.op'] === 'app.start.cold'
@@ -136,7 +136,7 @@ function ScreenSummary() {
                       },
                       {
                         type: 'duration',
-                        title: t('Cold Start (%s)', truncatedSecondary),
+                        title: t('Cold Start (R2)', truncatedSecondary),
                         dataKey: data => {
                           const matchingRow = data?.find(
                             row => row['span.op'] === 'app.start.cold'
@@ -150,7 +150,7 @@ function ScreenSummary() {
                       },
                       {
                         type: 'duration',
-                        title: t('Warm Start (%s)', truncatedPrimary),
+                        title: t('Warm Start (R1)', truncatedPrimary),
                         dataKey: data => {
                           const matchingRow = data?.find(
                             row => row['span.op'] === 'app.start.warm'
@@ -164,7 +164,7 @@ function ScreenSummary() {
                       },
                       {
                         type: 'duration',
-                        title: t('Warm Start (%s)', truncatedSecondary),
+                        title: t('Warm Start (R2)', truncatedSecondary),
                         dataKey: data => {
                           const matchingRow = data?.find(
                             row => row['span.op'] === 'app.start.warm'

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.spec.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.spec.tsx
@@ -82,8 +82,8 @@ describe('SpanOpSelector', function () {
 
     expect(await screen.findByRole('link', {name: 'Operation'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Span Description'})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Duration (release1)'})).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Duration (release2)'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Duration (R1)'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Duration (R2)'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Total Count'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Total Time Spent'})).toBeInTheDocument();
 

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -24,6 +24,10 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {
+  PRIMARY_RELEASE_ALIAS,
+  SECONDARY_RELEASE_ALIAS,
+} from 'sentry/views/starfish/components/releaseSelector';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
@@ -122,8 +126,14 @@ export function SpanOperationTable({
     [SPAN_OP]: t('Operation'),
     [SPAN_DESCRIPTION]: t('Span Description'),
     'count()': t('Total Count'),
-    [`avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`]: t('Duration (R1)'),
-    [`avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`]: t('Duration (R2)'),
+    [`avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`]: t(
+      'Duration (%s)',
+      PRIMARY_RELEASE_ALIAS
+    ),
+    [`avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`]: t(
+      'Duration (%s)',
+      SECONDARY_RELEASE_ALIAS
+    ),
     ['time_spent_percentage()']: t('Total Time Spent'),
   };
 

--- a/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screenSummary/spanOperationTable.tsx
@@ -26,7 +26,6 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 import {SpanOpSelector} from 'sentry/views/starfish/views/appStartup/screenSummary/spanOpSelector';
@@ -64,8 +63,6 @@ export function SpanOperationTable({
   const cursor = decodeScalar(location.query?.[MobileCursors.SPANS_TABLE]);
 
   const spanOp = decodeScalar(location.query[SpanMetricsField.SPAN_OP]) ?? '';
-  const truncatedPrimary = formatVersionAndCenterTruncate(primaryRelease ?? '', 15);
-  const truncatedSecondary = formatVersionAndCenterTruncate(secondaryRelease ?? '', 15);
 
   const searchQuery = new MutableSearch([
     'transaction.op:ui.load',
@@ -125,14 +122,8 @@ export function SpanOperationTable({
     [SPAN_OP]: t('Operation'),
     [SPAN_DESCRIPTION]: t('Span Description'),
     'count()': t('Total Count'),
-    [`avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`]: t(
-      'Duration (%s)',
-      truncatedPrimary
-    ),
-    [`avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`]: t(
-      'Duration (%s)',
-      truncatedSecondary
-    ),
+    [`avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`]: t('Duration (R1)'),
+    [`avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`]: t('Duration (R2)'),
     ['time_spent_percentage()']: t('Total Time Spent'),
   };
 

--- a/static/app/views/starfish/views/appStartup/screensTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screensTable.tsx
@@ -18,6 +18,10 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import TopResultsIndicator from 'sentry/views/discover/table/topResultsIndicator';
 import {COLD_START_COLOR, WARM_START_COLOR} from 'sentry/views/starfish/colours';
+import {
+  PRIMARY_RELEASE_ALIAS,
+  SECONDARY_RELEASE_ALIAS,
+} from 'sentry/views/starfish/components/releaseSelector';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import Breakdown from 'sentry/views/starfish/views/appStartup/breakdown';
 import {TOP_SCREENS} from 'sentry/views/starfish/views/screens';
@@ -36,14 +40,22 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
 
   const columnNameMap = {
     transaction: t('Screen'),
-    [`avg_if(measurements.app_start_cold,release,${primaryRelease})`]:
-      t('Cold Start (R1)'),
-    [`avg_if(measurements.app_start_cold,release,${secondaryRelease})`]:
-      t('Cold Start (R2)'),
-    [`avg_if(measurements.app_start_warm,release,${primaryRelease})`]:
-      t('Warm Start (R1)'),
-    [`avg_if(measurements.app_start_warm,release,${secondaryRelease})`]:
-      t('Warm Start (R2)'),
+    [`avg_if(measurements.app_start_cold,release,${primaryRelease})`]: t(
+      'Cold Start (%s)',
+      PRIMARY_RELEASE_ALIAS
+    ),
+    [`avg_if(measurements.app_start_cold,release,${secondaryRelease})`]: t(
+      'Cold Start (%s)',
+      SECONDARY_RELEASE_ALIAS
+    ),
+    [`avg_if(measurements.app_start_warm,release,${primaryRelease})`]: t(
+      'Warm Start (%s)',
+      PRIMARY_RELEASE_ALIAS
+    ),
+    [`avg_if(measurements.app_start_warm,release,${secondaryRelease})`]: t(
+      'Warm Start (%s)',
+      SECONDARY_RELEASE_ALIAS
+    ),
     app_start_breakdown: t('App Start Breakdown'),
     'count()': t('Total Count'),
   };

--- a/static/app/views/starfish/views/appStartup/screensTable.tsx
+++ b/static/app/views/starfish/views/appStartup/screensTable.tsx
@@ -19,11 +19,8 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import TopResultsIndicator from 'sentry/views/discover/table/topResultsIndicator';
 import {COLD_START_COLOR, WARM_START_COLOR} from 'sentry/views/starfish/colours';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
-import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import Breakdown from 'sentry/views/starfish/views/appStartup/breakdown';
 import {TOP_SCREENS} from 'sentry/views/starfish/views/screens';
-
-const MAX_TABLE_RELEASE_CHARS = 15;
 
 type Props = {
   data: TableData | undefined;
@@ -36,33 +33,17 @@ export function ScreensTable({data, eventView, isLoading, pageLinks}: Props) {
   const location = useLocation();
   const organization = useOrganization();
   const {primaryRelease, secondaryRelease} = useReleaseSelection();
-  const truncatedPrimary = formatVersionAndCenterTruncate(
-    primaryRelease ?? '',
-    MAX_TABLE_RELEASE_CHARS
-  );
-  const truncatedSecondary = formatVersionAndCenterTruncate(
-    secondaryRelease ?? '',
-    MAX_TABLE_RELEASE_CHARS
-  );
 
   const columnNameMap = {
     transaction: t('Screen'),
-    [`avg_if(measurements.app_start_cold,release,${primaryRelease})`]: t(
-      'Cold Start (%s)',
-      truncatedPrimary
-    ),
-    [`avg_if(measurements.app_start_cold,release,${secondaryRelease})`]: t(
-      'Cold Start (%s)',
-      truncatedSecondary
-    ),
-    [`avg_if(measurements.app_start_warm,release,${primaryRelease})`]: t(
-      'Warm Start (%s)',
-      truncatedPrimary
-    ),
-    [`avg_if(measurements.app_start_warm,release,${secondaryRelease})`]: t(
-      'Warm Start (%s)',
-      truncatedSecondary
-    ),
+    [`avg_if(measurements.app_start_cold,release,${primaryRelease})`]:
+      t('Cold Start (R1)'),
+    [`avg_if(measurements.app_start_cold,release,${secondaryRelease})`]:
+      t('Cold Start (R2)'),
+    [`avg_if(measurements.app_start_warm,release,${primaryRelease})`]:
+      t('Warm Start (R1)'),
+    [`avg_if(measurements.app_start_warm,release,${secondaryRelease})`]:
+      t('Warm Start (R2)'),
     app_start_breakdown: t('App Start Breakdown'),
     'count()': t('Total Count'),
   };

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.spec.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.spec.tsx
@@ -4,6 +4,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {
   MobileCursors,
   MobileSortKeys,
@@ -11,6 +12,7 @@ import {
 import {ScreenLoadEventSamples} from 'sentry/views/starfish/views/screens/screenLoadSpans/eventSamples';
 
 jest.mock('sentry/utils/usePageFilters');
+jest.mock('sentry/views/starfish/queries/useReleases');
 
 describe('ScreenLoadEventSamples', function () {
   const organization = OrganizationFixture();
@@ -33,6 +35,26 @@ describe('ScreenLoadEventSamples', function () {
         environments: [],
         projects: [parseInt(project.id, 10)],
       },
+    });
+    jest.mocked(useReleaseSelection).mockReturnValue({
+      primaryRelease: 'com.example.vu.android@2.10.5',
+      isLoading: false,
+      secondaryRelease: 'com.example.vu.android@2.10.3+42',
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/`,
+      body: [
+        {
+          id: 970136705,
+          version: 'com.example.vu.android@2.10.5',
+          dateCreated: '2023-12-19T21:37:53.895495Z',
+        },
+        {
+          id: 969902997,
+          version: 'com.example.vu.android@2.10.3+42',
+          dateCreated: '2023-12-19T18:04:06.953025Z',
+        },
+      ],
     });
     mockEventsRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
@@ -71,9 +93,7 @@ describe('ScreenLoadEventSamples', function () {
     );
 
     // Check that headers are set properly
-    expect(
-      screen.getByRole('columnheader', {name: 'Event ID (2.10.5)'})
-    ).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Event ID (R1)'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'Profile'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'TTID'})).toBeInTheDocument();
     expect(screen.getByRole('columnheader', {name: 'TTFD'})).toBeInTheDocument();

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.tsx
@@ -9,6 +9,10 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {
+  PRIMARY_RELEASE_ALIAS,
+  SECONDARY_RELEASE_ALIAS,
+} from 'sentry/views/starfish/components/releaseSelector';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {
   DEFAULT_PLATFORM,
@@ -82,7 +86,10 @@ export function ScreenLoadEventSamples({
   const sort = fromSorts(decodeScalar(location.query[sortKey]))[0] ?? DEFAULT_SORT;
 
   const columnNameMap = {
-    id: t('Event ID (%s)', release === primaryRelease ? 'R1' : 'R2'),
+    id: t(
+      'Event ID (%s)',
+      release === primaryRelease ? PRIMARY_RELEASE_ALIAS : SECONDARY_RELEASE_ALIAS
+    ),
     'profile.id': t('Profile'),
     'measurements.time_to_initial_display': t('TTID'),
     'measurements.time_to_full_display': t('TTFD'),

--- a/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/eventSamples.tsx
@@ -9,7 +9,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
+import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {
   DEFAULT_PLATFORM,
   PLATFORM_LOCAL_STORAGE_KEY,
@@ -44,6 +44,7 @@ export function ScreenLoadEventSamples({
   const location = useLocation();
   const {selection} = usePageFilters();
   const organization = useOrganization();
+  const {primaryRelease} = useReleaseSelection();
   const cursor = decodeScalar(location.query?.[cursorName]);
 
   const deviceClass = decodeScalar(location.query['device.class']);
@@ -81,7 +82,7 @@ export function ScreenLoadEventSamples({
   const sort = fromSorts(decodeScalar(location.query[sortKey]))[0] ?? DEFAULT_SORT;
 
   const columnNameMap = {
-    id: t('Event ID (%s)', formatVersionAndCenterTruncate(release)),
+    id: t('Event ID (%s)', release === primaryRelease ? 'R1' : 'R2'),
     'profile.id': t('Profile'),
     'measurements.time_to_initial_display': t('TTID'),
     'measurements.time_to_full_display': t('TTFD'),

--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.spec.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.spec.tsx
@@ -336,10 +336,10 @@ describe('Screen Summary', function () {
       });
 
       const blocks = [
-        {header: 'TTID (2.10.5)', value: '1.00s'},
-        {header: 'TTID (2.10.… (42))', value: '2.00s'},
-        {header: 'TTFD (2.10.5)', value: '3.00s'},
-        {header: 'TTFD (2.10.… (42))', value: '4.00s'},
+        {header: 'TTID (R1)', value: '1.00s'},
+        {header: 'TTID (R2)', value: '2.00s'},
+        {header: 'TTFD (R1)', value: '3.00s'},
+        {header: 'TTFD (R2)', value: '4.00s'},
         {header: 'Count', value: '20'},
       ];
 

--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
@@ -19,7 +19,11 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
-import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
+import {
+  PRIMARY_RELEASE_ALIAS,
+  ReleaseComparisonSelector,
+  SECONDARY_RELEASE_ALIAS,
+} from 'sentry/views/starfish/components/releaseSelector';
 import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/starfishPageFiltersContainer';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
@@ -136,22 +140,22 @@ function ScreenLoadSpans() {
                       {
                         type: 'duration',
                         dataKey: `avg_if(measurements.time_to_initial_display,release,${primaryRelease})`,
-                        title: t('TTID (R1)'),
+                        title: t('TTID (%s)', PRIMARY_RELEASE_ALIAS),
                       },
                       {
                         type: 'duration',
                         dataKey: `avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`,
-                        title: t('TTID (R2)'),
+                        title: t('TTID (%s)', SECONDARY_RELEASE_ALIAS),
                       },
                       {
                         type: 'duration',
                         dataKey: `avg_if(measurements.time_to_full_display,release,${primaryRelease})`,
-                        title: t('TTFD (R1)'),
+                        title: t('TTFD (%s)', PRIMARY_RELEASE_ALIAS),
                       },
                       {
                         type: 'duration',
                         dataKey: `avg_if(measurements.time_to_full_display,release,${secondaryRelease})`,
-                        title: t('TTFD (R2)'),
+                        title: t('TTFD (%s)', SECONDARY_RELEASE_ALIAS),
                       },
                       {
                         type: 'count',

--- a/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/index.tsx
@@ -22,7 +22,6 @@ import useRouter from 'sentry/utils/useRouter';
 import {ReleaseComparisonSelector} from 'sentry/views/starfish/components/releaseSelector';
 import {StarfishPageFiltersContainer} from 'sentry/views/starfish/components/starfishPageFiltersContainer';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
 import {
   MobileCursors,
@@ -90,9 +89,6 @@ function ScreenLoadSpans() {
     spanDescription,
   } = location.query;
 
-  const truncatedPrimary = formatVersionAndCenterTruncate(primaryRelease ?? '', 10);
-  const truncatedSecondary = formatVersionAndCenterTruncate(secondaryRelease ?? '', 10);
-
   return (
     <SentryDocumentTitle title={transactionName} orgSlug={organization.slug}>
       <Layout.Page>
@@ -140,22 +136,22 @@ function ScreenLoadSpans() {
                       {
                         type: 'duration',
                         dataKey: `avg_if(measurements.time_to_initial_display,release,${primaryRelease})`,
-                        title: t('TTID (%s)', truncatedPrimary),
+                        title: t('TTID (R1)'),
                       },
                       {
                         type: 'duration',
                         dataKey: `avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`,
-                        title: t('TTID (%s)', truncatedSecondary),
+                        title: t('TTID (R2)'),
                       },
                       {
                         type: 'duration',
                         dataKey: `avg_if(measurements.time_to_full_display,release,${primaryRelease})`,
-                        title: t('TTFD (%s)', truncatedPrimary),
+                        title: t('TTFD (R1)'),
                       },
                       {
                         type: 'duration',
                         dataKey: `avg_if(measurements.time_to_full_display,release,${secondaryRelease})`,
-                        title: t('TTFD (%s)', truncatedSecondary),
+                        title: t('TTFD (R2)'),
                       },
                       {
                         type: 'count',

--- a/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
@@ -27,6 +27,10 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {
+  PRIMARY_RELEASE_ALIAS,
+  SECONDARY_RELEASE_ALIAS,
+} from 'sentry/views/starfish/components/releaseSelector';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 import {useTTFDConfigured} from 'sentry/views/starfish/queries/useHasTtfdConfigured';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
@@ -149,8 +153,14 @@ export function ScreenLoadSpansTable({
     'count()': t('Total Count'),
     affects: hasTTFD ? t('Affects') : t('Affects TTID'),
     'time_spent_percentage()': t('Total Time Spent'),
-    [`avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`]: t('Duration (R1)'),
-    [`avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`]: t('Duration (R2)'),
+    [`avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`]: t(
+      'Duration (%s)',
+      PRIMARY_RELEASE_ALIAS
+    ),
+    [`avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`]: t(
+      'Duration (%s)',
+      SECONDARY_RELEASE_ALIAS
+    ),
   };
 
   function renderBodyCell(column, row): React.ReactNode {

--- a/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
+++ b/static/app/views/starfish/views/screens/screenLoadSpans/table.tsx
@@ -30,7 +30,6 @@ import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import {OverflowEllipsisTextContainer} from 'sentry/views/starfish/components/textAlign';
 import {useTTFDConfigured} from 'sentry/views/starfish/queries/useHasTtfdConfigured';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {STARFISH_CHART_INTERVAL_FIDELITY} from 'sentry/views/starfish/utils/constants';
 import {appendReleaseFilters} from 'sentry/views/starfish/utils/releaseComparison';
 import {QueryParameterNames} from 'sentry/views/starfish/views/queryParameters';
@@ -66,8 +65,6 @@ export function ScreenLoadSpansTable({
   const cursor = decodeScalar(location.query?.[MobileCursors.SPANS_TABLE]);
 
   const spanOp = decodeScalar(location.query[SpanMetricsField.SPAN_OP]) ?? '';
-  const truncatedPrimary = formatVersionAndCenterTruncate(primaryRelease ?? '', 15);
-  const truncatedSecondary = formatVersionAndCenterTruncate(secondaryRelease ?? '', 15);
   const {hasTTFD, isLoading: hasTTFDLoading} = useTTFDConfigured([
     `transaction:"${transaction}"`,
   ]);
@@ -152,14 +149,8 @@ export function ScreenLoadSpansTable({
     'count()': t('Total Count'),
     affects: hasTTFD ? t('Affects') : t('Affects TTID'),
     'time_spent_percentage()': t('Total Time Spent'),
-    [`avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`]: t(
-      'Duration (%s)',
-      truncatedPrimary
-    ),
-    [`avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`]: t(
-      'Duration (%s)',
-      truncatedSecondary
-    ),
+    [`avg_if(${SPAN_SELF_TIME},release,${primaryRelease})`]: t('Duration (R1)'),
+    [`avg_if(${SPAN_SELF_TIME},release,${secondaryRelease})`]: t('Duration (R2)'),
   };
 
   function renderBodyCell(column, row): React.ReactNode {

--- a/static/app/views/starfish/views/screens/screensTable.tsx
+++ b/static/app/views/starfish/views/screens/screensTable.tsx
@@ -26,10 +26,7 @@ import TopResultsIndicator from 'sentry/views/discover/table/topResultsIndicator
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
-import {formatVersionAndCenterTruncate} from 'sentry/views/starfish/utils/centerTruncate';
 import {TOP_SCREENS} from 'sentry/views/starfish/views/screens';
-
-const MAX_TABLE_RELEASE_CHARS = 15;
 
 type Props = {
   data: TableData | undefined;
@@ -51,34 +48,18 @@ export function ScreensTable({
   const location = useLocation();
   const organization = useOrganization();
   const {primaryRelease, secondaryRelease} = useReleaseSelection();
-  const truncatedPrimary = formatVersionAndCenterTruncate(
-    primaryRelease ?? '',
-    MAX_TABLE_RELEASE_CHARS
-  );
-  const truncatedSecondary = formatVersionAndCenterTruncate(
-    secondaryRelease ?? '',
-    MAX_TABLE_RELEASE_CHARS
-  );
   const eventViewColumns = eventView.getColumns();
 
   const columnNameMap = {
     transaction: t('Screen'),
-    [`avg_if(measurements.time_to_initial_display,release,${primaryRelease})`]: t(
-      'TTID (%s)',
-      truncatedPrimary
-    ),
-    [`avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`]: t(
-      'TTID (%s)',
-      truncatedSecondary
-    ),
-    [`avg_if(measurements.time_to_full_display,release,${primaryRelease})`]: t(
-      'TTFD (%s)',
-      truncatedPrimary
-    ),
-    [`avg_if(measurements.time_to_full_display,release,${secondaryRelease})`]: t(
-      'TTFD (%s)',
-      truncatedSecondary
-    ),
+    [`avg_if(measurements.time_to_initial_display,release,${primaryRelease})`]:
+      t('TTID (R1)'),
+    [`avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`]:
+      t('TTID (R2)'),
+    [`avg_if(measurements.time_to_full_display,release,${primaryRelease})`]:
+      t('TTFD (R1)'),
+    [`avg_if(measurements.time_to_full_display,release,${secondaryRelease})`]:
+      t('TTFD (R2)'),
     'count()': t('Total Count'),
   };
 

--- a/static/app/views/starfish/views/screens/screensTable.tsx
+++ b/static/app/views/starfish/views/screens/screensTable.tsx
@@ -24,6 +24,10 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 import TopResultsIndicator from 'sentry/views/discover/table/topResultsIndicator';
 import type {TableColumn} from 'sentry/views/discover/table/types';
+import {
+  PRIMARY_RELEASE_ALIAS,
+  SECONDARY_RELEASE_ALIAS,
+} from 'sentry/views/starfish/components/releaseSelector';
 import {useReleaseSelection} from 'sentry/views/starfish/queries/useReleases';
 import {SpanMetricsField} from 'sentry/views/starfish/types';
 import {TOP_SCREENS} from 'sentry/views/starfish/views/screens';
@@ -52,14 +56,22 @@ export function ScreensTable({
 
   const columnNameMap = {
     transaction: t('Screen'),
-    [`avg_if(measurements.time_to_initial_display,release,${primaryRelease})`]:
-      t('TTID (R1)'),
-    [`avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`]:
-      t('TTID (R2)'),
-    [`avg_if(measurements.time_to_full_display,release,${primaryRelease})`]:
-      t('TTFD (R1)'),
-    [`avg_if(measurements.time_to_full_display,release,${secondaryRelease})`]:
-      t('TTFD (R2)'),
+    [`avg_if(measurements.time_to_initial_display,release,${primaryRelease})`]: t(
+      'TTID (%s)',
+      PRIMARY_RELEASE_ALIAS
+    ),
+    [`avg_if(measurements.time_to_initial_display,release,${secondaryRelease})`]: t(
+      'TTID (%s)',
+      SECONDARY_RELEASE_ALIAS
+    ),
+    [`avg_if(measurements.time_to_full_display,release,${primaryRelease})`]: t(
+      'TTFD (%s)',
+      PRIMARY_RELEASE_ALIAS
+    ),
+    [`avg_if(measurements.time_to_full_display,release,${secondaryRelease})`]: t(
+      'TTFD (%s)',
+      SECONDARY_RELEASE_ALIAS
+    ),
     'count()': t('Total Count'),
   };
 


### PR DESCRIPTION
In order to simplify the text being shown in headers, we've decided to modify the release selector to prefix the primary release with "R1" and the secondary release with "R2" and update usages in the table headers and metrics ribbon to fit this abbreviation

I've updated both the app start module as well as the screen loads module to be consistent since they share the release selector and both modules will need this change eventually.

![Screenshot 2024-02-01 at 2 55 30 PM](https://github.com/getsentry/sentry/assets/22846452/287dcbbd-c417-4786-96b8-5848abe9ce52)
![Screenshot 2024-02-01 at 2 55 35 PM](https://github.com/getsentry/sentry/assets/22846452/cc0ec327-f4da-4946-9b5e-4639aa8b5095)
![Screenshot 2024-02-01 at 2 55 46 PM](https://github.com/getsentry/sentry/assets/22846452/3b1d1934-2d07-44f3-b8dd-64f8c0c4f33a)
