### PR TITLE
chore(hybrid-cloud): Update SentryAppDocsTest to be region silo default

### DIFF
--- a/tests/apidocs/endpoints/integration_platform/test_sentry_app_external_issues.py
+++ b/tests/apidocs/endpoints/integration_platform/test_sentry_app_external_issues.py
@@ -3,9 +3,12 @@ from django.urls import reverse
 
 from fixtures.apidocs_test_case import APIDocsTestCase
 from sentry.models.integrations.sentry_app_installation import SentryAppInstallation
+from sentry.silo import SiloMode
+from sentry.testutils.silo import assume_test_silo_mode, region_silo_test
 
 
-class SentryAppDocs(APIDocsTestCase):
+@region_silo_test
+class SentryAppDocsTest(APIDocsTestCase):
     def setUp(self):
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.project = self.create_project(organization=self.org)
@@ -13,10 +16,11 @@ class SentryAppDocs(APIDocsTestCase):
         self.sentry_app = self.create_sentry_app(
             name="Hellboy App", published=True, organization=self.org
         )
-        self.install = SentryAppInstallation(
-            sentry_app=self.sentry_app, organization_id=self.org.id
-        )
-        self.install.save()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.install = SentryAppInstallation(
+                sentry_app=self.sentry_app, organization_id=self.org.id
+            )
+            self.install.save()
         self.url = reverse(
             "sentry-api-0-sentry-app-installation-external-issues",
             kwargs={"uuid": self.install.uuid},


### PR DESCRIPTION
Update `tests/apidocs/endpoints/integration_platform/test_sentry_app_external_issues.py` to run in region silo by default.