### PR TITLE
ref(slack): Don't recreate actions

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -516,6 +516,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         )
         obj = self.event if self.event is not None else self.group
         action_text = ""
+
         if not self.issue_details or (
             self.recipient and self.recipient.actor_type == ActorType.TEAM
         ):
@@ -583,6 +584,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
             blocks.append(self.get_rich_text_preformatted_block(text))
 
         # build up actions text
+        if self.actions and self.identity and not action_text:
+            action_text = get_action_text(text, self.actions, self.identity)
+
         if self.actions:
             blocks.append(self.get_markdown_block(action_text))
 

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -627,7 +627,6 @@ class SlackActionEndpoint(Endpoint):
                 actions=action_list,
                 tags=original_tags_from_request,
                 rules=[rule] if rule else None,
-                issue_details=True,
             ).build()
             # XXX(isabella): for actions on link unfurls, we omit the fallback text from the
             # response so the unfurling endpoint understands the payload

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -523,16 +523,17 @@ class SlackActionEndpoint(Endpoint):
             except client.ApiError as error:
                 return self.api_error(slack_request, group, identity_user, error, "status_dialog")
 
-            attachment = SlackIssuesMessageBuilder(
+            blocks = SlackIssuesMessageBuilder(
                 group,
                 identity=identity,
                 actions=[action],
                 tags=original_tags_from_request,
                 rules=[rule] if rule else None,
+                issue_details=True,
                 skip_fallback=True,
             ).build()
             body = self.construct_reply(
-                attachment, is_message=slack_request.callback_data["is_message"]
+                blocks, is_message=slack_request.callback_data["is_message"]
             )
             # use the original response_url to update the link attachment
             slack_client = SlackClient(integration_id=slack_request.integration.id)
@@ -619,8 +620,6 @@ class SlackActionEndpoint(Endpoint):
         # Reload group as it may have been mutated by the action
         group = Group.objects.get(id=group.id)
 
-        use_block_kit = features.has("organizations:slack-block-kit", group.project.organization)
-
         if use_block_kit:
             response = SlackIssuesMessageBuilder(
                 group,
@@ -628,6 +627,7 @@ class SlackActionEndpoint(Endpoint):
                 actions=action_list,
                 tags=original_tags_from_request,
                 rules=[rule] if rule else None,
+                issue_details=True,
             ).build()
             # XXX(isabella): for actions on link unfurls, we omit the fallback text from the
             # response so the unfurling endpoint understands the payload


### PR DESCRIPTION
We noticed during prod testing that performing actions on a notification kept timing out because we rebuild the notification after a selection is made (e.g. resolving an issue) to include text about what just happened (issue resolved by colleen) and it was taking longer than the allotted 3 seconds. This PR skips re-building the actions as [building the list of members](https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/slack/message_builder/issues.py#L199) for assignment was taking a long time, and we don't render buttons after an action is taken anyway.

Note that this is a quick short term solution - we should [update the message](https://api.slack.com/interactivity/handling#updating_message_response) instead, but that'll take a little bit more time. 