### PR TITLE
fix(ai-autofix): use the event serializer to get event entries

### DIFF
--- a/src/sentry/api/endpoints/group_ai_autofix.py
+++ b/src/sentry/api/endpoints/group_ai_autofix.py
@@ -12,7 +12,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
-from sentry.api.serializers.models.event import get_entries
+from sentry.api.serializers import EventSerializer, serialize
 from sentry.models.commit import Commit
 from sentry.models.group import Group
 from sentry.models.release import Release
@@ -54,7 +54,8 @@ class GroupAiAutofixEndpoint(GroupEndpoint):
         if not latest_event:
             return None
 
-        return get_entries(latest_event, user)[0]
+        serialized_event = serialize(latest_event, user, EventSerializer())
+        return serialized_event["entries"]
 
     def _make_error_metadata(self, autofix: dict, reason: str):
         return {


### PR DESCRIPTION
Fixes SENTRY-2J35