### PR TITLE
perf: use pipeline for redis rate limiter

### DIFF
--- a/tests/sentry/ratelimits/test_redis_cluster.py
+++ b/tests/sentry/ratelimits/test_redis_cluster.py
@@ -1,0 +1,29 @@
+import uuid
+
+from django.test.utils import override_settings
+
+from sentry.ratelimits.redis import RedisRateLimiter
+from sentry.testutils.helpers import override_options
+from sentry.testutils.helpers.redis import get_redis_cluster_default_options
+
+
+@override_settings(
+    SENTRY_PROCESSING_SERVICES={"redis": {"redis": "cluster"}},
+    SENTRY_RATE_LIMIT_REDIS_CLUSTER="cluster",
+)
+@override_options(get_redis_cluster_default_options(id="cluster"))
+def test_integration_is_limited_with_value_with() -> None:
+    rate_limiter = RedisRateLimiter()
+    key = uuid.uuid4().hex
+
+    limited, value, reset_time = rate_limiter.is_limited_with_value(key=key, limit=2, window=60)
+    assert not limited
+    assert value == 1
+
+    limited, value, reset_time = rate_limiter.is_limited_with_value(key=key, limit=2, window=60)
+    assert not limited
+    assert value == 2
+
+    limited, value, reset_time = rate_limiter.is_limited_with_value(key=key, limit=2, window=60)
+    assert limited
+    assert value == 3


### PR DESCRIPTION
Currently, `RedisRateLimiter.is_limited_with_value` takes 8% of an operation such as `/api/0/projects`. This pull request is an attempt to improve the performance.

Instead of making 2 different Redis calls, using `multi` might improve the performance of the rate limiter.

<img width="811" alt="Screenshot 2024-02-01 at 6 02 50 PM" src="https://github.com/getsentry/sentry/assets/1935246/0f21bcb6-5c57-4e30-b689-5e013cbc0f56">