### PR TITLE
feat(ci): Adding migrations approval check to CI

### DIFF
--- a/.github/workflows/migrations-approval.yml
+++ b/.github/workflows/migrations-approval.yml
@@ -1,0 +1,63 @@
+name: migrations approval
+on:
+  pull_request:
+    types: [review_requested, synchronize, opened, reopened]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+# Cancel in progress workflows on pull_requests.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # the default default is:
+    #      bash --noprofile --norc -eo pipefail {0}
+    shell: bash --noprofile --norc -eo pipefail -ux {0}
+
+jobs:
+  did-migration-change:
+    name: check if any migration changes
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3
+    # Map a step output to a job output
+    outputs:
+      added: ${{ steps.changes.outputs.migrations_added }}
+      modified: ${{ steps.changes.outputs.migrations_modified }}
+    steps:
+      - name: Checkout sentry
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+
+      - name: Match migration files
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
+  check-migration-approval:
+    name: check if migration is approved
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3
+    needs: did-migration-change
+    if: needs.did-migration-change.outputs.added == 'true'
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        with:
+          persist-credentials: false
+
+      - name: getsentry token
+        uses: getsentry/action-github-app-token@97c9e23528286821f97fba885c1b1123284b29cc # v2.0.0
+        id: getsentry
+        with:
+          app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
+          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+
+      - uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
+        with:
+          github-token: ${{ steps.getsentry.outputs.token }}
+          script: |
+            const {check} = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/team-approval-check`);
+            await check({ github, context, core, team_slug: 'owners-migrations' });

--- a/.github/workflows/scripts/team-approval-check.js
+++ b/.github/workflows/scripts/team-approval-check.js
@@ -1,0 +1,42 @@
+/* eslint-env node */
+
+module.exports = {
+  check: async ({github, context, core, team_slug}) => {
+    const owner = context.repo.owner;
+    const repo = context.repo.repo;
+    const pull_number = context.issue.number;
+
+    // Get all reviews for this PR
+    const {data: reviews} = await github.rest.pulls.listReviews({
+      owner,
+      repo,
+      pull_number,
+    });
+
+    // If no reviews are found, fail early (reduces snumber of API calls)
+    if (reviews.length === 0) {
+      core.setFailed('No reviews found for this PR');
+      return;
+    }
+
+    // Collect all members of the team
+    const {data: members} = await github.rest.teams.listMembersInOrg({
+      org: owner,
+      team_slug,
+    });
+    if (!Array.isArray(members) || members.length === 0) {
+      core.setFailed(`No members found in ${team_slug}`);
+      return;
+    }
+    const memberIds = members.map(member => member.id);
+
+    // Check if any member of the team approved this PR
+    const isApprovedByMember = reviews.some(
+      review => memberIds.includes(review.user.id) && review.state === 'APPROVED'
+    );
+
+    if (!isApprovedByMember) {
+      core.setFailed(`No ${team_slug} member approved this PR`);
+    }
+  },
+};


### PR DESCRIPTION
As part of a push to prevent problematic migrations from being merged, this PR adds an additional check that ensures migrations are approved by a member of `owners-migrations`. One thing to note is that in order for this to work properly, we will have to make this a required action once this is merged. It is worth noting that if a change does not touch a migration, this workflow is skipped meaning it won't block merging (even if required).