### PR TITLE
feat(issue-platform): Use priority for high priority alerts

### DIFF
--- a/src/sentry/rules/conditions/high_priority_issue.py
+++ b/src/sentry/rules/conditions/high_priority_issue.py
@@ -1,8 +1,10 @@
 from datetime import datetime
 from typing import Optional, Sequence
 
+from sentry import features
 from sentry.event_manager import HIGH_SEVERITY_THRESHOLD
 from sentry.eventstore.models import GroupEvent
+from sentry.issues.priority import PriorityLevel
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.receivers.rules import has_high_priority_issue_alerts
@@ -30,6 +32,9 @@ class HighPriorityIssueCondition(EventCondition):
     def passes(self, event: GroupEvent, state: EventState) -> bool:
         if not has_high_priority_issue_alerts(self.project):
             return False
+
+        if features.has("projects:issue-priority", self.project):
+            return event.group.priority == PriorityLevel.HIGH
 
         is_new_high_severity = self.is_new_high_severity(state, event.group)
         is_escalating = state.has_reappeared or state.has_escalated

--- a/tests/sentry/rules/conditions/test_high_priority_issue.py
+++ b/tests/sentry/rules/conditions/test_high_priority_issue.py
@@ -1,3 +1,4 @@
+from sentry.issues.priority import PriorityLevel
 from sentry.rules.conditions.high_priority_issue import HighPriorityIssueCondition
 from sentry.testutils.cases import RuleTestCase
 from sentry.testutils.helpers.features import with_feature
@@ -28,4 +29,27 @@ class HighPriorityIssueConditionTest(RuleTestCase):
         event.group.data["metadata"] = {"severity": "0.0"}
         self.assertPasses(rule, event, is_new=False, has_reappeared=False, has_escalated=True)
         self.assertPasses(rule, event, is_new=False, has_reappeared=False, has_escalated=True)
+        self.assertDoesNotPass(rule, event, is_new=True, has_reappeared=False, has_escalated=False)
+
+    @with_feature("projects:high-priority-alerts")
+    @with_feature("projects:issue-priority")
+    def test_applies_correctly_with_priority(self):
+        rule = self.get_rule()
+        event = self.get_event()
+
+        # This will always pass
+        event.group.update(priority=PriorityLevel.HIGH)
+        self.assertPasses(rule, event, is_new=False, has_reappeared=False, has_escalated=False)
+        self.assertPasses(rule, event, is_new=True, has_reappeared=False, has_escalated=True)
+        self.assertPasses(rule, event, is_new=False, has_reappeared=False, has_escalated=False)
+        self.assertPasses(rule, event, is_new=True, has_reappeared=True, has_escalated=False)
+
+        # This will never pass
+        event.group.update(priority=PriorityLevel.LOW)
+        self.assertDoesNotPass(rule, event, is_new=True, has_reappeared=False, has_escalated=False)
+        self.assertDoesNotPass(rule, event, is_new=False, has_reappeared=False, has_escalated=False)
+
+        # This will never pass
+        event.group.update(priority=PriorityLevel.MEDIUM)
+        self.assertDoesNotPass(rule, event, is_new=False, has_reappeared=False, has_escalated=True)
         self.assertDoesNotPass(rule, event, is_new=True, has_reappeared=False, has_escalated=False)


### PR DESCRIPTION
The priority of an issue will be updated using the same severity calculations in this alert, or based on issue escalation as expected. We can simplify the rule by just checking the value of `group.priority`. 

This should _probably_ merge after we backfill priority for all rows so the alerts are accurate and useful. 

FIXES https://github.com/getsentry/sentry/issues/64420