### PR TITLE
fix(snuba): use toIPv4 for replays

### DIFF
--- a/src/sentry/replays/lib/new_query/conditions.py
+++ b/src/sentry/replays/lib/new_query/conditions.py
@@ -211,20 +211,20 @@ class IPv4Scalar(GenericBase):
 
     @staticmethod
     def visit_eq(expression: Expression, value: str) -> Condition:
-        return Condition(expression, Op.EQ, Function("IPv4StringToNum", parameters=[value]))
+        return Condition(expression, Op.EQ, Function("toIPv4", parameters=[value]))
 
     @staticmethod
     def visit_neq(expression: Expression, value: str) -> Condition:
-        return Condition(expression, Op.NEQ, Function("IPv4StringToNum", parameters=[value]))
+        return Condition(expression, Op.NEQ, Function("toIPv4", parameters=[value]))
 
     @staticmethod
     def visit_in(expression: Expression, value: list[str]) -> Condition:
-        values = [Function("IPv4StringToNum", parameters=[v]) for v in value]
+        values = [Function("toIPv4", parameters=[v]) for v in value]
         return Condition(expression, Op.IN, values)
 
     @staticmethod
     def visit_not_in(expression: Expression, value: list[str]) -> Condition:
-        values = [Function("IPv4StringToNum", parameters=[v]) for v in value]
+        values = [Function("toIPv4", parameters=[v]) for v in value]
         return Condition(expression, Op.NOT_IN, values)
 
 

--- a/src/sentry/replays/lib/query.py
+++ b/src/sentry/replays/lib/query.py
@@ -133,9 +133,9 @@ class IPAddress(Field):
         is_wildcard: bool = False,
     ) -> Condition:
         if isinstance(value, list):
-            value = [Function("IPv4StringToNum", parameters=[v]) for v in value]
+            value = [Function("toIPv4", parameters=[v]) for v in value]
         else:
-            value = Function("IPv4StringToNum", parameters=[value])
+            value = Function("toIPv4", parameters=[value])
 
         return Condition(Column(self.query_alias or self.attribute_name), operator, value)
 


### PR DESCRIPTION
Same fix that was added in https://github.com/getsentry/sentry/pull/64221, but for Replays. This is to fix compatibility for future versions of the ClickHouse (e.g. `23.8`)