### PR TITLE
ref(grouping): Add check for `suppress_unnecessary_secondary_hash` flag

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -504,12 +504,8 @@ class EventManager:
 
         try:
             with sentry_sdk.start_span(op="event_manager.save.save_aggregate_fn"):
-                group_info = _save_aggregate(
-                    event=job["event"],
-                    job=job,
-                    release=job["release"],
-                    received_timestamp=job["received_timestamp"],
-                    metric_tags=metric_tags,
+                group_info = assign_event_to_group(
+                    event=job["event"], job=job, metric_tags=metric_tags
                 )
                 job["groups"] = [group_info]
         except HashDiscarded as err:
@@ -1321,6 +1317,40 @@ def get_culprit(data: Mapping[str, Any]) -> str:
     return str(
         force_str(data.get("culprit") or data.get("transaction") or generate_culprit(data) or "")
     )
+
+
+def assign_event_to_group(event: Event, job: Job, metric_tags: MutableTags) -> GroupInfo | None:
+    project = event.project
+
+    primary_grouping_config = project.get_option("sentry:grouping_config")
+    secondary_grouping_config = project.get_option("sentry:secondary_grouping_config")
+    has_mobile_config = "mobile:2021-02-12" in [primary_grouping_config, secondary_grouping_config]
+
+    if (
+        features.has(
+            "organizations:grouping-suppress-unnecessary-secondary-hash",
+            project.organization,
+        )
+        and not has_mobile_config
+    ):
+        # This will be updated to the new logic once it's written
+        group_info = _save_aggregate(
+            event=event,
+            job=job,
+            release=job["release"],
+            received_timestamp=job["received_timestamp"],
+            metric_tags=metric_tags,
+        )
+    else:
+        group_info = _save_aggregate(
+            event=event,
+            job=job,
+            release=job["release"],
+            received_timestamp=job["received_timestamp"],
+            metric_tags=metric_tags,
+        )
+
+    return group_info
 
 
 def _save_aggregate(

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -507,7 +507,7 @@ class EventManager:
                 group_info = assign_event_to_group(
                     event=job["event"], job=job, metric_tags=metric_tags
                 )
-                job["groups"] = [group_info]
+
         except HashDiscarded as err:
             logger.info(
                 "event_manager.save.discard",
@@ -530,8 +530,6 @@ class EventManager:
                     },
                 )
             return job["event"]
-
-        job["event"].group = group_info.group
 
         # store a reference to the group id to guarantee validation of isolation
         # XXX(markus): No clue what this does
@@ -1349,6 +1347,10 @@ def assign_event_to_group(event: Event, job: Job, metric_tags: MutableTags) -> G
             received_timestamp=job["received_timestamp"],
             metric_tags=metric_tags,
         )
+
+    if group_info:
+        event.group = group_info.group
+    job["groups"] = [group_info]
 
     return group_info
 


### PR DESCRIPTION
_NOTE: This is a redo of https://github.com/getsentry/sentry/pull/64312, which got reverted when it seemed it might be causing an error. Turns out it wasn't to blame, so pushing it through again._

---------

This wraps `_save_aggregate` (whose logic is going to be updated in a new version of the function) in a new function, `assign_event_to_group`, which determines whether to run the current version or the new version. Which version to run is controlled both by the `suppress_unnecessary_secondary_hash` flag added in https://github.com/getsentry/sentry/pull/64128 and by the project's grouping configs - any project using the mobile config as either their primary or secondary config has to use the current logic, since the new logic won't include any of the hierarchical grouping code. Note: For now both branches call the current version of `_save_aggregate`, as the new version has yet to be written.

In addition, two bits of logic from `save_error_events`, which set group data on the event and the job, have been moved into the new wrapper.