### PR TITLE
perf(searchbar): remove autosize searchbar

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1043,11 +1043,16 @@ export const defaultConfig: SearchConfig = {
   },
 };
 
-const options = {
-  TokenConverter,
-  TermOperator,
-  FilterType,
-};
+function tryParseSearch<T extends {config: SearchConfig}>(
+  query: string,
+  config: T
+): ParseResult | null {
+  try {
+    return grammar.parse(query, config);
+  } catch (e) {
+    return null;
+  }
+}
 
 /**
  * Parse a search query into a ParseResult. Failing to parse the search query
@@ -1057,18 +1062,16 @@ export function parseSearch(
   query: string,
   additionalConfig?: Partial<SearchConfig>
 ): ParseResult | null {
-  const configCopy = {...defaultConfig};
+  const config = additionalConfig
+    ? merge({...defaultConfig}, additionalConfig)
+    : defaultConfig;
 
-  // Merge additionalConfig with defaultConfig
-  const config = merge(configCopy, additionalConfig);
-
-  try {
-    return grammar.parse(query, {...options, config});
-  } catch (e) {
-    // TODO(epurkhiser): Should we capture these errors somewhere?
-  }
-
-  return null;
+  return tryParseSearch(query, {
+    config,
+    TokenConverter,
+    TermOperator,
+    FilterType,
+  });
 }
 
 /**

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import merge from 'lodash/merge';
 import moment from 'moment';
 import type {LocationRange} from 'pegjs';
@@ -1050,6 +1051,7 @@ function tryParseSearch<T extends {config: SearchConfig}>(
   try {
     return grammar.parse(query, config);
   } catch (e) {
+    Sentry.captureException(e);
     return null;
   }
 }

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -46,7 +46,6 @@ import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {FieldDefinition} from 'sentry/utils/fields';
 import {FieldKind, FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
-import SearchBoxTextArea from 'sentry/utils/search/searchBoxTextArea';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 // eslint-disable-next-line no-restricted-imports
@@ -100,6 +99,15 @@ const generateOpAutocompleteGroup = (
     type: ItemType.TAG_OPERATOR,
   };
 };
+
+function maybeFocusInput(input: HTMLTextAreaElement | null) {
+  // Cannot focus if there is no input or if the input is already focused
+  if (!input || document.activeElement === input) {
+    return;
+  }
+
+  input.focus();
+}
 
 const pickParserOptions = (props: Props) => {
   const {
@@ -452,7 +460,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
     const {query, actionBarItems} = this.props;
     const parserOptions = pickParserOptions(this.props);
 
-    const {query: lastQuery, actionBarItems: lastAcionBarItems} = prevProps;
+    const {query: lastQuery, actionBarItems: lastActionBar} = prevProps;
     const prevParserOptions = pickParserOptions(prevProps);
 
     if (query !== lastQuery && (defined(query) || defined(lastQuery))) {
@@ -462,7 +470,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
       this.setState(this.makeQueryState(this.state.query));
     }
 
-    if (lastAcionBarItems?.length !== actionBarItems?.length) {
+    if (lastActionBar?.length !== actionBarItems?.length) {
       this.setState({numActionsVisible: actionBarItems?.length ?? 0});
     }
   }
@@ -591,7 +599,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
     const token = this.cursorToken;
 
     if (this.searchInput.current && filterTokens.length > 0) {
-      this.searchInput.current.focus();
+      maybeFocusInput(this.searchInput.current);
 
       let offset = filterTokens[0].location.end.offset;
       if (token) {
@@ -623,7 +631,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
 
       if (this.searchInput.current) {
         // Only use exec command if exists
-        this.searchInput.current.focus();
+        maybeFocusInput(this.searchInput.current);
 
         this.searchInput.current.selectionStart = 0;
         this.searchInput.current.selectionEnd = query.length;
@@ -651,7 +659,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
     if (token && token.type === Token.FILTER) {
       if (token.negated) {
         if (this.searchInput.current) {
-          this.searchInput.current.focus();
+          maybeFocusInput(this.searchInput.current);
 
           const tokenCursorOffset = this.cursorPosition - token.key.location.start.offset;
 
@@ -678,7 +686,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
         }
       } else {
         if (this.searchInput.current) {
-          this.searchInput.current.focus();
+          maybeFocusInput(this.searchInput.current);
 
           const tokenCursorOffset = this.cursorPosition - token.key.location.start.offset;
 
@@ -1727,7 +1735,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
     this.setState(this.makeQueryState(newQuery), () => {
       // setting a new input value will lose focus; restore it
       if (this.searchInput.current) {
-        this.searchInput.current.focus();
+        maybeFocusInput(this.searchInput.current);
         if (cursorPosition) {
           this.searchInput.current.selectionStart = cursorPosition;
           this.searchInput.current.selectionEnd = cursorPosition;
@@ -1933,7 +1941,6 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
 
     const input = (
       <SearchInput
-        type="text"
         placeholder={placeholder}
         id={id}
         data-test-id="smart-search-input"
@@ -1951,7 +1958,6 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
         disabled={disabled}
         maxLength={maxQueryLength}
         spellCheck={false}
-        maxRows={query ? undefined : 1}
       />
     );
 
@@ -1971,10 +1977,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
         return <ActionBarButton key={key} />;
       });
 
-    const overflowedActions = actionItems
-      .slice(numActionsVisible)
-      .map(({makeAction}) => makeAction(actionProps).menuItem);
-
+    const hasOverflownActions = actionItems.length > numActionsVisible;
     const cursor = this.cursorPosition;
 
     const visibleShortcuts = shortcuts.filter(
@@ -2029,7 +2032,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
             />
           )}
           {visibleActions}
-          {overflowedActions.length > 0 && (
+          {hasOverflownActions ? (
             <OverlowingActionsMenu
               position="bottom-end"
               trigger={props => (
@@ -2041,19 +2044,19 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
                 />
               )}
               triggerLabel={t('Show more')}
-              items={overflowedActions}
+              items={actionItems
+                .slice(numActionsVisible)
+                .map(({makeAction}) => makeAction(actionProps).menuItem)}
               size="sm"
             />
-          )}
+          ) : null}
         </ActionsBar>
 
         {this.shouldShowDatePicker && (
           <SearchBarDatePicker
             date={this.cursorValueIsoDate?.value}
             dateString={this.cursorValueIsoDate?.text}
-            handleSelectDateTime={value => {
-              this.onAutoCompleteIsoDate(value);
-            }}
+            handleSelectDateTime={this.onAutoCompleteIsoDate}
           />
         )}
 
@@ -2119,8 +2122,12 @@ export {SmartSearchBar};
 
 const Container = styled('div')<{inputHasFocus: boolean}>`
   min-height: ${p => p.theme.form.md.height}px;
-  border: 1px solid ${p => p.theme.border};
-  box-shadow: inset ${p => p.theme.dropShadowMedium};
+  border: ${p =>
+    p.inputHasFocus ? `1px solid ${p.theme.focusBorder}` : `1px solid ${p.theme.border}`};
+  box-shadow: ${p =>
+    p.inputHasFocus
+      ? `0 0 0 1px ${p.theme.focusBorder}`
+      : `inset ${p.theme.dropShadowMedium}`};
   background: ${p => p.theme.background};
   padding: 6px ${space(1)};
   position: relative;
@@ -2134,13 +2141,6 @@ const Container = styled('div')<{inputHasFocus: boolean}>`
   .show-sidebar & {
     background: ${p => p.theme.backgroundSecondary};
   }
-
-  ${p =>
-    p.inputHasFocus &&
-    `
-    border-color: ${p.theme.focusBorder};
-    box-shadow: 0 0 0 1px ${p.theme.focusBorder};
-  `}
 `;
 
 const SearchIconContainer = styled('div')`
@@ -2159,14 +2159,13 @@ const SearchLabel = styled('label')`
 
 const InputWrapper = styled('div')`
   position: relative;
+  width: 100%;
+  height: 100%;
 `;
 
 const Highlight = styled('div')`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  width: 100%;
+  height: 100%;
   user-select: none;
   white-space: pre-wrap;
   word-break: break-word;
@@ -2175,9 +2174,12 @@ const Highlight = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
 `;
 
-const SearchInput = styled(SearchBoxTextArea)`
-  position: relative;
-  display: flex;
+const SearchInput = styled('textarea')`
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
   resize: none;
   outline: none;
   border: 0;

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -2176,10 +2176,7 @@ const Highlight = styled('div')`
 
 const SearchInput = styled('textarea')`
   position: absolute;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
   resize: none;
   outline: none;
   border: 0;

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -2169,7 +2169,7 @@ const Highlight = styled('div')`
   user-select: none;
   white-space: pre-wrap;
   word-break: break-word;
-  line-height: 25px;
+  line-height: 24px;
   font-size: ${p => p.theme.fontSizeSmall};
   font-family: ${p => p.theme.text.familyMono};
 `;


### PR DESCRIPTION
Since we already have a wrapper component where we display highlighted items, there is no need to autosize the textbox and we can just stretch it over.

This also removes a INP issue with textbox as it triggers a resize event which causes layout thrashing.